### PR TITLE
docs: add sample dynamo inference workload to CUJ2

### DIFF
--- a/examples/demos/cuj2.md
+++ b/examples/demos/cuj2.md
@@ -153,14 +153,75 @@ phases:
     duration: 64µs
 ```
 
-## Run Job
+## Run Inference Workload
 
-TODO: Add simple Dynamo workload
+### Create namespace and HuggingFace secret
+
+```shell
+kubectl create ns dynamo-workload
+
+# Create HuggingFace token secret (set HF_TOKEN env var first)
+sed "s/<your-hf-token>/$HF_TOKEN/" \
+  examples/demos/workloads/inference/hf-token-secret.yaml | kubectl apply -f -
+```
+
+### Deploy the DynamoGraphDeployment
+
+```shell
+kubectl apply -f examples/demos/workloads/inference/vllm-agg.yaml
+
+# Monitor deployment
+kubectl get dynamographdeployments -n dynamo-workload
+kubectl get pods -n dynamo-workload -w
+```
+
+Wait until all pods are `Running` and ready:
+```
+NAME                                    READY   STATUS    RESTARTS   AGE
+vllm-agg-frontend-0                     1/1     Running   0          2m
+vllm-agg-vllmdecodeworker-0             1/1     Running   0          2m
+```
+
+### Test the endpoint
+
+```shell
+# Port-forward the frontend service
+kubectl port-forward -n dynamo-workload svc/vllm-agg-frontend 8000:8000 &
+
+# Send a chat completion request
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "What is Kubernetes?"}],
+    "max_tokens": 64
+  }'
+```
+
+Sample response:
+```json
+{
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "model": "Qwen/Qwen3-0.6B",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Kubernetes is an open-source container orchestration platform..."
+      },
+      "finish_reason": "length"
+    }
+  ]
+}
+```
 
 ## Success
 
-1) Job success
-2) Validation report correctly reflects the level of CNCF Conformance
+1) DynamoGraphDeployment pods are running and healthy
+2) OpenAI-compatible chat completions API returns successful responses
+3) Validation report correctly reflects the level of CNCF Conformance
 
 > Synthetic workload, perf checks beyond the basic fabric validation is out of scope here.
 

--- a/examples/demos/workloads/inference/hf-token-secret.yaml
+++ b/examples/demos/workloads/inference/hf-token-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token-secret
+  namespace: dynamo-workload
+type: Opaque
+stringData:
+  token: <your-hf-token>

--- a/examples/demos/workloads/inference/vllm-agg.yaml
+++ b/examples/demos/workloads/inference/vllm-agg.yaml
@@ -1,0 +1,46 @@
+apiVersion: dynamo.nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg
+  namespace: dynamo-workload
+spec:
+  services:
+    - name: Frontend
+      replicas: 1
+      componentType: frontend
+      spec:
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+        command:
+          - python
+          - -m
+          - dynamo.runtime
+          - --service
+          - Frontend
+        envs:
+          - name: SERVED_MODEL_NAME
+            value: Qwen/Qwen3-0.6B
+        envFrom:
+          - secretRef:
+              name: hf-token-secret
+    - name: VllmDecodeWorker
+      replicas: 1
+      componentType: worker
+      spec:
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+        command:
+          - python
+          - -m
+          - dynamo.runtime
+          - --service
+          - VllmDecodeWorker
+        envs:
+          - name: MODEL_NAME
+            value: Qwen/Qwen3-0.6B
+        envFrom:
+          - secretRef:
+              name: hf-token-secret
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+          requests:
+            nvidia.com/gpu: "1"


### PR DESCRIPTION
## Summary
- Replace the TODO placeholder in CUJ2 demo doc with a complete inference workload example
- Add DynamoGraphDeployment YAML (vllm-agg with Qwen3-0.6B) and HuggingFace token secret
- Document namespace setup, deployment, monitoring, and endpoint testing via OpenAI-compatible API

## Test plan
- [ ] YAML files pass `yamllint`
- [ ] Documentation steps are accurate and follow CUJ1 patterns
- [ ] Deploy vllm-agg on a cluster with dynamo-platform and verify chat completions endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)