### PR TITLE
fix: CRD-dependent resource detection and deployment ordering

### DIFF
--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -575,27 +575,19 @@ func (g *Generator) generateTemplates(ctx context.Context, input *GeneratorInput
 // Standard K8s resources (v1, apps/v1, etc.) return false.
 // Custom Resources (custom apiVersion like *.nvidia.com/*) return true.
 func (g *Generator) isCRDDependentResource(content []byte) bool {
-	// Parse just enough to get the apiVersion
-	var manifest struct {
-		APIVersion string `yaml:"apiVersion"`
-	}
-
-	// Handle Helm template conditionals - look for the actual resource definition
-	// Skip lines that are pure Helm template directives
-	lines := strings.Split(string(content), "\n")
-	var yamlContent strings.Builder
-	for _, line := range lines {
+	// Extract apiVersion using string matching instead of YAML parsing.
+	// Manifests may contain unquoted Helm template expressions (e.g., {{ .Chart.Name }})
+	// that break YAML parsing, so we scan for the apiVersion line directly.
+	var apiVersion string
+	for _, line := range strings.Split(string(content), "\n") {
 		trimmed := strings.TrimSpace(line)
-		// Skip Helm template-only lines
-		if strings.HasPrefix(trimmed, "{{-") && strings.HasSuffix(trimmed, "}}") {
-			continue
+		if strings.HasPrefix(trimmed, "apiVersion:") {
+			apiVersion = strings.TrimSpace(strings.TrimPrefix(trimmed, "apiVersion:"))
+			break
 		}
-		yamlContent.WriteString(line)
-		yamlContent.WriteString("\n")
 	}
 
-	if err := yaml.Unmarshal([]byte(yamlContent.String()), &manifest); err != nil {
-		// If we can't parse, assume it's a standard resource
+	if apiVersion == "" {
 		return false
 	}
 
@@ -619,7 +611,6 @@ func (g *Generator) isCRDDependentResource(content []byte) bool {
 		"scheduling.k8s.io/",            // PriorityClass
 	}
 
-	apiVersion := manifest.APIVersion
 	for _, stdAPI := range standardAPIs {
 		if apiVersion == stdAPI || strings.HasPrefix(apiVersion, stdAPI) {
 			return false
@@ -627,7 +618,7 @@ func (g *Generator) isCRDDependentResource(content []byte) bool {
 	}
 
 	// If apiVersion is not in the standard list, it's likely a Custom Resource
-	return apiVersion != ""
+	return true
 }
 
 // addHelmHookAnnotation adds Helm post-install/post-upgrade hook annotations to a manifest.

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -468,3 +468,62 @@ func TestGenerate_NoTimestampInOutput(t *testing.T) {
 		t.Fatalf("failed to walk directory: %v", err)
 	}
 }
+
+func TestIsCRDDependentResource(t *testing.T) {
+	g := NewGenerator()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "standard ConfigMap",
+			content:  "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test",
+			expected: false,
+		},
+		{
+			name:     "standard Deployment",
+			content:  "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test",
+			expected: false,
+		},
+		{
+			name:     "custom resource",
+			content:  "apiVersion: skyhook.nvidia.com/v1alpha1\nkind: Skyhook\nmetadata:\n  name: test",
+			expected: true,
+		},
+		{
+			name: "custom resource with Helm template expressions",
+			content: `{{- $cust := index .Values "skyhook-customizations" }}
+---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  name: test
+  namespace: {{ .Release.Namespace }}`,
+			expected: true,
+		},
+		{
+			name:     "no apiVersion",
+			content:  "kind: ConfigMap\nmetadata:\n  name: test",
+			expected: false,
+		},
+		{
+			name:     "RBAC resource",
+			content:  "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: test",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := g.isCRDDependentResource([]byte(tt.content))
+			if result != tt.expected {
+				t.Errorf("isCRDDependentResource() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
+++ b/pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
@@ -50,7 +50,7 @@ spec:
   {{- end }}
   # Static: Baked-in tuning for H100 Ubuntu training
   packages:
-    fix_mac_address_policy:
+    fix-mac-address-policy:
       image: ghcr.io/nvidia/skyhook-packages/shellscript
       version: "1.1.1"
       env:


### PR DESCRIPTION
## Summary

- **CRD detection fix**: `isCRDDependentResource` used `yaml.Unmarshal` to detect CRD-dependent resources, but manifests with unquoted Helm template expressions (e.g., `{{ .Chart.Name }}-{{ .Chart.Version }}`) broke YAML parsing. On failure it returned `false`, so Skyhook CRs were never annotated with `helm.sh/hook: post-install` and were applied before the CRD was registered. Replaced with line-by-line string matching on the `apiVersion:` field.
- **Deployment ordering**: Added `--wait --timeout 10m` to `helm install` instructions so Helm waits for all sub-chart pods (including operator webhooks) to be ready before firing post-install hooks.
- **Package name validation**: Renamed `fix_mac_address_policy` to `fix-mac-address-policy` in the Skyhook manifest to comply with CRD validation regex (`^[a-z][-a-z0-9]{0,41}[a-z]`).

## Test plan

- [x] `make test` passes with race detector
- [x] Added `TestIsCRDDependentResource` with 6 cases: standard ConfigMap, Deployment, custom resource, custom resource with Helm template expressions (the key bug), no apiVersion, RBAC resource
- [x] End-to-end verified: `eidos recipe` + `eidos bundle` + `helm install --wait` → Skyhook CR created and completed (2/2 nodes)