### PR TITLE
feat(ci): add ClamAV malware scanning GitHub Action

### DIFF
--- a/.github/actions/malware-scan/action.yml
+++ b/.github/actions/malware-scan/action.yml
@@ -1,0 +1,197 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'ClamAV Malware Scan'
+description: 'Run ClamAV malware scan on release artifacts and upload SARIF results to GitHub Security'
+
+inputs:
+  scan_path:
+    description: 'Path to scan for malware (e.g. dist/ for release binaries)'
+    required: false
+    default: '.'
+  output_file:
+    description: 'Output SARIF file name'
+    required: false
+    default: 'clamav-results.sarif'
+  category:
+    description: 'GitHub Security category for SARIF upload'
+    required: false
+    default: 'clamav'
+  fail_on_finding:
+    description: 'Fail the step if malware is detected (true/false)'
+    required: false
+    default: 'true'
+
+outputs:
+  infected_count:
+    description: 'Number of infected files found'
+    value: ${{ steps.scan.outputs.infected_count }}
+  scanned_count:
+    description: 'Number of files scanned'
+    value: ${{ steps.scan.outputs.scanned_count }}
+  outcome:
+    description: 'Scan outcome (clean, infected, error)'
+    value: ${{ steps.scan.outputs.outcome }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install ClamAV
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq clamav > /dev/null 2>&1
+        echo "Installed: $(clamscan --version)"
+
+    - name: Update virus definitions
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Stop freshclam daemon if running (it holds the lock)
+        sudo systemctl stop clamav-freshclam 2>/dev/null || true
+        sudo freshclam --quiet
+        echo "Virus definitions updated"
+
+    - name: Run ClamAV scan
+      id: scan
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        SCAN_PATH="${{ inputs.scan_path }}"
+        RAW_OUTPUT="clamav-raw.log"
+
+        echo "::group::ClamAV scan of ${SCAN_PATH}"
+
+        # clamscan exit codes: 0=clean, 1=infected found, 2=error
+        SCAN_EXIT=0
+        clamscan \
+          --recursive \
+          --infected \
+          --suppress-ok-results \
+          --max-filesize=100M \
+          --max-scansize=400M \
+          "${SCAN_PATH}" > "${RAW_OUTPUT}" 2>&1 || SCAN_EXIT=$?
+
+        cat "${RAW_OUTPUT}"
+        echo "::endgroup::"
+
+        # Parse summary line: "Infected files: N"
+        INFECTED=$(grep -oP 'Infected files:\s*\K\d+' "${RAW_OUTPUT}" || echo "0")
+        SCANNED=$(grep -oP 'Scanned files:\s*\K\d+' "${RAW_OUTPUT}" || echo "0")
+
+        echo "infected_count=${INFECTED}" >> "$GITHUB_OUTPUT"
+        echo "scanned_count=${SCANNED}" >> "$GITHUB_OUTPUT"
+
+        if [[ "${SCAN_EXIT}" -eq 2 ]]; then
+          echo "outcome=error" >> "$GITHUB_OUTPUT"
+          echo "::error::ClamAV encountered an error during scanning"
+          exit 1
+        elif [[ "${INFECTED}" -gt 0 ]]; then
+          echo "outcome=infected" >> "$GITHUB_OUTPUT"
+          echo "::error::ClamAV detected ${INFECTED} infected file(s)"
+        else
+          echo "outcome=clean" >> "$GITHUB_OUTPUT"
+          echo "Scan clean: ${SCANNED} files scanned, 0 infected"
+        fi
+
+    - name: Convert results to SARIF
+      id: convert
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        RAW_OUTPUT="clamav-raw.log"
+        SARIF_FILE="${{ inputs.output_file }}"
+        INFECTED="${{ steps.scan.outputs.infected_count }}"
+
+        # Build SARIF results array from infected lines
+        # ClamAV infected output format: "/path/to/file: SignatureName FOUND"
+        RESULTS="[]"
+        RULES="[]"
+
+        if [[ "${INFECTED}" -gt 0 ]]; then
+          while IFS= read -r line; do
+            # Parse: /path/to/file: MalwareName FOUND
+            FILE_PATH=$(echo "${line}" | sed 's/: .* FOUND$//')
+            SIGNATURE=$(echo "${line}" | sed 's/^.*: //; s/ FOUND$//')
+
+            # Check if rule already exists
+            RULE_ID="clamav/${SIGNATURE}"
+            RULE_EXISTS=$(echo "${RULES}" | jq --arg id "${RULE_ID}" 'map(.id) | index($id)')
+
+            if [[ "${RULE_EXISTS}" == "null" ]]; then
+              RULES=$(echo "${RULES}" | jq \
+                --arg id "${RULE_ID}" \
+                --arg name "${SIGNATURE}" \
+                '. += [{"id": $id, "name": $name, "shortDescription": {"text": ("Malware detected: " + $name)}, "properties": {"tags": ["security", "malware"]}}]')
+            fi
+
+            RESULTS=$(echo "${RESULTS}" | jq \
+              --arg rule_id "${RULE_ID}" \
+              --arg uri "${FILE_PATH}" \
+              --arg msg "ClamAV detected malware signature: ${SIGNATURE}" \
+              '. += [{"ruleId": $rule_id, "level": "error", "message": {"text": $msg}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": $uri}}}]}]')
+
+          done < <(grep "FOUND$" "${RAW_OUTPUT}" || true)
+        fi
+
+        # Emit SARIF v2.1.0
+        jq -n \
+          --argjson results "${RESULTS}" \
+          --argjson rules "${RULES}" \
+          --arg version "$(clamscan --version)" \
+          '{
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [{
+              "tool": {
+                "driver": {
+                  "name": "ClamAV",
+                  "informationUri": "https://www.clamav.net",
+                  "semanticVersion": $version,
+                  "rules": $rules
+                }
+              },
+              "results": $results
+            }]
+          }' > "${SARIF_FILE}"
+
+        echo "SARIF written to ${SARIF_FILE}"
+        echo "exists=true" >> "$GITHUB_OUTPUT"
+
+    - name: Upload SARIF to GitHub Security
+      if: steps.convert.outputs.exists == 'true'
+      id: upload_sarif
+      uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4.32.0
+      with:
+        sarif_file: ${{ inputs.output_file }}
+        category: ${{ inputs.category }}
+      continue-on-error: true
+
+    - name: SARIF upload status
+      if: steps.convert.outputs.exists == 'true'
+      shell: bash
+      run: |
+        if [[ "${{ steps.upload_sarif.outcome }}" == "failure" ]]; then
+          echo "::notice::SARIF upload skipped - GitHub Advanced Security may not be enabled for this repository"
+        fi
+
+    - name: Enforce scan result
+      if: inputs.fail_on_finding == 'true' && steps.scan.outputs.outcome == 'infected'
+      shell: bash
+      run: |
+        echo "::error::Malware scan failed: ${{ steps.scan.outputs.infected_count }} infected file(s) detected"
+        exit 1

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -72,10 +72,12 @@ jobs:
     outputs:
       release_outcome: ${{ steps.release.outputs.release_outcome }}
     permissions:
+      actions: read
       contents: write
       packages: write
       id-token: write
       attestations: write
+      security-events: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -98,6 +100,13 @@ jobs:
         uses: ./.github/actions/go-build-release
         with:
           ko_version: ${{ steps.versions.outputs.ko }}
+
+      - name: Malware Scan Release Binaries
+        if: steps.release.outcome == 'success'
+        uses: ./.github/actions/malware-scan
+        with:
+          scan_path: dist/
+          category: 'clamav-release-binaries'
 
   # =============================================================================
   # Docker Jobs: Native per-arch validator builds (parallel with GoReleaser)

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -85,3 +85,22 @@ jobs:
         uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4.32.0
         with:
           sarif_file: ${{ env.SARIF_OUTPUT }}
+
+  malware-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Malware Scan
+        uses: ./.github/actions/malware-scan
+        with:
+          scan_path: '.'
+          category: 'clamav'


### PR DESCRIPTION
## Summary
- Add a reusable composite action (`.github/actions/malware-scan/`) that scans release artifacts for malware using ClamAV
- Converts ClamAV findings to SARIF v2.1.0 for GitHub Security tab integration
- No external tokens or services required — runs entirely on the GitHub Actions runner

## Context
Addresses HIPPO-5119 malware scanning requirement for OSS Type III projects not registered with nSpect. Provides an equivalent open-source control using ClamAV (same approach as Dell's `common-github-actions/malware-scanner`).

## Usage
```yaml
- name: Malware Scan
  uses: ./.github/actions/malware-scan
  with:
    scan_path: dist/
```

## Test plan
- [ ] Validate action runs on `ubuntu-latest` runner
- [ ] Verify ClamAV installs and updates virus definitions
- [ ] Confirm clean scan produces SARIF with empty results array
- [ ] Confirm SARIF upload to GitHub Security tab works with GHAS enabled
- [ ] Test `fail_on_finding` input blocks pipeline on infected files