### PR TITLE
fix: mount host /etc/os-release in privileged snapshot agent

### DIFF
--- a/pkg/k8s/agent/deployer_test.go
+++ b/pkg/k8s/agent/deployer_test.go
@@ -257,8 +257,8 @@ func TestDeployer_EnsureJob(t *testing.T) {
 		}
 
 		// Verify volumes
-		if len(job.Spec.Template.Spec.Volumes) != 2 {
-			t.Errorf("expected 2 volumes, got %d", len(job.Spec.Template.Spec.Volumes))
+		if len(job.Spec.Template.Spec.Volumes) != 3 {
+			t.Errorf("expected 3 volumes, got %d", len(job.Spec.Template.Spec.Volumes))
 		}
 	})
 

--- a/pkg/k8s/agent/job.go
+++ b/pkg/k8s/agent/job.go
@@ -192,21 +192,39 @@ func (d *Deployer) applyPrivilegedSettings(spec *corev1.PodSpec) {
 			Add: []corev1.Capability{"SYS_ADMIN", "SYS_CHROOT"},
 		},
 	}
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      "run-systemd",
-		MountPath: "/run/systemd",
-		ReadOnly:  true,
-	})
+	container.VolumeMounts = append(container.VolumeMounts,
+		corev1.VolumeMount{
+			Name:      "run-systemd",
+			MountPath: "/run/systemd",
+			ReadOnly:  true,
+		},
+		corev1.VolumeMount{
+			Name:      "host-os-release",
+			MountPath: "/etc/os-release",
+			ReadOnly:  true,
+		},
+	)
 
-	spec.Volumes = append(spec.Volumes, corev1.Volume{
-		Name: "run-systemd",
-		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: "/run/systemd",
-				Type: ptr.To(corev1.HostPathDirectory),
+	spec.Volumes = append(spec.Volumes,
+		corev1.Volume{
+			Name: "run-systemd",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/run/systemd",
+					Type: ptr.To(corev1.HostPathDirectory),
+				},
 			},
 		},
-	})
+		corev1.Volume{
+			Name: "host-os-release",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/etc/os-release",
+					Type: ptr.To(corev1.HostPathFile),
+				},
+			},
+		},
+	)
 }
 
 // applyRestrictedSettings configures the pod for PSS-restricted namespaces (K8s collector only).


### PR DESCRIPTION
## Summary
- The OS collector reads `/etc/os-release` inside the container, which returns the **container image OS** (Debian 12 from `golang:bookworm`) instead of the host OS
- This causes OS constraint validation to fail on Ubuntu nodes
- Mounts the host `/etc/os-release` into the privileged agent pod so the collector reads the correct host OS information

## Before (without host mount)

The validation ran successfully but found 2 constraint failures:

| Constraint | Expected | Actual | Status |
|---|---|---|---|
| K8s.server.version >= 1.34 | >= 1.34 | v1.34.3-eks-ac2d5a0 | passed |
| OS.release.ID = ubuntu | ubuntu | debian | **failed** |
| OS.release.VERSION_ID = 24.04 | 24.04 | 12 | **failed** |
| OS.sysctl kernel >= 6.8 | >= 6.8 | 6.14.0-1018-aws | passed |

## After (with host mount)

All 4 constraints passed:

| Constraint | Expected | Actual | Status |
|---|---|---|---|
| K8s.server.version | >= 1.34 | v1.34.3-eks-ac2d5a0 | passed |
| OS.release.ID | ubuntu | ubuntu | passed |
| OS.release.VERSION_ID | 24.04 | 24.04 | passed |
| OS.sysctl kernel | >= 6.8 | 6.14.0-1018-aws | passed |

## Test plan
- [x] Tested on EKS cluster with H100 GPU nodes (Ubuntu 24.04)
- [x] `eidos validate --phase readiness` passes all 4 constraints
- [ ] Unit tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)