### PR TITLE
fix: skip --wait for KAI scheduler in deploy script

### DIFF
--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -20,25 +20,35 @@ if [[ "${1:-}" == "--no-wait" ]]; then
   WAIT_ARGS=""
 fi
 
+# Components that use operator patterns with custom resources that reconcile
+# asynchronously. Helm --wait may time out waiting for CR readiness even though
+# all pods start successfully. These components are installed without --wait.
+ASYNC_COMPONENTS="kai-scheduler"
+
 echo "Deploying Cloud Native Stack components..."
 
 # Install components in order
 {{ range .Components -}}
 {{ if .HasChart -}}
 echo "Installing {{ .Name }} ({{ .Namespace }})..."
+COMPONENT_WAIT_ARGS="${WAIT_ARGS}"
+if echo "${ASYNC_COMPONENTS}" | grep -qw "{{ .Name }}"; then
+  COMPONENT_WAIT_ARGS=""
+  echo "  (async component — skipping --wait)"
+fi
 {{ if .IsOCI -}}
 helm upgrade --install {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
-  ${WAIT_ARGS}
+  ${COMPONENT_WAIT_ARGS}
 {{ else -}}
 helm upgrade --install {{ .Name }} {{ .ChartName }} \
   --repo {{ .Repository }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
-  ${WAIT_ARGS}
+  ${COMPONENT_WAIT_ARGS}
 {{ end -}}
 {{ end -}}
 {{ if .HasManifests -}}


### PR DESCRIPTION
## Summary

Skip `--wait` for KAI scheduler in the generated deploy script to prevent transient timeout failures during fresh cluster installs.

## Motivation / Context

After moving KAI scheduler to `base.yaml` (#139), the deploy script can fail with `resource not ready, name: default, kind: SchedulingShard, status: InProgress` during initial cluster setup. The SchedulingShard CR is reconciled asynchronously by the kai-operator and becomes ready within seconds, but Helm's `--wait` may time out on the first attempt, causing the entire deploy script to exit.

Fixes: #165
Related: #139

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

- Added `ASYNC_COMPONENTS` list in `deploy.sh.tmpl` for components that use operator patterns with async CR reconciliation
- KAI scheduler is skipped from `--wait` since its SchedulingShard CR reconciles independently
- All other components still use `--wait --timeout 10m`
- When `--no-wait` is used, all components skip waiting (existing behavior)

**Root cause:** KAI scheduler's Helm chart creates a `SchedulingShard` CR that the kai-operator reconciles into child deployments. On fresh installs, the operator pod needs to start and reconcile before the shard becomes Ready. Helm's `--wait` blocks on this CR status and can time out, even though all pods start successfully within seconds.

## Testing

```bash
go test -race ./pkg/bundler/...   # all pass
```

Manually verified on the `aicr-demo` cluster from the bug report — KAI scheduler was stuck at `failed` Helm status but all pods were running. `helm upgrade` succeeded immediately.

## Risk Assessment

- [x] **Low** — Isolated change to generated deploy script, KAI scheduler still installs and reconciles normally

**Rollout notes:** Only affects newly generated bundles. Existing bundles need to be regenerated with `eidos bundle`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)