### PR TITLE
fix(e2e-test): create snapshot namespace before RBAC resources

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -543,14 +543,17 @@ setup_fake_gpu() {
     return 1
   fi
 
+  # Create namespace for snapshot tests (if it doesn't exist)
+  kubectl create namespace "$SNAPSHOT_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
   # Create RBAC for snapshot agent
   msg "Creating RBAC for snapshot agent"
-  kubectl apply -f - << 'EOF'
+  kubectl apply -f - << EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: eidos
-  namespace: gpu-operator
+  namespace: ${SNAPSHOT_NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -568,7 +571,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: eidos
-  namespace: gpu-operator
+  namespace: ${SNAPSHOT_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: eidos-e2e-reader


### PR DESCRIPTION
## Summary

The `make e2e-tilt` test was failing with multiple issues. This PR fixes the namespace creation issue in the e2e test script.

### Issue 1: Namespace Not Found
```
Error from server (NotFound): error when creating "STDIN": namespaces "gpu-operator" not found
```
**Root cause:** The test setup creates RBAC resources in `SNAPSHOT_NAMESPACE` without first creating the namespace.

**Fix:** Create namespace before applying RBAC resources using idempotent `kubectl create namespace --dry-run=client | kubectl apply`.

### Issue 2: Hardcoded Namespace
The ServiceAccount and ClusterRoleBinding had hardcoded `gpu-operator` namespace instead of using the `SNAPSHOT_NAMESPACE` variable.

**Fix:** Use `${SNAPSHOT_NAMESPACE}` variable consistently and change heredoc delimiter from `'EOF'` to `EOF` to enable shell variable expansion.

## Changes

```diff
+ # Create namespace for snapshot tests (if it doesn't exist)
+ kubectl create namespace "$SNAPSHOT_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -

  # Create RBAC for snapshot agent
- kubectl apply -f - << 'EOF'
+ kubectl apply -f - << EOF
  apiVersion: v1
  kind: ServiceAccount
  metadata:
    name: eidos
-   namespace: gpu-operator
+   namespace: ${SNAPSHOT_NAMESPACE}
  ---
  ...
  subjects:
  - kind: ServiceAccount
    name: eidos
-   namespace: gpu-operator
+   namespace: ${SNAPSHOT_NAMESPACE}
```

## Test Results

After this fix, the e2e-tilt snapshot tests pass:
- `setup/rbac` ✅
- `snapshot/deploy-agent` ✅
- `snapshot/configmap-created` ✅
- `snapshot/gpu-data` ✅
- `recipe/from-snapshot` ✅
- `validate/recipe` ✅

## Test plan

- [x] Run `make e2e-tilt` and verify namespace is created
- [x] Verify RBAC resources are created successfully
- [x] Verify snapshot collection tests pass
- [x] Verify recipe-from-snapshot tests pass
- [x] Verify validate tests pass