### PR TITLE
fix: use upstream default namespaces for components

### DIFF
--- a/pkg/recipe/components_test.go
+++ b/pkg/recipe/components_test.go
@@ -604,9 +604,9 @@ func TestHelmConfig_DefaultNamespace(t *testing.T) {
 		{"gpu-operator", "gpu-operator"},
 		{"network-operator", "nvidia-network-operator"},
 		{"cert-manager", "cert-manager"},
-		{"nvsentinel", "nvidia-system"},
+		{"nvsentinel", "nvsentinel"},
 		{"skyhook-operator", "skyhook"},
-		{"kube-prometheus-stack", "nvidia-system"},
+		{"kube-prometheus-stack", "monitoring"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/recipe/data/registry.yaml
+++ b/pkg/recipe/data/registry.yaml
@@ -83,7 +83,7 @@ components:
       defaultRepository: https://aws.github.io/eks-charts
       defaultChart: aws-efa-k8s-device-plugin
       defaultVersion: v0.5.3
-      defaultNamespace: nvidia-system
+      defaultNamespace: kube-system
     nodeScheduling:
       accelerated:
         nodeSelectorPaths:
@@ -151,7 +151,7 @@ components:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/nvsentinel
       defaultVersion: v0.8.0
-      defaultNamespace: nvidia-system
+      defaultNamespace: nvsentinel
     nodeScheduling:
       system:
         nodeSelectorPaths:
@@ -174,7 +174,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/nvidia-dra-driver-gpu
-      defaultNamespace: nvidia-system
+      defaultNamespace: nvidia-dra-driver
     nodeScheduling:
       system:
         nodeSelectorPaths:
@@ -196,7 +196,7 @@ components:
       defaultRepository: https://prometheus-community.github.io/helm-charts
       defaultChart: prometheus-community/kube-prometheus-stack
       defaultVersion: 81.2.2
-      defaultNamespace: nvidia-system
+      defaultNamespace: monitoring
     nodeScheduling:
       system:
         nodeSelectorPaths:
@@ -226,7 +226,7 @@ components:
       defaultRepository: https://prometheus-community.github.io/helm-charts
       defaultChart: prometheus-community/prometheus-adapter
       defaultVersion: 4.14.0
-      defaultNamespace: nvidia-system
+      defaultNamespace: monitoring
     nodeScheduling:
       system:
         nodeSelectorPaths:
@@ -243,7 +243,7 @@ components:
       defaultRepository: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
       defaultChart: aws-ebs-csi-driver/aws-ebs-csi-driver
       defaultVersion: 2.55.0
-      defaultNamespace: nvidia-system
+      defaultNamespace: kube-system
     nodeScheduling:
       system:
         nodeSelectorPaths:
@@ -263,7 +263,7 @@ components:
     helm:
       defaultRepository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
       defaultChart: k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics
-      defaultNamespace: nvidia-system
+      defaultNamespace: monitoring
     nodeScheduling:
       system:
         nodeSelectorPaths:
@@ -280,7 +280,7 @@ components:
       defaultRepository: oci://ghcr.io/kubeflow/charts
       defaultChart: kubeflow-trainer
       defaultVersion: 2.1.0
-      defaultNamespace: nvidia-system
+      defaultNamespace: kubeflow
     nodeScheduling:
       system:
         nodeSelectorPaths:


### PR DESCRIPTION
## Summary
Update `defaultNamespace` for 8 components from `nvidia-system` to match their upstream conventions.

## Complete namespace mapping

| Component | Before | After | Reason |
|-----------|--------|-------|--------|
| gpu-operator | gpu-operator | gpu-operator | Already correct |
| network-operator | nvidia-network-operator | nvidia-network-operator | Already correct |
| aws-efa | nvidia-system | **kube-system** | AWS EKS device plugins convention |
| cert-manager | cert-manager | cert-manager | Already correct |
| skyhook-operator | skyhook | skyhook | Already correct |
| skyhook-customizations | skyhook | skyhook | Already correct |
| nvsentinel | nvidia-system | **nvsentinel** | Own namespace per NVIDIA convention |
| nvidia-dra-driver-gpu | nvidia-system | **nvidia-dra-driver** | Upstream default |
| kube-prometheus-stack | nvidia-system | **monitoring** | Community standard |
| prometheus-adapter | nvidia-system | **monitoring** | Co-located with prometheus |
| aws-ebs-csi-driver | nvidia-system | **kube-system** | AWS EKS CSI drivers convention |
| k8s-ephemeral-storage-metrics | nvidia-system | **monitoring** | Co-located with monitoring stack |
| kubeflow-trainer | nvidia-system | **kubeflow** | Kubeflow upstream default |

## Test plan
- [x] `make test` passes (updated `TestHelmConfig_DefaultNamespace` expectations)