### PR TITLE
[DO-NOT-MERGE] feat: add kubeflow-trainer to h100-kind-inference-dynamo overlay

### DIFF
--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -19,7 +19,7 @@ metadata:
 
 spec:
   # Inherits from h100-kind-inference (H100 + kind + inference settings)
-  # Adds Dynamo inference platform components.
+  # Adds Dynamo inference platform and Kubeflow Training Operator components.
   base: h100-kind-inference
 
   criteria:
@@ -68,3 +68,9 @@ spec:
               fileStore:
                 pvc:
                   storageClassName: standard
+
+    - name: kubeflow-trainer
+      type: Helm
+      valuesFile: components/kubeflow-trainer/values.yaml
+      manifestFiles:
+        - components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml


### PR DESCRIPTION
## Summary
- Adds `kubeflow-trainer` (v2.1.0) component to the `h100-kind-inference-dynamo` overlay
- Provides PyTorchJob CRD and Kubeflow Training Operator in the Kind H100 CI cluster
- Enables running the gang scheduling test (`tests/manifests/gang-scheduling-test.yaml`) from #150 in the H100 smoke test
- Mirrors the pattern used in the EKS training overlay (`h100-eks-ubuntu-training-kubeflow`)

## Test plan
- [ ] `make test` passes (recipe resolution includes kubeflow-trainer)
- [ ] H100 smoke test deploys kubeflow-trainer successfully alongside existing components
- [ ] PyTorchJob CRD is available in the cluster after bundle install

🤖 Generated with [Claude Code](https://claude.com/claude-code)