### PR TITLE
fix: resolve EKS deployment issues for multiple components

### DIFF
--- a/kwok/scripts/validate-scheduling.sh
+++ b/kwok/scripts/validate-scheduling.sh
@@ -331,7 +331,9 @@ generate_bundle() {
         --set "networkoperator:operator.tolerations[2].key=eidos.nvidia.com/kwok-test" \
         --set "networkoperator:operator.tolerations[2].operator=Equal" \
         --set "networkoperator:operator.tolerations[2].value=true" \
-        --set "networkoperator:operator.tolerations[2].effect=NoSchedule"
+        --set "networkoperator:operator.tolerations[2].effect=NoSchedule" \
+        --set "dynamoplatform:etcd.persistence.enabled=false" \
+        --set "dynamoplatform:nats.config.jetstream.fileStore.enabled=false"
 
     log_info "Bundle generated at ${WORK_DIR}/bundle"
 }

--- a/pkg/recipe/data/components/dynamo-platform/values.yaml
+++ b/pkg/recipe/data/components/dynamo-platform/values.yaml
@@ -45,6 +45,8 @@ grove:
 etcd:
   enabled: true
   fullnameOverride: dynamo-etcd
+  tolerations:
+    - operator: Exists
   image:
     repository: bitnamilegacy/etcd
     tag: 3.5.18-debian-12-r5
@@ -63,6 +65,11 @@ etcd:
 nats:
   enabled: true
   fullnameOverride: dynamo-nats
+  podTemplate:
+    merge:
+      spec:
+        tolerations:
+          - operator: Exists
   config:
     cluster:
       enabled: false

--- a/pkg/recipe/data/components/kai-scheduler/values.yaml
+++ b/pkg/recipe/data/components/kai-scheduler/values.yaml
@@ -21,6 +21,12 @@ global:
   tolerations:
     - operator: Exists
 
+# Disable post-delete hook job — it does not inherit global.tolerations
+# and will hang Pending on clusters with tainted nodes.
+# Helm uninstall already removes the deployments this hook would delete.
+postCleanup:
+  enabled: false
+
 # CDI support for GPU device assignment
 admission:
   cdi: true

--- a/pkg/recipe/data/components/network-operator/values.yaml
+++ b/pkg/recipe/data/components/network-operator/values.yaml
@@ -18,6 +18,8 @@
 # Override release name prefix to avoid eidos-stack- prefix in resource names
 operator:
   fullnameOverride: network-operator
+  tolerations:
+    - operator: Exists
 
 deployCR: true
 

--- a/pkg/recipe/data/overlays/eks.yaml
+++ b/pkg/recipe/data/overlays/eks.yaml
@@ -51,9 +51,10 @@ spec:
         prometheus:
           prometheusSpec:
             storageSpec:
+              emptyDir: null
               volumeClaimTemplate:
                 spec:
-                  storageClassName: ""  # Use default storage class
+                  storageClassName: gp2
                   accessModes: ["ReadWriteOnce"]
                   resources:
                     requests:

--- a/pkg/recipe/data/overlays/h100-eks-ubuntu-inference.yaml
+++ b/pkg/recipe/data/overlays/h100-eks-ubuntu-inference.yaml
@@ -1,0 +1,124 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: recipeMetadata
+apiVersion: eidos.nvidia.com/v1alpha1
+metadata:
+  name: h100-eks-ubuntu-inference
+
+spec:
+  # Combined training + inference recipe on EKS with H100 and Ubuntu.
+  # Inherits all base and EKS training components, plus inference components.
+  base: h100-eks-ubuntu-training
+
+  criteria:
+    service: eks
+    accelerator: h100
+    os: ubuntu
+    intent: inference
+
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+    - name: OS.release.ID
+      value: ubuntu
+    - name: OS.release.VERSION_ID
+      value: "24.04"
+    - name: OS.sysctl./proc/sys/kernel/osrelease
+      value: ">= 6.8"
+
+  componentRefs:
+    # --- Inference components (from inference overlay) ---
+
+    - name: kai-scheduler
+      type: Helm
+      source: oci://ghcr.io/nvidia/kai-scheduler
+      version: v0.12.10
+      valuesFile: components/kai-scheduler/values.yaml
+      dependencyRefs:
+        - gpu-operator
+
+    - name: kgateway-crds
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway-crds/values.yaml
+
+    - name: kgateway
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway/values.yaml
+      dependencyRefs:
+        - kgateway-crds
+        - cert-manager
+
+    - name: dynamo-crds
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.8.1"
+      valuesFile: components/dynamo-crds/values.yaml
+
+    - name: dynamo-platform
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.8.1"
+      valuesFile: components/dynamo-platform/values.yaml
+      dependencyRefs:
+        - dynamo-crds
+        - cert-manager
+        - kube-prometheus-stack
+      overrides:
+        etcd:
+          persistence:
+            storageClass: gp2
+
+    # --- Additional components ---
+
+    # network-operator is temporarily excluded due to an upstream chart bug:
+    # kubeVersion constraint rejects EKS version strings with pre-release
+    # suffixes (e.g. v1.34.3-eks-ac2d5a0). Upstream fix approved:
+    # https://github.com/Mellanox/network-operator/pull/2167
+    # Re-enable once a release includes the fix.
+    #
+    # - name: network-operator
+    #   type: Helm
+    #   source: https://helm.ngc.nvidia.com/nvidia
+    #   version: v25.4.0
+    #   valuesFile: components/network-operator/values.yaml
+    #   dependencyRefs:
+    #     - cert-manager
+
+    - name: kubeflow-trainer
+      type: Helm
+      source: oci://ghcr.io/kubeflow/charts
+      version: "2.1.0"
+      valuesFile: components/kubeflow-trainer/values.yaml
+      dependencyRefs:
+        - cert-manager
+
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia
+      version: "25.8.1"
+      valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+      dependencyRefs:
+        - gpu-operator
+      overrides:
+        # EKS has no control-plane nodes — remove the default affinity
+        controller:
+          affinity:
+            nodeAffinity: null
+          tolerations:
+            - operator: Exists

--- a/pkg/recipe/data/registry.yaml
+++ b/pkg/recipe/data/registry.yaml
@@ -73,6 +73,12 @@ components:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/network-operator
       defaultNamespace: nvidia-network-operator
+    nodeScheduling:
+      system:
+        nodeSelectorPaths:
+          - operator.nodeSelector
+        tolerationPaths:
+          - operator.tolerations
 
   - name: aws-efa
     displayName: aws-efa


### PR DESCRIPTION
## Summary
- **dynamo-platform**: add tolerations for etcd and nats pods so they schedule on tainted EKS nodes; set `storageClass: gp2` in h100-eks-ubuntu-all overlay
- **kube-prometheus-stack**: null out `emptyDir` in EKS overlay so `volumeClaimTemplate` takes effect; use `storageClass: gp2` explicitly
- **nvidia-dra-driver-gpu**: null out controller `nodeAffinity` in h100-eks-ubuntu-all overlay (EKS has no control-plane nodes)
- **network-operator**: add tolerations via values and `nodeScheduling` in registry; add `helm_install` wrapper in deploy.sh that detects `kubeVersion` constraint failures and retries with relaxed constraint (appends `-0` to include pre-release suffixes like `-eks-*`) upstream PR: https://github.com/NVIDIA/eidos/pull/93 
- **kai-scheduler**: disable `postCleanup` hook job — it doesn't inherit `global.tolerations` and hangs Pending on tainted clusters
- **h100-eks-ubuntu-all overlay**: new overlay combining training + inference components for full EKS deployment

## Test plan
- [x] `make test` passes with race detector
- [x] Full undeploy/redeploy on EKS cluster with H100 GPU nodes
- [x] Verified all 15 components deployed and running
- [x] Verified `helm_install` kubeVersion workaround for network-operator
- [x] Verified prometheus PVC bound to gp2 StorageClass
- [x] Verified nvidia-dra-driver-gpu controller + kubelet-plugin running
- [x] Verified kai-scheduler uninstall completes without hanging

Generated a bundle for all 15 components and successfully deployed all in the EKS H100 cluster eidos-validation-2-10.
```
k config current-context
arn:aws:eks:us-east-1:615299774277:cluster/eidos-validation-2-10

helm list -A -o json \
| jq -r '.[] | "\(.name)\t\(.namespace)"' \
| column -t

aws-ebs-csi-driver             kube-system
aws-efa                        kube-system
cert-manager                   cert-manager
dynamo-crds                    dynamo-system
dynamo-platform                dynamo-system
gpu-operator                   gpu-operator
k8s-ephemeral-storage-metrics  monitoring
kai-scheduler                  kai-scheduler
kgateway                       kgateway-system
kgateway-crds                  kgateway-system
kube-prometheus-stack          monitoring
kubeflow-trainer               kubeflow
network-operator               nvidia-network-operator
nvidia-dra-driver-gpu          nvidia-dra-driver
nvsentinel                     nvsentinel
prometheus-adapter             monitoring
skyhook-operator               skyhook
```