### PR TITLE
feat: add nvidia-dra-driver-gpu to base recipe with EKS overrides

### DIFF
--- a/pkg/recipe/data/overlays/base.yaml
+++ b/pkg/recipe/data/overlays/base.yaml
@@ -70,3 +70,11 @@ spec:
       valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
       dependencyRefs:
         - kube-prometheus-stack
+
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia
+      version: "25.8.1"
+      valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+      dependencyRefs:
+        - gpu-operator

--- a/pkg/recipe/data/overlays/eks.yaml
+++ b/pkg/recipe/data/overlays/eks.yaml
@@ -63,3 +63,15 @@ spec:
       type: Helm
       version: v0.5.3
       valuesFile: components/aws-efa/values.yaml
+
+    # EKS has no control-plane nodes — remove the default nodeAffinity
+    # that targets node-role.kubernetes.io/control-plane
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      overrides:
+        gpuResourcesEnabledOverride: true
+        controller:
+          affinity:
+            nodeAffinity: null
+          tolerations:
+            - operator: Exists


### PR DESCRIPTION
## Summary
- Add nvidia-dra-driver-gpu (v25.8.1) as a base component in `base.yaml`, making DRA available to all recipes
- Add EKS-specific overrides in `eks.yaml`:
  - `gpuResourcesEnabledOverride: true`
  - Null out controller `nodeAffinity` (EKS has no control-plane nodes)
  - Add controller tolerations for tainted EKS nodes
  - kubelet-plugin tolerations are handled automatically by `nodeScheduling` in registry.yaml
- Satisfies CNCF AI Conformance requirement: DRA support

## Test plan
- [x] `go test -race ./pkg/recipe/... ./pkg/bundler/...` — all pass
- [x] DRA driver now included in all recipes
- [x] Bundle generation confirms kubelet-plugin tolerations injected via nodeScheduling
- [x] Verified on EKS H100 cluster: both controller and kubelet-plugin pods Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)