### PR TITLE
feat: add Dependabot grouping for Kubernetes dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
           - "sigs.k8s.io/*"
         exclude-patterns:
           # klog has independent versioning
-          - "k8s.io/klog/*"
+          - "k8s.io/klog/v2"
 
   - package-ecosystem: "github-actions"
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,16 @@ updates:
     labels: ["dependencies"]
     commit-message:
       prefix: "chore: deps"
+    # Group related Kubernetes dependencies into single PRs
+    # Reduces PR noise and ensures compatible versions
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+        exclude-patterns:
+          # klog has independent versioning
+          - "k8s.io/klog/*"
 
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
## Summary

Group `k8s.io/*` and `sigs.k8s.io/*` packages into single PRs instead of creating many separate ones.

**Benefits:**
- Reduces PR noise (one PR instead of 10+ for Kubernetes updates)
- Ensures all Kubernetes dependencies are updated together for version compatibility
- Easier to review and merge

**Configuration:**
- Patterns: `k8s.io/*`, `sigs.k8s.io/*`
- Excludes: `k8s.io/klog/*` (has independent versioning)

## Alignment

Pattern from nvidia-container-toolkit.

## Test plan

- [x] YAML passes yamllint
- [ ] Next Dependabot run will create grouped PRs

## Risk Assessment

**Low** - Only affects how Dependabot groups dependency update PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)