### PR TITLE
ci: skip workflows on forks to prevent duplicate check runs

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -43,8 +43,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # For create events, only run on pull-request/N branches (push/workflow_dispatch already filtered)
-    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
+    # Only run in main repo (not forks), and for create events only on pull-request/N branches
+    if: github.repository == 'NVIDIA/eidos' && (github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/'))
     steps:
 
       - name: Checkout Code
@@ -73,7 +73,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
+    if: github.repository == 'NVIDIA/eidos' && (github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/'))
     steps:
 
       - name: Checkout Code
@@ -92,7 +92,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
+    if: github.repository == 'NVIDIA/eidos' && (github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/'))
     steps:
 
       - name: Checkout Code


### PR DESCRIPTION
## Summary

Add repository check to only run workflows in `NVIDIA/eidos`, preventing forks from creating competing check runs.

## Motivation / Context

When a fork has Actions enabled, it creates its own check runs (skipped due to branch filters) that compete with the main repo's check runs. GitHub shows the **fork's skipped checks** on the PR instead of the main repo's actual successful results.

This is why PR checks weren't showing correctly despite workflows running successfully on `pull-request/N` branches.

Fixes: PR checks not showing on fork PRs
Related: #33

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/on-push.yaml`

## Implementation Notes

Added `github.repository == 'NVIDIA/eidos'` check to each job's `if` condition. This ensures:
- Workflows only run in the main repo
- Forks don't create competing check runs
- Main repo's check runs are the only ones associated with PR commits

## Testing

```bash
make lint  # YAML validation passes
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A - CI-only change

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)