### PR TITLE
ci: add license verification workflow

### DIFF
--- a/.github/workflows/verify-licenses.yaml
+++ b/.github/workflows/verify-licenses.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Verify Licenses
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-licenses:
+    name: Verify CNCF-Approved Licenses
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Report licenses
+        run: |
+          echo "=== Dependency Licenses ==="
+          go-licenses report ./... 2>/dev/null | sort -t',' -k3 | column -t -s','
+          echo ""
+          echo "=== License Summary ==="
+          go-licenses report ./... 2>/dev/null | cut -d',' -f3 | sort | uniq -c | sort -rn
+
+      - name: Check licenses
+        run: |
+          # Allowed licenses (all CNCF-approved)
+          go-licenses check ./... \
+            --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT


### PR DESCRIPTION
## Summary

Add GitHub Action to verify all Go dependencies use CNCF-approved licenses, inspired by Kubernetes' `verify-licenses.sh` pattern.

## Motivation / Context

Ensures compliance with CNCF license policy and prevents accidental introduction of incompatible licenses (similar to kubernetes). The workflow reports all dependency licenses in CI logs and fails if a non-approved license is detected.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/verify-licenses.yaml`

## Implementation Notes

Uses [google/go-licenses](https://github.com/google/go-licenses) to scan dependencies.

**Allowed licenses** (pruned to current usage):
| License | Count |
|---------|-------|
| Apache-2.0 | 39 |
| BSD-3-Clause | 17 |
| MIT | 9 |
| ISC | 1 |
| BSD-2-Clause | 1 |

**Workflow behavior:**
1. Reports all dependencies and their licenses in logs
2. Prints license summary (count by type)
3. Checks against allowed list, fails if violation found

**Triggers only on** `go.mod` / `go.sum` changes to minimize unnecessary runs.

## Testing

```bash
# Verified locally
go-licenses check ./... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT
# Passes with no errors
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** New workflow only. No impact on existing CI. If a future dependency introduces a disallowed license, the workflow will fail and require explicit approval to expand the allowed list.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (N/A - CI workflow)
- [ ] I updated docs if user-facing behavior changed (N/A)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)

🤖 Generated with [Claude Code](https://claude.ai/code)