### PR TITLE
fix: set fullnameOverride to remove eidos-stack- prefix

### DIFF
--- a/pkg/recipe/data/components/aws-ebs-csi-driver/values.yaml
+++ b/pkg/recipe/data/components/aws-ebs-csi-driver/values.yaml
@@ -15,6 +15,9 @@
 # AWS EBS CSI Driver Helm values
 # Base configuration for EKS deployments
 
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: aws-ebs-csi-driver
+
 image:
   repository: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
   pullPolicy: IfNotPresent

--- a/pkg/recipe/data/components/aws-efa/values.yaml
+++ b/pkg/recipe/data/components/aws-efa/values.yaml
@@ -56,8 +56,7 @@ additionalPodAnnotations: {}
 
 additionalPodLabels: {}
 
-nameOverride: ""
-
-fullnameOverride: ""
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+fullnameOverride: aws-efa-k8s-device-plugin
 
 imagePullSecrets: []

--- a/pkg/recipe/data/components/k8s-ephemeral-storage-metrics/values.yaml
+++ b/pkg/recipe/data/components/k8s-ephemeral-storage-metrics/values.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: add fullnameOverride once upstream chart exposes it in values.yaml
+# (_helpers.tpl has the logic but values.yaml doesn't declare it)
+
 # -- Set metrics you want to enable
 metrics:
   # -- Percentage of ephemeral storage used by a container in a pod

--- a/pkg/recipe/data/components/kube-prometheus-stack/values.yaml
+++ b/pkg/recipe/data/components/kube-prometheus-stack/values.yaml
@@ -73,6 +73,8 @@ alertmanager:
 # Node Exporter - for node-level metrics
 nodeExporter:
   enabled: true
+prometheus-node-exporter:
+  fullnameOverride: prometheus-node-exporter
 
 # kube-state-metrics - for Kubernetes object metrics
 kube-state-metrics:

--- a/pkg/recipe/data/components/prometheus-adapter/values.yaml
+++ b/pkg/recipe/data/components/prometheus-adapter/values.yaml
@@ -15,6 +15,9 @@
 # Prometheus Adapter Helm values
 # Enables Kubernetes HPA to scale workloads based on custom metrics from Prometheus
 
+# TODO: add fullnameOverride once upstream PR merges:
+# https://github.com/prometheus-community/helm-charts/pull/6584
+
 # Prometheus connection configuration
 prometheus:
   # URL of the Prometheus service deployed by kube-prometheus-stack


### PR DESCRIPTION
## Summary
- Set `fullnameOverride` on component charts that support it so resource names use canonical component names instead of inheriting the `eidos-stack-` release prefix
- Add TODO comments for charts where upstream support is pending

### Charts fixed
| Component | Change |
|---|---|
| **kube-prometheus-stack** | Added `prometheus-node-exporter.fullnameOverride` sub-chart override |
| **aws-ebs-csi-driver** | Added `fullnameOverride: aws-ebs-csi-driver` |
| **aws-efa** | Changed `fullnameOverride: ""` → `fullnameOverride: aws-efa-k8s-device-plugin` |

### Blocked on upstream
| Component | Status |
|---|---|
| **prometheus-adapter** | Waiting on [prometheus-community/helm-charts#6584](https://github.com/prometheus-community/helm-charts/pull/6584) |
| **k8s-ephemeral-storage-metrics** | Waiting on [upstream PR](https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pull/181) |

## Test plan
- [x] `make test` passes
- [ ] Deploy eidos-stack and verify pods no longer have `eidos-stack-` prefix for the fixed components

🤖 Generated with [Claude Code](https://claude.com/claude-code)