### PR TITLE
feat: add CUJ2 inference demo chat UI and update CUJ2 instructions

### DIFF
--- a/examples/demos/cuj2.md
+++ b/examples/demos/cuj2.md
@@ -184,11 +184,22 @@ vllm-agg-vllmdecodeworker-0             1/1     Running   0          2m
 
 ### Test the endpoint
 
+#### Option 1: Chat UI (browser)
+
 ```shell
-# Port-forward the frontend service
+# Launch the chat server (port-forward + local UI on port 9090)
+./examples/demos/workloads/inference/chat-server.sh
+```
+
+Then open http://127.0.0.1:9090/chat.html in your browser.
+
+Press `Ctrl+C` to stop.
+
+#### Option 2: curl (command line)
+
+```shell
 kubectl port-forward -n dynamo-workload svc/vllm-agg-frontend 8000:8000 &
 
-# Send a chat completion request
 curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{

--- a/examples/demos/workloads/inference/chat-server.sh
+++ b/examples/demos/workloads/inference/chat-server.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Dynamo Chat UI — single script to launch everything
+# Usage: ./chat-server.sh
+# Then open: http://127.0.0.1:9090/chat.html
+
+set -e
+
+NAMESPACE="${NAMESPACE:-dynamo-workload}"
+SERVICE="${SERVICE:-svc/vllm-agg-frontend}"
+API_PORT=8000
+UI_PORT=9090
+
+cleanup() {
+    echo "Shutting down..."
+    kill $PF_PID 2>/dev/null
+    kill $PY_PID 2>/dev/null
+    exit 0
+}
+trap cleanup EXIT INT TERM
+
+# Kill anything already on our ports
+for port in $API_PORT $UI_PORT; do
+    pids=$(lsof -ti :$port 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo "Killing existing processes on port $port"
+        echo "$pids" | xargs kill 2>/dev/null || true
+        sleep 1
+    fi
+done
+
+# Start port-forward to Dynamo frontend
+echo "Starting port-forward to $SERVICE on :$API_PORT..."
+kubectl port-forward -n "$NAMESPACE" "$SERVICE" "$API_PORT":8000 &
+PF_PID=$!
+sleep 2
+
+# Start chat UI + API proxy on UI_PORT
+echo "Starting chat UI on :$UI_PORT..."
+python3 -c "
+import http.server, urllib.request, io
+
+API = 'http://127.0.0.1:${API_PORT}'
+HTML = open('$(dirname "$0")/chat.html', 'rb').read() if __import__('os').path.exists('$(dirname "$0")/chat.html') else b''
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/' or self.path == '/chat.html':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.send_header('Content-Length', len(HTML))
+            self.end_headers()
+            self.wfile.write(HTML)
+        elif self.path.startswith('/v1/'):
+            self._proxy()
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path.startswith('/v1/'):
+            self._proxy()
+        else:
+            self.send_error(404)
+
+    def _proxy(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length) if length else None
+        req = urllib.request.Request(
+            API + self.path, data=body,
+            headers={'Content-Type': self.headers.get('Content-Type', 'application/json')},
+            method=self.command)
+        try:
+            with urllib.request.urlopen(req) as r:
+                data = r.read()
+                self.send_response(r.status)
+                self.send_header('Content-Type', r.headers.get('Content-Type', 'application/json'))
+                self.send_header('Content-Length', len(data))
+                self.end_headers()
+                self.wfile.write(data)
+        except urllib.error.URLError as e:
+            self.send_error(502, str(e))
+
+    def log_message(self, fmt, *args): pass
+
+http.server.HTTPServer(('127.0.0.1', ${UI_PORT}), H).serve_forever()
+" &
+PY_PID=$!
+
+echo ""
+echo "Ready! Open http://127.0.0.1:${UI_PORT}/chat.html"
+echo "Press Ctrl+C to stop."
+echo ""
+
+wait

--- a/examples/demos/workloads/inference/chat.html
+++ b/examples/demos/workloads/inference/chat.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Qwen Chat</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #1a1a2e; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
+  header { padding: 16px 24px; background: #16213e; border-bottom: 1px solid #0f3460; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 18px; font-weight: 600; }
+  header span { font-size: 12px; color: #888; background: #0f3460; padding: 2px 8px; border-radius: 10px; }
+  #chat { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+  .msg { max-width: 720px; width: 100%; margin: 0 auto; display: flex; gap: 12px; }
+  .msg.user { flex-direction: row-reverse; }
+  .msg .avatar { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; }
+  .msg.user .avatar { background: #533483; }
+  .msg.assistant .avatar { background: #0f3460; }
+  .msg .bubble { padding: 12px 16px; border-radius: 12px; line-height: 1.6; white-space: pre-wrap; word-break: break-word; }
+  .msg.user .bubble { background: #533483; border-bottom-right-radius: 4px; }
+  .msg.assistant .bubble { background: #16213e; border: 1px solid #0f3460; border-bottom-left-radius: 4px; }
+  .msg.assistant .bubble .thinking { color: #666; font-style: italic; font-size: 13px; }
+  #input-area { padding: 16px 24px; background: #16213e; border-top: 1px solid #0f3460; }
+  #input-row { max-width: 720px; margin: 0 auto; display: flex; gap: 8px; }
+  #input { flex: 1; padding: 12px 16px; border-radius: 12px; border: 1px solid #0f3460; background: #1a1a2e; color: #e0e0e0; font-size: 15px; outline: none; resize: none; font-family: inherit; }
+  #input:focus { border-color: #533483; }
+  #send { padding: 12px 24px; border-radius: 12px; border: none; background: #533483; color: white; font-size: 15px; cursor: pointer; font-weight: 600; }
+  #send:hover { background: #6b44a0; }
+  #send:disabled { background: #333; cursor: not-allowed; }
+  .status { text-align: center; color: #666; font-size: 13px; padding: 8px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Qwen3-0.6B Chat</h1>
+  <span>Dynamo + vLLM</span>
+</header>
+<div id="chat">
+  <div class="status">Send a message to start chatting</div>
+</div>
+<div id="input-area">
+  <div id="input-row">
+    <textarea id="input" rows="1" placeholder="Type a message... (Shift+Enter for newline)" autofocus></textarea>
+    <button id="send" onclick="send()">Send</button>
+  </div>
+</div>
+<script>
+const API = '/v1/chat/completions';
+const MODEL = 'Qwen/Qwen3-0.6B';
+let messages = [];
+let sending = false;
+
+const chat = document.getElementById('chat');
+const input = document.getElementById('input');
+const btn = document.getElementById('send');
+
+input.addEventListener('keydown', e => {
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+});
+
+input.addEventListener('input', () => {
+  input.style.height = 'auto';
+  input.style.height = Math.min(input.scrollHeight, 120) + 'px';
+});
+
+function addMsg(role, content) {
+  const status = chat.querySelector('.status');
+  if (status) status.remove();
+
+  const div = document.createElement('div');
+  div.className = `msg ${role}`;
+  const avatar = role === 'user' ? 'You' : 'AI';
+  div.innerHTML = `<div class="avatar">${avatar}</div><div class="bubble"></div>`;
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+
+  const bubble = div.querySelector('.bubble');
+  if (content) setContent(bubble, content);
+  return bubble;
+}
+
+function setContent(bubble, text) {
+  // Separate thinking from response
+  const thinkMatch = text.match(/<think>([\s\S]*?)<\/think>/);
+  let display = text.replace(/<think>[\s\S]*?<\/think>\s*/, '');
+  // Handle unclosed think tags (streaming)
+  if (!display && text.includes('<think>')) {
+    const after = text.split('<think>').pop();
+    bubble.innerHTML = `<div class="thinking">${after.replace('</think>', '').trim() || 'Thinking...'}</div>`;
+    return;
+  }
+  if (thinkMatch && thinkMatch[1].trim()) {
+    bubble.innerHTML = `<div class="thinking">${thinkMatch[1].trim()}</div><br>${display.trim()}`;
+  } else {
+    bubble.textContent = display.trim() || text;
+  }
+}
+
+async function send() {
+  const text = input.value.trim();
+  if (!text || sending) return;
+
+  sending = true;
+  btn.disabled = true;
+  input.value = '';
+  input.style.height = 'auto';
+
+  addMsg('user', text);
+  messages.push({ role: 'user', content: text });
+
+  const bubble = addMsg('assistant', '');
+  bubble.textContent = 'Thinking...';
+
+  try {
+    const res = await fetch(API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: MODEL, messages, max_tokens: 512 }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const content = data.choices[0].message.content;
+    messages.push({ role: 'assistant', content });
+    setContent(bubble, content);
+  } catch (err) {
+    bubble.textContent = `Error: ${err.message}. Make sure port-forward is running.`;
+  }
+
+  sending = false;
+  btn.disabled = false;
+  chat.scrollTop = chat.scrollHeight;
+  input.focus();
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add a browser-based chat UI for testing Dynamo inference deployments and update CUJ2
documentation with chat UI instructions.

## Motivation / Context

Provides a simple way to interactively test Dynamo vLLM inference deployments via a
browser chat interface, in addition to the existing curl-based approach.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/eidos`, `pkg/cli`)
- [ ] API server (`cmd/eidosd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- `examples/demos/workloads/inference/chat.html` — Browser chat UI targeting
  Dynamo's OpenAI-compatible `/v1/chat/completions` endpoint
- `examples/demos/workloads/inference/chat-server.sh` — Single script that starts
  kubectl port-forward and a local proxy server, then serves the chat UI on port 9090
- `examples/demos/cuj2.md` — Updated "Test the endpoint" section with chat UI as
  Option 1 and curl as Option 2

## Testing

```bash
make lint
```

Tested manually against Dynamo vLLM deployment on H100 EKS cluster.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)