### PR TITLE
test: improve unit test coverage to 70%

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -62,7 +62,7 @@ jobs:
           golangci_lint_version: ${{ steps.versions.outputs.golangci_lint }}
           addlicense_version: ${{ steps.versions.outputs.addlicense }}
           coverage_report: 'true'
-          coverage_threshold: '66'
+          coverage_threshold: '70'
 
   integration:
     name: Integration Tests

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -66,6 +66,73 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestNewWithConfig(t *testing.T) {
+	t.Run("nil config uses default", func(t *testing.T) {
+		bundler, err := NewWithConfig(nil)
+		if err != nil {
+			t.Fatalf("NewWithConfig(nil) error = %v", err)
+		}
+		if bundler.Config == nil {
+			t.Fatal("Config should not be nil")
+		}
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		cfg := config.NewConfig(config.WithVersion("v2.0.0"))
+		bundler, err := NewWithConfig(cfg)
+		if err != nil {
+			t.Fatalf("NewWithConfig() error = %v", err)
+		}
+		if bundler.Config.Version() != "v2.0.0" {
+			t.Errorf("expected version v2.0.0, got %s", bundler.Config.Version())
+		}
+	})
+
+	t.Run("equivalent to New(WithConfig())", func(t *testing.T) {
+		cfg := config.NewConfig(config.WithVersion("v3.0.0"))
+		b1, err := NewWithConfig(cfg)
+		if err != nil {
+			t.Fatalf("NewWithConfig() error = %v", err)
+		}
+		b2, err := New(WithConfig(cfg))
+		if err != nil {
+			t.Fatalf("New(WithConfig()) error = %v", err)
+		}
+		if b1.Config.Version() != b2.Config.Version() {
+			t.Errorf("versions differ: NewWithConfig=%s, New(WithConfig)=%s",
+				b1.Config.Version(), b2.Config.Version())
+		}
+	})
+}
+
+func TestWithAllowLists(t *testing.T) {
+	t.Run("nil allowlists", func(t *testing.T) {
+		bundler, err := New(WithAllowLists(nil))
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if bundler.AllowLists != nil {
+			t.Error("AllowLists should be nil")
+		}
+	})
+
+	t.Run("valid allowlists", func(t *testing.T) {
+		al := &recipe.AllowLists{
+			Services: []recipe.CriteriaServiceType{"eks", "gke"},
+		}
+		bundler, err := New(WithAllowLists(al))
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if bundler.AllowLists == nil {
+			t.Fatal("AllowLists should not be nil")
+		}
+		if len(bundler.AllowLists.Services) != 2 {
+			t.Errorf("expected 2 services, got %d", len(bundler.AllowLists.Services))
+		}
+	})
+}
+
 func TestMake_NilInput(t *testing.T) {
 	bundler, err := New()
 	if err != nil {

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -212,6 +212,14 @@ func TestNodeSelectorOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("SystemNodeSelector with nil input", func(t *testing.T) {
+		cfg := NewConfig(WithSystemNodeSelector(nil))
+		got := cfg.SystemNodeSelector()
+		if got != nil {
+			t.Errorf("SystemNodeSelector() = %v, want nil for nil input", got)
+		}
+	})
+
 	t.Run("SystemNodeSelector returns nil for nil config", func(t *testing.T) {
 		cfg := NewConfig()
 		got := cfg.SystemNodeSelector()
@@ -253,6 +261,14 @@ func TestNodeSelectorOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("AcceleratedNodeSelector with nil input", func(t *testing.T) {
+		cfg := NewConfig(WithAcceleratedNodeSelector(nil))
+		got := cfg.AcceleratedNodeSelector()
+		if got != nil {
+			t.Errorf("AcceleratedNodeSelector() = %v, want nil for nil input", got)
+		}
+	})
+
 	t.Run("AcceleratedNodeSelector returns nil for nil config", func(t *testing.T) {
 		cfg := NewConfig()
 		got := cfg.AcceleratedNodeSelector()
@@ -281,6 +297,14 @@ func TestNodeTolerationOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("SystemNodeTolerations with nil input", func(t *testing.T) {
+		cfg := NewConfig(WithSystemNodeTolerations(nil))
+		got := cfg.SystemNodeTolerations()
+		if got != nil {
+			t.Errorf("SystemNodeTolerations() = %v, want nil for nil input", got)
+		}
+	})
+
 	t.Run("SystemNodeTolerations returns nil for nil config", func(t *testing.T) {
 		cfg := NewConfig()
 		got := cfg.SystemNodeTolerations()
@@ -304,6 +328,14 @@ func TestNodeTolerationOptions(t *testing.T) {
 		}
 		if got[0].Key != "nvidia.com/gpu" {
 			t.Errorf("AcceleratedNodeTolerations()[0].Key = %s, want nvidia.com/gpu", got[0].Key)
+		}
+	})
+
+	t.Run("AcceleratedNodeTolerations with nil input", func(t *testing.T) {
+		cfg := NewConfig(WithAcceleratedNodeTolerations(nil))
+		got := cfg.AcceleratedNodeTolerations()
+		if got != nil {
+			t.Errorf("AcceleratedNodeTolerations() = %v, want nil for nil input", got)
 		}
 	})
 

--- a/pkg/bundler/deployer/argocd/argocd_test.go
+++ b/pkg/bundler/deployer/argocd/argocd_test.go
@@ -492,6 +492,32 @@ func TestApplicationData_NamespaceFromComponentRef(t *testing.T) {
 	}
 }
 
+func TestIsSafePathComponent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid name", "gpu-operator", true},
+		{"valid with dots", "cert-manager.io", true},
+		{"empty string", "", false},
+		{"forward slash", "path/traversal", false},
+		{"backslash", "path\\traversal", false},
+		{"double dot", "..", false},
+		{"contains double dot", "foo..bar", false},
+		{"single dot", ".", true},
+		{"dashes and numbers", "test-123", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSafePathComponent(tt.input); got != tt.want {
+				t.Errorf("isSafePathComponent(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeVersion(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -472,20 +472,69 @@ func TestSortComponentsByDeploymentOrder(t *testing.T) {
 		networkOperator = "network-operator"
 	)
 
-	components := []string{gpuOperator, certManager, networkOperator}
-	deploymentOrder := []string{certManager, gpuOperator, networkOperator}
+	t.Run("all in order map", func(t *testing.T) {
+		components := []string{gpuOperator, certManager, networkOperator}
+		deploymentOrder := []string{certManager, gpuOperator, networkOperator}
 
-	sorted := SortComponentsByDeploymentOrder(components, deploymentOrder)
+		sorted := SortComponentsByDeploymentOrder(components, deploymentOrder)
 
-	if sorted[0] != certManager {
-		t.Errorf("expected first component to be %s, got %s", certManager, sorted[0])
-	}
-	if sorted[1] != gpuOperator {
-		t.Errorf("expected second component to be %s, got %s", gpuOperator, sorted[1])
-	}
-	if sorted[2] != networkOperator {
-		t.Errorf("expected third component to be %s, got %s", networkOperator, sorted[2])
-	}
+		if sorted[0] != certManager {
+			t.Errorf("expected first %s, got %s", certManager, sorted[0])
+		}
+		if sorted[1] != gpuOperator {
+			t.Errorf("expected second %s, got %s", gpuOperator, sorted[1])
+		}
+		if sorted[2] != networkOperator {
+			t.Errorf("expected third %s, got %s", networkOperator, sorted[2])
+		}
+	})
+
+	t.Run("only one in order map", func(t *testing.T) {
+		// "alpha" is not in the order map, gpuOperator is.
+		// gpuOperator should come first (okI branch).
+		components := []string{"alpha", gpuOperator}
+		deploymentOrder := []string{gpuOperator}
+
+		sorted := SortComponentsByDeploymentOrder(components, deploymentOrder)
+		if sorted[0] != gpuOperator {
+			t.Errorf("expected ordered component first, got %s", sorted[0])
+		}
+	})
+
+	t.Run("only j in order map", func(t *testing.T) {
+		// "zebra" is not in the order map, certManager is.
+		// certManager should sort after "zebra" would normally, but since
+		// certManager is in the map and zebra is not, certManager gets priority=false (okJ branch).
+		components := []string{certManager, "zebra"}
+		deploymentOrder := []string{certManager}
+
+		sorted := SortComponentsByDeploymentOrder(components, deploymentOrder)
+		if sorted[0] != certManager {
+			t.Errorf("expected ordered component first, got %s", sorted[0])
+		}
+	})
+
+	t.Run("neither in order map", func(t *testing.T) {
+		// Both unknown — should fall back to alphabetical.
+		components := []string{"zebra", "alpha"}
+		deploymentOrder := []string{gpuOperator}
+
+		sorted := SortComponentsByDeploymentOrder(components, deploymentOrder)
+		if sorted[0] != "alpha" {
+			t.Errorf("expected alphabetical first, got %s", sorted[0])
+		}
+		if sorted[1] != "zebra" {
+			t.Errorf("expected alphabetical second, got %s", sorted[1])
+		}
+	})
+
+	t.Run("empty deployment order", func(t *testing.T) {
+		components := []string{"b", "a"}
+		sorted := SortComponentsByDeploymentOrder(components, nil)
+		if sorted[0] != "a" {
+			t.Errorf("expected alphabetical with empty order, got %s", sorted[0])
+		}
+	})
 }
 
 func TestIsSafePathComponent(t *testing.T) {
@@ -798,4 +847,75 @@ func TestGenerate_NoTimestampInOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to walk directory: %v", err)
 	}
+}
+
+func TestHelmFuncMap(t *testing.T) {
+	funcs := helmFuncMap()
+
+	t.Run("toYaml", func(t *testing.T) {
+		fn := funcs["toYaml"].(func(any) string)
+
+		// map input
+		got := fn(map[string]string{"key": "value"})
+		if !strings.Contains(got, "key: value") {
+			t.Errorf("toYaml(map) = %q, want to contain 'key: value'", got)
+		}
+
+		// string input
+		got = fn("hello")
+		if got != "hello" {
+			t.Errorf("toYaml(string) = %q, want 'hello'", got)
+		}
+
+		// nil input
+		got = fn(nil)
+		if got != "null" {
+			t.Errorf("toYaml(nil) = %q, want 'null'", got)
+		}
+	})
+
+	t.Run("nindent", func(t *testing.T) {
+		fn := funcs["nindent"].(func(int, string) string)
+		got := fn(4, "line1\nline2")
+		if !strings.Contains(got, "    line1") {
+			t.Errorf("nindent should indent line1: got %q", got)
+		}
+		if !strings.Contains(got, "    line2") {
+			t.Errorf("nindent should indent line2: got %q", got)
+		}
+		if got[0] != '\n' {
+			t.Error("nindent should start with newline")
+		}
+	})
+
+	t.Run("toString", func(t *testing.T) {
+		fn := funcs["toString"].(func(any) string)
+		if got := fn(42); got != "42" {
+			t.Errorf("toString(42) = %q, want '42'", got)
+		}
+		if got := fn(nil); got != "<nil>" {
+			t.Errorf("toString(nil) = %q, want '<nil>'", got)
+		}
+	})
+
+	t.Run("default", func(t *testing.T) {
+		fn := funcs["default"].(func(any, any) any)
+
+		// nil value returns default
+		if got := fn("fallback", nil); got != "fallback" {
+			t.Errorf("default(fallback, nil) = %v, want 'fallback'", got)
+		}
+		// empty string returns default
+		if got := fn("fallback", ""); got != "fallback" {
+			t.Errorf("default(fallback, empty) = %v, want 'fallback'", got)
+		}
+		// non-empty returns value
+		if got := fn("fallback", "actual"); got != "actual" {
+			t.Errorf("default(fallback, actual) = %v, want 'actual'", got)
+		}
+		// non-string non-nil returns value
+		if got := fn("fallback", 42); got != 42 {
+			t.Errorf("default(fallback, 42) = %v, want 42", got)
+		}
+	})
 }

--- a/pkg/bundler/result/result_test.go
+++ b/pkg/bundler/result/result_test.go
@@ -323,6 +323,31 @@ func TestResult_LargeFileSize(t *testing.T) {
 	}
 }
 
+// TestResult_SetOCIMetadata tests setting OCI metadata.
+func TestResult_SetOCIMetadata(t *testing.T) {
+	result := New(types.BundleType("gpu-operator"))
+
+	result.SetOCIMetadata("sha256:abc123", "ghcr.io/nvidia/bundle:v1.0.0", true)
+
+	if result.OCIDigest != "sha256:abc123" {
+		t.Errorf("OCIDigest = %q, want sha256:abc123", result.OCIDigest)
+	}
+	if result.OCIReference != "ghcr.io/nvidia/bundle:v1.0.0" {
+		t.Errorf("OCIReference = %q, want ghcr.io/nvidia/bundle:v1.0.0", result.OCIReference)
+	}
+	if !result.Pushed {
+		t.Error("Pushed = false, want true")
+	}
+
+	// Test with pushed=false
+	result2 := New(types.BundleType("network-operator"))
+	result2.SetOCIMetadata("sha256:def456", "localhost:5000/test:latest", false)
+
+	if result2.Pushed {
+		t.Error("Pushed = true, want false")
+	}
+}
+
 // TestResult_EmptyState tests result in empty state
 func TestResult_EmptyState(t *testing.T) {
 	result := New(types.BundleType("gpu-operator"))

--- a/pkg/collector/k8s/policy_test.go
+++ b/pkg/collector/k8s/policy_test.go
@@ -176,6 +176,135 @@ func TestPolicyCollector_ParsesClusterPolicySpec(t *testing.T) {
 	assert.Equal(t, "550.54.15", driver["version"])
 }
 
+func TestFlattenSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]any
+		prefix   string
+		expected map[string]string
+	}{
+		{
+			name: "simple string",
+			data: map[string]any{
+				"version": "550.54.15",
+			},
+			expected: map[string]string{
+				"version": "550.54.15",
+			},
+		},
+		{
+			name: "nested map",
+			data: map[string]any{
+				"driver": map[string]any{
+					"version": "580.82.07",
+					"enabled": true,
+				},
+			},
+			expected: map[string]string{
+				"driver.version": "580.82.07",
+				"driver.enabled": "true",
+			},
+		},
+		{
+			name: "bool value",
+			data: map[string]any{
+				"enabled": true,
+			},
+			expected: map[string]string{
+				"enabled": "true",
+			},
+		},
+		{
+			name: "float64 value",
+			data: map[string]any{
+				"ratio": float64(3.14),
+			},
+			expected: map[string]string{
+				"ratio": "3.14",
+			},
+		},
+		{
+			name: "int value",
+			data: map[string]any{
+				"count": 42,
+			},
+			expected: map[string]string{
+				"count": "42",
+			},
+		},
+		{
+			name: "array value",
+			data: map[string]any{
+				"items": []any{"a", "b", "c"},
+			},
+			expected: map[string]string{
+				"items": `["a","b","c"]`,
+			},
+		},
+		{
+			name: "empty array ignored",
+			data: map[string]any{
+				"items": []any{},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:   "with prefix",
+			prefix: "spec",
+			data: map[string]any{
+				"version": "1.0",
+			},
+			expected: map[string]string{
+				"spec.version": "1.0",
+			},
+		},
+		{
+			name: "deep nesting",
+			data: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": "deep",
+					},
+				},
+			},
+			expected: map[string]string{
+				"a.b.c": "deep",
+			},
+		},
+		{
+			name: "default type",
+			data: map[string]any{
+				"unknown": int64(99),
+			},
+			expected: map[string]string{
+				"unknown": "99",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := make(map[string]measurement.Reading)
+			flattenSpec(tt.data, tt.prefix, result)
+
+			if len(result) != len(tt.expected) {
+				t.Fatalf("got %d readings, want %d", len(result), len(tt.expected))
+			}
+
+			for key, wantVal := range tt.expected {
+				got, exists := result[key]
+				if !exists {
+					t.Errorf("missing key %q", key)
+					continue
+				}
+				if got.Any() != wantVal {
+					t.Errorf("key %q = %v, want %q", key, got.Any(), wantVal)
+				}
+			}
+		})
+	}
+}
+
 func TestPolicyCollector_SpecSerialization(t *testing.T) {
 	// Test that spec can be properly serialized to JSON
 	policy := createMockClusterPolicy("test-policy", "")

--- a/pkg/component/overrides_test.go
+++ b/pkg/component/overrides_test.go
@@ -20,6 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const testTolKeyDedicated = "dedicated"
+
 // TestStruct is a test struct with various field types.
 type TestStruct struct {
 	// Simple fields
@@ -573,7 +575,7 @@ func TestApplyTolerationsOverrides(t *testing.T) {
 			values: make(map[string]any),
 			tolerations: []corev1.Toleration{
 				{
-					Key:      "dedicated",
+					Key:      testTolKeyDedicated,
 					Value:    "system-workload",
 					Operator: corev1.TolerationOpEqual,
 					Effect:   corev1.TaintEffectNoSchedule,
@@ -592,7 +594,7 @@ func TestApplyTolerationsOverrides(t *testing.T) {
 				if !ok {
 					t.Fatal("toleration entry wrong type")
 				}
-				if tol["key"] != "dedicated" {
+				if tol["key"] != testTolKeyDedicated {
 					t.Errorf("key = %v, want dedicated", tol["key"])
 				}
 				if tol["value"] != "system-workload" {
@@ -663,7 +665,7 @@ func TestTolerationsToPodSpec(t *testing.T) {
 			name: "converts full toleration",
 			tolerations: []corev1.Toleration{
 				{
-					Key:      "dedicated",
+					Key:      testTolKeyDedicated,
 					Operator: corev1.TolerationOpEqual,
 					Value:    "gpu",
 					Effect:   corev1.TaintEffectNoSchedule,
@@ -674,7 +676,7 @@ func TestTolerationsToPodSpec(t *testing.T) {
 					t.Fatalf("expected 1 result, got %d", len(result))
 				}
 				tol := result[0]
-				if tol["key"] != "dedicated" {
+				if tol["key"] != testTolKeyDedicated {
 					t.Errorf("key = %v, want dedicated", tol["key"])
 				}
 				if tol["operator"] != "Equal" {
@@ -1067,6 +1069,393 @@ func TestSetFieldValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPathToFieldName(t *testing.T) {
+	tests := []struct {
+		segment string
+		want    string
+	}{
+		// Known acronyms
+		{"gds", "GDS"},
+		{"gpu", "GPU"},
+		{"mig", "MIG"},
+		{"dcgm", "DCGM"},
+		{"cpu", "CPU"},
+		{"api", "API"},
+		{"cdi", "CDI"},
+		{"gdr", "GDR"},
+		{"rdma", "RDMA"},
+		{"sriov", "SRIOV"},
+		{"vfio", "VFIO"},
+		{"vgpu", "VGPU"},
+		{"ofed", "OFED"},
+		{"crds", "CRDs"},
+		{"rbac", "RBAC"},
+		{"tls", "TLS"},
+		{"nfd", "NFD"},
+		{"gfd", "GFD"},
+		// Case-insensitive acronym lookup
+		{"GPU", "GPU"},
+		{"Gds", "GDS"},
+		// Underscore-separated with acronym
+		{"mig_strategy", "MIGStrategy"},
+		{"gpu_version", "GPUVersion"},
+		// Underscore-separated without acronym
+		{"node_selector", "NodeSelector"},
+		// Dash-separated with acronym
+		{"gpu-operator", "GPUOperator"},
+		{"rdma-driver", "RDMADriver"},
+		// Dash-separated without acronym
+		{"network-operator", "NetworkOperator"},
+		// Simple title case
+		{"enabled", "Enabled"},
+		{"version", "Version"},
+		{"driver", "Driver"},
+		{"strategy", "Strategy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.segment, func(t *testing.T) {
+			got := pathToFieldName(tt.segment)
+			if got != tt.want {
+				t.Errorf("pathToFieldName(%q) = %q, want %q", tt.segment, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesPattern(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldName string
+		segment   string
+		want      bool
+	}{
+		// Containment
+		{"field contains segment", "DriverVersion", "driver", true},
+		{"field contains segment mixed case", "GPUOperatorVersion", "operator", true},
+		// Enable prefix
+		{"enable prefix match", "EnableGDS", "gds", true},
+		{"enable prefix no match", "EnableGDS", "mig", false},
+		// Starts with
+		{"field starts with segment", "DriverVersion", "driverversion", true},
+		// Dash-separated
+		{"dash-separated match", "GPUOperator", "gpu-operator", true},
+		{"dash-separated no match", "GPUOperator", "network-operator", false},
+		// Negative cases
+		{"no match at all", "EnableGDS", "version", false},
+		{"empty segment", "DriverVersion", "", true}, // empty string is contained in anything
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesPattern(tt.fieldName, tt.segment)
+			if got != tt.want {
+				t.Errorf("matchesPattern(%q, %q) = %v, want %v", tt.fieldName, tt.segment, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveFlatFieldName(t *testing.T) {
+	tests := []struct {
+		prefix string
+		suffix string
+		want   string
+	}{
+		// Special mappings
+		{"operator", "version", "GPUOperatorVersion"},
+		{"toolkit", "version", "NvidiaContainerToolkitVersion"},
+		{"driver", "repository", "DriverRegistry"},
+		{"driver", "registry", "DriverRegistry"},
+		{"ofed", "version", "OFEDVersion"},
+		{"ofed", "deploy", "DeployOFED"},
+		{"nic", "type", "NicType"},
+		{"containerRuntime", "socket", "ContainerRuntimeSocket"},
+		{"hostDevice", "enabled", "EnableHostDevice"},
+		{"operator", "registry", "OperatorRegistry"},
+		{"kubeRbacProxy", "version", "KubeRbacProxyVersion"},
+		{"agent", "image", "SkyhookAgentImage"},
+		// Tolerations
+		{"tolerations", "key", "TolerationKey"},
+		{"tolerations", "value", "TolerationValue"},
+		// Sandbox / secure boot
+		{"sandboxWorkloads", "enabled", "EnableSecureBoot"},
+		// Open kernel module
+		{"driver", "useOpenKernelModules", "UseOpenKernelModule"},
+		{"driver", "useOpenKernelModule", "UseOpenKernelModule"},
+		// Generic enabled suffix
+		{"gds", "enabled", "EnableGDS"},
+		{"mig", "enabled", "EnableMIG"},
+		// Default concatenation
+		{"driver", "version", "DriverVersion"},
+		{"mig", "strategy", "MIGStrategy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.prefix+"."+tt.suffix, func(t *testing.T) {
+			got := deriveFlatFieldName(tt.prefix, tt.suffix)
+			if got != tt.want {
+				t.Errorf("deriveFlatFieldName(%q, %q) = %q, want %q", tt.prefix, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveMultiSegmentFieldName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{
+			"cpu limit",
+			[]string{"manager", "resources", "cpu", "limit"},
+			"ManagerCPULimit",
+		},
+		{
+			"memory limit",
+			[]string{"manager", "resources", "memory", "limit"},
+			"ManagerMemoryLimit",
+		},
+		{
+			"cpu request",
+			[]string{"manager", "resources", "cpu", "request"},
+			"ManagerCPURequest",
+		},
+		{
+			"memory request",
+			[]string{"manager", "resources", "memory", "request"},
+			"ManagerMemoryRequest",
+		},
+		{
+			"wrong prefix",
+			[]string{"worker", "resources", "cpu", "limit"},
+			"",
+		},
+		{
+			"wrong second segment",
+			[]string{"manager", "config", "cpu", "limit"},
+			"",
+		},
+		{
+			"wrong length - 3 parts",
+			[]string{"manager", "resources", "cpu"},
+			"",
+		},
+		{
+			"wrong length - 5 parts",
+			[]string{"manager", "resources", "cpu", "limit", "extra"},
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveMultiSegmentFieldName(tt.parts)
+			if got != tt.want {
+				t.Errorf("deriveMultiSegmentFieldName(%v) = %q, want %q", tt.parts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetNodeSelectorAtPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		nodeSelector map[string]string
+		verify       func(t *testing.T, values map[string]any)
+	}{
+		{
+			name: "single-segment path",
+			path: "nodeSelector",
+			nodeSelector: map[string]string{
+				"role": "gpu",
+			},
+			verify: func(t *testing.T, values map[string]any) {
+				ns, ok := values["nodeSelector"].(map[string]any)
+				if !ok {
+					t.Fatal("nodeSelector not found")
+				}
+				if ns["role"] != "gpu" {
+					t.Errorf("nodeSelector.role = %v, want gpu", ns["role"])
+				}
+			},
+		},
+		{
+			name: "multi-segment path creates intermediate maps",
+			path: "webhook.nodeSelector",
+			nodeSelector: map[string]string{
+				"zone": "us-east",
+			},
+			verify: func(t *testing.T, values map[string]any) {
+				wh, ok := values["webhook"].(map[string]any)
+				if !ok {
+					t.Fatal("webhook not found")
+				}
+				ns, ok := wh["nodeSelector"].(map[string]any)
+				if !ok {
+					t.Fatal("webhook.nodeSelector not found")
+				}
+				if ns["zone"] != "us-east" {
+					t.Errorf("webhook.nodeSelector.zone = %v, want us-east", ns["zone"])
+				}
+			},
+		},
+		{
+			name: "deep nesting",
+			path: "a.b.c.nodeSelector",
+			nodeSelector: map[string]string{
+				"key": "val",
+			},
+			verify: func(t *testing.T, values map[string]any) {
+				a, ok := values["a"].(map[string]any)
+				if !ok {
+					t.Fatal("a not found")
+				}
+				b, ok := a["b"].(map[string]any)
+				if !ok {
+					t.Fatal("a.b not found")
+				}
+				c, ok := b["c"].(map[string]any)
+				if !ok {
+					t.Fatal("a.b.c not found")
+				}
+				ns, ok := c["nodeSelector"].(map[string]any)
+				if !ok {
+					t.Fatal("a.b.c.nodeSelector not found")
+				}
+				if ns["key"] != "val" {
+					t.Errorf("got %v, want val", ns["key"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := make(map[string]any)
+			setNodeSelectorAtPath(values, tt.nodeSelector, tt.path)
+			tt.verify(t, values)
+		})
+	}
+
+	t.Run("intermediate path is non-map value", func(t *testing.T) {
+		values := map[string]any{
+			"webhook": "not-a-map", // string instead of map
+		}
+		setNodeSelectorAtPath(values, map[string]string{"key": "val"}, "webhook.nodeSelector")
+		wh, ok := values["webhook"].(map[string]any)
+		if !ok {
+			t.Fatal("webhook should have been replaced with a map")
+		}
+		ns, ok := wh["nodeSelector"].(map[string]any)
+		if !ok {
+			t.Fatal("webhook.nodeSelector not found")
+		}
+		if ns["key"] != "val" {
+			t.Errorf("got %v, want val", ns["key"])
+		}
+	})
+}
+
+func TestSetTolerationsAtPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		tolerations []map[string]any
+		verify      func(t *testing.T, values map[string]any)
+	}{
+		{
+			name: "single-segment path",
+			path: "tolerations",
+			tolerations: []map[string]any{
+				{"key": testTolKeyDedicated, "operator": "Equal", "value": "gpu", "effect": "NoSchedule"},
+			},
+			verify: func(t *testing.T, values map[string]any) {
+				tols, ok := values["tolerations"].([]any)
+				if !ok {
+					t.Fatal("tolerations not found or wrong type")
+				}
+				if len(tols) != 1 {
+					t.Fatalf("expected 1 toleration, got %d", len(tols))
+				}
+				tol, ok := tols[0].(map[string]any)
+				if !ok {
+					t.Fatal("toleration entry wrong type")
+				}
+				if tol["key"] != testTolKeyDedicated {
+					t.Errorf("key = %v, want dedicated", tol["key"])
+				}
+			},
+		},
+		{
+			name: "multi-segment path creates intermediate maps",
+			path: "webhook.tolerations",
+			tolerations: []map[string]any{
+				{"operator": "Exists"},
+			},
+			verify: func(t *testing.T, values map[string]any) {
+				wh, ok := values["webhook"].(map[string]any)
+				if !ok {
+					t.Fatal("webhook not found")
+				}
+				tols, ok := wh["tolerations"].([]any)
+				if !ok {
+					t.Fatal("webhook.tolerations not found")
+				}
+				if len(tols) != 1 {
+					t.Fatalf("expected 1 toleration, got %d", len(tols))
+				}
+			},
+		},
+		{
+			name: "multiple tolerations",
+			path: "tolerations",
+			tolerations: []map[string]any{
+				{"key": "key1", "operator": "Equal", "value": "val1"},
+				{"key": "key2", "operator": "Exists"},
+			},
+			verify: func(t *testing.T, values map[string]any) {
+				tols, ok := values["tolerations"].([]any)
+				if !ok {
+					t.Fatal("tolerations not found or wrong type")
+				}
+				if len(tols) != 2 {
+					t.Fatalf("expected 2 tolerations, got %d", len(tols))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := make(map[string]any)
+			setTolerationsAtPath(values, tt.tolerations, tt.path)
+			tt.verify(t, values)
+		})
+	}
+
+	t.Run("intermediate path is non-map value", func(t *testing.T) {
+		values := map[string]any{
+			"webhook": "not-a-map",
+		}
+		tols := []map[string]any{{"operator": "Exists"}}
+		setTolerationsAtPath(values, tols, "webhook.tolerations")
+		wh, ok := values["webhook"].(map[string]any)
+		if !ok {
+			t.Fatal("webhook should have been replaced with a map")
+		}
+		result, ok := wh["tolerations"].([]any)
+		if !ok {
+			t.Fatal("webhook.tolerations not found")
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 toleration, got %d", len(result))
+		}
+	})
 }
 
 func TestNodeSelectorToMatchExpressions(t *testing.T) {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -110,6 +110,36 @@ func TestUnwrap(t *testing.T) {
 	}
 }
 
+func TestNewWithContext(t *testing.T) {
+	ctx := map[string]any{
+		"component": "gpu-collector",
+		"timeout":   "10s",
+	}
+	err := NewWithContext(ErrCodeTimeout, "operation timed out", ctx)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+		return
+	}
+	if err.Code != ErrCodeTimeout {
+		t.Errorf("expected code %s, got %s", ErrCodeTimeout, err.Code)
+	}
+	if err.Message != "operation timed out" {
+		t.Errorf("expected message 'operation timed out', got %s", err.Message)
+	}
+	if err.Context == nil {
+		t.Fatal("expected context to be set")
+	}
+	if err.Context["component"] != "gpu-collector" {
+		t.Errorf("expected component to be gpu-collector, got %v", err.Context["component"])
+	}
+	if err.Context["timeout"] != "10s" {
+		t.Errorf("expected timeout to be 10s, got %v", err.Context["timeout"])
+	}
+	if err.Cause != nil {
+		t.Errorf("expected nil cause, got %v", err.Cause)
+	}
+}
+
 func TestErrorCodes(t *testing.T) {
 	codes := []ErrorCode{
 		ErrCodeNotFound,

--- a/pkg/logging/cli_test.go
+++ b/pkg/logging/cli_test.go
@@ -177,6 +177,56 @@ func TestCLIHandler_IncludesAttributes(t *testing.T) {
 	}
 }
 
+func TestGetLogPrefix(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(LogPrefixEnvVar, "")
+		if got := getLogPrefix(); got != "cli" {
+			t.Errorf("getLogPrefix() = %q, want cli", got)
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Setenv(LogPrefixEnvVar, "test-prefix")
+		if got := getLogPrefix(); got != "test-prefix" {
+			t.Errorf("getLogPrefix() = %q, want test-prefix", got)
+		}
+	})
+}
+
+func TestCLIHandler_WithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewCLIHandler(&buf, slog.LevelInfo)
+
+	// WithAttrs should return the same handler (no-op implementation)
+	result := handler.WithAttrs([]slog.Attr{slog.String("key", "value")})
+	if result != handler {
+		t.Error("WithAttrs should return the same handler")
+	}
+
+	// nil attrs
+	result = handler.WithAttrs(nil)
+	if result != handler {
+		t.Error("WithAttrs(nil) should return the same handler")
+	}
+}
+
+func TestCLIHandler_WithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewCLIHandler(&buf, slog.LevelInfo)
+
+	// WithGroup should return the same handler (no-op implementation)
+	result := handler.WithGroup("test-group")
+	if result != handler {
+		t.Error("WithGroup should return the same handler")
+	}
+
+	// empty group
+	result = handler.WithGroup("")
+	if result != handler {
+		t.Error("WithGroup(\"\") should return the same handler")
+	}
+}
+
 func TestSetDefaultCLILogger(t *testing.T) {
 	// Save original default logger
 	originalLogger := slog.Default()

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -113,6 +113,28 @@ func TestParseLogLevel(t *testing.T) {
 	}
 }
 
+func TestNewLogLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		module  string
+		version string
+		level   string
+	}{
+		{"debug level", "test", "v1.0.0", "debug"},
+		{"info level", "test", "v1.0.0", "info"},
+		{"error level", "test", "v1.0.0", "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewLogLogger(tt.module, tt.version, tt.level)
+			if logger == nil {
+				t.Fatal("NewLogLogger returned nil")
+			}
+		})
+	}
+}
+
 func TestNewStructuredLogger(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/measurement/types_test.go
+++ b/pkg/measurement/types_test.go
@@ -1166,3 +1166,75 @@ func TestScalar_MarshalYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestSubtype_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantData map[string]any
+		wantErr  bool
+	}{
+		{
+			name:     "string values",
+			input:    `{"subtype":"server","data":{"version":"v1.32.0"}}`,
+			wantName: "server",
+			wantData: map[string]any{"version": "v1.32.0"},
+		},
+		{
+			name:     "numeric values",
+			input:    `{"subtype":"gpu","data":{"count":4}}`,
+			wantName: "gpu",
+			wantData: map[string]any{"count": float64(4)},
+		},
+		{
+			name:     "boolean values",
+			input:    `{"subtype":"feature","data":{"enabled":true}}`,
+			wantName: "feature",
+			wantData: map[string]any{"enabled": true},
+		},
+		{
+			name:     "with context",
+			input:    `{"subtype":"node","data":{"hostname":"node-1"},"context":{"zone":"us-east"}}`,
+			wantName: "node",
+			wantData: map[string]any{"hostname": "node-1"},
+		},
+		{
+			name:    "invalid json",
+			input:   `{invalid`,
+			wantErr: true,
+		},
+		{
+			name:     "empty data",
+			input:    `{"subtype":"empty","data":{}}`,
+			wantName: "empty",
+			wantData: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var st Subtype
+			err := json.Unmarshal([]byte(tt.input), &st)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if st.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", st.Name, tt.wantName)
+			}
+			for k, wantV := range tt.wantData {
+				gotReading, ok := st.Data[k]
+				if !ok {
+					t.Errorf("missing key %q in data", k)
+					continue
+				}
+				if gotReading.Any() != wantV {
+					t.Errorf("Data[%q] = %v, want %v", k, gotReading.Any(), wantV)
+				}
+			}
+		})
+	}
+}

--- a/pkg/recipe/adapter_test.go
+++ b/pkg/recipe/adapter_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 )
 
+const testVersionV2 = "v2.0"
+
 func TestMergeValues(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -457,4 +459,132 @@ func TestGetValuesForComponent_BuilderIntegration(t *testing.T) {
 	if len(ref.Overrides) > 0 {
 		t.Logf("   Recipe has %d inline override keys", len(ref.Overrides))
 	}
+}
+
+func TestGetManifestContent(t *testing.T) {
+	t.Run("existing manifest", func(t *testing.T) {
+		content, err := GetManifestContent("components/gpu-operator/manifests/dcgm-exporter.yaml")
+		if err != nil {
+			t.Fatalf("GetManifestContent() error = %v", err)
+		}
+		if len(content) == 0 {
+			t.Error("expected non-empty content")
+		}
+	})
+
+	t.Run("missing manifest", func(t *testing.T) {
+		_, err := GetManifestContent("components/nonexistent/manifests/missing.yaml")
+		if err == nil {
+			t.Error("expected error for missing manifest")
+		}
+	})
+}
+
+func TestMustGetComponentRegistry(t *testing.T) {
+	reg := MustGetComponentRegistry()
+	if reg == nil {
+		t.Fatal("MustGetComponentRegistry() returned nil")
+	}
+	if len(reg.Components) == 0 {
+		t.Error("expected non-empty component registry")
+	}
+}
+
+func TestRecipe_Accessors(t *testing.T) {
+	t.Run("GetComponentRef always nil", func(t *testing.T) {
+		r := &Recipe{}
+		if got := r.GetComponentRef("anything"); got != nil {
+			t.Errorf("Recipe.GetComponentRef() = %v, want nil", got)
+		}
+	})
+
+	t.Run("GetValuesForComponent returns empty map", func(t *testing.T) {
+		r := &Recipe{}
+		got, err := r.GetValuesForComponent("anything")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+
+	t.Run("GetVersion with nil metadata", func(t *testing.T) {
+		r := &Recipe{}
+		if got := r.GetVersion(); got != "" {
+			t.Errorf("Recipe.GetVersion() = %q, want empty", got)
+		}
+	})
+
+	t.Run("GetVersion with metadata", func(t *testing.T) {
+		r := &Recipe{}
+		r.Metadata = map[string]string{"recipe-version": "v1.0"}
+		if got := r.GetVersion(); got != "v1.0" {
+			t.Errorf("Recipe.GetVersion() = %q, want v1.0", got)
+		}
+	})
+
+	t.Run("GetCriteria always nil", func(t *testing.T) {
+		r := &Recipe{}
+		if got := r.GetCriteria(); got != nil {
+			t.Errorf("Recipe.GetCriteria() = %v, want nil", got)
+		}
+	})
+}
+
+func TestRecipeResult_Accessors(t *testing.T) {
+	t.Run("GetVersion", func(t *testing.T) {
+		rr := &RecipeResult{}
+		rr.Metadata.Version = testVersionV2
+		if got := rr.GetVersion(); got != testVersionV2 {
+			t.Errorf("RecipeResult.GetVersion() = %q, want v2.0", got)
+		}
+	})
+
+	t.Run("GetCriteria", func(t *testing.T) {
+		c := &Criteria{Service: "eks"}
+		rr := &RecipeResult{Criteria: c}
+		if got := rr.GetCriteria(); got != c {
+			t.Errorf("RecipeResult.GetCriteria() != expected criteria")
+		}
+	})
+
+	t.Run("GetComponentRef found", func(t *testing.T) {
+		rr := &RecipeResult{
+			ComponentRefs: []ComponentRef{
+				{Name: "gpu-operator", Version: "v1.0"},
+				{Name: "network-operator", Version: testVersionV2},
+			},
+		}
+		got := rr.GetComponentRef("network-operator")
+		if got == nil {
+			t.Fatal("expected non-nil component ref")
+		}
+		if got.Version != testVersionV2 {
+			t.Errorf("Version = %q, want v2.0", got.Version)
+		}
+	})
+
+	t.Run("GetComponentRef not found", func(t *testing.T) {
+		rr := &RecipeResult{ComponentRefs: []ComponentRef{{Name: "gpu-operator"}}}
+		if got := rr.GetComponentRef("missing"); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+}
+
+func TestHasComponentRefs(t *testing.T) {
+	t.Run("RecipeResult returns true", func(t *testing.T) {
+		rr := &RecipeResult{}
+		if !HasComponentRefs(rr) {
+			t.Error("expected true for RecipeResult")
+		}
+	})
+
+	t.Run("Recipe returns false", func(t *testing.T) {
+		r := &Recipe{}
+		if HasComponentRefs(r) {
+			t.Error("expected false for Recipe")
+		}
+	})
 }

--- a/pkg/recipe/allowlist_test.go
+++ b/pkg/recipe/allowlist_test.go
@@ -235,6 +235,71 @@ func TestAllowLists_IsEmpty(t *testing.T) {
 	}
 }
 
+func TestAllowLists_StringMethods(t *testing.T) {
+	al := &AllowLists{
+		Accelerators: []CriteriaAcceleratorType{CriteriaAcceleratorH100, CriteriaAcceleratorL40},
+		Services:     []CriteriaServiceType{CriteriaServiceEKS, CriteriaServiceGKE},
+		Intents:      []CriteriaIntentType{CriteriaIntentTraining},
+		OSTypes:      []CriteriaOSType{CriteriaOSUbuntu},
+	}
+
+	t.Run("AcceleratorStrings", func(t *testing.T) {
+		got := al.AcceleratorStrings()
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("AcceleratorStrings nil", func(t *testing.T) {
+		var nilAL *AllowLists
+		if got := nilAL.AcceleratorStrings(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("ServiceStrings", func(t *testing.T) {
+		got := al.ServiceStrings()
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("ServiceStrings nil", func(t *testing.T) {
+		var nilAL *AllowLists
+		if got := nilAL.ServiceStrings(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("IntentStrings", func(t *testing.T) {
+		got := al.IntentStrings()
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+	})
+
+	t.Run("IntentStrings nil", func(t *testing.T) {
+		var nilAL *AllowLists
+		if got := nilAL.IntentStrings(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("OSTypeStrings", func(t *testing.T) {
+		got := al.OSTypeStrings()
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+	})
+
+	t.Run("OSTypeStrings nil", func(t *testing.T) {
+		var nilAL *AllowLists
+		if got := nilAL.OSTypeStrings(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+}
+
 func TestParseAllowListsFromEnv(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/recipe/builder_test.go
+++ b/pkg/recipe/builder_test.go
@@ -239,6 +239,43 @@ func TestBuilder_BuildFromCriteriaWithEvaluator(t *testing.T) {
 	}
 }
 
+// TestWithAllowLists tests the WithAllowLists builder option.
+func TestWithAllowLists(t *testing.T) {
+	t.Run("nil allowlists", func(t *testing.T) {
+		b := NewBuilder(WithAllowLists(nil))
+		if b.AllowLists != nil {
+			t.Error("expected nil AllowLists")
+		}
+	})
+
+	t.Run("valid allowlists", func(t *testing.T) {
+		al := &AllowLists{
+			Services: []CriteriaServiceType{CriteriaServiceEKS},
+		}
+		b := NewBuilder(WithAllowLists(al))
+		if b.AllowLists == nil {
+			t.Fatal("expected non-nil AllowLists")
+		}
+		if len(b.AllowLists.Services) != 1 {
+			t.Errorf("Services length = %d, want 1", len(b.AllowLists.Services))
+		}
+	})
+}
+
+// TestGetEmbeddedFS tests that the embedded filesystem is accessible.
+func TestGetEmbeddedFS(t *testing.T) {
+	fs := GetEmbeddedFS()
+
+	// Should be able to read the registry file
+	data, err := fs.ReadFile("data/registry.yaml")
+	if err != nil {
+		t.Fatalf("failed to read registry.yaml from embedded FS: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("registry.yaml is empty")
+	}
+}
+
 // TestConstraintWarning tests the ConstraintWarning struct.
 func TestConstraintWarning(t *testing.T) {
 	warning := ConstraintWarning{

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -1306,6 +1306,101 @@ func TestParseCriteriaFromBody_NilBody(t *testing.T) {
 	}
 }
 
+func TestCriteria_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		criteria Criteria
+		want     string
+	}{
+		{
+			name:     "all defaults (any)",
+			criteria: Criteria{Service: CriteriaServiceAny, Accelerator: CriteriaAcceleratorAny, Intent: CriteriaIntentAny, OS: CriteriaOSAny, Platform: CriteriaPlatformAny},
+			want:     "criteria(any)",
+		},
+		{
+			name:     "single field set",
+			criteria: Criteria{Service: "eks", Accelerator: CriteriaAcceleratorAny, Intent: CriteriaIntentAny, OS: CriteriaOSAny, Platform: CriteriaPlatformAny},
+			want:     "criteria(service=eks)",
+		},
+		{
+			name:     "multiple fields set",
+			criteria: Criteria{Service: "eks", Accelerator: "h100", Intent: "training", OS: CriteriaOSAny, Platform: CriteriaPlatformAny},
+			want:     "criteria(service=eks, accelerator=h100, intent=training)",
+		},
+		{
+			name:     "all fields set",
+			criteria: Criteria{Service: "gke", Accelerator: "l40", Intent: "inference", OS: "ubuntu", Platform: "kubeflow", Nodes: 8},
+			want:     "criteria(service=gke, accelerator=l40, intent=inference, os=ubuntu, platform=kubeflow, nodes=8)",
+		},
+		{
+			name:     "only nodes set",
+			criteria: Criteria{Service: CriteriaServiceAny, Accelerator: CriteriaAcceleratorAny, Intent: CriteriaIntentAny, OS: CriteriaOSAny, Platform: CriteriaPlatformAny, Nodes: 4},
+			want:     "criteria(nodes=4)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.criteria.String()
+			if got != tt.want {
+				t.Errorf("Criteria.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithCriteriaOS(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantOS  CriteriaOSType
+		wantErr bool
+	}{
+		{"valid ubuntu", "ubuntu", "ubuntu", false},
+		{"valid any", "any", CriteriaOSAny, false},
+		{"invalid os", "windows", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criteria, err := BuildCriteria(WithCriteriaOS(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithCriteriaOS(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && criteria.OS != tt.wantOS {
+				t.Errorf("OS = %v, want %v", criteria.OS, tt.wantOS)
+			}
+		})
+	}
+}
+
+func TestWithCriteriaNodes(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodes     int
+		wantNodes int
+		wantErr   bool
+	}{
+		{"zero nodes", 0, 0, false},
+		{"positive nodes", 8, 8, false},
+		{"negative nodes", -1, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criteria, err := BuildCriteria(WithCriteriaNodes(tt.nodes))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && criteria.Nodes != tt.wantNodes {
+				t.Errorf("Nodes = %d, want %d", criteria.Nodes, tt.wantNodes)
+			}
+		})
+	}
+}
+
 // writeTestFile is a helper to create test files.
 func writeTestFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"testing"
+)
+
+const (
+	testRecipeBase = "base"
+	testOverlayEKS = "eks"
+)
+
+func TestMetadataStore_GetValuesFile(t *testing.T) {
+	store := &MetadataStore{
+		ValuesFiles: map[string][]byte{
+			"components/gpu-operator/values.yaml": []byte("driver:\n  enabled: true"),
+		},
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		wantErr  bool
+	}{
+		{"existing file", "components/gpu-operator/values.yaml", false},
+		{"missing file", "components/missing/values.yaml", true},
+		{"empty filename", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := store.GetValuesFile(tt.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetValuesFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(content) == 0 {
+				t.Error("expected non-empty content")
+			}
+		})
+	}
+}
+
+func TestMetadataStore_GetRecipeByName(t *testing.T) {
+	baseMeta := &RecipeMetadata{}
+	baseMeta.Metadata.Name = testRecipeBase
+
+	overlayMeta := &RecipeMetadata{}
+	overlayMeta.Metadata.Name = "h100-eks"
+
+	store := &MetadataStore{
+		Base: baseMeta,
+		Overlays: map[string]*RecipeMetadata{
+			"h100-eks": overlayMeta,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantFound bool
+	}{
+		{"empty returns base", "", testRecipeBase, true},
+		{"base returns base", testRecipeBase, testRecipeBase, true},
+		{"existing overlay", "h100-eks", "h100-eks", true},
+		{"missing overlay", "nonexistent", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, found := store.GetRecipeByName(tt.input)
+			if found != tt.wantFound {
+				t.Errorf("found = %v, want %v", found, tt.wantFound)
+				return
+			}
+			if found && meta.Metadata.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", meta.Metadata.Name, tt.wantName)
+			}
+		})
+	}
+
+	// Test with nil base
+	t.Run("nil base", func(t *testing.T) {
+		nilStore := &MetadataStore{Overlays: map[string]*RecipeMetadata{}}
+		meta, found := nilStore.GetRecipeByName("")
+		if found {
+			t.Error("expected found=false for nil base")
+		}
+		if meta != nil {
+			t.Error("expected nil meta for nil base")
+		}
+	})
+}
+
+func TestMetadataStore_ResolveInheritanceChain(t *testing.T) {
+	baseMeta := &RecipeMetadata{}
+	baseMeta.Metadata.Name = testRecipeBase
+
+	eksMeta := &RecipeMetadata{}
+	eksMeta.Metadata.Name = testOverlayEKS
+
+	eksTraining := &RecipeMetadata{}
+	eksTraining.Metadata.Name = "eks-training"
+	eksTraining.Spec.Base = testOverlayEKS
+
+	t.Run("single overlay", func(t *testing.T) {
+		store := &MetadataStore{
+			Base: baseMeta,
+			Overlays: map[string]*RecipeMetadata{
+				testOverlayEKS: eksMeta,
+			},
+		}
+		chain, err := store.resolveInheritanceChain(testOverlayEKS)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chain) != 2 {
+			t.Fatalf("chain length = %d, want 2", len(chain))
+		}
+	})
+
+	t.Run("two-level chain", func(t *testing.T) {
+		store := &MetadataStore{
+			Base: baseMeta,
+			Overlays: map[string]*RecipeMetadata{
+				testOverlayEKS: eksMeta,
+				"eks-training": eksTraining,
+			},
+		}
+		chain, err := store.resolveInheritanceChain("eks-training")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chain) != 3 {
+			t.Fatalf("chain length = %d, want 3", len(chain))
+		}
+	})
+
+	t.Run("missing recipe", func(t *testing.T) {
+		store := &MetadataStore{
+			Base:     baseMeta,
+			Overlays: map[string]*RecipeMetadata{},
+		}
+		_, err := store.resolveInheritanceChain("nonexistent")
+		if err == nil {
+			t.Error("expected error for missing recipe")
+		}
+	})
+
+	t.Run("cycle detection", func(t *testing.T) {
+		cycleA := &RecipeMetadata{}
+		cycleA.Metadata.Name = "a"
+		cycleA.Spec.Base = "b"
+
+		cycleB := &RecipeMetadata{}
+		cycleB.Metadata.Name = "b"
+		cycleB.Spec.Base = "a"
+
+		store := &MetadataStore{
+			Base: baseMeta,
+			Overlays: map[string]*RecipeMetadata{
+				"a": cycleA,
+				"b": cycleB,
+			},
+		}
+		_, err := store.resolveInheritanceChain("a")
+		if err == nil {
+			t.Error("expected error for circular inheritance")
+		}
+	})
+
+	t.Run("nil base in store", func(t *testing.T) {
+		store := &MetadataStore{
+			Overlays: map[string]*RecipeMetadata{
+				testOverlayEKS: eksMeta,
+			},
+		}
+		chain, err := store.resolveInheritanceChain(testOverlayEKS)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chain) != 1 {
+			t.Fatalf("chain length = %d, want 1", len(chain))
+		}
+	})
+}
+
+func TestMetadataStore_FindMatchingOverlays(t *testing.T) {
+	baseMeta := &RecipeMetadata{}
+	baseMeta.Metadata.Name = testRecipeBase
+
+	eksOverlay := &RecipeMetadata{}
+	eksOverlay.Metadata.Name = "eks-overlay"
+	eksOverlay.Spec.Criteria = &Criteria{
+		Service: CriteriaServiceEKS,
+	}
+
+	gkeOverlay := &RecipeMetadata{}
+	gkeOverlay.Metadata.Name = "gke-overlay"
+	gkeOverlay.Spec.Criteria = &Criteria{
+		Service: CriteriaServiceGKE,
+	}
+
+	noCriteriaOverlay := &RecipeMetadata{}
+	noCriteriaOverlay.Metadata.Name = "no-criteria"
+
+	store := &MetadataStore{
+		Base: baseMeta,
+		Overlays: map[string]*RecipeMetadata{
+			"eks-overlay": eksOverlay,
+			"gke-overlay": gkeOverlay,
+			"no-criteria": noCriteriaOverlay,
+		},
+	}
+
+	t.Run("matching criteria", func(t *testing.T) {
+		criteria := &Criteria{Service: CriteriaServiceEKS}
+		matches := store.FindMatchingOverlays(criteria)
+		found := false
+		for _, m := range matches {
+			if m.Metadata.Name == "eks-overlay" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected eks-overlay to match")
+		}
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		criteria := &Criteria{Service: CriteriaServiceAKS}
+		matches := store.FindMatchingOverlays(criteria)
+		if len(matches) != 0 {
+			t.Errorf("expected 0 matches, got %d", len(matches))
+		}
+	})
+
+	t.Run("empty store returns empty", func(t *testing.T) {
+		emptyStore := &MetadataStore{
+			Base:     baseMeta,
+			Overlays: map[string]*RecipeMetadata{},
+		}
+		criteria := &Criteria{Service: CriteriaServiceEKS}
+		matches := emptyStore.FindMatchingOverlays(criteria)
+		if len(matches) != 0 {
+			t.Errorf("expected 0 matches for empty store, got %d", len(matches))
+		}
+	})
+}

--- a/pkg/serializer/writer_test.go
+++ b/pkg/serializer/writer_test.go
@@ -160,6 +160,26 @@ func TestNewWriter_DefaultsToStdout(t *testing.T) {
 	}
 }
 
+func TestNewStdoutWriter(t *testing.T) {
+	tests := []struct {
+		name   string
+		format Format
+	}{
+		{"json format", FormatJSON},
+		{"yaml format", FormatYAML},
+		{"unknown format defaults to JSON", Format("unknown")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewStdoutWriter(tt.format)
+			if w == nil {
+				t.Fatal("NewStdoutWriter() returned nil")
+			}
+		})
+	}
+}
+
 func TestWriter_Close(t *testing.T) {
 	// Test closing stdout writer (should be safe)
 	writer := NewStdoutWriter(FormatJSON)

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -82,4 +82,34 @@ func TestParseConfig(t *testing.T) {
 			t.Errorf("expected default port 8080 for invalid env, got %d", cfg.Port)
 		}
 	})
+
+	t.Run("custom shutdown timeout from environment", func(t *testing.T) {
+		t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "60")
+
+		cfg := parseConfig()
+
+		if cfg.ShutdownTimeout != 60*time.Second {
+			t.Errorf("expected shutdown timeout 60s, got %v", cfg.ShutdownTimeout)
+		}
+	})
+
+	t.Run("invalid shutdown timeout uses default", func(t *testing.T) {
+		t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "invalid")
+
+		cfg := parseConfig()
+
+		if cfg.ShutdownTimeout != 30*time.Second {
+			t.Errorf("expected default shutdown timeout 30s for invalid env, got %v", cfg.ShutdownTimeout)
+		}
+	})
+
+	t.Run("zero shutdown timeout uses default", func(t *testing.T) {
+		t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "0")
+
+		cfg := parseConfig()
+
+		if cfg.ShutdownTimeout != 30*time.Second {
+			t.Errorf("expected default shutdown timeout 30s for zero, got %v", cfg.ShutdownTimeout)
+		}
+	})
 }

--- a/pkg/server/errors_test.go
+++ b/pkg/server/errors_test.go
@@ -181,6 +181,45 @@ func TestWriteErrorFromErr_StructuredErrorMapsStatusAndDetails(t *testing.T) {
 	}
 }
 
+func TestWriteErrorFromErr_NilError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	WriteErrorFromErr(w, req, nil, "fallback msg", nil)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Message != "fallback msg" {
+		t.Fatalf("expected message %q, got %q", "fallback msg", resp.Message)
+	}
+}
+
+func TestWriteErrorFromErr_StructuredErrorEmptyMessage(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	err := eidoserrors.New(eidoserrors.ErrCodeNotFound, "")
+	WriteErrorFromErr(w, req, err, "fallback", nil)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+
+	var resp ErrorResponse
+	if uerr := json.Unmarshal(w.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("failed to unmarshal: %v", uerr)
+	}
+	if resp.Message != "fallback" {
+		t.Fatalf("expected fallback message, got %q", resp.Message)
+	}
+}
+
 func TestWriteErrorFromErr_NonStructuredFallsBackToInternal(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -101,6 +101,19 @@ func TestReadyEndpoint(t *testing.T) {
 	}
 }
 
+func TestReadyEndpoint_MethodNotAllowed(t *testing.T) {
+	s := New()
+
+	req := httptest.NewRequest(http.MethodPost, "/ready", nil)
+	w := httptest.NewRecorder()
+
+	s.handleReady(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+}
+
 func TestRateLimiting(t *testing.T) {
 	routes := map[string]http.HandlerFunc{
 		"/test": func(w http.ResponseWriter, _ *http.Request) {
@@ -330,6 +343,27 @@ func TestCustomRootHandlerNotOverridden(t *testing.T) {
 	}
 }
 
+func TestHealthEndpoint_MethodNotAllowed(t *testing.T) {
+	s := New()
+
+	req := httptest.NewRequest(http.MethodPost, "/health", nil)
+	w := httptest.NewRecorder()
+
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+}
+
+func TestWithVersion(t *testing.T) {
+	s := New(WithVersion("v1.2.3"))
+
+	if s.config.Version != "v1.2.3" {
+		t.Errorf("expected version v1.2.3, got %s", s.config.Version)
+	}
+}
+
 func TestWithName(t *testing.T) {
 	customName := "custom-api-server"
 	s := New(WithName(customName))
@@ -389,6 +423,49 @@ func TestDefaultServerName(t *testing.T) {
 	if s.config.Name != "server" {
 		t.Errorf("expected default name 'server', got %s", s.config.Name)
 	}
+}
+
+func TestResponseWriter(t *testing.T) {
+	t.Run("WriteHeader deduplication", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		rw := newResponseWriter(w)
+
+		rw.WriteHeader(http.StatusCreated)
+		if rw.Status() != http.StatusCreated {
+			t.Errorf("status = %d, want %d", rw.Status(), http.StatusCreated)
+		}
+
+		// Second WriteHeader should be ignored
+		rw.WriteHeader(http.StatusBadRequest)
+		if rw.Status() != http.StatusCreated {
+			t.Errorf("status changed to %d after duplicate write", rw.Status())
+		}
+	})
+
+	t.Run("Write auto-writes header", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		rw := newResponseWriter(w)
+
+		n, err := rw.Write([]byte("hello"))
+		if err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+		if n != 5 {
+			t.Errorf("Write() = %d, want 5", n)
+		}
+		if rw.Status() != http.StatusOK {
+			t.Errorf("auto status = %d, want %d", rw.Status(), http.StatusOK)
+		}
+	})
+
+	t.Run("default status is OK", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		rw := newResponseWriter(w)
+
+		if rw.Status() != http.StatusOK {
+			t.Errorf("default status = %d, want %d", rw.Status(), http.StatusOK)
+		}
+	})
 }
 
 func contains(s, substr string) bool {

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -815,6 +815,103 @@ func TestDetermineStartPhase(t *testing.T) {
 	}
 }
 
+func TestCheckNameToTestName(t *testing.T) {
+	tests := []struct {
+		name      string
+		checkName string
+		want      string
+	}{
+		{"hyphenated name", "operator-health", "TestOperatorHealth"},
+		{"single word", "health", "TestHealth"},
+		{"multiple hyphens", "gpu-hardware-detection", "TestGpuHardwareDetection"},
+		{"already capitalized", "GPU", "TestGPU"},
+		{"empty string", "", "Test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkNameToTestName(tt.checkName)
+			if got != tt.want {
+				t.Errorf("checkNameToTestName(%q) = %q, want %q", tt.checkName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTestPattern(t *testing.T) {
+	tests := []struct {
+		name   string
+		recipe *recipe.RecipeResult
+		phase  string
+		want   string
+	}{
+		{
+			name: "nil validation returns empty",
+			recipe: &recipe.RecipeResult{
+				Validation: nil,
+			},
+			phase: "deployment",
+			want:  "",
+		},
+		{
+			name: "empty deployment returns empty",
+			recipe: &recipe.RecipeResult{
+				Validation: &recipe.ValidationConfig{
+					Deployment: &recipe.ValidationPhase{},
+				},
+			},
+			phase: "deployment",
+			want:  "",
+		},
+		{
+			name: "deployment with checks builds pattern",
+			recipe: &recipe.RecipeResult{
+				Validation: &recipe.ValidationConfig{
+					Deployment: &recipe.ValidationPhase{
+						Checks: []string{"operator-health", "expected-resources"},
+					},
+				},
+			},
+			phase: "deployment",
+			want:  "^(TestOperatorHealth|TestExpectedResources)$",
+		},
+		{
+			name: "performance phase returns empty (TODO stub)",
+			recipe: &recipe.RecipeResult{
+				Validation: &recipe.ValidationConfig{
+					Performance: &recipe.ValidationPhase{
+						Checks: []string{"nccl-bandwidth-test"},
+					},
+				},
+			},
+			phase: "performance",
+			want:  "",
+		},
+		{
+			name: "conformance phase returns empty (TODO stub)",
+			recipe: &recipe.RecipeResult{
+				Validation: &recipe.ValidationConfig{
+					Conformance: &recipe.ValidationPhase{
+						Checks: []string{"ai-workload-validation"},
+					},
+				},
+			},
+			phase: "conformance",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := New()
+			got := v.buildTestPattern(tt.recipe, tt.phase)
+			if got != tt.want {
+				t.Errorf("buildTestPattern() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateRecipeRegistrations(t *testing.T) {
 	validator := New()
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -147,6 +147,36 @@ func TestValidator_Validate(t *testing.T) {
 			wantSkipped: 1,
 		},
 		{
+			name: "value not found in snapshot",
+			constraints: []recipe.Constraint{
+				{Name: "K8s.server.nonexistent", Value: "test"}, // Valid type but missing key
+			},
+			wantStatus:  ValidationStatusPartial,
+			wantPassed:  0,
+			wantFailed:  0,
+			wantSkipped: 1,
+		},
+		{
+			name: "invalid constraint expression",
+			constraints: []recipe.Constraint{
+				{Name: "K8s.server.version", Value: ""}, // Empty expression
+			},
+			wantStatus:  ValidationStatusPartial,
+			wantPassed:  0,
+			wantFailed:  0,
+			wantSkipped: 1,
+		},
+		{
+			name: "evaluation failure on version parse",
+			constraints: []recipe.Constraint{
+				{Name: "OS.release.ID", Value: ">= 1.0.0"}, // Version comparison on non-version "ubuntu"
+			},
+			wantStatus:  ValidationStatusFail,
+			wantPassed:  0,
+			wantFailed:  1,
+			wantSkipped: 0,
+		},
+		{
 			name:        "empty constraints",
 			constraints: []recipe.Constraint{},
 			wantStatus:  ValidationStatusPass,
@@ -574,6 +604,14 @@ func TestGenerateRunID_Uniqueness(t *testing.T) {
 			t.Errorf("Generated duplicate RunID: %s", runID)
 		}
 		runIDs[runID] = true
+	}
+}
+
+func TestNew_CustomImageFromEnv(t *testing.T) {
+	t.Setenv("EIDOS_VALIDATOR_IMAGE", "custom-image:latest")
+	v := New()
+	if v.Image != "custom-image:latest" {
+		t.Errorf("Image = %q, want custom-image:latest", v.Image)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds and expands unit tests across 22 packages to raise overall statement coverage to 70%
- Adds new `pkg/recipe/metadata_store_test.go` for metadata store coverage
- Updates CI coverage threshold in `on-push.yaml` to match 70% target

## Test plan
- [x] `make test` passes with `-race` (70.0% coverage)
- [x] `make lint` passes (0 issues)
- [ ] CI pipeline passes