### PR TITLE
refactor: move kai-scheduler and DRA driver to base overlay for CNCF AI conformance

### DIFF
--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -70,3 +70,19 @@ spec:
       valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
       dependencyRefs:
         - kube-prometheus-stack
+
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia
+      version: "25.12.0"
+      valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+      dependencyRefs:
+        - gpu-operator
+
+    - name: kai-scheduler
+      type: Helm
+      source: oci://ghcr.io/nvidia/kai-scheduler
+      version: v0.12.14
+      valuesFile: components/kai-scheduler/values.yaml
+      dependencyRefs:
+        - gpu-operator

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -75,11 +75,6 @@ spec:
 
     - name: nvidia-dra-driver-gpu
       type: Helm
-      source: https://helm.ngc.nvidia.com/nvidia
-      version: "25.12.0"
-      valuesFile: components/nvidia-dra-driver-gpu/values.yaml
-      dependencyRefs:
-        - gpu-operator
       overrides:
         gpuResourcesEnabledOverride: true
         # EKS has no control-plane nodes — remove the default nodeAffinity
@@ -88,14 +83,6 @@ spec:
             nodeAffinity: null
           tolerations:
             - operator: Exists
-
-    - name: kai-scheduler
-      type: Helm
-      source: oci://ghcr.io/nvidia/kai-scheduler
-      version: v0.12.14
-      valuesFile: components/kai-scheduler/values.yaml
-      dependencyRefs:
-        - gpu-operator
 
     - name: dynamo-crds
       type: Helm

--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -34,14 +34,6 @@ spec:
       value: ">= 1.34"
 
   componentRefs:
-    - name: kai-scheduler
-      type: Helm
-      source: oci://ghcr.io/nvidia/kai-scheduler
-      version: v0.12.14
-      valuesFile: components/kai-scheduler/values.yaml
-      dependencyRefs:
-        - gpu-operator
-
     - name: dynamo-crds
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -179,15 +179,9 @@ spec:
                 cpu: 500m
                 memory: 1Gi
 
-    # nvidia-dra-driver-gpu: DRA driver for GPU resource management
-    # For kind with GPU passthrough, use "/" as driver root (host drivers)
+    # nvidia-dra-driver-gpu: override driver root for kind GPU passthrough
     - name: nvidia-dra-driver-gpu
       type: Helm
-      source: https://helm.ngc.nvidia.com/nvidia
-      version: "25.12.0"
-      valuesFile: components/nvidia-dra-driver-gpu/values.yaml
-      dependencyRefs:
-        - gpu-operator
       overrides:
         # Use "/" for host-installed drivers (kind GPU passthrough)
         nvidiaDriverRoot: "/"

--- a/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
@@ -40,8 +40,10 @@ componentRefs: ## alphabetically sorted
   - name: cert-manager
   - name: gpu-operator
   - name: k8s-ephemeral-storage-metrics
+  - name: kai-scheduler
   - name: kube-prometheus-stack
   - name: kubeflow-trainer
+  - name: nvidia-dra-driver-gpu
   - name: nvsentinel
   - name: prometheus-adapter
   - name: skyhook-customizations
@@ -51,9 +53,11 @@ deploymentOrder:
   - aws-efa
   - cert-manager
   - gpu-operator
+  - kai-scheduler
   - kube-prometheus-stack
   - k8s-ephemeral-storage-metrics
   - kubeflow-trainer
+  - nvidia-dra-driver-gpu
   - nvsentinel
   - prometheus-adapter
   - skyhook-operator


### PR DESCRIPTION
## Summary

Move `nvidia-dra-driver-gpu` and `kai-scheduler` component definitions from overlay-specific configs into `base.yaml`.

## Motivation / Context

Both training and inference clusters need gang scheduling (kai-scheduler) and DRA support (nvidia-dra-driver-gpu) to meet CNCF AI Conformance requirements. Moving them to base ensures all recipe variants include these components. Overlays retain only environment-specific overrides (EKS: controller affinity/tolerations, Kind: nvidiaDriverRoot).

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- CUJ1 training test assertion updated to include the two new base components in `componentRefs` and `deploymentOrder`
- Overlay-specific overrides preserved (EKS affinity/tolerations, Kind nvidiaDriverRoot)

## Testing

```bash
make test
make lint
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)