### PR TITLE
feat: add dynamo-platform and dynamo-crds for AI inference serving 

### DIFF
--- a/pkg/recipe/data/components/dynamo-crds/values.yaml
+++ b/pkg/recipe/data/components/dynamo-crds/values.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dynamo CRDs Helm values
+# Installs Custom Resource Definitions for NVIDIA Dynamo inference platform.
+# CRDs: DynamoGraphDeployment, DynamoGraphDeploymentRequest,
+#        DynamoComponentDeployment, DynamoModel, DynamoWorkerMetadata,
+#        DynamoGraphDeploymentScalingAdapter
+
+# This chart has no configurable values — it only installs CRDs.
+# The enabled flag is managed by the umbrella chart condition.
+enabled: true

--- a/pkg/recipe/data/components/dynamo-platform/values.yaml
+++ b/pkg/recipe/data/components/dynamo-platform/values.yaml
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dynamo Platform Helm values
+# NVIDIA Dynamo inference serving platform: operator, etcd, NATS.
+# Provides OpenAI-compatible endpoints, KV-cache-aware routing,
+# disaggregated prefill/decode, and SLA-driven autoscaling.
+
+# Override release name prefix to avoid eidos-stack- prefix in resource names
+dynamo-operator:
+  fullnameOverride: dynamo-operator
+  controllerManager:
+    tolerations:
+      - operator: Exists
+
+  # Use Kubernetes-native service discovery (no external etcd dependency for discovery)
+  discoveryBackend: "kubernetes"
+
+  # Point Dynamo to the existing kube-prometheus-stack for metrics collection.
+  # PodMonitor CRs are auto-created by the operator for metric discovery.
+  dynamo:
+    metrics:
+      prometheusEndpoint: "http://kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
+
+# Disable kai-scheduler sub-chart — managed as a separate eidos component
+kai-scheduler:
+  enabled: false
+
+# Disable grove — enable when multinode inference coordination is needed
+grove:
+  enabled: false
+
+# etcd for operator state storage
+etcd:
+  enabled: true
+  fullnameOverride: dynamo-etcd
+  image:
+    repository: bitnamilegacy/etcd
+    tag: 3.5.18-debian-12-r5
+  persistence:
+    enabled: true
+    size: 1Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# NATS message broker for component communication
+nats:
+  enabled: true
+  fullnameOverride: dynamo-nats
+  config:
+    cluster:
+      enabled: false
+    jetstream:
+      enabled: true

--- a/pkg/recipe/data/overlays/inference.yaml
+++ b/pkg/recipe/data/overlays/inference.yaml
@@ -19,9 +19,11 @@ metadata:
 
 spec:
   # Inherits from base (implicit when spec.base is empty)
-  # This recipe adds inference-serving components for AI workloads.
+  # This recipe adds inference components for AI workloads.
   # Satisfies CNCF AI Conformance requirements:
   #   - Gang scheduling (kai-scheduler)
+  #   - AI inference serving (dynamo-platform)
+  #   - AI service metrics (dynamo metrics + kube-prometheus-stack)
 
   criteria:
     intent: inference
@@ -34,3 +36,19 @@ spec:
       valuesFile: components/kai-scheduler/values.yaml
       dependencyRefs:
         - gpu-operator
+
+    - name: dynamo-crds
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.8.1"
+      valuesFile: components/dynamo-crds/values.yaml
+
+    - name: dynamo-platform
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.8.1"
+      valuesFile: components/dynamo-platform/values.yaml
+      dependencyRefs:
+        - dynamo-crds
+        - cert-manager
+        - kube-prometheus-stack

--- a/pkg/recipe/data/registry.yaml
+++ b/pkg/recipe/data/registry.yaml
@@ -287,6 +287,33 @@ components:
         tolerationPaths:
           - global.tolerations
 
+  - name: dynamo-crds
+    displayName: dynamo-crds
+    valueOverrideKeys:
+      - dynamocrds
+    helm:
+      defaultRepository: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      defaultChart: dynamo-crds
+      defaultVersion: "0.8.1"
+      defaultNamespace: dynamo-system
+
+  - name: dynamo-platform
+    displayName: dynamo-platform
+    valueOverrideKeys:
+      - dynamoplatform
+      - dynamo
+    helm:
+      defaultRepository: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      defaultChart: dynamo-platform
+      defaultVersion: "0.8.1"
+      defaultNamespace: dynamo-system
+    nodeScheduling:
+      system:
+        nodeSelectorPaths:
+          - dynamo-operator.controllerManager.nodeSelector
+        tolerationPaths:
+          - dynamo-operator.controllerManager.tolerations
+
   - name: kubeflow-trainer
     displayName: kubeflow-trainer
     valueOverrideKeys:


### PR DESCRIPTION
## Summary
- Add NVIDIA Dynamo inference platform (dynamo-platform + dynamo-crds) as eidos components
- Create `inference` recipe overlay for inference-serving workloads
- Add to `kind` overlay for local testing

## Components
- **dynamo-crds** (v0.8.1): 6 CRDs — DynamoGraphDeployment, DynamoModel, DynamoWorkerMetadata, etc.
- **dynamo-platform** (v0.8.1): Operator + etcd + NATS with Kubernetes-native service discovery

## Configuration
- kai-scheduler sub-chart disabled (managed as separate eidos component, see #80)
- grove disabled (enable for multinode inference)
- Prometheus endpoint configured for existing kube-prometheus-stack
- Kubernetes-native service discovery (no external etcd dependency for discovery)
- Kind overlay with reduced etcd resources

## CNCF AI Conformance
Addresses inference-related requirements:
- **AI inference serving**: Dynamo provides OpenAI-compatible endpoints, KV-cache-aware routing, disaggregated prefill/decode
- **AI service metrics**: Prometheus-compatible `/metrics` endpoints, PodMonitor auto-creation, Grafana dashboards

## Dependencies
- Depends on #80 (kai-scheduler) for the `kai-scheduler` dependency reference in overlays

## Test plan
- [x] `make test` passes
- [x] `eidos recipe --service kind` generates recipe with 12 components
- [x] `eidos bundle` generates correct Chart.yaml and values.yaml
- [x] `helm dependency update` downloads dynamo-crds, dynamo-platform, kai-scheduler
- [x] `helm upgrade --install` on Kind cluster — all 36 pods healthy:
  ```
  eidos-stack-dynamo-operator-controller-manager   2/2   Running
  eidos-stack-etcd-0                               1/1   Running
  eidos-stack-nats-0                               2/2   Running
  kai-operator                                     1/1   Running
  kai-scheduler-default                            1/1   Running
  ```
- [x] Dynamo CRDs installed (7 CRDs)
- [x] KAI queues created (default + dynamo)
- [x] cert-manager startupapicheck passes