### PR TITLE
fix: fix deploy.sh failing when run from within the bundle directory.

### DIFF
--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -9,6 +9,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Run helm commands from a temp directory to prevent local chart directories
+# (e.g., bundle/skyhook-operator/) from shadowing remote chart references.
+HELM_WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${HELM_WORKDIR}"' EXIT
+cd "${HELM_WORKDIR}"
+
 WAIT_ARGS="--wait --timeout 10m"
 if [[ "${1:-}" == "--no-wait" ]]; then
   WAIT_ARGS=""


### PR DESCRIPTION
## Summary
Fix deploy.sh failing when run from within the bundle directory.

## Problem
When `deploy.sh` is executed from inside the bundle directory (e.g., `cd bundle && ./deploy.sh`), Helm resolves chart names like `skyhook-operator` as local directories instead of fetching from the remote `--repo` URL. This causes errors like:

```
WARN local chart found in current working directory. repository url ignored
Error: Chart.yaml file is missing
```

Or template rendering errors when the local values directory doesn't match a chart structure.

## Fix
Change the working directory to a temp dir before running Helm commands, ensuring local bundle directories (e.g., `bundle/skyhook-operator/`, `bundle/cert-manager/`) don't shadow remote chart references.

## Test plan
- [x] `make test` passes
- [x] Verified `deploy.sh` runs successfully from within the bundle directory