### PR TITLE
feat: add Windows binary builds (amd64, arm64)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
## Summary

Add Windows binary builds (amd64 and arm64) to GoReleaser configuration, enabling Windows users to run the eidos CLI natively.

## Motivation / Context

Following Docker CLI's multi-platform support pattern, this enables Windows developers and CI/CD pipelines to use eidos without WSL or containers.

**New artifacts generated on release:**
- `eidos_v{version}_windows_amd64.exe`
- `eidos_v{version}_windows_arm64.exe`

Fixes: N/A
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.goreleaser.yaml` (release configuration)

## Implementation Notes

- Added `windows` to the `goos` list for the `eidos` build target
- `eidosd` (daemon) remains Linux-only since it's designed for Kubernetes server environments
- Cross-compilation verified on macOS for both `windows/amd64` and `windows/arm64`

## Testing

```bash
# Cross-compilation verification
GOOS=windows GOARCH=amd64 go build -o /tmp/test.exe ./cmd/eidos  # OK
GOOS=windows GOARCH=arm64 go build -o /tmp/test.exe ./cmd/eidos  # OK
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Additive change only. Existing Linux/macOS builds unaffected. New Windows binaries will appear in the next release.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (N/A - build config only)
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)