### PR TITLE
fix: remove redundant driver resource limits

### DIFF
--- a/pkg/recipe/data/components/gpu-operator/values.yaml
+++ b/pkg/recipe/data/components/gpu-operator/values.yaml
@@ -63,13 +63,6 @@ driver:
   maxParallelUpgrades: 5
   rdma:
     enabled: true
-  resources:
-    limits:
-      cpu: "8"
-      memory: 16Gi
-    requests:
-      cpu: "2"
-      memory: 8Gi
 
 devicePlugin:
   env:


### PR DESCRIPTION
## Summary

- Remove explicit `driver.resources` from gpu-operator values — the skyhook LimitRange already covers it

## Rationale

PR #70 raised the skyhook LimitRange defaults from 512Mi to 16Gi to prevent driver OOMKill during kernel module compilation. It also added explicit `driver.resources` (16Gi limit, 8Gi request) to the gpu-operator values.

However, the GPU Operator does not set default resource limits on the driver container. Without explicit `driver.resources`, the container inherits the namespace LimitRange defaults (16Gi). The explicit driver resources are therefore redundant.

## Changes

- **Modified**: `pkg/recipe/data/components/gpu-operator/values.yaml` — removed `driver.resources` section

## Test plan

- [ ] `go test ./pkg/recipe/... ./pkg/bundler/...` — all pass
- [ ] Verify driver still compiles successfully on EKS with H100 (inherits 16Gi from LimitRange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)