### PR TITLE
fix: add kube-prometheus-stack as gpu-operator dependency

### DIFF
--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -152,6 +152,7 @@ componentRefs:
 
 deploymentOrder:
   - cert-manager
+  - kube-prometheus-stack
   - gpu-operator
   - nvidia-dra-driver-gpu
   - nvsentinel

--- a/examples/recipes/eks-training.yaml
+++ b/examples/recipes/eks-training.yaml
@@ -63,6 +63,7 @@ componentRefs:
     valuesFile: components/skyhook-operator/values.yaml
 deploymentOrder:
   - cert-manager
+  - kube-prometheus-stack
   - gpu-operator
   - nvsentinel
   - skyhook-operator

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -50,6 +50,7 @@ spec:
           namespace: gpu-operator
       dependencyRefs:
         - cert-manager
+        - kube-prometheus-stack
 
     - name: nvsentinel
       type: Helm

--- a/tests/chainsaw/ai-conformance/offline/assert-recipe.yaml
+++ b/tests/chainsaw/ai-conformance/offline/assert-recipe.yaml
@@ -57,13 +57,13 @@ deploymentOrder:
   - aws-efa
   - cert-manager
   - dynamo-crds
-  - gpu-operator
-  - kai-scheduler
   - kgateway-crds
   - kgateway
   - kube-prometheus-stack
   - dynamo-platform
+  - gpu-operator
   - k8s-ephemeral-storage-metrics
+  - kai-scheduler
   - nvidia-dra-driver-gpu
   - nvsentinel
   - prometheus-adapter

--- a/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
@@ -52,10 +52,10 @@ deploymentOrder:
   - aws-ebs-csi-driver
   - aws-efa
   - cert-manager
-  - gpu-operator
-  - kai-scheduler
   - kube-prometheus-stack
+  - gpu-operator
   - k8s-ephemeral-storage-metrics
+  - kai-scheduler
   - kubeflow-trainer
   - nvidia-dra-driver-gpu
   - nvsentinel


### PR DESCRIPTION
## Summary

Add `kube-prometheus-stack` as a dependency of `gpu-operator` in `base.yaml` to ensure the ServiceMonitor CRD exists before the GPU operator tries to create one.

## Motivation / Context

With `dcgmExporter.serviceMonitor.enabled: true` (PR #157), the GPU operator attempts to create a `ServiceMonitor` CR for the DCGM exporter during reconciliation. If `kube-prometheus-stack` hasn't been installed yet, the CRD doesn't exist and the operator reports `ClusterPolicy` as `notReady`:

```
"Install Prometheus and necessary CRDs for gathering GPU metrics!"
"error": "couldn't find ServiceMonitor CRD"
"ClusterPolicy is not ready, states not ready: [state-dcgm-exporter]"
```

This was observed on the `aicr-demo` cluster from issue #165.

Fixes: #165
Related: #157

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

Added `kube-prometheus-stack` to `gpu-operator`'s `dependencyRefs` in `base.yaml`. This changes the install order:

Before:
```
cert-manager → gpu-operator → ... → kube-prometheus-stack
```

After:
```
cert-manager → kube-prometheus-stack → gpu-operator → ...
```

## Testing

```bash
go test -race ./pkg/recipe/... ./pkg/bundler/...   # all pass
```

## Risk Assessment

- [x] **Low** — Only changes component install ordering, no functional changes

**Rollout notes:** Existing bundles need to be regenerated with `eidos bundle`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)