### PR TITLE
feat: custom resources must explicity set their helm hooks OR opt out

### DIFF
--- a/examples/bundles/README.md
+++ b/examples/bundles/README.md
@@ -74,8 +74,11 @@ vim values.yaml
 4. **Install the chart**:
 
 ```bash
-helm install eidos-stack . -f values.yaml
+helm install eidos-stack . --wait --timeout 10m -f values.yaml
 ```
+
+> **Note**: The `--wait --timeout 10m` flags ensure Helm waits for all resources to be ready
+> and that Helm hooks (used for CRD-dependent resources) execute in the correct order.
 
 ## Customization
 
@@ -84,7 +87,7 @@ helm install eidos-stack . -f values.yaml
 To skip installing a specific component, set `<component>.enabled=false`:
 
 ```bash
-helm install eidos-stack . \
+helm install eidos-stack . --wait --timeout 10m \
   --set cert-manager.enabled=false
 ```
 
@@ -93,7 +96,7 @@ helm install eidos-stack . \
 Override specific values using `--set`:
 
 ```bash
-helm install eidos-stack . \
+helm install eidos-stack . --wait --timeout 10m \
   --set gpu-operator.driver.enabled=false \
   --set gpu-operator.toolkit.enabled=true
 ```
@@ -103,7 +106,7 @@ helm install eidos-stack . \
 Create a custom values file and merge it:
 
 ```bash
-helm install eidos-stack . -f values.yaml -f custom-values.yaml
+helm install eidos-stack . --wait --timeout 10m -f values.yaml -f custom-values.yaml
 ```
 
 ## Upgrade
@@ -111,7 +114,7 @@ helm install eidos-stack . -f values.yaml -f custom-values.yaml
 To upgrade an existing installation:
 
 ```bash
-helm upgrade eidos-stack . -f values.yaml
+helm upgrade eidos-stack . --wait --timeout 10m -f values.yaml
 ```
 
 ## Uninstall

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -515,9 +515,9 @@ func SortComponentsByDeploymentOrder(components []string, deploymentOrder []stri
 }
 
 // generateTemplates creates manifest files in the templates/ directory.
-//   - Standard K8s resources (ConfigMaps, Secrets, etc.) are deployed normally during helm install
-//   - CRD-dependent resources (Custom Resources) get Helm post-install hook annotations,
-//     so they are applied after all sub-charts (including CRDs) are installed
+// Manifest files are copied as-is. CRD-dependent resources (Custom Resources) must
+// include Helm hook annotations in the source manifest to ensure proper deployment
+// ordering. This is validated by TestManifestHelmHooksRequired in yaml_test.go.
 func (g *Generator) generateTemplates(ctx context.Context, input *GeneratorInput, outputDir string) ([]string, int64, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, 0, err
@@ -537,181 +537,18 @@ func (g *Generator) generateTemplates(ctx context.Context, input *GeneratorInput
 
 	for path, content := range input.ManifestContents {
 		filename := filepath.Base(path)
-
-		// Determine if this is a CRD-dependent resource (Custom Resource)
-		isCRDDependent := g.isCRDDependentResource(content)
-
-		var processedContent []byte
-		if isCRDDependent {
-			// Add Helm post-install hook annotation to CRD-dependent resources
-			// This ensures they are applied after all sub-charts (including CRDs) are installed
-			processedContent = g.addHelmHookAnnotation(content)
-		} else {
-			// Standard K8s resources are deployed normally
-			processedContent = content
-		}
-
 		outputPath := filepath.Join(templatesDir, filename)
 
-		if err := os.WriteFile(outputPath, processedContent, 0600); err != nil {
+		if err := os.WriteFile(outputPath, content, 0600); err != nil {
 			return nil, 0, errors.WrapWithContext(errors.ErrCodeInternal, "failed to write template", err,
 				map[string]any{"filename": filename})
 		}
 
 		files = append(files, outputPath)
-		totalSize += int64(len(processedContent))
+		totalSize += int64(len(content))
 
-		slog.Debug("wrote template",
-			"filename", filename,
-			"crd_dependent", isCRDDependent,
-			"helm_hook", isCRDDependent)
+		slog.Debug("wrote template", "filename", filename)
 	}
 
 	return files, totalSize, nil
-}
-
-// isCRDDependentResource checks if a manifest contains a Custom Resource
-// that depends on a CRD installed by a sub-chart.
-// Standard K8s resources (v1, apps/v1, etc.) return false.
-// Custom Resources (custom apiVersion like *.nvidia.com/*) return true.
-func (g *Generator) isCRDDependentResource(content []byte) bool {
-	// Parse just enough to get the apiVersion
-	var manifest struct {
-		APIVersion string `yaml:"apiVersion"`
-	}
-
-	// Handle Helm template conditionals - look for the actual resource definition
-	// Skip lines that are pure Helm template directives
-	lines := strings.Split(string(content), "\n")
-	var yamlContent strings.Builder
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		// Skip Helm template-only lines
-		if strings.HasPrefix(trimmed, "{{-") && strings.HasSuffix(trimmed, "}}") {
-			continue
-		}
-		yamlContent.WriteString(line)
-		yamlContent.WriteString("\n")
-	}
-
-	if err := yaml.Unmarshal([]byte(yamlContent.String()), &manifest); err != nil {
-		// If we can't parse, assume it's a standard resource
-		return false
-	}
-
-	// Standard Kubernetes API groups that don't require CRDs
-	standardAPIs := []string{
-		"v1",                            // Core API (ConfigMap, Secret, Service, Pod, etc.)
-		"apps/v1",                       // Deployments, StatefulSets, DaemonSets, ReplicaSets
-		"batch/v1",                      // Jobs, CronJobs
-		"networking.k8s.io/",            // NetworkPolicy, Ingress
-		"rbac.authorization.k8s.io/",    // Roles, RoleBindings, ClusterRoles
-		"policy/v1",                     // PodDisruptionBudget
-		"autoscaling/",                  // HorizontalPodAutoscaler
-		"storage.k8s.io/",               // StorageClass, CSIDriver
-		"admissionregistration.k8s.io/", // ValidatingWebhookConfiguration
-		"certificates.k8s.io/",          // CertificateSigningRequest
-		"coordination.k8s.io/",          // Lease
-		"discovery.k8s.io/",             // EndpointSlice
-		"events.k8s.io/",                // Event
-		"flowcontrol.apiserver.k8s.io/", // FlowSchema, PriorityLevelConfiguration
-		"node.k8s.io/",                  // RuntimeClass
-		"scheduling.k8s.io/",            // PriorityClass
-	}
-
-	apiVersion := manifest.APIVersion
-	for _, stdAPI := range standardAPIs {
-		if apiVersion == stdAPI || strings.HasPrefix(apiVersion, stdAPI) {
-			return false
-		}
-	}
-
-	// If apiVersion is not in the standard list, it's likely a Custom Resource
-	return apiVersion != ""
-}
-
-// addHelmHookAnnotation adds Helm post-install/post-upgrade hook annotations to a manifest.
-// This ensures CRD-dependent resources are applied after all sub-charts (including CRDs) are installed.
-// The before-hook-creation delete policy ensures old CRs are cleaned up before upgrade/install.
-func (g *Generator) addHelmHookAnnotation(content []byte) []byte {
-	lines := strings.Split(string(content), "\n")
-	var result strings.Builder
-	hookAdded := false
-
-	// Helm hook annotations to add
-	hookAnnotations := []string{
-		"\"helm.sh/hook\": post-install,post-upgrade",
-		"\"helm.sh/hook-weight\": \"10\"",
-		"\"helm.sh/hook-delete-policy\": before-hook-creation",
-	}
-
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-		trimmed := strings.TrimSpace(line)
-
-		// When we find metadata:, check what follows and insert annotations appropriately
-		if trimmed == "metadata:" {
-			result.WriteString(line)
-			result.WriteString("\n")
-
-			// Find the indentation level for metadata fields
-			metadataIndent := "  " // default
-			nextIdx := i + 1
-			for nextIdx < len(lines) {
-				nextLine := lines[nextIdx]
-				nextTrimmed := strings.TrimSpace(nextLine)
-				// Skip empty lines and pure template directives
-				if nextTrimmed == "" || (strings.HasPrefix(nextTrimmed, "{{-") && strings.HasSuffix(nextTrimmed, "}}")) {
-					nextIdx++
-					continue
-				}
-				// Found a non-empty line, get its indentation
-				metadataIndent = nextLine[:len(nextLine)-len(strings.TrimLeft(nextLine, " \t"))]
-				break
-			}
-
-			// Check if annotations: already exists in metadata
-			hasAnnotations := false
-			for j := i + 1; j < len(lines); j++ {
-				checkTrimmed := strings.TrimSpace(lines[j])
-				// Stop if we hit spec: or another top-level field
-				if len(lines[j]) > 0 && lines[j][0] != ' ' && lines[j][0] != '\t' && !strings.HasPrefix(checkTrimmed, "{{") {
-					break
-				}
-				if checkTrimmed == "annotations:" {
-					hasAnnotations = true
-					break
-				}
-			}
-
-			if !hasAnnotations {
-				// Insert annotations: with helm hooks right after metadata:
-				result.WriteString(metadataIndent + "annotations:\n")
-				for _, ann := range hookAnnotations {
-					result.WriteString(metadataIndent + "  " + ann + "\n")
-				}
-				hookAdded = true
-			}
-			continue
-		}
-
-		// If annotations: exists, add our hooks right after it
-		if !hookAdded && trimmed == "annotations:" {
-			result.WriteString(line)
-			result.WriteString("\n")
-			// Get the indentation of the annotations line and add one more level
-			annotationsIndent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
-			hookIndent := annotationsIndent + "  "
-			for _, ann := range hookAnnotations {
-				result.WriteString(hookIndent + ann + "\n")
-			}
-			hookAdded = true
-			continue
-		}
-
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return []byte(result.String())
 }

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -178,7 +178,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	output.DeploymentSteps = []string{
 		fmt.Sprintf("cd %s", outputDir),
 		"helm dependency update",
-		"helm install eidos-stack . -n eidos-stack --create-namespace",
+		"helm install eidos-stack . -n eidos-stack --create-namespace --wait --timeout 10m",
 	}
 
 	slog.Debug("umbrella chart generated",

--- a/pkg/bundler/deployer/helm/templates/README.md.tmpl
+++ b/pkg/bundler/deployer/helm/templates/README.md.tmpl
@@ -62,8 +62,11 @@ vim values.yaml
 4. **Install the chart**:
 
 ```bash
-helm install {{ .ChartName }} . -n eidos-stack --create-namespace -f values.yaml
+helm install {{ .ChartName }} . -n eidos-stack --create-namespace --wait --timeout 10m -f values.yaml
 ```
+
+> **Note**: The `--wait --timeout 10m` flags ensure Helm waits for all resources to be ready
+> and that Helm hooks (used for CRD-dependent resources) execute in the correct order.
 
 ## Customization
 
@@ -72,7 +75,7 @@ helm install {{ .ChartName }} . -n eidos-stack --create-namespace -f values.yaml
 To skip installing a specific component, set `<component>.enabled=false`:
 
 ```bash
-helm install {{ .ChartName }} . -n eidos-stack --create-namespace \
+helm install {{ .ChartName }} . -n eidos-stack --create-namespace --wait --timeout 10m \
   --set cert-manager.enabled=false
 ```
 
@@ -81,7 +84,7 @@ helm install {{ .ChartName }} . -n eidos-stack --create-namespace \
 Override specific values using `--set`:
 
 ```bash
-helm install {{ .ChartName }} . -n eidos-stack --create-namespace \
+helm install {{ .ChartName }} . -n eidos-stack --create-namespace --wait --timeout 10m \
   --set gpu-operator.driver.enabled=false \
   --set gpu-operator.toolkit.enabled=true
 ```
@@ -91,7 +94,7 @@ helm install {{ .ChartName }} . -n eidos-stack --create-namespace \
 Create a custom values file and merge it:
 
 ```bash
-helm install {{ .ChartName }} . -n eidos-stack --create-namespace -f values.yaml -f custom-values.yaml
+helm install {{ .ChartName }} . -n eidos-stack --create-namespace --wait --timeout 10m -f values.yaml -f custom-values.yaml
 ```
 
 ## Upgrade
@@ -99,7 +102,7 @@ helm install {{ .ChartName }} . -n eidos-stack --create-namespace -f values.yaml
 To upgrade an existing installation:
 
 ```bash
-helm upgrade {{ .ChartName }} . -n eidos-stack -f values.yaml
+helm upgrade {{ .ChartName }} . -n eidos-stack --wait --timeout 10m -f values.yaml
 ```
 
 ## Uninstall

--- a/pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
+++ b/pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
@@ -25,6 +25,11 @@
 apiVersion: skyhook.nvidia.com/v1alpha1
 kind: Skyhook
 metadata:
+  annotations:
+    # Helm hooks ensure this CR is applied after skyhook-operator CRD is installed
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app.kubernetes.io/part-of: skyhook-operator
     app.kubernetes.io/created-by: eidos

--- a/pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
+++ b/pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
@@ -55,7 +55,7 @@ spec:
   {{- end }}
   # Static: Baked-in tuning for H100 Ubuntu training
   packages:
-    fix_mac_address_policy:
+    fix-mac-address-policy:
       image: ghcr.io/nvidia/skyhook-packages/shellscript
       version: "1.1.1"
       env:

--- a/pkg/recipe/yaml_test.go
+++ b/pkg/recipe/yaml_test.go
@@ -43,12 +43,13 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // testMetadataFS embeds all recipe data files for testing.
-// This uses a separate embed directive to include component values files.
+// This uses a separate embed directive to include component values files and manifests.
 //
-//go:embed data/overlays/*.yaml data/components/**/*.yaml
+//go:embed data/overlays/*.yaml data/components/*/*.yaml data/components/*/manifests/*.yaml
 var testMetadataFS embed.FS
 
 // validMeasurementTypes are the valid top-level measurement types for constraints.
@@ -879,6 +880,313 @@ func TestAllComponentTypesValid(t *testing.T) {
 }
 
 // ============================================================================
+// Manifest Helm Hooks Validation Tests
+// ============================================================================
+
+// standardK8sAPIVersions returns the set of Kubernetes API versions that don't require CRDs.
+// Resources with these apiVersions don't need Helm hook annotations.
+// The list is derived from k8s.io/client-go/kubernetes/scheme which contains all standard K8s types.
+var standardK8sAPIVersions = func() map[string]bool {
+	versions := make(map[string]bool)
+	for gv := range scheme.Scheme.AllKnownTypes() {
+		// Format: "group/version" or just "version" for core API
+		var apiVersion string
+		if gv.Group == "" {
+			apiVersion = gv.Version // e.g., "v1"
+		} else {
+			apiVersion = gv.Group + "/" + gv.Version // e.g., "apps/v1"
+		}
+		versions[apiVersion] = true
+	}
+	return versions
+}()
+
+// TestManifestHelmHooksRequired validates that CRD-dependent manifests
+// have the required Helm hook annotations for proper deployment ordering.
+//
+// Custom Resources (CRs) depend on CRDs installed by sub-charts. Without
+// Helm hooks, the CR may be applied before its CRD exists, causing installation
+// failures. This test ensures manifest authors add the required annotations.
+//
+// Required annotations for CRD-dependent resources:
+//
+//	metadata:
+//	  annotations:
+//	    "helm.sh/hook": post-install,post-upgrade
+//	    "helm.sh/hook-weight": "10"
+//	    "helm.sh/hook-delete-policy": before-hook-creation
+//
+// To opt-out (not recommended), add:
+//
+//	metadata:
+//	  annotations:
+//	    eidos/skip-hook-validation: "true"
+func TestManifestHelmHooksRequired(t *testing.T) {
+	// Patterns to extract apiVersion and check for annotations
+	// Using regex to avoid YAML parsing issues with Helm template syntax
+	apiVersionPattern := regexp.MustCompile(`(?m)^apiVersion:\s*(\S+)`)
+	helmHookPattern := regexp.MustCompile(`(?m)["']?helm\.sh/hook["']?:\s*`)
+	skipValidationPattern := regexp.MustCompile(`(?m)["']?eidos/skip-hook-validation["']?:\s*["']?true["']?`)
+
+	manifestFiles := collectManifestFiles(t)
+	if len(manifestFiles) == 0 {
+		t.Log("no manifest files found in data/components/*/manifests/")
+		return
+	}
+
+	for _, path := range manifestFiles {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			content, err := testMetadataFS.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", path, err)
+			}
+
+			contentStr := string(content)
+
+			// Extract apiVersion
+			matches := apiVersionPattern.FindStringSubmatch(contentStr)
+			if len(matches) < 2 {
+				t.Logf("no apiVersion found in %s, skipping", path)
+				return
+			}
+			apiVersion := matches[1]
+
+			// Check if this is a standard K8s API (no hooks needed)
+			if isStandardK8sAPI(apiVersion) {
+				return // Standard K8s resource, no hooks required
+			}
+
+			// This is a CRD-dependent resource - check for required annotations
+
+			// Check for opt-out annotation
+			if skipValidationPattern.MatchString(contentStr) {
+				t.Logf("%s has eidos/skip-hook-validation annotation, skipping validation", path)
+				return
+			}
+
+			// Check for helm.sh/hook annotation
+			if !helmHookPattern.MatchString(contentStr) {
+				t.Errorf(`manifest %q has custom apiVersion %q but is missing required Helm hook annotations.
+
+CRD-dependent resources must include these annotations to ensure proper deployment ordering:
+
+  metadata:
+    annotations:
+      "helm.sh/hook": post-install,post-upgrade
+      "helm.sh/hook-weight": "10"
+      "helm.sh/hook-delete-policy": before-hook-creation
+
+To skip this validation (not recommended), add:
+  metadata:
+    annotations:
+      eidos/skip-hook-validation: "true"
+`, filepath.Base(path), apiVersion)
+			}
+		})
+	}
+}
+
+// TestManifestHelmHooksValidation tests the validation logic with controlled inputs
+// to ensure missing annotations are caught and skip annotations work correctly.
+func TestManifestHelmHooksValidation(t *testing.T) {
+	apiVersionPattern := regexp.MustCompile(`(?m)^apiVersion:\s*(\S+)`)
+	helmHookPattern := regexp.MustCompile(`(?m)["']?helm\.sh/hook["']?:\s*`)
+	skipValidationPattern := regexp.MustCompile(`(?m)["']?eidos/skip-hook-validation["']?:\s*["']?true["']?`)
+
+	tests := []struct {
+		name        string
+		content     string
+		expectError bool
+	}{
+		{
+			name: "custom_resource_missing_hooks_should_fail",
+			content: `apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Recipe
+metadata:
+  name: test-recipe
+spec:
+  template: {}`,
+			expectError: true,
+		},
+		{
+			name: "custom_resource_with_hooks_should_pass",
+			content: `apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Recipe
+metadata:
+  name: test-recipe
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+spec:
+  template: {}`,
+			expectError: false,
+		},
+		{
+			name: "custom_resource_with_skip_annotation_should_pass",
+			content: `apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Recipe
+metadata:
+  name: test-recipe
+  annotations:
+    eidos/skip-hook-validation: "true"
+spec:
+  template: {}`,
+			expectError: false,
+		},
+		{
+			name: "standard_k8s_resource_without_hooks_should_pass",
+			content: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value`,
+			expectError: false,
+		},
+		{
+			name: "apps_v1_resource_without_hooks_should_pass",
+			content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1`,
+			expectError: false,
+		},
+		{
+			name: "custom_resource_with_helm_template_syntax_missing_hooks_should_fail",
+			content: `apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Recipe
+metadata:
+  name: {{ .Release.Name }}-recipe
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  template: {}`,
+			expectError: true,
+		},
+		{
+			name: "custom_resource_with_helm_template_and_hooks_should_pass",
+			content: `apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Recipe
+metadata:
+  name: {{ .Release.Name }}-recipe
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  template: {}`,
+			expectError: false,
+		},
+		{
+			name: "networking_k8s_io_resource_should_pass",
+			content: `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-policy
+spec:
+  podSelector: {}`,
+			expectError: false,
+		},
+		{
+			name: "rbac_resource_should_pass",
+			content: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-role
+rules: []`,
+			expectError: false,
+		},
+		{
+			name: "custom_api_different_domain_missing_hooks_should_fail",
+			content: `apiVersion: mycompany.example.com/v1
+kind: CustomThing
+metadata:
+  name: test-thing
+spec: {}`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			contentStr := tc.content
+
+			// Extract apiVersion
+			matches := apiVersionPattern.FindStringSubmatch(contentStr)
+			if len(matches) < 2 {
+				t.Fatalf("no apiVersion found in test case")
+			}
+			apiVersion := matches[1]
+
+			// Check if this is a standard K8s API (no hooks needed)
+			if isStandardK8sAPI(apiVersion) {
+				if tc.expectError {
+					t.Error("expected error for standard K8s resource, but it would be skipped")
+				}
+				return
+			}
+
+			// Check for opt-out annotation
+			if skipValidationPattern.MatchString(contentStr) {
+				if tc.expectError {
+					t.Error("expected error, but skip annotation would bypass validation")
+				}
+				return
+			}
+
+			// Check for helm.sh/hook annotation
+			hasHook := helmHookPattern.MatchString(contentStr)
+
+			if tc.expectError && hasHook {
+				t.Error("expected error (missing hooks), but helm.sh/hook was found")
+			}
+			if !tc.expectError && !hasHook {
+				t.Error("expected pass (hooks present), but helm.sh/hook was not found")
+			}
+		})
+	}
+}
+
+// isStandardK8sAPI checks if an apiVersion is a standard Kubernetes API
+// that doesn't require a CRD.
+func isStandardK8sAPI(apiVersion string) bool {
+	return standardK8sAPIVersions[apiVersion]
+}
+
+// collectManifestFiles returns all manifest YAML files in data/components/*/manifests/.
+func collectManifestFiles(t *testing.T) []string {
+	t.Helper()
+
+	var files []string
+	err := fs.WalkDir(testMetadataFS, "data/components", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Only include files in manifests/ directories
+		if !strings.Contains(path, "/manifests/") {
+			return nil
+		}
+		// Only YAML files
+		if !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk components directory: %v", err)
+	}
+
+	return files
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 
@@ -916,7 +1224,7 @@ func collectMetadataFiles(t *testing.T) []string {
 	return files
 }
 
-// collectValuesFiles returns all values files in data/components/.
+// collectValuesFiles returns all values files in data/components/ (excluding manifests/).
 func collectValuesFiles(t *testing.T) map[string]bool {
 	t.Helper()
 
@@ -926,6 +1234,10 @@ func collectValuesFiles(t *testing.T) map[string]bool {
 			return err
 		}
 		if d.IsDir() {
+			return nil
+		}
+		// Skip manifest files (they contain Helm templates, not plain YAML)
+		if strings.Contains(path, "/manifests/") {
 			return nil
 		}
 		// Store relative path from data/


### PR DESCRIPTION
## Summary

Tests will check if helm.sh/hook is on custom resources. If not it will error with suggested fix. The fix is to either add them or add a skip annotation if the user knows it isn't needed.

## Motivation / Context

The logic behind this is that the developer of the manifest knows best if the resource needs additions hooks or not. Attempting to detect and add automatically can have unintended behaviour. By being declarative and checking we get the best of both worlds: known state and avoiding un-intentional issues.

Fixes:  Issue with Skyhook-customizations needing to be after operator installs
Related: <!-- #123 or N/A -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

## Problem

The automatic detection of CRD-dependent resources fails because manifest files contain embedded Helm templates (e.g., `{{ .Release.Service }}`) that break YAML parsing. Instead of trying to reliably strip Helm syntax, we shift responsibility to manifest authors.

## Solution

1. **Require explicit annotations** on CRD-dependent manifests (Custom Resources)
2. **Add a validation test** that runs during `make test` to catch violations early
3. **Remove the unreliable auto-detection code** from the bundler

## Implementation

### 1. Update the Skyhook manifest to include Helm hooks

File: [`pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml`](pkg/recipe/data/components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml)

Add annotations after `metadata:`:

```yaml
metadata:
  annotations:
    "helm.sh/hook": post-install,post-upgrade
    "helm.sh/hook-weight": "10"
    "helm.sh/hook-delete-policy": before-hook-creation
  labels:
    ...
```

### 2. Add validation test

File: [`pkg/recipe/yaml_test.go`](pkg/recipe/yaml_test.go) (new test function)

```go
// TestManifestHelmHooksRequired validates that CRD-dependent manifests
// have the required Helm hook annotations for proper deployment ordering.
func TestManifestHelmHooksRequired(t *testing.T) {
    // 1. Walk all files in data/components/*/manifests/*.yaml
    // 2. For each file, extract apiVersion using regex (avoiding YAML parse issues)
    // 3. If apiVersion is NOT a standard K8s API, check for:
    //    - helm.sh/hook annotation (required), OR
    //    - eidos/skip-hook-validation: "true" annotation (opt-out)
    // 4. Fail with helpful message suggesting the fix
}
```

Standard K8s APIs (no hooks needed): `v1`, `apps/v1`, `batch/v1`, `networking.k8s.io/*`, `rbac.authorization.k8s.io/*`, etc.

### 3. Simplify the bundler code

File: [`pkg/bundler/deployer/helm/helm.go`](pkg/bundler/deployer/helm/helm.go)

- Remove `isCRDDependentResource()` function (unreliable)
- Remove `addHelmHookAnnotation()` function (no longer needed)
- Simplify `generateTemplates()` to just copy manifest content as-is

### 4. Error message format

When a manifest fails validation:

```
manifest "h100-eks-ubuntu-training.yaml" has custom apiVersion "skyhook.nvidia.com/v1alpha1"
but is missing required Helm hook annotations.

CRD-dependent resources must include these annotations to ensure proper deployment ordering:

  metadata:
    annotations:
      "helm.sh/hook": post-install,post-upgrade
      "helm.sh/hook-weight": "10"
      "helm.sh/hook-delete-policy": before-hook-creation

To skip this validation (not recommended), add:
  metadata:
    annotations:
      eidos/skip-hook-validation: "true"
```

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [ ] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)
