### PR TITLE
feat: add fullnameOverride to remove release prefix from deployment names

### DIFF
--- a/pkg/recipe/data/components/cert-manager/values.yaml
+++ b/pkg/recipe/data/components/cert-manager/values.yaml
@@ -15,6 +15,9 @@
 # cert-manager Helm values
 # Base configuration for all deployments
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: cert-manager
+
 resources:
   requests:
     memory: "90Mi"

--- a/pkg/recipe/data/components/gpu-operator/values.yaml
+++ b/pkg/recipe/data/components/gpu-operator/values.yaml
@@ -15,6 +15,9 @@
 # GPU Operator Helm values
 # Base configuration for all deployments
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: gpu-operator
+
 operator:
   upgradeCRD: true
   resources:
@@ -70,3 +73,7 @@ devicePlugin:
 
 migManager:
   enabled: true
+
+# Node Feature Discovery sub-chart
+node-feature-discovery:
+  fullnameOverride: node-feature-discovery

--- a/pkg/recipe/data/components/kube-prometheus-stack/values.yaml
+++ b/pkg/recipe/data/components/kube-prometheus-stack/values.yaml
@@ -15,6 +15,9 @@
 # Kube Prometheus Stack Helm values
 # Comprehensive monitoring stack with Prometheus, Grafana, and AlertManager
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: kube-prometheus
+
 # Prometheus configuration
 prometheus:
   prometheusSpec:
@@ -47,6 +50,7 @@ prometheus:
 # Grafana configuration
 grafana:
   enabled: true
+  fullnameOverride: grafana
   adminPassword: admin  # Change in production
   resources:
     requests:
@@ -73,5 +77,5 @@ nodeExporter:
   enabled: true
 
 # kube-state-metrics - for Kubernetes object metrics
-kubeStateMetrics:
-  enabled: true
+kube-state-metrics:
+  fullnameOverride: kube-state-metrics

--- a/pkg/recipe/data/components/network-operator/values.yaml
+++ b/pkg/recipe/data/components/network-operator/values.yaml
@@ -15,6 +15,10 @@
 # Network Operator Helm values
 # Base configuration for all deployments
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+operator:
+  fullnameOverride: network-operator
+
 deployCR: true
 
 nfd:

--- a/pkg/recipe/data/components/nvidia-dra-driver-gpu/values.yaml
+++ b/pkg/recipe/data/components/nvidia-dra-driver-gpu/values.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NVIDIA DRA Driver GPU Helm values
+
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: nvidia-dra-driver-gpu
+
 # Specify the driver root on the host.
 # If the NVIDIA GPU driver is managed using the NVIDIA GPU Driver Container,
 # this is typically /run/nvidia/driver.

--- a/pkg/recipe/data/components/nvsentinel/values.yaml
+++ b/pkg/recipe/data/components/nvsentinel/values.yaml
@@ -15,6 +15,9 @@
 # NVSentinel Helm values
 # Base configuration for all deployments
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: nvsentinel
+
 global: {}
 
 platformConnector:

--- a/pkg/recipe/data/components/prometheus-adapter/values.yaml
+++ b/pkg/recipe/data/components/prometheus-adapter/values.yaml
@@ -18,8 +18,8 @@
 # Prometheus connection configuration
 prometheus:
   # URL of the Prometheus service deployed by kube-prometheus-stack
-  # Format: http://<release-name>-kube-prometheus-prometheus.<namespace>.svc
-  url: http://prometheus-kube-prometheus-prometheus
+  # With fullnameOverride: kube-prometheus, the service name is kube-prometheus-prometheus
+  url: http://kube-prometheus-prometheus
   port: 9090
 
 # Custom metrics rules for GPU-based autoscaling

--- a/pkg/recipe/data/components/skyhook-operator/values.yaml
+++ b/pkg/recipe/data/components/skyhook-operator/values.yaml
@@ -15,6 +15,9 @@
 # Skyhook Helm values
 # Base configuration for all deployments
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: skyhook-operator
+
 controllerManager:
   manager:
     resources:


### PR DESCRIPTION
## Summary
- Add `fullnameOverride` to component values to generate cleaner resource names without the umbrella chart release name prefix (`eidos-stack-`)
- Configure sub-chart `fullnameOverride` for nested components (grafana, kube-state-metrics, node-feature-discovery)
- Update prometheus-adapter's prometheus URL to match the new kube-prometheus naming

## Motivation
When deploying the eidos umbrella chart with release name `eidos-stack`, all resources get prefixed with `eidos-stack-`, resulting in verbose names like `eidos-stack-kube-prometheus-prometheus`. This change removes the prefix for cleaner, more intuitive resource names.

## Changes

| Component | Sub-chart | Before | After |
|-----------|-----------|--------|-------|
| kube-prometheus-stack | (root) | `eidos-stack-kube-prometheus-*` | `kube-prometheus-*` |
| | grafana | `eidos-stack-grafana` | `grafana` |
| | kube-state-metrics | `eidos-stack-kube-state-metrics` | `kube-state-metrics` |
| gpu-operator | (root) | `gpu-operator` | `gpu-operator` |
| | node-feature-discovery | `eidos-stack-node-feature-discovery-*` | `node-feature-discovery-*` |
| cert-manager | | `eidos-stack-cert-manager` | `cert-manager` |
| network-operator | | `eidos-stack-network-operator` | `network-operator` |
| nvsentinel | | `eidos-stack-nvsentinel` | `nvsentinel` |
| nvidia-dra-driver-gpu | | `nvidia-dra-driver-gpu-*` | `nvidia-dra-driver-gpu-*` |
| skyhook-operator | | `eidos-stack-skyhook-operator` | `skyhook-operator` |

## Known Limitations
- **prometheus-adapter**: `fullnameOverride` not yet supported upstream. PR submitted: https://github.com/prometheus-community/helm-charts/pull/6584
- **skyhook-operator**: May need upstream chart fix - deployment still shows `eidos-stack-skyhook-operator-controller-manager`

## Test plan
- [x] Unit tests pass (`make test`)
- [ ] E2E deployment verification - check deployment names no longer have `eidos-stack-` prefix

🤖 Generated with [Claude Code](https://claude.ai/code)