### PR TITLE
trigger CodeQL workflow on pull requests

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,6 +19,9 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 5 * * 1'
 


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to CodeQL workflow targeting `main` branch

## Problem
The branch ruleset requires CodeQL results for merging, but the workflow only ran on:
- push to `main`
- push to `pull-request/[0-9]+` branches

PRs with other branch names (like `fix/cert-manager-startup-timeout`) are blocked with:
> Code scanning is waiting for results from CodeQL

## Solution
Add `pull_request` trigger so CodeQL runs on all PRs targeting main.

---
🤖 Generated with [Claude Code](https://claude.ai/code)