### PR TITLE
fix: preserve version prefix in deploy.sh for helm install

### DIFF
--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -54,7 +54,8 @@ type ComponentData struct {
 	Namespace    string
 	Repository   string
 	ChartName    string
-	Version      string
+	Version      string // Original version string (preserves 'v' prefix) for helm install --version
+	ChartVersion string // Normalized version (no 'v' prefix) for chart metadata labels
 	HasManifests bool
 	HasChart     bool
 	IsOCI        bool
@@ -229,10 +230,9 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 		}
 
 		isOCI := strings.HasPrefix(ref.Source, "oci://")
-		version := normalizeVersion(ref.Version)
-		if isOCI {
-			version = ref.Version
-		}
+		// Preserve version string as-is for deploy.sh --version flag.
+		// Helm handles 'v' prefixes correctly via fuzzy matching.
+		version := ref.Version
 
 		components = append(components, ComponentData{
 			Name:         ref.Name,
@@ -240,6 +240,7 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 			Repository:   ref.Source,
 			ChartName:    chartName,
 			Version:      version,
+			ChartVersion: normalizeVersion(ref.Version),
 			HasManifests: hasManifests,
 			HasChart:     ref.Source != "",
 			IsOCI:        isOCI,
@@ -595,7 +596,7 @@ func renderManifest(content []byte, data ComponentData, values map[string]any) (
 		},
 		Chart: chartData{
 			Name:    data.ChartName,
-			Version: data.Version,
+			Version: data.ChartVersion,
 		},
 	}
 

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -219,7 +219,7 @@ func TestGenerate_WithManifests(t *testing.T) {
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	manifestContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: {{ .Namespace }}\n  labels:\n    helm.sh/chart: {{ .ChartName }}-{{ .Version }}\n"
+	manifestContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: {{ .Release.Namespace }}\n  labels:\n    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}\n"
 
 	input := &GeneratorInput{
 		RecipeResult: createTestRecipeResult(),
@@ -258,7 +258,7 @@ func TestGenerate_WithManifests(t *testing.T) {
 	if !strings.Contains(rendered, "namespace: gpu-operator") {
 		t.Errorf("manifest namespace not rendered, got: %s", rendered)
 	}
-	if !strings.Contains(rendered, "gpu-operator-25.3.3") {
+	if !strings.Contains(rendered, "gpu-operator-25.3.3") { // normalizeVersion strips 'v' prefix for chart labels
 		t.Errorf("manifest chart label not rendered, got: %s", rendered)
 	}
 }


### PR DESCRIPTION
## Summary
Fix Helm version warning when deploy.sh strips the `v` prefix from chart versions.

## Problem
The `normalizeVersion()` function strips the `v` prefix from version strings for all uses, including `helm install --version`. This causes Helm to log warnings:

```
WARN unable to find exact version requested; falling back to closest
     available version chart=gpu-operator requested=25.10.1 selected=v25.10.1
```

## Fix
Split version into two fields in `ComponentData`:
- **`Version`**: Original string (preserves `v` prefix) — used in `deploy.sh` for `helm install --version`
- **`ChartVersion`**: Normalized string (no `v` prefix) — used in manifest chart metadata labels

Also updated the test manifest template to use `{{ .Chart.Version }}` matching the pattern used by real manifests.

## Test plan
- [x] `make test` passes
- [x] `TestGenerate_WithManifests` passes with correct chart label (`gpu-operator-25.3.3`)
- [x] Generated deploy.sh preserves `v` prefix for `--version` flag