### PR TITLE
fix(ci): re-enable CDI for H100 kind smoke test

### DIFF
--- a/.github/workflows/gpu-h100-smoke-test.yaml
+++ b/.github/workflows/gpu-h100-smoke-test.yaml
@@ -30,6 +30,10 @@ on:
       - 'tests/manifests/**'
       - 'tests/chainsaw/ai-conformance/**'
       - 'recipes/components/dynamo-platform/**'
+      - 'recipes/overlays/kind.yaml'
+      - 'recipes/overlays/kind-inference.yaml'
+      - 'recipes/overlays/h100-kind-inference.yaml'
+      - 'recipes/overlays/h100-kind-inference-dynamo.yaml'
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:

--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -34,14 +34,6 @@ spec:
       value: ">= 1.34"
 
   componentRefs:
-    # Disable CDI in the GPU Operator ClusterPolicy to prevent the
-    # KAI scheduler binder from injecting unresolvable CDI annotations.
-    - name: gpu-operator
-      type: Helm
-      overrides:
-        cdi:
-          enabled: false
-
     - name: kai-scheduler
       type: Helm
       source: oci://ghcr.io/nvidia/kai-scheduler

--- a/tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml
+++ b/tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml
@@ -17,16 +17,16 @@
 # Provides NVIDIA Dynamo inference serving: OpenAI-compatible endpoints,
 # KV-cache-aware routing, disaggregated prefill/decode, SLA-driven autoscaling.
 #
-# Resource naming:
-#   dynamo-operator: fullnameOverride=dynamo-operator
-#   etcd: default (<release>-etcd = dynamo-platform-etcd)
-#   nats: default (<release>-nats = dynamo-platform-nats)
+# Resource naming (all use default <release>-<subchart> pattern):
+#   dynamo-operator: <release>-dynamo-operator = dynamo-platform-dynamo-operator
+#   etcd: <release>-etcd = dynamo-platform-etcd
+#   nats: <release>-nats = dynamo-platform-nats
 
 # Dynamo Operator — manages DynamoComponent and DynamoGraphDeployment CRs
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dynamo-operator-controller-manager
+  name: dynamo-platform-dynamo-operator-controller-manager
   namespace: dynamo-system
 status:
   (conditions[?type == 'Available']):


### PR DESCRIPTION
## Summary

Fix H100 GPU smoke test failures by re-enabling CDI and correcting the Dynamo operator deployment name in chainsaw assertions.

## Motivation / Context

The H100 smoke test consistently fails with `gpu-count: 0` because the `h100-kind-inference-dynamo` overlay disables CDI at the GPU Operator level. Without CDI, the NVIDIA container runtime does not inject `nvidia-smi` into the eidos agent pod, causing the GPU collector to take the graceful no-GPU path (`noGPUMeasurement()`).

Additionally, the chainsaw health check asserts a Deployment named `dynamo-operator-controller-manager`, but the actual Helm-generated name is `dynamo-platform-dynamo-operator-controller-manager` (no `fullnameOverride` is set in the values file).

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI workflow, recipe overlays, chainsaw test assertions

## Implementation Notes

- Removed `cdi: enabled: false` override from `h100-kind-inference-dynamo` overlay — GPU Operator now uses default CDI settings, allowing nvidia-smi injection into agent pods
- Added kind-related overlay paths to the H100 workflow trigger so changes to the overlay chain trigger a CI run
- Fixed Dynamo operator Deployment name in chainsaw assert to match actual Helm naming (`dynamo-platform-dynamo-operator-controller-manager`)

## Testing

CI run with CDI fix confirmed snapshot step now passes: https://github.com/NVIDIA/eidos/actions/runs/22146291973

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)