### PR TITLE
feat: add GPU training CI workflow with gang scheduling test

### DIFF
--- a/.github/actions/gpu-operator-install/action.yml
+++ b/.github/actions/gpu-operator-install/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Accelerator type for recipe generation (bundle mode only, e.g. h100)'
     required: false
     default: ''
+  intent:
+    description: 'Intent for recipe generation (bundle mode only, e.g. inference, training)'
+    required: false
+    default: 'inference'
   platform:
     description: 'Platform for recipe generation (bundle mode only, e.g. dynamo)'
     required: false
@@ -63,7 +67,7 @@ runs:
 
     # --- Bundle mode: eidos recipe → bundle → deploy ---
 
-    - name: Generate inference recipe
+    - name: Generate recipe
       if: inputs.method == 'bundle'
       shell: bash
       run: |
@@ -75,7 +79,7 @@ runs:
           --service kind \
           --accelerator ${{ inputs.accelerator }} \
           --os ubuntu \
-          --intent inference \
+          --intent ${{ inputs.intent }} \
           ${PLATFORM_FLAG} \
           --output recipe.yaml
         echo "--- Recipe ---"

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: GPU Smoke Test (nvkind + H100)
+name: GPU Inference Test (nvkind + H100)
 
 on:
   schedule:
@@ -21,7 +21,7 @@ on:
     branches:
       - "pull-request/[0-9]+"
     paths:
-      - '.github/workflows/gpu-h100-smoke-test.yaml'
+      - '.github/workflows/gpu-h100-inference-test.yaml'
       - '.github/actions/gpu-cluster-setup/**'
       - '.github/actions/gpu-operator-install/**'
       - '.github/actions/eidos-build/**'
@@ -46,13 +46,13 @@ concurrency:
 
 jobs:
 
-  gpu-smoke-test:
-    name: GPU Smoke Test (nvkind + H100)
+  gpu-inference-test:
+    name: GPU Inference Test (nvkind + H100)
     runs-on: linux-amd64-gpu-h100-latest-1
     timeout-minutes: 45
 
     env:
-      KIND_CLUSTER_NAME: gpu-smoke-test
+      KIND_CLUSTER_NAME: gpu-inference-test
 
     steps:
 

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -1,0 +1,182 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: GPU Training Test (nvkind + H100 x2)
+
+on:
+  schedule:
+    - cron: '0 6,18 * * *'  # Every 12 hours (2x daily)
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+    paths:
+      - '.github/workflows/gpu-h100-training-test.yaml'
+      - '.github/actions/gpu-cluster-setup/**'
+      - '.github/actions/gpu-operator-install/**'
+      - '.github/actions/eidos-build/**'
+      - '.github/actions/gpu-test-cleanup/**'
+      - '.github/actions/load-versions/**'
+      - 'docs/conformance/cncf/manifests/gang-scheduling-test.yaml'
+      - 'tests/chainsaw/ai-conformance/kind-training/**'
+      - 'recipes/components/dynamo-platform/**'
+      - 'recipes/overlays/kind.yaml'
+      - 'recipes/overlays/h100-kind-training.yaml'
+  workflow_dispatch: {}  # Allow manual runs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  gpu-training-test:
+    name: GPU Training Test (nvkind + H100 x2)
+    runs-on: linux-amd64-gpu-h100-latest-2
+    timeout-minutes: 45
+
+    env:
+      KIND_CLUSTER_NAME: gpu-training-test
+
+    steps:
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up GPU cluster
+        uses: ./.github/actions/gpu-cluster-setup
+
+      - name: Build eidos
+        uses: ./.github/actions/eidos-build
+
+      - name: Install GPU operator (bundle)
+        uses: ./.github/actions/gpu-operator-install
+        with:
+          method: bundle
+          accelerator: h100
+          intent: training
+
+      # --- Health checks ---
+
+      - name: Install chainsaw
+        run: |
+          CHAINSAW_VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
+          GOFLAGS= go install "github.com/kyverno/chainsaw@${CHAINSAW_VERSION}"
+          chainsaw version
+
+      - name: Run chainsaw health checks
+        run: |
+          chainsaw test \
+            --test-dir tests/chainsaw/ai-conformance/kind-training \
+            --config tests/chainsaw/chainsaw-config.yaml
+
+      # --- Gang scheduling test with PodGroup + KAI scheduler ---
+
+      - name: Deploy gang scheduling test
+        run: |
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
+            -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml
+
+          echo "Waiting for gang scheduling pods to complete..."
+          for i in $(seq 1 60); do
+            PHASE_0=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
+              -n gang-scheduling-test get pod gang-worker-0 \
+              -o jsonpath='{.status.phase}' 2>/dev/null)
+            PHASE_1=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
+              -n gang-scheduling-test get pod gang-worker-1 \
+              -o jsonpath='{.status.phase}' 2>/dev/null)
+
+            if [[ "${PHASE_0}" == "Succeeded" && "${PHASE_1}" == "Succeeded" ]]; then
+              echo "Both gang scheduling pods succeeded!"
+              break
+            fi
+
+            if [[ "${PHASE_0}" == "Failed" || "${PHASE_1}" == "Failed" ]]; then
+              echo "::error::Gang scheduling pod failed (worker-0=${PHASE_0}, worker-1=${PHASE_1})"
+              kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+                describe pods 2>/dev/null || true
+              exit 1
+            fi
+
+            echo "Waiting for pod completion... worker-0=${PHASE_0}, worker-1=${PHASE_1} (${i}/60)"
+            sleep 10
+          done
+
+          if [[ "${PHASE_0}" != "Succeeded" || "${PHASE_1}" != "Succeeded" ]]; then
+            echo "::error::Gang scheduling pods did not complete within 10 minutes"
+            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+              describe pods 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "=== gang-worker-0 logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            logs gang-worker-0 2>/dev/null || true
+          echo "=== gang-worker-1 logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            logs gang-worker-1 2>/dev/null || true
+
+      # --- Debug diagnostics (before cleanup so resources still exist) ---
+
+      - name: Debug diagnostics
+        if: failure()
+        run: |
+          echo "=== KAI scheduler pods ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n kai-scheduler get pods -o wide 2>/dev/null || true
+          echo "=== KAI scheduler logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n kai-scheduler \
+            logs deployment/kai-scheduler-default --tail=100 2>/dev/null || true
+          echo "=== KAI scheduler queues ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" get queues -A 2>/dev/null || true
+          echo "=== KAI scheduler podgroups ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" get podgroups -A 2>/dev/null || true
+          echo "=== Gang scheduling test pods ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            describe pods 2>/dev/null || true
+          echo "=== gang-worker-0 logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            logs gang-worker-0 --tail=50 2>/dev/null || true
+          echo "=== gang-worker-1 logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            logs gang-worker-1 --tail=50 2>/dev/null || true
+          echo "=== ResourceClaims ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            get resourceclaims -o yaml 2>/dev/null || true
+          echo "=== Non-running pods (all namespaces) ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" get pods -A \
+            --field-selector=status.phase!=Running,status.phase!=Succeeded 2>/dev/null || true
+          echo "=== Recent events (gang-scheduling-test) ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
+            get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+          echo "=== GPU Operator pods ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator get pods -o wide 2>/dev/null || true
+          echo "=== Node resources ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" describe nodes 2>/dev/null | \
+            grep -A 20 "Allocated resources" || true
+
+      - name: Gang scheduling test cleanup
+        if: always()
+        run: |
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" delete \
+            -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml --ignore-not-found 2>/dev/null || true
+
+      - name: GPU Test Cleanup
+        if: always()
+        uses: ./.github/actions/gpu-test-cleanup
+        with:
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}

--- a/recipes/overlays/h100-kind-training.yaml
+++ b/recipes/overlays/h100-kind-training.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: eidos.nvidia.com/v1alpha1
+metadata:
+  name: h100-kind-training
+
+spec:
+  # Inherits from kind recipe (kind-specific GPU operator + monitoring settings)
+  # Adds Dynamo platform components for the training stack.
+  base: kind
+
+  criteria:
+    service: kind
+    accelerator: h100
+    intent: training
+
+  # DRA requires Kubernetes 1.34+ (GA)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.34"
+
+  componentRefs:
+    # Dynamo platform (model serving, orchestration)
+    - name: dynamo-crds
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.8.1"
+      valuesFile: components/dynamo-crds/values.yaml
+
+    - name: dynamo-platform
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.8.1"
+      valuesFile: components/dynamo-platform/values.yaml
+      dependencyRefs:
+        - dynamo-crds
+        - cert-manager
+        - kube-prometheus-stack
+      overrides:
+        # Use kind's local-path-provisioner instead of EBS gp2
+        etcd:
+          persistence:
+            storageClass: standard
+        nats:
+          config:
+            jetstream:
+              fileStore:
+                pvc:
+                  storageClassName: standard

--- a/tests/chainsaw/ai-conformance/kind-training/assert-crds.yaml
+++ b/tests/chainsaw/ai-conformance/kind-training/assert-crds.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert that critical CRDs are installed by the kind training stack.
+# Compared to the cluster (inference) assert-crds:
+#   Removed: kgateway-crds (Gateway API, Inference Extension) — inference-only
+
+# ── GPU Operator ───────────────────────────────────────────────────────
+# ClusterPolicy CRD — the GPU operator's primary configuration object
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterpolicies.nvidia.com
+---
+# ── cert-manager ───────────────────────────────────────────────────────
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.cert-manager.io
+---
+# ── dynamo-crds ────────────────────────────────────────────────────────
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamocomponentdeployments.nvidia.com
+---
+# ── Skyhook ────────────────────────────────────────────────────────────
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: skyhooks.skyhook.nvidia.com

--- a/tests/chainsaw/ai-conformance/kind-training/assert-namespaces.yaml
+++ b/tests/chainsaw/ai-conformance/kind-training/assert-namespaces.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert that all namespaces created by the kind training stack exist.
+# Compared to the kind inference test:
+#   Removed: kgateway-system (inference-only)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-operator
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvsentinel
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skyhook
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-dra-driver
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kai-scheduler
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dynamo-system
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-network-operator
+status:
+  phase: Active

--- a/tests/chainsaw/ai-conformance/kind-training/chainsaw-test.yaml
+++ b/tests/chainsaw/ai-conformance/kind-training/chainsaw-test.yaml
@@ -1,0 +1,115 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kind-training-cluster-health
+spec:
+  description: |
+    Kind Training Stack — Cluster Health Check.
+    Validates that all components of the h100-kind-training recipe are healthy
+    on a kind cluster with GPU passthrough. This test does NOT deploy workloads —
+    it validates already-deployed infrastructure.
+    Prerequisites: kind cluster with the training stack deployed.
+    Run with: chainsaw test --test-dir tests/chainsaw/ai-conformance/kind-training
+  timeouts:
+    assert: 300s
+  steps:
+
+    # ── Namespaces ─────────────────────────────────────────────────────
+    - name: assert-namespaces
+      description: Verify all expected namespaces exist and are active.
+      timeouts:
+        assert: 120s
+      try:
+        - assert:
+            file: assert-namespaces.yaml
+
+    # ── CRDs ───────────────────────────────────────────────────────────
+    - name: assert-crds
+      description: Verify critical CRDs are installed (dynamo, GPU operator, cert-manager).
+      timeouts:
+        assert: 120s
+      try:
+        - assert:
+            file: assert-crds.yaml
+
+    # ── cert-manager ───────────────────────────────────────────────────
+    - name: assert-cert-manager
+      description: Verify cert-manager controller, webhook, and cainjector are available.
+      try:
+        - assert:
+            file: ../cluster/assert-cert-manager.yaml
+
+    # ── GPU Operator ───────────────────────────────────────────────────
+    - name: assert-gpu-operator
+      description: Verify GPU operator and managed components are healthy (kind profile — no driver DaemonSet).
+      timeouts:
+        assert: 600s
+      try:
+        - assert:
+            file: ../kind/assert-gpu-operator.yaml
+
+    # ── Monitoring ─────────────────────────────────────────────────────
+    - name: assert-monitoring
+      description: Verify kube-prometheus-stack, ephemeral storage metrics, and prometheus-adapter.
+      try:
+        - assert:
+            file: ../cluster/assert-monitoring.yaml
+
+    # ── Skyhook ────────────────────────────────────────────────────────
+    - name: assert-skyhook
+      description: Verify Skyhook operator controller-manager is available.
+      try:
+        - assert:
+            file: ../cluster/assert-skyhook.yaml
+
+    # ── NVSentinel ─────────────────────────────────────────────────────
+    - name: assert-nvsentinel
+      description: Verify NVSentinel controller and platform connector are healthy (kind profile).
+      try:
+        - assert:
+            file: ../kind/assert-nvsentinel.yaml
+
+    # ── NVIDIA DRA Driver ──────────────────────────────────────────────
+    - name: assert-dra-driver
+      description: Verify DRA driver controller and kubelet plugin are healthy.
+      timeouts:
+        assert: 600s
+      try:
+        - assert:
+            file: ../cluster/assert-dra-driver.yaml
+
+    # ── Network Operator ───────────────────────────────────────────────
+    - name: assert-network-operator
+      description: Verify NVIDIA Network Operator is available.
+      try:
+        - assert:
+            file: ../kind/assert-network-operator.yaml
+
+    # ── KAI Scheduler ──────────────────────────────────────────────────
+    - name: assert-kai-scheduler
+      description: Verify KAI scheduler is available.
+      try:
+        - assert:
+            file: ../cluster/assert-kai-scheduler.yaml
+
+    # ── Dynamo Platform ────────────────────────────────────────────────
+    - name: assert-dynamo
+      description: Verify Dynamo operator, etcd, and NATS are healthy.
+      try:
+        - assert:
+            file: ../cluster/assert-dynamo.yaml


### PR DESCRIPTION
## Summary
- Add `gpu-h100-training-test.yaml` workflow targeting `linux-amd64-gpu-h100-latest-2` (2-GPU) runner to validate PodGroup-based gang scheduling with KAI scheduler and DRA ResourceClaims
- Add `h100-kind-training.yaml` overlay (kind + training + dynamo)
- Add `kind-training/` chainsaw health checks for the training stack
- Parameterize `intent` in `gpu-operator-install` action (default: `inference`, backwards compatible) so training workflows can pass `--intent training`
- Rename `gpu-h100-smoke-test.yaml` → `gpu-h100-inference-test.yaml` for clarity

## Test plan
- [ ] Verify `gpu-h100-training-test` workflow runs successfully on 2-GPU H100 runner
- [ ] Verify existing `gpu-h100-inference-test` workflow is unaffected (action default is `inference`)
- [ ] Verify gang-worker-0 and gang-worker-1 pods are gang-scheduled by KAI scheduler via PodGroup and complete successfully