### PR TITLE
feat: restructure inference overlay hierarchy

### DIFF
--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -174,6 +174,7 @@ type CriteriaPlatformType string
 // CriteriaPlatformType constants for supported platforms.
 const (
 	CriteriaPlatformAny      CriteriaPlatformType = "any"
+	CriteriaPlatformDynamo   CriteriaPlatformType = "dynamo"
 	CriteriaPlatformKubeflow CriteriaPlatformType = "kubeflow"
 )
 
@@ -182,6 +183,8 @@ func ParseCriteriaPlatformType(s string) (CriteriaPlatformType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", criteriaAnyValue:
 		return CriteriaPlatformAny, nil
+	case "dynamo":
+		return CriteriaPlatformDynamo, nil
 	case "kubeflow":
 		return CriteriaPlatformKubeflow, nil
 	default:
@@ -191,7 +194,7 @@ func ParseCriteriaPlatformType(s string) (CriteriaPlatformType, error) {
 
 // GetCriteriaPlatformTypes returns all supported platform types sorted alphabetically.
 func GetCriteriaPlatformTypes() []string {
-	return []string{"kubeflow"}
+	return []string{"dynamo", "kubeflow"}
 }
 
 // Criteria represents the input parameters for recipe matching.

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -762,6 +762,8 @@ func TestParseCriteriaPlatformType(t *testing.T) {
 	}{
 		{"empty", "", CriteriaPlatformAny, false},
 		{"any", "any", CriteriaPlatformAny, false},
+		{"dynamo", "dynamo", CriteriaPlatformDynamo, false},
+		{"Dynamo uppercase", "Dynamo", CriteriaPlatformDynamo, false},
 		{"kubeflow", "kubeflow", CriteriaPlatformKubeflow, false},
 		{"Kubeflow uppercase", "Kubeflow", CriteriaPlatformKubeflow, false},
 		{"invalid", "invalid", CriteriaPlatformAny, true},
@@ -785,7 +787,7 @@ func TestGetCriteriaPlatformTypes(t *testing.T) {
 	types := GetCriteriaPlatformTypes()
 
 	// Should return sorted list
-	expected := []string{"kubeflow"}
+	expected := []string{"dynamo", "kubeflow"}
 	if len(types) != len(expected) {
 		t.Errorf("GetCriteriaPlatformTypes() returned %d types, want %d", len(types), len(expected))
 	}

--- a/pkg/recipe/data/overlays/eks-inference.yaml
+++ b/pkg/recipe/data/overlays/eks-inference.yaml
@@ -15,38 +15,34 @@
 kind: recipeMetadata
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
-  name: h100-eks-ubuntu-inference
+  name: eks-inference
 
 spec:
-  # Inherits from h100-eks-inference recipe (H100 + EKS + inference settings)
-  # This overlay adds Ubuntu-specific configurations
-  base: h100-eks-inference
+  # Inherits from eks recipe (EKS-specific settings)
+  base: eks
 
   criteria:
     service: eks
-    accelerator: h100
-    os: ubuntu
     intent: inference
 
-  # H100 + Ubuntu specific constraints for inference workloads
+  # Inference specific constraints for EKS workloads
   # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
   constraints:
     - name: K8s.server.version
-      value: ">= 1.32.4"
-    - name: OS.release.ID
-      value: ubuntu
-    - name: OS.release.VERSION_ID
-      value: "24.04"
-    - name: OS.sysctl./proc/sys/kernel/osrelease
-      value: ">= 6.8"
+      value: ">= 1.30"
 
   componentRefs:
-    # Ubuntu node customizations via skyhook-customizations component.
-    # Reuses the training manifest — it contains H100+EKS+Ubuntu node
-    # customizations that apply to both training and inference workloads.
-    - name: skyhook-customizations
+    - name: kgateway-crds
       type: Helm
-      manifestFiles:
-        - components/skyhook-customizations/manifests/h100-eks-ubuntu-training.yaml
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway-crds/values.yaml
+
+    - name: kgateway
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway/values.yaml
       dependencyRefs:
-        - skyhook-operator
+        - kgateway-crds
+        - cert-manager

--- a/pkg/recipe/data/overlays/h100-eks-inference.yaml
+++ b/pkg/recipe/data/overlays/h100-eks-inference.yaml
@@ -15,34 +15,19 @@
 kind: recipeMetadata
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
-  name: h100-inference
+  name: h100-eks-inference
 
 spec:
-  base: inference
+  # Inherits from eks-inference recipe (EKS + inference settings)
+  base: eks-inference
 
   criteria:
+    service: eks
     accelerator: h100
-    os: ubuntu
     intent: inference
 
-  # Specific constraints for H100 inference workloads
+  # Specific constraints for H100 on EKS inference workloads
   # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
   constraints:
     - name: K8s.server.version
-      value: ">= 1.31"
-    - name: OS.release.ID
-      value: ubuntu
-    - name: OS.release.VERSION_ID
-      value: ">= 24.04"
-    - name: OS.sysctl./proc/sys/kernel/osrelease
-      value: ">= 6.8"
-
-  componentRefs:
-
-    - name: network-operator
-      type: Helm
-      source: https://helm.ngc.nvidia.com/nvidia
-      version: v25.4.0
-      valuesFile: components/network-operator/values.yaml
-      dependencyRefs:
-        - cert-manager
+      value: ">= 1.32.4"

--- a/pkg/recipe/data/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/pkg/recipe/data/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -15,21 +15,42 @@
 kind: recipeMetadata
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
-  name: inference
+  name: h100-eks-ubuntu-inference-dynamo
 
 spec:
-  # Inherits from base (implicit when spec.base is empty)
-  # This recipe adds inference components for AI workloads.
-  # Satisfies CNCF AI Conformance requirements:
-  #   - Gang scheduling (kai-scheduler)
-  #   - Advanced Ingress for AI/ML Inference (kgateway with inference extension)
-  #   - AI inference serving (dynamo-platform)
-  #   - AI service metrics (dynamo metrics + kube-prometheus-stack)
+  # Inherits from h100-eks-ubuntu-inference (H100 + Ubuntu inference settings)
+  # Adds Dynamo inference platform components.
+  base: h100-eks-ubuntu-inference
 
   criteria:
+    service: eks
+    accelerator: h100
+    os: ubuntu
     intent: inference
+    platform: dynamo
+
+  # DRA requires Kubernetes 1.34+ (GA)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.34"
 
   componentRefs:
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia
+      version: "25.8.1"
+      valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+      dependencyRefs:
+        - gpu-operator
+      overrides:
+        gpuResourcesEnabledOverride: true
+        # EKS has no control-plane nodes — remove the default nodeAffinity
+        controller:
+          affinity:
+            nodeAffinity: null
+          tolerations:
+            - operator: Exists
+
     - name: kai-scheduler
       type: Helm
       source: oci://ghcr.io/nvidia/kai-scheduler
@@ -37,21 +58,6 @@ spec:
       valuesFile: components/kai-scheduler/values.yaml
       dependencyRefs:
         - gpu-operator
-
-    - name: kgateway-crds
-      type: Helm
-      source: oci://cr.kgateway.dev/kgateway-dev/charts
-      version: v2.0.0
-      valuesFile: components/kgateway-crds/values.yaml
-
-    - name: kgateway
-      type: Helm
-      source: oci://cr.kgateway.dev/kgateway-dev/charts
-      version: v2.0.0
-      valuesFile: components/kgateway/values.yaml
-      dependencyRefs:
-        - kgateway-crds
-        - cert-manager
 
     - name: dynamo-crds
       type: Helm
@@ -68,3 +74,7 @@ spec:
         - dynamo-crds
         - cert-manager
         - kube-prometheus-stack
+      overrides:
+        etcd:
+          persistence:
+            storageClass: gp2

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -346,15 +346,16 @@ func containsString(s, substr string) bool {
 func TestOverlayAddsNewComponent(t *testing.T) {
 	ctx := context.Background()
 
-	// Build recipe for H100 inference workload
-	// h100-ubuntu-inference.yaml adds network-operator which is NOT in base.yaml
-	// Note: The overlay file requires accelerator=h100, os=ubuntu, intent=inference
-	// so we must specify all criteria to match it (asymmetric matching).
+	// Build recipe for H100 EKS inference workload with dynamo platform
+	// h100-eks-ubuntu-inference-dynamo.yaml adds kai-scheduler, dynamo-crds, dynamo-platform
+	// which are NOT in base.yaml
 	builder := NewBuilder()
 	criteria := NewCriteria()
+	criteria.Service = CriteriaServiceEKS
 	criteria.Accelerator = CriteriaAcceleratorH100
 	criteria.OS = CriteriaOSUbuntu
 	criteria.Intent = CriteriaIntentInference
+	criteria.Platform = CriteriaPlatformDynamo
 
 	result, err := builder.BuildFromCriteria(ctx, criteria)
 	if err != nil {
@@ -374,20 +375,20 @@ func TestOverlayAddsNewComponent(t *testing.T) {
 	}
 
 	// Verify overlay-added component exists
-	networkOp := result.GetComponentRef("network-operator")
-	if networkOp == nil {
-		t.Fatalf("network-operator not found (should be added by h100-inference overlay)")
+	dynamoPlatform := result.GetComponentRef("dynamo-platform")
+	if dynamoPlatform == nil {
+		t.Fatalf("dynamo-platform not found (should be added by h100-eks-ubuntu-inference-dynamo overlay)")
 	}
 
-	// Verify network-operator properties
-	if networkOp.Version == "" {
-		t.Error("network-operator has empty version")
+	// Verify dynamo-platform properties
+	if dynamoPlatform.Version == "" {
+		t.Error("dynamo-platform has empty version")
 	}
-	if networkOp.Type != "Helm" {
-		t.Errorf("network-operator type = %q, want Helm", networkOp.Type)
+	if dynamoPlatform.Type != "Helm" {
+		t.Errorf("dynamo-platform type = %q, want Helm", dynamoPlatform.Type)
 	}
-	if len(networkOp.DependencyRefs) == 0 {
-		t.Error("network-operator has no dependencies (should depend on cert-manager)")
+	if len(dynamoPlatform.DependencyRefs) == 0 {
+		t.Error("dynamo-platform has no dependencies (should depend on dynamo-crds, cert-manager, kube-prometheus-stack)")
 	}
 
 	// Build recipe for EKS H100 training workload with kubeflow platform
@@ -418,7 +419,7 @@ func TestOverlayAddsNewComponent(t *testing.T) {
 	t.Logf("Successfully verified overlay can add new components")
 	t.Logf("   Base components: %d", len(baseComponents))
 	t.Logf("   Total components: %d", len(result.ComponentRefs))
-	t.Logf("   network-operator version: %s", networkOp.Version)
+	t.Logf("   dynamo-platform version: %s", dynamoPlatform.Version)
 	t.Logf("   kubeflow-trainer version: %s", kubeflowTrainer.Version)
 }
 
@@ -428,13 +429,14 @@ func TestOverlayMergeDoesNotLoseBaseComponents(t *testing.T) {
 	ctx := context.Background()
 	builder := NewBuilder()
 
-	// Build H100 inference recipe (matches overlay that adds network-operator)
-	// Note: The h100-ubuntu-inference.yaml overlay requires all three criteria
-	// (accelerator=h100, os=ubuntu, intent=inference) to match due to asymmetric matching.
+	// Build H100 EKS inference recipe with dynamo platform
+	// Matches overlay chain that adds kgateway, dynamo-platform, kai-scheduler, etc.
 	criteria := NewCriteria()
+	criteria.Service = CriteriaServiceEKS
 	criteria.Accelerator = CriteriaAcceleratorH100
 	criteria.OS = CriteriaOSUbuntu
 	criteria.Intent = CriteriaIntentInference
+	criteria.Platform = CriteriaPlatformDynamo
 
 	result, err := builder.BuildFromCriteria(ctx, criteria)
 	if err != nil {
@@ -449,10 +451,10 @@ func TestOverlayMergeDoesNotLoseBaseComponents(t *testing.T) {
 		}
 	}
 
-	// Verify network-operator was added
-	networkOp := result.GetComponentRef("network-operator")
-	if networkOp == nil {
-		t.Error("network-operator not found (should be added by overlay)")
+	// Verify dynamo-platform was added by overlay
+	dynamoPlatform := result.GetComponentRef("dynamo-platform")
+	if dynamoPlatform == nil {
+		t.Error("dynamo-platform not found (should be added by overlay)")
 	}
 
 	// Result should have at least 5 components (4 base + 1 added)
@@ -462,8 +464,8 @@ func TestOverlayMergeDoesNotLoseBaseComponents(t *testing.T) {
 
 	t.Logf("Base components preserved when overlay adds new components")
 	t.Logf("   Total components: %d (4 base + additions)", len(result.ComponentRefs))
-	if networkOp != nil {
-		t.Logf("   network-operator added: version %s", networkOp.Version)
+	if dynamoPlatform != nil {
+		t.Logf("   dynamo-platform added: version %s", dynamoPlatform.Version)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Restructure the inference recipe overlay chain to mirror the training hierarchy, eliminating component duplication and establishing proper inheritance
- Delete `inference.yaml` and `h100-ubuntu-inference.yaml` (replaced by EKS-specific chain)
- Create `eks-inference.yaml` with kgateway components (parallel to `eks-training.yaml`)
- Create `h100-eks-inference.yaml` with H100-specific constraints (parallel to `h100-eks-training.yaml`)
- Create `h100-eks-ubuntu-inference.yaml` with skyhook-customizations
- Rework `h100-eks-ubuntu-inference-dynamo.yaml` to inherit from inference chain instead of training; contains dynamo-specific components (kai-scheduler, dynamo-crds, dynamo-platform) and nvidia-dra-driver-gpu with K8s >= 1.34 constraint
- Add `dynamo` as a supported platform type in criteria

### Overlay hierarchy (training vs inference)
```
Training:                                  Inference:
base                                       base
└── eks                                    └── eks
    └── eks-training                           └── eks-inference (NEW)
        └── h100-eks-training                      └── h100-eks-inference (NEW)
            └── h100-eks-ubuntu-training               └── h100-eks-ubuntu-inference (NEW)
                └── h100-eks-ubuntu-training-kubeflow       └── h100-eks-ubuntu-inference-dynamo (REWORK)
```

### h100-eks-ubuntu-inference-dynamo components
- nvidia-dra-driver-gpu (DRA GA, K8s >= 1.34, with EKS affinity override)
- kai-scheduler (gang scheduling)
- dynamo-crds + dynamo-platform (inference serving)

## Test plan
- [x] `go test -race ./pkg/recipe/... ./pkg/bundler/...` — all pass
- [x] Recipe generation produces correct components for `--service eks --intent inference --accelerator h100 --os ubuntu --platform dynamo`
- [x] Training recipes unaffected
- [x] No duplicated components across inference chain
- [x] Each overlay has consistent criteria matching its level in the hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)