### PR TITLE
Use emptyDir storage for Prometheus by default, PVC for EKS

### DIFF
--- a/pkg/recipe/data/components/kube-prometheus-stack/values.yaml
+++ b/pkg/recipe/data/components/kube-prometheus-stack/values.yaml
@@ -35,14 +35,12 @@ prometheus:
         memory: 2Gi
 
     # Storage configuration
+    # Use emptyDir for local testing (no PVC required, data lost on pod restart)
+    # For EKS deployments with persistent storage, this is overridden via overlay.
     storageSpec:
-      volumeClaimTemplate:
-        spec:
-          storageClassName: ""  # Use default storage class
-          accessModes: ["ReadWriteOnce"]
-          resources:
-            requests:
-              storage: 50Gi
+      emptyDir:
+        medium: ""
+        sizeLimit: 10Gi
 
     # Data retention
     retention: 15d

--- a/pkg/recipe/data/overlays/eks.yaml
+++ b/pkg/recipe/data/overlays/eks.yaml
@@ -37,3 +37,18 @@ spec:
       source: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
       version: 2.55.0
       valuesFile: components/aws-ebs-csi-driver/values.yaml
+
+    # Enable Prometheus persistent storage for EKS (requires EBS CSI driver)
+    - name: kube-prometheus-stack
+      type: Helm
+      overrides:
+        prometheus:
+          prometheusSpec:
+            storageSpec:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: ""  # Use default storage class
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 50Gi


### PR DESCRIPTION
## Summary
- Change Prometheus storage from PVC-based to emptyDir by default
- Add EKS overlay to enable persistent PVC storage for EKS deployments

## Problem
The default Prometheus configuration uses PVC-based storage which requires a storage provisioner. On local clusters (Kind, minikube) without a storage class, Prometheus pods remain in Pending state:

```
prometheus-kube-prometheus-prometheus-0    0/2     Pending    0    114s

Events:
  Warning  FailedScheduling  pod has unbound immediate PersistentVolumeClaims
```

## Solution
1. **Base configuration**: Use `emptyDir` storage which works on any cluster without requiring a storage provisioner. Data is lost on pod restart but suitable for testing.

2. **EKS overlay**: Override with PVC-based storage for production deployments where EBS CSI driver provides persistent storage.

### Base values (kube-prometheus-stack/values.yaml):
```yaml
storageSpec:
  emptyDir:
    medium: ""
    sizeLimit: 10Gi
```

### EKS overlay (overlays/eks.yaml):
```yaml
- name: kube-prometheus-stack
  type: Helm
  overrides:
    prometheus:
      prometheusSpec:
        storageSpec:
          volumeClaimTemplate:
            spec:
              storageClassName: ""
              accessModes: ["ReadWriteOnce"]
              resources:
                requests:
                  storage: 50Gi
```

## Test plan
- [ ] Deploy without `--service eks` and verify Prometheus uses emptyDir (no PVC)
- [ ] Deploy with `--service eks` and verify Prometheus uses PVC storage
- [ ] Verify Prometheus pod starts successfully on Kind cluster

🤖 Generated with [Claude Code](https://claude.ai/code)