### PR TITLE
fix: add actions:read permission for artifact download

### DIFF
--- a/.github/workflows/on-push-comment.yaml
+++ b/.github/workflows/on-push-comment.yaml
@@ -25,6 +25,7 @@ on:
       - completed
 
 permissions:
+  actions: read        # Required to download artifacts from other workflow runs
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

Add missing `actions: read` permission to the `Post PR Comment` workflow so it can download artifacts from other workflow runs.

## Motivation / Context

The `workflow_run` triggered workflow needs `actions: read` permission to download artifacts from the triggering workflow. Without this, the `download-artifact` action fails with "Resource not accessible by integration".

Error from [run 21550864730](https://github.com/NVIDIA/eidos/actions/runs/21550864730):
```
Unable to download artifact(s): Resource not accessible by integration
```

Fixes: Follow-up to #5
Related: #3

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions workflows (`.github/`)

## Implementation Notes

Added `actions: read` permission to `.github/workflows/on-push-comment.yaml`. This is the minimum permission needed to download artifacts from other workflow runs.

## Testing

- CI will validate the workflow has correct permissions
- The next PR update on #3 will trigger the workflow and post the coverage comment

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A - single line permission addition

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)