### PR TITLE
ci: match nvsentinel workflow pattern for copy-pr-bot

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -19,32 +19,28 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-  create: {}  # Triggers when copy-pr-bot creates pull-request/N branches
-  workflow_dispatch: {}  # Allow manual runs
-
-permissions:
-  actions: read
-  contents: read
-  id-token: write
-  pull-requests: write
-  security-events: write
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+  id-token: write
+  security-events: write
 
 jobs:
 
   unit:
+    if: github.repository == 'nvidia/eidos'
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Only run in main repo (not forks), and for create events only on pull-request/N branches
-    if: github.repository == 'NVIDIA/eidos' && (github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/'))
     steps:
 
       - name: Checkout Code
@@ -70,10 +66,10 @@ jobs:
           category: 'trivy-fs'
 
   integration:
+    if: github.repository == 'nvidia/eidos'
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.repository == 'NVIDIA/eidos' && (github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/'))
     steps:
 
       - name: Checkout Code
@@ -89,10 +85,10 @@ jobs:
           go_version: ${{ steps.versions.outputs.go }}
 
   e2e:
+    if: github.repository == 'nvidia/eidos'
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.repository == 'NVIDIA/eidos' && (github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/'))
     steps:
 
       - name: Checkout Code


### PR DESCRIPTION
## Summary

Align `on-push.yaml` with nvsentinel's `lint-test.yml` pattern for copy-pr-bot integration.

## Changes

| Aspect | Before | After (matches nvsentinel) |
|--------|--------|---------------------------|
| `create` trigger | Yes | **Removed** |
| `paths-ignore` | `**.md`, `docs/**`, `LICENSE` | **Removed** |
| `tags` trigger | None | `v*` |
| Job `if` condition | Complex with create check | Simple: `github.repository == 'NVIDIA/eidos'` |
| `cancel-in-progress` | `true` | `${{ github.ref != 'refs/heads/main' }}` |
| `permissions.actions` | `read` | `write` |

## Motivation

Previous attempts to trigger workflows on `create` events didn't work reliably. nvsentinel uses a simpler pattern that relies only on `push` events to `pull-request/[0-9]+` branches, which copy-pr-bot generates.

## Type of Change

- [x] Build/CI/tooling

## Risk Assessment

- [x] **Low** — Matches proven pattern from nvsentinel

## Checklist

- [x] Linter passes (`make lint`)
- [x] Changes follow existing patterns (nvsentinel)
- [x] Commits are signed off