### PR TITLE
docs: add DEVELOPMENT.md link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You are responsible for deploying and operating GPU-accelerated Kubernetes clust
 You are contributing code, extending functionality, or working on Eidos internals. 
 
 - **[Contributing Guide](CONTRIBUTING.md)** – Development setup, testing, and PR process
+- **[Development Guide](DEVELOPMENT.md)** – Local development, Make targets, and tooling
 - **[Architecture Overview](docs/architecture/README.md)** – System design and components
 - **[Bundler Development](docs/architecture/component.md)** – How to create new bundlers
 - **[Data Architecture](docs/architecture/data.md)** – Recipe data model and query matching


### PR DESCRIPTION
## Summary

Add DEVELOPMENT.md link to the "Developers and Contributors" section in README for easier discovery.

## Motivation / Context

DEVELOPMENT.md contains important information about local development setup, Make targets, and tooling, but wasn't linked from the main README's developer section.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Testing

N/A - Documentation only change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`)