### PR TITLE
Disable cert-manager startupapicheck as nvsentinel workaround

### DIFF
--- a/pkg/recipe/data/components/cert-manager/values.yaml
+++ b/pkg/recipe/data/components/cert-manager/values.yaml
@@ -50,6 +50,9 @@ cainjector:
       memory: "320Mi"
       cpu: "50m"
 
-# Startup API check job - increase timeout from default 1m for slow clusters
+# Startup API check job - disabled as workaround for nvsentinel network policy
+# blocking webhook traffic (port 10250). The metrics-access policy only allows
+# ports 2112 and 9216, causing the API check to hang.
+# TODO: Re-enable when nvsentinel provides a way to disable the network policy
 startupapicheck:
-  timeout: 5m
+  enabled: false


### PR DESCRIPTION
## Summary

- Disable the cert-manager startupapicheck job as a temporary workaround for the nvsentinel network policy issue

## Problem

The nvsentinel `metrics-access` network policy only allows traffic on ports 2112 (metrics) and 9216 (dcgm-exporter). This blocks the cert-manager webhook port 443, causing the startupapicheck job to hang indefinitely during `helm install`.

The previous fix (PR #51) increased the timeout to 5m, but this doesn't address the root cause - the job still hangs and eventually times out.

## Solution

Disable the startupapicheck job entirely with `enabled: false`. This allows the helm install to complete without waiting for the API check.

## Upstream Fix

An upstream PR has been submitted to NVSentinel to make the network policy configurable:
- **PR:** https://github.com/NVIDIA/NVSentinel/pull/789

Once merged, users can set `nvsentinel.networkPolicy.enabled: false` instead of disabling the startupapicheck.

## TODO

Re-enable the startupapicheck when the upstream NVSentinel fix is available and integrated.

## Test plan

- [x] Run `helm install` and verify cert-manager deploys without hanging
- [x] Verify cert-manager pods are running and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)