### PR TITLE
feat: link GitHub usernames in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -38,7 +38,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {{ commit.message | upper_first }}\
-            {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+            {% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){%- endif %}\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Summary

Format `@username` mentions as markdown links to GitHub profiles so they're clickable in the rendered changelog.

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `cliff.toml` (changelog generation config)

## Testing

No tests needed - template change only affects changelog output format.

## Risk Assessment

- [x] **Low** — Isolated change to changelog template, easy to revert