### PR TITLE
fix: build eidos CLI in validator image and update binary path

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -141,6 +141,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.VALIDATOR_IMAGE }}:${{ github.ref_name }}-${{ matrix.arch }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -32,6 +32,26 @@ COPY vendor ./vendor/
 # changes don't re-download deps. See .dockerignore for context trimming.
 COPY . .
 
+# Build the eidos CLI binary at the path expected by the agent Job
+# Build flags match .goreleaser.yaml configuration
+# Extract version info from git (same as Makefile/GoReleaser)
+# ARG values can be overridden via --build-arg during CI builds
+ARG VERSION
+ARG COMMIT
+ARG DATE
+RUN set -e; \
+    VERSION="${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo 'dev')}"; \
+    COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')}"; \
+    DATE="${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"; \
+    CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-w -s -extldflags '-static' \
+          -X github.com/NVIDIA/eidos/pkg/cli.version=${VERSION} \
+          -X github.com/NVIDIA/eidos/pkg/cli.commit=${COMMIT} \
+          -X github.com/NVIDIA/eidos/pkg/cli.date=${DATE}" \
+        -o /usr/local/bin/eidos \
+        ./cmd/eidos
+
 # Pre-compile test binaries for faster Job startup
 RUN go test -c -o /usr/local/bin/readiness.test ./pkg/validator/checks/readiness && \
     go test -c -o /usr/local/bin/deployment.test ./pkg/validator/checks/deployment && \

--- a/deployments/eidos-agent/2-job.yaml
+++ b/deployments/eidos-agent/2-job.yaml
@@ -68,7 +68,7 @@ spec:
           args:
             - |
               set -e
-              /usr/local/bin/eidos --debug --log-json snapshot -o cm://gpu-operator/eidos-snapshot
+              eidos --debug --log-json snapshot -o cm://gpu-operator/eidos-snapshot
           resources:
             requests:
               cpu: "1"

--- a/deployments/eidos-agent/2-job.yaml
+++ b/deployments/eidos-agent/2-job.yaml
@@ -56,7 +56,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: eidos
-          image: ghcr.io/nvidia/eidos:latest
+          image: ghcr.io/nvidia/eidos-validator:latest
           command: ["/bin/sh", "-c"]
           env:
             - name: EIDOS_LOG_PREFIX
@@ -68,7 +68,7 @@ spec:
           args:
             - |
               set -e
-              /ko-app/eidos --debug --log-json snapshot -o cm://gpu-operator/eidos-snapshot
+              /usr/local/bin/eidos --debug --log-json snapshot -o cm://gpu-operator/eidos-snapshot
           resources:
             requests:
               cpu: "1"

--- a/docs/contributor/cli.md
+++ b/docs/contributor/cli.md
@@ -348,7 +348,7 @@ spec:
       serviceAccountName: eidos
       containers:
       - name: eidos
-        image: ghcr.io/nvidia/eidos:latest
+        image: ghcr.io/nvidia/eidos-validator:latest
         command:
         - eidos
         - snapshot
@@ -2116,7 +2116,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: eidos
-        image: ghcr.io/nvidia/eidos:latest
+        image: ghcr.io/nvidia/eidos-validator:latest
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -311,7 +311,7 @@ spec:
       
       containers:
       - name: eidos
-        image: ghcr.io/nvidia/eidos:latest
+        image: ghcr.io/nvidia/eidos-validator:latest
         imagePullPolicy: IfNotPresent
         
         command:

--- a/docs/user/agent-deployment.md
+++ b/docs/user/agent-deployment.md
@@ -364,7 +364,7 @@ spec:
         - name: eidos
           image: ghcr.io/nvidia/eidos-validator:latest
           command: ["/bin/sh", "-c"]
-          args: ["/usr/local/bin/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
+          args: ["eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
           securityContext:
             privileged: true
           volumeMounts:
@@ -408,7 +408,7 @@ spec:
         - name: eidos
           image: ghcr.io/nvidia/eidos-validator:latest
           command: ["/bin/sh", "-c"]
-          args: ["/usr/local/bin/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
+          args: ["eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
           securityContext:
             privileged: true
           volumeMounts:
@@ -458,7 +458,7 @@ spec:
             - name: eidos
               image: ghcr.io/nvidia/eidos-validator:latest
               command: ["/bin/sh", "-c"]
-              args: ["/usr/local/bin/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
+              args: ["eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
               securityContext:
                 privileged: true
               volumeMounts:

--- a/docs/user/agent-deployment.md
+++ b/docs/user/agent-deployment.md
@@ -128,7 +128,7 @@ eidos snapshot --deploy-agent \
 - `--deploy-agent`: Enable agent deployment mode
 - `--kubeconfig`: Custom kubeconfig path (default: `~/.kube/config` or `$KUBECONFIG`)
 - `--namespace`: Deployment namespace (default: `gpu-operator`)
-- `--image`: Container image (default: `ghcr.io/nvidia/eidos:latest`)
+- `--image`: Container image (default: `ghcr.io/nvidia/eidos-validator:latest`)
 - `--job-name`: Job name (default: `eidos`)
 - `--service-account-name`: ServiceAccount name (default: `eidos`)
 - `--node-selector`: Node selector (format: `key=value`, repeatable)
@@ -362,9 +362,9 @@ spec:
         fsGroup: 0
       containers:
         - name: eidos
-          image: ghcr.io/nvidia/eidos:latest
+          image: ghcr.io/nvidia/eidos-validator:latest
           command: ["/bin/sh", "-c"]
-          args: ["/ko-app/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
+          args: ["/usr/local/bin/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
           securityContext:
             privileged: true
           volumeMounts:
@@ -406,9 +406,9 @@ spec:
         fsGroup: 0
       containers:
         - name: eidos
-          image: ghcr.io/nvidia/eidos:latest
+          image: ghcr.io/nvidia/eidos-validator:latest
           command: ["/bin/sh", "-c"]
-          args: ["/ko-app/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
+          args: ["/usr/local/bin/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
           securityContext:
             privileged: true
           volumeMounts:
@@ -456,9 +456,9 @@ spec:
             fsGroup: 0
           containers:
             - name: eidos
-              image: ghcr.io/nvidia/eidos:latest
+              image: ghcr.io/nvidia/eidos-validator:latest
               command: ["/bin/sh", "-c"]
-              args: ["/ko-app/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
+              args: ["/usr/local/bin/eidos snapshot -o cm://gpu-operator/eidos-snapshot"]
               securityContext:
                 privileged: true
               volumeMounts:

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -79,7 +79,7 @@ eidos snapshot [flags]
 | `--kubeconfig` | `-k` | string | ~/.kube/config | Path to kubeconfig file (overrides KUBECONFIG env) |
 | `--deploy-agent` | | bool | false | Deploy Kubernetes Job to capture snapshot on cluster nodes |
 | `--namespace` | `-n` | string | gpu-operator | Kubernetes namespace for agent deployment |
-| `--image` | | string | ghcr.io/nvidia/eidos:latest | Container image for agent Job |
+| `--image` | | string | ghcr.io/nvidia/eidos-validator:latest | Container image for agent Job |
 | `--job-name` | | string | eidos | Name for the agent Job |
 | `--service-account-name` | | string | eidos | ServiceAccount name for agent Job |
 | `--node-selector` | | string[] | | Node selector for agent scheduling (key=value, repeatable) |

--- a/examples/demos/e2e.md
+++ b/examples/demos/e2e.md
@@ -105,6 +105,7 @@ Validate Recipe:
 ```shell
 eidos validate \
   --recipe recipe.yaml \
+  --namespace gpu-operator \
   --snapshot cm://gpu-operator/eidos-snapshot | yq .
 ```
 
@@ -112,10 +113,8 @@ Validate Recipe sans Snapshot
 
 ```shell
 eidos validate \
-  --phase readiness \
-  --namespace gpu-operator \
+  --recipe recipe.yaml \
   --node-selector nodeGroup=customer-gpu
-  --output recipe.yaml
 ```
 
 ## Bundle

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -136,7 +136,7 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				Name:    "image",
 				Usage:   "Container image for agent Job",
 				Sources: cli.EnvVars("EIDOS_IMAGE"),
-				Value:   "ghcr.io/nvidia/eidos:latest",
+				Value:   "ghcr.io/nvidia/eidos-validator:latest",
 			},
 			&cli.StringSliceFlag{
 				Name:  "image-pull-secret",

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -133,8 +133,8 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				Value:   "gpu-operator",
 			},
 			&cli.StringFlag{
-				Name:    "image",
-				Usage:   "Container image for agent Job",
+				Name:  "image",
+				Usage: "Container image for agent Job (must contain /usr/local/bin/eidos)",
 				Sources: cli.EnvVars("EIDOS_IMAGE"),
 				Value:   "ghcr.io/nvidia/eidos-validator:latest",
 			},

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -133,8 +133,8 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				Value:   "gpu-operator",
 			},
 			&cli.StringFlag{
-				Name:  "image",
-				Usage: "Container image for agent Job (must contain /usr/local/bin/eidos)",
+				Name:    "image",
+				Usage:   "Container image for agent Job",
 				Sources: cli.EnvVars("EIDOS_IMAGE"),
 				Value:   "ghcr.io/nvidia/eidos-validator:latest",
 			},

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -279,7 +279,7 @@ func validateCmdFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    "image",
-			Usage:   "Container image for validation Jobs (must contain /usr/local/bin/eidos and Go toolchain)",
+			Usage:   "Container image for validation Jobs (must include Go toolchain)",
 			Sources: cli.EnvVars("EIDOS_VALIDATOR_IMAGE"),
 			Value:   "ghcr.io/nvidia/eidos-validator:latest",
 		},

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -279,7 +279,7 @@ func validateCmdFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    "image",
-			Usage:   "Container image for validation Jobs (must include Go toolchain)",
+			Usage:   "Container image for validation Jobs (must contain /usr/local/bin/eidos and Go toolchain)",
 			Sources: cli.EnvVars("EIDOS_VALIDATOR_IMAGE"),
 			Value:   "ghcr.io/nvidia/eidos-validator:latest",
 		},

--- a/pkg/k8s/agent/deployer_test.go
+++ b/pkg/k8s/agent/deployer_test.go
@@ -36,7 +36,7 @@ func TestDeployer_EnsureRBAC(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 	}
 	deployer := NewDeployer(clientset, config)
@@ -159,7 +159,7 @@ func TestDeployer_EnsureRBAC_Idempotent(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 	}
 	deployer := NewDeployer(clientset, config)
@@ -191,7 +191,7 @@ func TestDeployer_EnsureJob(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 		Privileged:         true, // Test privileged mode (default for agent deployment)
 		NodeSelector: map[string]string{
@@ -289,7 +289,7 @@ func TestDeployer_EnsureJob_Unprivileged(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 		Privileged:         false, // Test unprivileged mode for PSS-restricted namespaces
 	}
@@ -374,7 +374,7 @@ func TestDeployer_Deploy(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 	}
 	deployer := NewDeployer(clientset, config)
@@ -445,7 +445,7 @@ func TestDeployer_Cleanup(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 	}
 	deployer := NewDeployer(clientset, config)
@@ -505,7 +505,7 @@ func TestDeployer_Cleanup_AttemptsAllDeletions(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 	}
 	deployer := NewDeployer(clientset, config)
@@ -569,7 +569,7 @@ func TestDeployer_Cleanup_ReportsAllErrors(t *testing.T) {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		Output:             "cm://test-namespace/eidos-snapshot",
 	}
 	deployer := NewDeployer(clientset, config)

--- a/pkg/k8s/agent/doc.go
+++ b/pkg/k8s/agent/doc.go
@@ -49,7 +49,7 @@ recreated for each snapshot to ensure clean state.
 		// Configure deployer
 		config := agent.Config{
 			Namespace: "gpu-operator",
-			Image:     "ghcr.io/nvidia/eidos:latest",
+			Image:     "ghcr.io/nvidia/eidos-validator:latest",
 			Output:    "cm://gpu-operator/eidos-snapshot",
 			NodeSelector: map[string]string{
 				"nodeGroup": "customer-gpu",

--- a/pkg/k8s/agent/job.go
+++ b/pkg/k8s/agent/job.go
@@ -115,7 +115,7 @@ func (d *Deployer) buildPodSpec(args []string) corev1.PodSpec {
 			{
 				Name:    "eidos",
 				Image:   d.config.Image,
-				Command: []string{"/usr/local/bin/eidos"},
+				Command: []string{"eidos"},
 				Args:    args,
 				Env: []corev1.EnvVar{
 					{

--- a/pkg/k8s/agent/job.go
+++ b/pkg/k8s/agent/job.go
@@ -115,7 +115,7 @@ func (d *Deployer) buildPodSpec(args []string) corev1.PodSpec {
 			{
 				Name:    "eidos",
 				Image:   d.config.Image,
-				Command: []string{"/ko-app/eidos"},
+				Command: []string{"/usr/local/bin/eidos"},
 				Args:    args,
 				Env: []corev1.EnvVar{
 					{

--- a/pkg/k8s/doc.go
+++ b/pkg/k8s/doc.go
@@ -65,7 +65,7 @@
 //	// Deploy snapshot agent
 //	config := agent.Config{
 //	    Namespace: "gpu-operator",
-//	    Image:     "ghcr.io/nvidia/eidos:latest",
+//	    Image:     "ghcr.io/nvidia/eidos-validator:latest",
 //	}
 //	deployer := agent.NewDeployer(clientset, config)
 //

--- a/pkg/validator/agent/deployer_test.go
+++ b/pkg/validator/agent/deployer_test.go
@@ -41,7 +41,7 @@ func createConfig() Config {
 		Namespace:          "test-namespace",
 		ServiceAccountName: testName,
 		JobName:            testName,
-		Image:              "ghcr.io/nvidia/eidos:latest",
+		Image:              "ghcr.io/nvidia/eidos-validator:latest",
 		SnapshotConfigMap:  "test-snapshot",
 		RecipeConfigMap:    "test-recipe",
 		TestPackage:        "./pkg/validator/checks/readiness",

--- a/pkg/validator/checks/README.md
+++ b/pkg/validator/checks/README.md
@@ -1645,9 +1645,9 @@ kubectl describe pod <pod-name> -n eidos-validation
 
 Verify image exists:
 ```bash
-docker pull ghcr.io/nvidia/eidos:latest
+docker pull ghcr.io/nvidia/eidos-validator:latest
 # or
-kubectl run test --image=ghcr.io/nvidia/eidos:latest --rm -it --restart=Never -- /bin/sh
+kubectl run test --image=ghcr.io/nvidia/eidos-validator:latest --rm -it --restart=Never -- /bin/sh
 ```
 
 #### Job Pods Crash

--- a/tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml
+++ b/tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: eidos
           image: localhost:5001/eidos:local
-          command: ["/ko-app/eidos"]
+          command: ["eidos"]
           args: ["snapshot", "-o", "cm://gpu-operator/eidos-e2e-snapshot"]
           env:
             - name: EIDOS_LOG_PREFIX

--- a/tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml
+++ b/tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: eidos
           image: localhost:5001/eidos:local
-          command: ["/usr/local/bin/eidos"]
+          command: ["/ko-app/eidos"]
           args: ["snapshot", "-o", "cm://gpu-operator/eidos-e2e-snapshot"]
           env:
             - name: EIDOS_LOG_PREFIX

--- a/tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml
+++ b/tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: eidos
           image: localhost:5001/eidos:local
-          command: ["/ko-app/eidos"]
+          command: ["/usr/local/bin/eidos"]
           args: ["snapshot", "-o", "cm://gpu-operator/eidos-e2e-snapshot"]
           env:
             - name: EIDOS_LOG_PREFIX

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -639,7 +639,7 @@ spec:
       containers:
       - name: eidos
         image: ${EIDOS_IMAGE}
-        command: ["/ko-app/eidos"]
+        command: ["eidos"]
         args: ["snapshot", "-o", "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}"]
         env:
         - name: EIDOS_LOG_PREFIX

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -639,7 +639,7 @@ spec:
       containers:
       - name: eidos
         image: ${EIDOS_IMAGE}
-        command: ["/usr/local/bin/eidos"]
+        command: ["/ko-app/eidos"]
         args: ["snapshot", "-o", "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}"]
         env:
         - name: EIDOS_LOG_PREFIX

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -639,7 +639,7 @@ spec:
       containers:
       - name: eidos
         image: ${EIDOS_IMAGE}
-        command: ["/ko-app/eidos"]
+        command: ["/usr/local/bin/eidos"]
         args: ["snapshot", "-o", "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}"]
         env:
         - name: EIDOS_LOG_PREFIX


### PR DESCRIPTION
## Problem

The validator image (`ghcr.io/nvidia/eidos-validator:latest`) was missing the eidos CLI binary, causing agent Job deployments to fail with:

```
Error: exec: "/ko-app/eidos": stat /ko-app/eidos: no such file or directory
```

This affected both `eidos snapshot --deploy-agent` and `eidos validate` commands when deploying in-cluster agents.

## Solution

### 1. Build eidos CLI in Dockerfile.validator

Added eidos binary build with goreleaser-matching flags:
- CGO_ENABLED=0 for static binary
- -trimpath, -w, -s, -extldflags '-static'
- Version/commit/date injection (auto-extracted from git, overridable via --build-arg)
- Output to `/usr/local/bin/eidos` (consistent with test binary location)

### 2. Standardize binary path across all agent Jobs

Changed from `/ko-app/eidos` to `/usr/local/bin/eidos`:
- pkg/k8s/agent/job.go - Core agent Job builder
- deployments/eidos-agent/2-job.yaml - Deployment manifest
- tests/e2e/run.sh, tests/chainsaw/ - Test Jobs
- All documentation examples

### 3. Update default images

Agent deployment commands now default to validator image:
- `eidos snapshot --deploy-agent` → `ghcr.io/nvidia/eidos-validator:latest`
- `eidos validate` → `ghcr.io/nvidia/eidos-validator:latest`

CI/CD pipelines continue using `ghcr.io/nvidia/eidos:latest` for direct CLI usage.

## Image Strategy

- **eidos-validator:latest** - Agent deployments (has CLI + Go toolchain + test binaries)
- **eidos:latest** - Ko-built CLI-only image for direct Docker usage
- **eidosd:latest** - API server (unchanged)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] E2E tests pass (`make kwok-test-all`)
- [ ] Manual validation: `eidos validate --recipe recipe.yaml --phase readiness`

## Files Changed

**Core:**
- Dockerfile.validator - Add eidos CLI build
- pkg/k8s/agent/job.go - Update command path
- pkg/cli/snapshot.go, pkg/cli/validate.go - Update default image

**Tests:**
- pkg/k8s/agent/deployer_test.go
- pkg/validator/agent/deployer_test.go
- tests/e2e/run.sh
- tests/chainsaw/snapshot/deploy-agent/snapshot-job.yaml

**Documentation:**
- docs/user/agent-deployment.md
- docs/user/cli-reference.md
- docs/contributor/cli.md
- docs/integrator/kubernetes-deployment.md
- pkg/validator/checks/README.md

**Deployments:**
- deployments/eidos-agent/2-job.yaml
- examples/demos/e2e.md