### PR TITLE
fix: update stale kind values to PascalCase, remove missing performance check

### DIFF
--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -35,7 +35,6 @@ COPY . .
 # Pre-compile test binaries for faster Job startup
 RUN go test -c -o /usr/local/bin/readiness.test ./pkg/validator/checks/readiness && \
     go test -c -o /usr/local/bin/deployment.test ./pkg/validator/checks/deployment && \
-    go test -c -o /usr/local/bin/performance.test ./pkg/validator/checks/performance && \
-    go test -c -o /usr/local/bin/conformance.test ./pkg/validator/checks/conformance || true
+    go test -c -o /usr/local/bin/conformance.test ./pkg/validator/checks/conformance
 
 CMD ["/bin/bash"]

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -703,7 +703,7 @@ deployOrder, err := mergedSpec.TopologicalSort()
 
 ```go
 return &RecipeResult{
-    Kind:            "recipeResult",
+    Kind:            "RecipeResult",
     APIVersion:      "eidos.nvidia.com/v1alpha1",
     Metadata:        metadata,
     Criteria:        criteria,
@@ -795,7 +795,7 @@ curl "http://localhost:8080/v1/recipe?os=ubuntu&service=eks&accelerator=gb200&in
 
 ```json
 {
-  "kind": "recipeResult",
+  "kind": "RecipeResult",
   "apiVersion": "eidos.nvidia.com/v1alpha1",
   "metadata": {
     "version": "v0.8.0",

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -188,7 +188,7 @@ spec:
 curl -X POST "http://localhost:8080/v1/recipe" \
   -H "Content-Type: application/json" \
   -d '{
-    "kind": "recipeCriteria",
+    "kind": "RecipeCriteria",
     "apiVersion": "eidos.nvidia.com/v1alpha1",
     "metadata": {"name": "training-config"},
     "spec": {
@@ -206,7 +206,7 @@ curl -X POST "http://localhost:8080/v1/recipe" \
 # Pretty print response
 curl -s -X POST "http://localhost:8080/v1/recipe" \
   -H "Content-Type: application/json" \
-  -d '{"kind":"recipeCriteria","apiVersion":"eidos.nvidia.com/v1alpha1","spec":{"service":"eks","accelerator":"h100"}}' \
+  -d '{"kind":"RecipeCriteria","apiVersion":"eidos.nvidia.com/v1alpha1","spec":{"service":"eks","accelerator":"h100"}}' \
   | jq '.'
 ```
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -197,7 +197,7 @@ test_cli_recipe() {
     --os ubuntu \
     --intent training \
     --output "$basic_recipe" 2>&1; then
-    if [ -f "$basic_recipe" ] && grep -q "kind: recipeResult" "$basic_recipe"; then
+    if [ -f "$basic_recipe" ] && grep -q "kind: RecipeResult" "$basic_recipe"; then
       # Show components from recipe
       local components
       components=$(grep "^  - name:" "$basic_recipe" 2>/dev/null | wc -l | tr -d ' ')
@@ -214,7 +214,7 @@ test_cli_recipe() {
   msg "--- Test: Recipe from criteria file ---"
   local criteria_file="${recipe_dir}/criteria.yaml"
   cat > "$criteria_file" << 'EOF'
-kind: recipeCriteria
+kind: RecipeCriteria
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
   name: h100-eks-ubuntu-training
@@ -283,7 +283,7 @@ test_api_recipe() {
   http_code=$(curl -s -w "%{http_code}" -o "$post_recipe" \
     -X POST "${eidosd_URL}/v1/recipe" \
     -H "Content-Type: application/x-yaml" \
-    -d 'kind: recipeCriteria
+    -d 'kind: RecipeCriteria
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
   name: h100-training
@@ -741,7 +741,7 @@ test_recipe_from_snapshot() {
     --snapshot "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}" \
     --intent training \
     --output "$snapshot_recipe" 2>&1; then
-    if [ -f "$snapshot_recipe" ] && grep -q "kind: recipeResult" "$snapshot_recipe"; then
+    if [ -f "$snapshot_recipe" ] && grep -q "kind: RecipeResult" "$snapshot_recipe"; then
       # Show detected criteria
       local service accelerator
       service=$(grep "^  service:" "$snapshot_recipe" 2>/dev/null | head -1 | awk '{print $2}')
@@ -1003,7 +1003,7 @@ YAML
   # Generate a recipe with deployment constraints
   local recipe_file="${validate_dir}/recipe-with-constraints.yaml"
   cat > "$recipe_file" <<RECIPE
-kind: recipeResult
+kind: RecipeResult
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
   version: dev
@@ -1066,7 +1066,7 @@ RECIPE
   msg "--- Test: Deployment constraint (should fail) ---"
   local recipe_file_fail="${validate_dir}/recipe-with-failing-constraint.yaml"
   cat > "$recipe_file_fail" <<RECIPE
-kind: recipeResult
+kind: RecipeResult
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
   version: dev

--- a/tools/generate-validator
+++ b/tools/generate-validator
@@ -266,7 +266,7 @@ func TestValidate{{.FuncName}}Registration(t *testing.T) {
 
 CHECK_RECIPE_TEMPLATE = """\
 # Sample recipe for testing {{.CheckName}} check
-kind: recipeResult
+kind: RecipeResult
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
   version: dev
@@ -625,7 +625,7 @@ func TestValidate{{.FuncName}}Registration(t *testing.T) {
 
 CONSTRAINT_RECIPE_TEMPLATE = """\
 # Sample recipe for testing {{.ConstraintName}} constraint
-kind: recipeResult
+kind: RecipeResult
 apiVersion: eidos.nvidia.com/v1alpha1
 metadata:
   version: dev


### PR DESCRIPTION
## Summary

- Fix E2E test failures introduced by #127 (PascalCase kind standardization) — `recipeCriteria` → `RecipeCriteria`, `recipeResult` → `RecipeResult` in test scripts, tools, and docs
- Remove reference to non-existent `pkg/validator/checks/performance` from `Dockerfile.validator` and drop `|| true` that was masking the build error

## Files changed

| File | Fix |
|------|-----|
| `tests/e2e/run.sh` | 6 lowercase kind references → PascalCase |
| `tools/generate-validator` | 2 template references → PascalCase |
| `docs/user/api-reference.md` | API examples → PascalCase |
| `docs/contributor/data.md` | Code/JSON examples → PascalCase |
| `Dockerfile.validator` | Remove non-existent `performance` package, drop `\|\| true` |

## Test plan

- [ ] E2E tests pass (criteria-file, query-params, from-snapshot, API POST no longer fail)
- [ ] Dockerfile.validator builds without `|| true` masking errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)