### PR TITLE
add k8s-ephemeral-storage-metrics component to base configuration

### DIFF
--- a/examples/recipes/kind.yaml
+++ b/examples/recipes/kind.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: recipeResult
+apiVersion: eidos.nvidia.com/v1alpha1
+metadata:
+  version: v0.26.7-next
+criteria:
+  service: kind
+  accelerator: any
+  intent: training
+  os: any
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+componentRefs:
+  - name: cert-manager
+    type: Helm
+    source: https://charts.jetstack.io
+    version: v1.17.2
+    valuesFile: components/cert-manager/values.yaml
+  - name: skyhook-operator
+    type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia/skyhook
+    version: 0.11.1
+    valuesFile: components/skyhook-operator/values.yaml
+  - name: kube-prometheus-stack
+    type: Helm
+    source: https://prometheus-community.github.io/helm-charts
+    version: 81.2.2
+    valuesFile: components/kube-prometheus-stack/values.yaml
+  - name: k8s-ephemeral-storage-metrics
+    type: Helm
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    version: 1.19.2
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+  
+deploymentOrder:
+  - cert-manager
+  - skyhook-operator
+  - kube-prometheus-stack
+  - k8s-ephemeral-storage-metrics

--- a/pkg/recipe/data/components/k8s-ephemeral-storage-metrics/values.yaml
+++ b/pkg/recipe/data/components/k8s-ephemeral-storage-metrics/values.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -- Set metrics you want to enable
+metrics:
+  # -- Percentage of ephemeral storage used by a container in a pod
+  ephemeral_storage_container_limit_percentage: true
+  # -- Current ephemeral storage used by a container's volume in a pod
+  ephemeral_storage_container_volume_usage: true
+  # -- Percentage of ephemeral storage used by a container's volume in a pod
+  ephemeral_storage_container_volume_limit_percentage: true
+  # -- Current ephemeral byte usage of pod
+  ephemeral_storage_pod_usage: true
+  # -- Available ephemeral storage for a node
+  ephemeral_storage_node_available: true
+  # -- Capacity of ephemeral storage for a node
+  ephemeral_storage_node_capacity: true
+  # -- Percentage of ephemeral storage used on a node
+  ephemeral_storage_node_percentage: true
+  # -- Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing.
+  adjusted_polling_rate: false
+
+log_level: info
+# -- Set as Deployment for single controller to query all nodes or Daemonset
+deploy_type: Deployment
+prometheus:
+  enable: true
+  release: kube-prometheus-stack

--- a/pkg/recipe/data/overlays/base.yaml
+++ b/pkg/recipe/data/overlays/base.yaml
@@ -60,3 +60,11 @@ spec:
       source: https://prometheus-community.github.io/helm-charts
       version: 81.2.2
       valuesFile: components/kube-prometheus-stack/values.yaml
+
+    - name: k8s-ephemeral-storage-metrics
+      type: Helm
+      source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+      version: 1.19.2
+      valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+      dependencyRefs:
+        - kube-prometheus-stack

--- a/pkg/recipe/data/registry.yaml
+++ b/pkg/recipe/data/registry.yaml
@@ -195,3 +195,11 @@ components:
           - node.nodeSelector
         tolerationPaths:
           - node.tolerations
+
+  - name: k8s-ephemeral-storage-metrics
+    displayName: k8s-ephemeral-storage-metrics
+    valueOverrideKeys:
+      - k8sephemeralstoragemetrics
+    helm:
+      defaultRepository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+      defaultChart: k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics


### PR DESCRIPTION
## Summary

<!-- What changed? Keep it short (1-2 sentences). -->

adding k8s-ephermeral-storage-metrics component to system

## Motivation / Context

Required base component for eidos installs.

<!-- Why is this change needed? Link issues/discussions. -->

Fixes: N/A
Related: N/A

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

spun up a kind cluster locally, installed a minimal stack of eidos (no gpu components) and ensured things worked before and after adding new component.

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [ ] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)
