### PR TITLE
ci: add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,7 @@ on:
     - cron: '0 5 * * 1'
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -25,5 +25,5 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: go
-      - run: make build
+      - run: go build ./...
       - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,7 @@ on:
     - cron: '0 5 * * 1'
 
 permissions:
+  contents: read
   security-events: write
 
 jobs:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,28 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * 1'
+
+permissions:
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/load-versions
+        id: versions
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.versions.outputs.go }}
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+      - run: make build
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Add automated code scanning using GitHub CodeQL for Go code.

## Summary

Add CodeQL security analysis workflow for automated vulnerability detection in Go code.

## Motivation / Context

All other NVIDIA Go repos (gpu-operator, k8s-device-plugin, NeMo) have CodeQL enabled. This brings eidos in line with NVIDIA OSS security standards.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI workflows (`.github/workflows/`)

## Implementation Notes

- Uses existing `load-versions` action for Go version consistency
- Runs on push/PR to main + weekly schedule (Mondays 5 AM UTC)
- Builds with `make build` before analysis to ensure accurate results

## Testing

```bash
# Workflow syntax validated
gh workflow view codeql.yaml
```

N/A - CI workflow, will be validated by GitHub Actions on merge.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A - additive CI workflow, no impact on existing functionality.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI config)
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)