### PR TITLE
fix: add merge logic for ExpectedResources, Cleanup, and ValidationConfig in recipe overlays

### DIFF
--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -371,6 +371,26 @@ func (s *RecipeMetadataSpec) Merge(other *RecipeMetadataSpec) {
 	sort.Slice(s.ComponentRefs, func(i, j int) bool {
 		return s.ComponentRefs[i].Name < s.ComponentRefs[j].Name
 	})
+
+	// Merge validation config - overlay phases take precedence
+	if other.Validation != nil {
+		if s.Validation == nil {
+			s.Validation = other.Validation
+		} else {
+			if other.Validation.PreDeployment != nil {
+				s.Validation.PreDeployment = other.Validation.PreDeployment
+			}
+			if other.Validation.Deployment != nil {
+				s.Validation.Deployment = other.Validation.Deployment
+			}
+			if other.Validation.Performance != nil {
+				s.Validation.Performance = other.Validation.Performance
+			}
+			if other.Validation.Conformance != nil {
+				s.Validation.Conformance = other.Validation.Conformance
+			}
+		}
+	}
 }
 
 // mergeComponentRef merges overlay into base, with overlay taking precedence
@@ -447,6 +467,16 @@ func mergeComponentRef(base, overlay ComponentRef) ComponentRef {
 	// Path: overlay takes precedence if set (for Kustomize)
 	if overlay.Path != "" {
 		result.Path = overlay.Path
+	}
+
+	// Cleanup: overlay takes precedence if true
+	if overlay.Cleanup {
+		result.Cleanup = overlay.Cleanup
+	}
+
+	// ExpectedResources: overlay replaces if set
+	if len(overlay.ExpectedResources) > 0 {
+		result.ExpectedResources = overlay.ExpectedResources
 	}
 
 	return result

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -299,6 +299,7 @@ func finalizeRecipeResult(criteria *Criteria, mergedSpec *RecipeMetadataSpec, ap
 		Constraints:     mergedSpec.Constraints,
 		ComponentRefs:   mergedSpec.ComponentRefs,
 		DeploymentOrder: deployOrder,
+		Validation:      mergedSpec.Validation,
 	}
 	result.Metadata.AppliedOverlays = appliedOverlays
 

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -420,6 +420,180 @@ func TestMergeComponentRef_AdvancedFields(t *testing.T) {
 			t.Errorf("tag = %q, want v2.0", result.Tag)
 		}
 	})
+
+	t.Run("expectedResources replaced by overlay", func(t *testing.T) {
+		base := ComponentRef{
+			Name: "gpu-operator",
+			ExpectedResources: []ExpectedResource{
+				{Kind: "Deployment", Name: "gpu-operator", Namespace: "gpu-operator"},
+			},
+		}
+		overlay := ComponentRef{
+			Name: "gpu-operator",
+			ExpectedResources: []ExpectedResource{
+				{Kind: "DaemonSet", Name: "nvidia-driver", Namespace: "gpu-operator"},
+				{Kind: "DaemonSet", Name: "dcgm-exporter", Namespace: "gpu-operator"},
+			},
+		}
+		result := mergeComponentRef(base, overlay)
+		if len(result.ExpectedResources) != 2 {
+			t.Errorf("expectedResources len = %d, want 2", len(result.ExpectedResources))
+		}
+		if result.ExpectedResources[0].Kind != "DaemonSet" {
+			t.Errorf("expectedResources[0].Kind = %q, want DaemonSet", result.ExpectedResources[0].Kind)
+		}
+	})
+
+	t.Run("expectedResources inherited from base", func(t *testing.T) {
+		base := ComponentRef{
+			Name: "gpu-operator",
+			ExpectedResources: []ExpectedResource{
+				{Kind: "Deployment", Name: "gpu-operator", Namespace: "gpu-operator"},
+			},
+		}
+		overlay := ComponentRef{
+			Name:      "gpu-operator",
+			Overrides: map[string]any{"cdi.enabled": true},
+		}
+		result := mergeComponentRef(base, overlay)
+		if len(result.ExpectedResources) != 1 {
+			t.Errorf("expectedResources len = %d, want 1 (inherited from base)", len(result.ExpectedResources))
+		}
+		if result.ExpectedResources[0].Name != "gpu-operator" {
+			t.Errorf("expectedResources[0].Name = %q, want gpu-operator", result.ExpectedResources[0].Name)
+		}
+	})
+
+	t.Run("cleanup inherited from base", func(t *testing.T) {
+		base := ComponentRef{Name: "nccl-doctor", Cleanup: true}
+		overlay := ComponentRef{Name: "nccl-doctor", Version: "v2.0"}
+		result := mergeComponentRef(base, overlay)
+		if !result.Cleanup {
+			t.Error("cleanup should be inherited from base when overlay doesn't set it")
+		}
+	})
+
+	t.Run("cleanup set by overlay", func(t *testing.T) {
+		base := ComponentRef{Name: "nccl-doctor"}
+		overlay := ComponentRef{Name: "nccl-doctor", Cleanup: true}
+		result := mergeComponentRef(base, overlay)
+		if !result.Cleanup {
+			t.Error("cleanup should be true when overlay sets it")
+		}
+	})
+}
+
+func TestMergeValidationConfig(t *testing.T) {
+	t.Run("overlay phases merge with base", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				PreDeployment: &ValidationPhase{
+					Checks: []string{"gpu-hardware-detection"},
+				},
+				Deployment: &ValidationPhase{
+					Timeout: "5m",
+					Checks:  []string{"operator-health"},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Timeout: "10m",
+					Checks:  []string{"operator-health", "expected-resources"},
+				},
+				Performance: &ValidationPhase{
+					Timeout:        "15m",
+					Infrastructure: "nccl-doctor",
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		if base.Validation == nil {
+			t.Fatal("validation should not be nil after merge")
+		}
+		if base.Validation.PreDeployment == nil {
+			t.Fatal("preDeployment should be preserved from base")
+		}
+		if base.Validation.PreDeployment.Checks[0] != "gpu-hardware-detection" {
+			t.Error("preDeployment checks should be preserved from base")
+		}
+		if base.Validation.Deployment.Timeout != "10m" {
+			t.Errorf("deployment timeout = %q, want 10m (from overlay)", base.Validation.Deployment.Timeout)
+		}
+		if len(base.Validation.Deployment.Checks) != 2 {
+			t.Errorf("deployment checks len = %d, want 2 (from overlay)", len(base.Validation.Deployment.Checks))
+		}
+		if base.Validation.Performance == nil {
+			t.Fatal("performance should be added from overlay")
+		}
+		if base.Validation.Performance.Infrastructure != "nccl-doctor" {
+			t.Errorf("performance infrastructure = %q, want nccl-doctor", base.Validation.Performance.Infrastructure)
+		}
+	})
+
+	t.Run("overlay validation into nil base", func(t *testing.T) {
+		base := RecipeMetadataSpec{}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Checks: []string{"operator-health"},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		if base.Validation == nil {
+			t.Fatal("validation should be set from overlay")
+		}
+		if base.Validation.Deployment == nil || base.Validation.Deployment.Checks[0] != "operator-health" {
+			t.Error("deployment check should be set from overlay")
+		}
+	})
+
+	t.Run("nil overlay validation preserves base", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Checks: []string{"operator-health"},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{}
+		base.Merge(&overlay)
+
+		if base.Validation == nil || base.Validation.Deployment == nil {
+			t.Fatal("validation should be preserved from base when overlay has nil")
+		}
+	})
+}
+
+func TestFinalizeRecipeResultIncludesValidation(t *testing.T) {
+	spec := RecipeMetadataSpec{
+		ComponentRefs: []ComponentRef{
+			{Name: "gpu-operator", Type: "Helm", Source: "https://example.com"},
+		},
+		Validation: &ValidationConfig{
+			Deployment: &ValidationPhase{
+				Checks: []string{"operator-health"},
+			},
+		},
+	}
+	criteria := NewCriteria()
+	result, err := finalizeRecipeResult(criteria, &spec, []string{"base"})
+	if err != nil {
+		t.Fatalf("finalizeRecipeResult() error: %v", err)
+	}
+	if result.Validation == nil {
+		t.Fatal("result.Validation should not be nil")
+	}
+	if result.Validation.Deployment == nil {
+		t.Fatal("result.Validation.Deployment should not be nil")
+	}
+	if result.Validation.Deployment.Checks[0] != "operator-health" {
+		t.Errorf("check = %q, want operator-health", result.Validation.Deployment.Checks[0])
+	}
 }
 
 // Helper function


### PR DESCRIPTION
## Summary

Fix recipe overlay merge logic to preserve `ExpectedResources`, `Cleanup`, and `ValidationConfig` across overlay chains, and wire `Validation` into the final `RecipeResult`.

## Motivation / Context

The recipe overlay merge system (`mergeComponentRef()` and `Merge()`) was silently dropping three fields when overlays re-declared the same component. This blocked the `expected-resources` deployment check because `ExpectedResources` defined in base recipes were lost after merging. Additionally, `ValidationConfig` was never propagated to the final `RecipeResult`, making validation phase configuration invisible to `eidos validate`.

Fixes: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

**Recipe merge fixes (`pkg/recipe/metadata.go`):**
- `mergeComponentRef()`: Added `ExpectedResources` (overlay replaces if set, inherits from base if omitted) and `Cleanup` (overlay takes precedence if `true`, inherits from base otherwise)
- `Merge()`: Added `ValidationConfig` phase-by-phase merge — overlay phase replaces base phase, base phases are preserved if overlay doesn't define them
- `finalizeRecipeResult()`: Now populates `result.Validation` from merged spec

**Validator fixes (`pkg/validator/`):**
- Pre-existing lint issues fixed: `govet` shadow, `unparam`, `exhaustive` switch, `contextcheck`

**Merge strategy summary:**

| Field | Strategy |
|-------|----------|
| `ExpectedResources` | Overlay replaces if set (same as Patches) |
| `Cleanup` | Overlay takes precedence if `true` |
| `ValidationConfig` | Per-phase replace (overlay phase wins) |

## Testing

```bash
# Commands run
make test   # all pass, 70.5% coverage
make lint   # 0 issues
```

New tests added:
- `TestMergeComponentRef_AdvancedFields` — 4 subtests for ExpectedResources and Cleanup merge
- `TestMergeValidationConfig` — 3 subtests for phase-by-phase validation merge
- `TestFinalizeRecipeResultIncludesValidation` — verifies Validation wired into RecipeResult

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration needed. The merge fixes are additive — existing recipes that don't use `expectedResources`, `cleanup`, or `validation` are unaffected. Recipes that do use these fields will now correctly preserve them through the overlay chain.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [ ] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
