### PR TITLE
chore: add copy-pr-bot configuration

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+enabled: true
+additional_trustees:
+  - ayuskauskas
+  - coffeepac
+  - cullenmcdermott
+  - dims
+  - Kevin-Hawkins
+  - lockwobr
+  - mchmarny
+  - svcsectool
+  - tabern
+  - valcharry
+  - yuanchen8911


### PR DESCRIPTION
Enable copy-pr-bot with trustees from eidos GitHub teams:
- eidos-maintainer
- eidos-maintainers
- eidos-triage
- eidos-write

## Summary

Add copy-pr-bot configuration to enable automated PR copying between repos with team-based trustees.

## Motivation / Context

Enables the copy-pr-bot GitHub Action for this repository, allowing PRs to be copied with proper access controls.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.github/copy-pr-bot.yaml`

## Testing

```bash
make qualify
```

All checks pass. This is a configuration-only change with no code impact.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A - Configuration only, no migration needed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)