### PR TITLE
fix: re-enable cert-manager startupapicheck

### DIFF
--- a/pkg/recipe/data/components/cert-manager/values.yaml
+++ b/pkg/recipe/data/components/cert-manager/values.yaml
@@ -50,9 +50,9 @@ cainjector:
       memory: "320Mi"
       cpu: "50m"
 
-# Startup API check job - disabled as workaround for nvsentinel network policy
-# blocking webhook traffic (port 10250). The metrics-access policy only allows
-# ports 2112 and 9216, causing the API check to hang.
-# TODO: Re-enable when nvsentinel provides a way to disable the network policy
+# Startup API check job - verifies cert-manager webhook is reachable after install.
+# Previously disabled due to nvsentinel network policy blocking webhook traffic,
+# now re-enabled since the allow-intra-namespace NetworkPolicy workaround (PR #68)
+# neutralizes the restriction.
 startupapicheck:
-  enabled: false
+  enabled: true

--- a/pkg/recipe/data/overlays/kind.yaml
+++ b/pkg/recipe/data/overlays/kind.yaml
@@ -31,13 +31,6 @@ spec:
 
   # Kind-specific component overrides
   componentRefs:
-    # cert-manager: disable startupapicheck due to nvsentinel network policy issue
-    - name: cert-manager
-      type: Helm
-      overrides:
-        startupapicheck:
-          enabled: false
-
     # gpu-operator: configure for kind with GPU passthrough
     # Assumes host has NVIDIA drivers pre-installed and GPUs passed through to kind
     - name: gpu-operator


### PR DESCRIPTION
## Summary

- Re-enable cert-manager `startupapicheck` now that the nvsentinel network policy restriction has been resolved

## Background

The cert-manager startup API check was disabled as a workaround for nvsentinel's `metrics-access` NetworkPolicy, which blocked webhook traffic (port 10250) — only allowing ports 2112 and 9216. This caused the API check to hang indefinitely.

PR #68 added an `allow-intra-namespace` NetworkPolicy that neutralizes this restriction, so the startup check can be safely re-enabled.

## Changes

- **Modified**: `pkg/recipe/data/components/cert-manager/values.yaml` — set `startupapicheck.enabled: true`
- **Modified**: `pkg/recipe/data/overlays/kind.yaml` — removed the cert-manager override that disabled startupapicheck

## Test plan

- [x] `go test ./pkg/recipe/... ./pkg/bundler/...` — all pass
- [ ] Verify cert-manager startupapicheck job completes successfully on deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)