### PR TITLE
fix: remove nodeSelector from EBS CSI node DaemonSet scheduling

### DIFF
--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -261,9 +261,10 @@ components:
           - controller.nodeSelector
         tolerationPaths:
           - controller.tolerations
+          - node.tolerations
       accelerated:
-        nodeSelectorPaths:
-          - node.nodeSelector
+        # No nodeSelectorPaths — CSI node DaemonSet must run on ALL nodes
+        # (not just GPU nodes) since any node may need EBS volumes.
         tolerationPaths:
           - node.tolerations
 


### PR DESCRIPTION
## Summary

Remove `nodeSelectorPaths` from the EBS CSI driver's `accelerated` node scheduling config so the CSI node DaemonSet runs on all nodes, not just GPU nodes.

## Motivation / Context

The EBS CSI node DaemonSet was constrained to GPU nodes via `accelerated.nodeSelectorPaths: [node.nodeSelector]` in the registry. This prevented the CSI driver from registering on system/CPU nodes, causing PVC provisioning to fail:

```
error generating accessibility requirements: no topology key found for node ip-10-0-7-217.ec2.internal
```

Prometheus (running on a system node) couldn't get its EBS volume because the CSI node plugin wasn't running there.

Fixes: #165
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: `recipes/registry.yaml`

## Implementation Notes

- Removed `nodeSelectorPaths` from `aws-ebs-csi-driver` `accelerated` section — CSI node DaemonSet must run on ALL nodes
- Added `node.tolerations` to `system.tolerationPaths` so system node tolerations also apply to the node DaemonSet
- Kept `accelerated.tolerationPaths` so the node DaemonSet tolerates GPU node taints

## Testing

```bash
go test -race ./pkg/recipe/... ./pkg/bundler/...   # all pass
```

Verified on `aicr-demo` cluster — after removing the nodeSelector, EBS CSI node pods ran on all 6 nodes and Prometheus PVC provisioned successfully.

## Risk Assessment

- [x] **Low** — Removes an incorrect constraint, CSI node DaemonSet should always run everywhere

**Rollout notes:** Existing bundles need to be regenerated.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)