### PR TITLE
feat: add kgateway for CNCF AI Conformance inference gateway

### DIFF
--- a/pkg/recipe/data/components/kgateway-crds/values.yaml
+++ b/pkg/recipe/data/components/kgateway-crds/values.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# kgateway CRDs Helm values
+# Installs kgateway-specific CRDs (Backends, DirectResponses, GatewayExtensions,
+# GatewayParameters, HTTPListenerPolicies, TrafficPolicies).
+#
+# Note: Standard Gateway API CRDs (GatewayClass, Gateway, HTTPRoute) and
+# Inference Extension CRDs (InferencePool, InferenceModel) must be installed
+# separately before deploying kgateway. See the kgateway getting started guide:
+# https://gateway-api-inference-extension.sigs.k8s.io/guides/
+
+# This chart has no configurable values — it only installs CRDs.
+# The enabled flag is managed by the umbrella chart condition.
+enabled: true

--- a/pkg/recipe/data/components/kgateway/values.yaml
+++ b/pkg/recipe/data/components/kgateway/values.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# kgateway Helm values
+# Gateway API and Inference Gateway v1.0.0 conformant implementation.
+# Satisfies CNCF AI Conformance Advanced Ingress for AI/ML Inference requirement.
+# Provides model-aware routing, weighted traffic splitting, and header-based routing.
+
+# Override release name prefix to avoid eidos-stack- prefix
+fullnameOverride: kgateway
+
+tolerations:
+  - operator: Exists
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Enable Gateway API Inference Extension for model-aware routing
+inferenceExtension:
+  enabled: true

--- a/pkg/recipe/data/overlays/inference.yaml
+++ b/pkg/recipe/data/overlays/inference.yaml
@@ -22,6 +22,7 @@ spec:
   # This recipe adds inference components for AI workloads.
   # Satisfies CNCF AI Conformance requirements:
   #   - Gang scheduling (kai-scheduler)
+  #   - Advanced Ingress for AI/ML Inference (kgateway with inference extension)
   #   - AI inference serving (dynamo-platform)
   #   - AI service metrics (dynamo metrics + kube-prometheus-stack)
 
@@ -36,6 +37,21 @@ spec:
       valuesFile: components/kai-scheduler/values.yaml
       dependencyRefs:
         - gpu-operator
+
+    - name: kgateway-crds
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway-crds/values.yaml
+
+    - name: kgateway
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway/values.yaml
+      dependencyRefs:
+        - kgateway-crds
+        - cert-manager
 
     - name: dynamo-crds
       type: Helm

--- a/pkg/recipe/data/registry.yaml
+++ b/pkg/recipe/data/registry.yaml
@@ -314,6 +314,32 @@ components:
         tolerationPaths:
           - dynamo-operator.controllerManager.tolerations
 
+  - name: kgateway-crds
+    displayName: kgateway-crds
+    valueOverrideKeys:
+      - kgatewaycrds
+    helm:
+      defaultRepository: oci://cr.kgateway.dev/kgateway-dev/charts
+      defaultChart: kgateway-crds
+      defaultVersion: v2.0.0
+      defaultNamespace: kgateway-system
+
+  - name: kgateway
+    displayName: kgateway
+    valueOverrideKeys:
+      - kgateway
+    helm:
+      defaultRepository: oci://cr.kgateway.dev/kgateway-dev/charts
+      defaultChart: kgateway
+      defaultVersion: v2.0.0
+      defaultNamespace: kgateway-system
+    nodeScheduling:
+      system:
+        nodeSelectorPaths:
+          - nodeSelector
+        tolerationPaths:
+          - tolerations
+
   - name: kubeflow-trainer
     displayName: kubeflow-trainer
     valueOverrideKeys:


### PR DESCRIPTION
## Summary
- Add kgateway as an eidos component to satisfy the CNCF AI Conformance **Advanced Ingress for AI/ML Inference** requirement
- kgateway is the only v1.0.0 Inference Gateway conformant implementation
- Create `inference` recipe overlay for inference-related components

## Components
- **kgateway-crds** (v2.0.0): kgateway-specific CRDs (Backends, DirectResponses, GatewayExtensions, GatewayParameters, HTTPListenerPolicies, TrafficPolicies)
- **kgateway** (v2.0.0): Gateway controller with `inferenceExtension.enabled=true` for model-aware routing

## CNCF AI Conformance
Satisfies the `ai_inference` requirement:
- Gateway API support with weighted traffic splitting
- Header-based routing (OpenAI protocol headers)
- Model-aware routing via Gateway API Inference Extension

## Configuration
- `fullnameOverride: kgateway` to avoid `eidos-stack-` prefix
- Inference extension enabled for model-aware routing
- Universal tolerations for scheduling flexibility
- Resource limits set (100m/128Mi request, 500m/256Mi limit)

## Note
Standard Gateway API CRDs and Inference Extension CRDs (InferencePool, InferenceModel) must be installed separately before deploying kgateway. See the [kgateway getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/).

## Test plan
- [x] `make test` passes
- [x] `eidos recipe --service kind` generates recipe with 11 components
- [x] `eidos bundle` generates correct Chart.yaml and values.yaml
- [x] `helm dependency update` downloads kgateway-crds and kgateway charts
- [x] `helm upgrade --install` on Kind cluster — all 25 pods healthy:
  ```
  kgateway-6d5df75b8f-mx62w   1/1   Running
  ```
- [x] kgateway CRDs installed (6 CRDs)
- [x] cert-manager startupapicheck passes