### PR TITLE
feat(ci): add metrics-driven cluster autoscaling validation with Karpenter + KWOK

### DIFF
--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -36,6 +36,9 @@ on:
       - 'recipes/overlays/kind-inference.yaml'
       - 'recipes/overlays/h100-kind-inference.yaml'
       - 'recipes/overlays/h100-kind-inference-dynamo.yaml'
+      - 'kwok/manifests/karpenter/**'
+      - 'kwok/scripts/install-karpenter-kwok.sh'
+      - 'kwok/scripts/validate-cluster-autoscaling.sh'
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -169,6 +172,31 @@ jobs:
 
       - name: Deploy Dynamo vLLM smoke test
         run: |
+          # Create kai-scheduler queue for Dynamo (grove-operator sets kai.scheduler/queue=dynamo).
+          # The kai-scheduler chart creates default-parent-queue + default-queue on install,
+          # but Dynamo needs its own queue as a child of the parent.
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" apply -f - <<'EOF'
+          apiVersion: scheduling.run.ai/v2
+          kind: Queue
+          metadata:
+            name: dynamo
+          spec:
+            parentQueue: default-parent-queue
+            resources:
+              gpu:
+                quota: 0
+                limit: -1
+                overQuotaWeight: 1
+              cpu:
+                quota: 0
+                limit: -1
+                overQuotaWeight: 1
+              memory:
+                quota: 0
+                limit: -1
+                overQuotaWeight: 1
+          EOF
+
           kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
             -f tests/manifests/dynamo-vllm-smoke-test.yaml -n dynamo-system
 
@@ -230,6 +258,7 @@ jobs:
       # --- Accelerator & AI Service Metrics validation (CNCF AI Conformance #4/#5) ---
 
       - name: Validate accelerator metrics
+
         run: |
           echo "=== DCGM Exporter pod ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator \
@@ -294,11 +323,14 @@ jobs:
       # → custom metrics API) that HPA consumes. Dynamo uses PodCliqueSets (not
       # Deployments), so we validate the API directly rather than creating an HPA.
       #
-      # Note: DCGM exporter runs as a DaemonSet in gpu-operator namespace, so
-      # Prometheus labels GPU metrics with namespace=gpu-operator. We query that
-      # namespace to validate the full metrics pipeline.
+      # DCGM exporter pod-mapping relabels metrics with the GPU workload's
+      # namespace/pod when a GPU is in use. Metrics may appear in gpu-operator
+      # (idle GPU) or dynamo-system (active workload). prometheus-adapter also
+      # needs relist cycles (30s each) to discover new label combinations, so
+      # we poll with retries.
 
       - name: Validate custom metrics for pod autoscaling
+
         run: |
           echo "=== Custom metrics API availability ==="
           RESOURCES=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
@@ -310,23 +342,27 @@ jobs:
           echo "Custom metrics API is available"
           echo "${RESOURCES}" | jq -r '.resources[].name' 2>/dev/null | head -20
 
-          # DCGM exporter runs in gpu-operator namespace, so custom metrics are
-          # attributed to the DCGM exporter pod there (not workload pods).
-          METRICS_NS="gpu-operator"
+          NAMESPACES="gpu-operator dynamo-system"
+          METRICS="gpu_utilization gpu_memory_used gpu_power_usage"
 
-          # At least one GPU metric must be available via the custom metrics API
+          # Poll for up to 3 minutes — prometheus-adapter relists every 30s and
+          # avg_over_time(...[2m]) queries need sufficient data points.
           HAS_METRICS=false
-          for METRIC in gpu_utilization gpu_memory_used gpu_power_usage; do
-            echo "=== Query ${METRIC} ==="
-            RESULT=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" get --raw \
-              "/apis/custom.metrics.k8s.io/v1beta1/namespaces/${METRICS_NS}/pods/*/${METRIC}" 2>/dev/null)
-            if [[ -n "${RESULT}" ]] && echo "${RESULT}" | jq -e '.items | length > 0' >/dev/null 2>&1; then
-              echo "${METRIC} metrics available:"
-              echo "${RESULT}" | jq '.items[] | {pod: .describedObject.name, value: .value}' 2>/dev/null
-              HAS_METRICS=true
-            else
-              echo "::warning::${METRIC} not available in ${METRICS_NS} namespace"
-            fi
+          for ATTEMPT in $(seq 1 18); do
+            for METRIC in ${METRICS}; do
+              for NS in ${NAMESPACES}; do
+                RESULT=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" get --raw \
+                  "/apis/custom.metrics.k8s.io/v1beta1/namespaces/${NS}/pods/*/${METRIC}" 2>/dev/null || true)
+                if [[ -n "${RESULT}" ]] && echo "${RESULT}" | jq -e '.items | length > 0' >/dev/null 2>&1; then
+                  echo "${METRIC} metrics available in ${NS}:"
+                  echo "${RESULT}" | jq '.items[] | {pod: .describedObject.name, value: .value}' 2>/dev/null
+                  HAS_METRICS=true
+                  break 3
+                fi
+              done
+            done
+            echo "Waiting for custom metrics to appear... (${ATTEMPT}/18)"
+            sleep 10
           done
 
           if [[ "${HAS_METRICS}" != "true" ]]; then
@@ -336,9 +372,16 @@ jobs:
 
           echo "Custom metrics pipeline validated — GPU metrics available for HPA consumption."
 
+      # --- Cluster Autoscaling validation ---
+
+      - name: Cluster Autoscaling (Karpenter + KWOK)
+
+        run: bash kwok/scripts/validate-cluster-autoscaling.sh
+
       # --- DRA GPU allocation test ---
 
       - name: Deploy DRA GPU test
+
         run: |
           kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
             -f docs/conformance/cncf/manifests/dra-gpu-test.yaml
@@ -363,6 +406,7 @@ jobs:
       # --- Secure Accelerator Access validation (CNCF AI Conformance #3) ---
 
       - name: Validate secure accelerator access
+
         run: |
           echo "=== Verify DRA-mediated access (no hostPath, no device plugin) ==="
 
@@ -474,8 +518,10 @@ jobs:
           echo "=== Custom metrics API ==="
           for METRIC in gpu_utilization gpu_memory_used gpu_power_usage; do
             echo "--- ${METRIC} ---"
-            kubectl --context="kind-${KIND_CLUSTER_NAME}" get --raw \
-              "/apis/custom.metrics.k8s.io/v1beta1/namespaces/gpu-operator/pods/*/${METRIC}" 2>/dev/null | jq . || true
+            for NS in gpu-operator dynamo-system; do
+              kubectl --context="kind-${KIND_CLUSTER_NAME}" get --raw \
+                "/apis/custom.metrics.k8s.io/v1beta1/namespaces/${NS}/pods/*/${METRIC}" 2>/dev/null | jq . || true
+            done
           done
           echo "=== prometheus-adapter pods ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n monitoring get pods -l app.kubernetes.io/name=prometheus-adapter -o wide 2>/dev/null || true

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -32,6 +32,10 @@ on:
       - 'recipes/components/dynamo-platform/**'
       - 'recipes/overlays/kind.yaml'
       - 'recipes/overlays/h100-kind-training.yaml'
+      - 'kwok/manifests/karpenter/**'
+      - 'kwok/scripts/install-karpenter-kwok.sh'
+      - 'kwok/scripts/validate-cluster-autoscaling.sh'
+      - 'recipes/components/prometheus-adapter/**'
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -171,6 +175,12 @@ jobs:
           echo "=== gang-worker-1 logs ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
             logs gang-worker-1 2>/dev/null || true
+
+      # --- Cluster Autoscaling validation ---
+
+      - name: Cluster Autoscaling (Karpenter + KWOK)
+
+        run: bash kwok/scripts/validate-cluster-autoscaling.sh
 
       # --- Evidence collection ---
 

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -44,6 +44,7 @@ testing_tools:
   kwok: 'v0.7.0'
   chainsaw: 'v0.2.14'
   yq: 'v4.52.4'
+  karpenter: 'v1.8.0'
 
 # Quality Thresholds
 quality:

--- a/kwok/manifests/karpenter/hpa-gpu-scale-test.yaml
+++ b/kwok/manifests/karpenter/hpa-gpu-scale-test.yaml
@@ -1,0 +1,99 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HPA-driven GPU autoscaling test for CNCF AI Conformance cluster_autoscaling.
+#
+# This validates the full metrics-driven autoscaling chain:
+#   GPU workload → DCGM metrics → Prometheus → prometheus-adapter → HPA
+#   → Deployment scales → pending pods → Karpenter → KWOK nodes provisioned
+#
+# The HPA uses an external GPU metric (dcgm_gpu_power_usage) which is always > 0
+# when a GPU exists (idle H100 draws ~46W). When the metric exceeds the low
+# threshold, HPA scales the Deployment beyond what the real GPU node can serve,
+# causing overflow pods to trigger Karpenter KWOK node provisioning.
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-overflow-workers
+  namespace: autoscaling-test
+  labels:
+    app: gpu-overflow-workers
+    test: cluster-autoscaling
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gpu-overflow-workers
+  template:
+    metadata:
+      labels:
+        app: gpu-overflow-workers
+        test: cluster-autoscaling
+    spec:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Equal
+          value: "present"
+          effect: NoSchedule
+        - key: kwok.x-k8s.io/node
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        karpenter.sh/nodepool: gpu-autoscaling-test
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gpu-workload
+          image: ubuntu:22.04
+          command: ["sleep", "120"]
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+      restartPolicy: Always
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gpu-overflow-hpa
+  namespace: autoscaling-test
+  labels:
+    test: cluster-autoscaling
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gpu-overflow-workers
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+    # External metric: cluster-wide average GPU power draw (watts).
+    # Power usage is always > 0 when a GPU exists (idle H100 draws ~46W).
+    # With a low threshold, this reliably triggers scale-up.
+    - type: External
+      external:
+        metric:
+          name: dcgm_gpu_power_usage
+        target:
+          type: AverageValue
+          averageValue: "10"

--- a/kwok/manifests/karpenter/instance-types.json
+++ b/kwok/manifests/karpenter/instance-types.json
@@ -1,0 +1,89 @@
+[
+  {
+    "name": "p5.48xlarge",
+    "offerings": [
+      {
+        "Price": 98.32,
+        "Available": true,
+        "Requirements": [
+          { "key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"] },
+          { "key": "topology.kubernetes.io/zone", "operator": "In", "values": ["us-east-1a"] }
+        ]
+      },
+      {
+        "Price": 98.32,
+        "Available": true,
+        "Requirements": [
+          { "key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"] },
+          { "key": "topology.kubernetes.io/zone", "operator": "In", "values": ["us-east-1b"] }
+        ]
+      }
+    ],
+    "architecture": "amd64",
+    "operatingSystems": ["linux"],
+    "resources": {
+      "cpu": "192",
+      "memory": "2048Gi",
+      "ephemeral-storage": "3800Gi",
+      "nvidia.com/gpu": "8"
+    }
+  },
+  {
+    "name": "g5.xlarge",
+    "offerings": [
+      {
+        "Price": 1.006,
+        "Available": true,
+        "Requirements": [
+          { "key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"] },
+          { "key": "topology.kubernetes.io/zone", "operator": "In", "values": ["us-east-1a"] }
+        ]
+      },
+      {
+        "Price": 1.006,
+        "Available": true,
+        "Requirements": [
+          { "key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"] },
+          { "key": "topology.kubernetes.io/zone", "operator": "In", "values": ["us-east-1b"] }
+        ]
+      }
+    ],
+    "architecture": "amd64",
+    "operatingSystems": ["linux"],
+    "resources": {
+      "cpu": "4",
+      "memory": "16Gi",
+      "ephemeral-storage": "250Gi",
+      "nvidia.com/gpu": "1"
+    }
+  },
+  {
+    "name": "g5.2xlarge",
+    "offerings": [
+      {
+        "Price": 1.212,
+        "Available": true,
+        "Requirements": [
+          { "key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"] },
+          { "key": "topology.kubernetes.io/zone", "operator": "In", "values": ["us-east-1a"] }
+        ]
+      },
+      {
+        "Price": 1.212,
+        "Available": true,
+        "Requirements": [
+          { "key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"] },
+          { "key": "topology.kubernetes.io/zone", "operator": "In", "values": ["us-east-1b"] }
+        ]
+      }
+    ],
+    "architecture": "amd64",
+    "operatingSystems": ["linux"],
+    "resources": {
+      "cpu": "8",
+      "memory": "32Gi",
+      "ephemeral-storage": "450Gi",
+      "nvidia.com/gpu": "1"
+    }
+  }
+]

--- a/kwok/manifests/karpenter/nodepool.yaml
+++ b/kwok/manifests/karpenter/nodepool.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Karpenter NodePool and KWOKNodeClass for GPU autoscaling validation.
+#
+# This configuration tells Karpenter to provision KWOK (simulated) nodes
+# with GPU capacity when pending pods request nvidia.com/gpu resources.
+# Used to validate CNCF AI Conformance cluster_autoscaling requirement.
+
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: gpu-autoscaling-test
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+      nodeClassRef:
+        name: default
+        kind: KWOKNodeClass
+        group: karpenter.kwok.sh
+      taints:
+        - key: nvidia.com/gpu
+          value: "present"
+          effect: NoSchedule
+    metadata:
+      labels:
+        eidos.nvidia.com/test: cluster-autoscaling
+  limits:
+    nvidia.com/gpu: 100
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 10s
+---
+apiVersion: karpenter.kwok.sh/v1alpha1
+kind: KWOKNodeClass
+metadata:
+  name: default

--- a/kwok/scripts/install-karpenter-kwok.sh
+++ b/kwok/scripts/install-karpenter-kwok.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Karpenter with KWOK cloud provider into a kind cluster.
+#
+# This script sets up Karpenter to use simulated (KWOK) nodes for testing
+# GPU cluster autoscaling without real cloud infrastructure. It:
+#   1. Installs KWOK controller via Helm
+#   2. Clones Karpenter and builds the KWOK provider image via ko
+#   3. Creates GPU instance types ConfigMap
+#   4. Deploys Karpenter via Helm with the locally-built image and instance types
+#
+# Prerequisites: Go, ko, Helm, kubectl, kind cluster running
+#
+# Environment variables:
+#   KIND_CLUSTER_NAME  (required) - Name of the kind cluster
+#   KARPENTER_VERSION  (optional) - Karpenter version tag (default: v1.8.0)
+#
+# Usage:
+#   export KIND_CLUSTER_NAME=gpu-inference-test
+#   ./install-karpenter-kwok.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../manifests/karpenter"
+
+KARPENTER_VERSION="${KARPENTER_VERSION:-v1.8.0}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:?KIND_CLUSTER_NAME must be set}"
+KARPENTER_NAMESPACE="${KARPENTER_NAMESPACE:-karpenter}"
+KARPENTER_CLONE_DIR="${KARPENTER_CLONE_DIR:-/tmp/karpenter}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# -------------------------------------------------------------------
+# Step 1: Install KWOK controller
+# Uses the same approach as kwok/scripts/run-all-recipes.sh
+# -------------------------------------------------------------------
+install_kwok() {
+    log_info "Installing KWOK controller..."
+
+    if kubectl get deployment -n kube-system kwok-controller &>/dev/null; then
+        log_info "KWOK controller already installed, skipping"
+        return 0
+    fi
+
+    helm repo add kwok https://kwok.sigs.k8s.io/charts/ --force-update
+    helm upgrade --install kwok-controller kwok/kwok \
+        --namespace kube-system \
+        --set hostNetwork=true \
+        --wait --timeout 120s
+
+    helm upgrade --install kwok-stage-fast kwok/stage-fast \
+        --namespace kube-system
+
+    log_info "KWOK controller installed"
+}
+
+# -------------------------------------------------------------------
+# Step 2: Clone and build Karpenter KWOK provider
+# Uses ko to build the Go binary into a container image and
+# side-load it directly into the kind cluster (kind.local).
+# -------------------------------------------------------------------
+build_karpenter() {
+    log_info "Building Karpenter KWOK provider ${KARPENTER_VERSION}..."
+
+    if [[ -d "${KARPENTER_CLONE_DIR}" ]]; then
+        log_info "Removing previous Karpenter clone"
+        rm -rf "${KARPENTER_CLONE_DIR}"
+    fi
+
+    git clone --depth 1 --branch "${KARPENTER_VERSION}" \
+        https://github.com/kubernetes-sigs/karpenter.git "${KARPENTER_CLONE_DIR}"
+
+    pushd "${KARPENTER_CLONE_DIR}" >/dev/null
+
+    # ko build with kind.local side-loads the image directly into the kind cluster.
+    # Redirect stderr to avoid Go compilation warnings corrupting the image reference.
+    # Output format: kind.local/<name>:<content-hash>
+    CONTROLLER_IMG=$(KO_DOCKER_REPO=kind.local \
+        KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME}" \
+        ko build sigs.k8s.io/karpenter/kwok 2>/dev/null)
+
+    popd >/dev/null
+
+    # Validate the captured image reference
+    if [[ ! "${CONTROLLER_IMG}" =~ ^kind\.local/ ]]; then
+        log_error "ko build produced unexpected output: ${CONTROLLER_IMG}"
+        exit 1
+    fi
+
+    # Extract repository and tag from the ko output.
+    # ko outputs "kind.local/<name>:<hash>" — split on the first colon after the repo.
+    if [[ "${CONTROLLER_IMG}" == *":"* ]]; then
+        IMG_REPOSITORY="${CONTROLLER_IMG%%:*}"
+        IMG_TAG="${CONTROLLER_IMG#*:}"
+    else
+        IMG_REPOSITORY="${CONTROLLER_IMG}"
+        IMG_TAG=""
+    fi
+
+    log_info "Built image: ${CONTROLLER_IMG}"
+    log_info "Repository: ${IMG_REPOSITORY}"
+    log_info "Tag: ${IMG_TAG:-<none>}"
+
+    # Export for use in deploy step
+    export CONTROLLER_IMG IMG_REPOSITORY IMG_TAG
+}
+
+# -------------------------------------------------------------------
+# Step 3: Deploy Karpenter via Helm
+# Creates the instance types ConfigMap first, then deploys Karpenter
+# with volume mounts and env vars configured via Helm values.
+# -------------------------------------------------------------------
+deploy_karpenter() {
+    log_info "Deploying Karpenter to namespace ${KARPENTER_NAMESPACE}..."
+
+    # Apply CRDs first
+    kubectl apply -f "${KARPENTER_CLONE_DIR}/kwok/charts/crds"
+
+    # Create namespace and instance types ConfigMap before Helm install
+    # so the volume mount can reference it immediately.
+    kubectl create namespace "${KARPENTER_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+    local instance_types_file="${MANIFESTS_DIR}/instance-types.json"
+    if [[ ! -f "${instance_types_file}" ]]; then
+        log_error "Instance types file not found: ${instance_types_file}"
+        exit 1
+    fi
+    kubectl create configmap -n "${KARPENTER_NAMESPACE}" karpenter-instance-types \
+        --from-file=instance-types.json="${instance_types_file}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    # Build the image tag argument. If ko provided a tag, use it.
+    # If not, omit it and let the chart default to its AppVersion.
+    local tag_arg=""
+    if [[ -n "${IMG_TAG}" ]]; then
+        tag_arg="--set controller.image.tag=${IMG_TAG}"
+    fi
+
+    # Deploy via Helm with the locally-built image.
+    # - imagePullPolicy=Never: image is side-loaded into kind, no registry to pull from
+    # - staticCapacity=true: required by the deployment template but missing from chart defaults
+    # - extraVolumes + extraVolumeMounts: mount the instance types ConfigMap
+    # - controller.env: set INSTANCE_TYPES_FILE_PATH for the KWOK provider
+    # shellcheck disable=SC2086
+    helm upgrade --install karpenter "${KARPENTER_CLONE_DIR}/kwok/charts" \
+        --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
+        --set controller.image.repository="${IMG_REPOSITORY}" \
+        ${tag_arg} \
+        --set imagePullPolicy=Never \
+        --set logLevel=info \
+        --set settings.featureGates.staticCapacity=true \
+        --set controller.resources.requests.cpu=500m \
+        --set controller.resources.requests.memory=512Mi \
+        --set controller.resources.limits.cpu=1 \
+        --set controller.resources.limits.memory=1Gi \
+        --set 'extraVolumes[0].name=instance-types' \
+        --set 'extraVolumes[0].configMap.name=karpenter-instance-types' \
+        --set 'controller.extraVolumeMounts[0].name=instance-types' \
+        --set 'controller.extraVolumeMounts[0].mountPath=/etc/karpenter/instance-types' \
+        --set 'controller.extraVolumeMounts[0].readOnly=true' \
+        --set 'controller.env[0].name=INSTANCE_TYPES_FILE_PATH' \
+        --set 'controller.env[0].value=/etc/karpenter/instance-types/instance-types.json' \
+        --wait --timeout 300s \
+        || {
+            log_error "Helm install failed. Diagnostics:"
+            kubectl -n "${KARPENTER_NAMESPACE}" get pods -o wide 2>/dev/null || true
+            kubectl -n "${KARPENTER_NAMESPACE}" describe deployment karpenter 2>/dev/null || true
+            local POD
+            POD=$(kubectl -n "${KARPENTER_NAMESPACE}" get pods -l app.kubernetes.io/name=karpenter \
+                -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+            if [[ -n "${POD}" ]]; then
+                kubectl -n "${KARPENTER_NAMESPACE}" describe pod "${POD}" 2>/dev/null || true
+                kubectl -n "${KARPENTER_NAMESPACE}" logs "${POD}" --tail=50 2>/dev/null || true
+            fi
+            exit 1
+        }
+
+    log_info "Karpenter deployed with GPU instance types configured"
+}
+
+# -------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------
+main() {
+    log_info "=== Karpenter KWOK Provider Installation ==="
+    log_info "Karpenter version: ${KARPENTER_VERSION}"
+    log_info "Kind cluster: ${KIND_CLUSTER_NAME}"
+    log_info "Namespace: ${KARPENTER_NAMESPACE}"
+
+    install_kwok
+    build_karpenter
+    deploy_karpenter
+
+    log_info "=== Karpenter KWOK provider ready ==="
+    log_info "Create a NodePool + KWOKNodeClass to start autoscaling"
+}
+
+main "$@"

--- a/kwok/scripts/validate-cluster-autoscaling.sh
+++ b/kwok/scripts/validate-cluster-autoscaling.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validate Cluster Autoscaling (Karpenter + KWOK)
+#
+# This script validates the full metrics-driven GPU autoscaling chain:
+#   GPU workload → DCGM metrics → Prometheus → prometheus-adapter (external metric)
+#   → HPA scales Deployment → pending pods → Karpenter → KWOK nodes provisioned
+#
+# It installs Karpenter with the KWOK cloud provider, creates a NodePool,
+# verifies external GPU metrics are available, deploys an HPA-driven test
+# workload, and confirms that Karpenter provisions KWOK nodes for overflow
+# pods. Finally, it tests scale-down consolidation.
+#
+# Prerequisites: kind cluster with GPU operator, prometheus, prometheus-adapter
+#
+# Environment variables:
+#   KIND_CLUSTER_NAME  (required) - Name of the kind cluster
+#   KARPENTER_VERSION  (optional) - Override version from .settings.yaml
+#
+# Usage:
+#   export KIND_CLUSTER_NAME=gpu-inference-test
+#   ./validate-cluster-autoscaling.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../manifests/karpenter"
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:?KIND_CLUSTER_NAME must be set}"
+KUBE_CTX="kind-${KIND_CLUSTER_NAME}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# -------------------------------------------------------------------
+# Step 1: Install Karpenter with KWOK provider
+# -------------------------------------------------------------------
+install_karpenter() {
+    log_info "=== Installing Karpenter with KWOK provider ==="
+    export KIND_CLUSTER_NAME
+    export KARPENTER_VERSION="${KARPENTER_VERSION:-$(yq eval '.testing_tools.karpenter' "${REPO_ROOT}/.settings.yaml")}"
+    bash "${SCRIPT_DIR}/install-karpenter-kwok.sh"
+}
+
+# -------------------------------------------------------------------
+# Step 2: Create NodePool and KWOKNodeClass
+# -------------------------------------------------------------------
+create_nodepool() {
+    log_info "=== Creating NodePool and KWOKNodeClass ==="
+    kubectl --context="${KUBE_CTX}" apply -f "${MANIFESTS_DIR}/nodepool.yaml"
+}
+
+# -------------------------------------------------------------------
+# Step 3: Verify external metrics API has GPU metrics
+# -------------------------------------------------------------------
+verify_external_metrics() {
+    log_info "=== Verifying external metrics API has GPU metrics ==="
+
+    # Phase 1: Wait for the metric name to be registered in the external metrics API.
+    local ext_available=false
+    for i in $(seq 1 12); do
+        local ext_metrics
+        ext_metrics=$(kubectl --context="${KUBE_CTX}" get --raw \
+            /apis/external.metrics.k8s.io/v1beta1 2>/dev/null || true)
+        if [[ -n "${ext_metrics}" ]] && echo "${ext_metrics}" | \
+                jq -e '.resources[]? | select(.name=="dcgm_gpu_power_usage")' >/dev/null 2>&1; then
+            log_info "External metric dcgm_gpu_power_usage is registered"
+            ext_available=true
+            break
+        fi
+        echo "Waiting for external metrics API... (${i}/12)"
+        sleep 10
+    done
+
+    if [[ "${ext_available}" != "true" ]]; then
+        log_error "External metric dcgm_gpu_power_usage not available"
+        kubectl --context="${KUBE_CTX}" get --raw \
+            /apis/external.metrics.k8s.io/v1beta1 2>/dev/null | jq . || true
+        exit 1
+    fi
+
+    # Phase 2: Wait for the metric to have actual data in Prometheus.
+    # The metric name can be registered by prometheus-adapter before Prometheus
+    # has scraped enough DCGM exporter samples. The HPA will fail with
+    # "unable to fetch metrics" if we proceed before data exists.
+    log_info "Waiting for external metric to have data..."
+    local has_data=false
+    for i in $(seq 1 24); do
+        local ext_value
+        ext_value=$(kubectl --context="${KUBE_CTX}" get --raw \
+            "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage" 2>/dev/null || true)
+        local metric_val
+        metric_val=$(echo "${ext_value}" | jq -r '.items[0].value // empty' 2>/dev/null || true)
+        if [[ -n "${metric_val}" ]]; then
+            log_info "External metric has data: dcgm_gpu_power_usage=${metric_val}"
+            has_data=true
+            break
+        fi
+        echo "Waiting for Prometheus to collect DCGM metrics... (${i}/24)"
+        sleep 10
+    done
+
+    if [[ "${has_data}" != "true" ]]; then
+        log_error "External metric dcgm_gpu_power_usage has no data after 4 minutes"
+
+        # Diagnostic 1: Raw external metrics API responses for BOTH metrics
+        log_warn "--- External API: dcgm_gpu_power_usage ---"
+        kubectl --context="${KUBE_CTX}" get --raw \
+            "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage" 2>&1 || true
+        log_warn "--- External API: dcgm_gpu_utilization ---"
+        kubectl --context="${KUBE_CTX}" get --raw \
+            "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_utilization" 2>&1 || true
+
+        # Diagnostic 2: Run the exact PromQL the adapter would execute
+        local prom_svc="http://kube-prometheus-prometheus.monitoring.svc:9090"
+        log_warn "--- Prometheus: exact adapter PromQL ---"
+        kubectl --context="${KUBE_CTX}" -n monitoring run prom-diag --rm -i --restart=Never \
+            --image=curlimages/curl:latest -- sh -c "
+                echo 'Raw series count:';
+                curl -sf '${prom_svc}/api/v1/query?query=DCGM_FI_DEV_POWER_USAGE' | head -c 500;
+                echo;
+                echo 'Adapter metricsQuery result:';
+                curl -sf '${prom_svc}/api/v1/query?query=avg(avg_over_time(DCGM_FI_DEV_POWER_USAGE%5B2m%5D))' | head -c 500;
+                echo;
+            " 2>/dev/null || true
+
+        # Diagnostic 3: Full externalRules from ConfigMap (not truncated)
+        log_warn "--- prometheus-adapter externalRules (full) ---"
+        kubectl --context="${KUBE_CTX}" -n monitoring get configmap -l app.kubernetes.io/name=prometheus-adapter \
+            -o jsonpath='{.items[0].data.config\.yaml}' 2>/dev/null \
+            | python3 -c "import sys,yaml; cfg=yaml.safe_load(sys.stdin); print(yaml.dump(cfg.get('externalRules', 'MISSING')))" 2>/dev/null \
+            || kubectl --context="${KUBE_CTX}" -n monitoring get configmap -l app.kubernetes.io/name=prometheus-adapter \
+                -o jsonpath='{.items[0].data.config\.yaml}' 2>/dev/null | grep -A20 'externalRules' || echo "No externalRules found"
+
+        # Diagnostic 4: Adapter deployment args (verify metricsRelistInterval)
+        log_warn "--- prometheus-adapter container args ---"
+        kubectl --context="${KUBE_CTX}" -n monitoring get deployment -l app.kubernetes.io/name=prometheus-adapter \
+            -o jsonpath='{.items[0].spec.template.spec.containers[0].args}' 2>/dev/null || true
+        echo
+
+        # Diagnostic 5: prometheus-adapter logs (last 30 lines)
+        log_warn "--- prometheus-adapter logs (tail) ---"
+        kubectl --context="${KUBE_CTX}" -n monitoring logs deployment/prometheus-adapter --tail=30 2>/dev/null || true
+
+        exit 1
+    fi
+}
+
+# -------------------------------------------------------------------
+# Step 4: Deploy HPA-driven autoscaling test
+# -------------------------------------------------------------------
+deploy_test_workload() {
+    log_info "=== Deploying HPA-driven autoscaling test ==="
+    kubectl --context="${KUBE_CTX}" create namespace autoscaling-test
+    kubectl --context="${KUBE_CTX}" apply -f "${MANIFESTS_DIR}/hpa-gpu-scale-test.yaml"
+}
+
+# -------------------------------------------------------------------
+# Step 5: Wait for HPA to read metrics and scale
+# -------------------------------------------------------------------
+wait_for_hpa_scale() {
+    log_info "=== Waiting for HPA to read metrics and scale ==="
+    local hpa_scaled=false
+    for i in $(seq 1 20); do
+        local desired current metrics
+        desired=$(kubectl --context="${KUBE_CTX}" -n autoscaling-test \
+            get hpa gpu-overflow-hpa -o jsonpath='{.status.desiredReplicas}' 2>/dev/null || true)
+        current=$(kubectl --context="${KUBE_CTX}" -n autoscaling-test \
+            get hpa gpu-overflow-hpa -o jsonpath='{.status.currentReplicas}' 2>/dev/null || true)
+        metrics=$(kubectl --context="${KUBE_CTX}" -n autoscaling-test \
+            get hpa gpu-overflow-hpa -o jsonpath='{.status.currentMetrics}' 2>/dev/null || true)
+
+        if [[ -n "${desired}" && "${desired}" -gt 1 ]]; then
+            log_info "HPA scaled: desired=${desired} current=${current}"
+            log_info "HPA metrics: ${metrics}"
+            hpa_scaled=true
+            break
+        fi
+        echo "Waiting for HPA to compute scaling decision... desired=${desired:-?} (${i}/20)"
+        sleep 15
+    done
+
+    if [[ "${hpa_scaled}" != "true" ]]; then
+        log_error "HPA did not scale beyond 1 replica"
+        kubectl --context="${KUBE_CTX}" -n autoscaling-test describe hpa gpu-overflow-hpa 2>/dev/null || true
+        exit 1
+    fi
+}
+
+# -------------------------------------------------------------------
+# Step 6: Wait for Karpenter to provision KWOK nodes
+# -------------------------------------------------------------------
+wait_for_kwok_nodes() {
+    log_info "=== Waiting for Karpenter to provision KWOK nodes ==="
+    KWOK_NODES=0
+    for i in $(seq 1 30); do
+        KWOK_NODES=$(kubectl --context="${KUBE_CTX}" get nodes \
+            -l karpenter.sh/nodepool=gpu-autoscaling-test --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "${KWOK_NODES}" -gt 0 ]]; then
+            log_info "Karpenter provisioned ${KWOK_NODES} KWOK GPU node(s)"
+            break
+        fi
+        echo "Waiting for Karpenter to provision nodes... (${i}/30)"
+        sleep 10
+    done
+
+    if [[ "${KWOK_NODES}" -eq 0 ]]; then
+        log_error "Karpenter did not provision GPU nodes"
+        kubectl --context="${KUBE_CTX}" -n karpenter logs deployment/karpenter --tail=50 2>/dev/null || true
+        exit 1
+    fi
+
+    log_info "=== Verifying nodes have GPU capacity ==="
+    kubectl --context="${KUBE_CTX}" get nodes \
+        -l karpenter.sh/nodepool=gpu-autoscaling-test \
+        -o jsonpath='{range .items[*]}{.metadata.name}: nvidia.com/gpu={.status.capacity.nvidia\.com/gpu}{"\n"}{end}'
+}
+
+# -------------------------------------------------------------------
+# Step 7: Verify pods scheduled onto KWOK nodes
+# -------------------------------------------------------------------
+verify_pods_scheduled() {
+    log_info "=== Verifying pods scheduled onto KWOK nodes ==="
+    local scheduled=0
+    local total=0
+    for i in $(seq 1 20); do
+        scheduled=$(kubectl --context="${KUBE_CTX}" get pods -n autoscaling-test \
+            --field-selector=status.phase!=Pending --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        total=$(kubectl --context="${KUBE_CTX}" get pods -n autoscaling-test \
+            --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "${scheduled}" -eq "${total}" && "${total}" -gt 1 ]]; then
+            log_info "All ${total} GPU pods scheduled successfully (HPA-driven)"
+            break
+        fi
+        echo "Waiting for pods to schedule... (${scheduled}/${total}, attempt ${i}/20)"
+        sleep 5
+    done
+
+    if [[ "${total}" -le 1 ]]; then
+        log_error "HPA did not create additional replicas"
+        kubectl --context="${KUBE_CTX}" -n autoscaling-test describe hpa gpu-overflow-hpa 2>/dev/null || true
+        exit 1
+    fi
+
+    log_info "=== Full chain verified ==="
+    echo "  GPU metrics → Prometheus → external metrics API → HPA → Deployment scaled"
+    echo "  → pending pods → Karpenter → ${KWOK_NODES} KWOK node(s) → ${total} pods scheduled"
+}
+
+# -------------------------------------------------------------------
+# Step 8: Test scale-down (consolidation)
+# -------------------------------------------------------------------
+test_consolidation() {
+    log_info "=== Testing scale-down (consolidation) ==="
+    kubectl --context="${KUBE_CTX}" delete namespace autoscaling-test --wait=false
+    sleep 15
+    local kwok_remaining=0
+    for i in $(seq 1 12); do
+        kwok_remaining=$(kubectl --context="${KUBE_CTX}" get nodes \
+            -l karpenter.sh/nodepool=gpu-autoscaling-test --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "${kwok_remaining}" -eq 0 ]]; then
+            log_info "Karpenter consolidated all KWOK nodes (scale to zero)"
+            break
+        fi
+        echo "Waiting for consolidation... (${kwok_remaining} nodes remaining, ${i}/12)"
+        sleep 10
+    done
+
+    if [[ "${kwok_remaining}" -gt 0 ]]; then
+        log_warn "Karpenter did not consolidate all nodes (${kwok_remaining} remaining)"
+    fi
+}
+
+# -------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------
+main() {
+    log_info "=== Cluster Autoscaling ==="
+    log_info "Kind cluster: ${KIND_CLUSTER_NAME}"
+
+    install_karpenter
+    create_nodepool
+    verify_external_metrics
+    deploy_test_workload
+    wait_for_hpa_scale
+    wait_for_kwok_nodes
+    verify_pods_scheduled
+    test_consolidation
+
+    log_info "=== Cluster autoscaling validation PASSED ==="
+}
+
+main "$@"

--- a/recipes/components/prometheus-adapter/values.yaml
+++ b/recipes/components/prometheus-adapter/values.yaml
@@ -63,6 +63,63 @@ rules:
           namespace: {resource: "namespace"}
           pod: {resource: "pod"}
 
+    # Workload-attributed GPU metrics
+    # DCGM exporter adds exported_namespace/exported_pod labels when a GPU is
+    # actively used by a workload. These rules map those labels to Kubernetes
+    # resources so HPA can read per-pod GPU metrics in the workload namespace.
+    - seriesQuery: 'DCGM_FI_DEV_GPU_UTIL{exported_namespace!="",exported_pod!=""}'
+      metricsQuery: 'avg_over_time(<<.Series>>{<<.LabelMatchers>>}[2m])'
+      name:
+        matches: "DCGM_FI_DEV_GPU_UTIL"
+        as: "workload_gpu_utilization"
+      resources:
+        overrides:
+          exported_namespace: {resource: "namespace"}
+          exported_pod: {resource: "pod"}
+
+    - seriesQuery: 'DCGM_FI_DEV_FB_USED{exported_namespace!="",exported_pod!=""}'
+      metricsQuery: 'avg_over_time(<<.Series>>{<<.LabelMatchers>>}[2m])'
+      name:
+        matches: "DCGM_FI_DEV_FB_USED"
+        as: "workload_gpu_memory_used"
+      resources:
+        overrides:
+          exported_namespace: {resource: "namespace"}
+          exported_pod: {resource: "pod"}
+
+  # External metrics for cluster-wide GPU autoscaling (HPA type: External)
+  # These are not scoped to any pod or namespace, enabling HPA in any namespace
+  # to scale based on cluster-wide GPU metrics.
+  # Note: no <<.LabelMatchers>> — these are unconditional cluster-wide aggregations.
+  external:
+    - seriesQuery: 'DCGM_FI_DEV_GPU_UTIL'
+      metricsQuery: 'avg(avg_over_time(DCGM_FI_DEV_GPU_UTIL[2m]))'
+      name:
+        matches: "DCGM_FI_DEV_GPU_UTIL"
+        as: "dcgm_gpu_utilization"
+      resources:
+        namespaced: false
+
+    - seriesQuery: 'DCGM_FI_DEV_FB_USED'
+      metricsQuery: 'avg(avg_over_time(DCGM_FI_DEV_FB_USED[2m]))'
+      name:
+        matches: "DCGM_FI_DEV_FB_USED"
+        as: "dcgm_gpu_memory_used"
+      resources:
+        namespaced: false
+
+    - seriesQuery: 'DCGM_FI_DEV_POWER_USAGE'
+      metricsQuery: 'avg(avg_over_time(DCGM_FI_DEV_POWER_USAGE[2m]))'
+      name:
+        matches: "DCGM_FI_DEV_POWER_USAGE"
+        as: "dcgm_gpu_power_usage"
+      resources:
+        namespaced: false
+
+# Shorten the metrics relist interval so external metrics discovery
+# picks up new Prometheus series faster (chart default is 1m).
+metricsRelistInterval: 30s
+
 # Resource configuration for the adapter
 resources:
   requests:


### PR DESCRIPTION
## Summary

Add CNCF AI Conformance #8a (`cluster_autoscaling`) validation to both H100 GPU CI workflows
(inference and training). Validates the full metrics-driven autoscaling chain end-to-end:

```
DCGM metrics → Prometheus → prometheus-adapter (external metric) → HPA scales Deployment
  → pending GPU pods → Karpenter provisions KWOK nodes → pods schedule → consolidation
```

Also adds external metrics rules and workload-attributed custom metrics to prometheus-adapter,
enabling HPA-based GPU autoscaling from any namespace.

Fixes custom metrics validation to handle DCGM exporter pod-mapping (which relabels metrics
with the GPU workload's namespace when a GPU is in use) and adds retry logic for
prometheus-adapter metric discovery timing.

Adds kai-scheduler `dynamo` Queue CR creation before DynamoGraphDeployment in the inference
workflow (grove-operator sets `kai.scheduler/queue=dynamo` on pods, but the kai-scheduler
chart only creates `default-parent-queue` and `default-queue`).

## Changes

**New files:**
- `kwok/scripts/install-karpenter-kwok.sh` — Builds Karpenter KWOK provider from source via `ko`, side-loads into kind, deploys via Helm with GPU instance types
- `kwok/scripts/validate-cluster-autoscaling.sh` — End-to-end cluster autoscaling validation script (external metrics → HPA → Karpenter → KWOK nodes → consolidation)
- `kwok/manifests/karpenter/instance-types.json` — GPU instance types for Karpenter KWOK provider (p5.48xlarge 8×GPU, g5.xlarge 1×GPU, g5.2xlarge 1×GPU)
- `kwok/manifests/karpenter/nodepool.yaml` — NodePool with GPU taint + KWOKNodeClass
- `kwok/manifests/karpenter/hpa-gpu-scale-test.yaml` — Deployment + HPA using external `dcgm_gpu_power_usage` metric

**Modified files:**
- `recipes/components/prometheus-adapter/values.yaml` — Add external metrics rules (`dcgm_gpu_utilization`, `dcgm_gpu_memory_used`, `dcgm_gpu_power_usage`) and workload-attributed custom metrics (`workload_gpu_utilization`, `workload_gpu_memory_used`)
- `.github/workflows/gpu-h100-inference-test.yaml` — Add cluster autoscaling step, Dynamo kai-scheduler queue, custom metrics namespace/retry fix, trigger paths
- `.github/workflows/gpu-h100-training-test.yaml` — Add cluster autoscaling step, trigger paths
- `.settings.yaml` — Add `karpenter: v1.8.0` to testing_tools

## How it works

1. **Install**: Karpenter KWOK provider built from source (`ko build sigs.k8s.io/karpenter/kwok`) and deployed into kind cluster
2. **Configure**: NodePool + KWOKNodeClass created with GPU taints; GPU instance types loaded via ConfigMap
3. **Verify metrics**: External metric `dcgm_gpu_power_usage` confirmed available via `external.metrics.k8s.io` API
4. **Scale up**: HPA reads real GPU power metric, scales Deployment beyond node capacity → overflow pods trigger Karpenter
5. **Provision**: Karpenter provisions simulated KWOK nodes with `nvidia.com/gpu` capacity
6. **Schedule**: All GPU pods schedule onto KWOK nodes
7. **Scale down**: After cleanup, Karpenter consolidates KWOK nodes back to zero

## CI Results

Both H100 workflows pass all steps on commit `00cc5512`:

**Inference (24 steps):** Dynamo deploy + inference, accelerator metrics, custom metrics (pod autoscaling), cluster autoscaling (Karpenter+KWOK), DRA GPU test, secure accelerator access, conformance evidence (54/54 resources)

**Training (19 steps):** Gang scheduling (2× H100 NVL), cluster autoscaling (Karpenter+KWOK), conformance evidence (39/39 resources)

## Test plan

- [x] H100 inference workflow: cluster autoscaling step passes
- [x] H100 training workflow: cluster autoscaling step passes
- [x] prometheus-adapter serves external metrics (`dcgm_gpu_power_usage`)
- [x] HPA reads external metric and computes `desiredReplicas > 1`
- [x] Karpenter provisions KWOK nodes with `nvidia.com/gpu` capacity
- [x] All GPU pods schedule onto KWOK nodes
- [x] Scale-down consolidation removes KWOK nodes
- [x] Custom metrics validation handles DCGM pod-mapping namespaces
- [x] Dynamo deployment works with kai-scheduler queue
- [x] All other existing steps continue to pass (no regressions)