### PR TITLE
fix: remove admission.cdi from kai-scheduler values

### DIFF
--- a/recipes/components/kai-scheduler/values.yaml
+++ b/recipes/components/kai-scheduler/values.yaml
@@ -26,7 +26,3 @@ global:
 # Helm uninstall already removes the deployments this hook would delete.
 postCleanup:
   enabled: false
-
-# CDI support for GPU device assignment
-admission:
-  cdi: true


### PR DESCRIPTION
## Summary

Remove unused `admission.cdi: true` from kai-scheduler component values.

## Motivation / Context

CDI admission is only required for GPU sharing (fractional GPU) scenarios not currently
deployed. The reference cluster does not set this flag, and removing it avoids potential
compatibility issues with GPU Operator.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Removed `admission.cdi: true` from `recipes/components/kai-scheduler/values.yaml`.

## Testing

```bash
make lint
make test
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)