### PR TITLE
Increase cert-manager startupapicheck timeout to 5m

### DIFF
--- a/pkg/recipe/data/components/cert-manager/values.yaml
+++ b/pkg/recipe/data/components/cert-manager/values.yaml
@@ -49,3 +49,7 @@ cainjector:
     limits:
       memory: "320Mi"
       cpu: "50m"
+
+# Startup API check job - increase timeout from default 1m for slow clusters
+startupapicheck:
+  timeout: 5m


### PR DESCRIPTION
## Summary
- Increase cert-manager startupapicheck job timeout from default 1m to 5m

## Problem
The cert-manager startupapicheck job verifies the webhook API is ready after installation. The default 1 minute timeout is often insufficient, causing helm install to fail:

```
Error: INSTALLATION FAILED: failed post-install: resource not ready, 
name: cert-manager-startupapicheck, kind: Job, status: InProgress
context deadline exceeded
```

This happens because:
- Network policies (e.g., nvsentinel metrics-access) can delay webhook connectivity
- Slow cluster provisioning
- Other resources competing for startup time

## Solution
Add `startupapicheck.timeout: 5m` to cert-manager values:

```yaml
startupapicheck:
  timeout: 5m
```

## Test plan
- [ ] Deploy to test cluster and verify cert-manager startupapicheck completes
- [ ] Verify helm install succeeds without timeout errors

🤖 Generated with [Claude Code](https://claude.ai/code)