### PR TITLE
fix: enable GPU resources and upgrade DRA driver to 25.12.0

### DIFF
--- a/recipes/components/nvidia-dra-driver-gpu/values.yaml
+++ b/recipes/components/nvidia-dra-driver-gpu/values.yaml
@@ -25,10 +25,10 @@ fullnameOverride: nvidia-dra-driver-gpu
 
 nvidiaDriverRoot: /run/nvidia/driver
 
-gpuResourcesEnabledOverride: false
+gpuResourcesEnabledOverride: true
 resources:
   gpus:
-    enabled: false
+    enabled: true
 
 controller:
   priorityClassName: ""

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -74,7 +74,7 @@ spec:
     - name: nvidia-dra-driver-gpu
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia
-      version: "25.8.1"
+      version: "25.12.0"
       valuesFile: components/nvidia-dra-driver-gpu/values.yaml
       dependencyRefs:
         - gpu-operator

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -184,7 +184,7 @@ spec:
     - name: nvidia-dra-driver-gpu
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia
-      version: "25.8.1"
+      version: "25.12.0"
       valuesFile: components/nvidia-dra-driver-gpu/values.yaml
       dependencyRefs:
         - gpu-operator


### PR DESCRIPTION
## Summary
- Enable `gpuResourcesEnabledOverride: true` and `resources.gpus.enabled: true` in the NVIDIA DRA driver component values so individual GPUs are published as DRA ResourceSlices with the `gpu.nvidia.com` DeviceClass
- Upgrade DRA driver version from 25.8.1 to 25.12.0 in Kind and EKS inference overlays

## Test plan
- [ ] Deploy DRA driver with updated values
- [ ] Verify `kubectl get deviceclass` shows `gpu.nvidia.com`
- [ ] Verify `kubectl get resourceslices` shows GPU devices
- [ ] Deploy a pod with a DRA ResourceClaim requesting `gpu.nvidia.com` and confirm GPU access

🤖 Generated with [Claude Code](https://claude.com/claude-code)