### PR TITLE
fix(ci): run attestation and vuln scan concurrently in release workflow

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -259,7 +259,7 @@ jobs:
   attest:
     name: Attest Images
     runs-on: ubuntu-latest
-    needs: [build, docker-manifest, image-vuln-scan]
+    needs: [build, docker-manifest]
     if: needs.build.outputs.release_outcome == 'success'
     timeout-minutes: 10
     permissions:
@@ -305,7 +305,7 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
-    needs: [attest]
+    needs: [attest, image-vuln-scan]
     timeout-minutes: 5
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Run `image-vuln-scan` and `attest` jobs in parallel instead of sequentially in the release workflow
- `publish` (which marks the release as non-draft) now waits for both to complete

Before:
```
build + docker-manifest → image-vuln-scan → attest → publish
```

After:
```
build + docker-manifest ──→ image-vuln-scan ──→ publish
                        └──→ attest ───────────↗
```

## Test plan
- [ ] Verify workflow YAML is valid (job dependency graph has no cycles)
- [ ] Next tag release confirms both jobs run concurrently