### PR TITLE
fix: add contents:read permission for coverage comment workflow

### DIFF
--- a/.github/workflows/on-push-comment.yaml
+++ b/.github/workflows/on-push-comment.yaml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   actions: read        # Required to download artifacts from other workflow runs
+  contents: read       # Required to checkout repository for go.mod and changed-files
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

Add missing `contents: read` permission to the coverage comment workflow.

## Motivation / Context

The checkout action needs `contents: read` to access the repository. Without it, the workflow fails with "Repository not found" error, preventing coverage comments from being posted on PRs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: `.github/workflows/on-push-comment.yaml`

## Risk Assessment

- [x] **Low** — Adds a read-only permission, no security impact
