### PR TITLE
docs: add AWS Security Group prerequisites for dynamo-platform EKS overlay

### DIFF
--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -34,6 +34,30 @@ spec:
     - name: K8s.server.version
       value: ">= 1.34"
 
+  # AWS Security Group Prerequisites (EKS only):
+  #
+  # Dynamo-platform's etcd (port 2379) and NATS (port 4222) typically run on
+  # system nodes. If GPU worker nodes are in a different subnet/security group,
+  # AWS SGs may block this traffic, causing pods to fail with:
+  #   - "Unable to create lease" (etcd unreachable)
+  #   - "JetStream not available" (NATS unreachable)
+  #
+  # To fix, allow ingress from the GPU node SG to the system node SG:
+  #
+  #   # 1. Find security group IDs for system and GPU nodes:
+  #   aws ec2 describe-instances \
+  #     --filters "Name=tag:eks:nodegroup-name,Values=<system-nodegroup>" \
+  #     --query "Reservations[0].Instances[0].SecurityGroups[*].GroupId" --output text
+  #   aws ec2 describe-instances \
+  #     --filters "Name=tag:eks:nodegroup-name,Values=<gpu-nodegroup>" \
+  #     --query "Reservations[0].Instances[0].SecurityGroups[*].GroupId" --output text
+  #
+  #   # 2. Allow etcd and NATS traffic from GPU nodes to system nodes:
+  #   aws ec2 authorize-security-group-ingress --group-id <system-sg-id> \
+  #     --protocol tcp --port 2379 --source-group <gpu-sg-id>
+  #   aws ec2 authorize-security-group-ingress --group-id <system-sg-id> \
+  #     --protocol tcp --port 4222 --source-group <gpu-sg-id>
+
   componentRefs:
     - name: nvidia-dra-driver-gpu
       type: Helm


### PR DESCRIPTION
## Summary
- Document cross-security-group connectivity requirement for EKS clusters where GPU and system nodes are in different subnets
- Without ingress rules, dynamo worker pods cannot reach etcd (port 2379) or NATS (port 4222) on system nodes, causing "Unable to create lease" and "JetStream not available" errors
- Include AWS CLI commands to identify security groups and authorize the required traffic

## Test plan
- [ ] `yamllint` passes on the modified overlay
- [ ] Documentation is accurate based on manual EKS deployment experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)