### PR TITLE
feat(ci): add Dynamo vLLM smoke test and fix etcd/NATS naming

### DIFF
--- a/.github/workflows/gpu-h100-smoke-test.yaml
+++ b/.github/workflows/gpu-h100-smoke-test.yaml
@@ -27,6 +27,9 @@ on:
       - '.github/actions/eidos-build/**'
       - '.github/actions/gpu-test-cleanup/**'
       - '.github/actions/load-versions/**'
+      - 'tests/manifests/**'
+      - 'tests/chainsaw/ai-conformance/**'
+      - 'recipes/components/dynamo-platform/**'
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -41,7 +44,7 @@ jobs:
   gpu-smoke-test:
     name: GPU Smoke Test (nvkind + H100)
     runs-on: linux-amd64-gpu-h100-latest-1
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     env:
       KIND_CLUSTER_NAME: gpu-smoke-test
@@ -119,6 +122,68 @@ jobs:
             --test-dir tests/chainsaw/ai-conformance/kind \
             --config tests/chainsaw/chainsaw-config.yaml
 
+      # --- Dynamo vLLM inference smoke test ---
+
+      - name: Deploy Dynamo vLLM smoke test
+        run: |
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
+            -f tests/manifests/dynamo-vllm-smoke-test.yaml -n dynamo-system
+
+          echo "Waiting for DynamoGraphDeployment to be reconciled..."
+          for i in $(seq 1 60); do
+            PHASE=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+              get dynamographdeployment vllm-smoke-test \
+              -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+            if [[ "${PHASE}" == "True" ]]; then
+              echo "DynamoGraphDeployment is ready."
+              break
+            fi
+            echo "Waiting for DGD readiness... (${i}/60)"
+            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get pods 2>/dev/null || true
+            sleep 10
+          done
+
+          if [[ "${PHASE}" != "True" ]]; then
+            echo "::error::DynamoGraphDeployment did not become ready within 10 minutes"
+            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+              get dynamographdeployment vllm-smoke-test -o yaml 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "Dynamo pods:"
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get pods
+
+      - name: Validate Dynamo inference
+        run: |
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+            port-forward svc/vllm-smoke-test-frontend 8000:8000 &
+          PF_PID=$!
+          sleep 3
+
+          cleanup() { kill "${PF_PID}" 2>/dev/null || true; }
+          trap cleanup EXIT
+
+          echo "=== Checking /v1/models ==="
+          MODELS=$(curl -sf http://localhost:8000/v1/models)
+          echo "${MODELS}" | jq .
+          if ! echo "${MODELS}" | jq -e '.data | length > 0' >/dev/null 2>&1; then
+            echo "::error::No models reported by frontend"
+            exit 1
+          fi
+
+          echo "=== Sending chat completion ==="
+          RESPONSE=$(curl -sf http://localhost:8000/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":30,"stream":false}')
+          echo "${RESPONSE}" | jq .
+
+          CONTENT=$(echo "${RESPONSE}" | jq -r '.choices[0].message.content')
+          if [[ -z "${CONTENT}" || "${CONTENT}" == "null" ]]; then
+            echo "::error::Empty response from vLLM"
+            exit 1
+          fi
+          echo "Dynamo vLLM inference smoke test passed."
+
       - name: Debug diagnostics
         if: failure()
         run: |
@@ -130,8 +195,36 @@ jobs:
           kubectl --context="kind-${KIND_CLUSTER_NAME}" get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded 2>/dev/null || true
           echo "=== Recent events (gpu-operator) ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+          echo "=== Dynamo pods ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get pods -o wide 2>/dev/null || true
+          echo "=== DynamoGraphDeployment status ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get dynamographdeployment -o yaml 2>/dev/null || true
+          echo "=== Dynamo vLLM frontend logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+            logs deployment/vllm-smoke-test-frontend --tail=200 2>/dev/null || true
+          echo "=== Dynamo vLLM frontend previous logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+            logs deployment/vllm-smoke-test-frontend --previous --tail=200 2>/dev/null || true
+          echo "=== Dynamo vLLM worker logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+            logs deployment/vllm-smoke-test-vllmdecodeworker --tail=200 2>/dev/null || true
+          echo "=== Dynamo vLLM worker previous logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+            logs deployment/vllm-smoke-test-vllmdecodeworker --previous --tail=200 2>/dev/null || true
+          echo "=== Dynamo operator logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
+            logs deployment/dynamo-operator-controller-manager --tail=100 -c manager 2>/dev/null || true
+          echo "=== Recent events (dynamo-system) ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
           echo "=== Node status ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" get nodes -o wide 2>/dev/null || true
+
+      - name: Dynamo vLLM cleanup
+        if: always()
+        run: |
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" delete \
+            -f tests/manifests/dynamo-vllm-smoke-test.yaml \
+            -n dynamo-system --ignore-not-found 2>/dev/null || true
 
       - name: GPU Test Cleanup
         if: always()

--- a/recipes/components/dynamo-platform/values.yaml
+++ b/recipes/components/dynamo-platform/values.yaml
@@ -42,9 +42,10 @@ grove:
   enabled: false
 
 # etcd for operator state storage
+# Do NOT set fullnameOverride — the operator constructs the etcd endpoint from
+# the release name (<release>-etcd). Overriding the name breaks connectivity.
 etcd:
   enabled: true
-  fullnameOverride: dynamo-etcd
   tolerations:
     - operator: Exists
   image:
@@ -62,9 +63,10 @@ etcd:
       memory: 512Mi
 
 # NATS message broker for component communication
+# Do NOT set fullnameOverride — the operator constructs the NATS endpoint from
+# the release name (<release>-nats). Overriding the name breaks connectivity.
 nats:
   enabled: true
-  fullnameOverride: dynamo-nats
   podTemplate:
     merge:
       spec:

--- a/tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml
+++ b/tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml
@@ -17,10 +17,10 @@
 # Provides NVIDIA Dynamo inference serving: OpenAI-compatible endpoints,
 # KV-cache-aware routing, disaggregated prefill/decode, SLA-driven autoscaling.
 #
-# Resource naming from fullnameOverride values:
+# Resource naming:
 #   dynamo-operator: fullnameOverride=dynamo-operator
-#   etcd: fullnameOverride=dynamo-etcd
-#   nats: fullnameOverride=dynamo-nats
+#   etcd: default (<release>-etcd = dynamo-platform-etcd)
+#   nats: default (<release>-nats = dynamo-platform-nats)
 
 # Dynamo Operator — manages DynamoComponent and DynamoGraphDeployment CRs
 apiVersion: apps/v1
@@ -36,7 +36,7 @@ status:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: dynamo-etcd
+  name: dynamo-platform-etcd
   namespace: dynamo-system
 status:
   (readyReplicas > `0`): true
@@ -45,7 +45,7 @@ status:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: dynamo-nats
+  name: dynamo-platform-nats
   namespace: dynamo-system
 status:
   (readyReplicas > `0`): true

--- a/tests/manifests/dynamo-vllm-smoke-test.yaml
+++ b/tests/manifests/dynamo-vllm-smoke-test.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dynamo vLLM smoke test — minimal aggregated inference deployment.
+# Deploys a Frontend (API gateway) and a single vLLM decode worker
+# serving Qwen/Qwen3-0.6B (public, ungated, ~1.2GB).
+# No HuggingFace token required.
+#
+# Usage:
+#   kubectl apply -f tests/manifests/dynamo-vllm-smoke-test.yaml -n dynamo-system
+#   kubectl port-forward svc/vllm-smoke-test-frontend 8000:8000 -n dynamo-system
+#   curl http://localhost:8000/v1/models
+#   curl http://localhost:8000/v1/chat/completions \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello!"}],"max_tokens":30,"stream":false}'
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-smoke-test
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+    VllmDecodeWorker:
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+          workingDir: /workspace/examples/backends/vllm
+          command: ["python3", "-m", "dynamo.vllm"]
+          args: ["--model", "Qwen/Qwen3-0.6B"]


### PR DESCRIPTION
## Summary

- Add end-to-end Dynamo vLLM inference smoke test to the H100 CI workflow
- Fix etcd/NATS connectivity broken by `fullnameOverride` in dynamo-platform values

## Motivation / Context

The H100 smoke test deploys the full Dynamo inference platform (operator, etcd, NATS) and verifies health via chainsaw, but never actually deploys an inference workload. This adds a real inference round-trip to catch integration issues between Dynamo, kai-scheduler, and the GPU operator.

While implementing this, discovered that the `fullnameOverride` settings for etcd (`dynamo-etcd`) and NATS (`dynamo-nats`) break connectivity. The Dynamo operator constructs endpoints from the Helm release name (`dynamo-platform-etcd`, `dynamo-platform-nats`), so overriding the sub-chart names causes a DNS mismatch — pods crash immediately with `Unable to create lease`.

Related: #128

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI workflows, test manifests, recipe component values

## Implementation Notes

**Smoke test:**
- **Manifest:** `tests/manifests/dynamo-vllm-smoke-test.yaml` — minimal `DynamoGraphDeployment` with Frontend + single VllmDecodeWorker serving `Qwen/Qwen3-0.6B` (~1.2GB, public/ungated — no HF token needed)
- **Image:** `nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1` (matches dynamo-platform chart version)
- **kai-scheduler:** Auto-detected by Dynamo operator when `scheduling.run.ai` API group is present
- **Validation:** Port-forward to frontend, check `/v1/models`, send chat completion, verify non-empty response
- **Cleanup:** `if: always()` step deletes the DGD unconditionally
- **Timeout:** 30→45 min to accommodate vllm-runtime image pull (~11GB) + model download

**etcd/NATS fix:**
- Removed `etcd.fullnameOverride: dynamo-etcd` and `nats.fullnameOverride: dynamo-nats` from `recipes/components/dynamo-platform/values.yaml`
- Services now use default names: `dynamo-platform-etcd`, `dynamo-platform-nats` (matching what the operator injects into pods)
- Updated chainsaw assertion (`assert-dynamo.yaml`) for the new StatefulSet names

**Diagnostics improvements:**
- Debug step uses `deployment/` names instead of label selectors for log collection
- Added `--previous` flag to capture logs from crashed containers
- Added dynamo operator controller-manager logs

## Testing

CI-only change — the new steps run on the H100 runner after existing chainsaw health checks pass. No local `make qualify` impact (no Go code changed).

## Risk Assessment

- [x] **Low** — Additive CI steps; etcd/NATS fix aligns naming with operator expectations
- [ ] **Medium**
- [ ] **High**

**Note:** The etcd/NATS naming fix changes resource names in production bundles (`dynamo-etcd` → `dynamo-platform-etcd`). Existing clusters using the old names would need the dynamo-platform chart re-installed (not upgraded) since StatefulSet names are immutable.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)