### PR TITLE
Fix gpu-operator ClusterPolicy validator.plugin null error

### DIFF
--- a/pkg/recipe/data/components/gpu-operator/values.yaml
+++ b/pkg/recipe/data/components/gpu-operator/values.yaml
@@ -74,6 +74,15 @@ devicePlugin:
 migManager:
   enabled: true
 
+validator:
+  plugin:
+    # Note: env must have at least one entry due to gpu-operator chart template bug.
+    # When env is empty/null, the chart renders spec.validator.plugin as null instead
+    # of an empty object, causing validation error: "must be of type object: null"
+    env:
+      - name: WITH_WORKLOAD
+        value: "false"
+
 # Node Feature Discovery sub-chart
 node-feature-discovery:
   fullnameOverride: node-feature-discovery


### PR DESCRIPTION
## Summary
- Add non-empty `env` value to `validator.plugin` configuration to work around a gpu-operator Helm chart template bug

## Problem
When deploying the gpu-operator, the ClusterPolicy validation fails with:

```
Error: INSTALLATION FAILED: failed to create resource: ClusterPolicy.nvidia.com 
"cluster-policy" is invalid: spec.validator.plugin: Invalid value: "null": 
spec.validator.plugin in body must be of type object: "null"
```

This occurs because the gpu-operator Helm chart template renders `spec.validator.plugin` as `null` instead of an empty object when the `env` array is empty or not specified.

## Solution
Add a non-empty `env` value to the `validator.plugin` configuration:

```yaml
validator:
  plugin:
    # Note: env must have at least one entry due to gpu-operator chart template bug.
    # When env is empty/null, the chart renders spec.validator.plugin as null instead
    # of an empty object, causing validation error: "must be of type object: null"
    env:
      - name: WITH_WORKLOAD
        value: "false"
```

The `WITH_WORKLOAD=false` setting is a benign configuration that satisfies the chart's requirement for a non-empty env array without changing behavior.

## Test plan
- [ ] Run `eidos bundle` and verify gpu-operator values include validator.plugin.env
- [ ] Deploy to test cluster and verify ClusterPolicy is created successfully
- [ ] Verify gpu-operator pods start without errors

🤖 Generated with [Claude Code](https://claude.ai/code)