### PR TITLE
ci: use copy-pr-bot branch pattern for PR workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "pull-request/[0-9]+"
   schedule:
     - cron: '0 5 * * 1'
 

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -18,13 +18,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-  pull_request:
-    branches:
-      - main
+      - "pull-request/[0-9]+"
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/verify-licenses.yaml
+++ b/.github/workflows/verify-licenses.yaml
@@ -16,13 +16,9 @@ name: Verify Licenses
 
 on:
   push:
-    branches: [main]
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/verify-licenses.yaml'
-  pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "pull-request/[0-9]+"
     paths:
       - 'go.mod'
       - 'go.sum'


### PR DESCRIPTION
Update workflows to trigger on push to `pull-request/[0-9]+` branches instead of `pull_request` events. This aligns with copy-pr-bot which creates these branches for secure PR testing.

## Summary

Replace `pull_request` triggers with `push` to `pull-request/[0-9]+` branches to enable copy-pr-bot workflow.

## Motivation / Context

The repo has copy-pr-bot configured (`.github/copy-pr-bot.yaml` merged in #28), but workflows were still using `pull_request` triggers. This prevents the bot from working as intended.

With this change:
- Trusted PRs (NVIDIA org members with signed commits) auto-sync to `pull-request/N` branches
- Untrusted/fork PRs require vetter approval via `/ok to test <SHA>`
- CI runs on branch push, not directly on PR events (more secure)

This matches the pattern used by nvsentinel. See:
- https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
- https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/faqs/

Fixes: N/A
Related: #28

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI workflows (`.github/workflows/`)

## Implementation Notes

Updated workflows:
- `on-push.yaml` - Main CI qualification
- `codeql.yaml` - Security scanning
- `verify-licenses.yaml` - License verification

Change pattern:
```yaml
# Before
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]

# After
on:
  push:
    branches:
      - main
      - "pull-request/[0-9]+"
```

## Testing

> **Note**: This is a bootstrap PR - CI workflows won't run because the current workflows on `main` don't yet have the `pull-request/[0-9]+` trigger pattern that this PR adds. Once merged, future PRs will trigger correctly via copy-pr-bot branches.

The changes are identical to the pattern used in nvsentinel which is working in production.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A - CI changes only. After merge, new PRs will trigger via copy-pr-bot branches instead of PR events.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI config)
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase (matches nvsentinel)
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)