### PR TITLE
fix: use workflow_run for PR coverage comments on fork PRs

### DIFF
--- a/.github/actions/go-coverage/action.yml
+++ b/.github/actions/go-coverage/action.yml
@@ -98,62 +98,31 @@ runs:
         echo "| Threshold | $THRESHOLD% |" >> $GITHUB_STEP_SUMMARY
         echo "| Status | $([ \"$PASS\" = \"true\" ] && echo '✅ Pass' || echo '❌ Fail') |" >> $GITHUB_STEP_SUMMARY
 
-    - name: Post PR Comment
+    # Save coverage data as artifact for workflow_run to post comment
+    # This avoids permission issues with fork PRs
+    - name: Save PR Coverage Data
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      shell: bash
+      run: |
+        mkdir -p coverage-comment-data
+        cat > coverage-comment-data/coverage-data.json << 'EOF'
+        {
+          "coverage": "${{ steps.coverage.outputs.coverage }}",
+          "threshold": "${{ inputs.threshold }}",
+          "pass": "${{ steps.coverage.outputs.pass }}",
+          "color": "${{ steps.coverage.outputs.color }}",
+          "pr_number": "${{ github.event.pull_request.number }}"
+        }
+        EOF
+        cat coverage-comment-data/coverage-data.json
+
+    - name: Upload Coverage Data
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       with:
-        script: |
-          const coverage = '${{ steps.coverage.outputs.coverage }}';
-          const threshold = '${{ inputs.threshold }}';
-          const pass = '${{ steps.coverage.outputs.pass }}' === 'true';
-          const color = '${{ steps.coverage.outputs.color }}';
-
-          const status = pass ? '✅' : '❌';
-          const statusText = pass ? 'Pass' : 'Fail';
-
-          const body = `## Coverage Report ${status}
-
-          | Metric | Value |
-          |--------|-------|
-          | Coverage | **${coverage}%** |
-          | Threshold | ${threshold}% |
-          | Status | ${statusText} |
-
-          <details>
-          <summary>Coverage Badge</summary>
-
-          \`\`\`
-          ![Coverage](https://img.shields.io/badge/coverage-${coverage}%25-${color})
-          \`\`\`
-          </details>`;
-
-          // Find existing comment
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-
-          const botComment = comments.find(comment =>
-            comment.user.type === 'Bot' &&
-            comment.body.includes('## Coverage Report')
-          );
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: body
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
-            });
-          }
+        name: coverage-comment-data
+        path: coverage-comment-data/
+        retention-days: 1
 
     - name: Update Badge Gist
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.badge_gist_id != '' && inputs.badge_gist_token != ''

--- a/.github/workflows/on-push-comment.yaml
+++ b/.github/workflows/on-push-comment.yaml
@@ -1,0 +1,114 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow posts coverage comments on PRs after the main workflow completes.
+# Using workflow_run gives us write permissions even for fork PRs.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+
+name: Post PR Comment
+
+on:
+  workflow_run:
+    workflows: ["On Push Qualification"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post-coverage-comment:
+    name: Post Coverage Comment
+    runs-on: ubuntu-latest
+    # Run for PRs regardless of conclusion - coverage might exist even if other steps failed
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download Coverage Data
+        id: download
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        continue-on-error: true
+        with:
+          name: coverage-comment-data
+          path: coverage-comment-data
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Check Artifact Exists
+        if: steps.download.outcome == 'failure'
+        run: |
+          echo "No coverage data artifact found - skipping comment"
+          exit 0
+
+      - name: Post PR Comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('coverage-comment-data/coverage-data.json', 'utf8'));
+
+            const coverage = data.coverage;
+            const threshold = data.threshold;
+            const pass = data.pass === 'true';
+            const color = data.color;
+            const prNumber = parseInt(data.pr_number, 10);
+
+            const status = pass ? '✅' : '❌';
+            const statusText = pass ? 'Pass' : 'Fail';
+
+            const body = `## Coverage Report ${status}
+
+            | Metric | Value |
+            |--------|-------|
+            | Coverage | **${coverage}%** |
+            | Threshold | ${threshold}% |
+            | Status | ${statusText} |
+
+            <details>
+            <summary>Coverage Badge</summary>
+
+            \`\`\`
+            ![Coverage](https://img.shields.io/badge/coverage-${coverage}%25-${color})
+            \`\`\`
+            </details>`;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('## Coverage Report')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+              console.log(`Updated existing comment ${botComment.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+              console.log(`Created new comment on PR #${prNumber}`);
+            }


### PR DESCRIPTION
## Summary

Use `workflow_run` pattern to post coverage comments on fork PRs, fixing the 403 permission error that was causing CI failures.

## Motivation / Context

Fork PRs have restricted `GITHUB_TOKEN` permissions that prevent posting comments directly. The previous implementation tried to post PR comments using `actions/github-script` during the `pull_request` event, which fails with "Resource not accessible by integration" (HTTP 403) for fork PRs.

This change uses the `workflow_run` pattern recommended by GitHub Security Lab:
1. Main workflow uploads coverage data as artifact (read-only, safe)
2. Separate `workflow_run` triggered workflow posts comment (has write permissions)

Reference: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

related to comments in #3
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions workflows (`.github/`)

## Implementation Notes

- The `go-coverage` action now saves coverage data (coverage %, threshold, pass/fail, PR number) as a JSON artifact instead of posting directly
- New `on-push-comment.yaml` workflow triggers via `workflow_run` after "On Push Qualification" completes
- The `workflow_run` event runs in the context of the base repository, giving it write permissions even for fork PRs
- Artifact retention is set to 1 day since it's only needed briefly for the comment workflow

**Note:** The `workflow_run` workflow won't trigger until this PR is merged (it must exist on the default branch). For this PR specifically, coverage will appear in the Step Summary but not as a PR comment.

## Testing

```bash
# YAML validation
yamllint .github/workflows/on-push-comment.yaml .github/actions/go-coverage/action.yml
```

- YAML syntax validated locally
- CI will validate the workflow runs without the 403 error
- Full coverage comment functionality will be testable after merge

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration needed. The change is backwards compatible - coverage is still calculated and shown in Step Summary. PR comments will start appearing for future PRs after this merges.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI workflow change)
- [ ] I updated docs if user-facing behavior changed — N/A (internal CI)
- [ ] Changes follow existing patterns in the codebase
- [ ] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)