### PR TITLE
fix: add retry logic to deploy script for transient Helm failures

### DIFF
--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -16,9 +16,25 @@ trap 'rm -rf "${HELM_WORKDIR}"' EXIT
 cd "${HELM_WORKDIR}"
 
 WAIT_ARGS="--wait --timeout 10m"
+MAX_RETRIES=2
 if [[ "${1:-}" == "--no-wait" ]]; then
   WAIT_ARGS=""
+  MAX_RETRIES=0
 fi
+
+helm_install() {
+  local attempt=0
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    if [[ ${MAX_RETRIES} -eq 0 ]] || [[ ${attempt} -ge ${MAX_RETRIES} ]]; then
+      return 1
+    fi
+    echo "Retrying (${attempt}/${MAX_RETRIES})..."
+  done
+}
 
 echo "Deploying Cloud Native Stack components..."
 
@@ -27,13 +43,13 @@ echo "Deploying Cloud Native Stack components..."
 {{ if .HasChart -}}
 echo "Installing {{ .Name }} ({{ .Namespace }})..."
 {{ if .IsOCI -}}
-helm upgrade --install {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
+helm_install helm upgrade --install {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
   ${WAIT_ARGS}
 {{ else -}}
-helm upgrade --install {{ .Name }} {{ .ChartName }} \
+helm_install helm upgrade --install {{ .Name }} {{ .ChartName }} \
   --repo {{ .Repository }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \


### PR DESCRIPTION
## Summary

Add retry logic to the generated deploy script to handle transient Helm install timeouts, particularly for KAI scheduler's SchedulingShard CR reconciliation.

## Motivation / Context

After moving KAI scheduler to `base.yaml` (#139), the deploy script can fail with `resource not ready, name: default, kind: SchedulingShard, status: InProgress` during initial cluster setup. The SchedulingShard CR is reconciled by the kai-operator, which needs a few seconds after pod startup. With `--wait --timeout 10m`, Helm may time out on the first attempt, but a retry succeeds immediately since all resources are already running.

Fixes: #165
Related: #139

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

- Added `helm_install` wrapper function to `deploy.sh.tmpl` that retries once on failure
- `MAX_RETRIES=2` (1 initial attempt + 1 retry) by default
- When `--no-wait` is used, retries are disabled (`MAX_RETRIES=0`)
- On retry, `helm upgrade --install` succeeds immediately since the release already exists and resources are running

**Root cause analysis:** On the reporter's `aicr-demo` cluster, the SchedulingShard was created and became Ready in ~11 seconds, but Helm's `--wait` check timed out during the initial install. The Helm release was marked `failed` even though all KAI pods were running. A `helm upgrade --reuse-values` immediately succeeded.

## Testing

```bash
go test -race ./pkg/bundler/...   # all pass
```

Also manually fixed the reporter's cluster by running `helm upgrade kai-scheduler` which succeeded immediately.

## Risk Assessment

- [x] **Low** — Isolated change to generated deploy script, adds resilience without changing behavior on success

**Rollout notes:** Only affects newly generated bundles. Existing bundles need to be regenerated with `eidos bundle`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)