### PR TITLE
fix: enable DCGM exporter ServiceMonitor for Prometheus scraping

### DIFF
--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -41,7 +41,7 @@ toolkit:
 
 dcgmExporter:
   serviceMonitor:
-    enabled: false
+    enabled: true
     interval: 60s
   config:
     name: "dcgm-exporter"


### PR DESCRIPTION
## Summary

Enable DCGM exporter ServiceMonitor in GPU Operator values so Prometheus can discover and scrape GPU metrics.

## Motivation / Context

During CNCF AI Conformance evidence collection, we found that Prometheus was not scraping DCGM exporter metrics because the ServiceMonitor was disabled (`enabled: false`). The DCGM exporter was running and exposing metrics at `:9400/metrics`, but Prometheus had no scrape target configured for it. This prevents GPU metrics from being available for dashboards, alerting, and HPA autoscaling.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: recipes/components/gpu-operator

## Implementation Notes

One-line change: `dcgmExporter.serviceMonitor.enabled: false` → `true`

The GPU Operator chart creates a ServiceMonitor resource when enabled, which tells Prometheus to scrape the DCGM exporter service on port 9400 at 60s intervals.

## Testing

Verified on EKS H100 cluster that DCGM exporter metrics endpoint works and Prometheus has no DCGM scrape target without this change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — only adds a ServiceMonitor resource, no impact on existing workloads.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)