### PR TITLE
ci: add pull_request trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,7 +18,9 @@ on:
   push:
     branches:
       - main
-      - "pull-request/[0-9]+"
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 5 * * 1'
 


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to CodeQL workflow so it runs directly on PR events
- Remove the `pull-request/[0-9]+` branch pattern which relied on `copy-pr-bot` syncing

## Problem

The CodeQL workflow only triggered on pushes to `main` and `pull-request/[0-9]+` branches. The `pull-request/*` branches are synced by `copy-pr-bot`, but **bot pushes don't trigger workflow runs** (this is a GitHub security feature to prevent infinite loops).

This caused PRs to be blocked with:
> "Code scanning is waiting for results from CodeQL"

Because CodeQL never ran for the new PR commits after the bot synced them.

## Solution

Add a direct `pull_request` trigger targeting `main`, which is the standard pattern for PR-based CI workflows. This ensures CodeQL runs on every PR without relying on the bot sync mechanism.

## Test plan

- [ ] Verify this PR triggers CodeQL (it will, ironically, have the same issue until merged)
- [ ] After merge, verify new PRs trigger CodeQL directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)