### PR TITLE
Enable copy-pr-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+enabled: true
+additional_trustees:
+  - ayuskauskas
+  - coffeepac
+  - cullenmcdermott
+  - dims
+  - Kevin-Hawkins
+  - lockwobr
+  - mchmarny
+  - svcsectool
+  - tabern
+  - valcharry
+  - yuanchen8911


### PR DESCRIPTION
## Summary

Enable [copy-pr-bot](https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/) to safely run CI on external PRs by copying fork branches into trusted repo branches.

## Motivation / Context

PRs from forks cannot access repository secrets needed for CI. The copy-pr-bot creates trusted branches from fork PRs so CI workflows can run safely without exposing secrets to untrusted code. See [CircleCI blog on this pattern](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/).

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/copy-pr-bot.yaml`

## Implementation Notes

Adds `.github/copy-pr-bot.yaml` with `enabled: true` and a list of additional trustees who can trigger the bot.

## Testing

No tests needed — configuration-only change for a GitHub App.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] Commits are signed off (`git commit -s`) — [DCO info](https://developercertificate.org/)