### PR TITLE
docs: add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,41 @@
+# Maintainers
+
+This document lists the maintainers of the NVIDIA Eidos project.
+
+## Current Maintainers
+
+| Name | GitHub | Role | Affiliation |
+|------|--------|------|-------------|
+| Mark Chmarny | [@mchmarny](https://github.com/mchmarny) | Maintainer | NVIDIA |
+
+## Maintainer Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues and discussions
+- Ensuring code quality and test coverage
+- Making release decisions
+- Upholding the [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Becoming a Maintainer
+
+Maintainers are selected based on:
+
+1. **Sustained contributions** - Regular, quality contributions over time
+2. **Code review quality** - Thoughtful, constructive reviews
+3. **Community engagement** - Helping others, answering questions
+4. **Domain expertise** - Deep understanding of the codebase
+
+To be considered, contributors should:
+
+1. Have made significant contributions to the project
+2. Demonstrated understanding of the [Design Principles](CONTRIBUTING.md#design-principles)
+3. Been nominated by an existing maintainer
+4. Received approval from the majority of current maintainers
+
+## Emeritus Maintainers
+
+Maintainers who are no longer actively maintaining the project:
+
+_None yet_


### PR DESCRIPTION
## Summary

Add maintainers documentation to provide transparency about project governance.

**Benefits:**
- Users know who to contact for questions
- Contributors understand the governance structure
- New maintainers have a clear path to join

## Current Maintainers

| Name | GitHub | Role | Affiliation |
|------|--------|------|-------------|
| Mark Chmarny | @mchmarny | Maintainer | NVIDIA |

## Alignment

Pattern from KAI-Scheduler.

## Test plan

- [x] Markdown renders correctly
- [x] Links to CODE_OF_CONDUCT.md and CONTRIBUTING.md are valid

## Risk Assessment

**Low** - Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.ai/code)