### PR TITLE
feat: add contextcheck and depguard linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,7 +66,11 @@ linters:
     - gosec           # Security checks
 
     # HTTP/Context
+    - contextcheck    # Context propagation in function calls
     - noctx           # HTTP requests without context
+
+    # Dependency management
+    - depguard        # Ban deprecated/unwanted packages
 
     # Testing
     - tparallel       # t.Parallel() usage
@@ -111,6 +115,16 @@ linters:
           disabled: false
           arguments:
             - disableStutteringCheck
+
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          deny:
+            - pkg: io/ioutil
+              desc: "Deprecated since Go 1.16. Use io and os packages instead."
+            - pkg: math/rand$
+              desc: "Use math/rand/v2 for new code, or crypto/rand for security-sensitive code."
 
   exclusions:
     generated: lax

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -175,7 +175,8 @@ Override snapshot-detected criteria:
 			} else if criteriaFilePath != "" {
 				// Load criteria from file
 				slog.Info("loading criteria from file", "path", criteriaFilePath)
-				criteria, loadErr := recipe.LoadCriteriaFromFile(criteriaFilePath)
+				// TODO: Add context support to LoadCriteriaFromFile for HTTP URL timeout/cancellation
+				criteria, loadErr := recipe.LoadCriteriaFromFile(criteriaFilePath) //nolint:contextcheck // serializer.FromFile doesn't support context yet
 				if loadErr != nil {
 					return fmt.Errorf("failed to load criteria from %q: %w", criteriaFilePath, loadErr)
 				}

--- a/pkg/serializer/http.go
+++ b/pkg/serializer/http.go
@@ -308,7 +308,7 @@ func (r *HttpReader) Read(url string) ([]byte, error) {
 // ReadWithContext fetches data from the specified URL and returns it as a byte slice.
 // The request is bound to the provided context for cancellation and deadlines.
 // Callers must provide a non-nil context.
-func (r *HttpReader) ReadWithContext(ctx context.Context, url string) ([]byte, error) { //nolint:contextcheck // ctx is used via NewRequestWithContext below
+func (r *HttpReader) ReadWithContext(ctx context.Context, url string) ([]byte, error) {
 	if url == "" {
 		return nil, fmt.Errorf("url is empty")
 	}

--- a/pkg/serializer/http.go
+++ b/pkg/serializer/http.go
@@ -307,12 +307,10 @@ func (r *HttpReader) Read(url string) ([]byte, error) {
 
 // ReadWithContext fetches data from the specified URL and returns it as a byte slice.
 // The request is bound to the provided context for cancellation and deadlines.
-func (r *HttpReader) ReadWithContext(ctx context.Context, url string) ([]byte, error) {
+// Callers must provide a non-nil context.
+func (r *HttpReader) ReadWithContext(ctx context.Context, url string) ([]byte, error) { //nolint:contextcheck // ctx is used via NewRequestWithContext below
 	if url == "" {
 		return nil, fmt.Errorf("url is empty")
-	}
-	if ctx == nil {
-		ctx = context.Background()
 	}
 
 	if r.Client == nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,7 +148,8 @@ func (s *Server) Start(ctx context.Context) error {
 	// Wait for context cancellation or server error
 	select {
 	case <-ctx.Done():
-		return s.Shutdown(context.Background())
+		// Use fresh context for shutdown - parent context is already canceled
+		return s.Shutdown(context.Background()) //nolint:contextcheck // intentional: need fresh context for graceful shutdown
 	case err := <-errChan:
 		return err
 	}

--- a/pkg/snapshotter/agent.go
+++ b/pkg/snapshotter/agent.go
@@ -192,6 +192,7 @@ func (n *NodeSnapshotter) measureWithAgent(ctx context.Context) error {
 	deployer := agent.NewDeployer(clientset, agentConfig)
 
 	// Ensure cleanup on error or success
+	//nolint:contextcheck // intentional: need fresh context for cleanup when parent is canceled
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()


### PR DESCRIPTION
## Summary

Enable two additional linters to improve code quality and catch common issues:

- **contextcheck**: Ensures functions that accept `context.Context` actually propagate it. Critical for distributed systems to handle cancellation, timeouts, and request-scoped values correctly. All NVIDIA Go repos enable this linter.

- **depguard**: Bans deprecated packages to prevent new code from using APIs scheduled for removal:
  - `io/ioutil` (deprecated since Go 1.16, use `io` and `os` packages)
  - `math/rand` (use `math/rand/v2` or `crypto/rand` for security)

## Changes

- `.golangci.yaml`: Added `contextcheck` and `depguard` linters with appropriate settings
- Fixed existing contextcheck violations:
  - `pkg/server`: nolint for intentional `context.Background()` during shutdown
  - `pkg/snapshotter`: nolint for intentional `context.Background()` during cleanup
  - `pkg/serializer`: Removed unnecessary nil context fallback
  - `pkg/cli`: Added TODO for future context support in `LoadCriteriaFromFile`

## Test plan

- [x] `make lint-go` passes (0 issues)
- [x] `make test` passes (73.5% coverage)

## Risk Assessment

**Low** - Adds stricter linting rules; existing code violations addressed with appropriate nolint directives and explanatory comments.

🤖 Generated with [Claude Code](https://claude.ai/code)