### PR TITLE
fix: disable skyhook LimitRange by bumping to v0.12.0

### DIFF
--- a/pkg/recipe/data/components/skyhook-operator/values.yaml
+++ b/pkg/recipe/data/components/skyhook-operator/values.yaml
@@ -18,20 +18,11 @@
 # Override release name prefix to avoid eidos-stack- prefix in resource names
 fullnameOverride: skyhook-operator
 
-# Raise LimitRange defaults to prevent OOMKill of other namespace pods.
-# The skyhook chart creates a namespace-wide LimitRange that applies to ALL
-# containers without explicit resource limits. The upstream default (512Mi)
-# is too low for GPU driver kernel module compilation.
-# TODO: disable LimitRange entirely once the skyhook chart adds a nil guard
-# in cleanup-webhook-job.yaml (currently references limitRange.default.cpu
-# without a conditional check, so setting limitRange to null causes a render error).
-limitRange:
-  default:
-    cpu: "8"
-    memory: 16Gi
-  defaultRequest:
-    cpu: "1"
-    memory: 2Gi
+# Disable the namespace-wide LimitRange. The upstream default (512Mi) was too low
+# for GPU driver compilation, requiring inflated values that bloated every pod.
+# Components that need high resources (e.g. gpu-operator driver) set them explicitly.
+# Requires skyhook chart with nil guard in cleanup-webhook-job.yaml (>= v0.12.0).
+limitRange: null
 
 controllerManager:
   manager:

--- a/pkg/recipe/data/overlays/base.yaml
+++ b/pkg/recipe/data/overlays/base.yaml
@@ -54,7 +54,7 @@ spec:
     - name: skyhook-operator
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/skyhook
-      version: v0.11.1
+      version: v0.12.0
       valuesFile: components/skyhook-operator/values.yaml
 
     - name: kube-prometheus-stack


### PR DESCRIPTION
## Summary
- Bump skyhook-operator from v0.11.1 to v0.12.0 (includes nil guard in `cleanup-webhook-job.yaml`)
- Set `limitRange: null` to disable the namespace-wide LimitRange that bloated all pods

## Context
The skyhook chart creates a namespace-wide LimitRange that applies to ALL containers without explicit resource limits. The upstream default (512Mi) was too low for GPU driver compilation, so eidos raised it to 16Gi — but this inflated every pod in the namespace, causing OOM scheduling failures on resource-constrained clusters (e.g. Kind).

With skyhook v0.12.0, `limitRange` can be set to null to disable the LimitRange entirely. Without the LimitRange, pods use node defaults, which is sufficient for all components.

## Test plan
- [x] `make test` passes
- [x] Deployed with `kind` recipe — no LimitRange, all 24 pods healthy
- [x] Deployed with `eks` recipe — Skyhook completes 2/2 nodes, no OOM
- [x] cert-manager startupapicheck passes