### PR TITLE
fix(docs): update bundle commands with correct tolerations in CUJ demos

### DIFF
--- a/demos/cuj1.md
+++ b/demos/cuj1.md
@@ -21,8 +21,11 @@ eidos recipe \
 ```shell
 eidos bundle \
   --recipe recipe.yaml \
-  --accelerated-node-selector nodeGroup=gpu-worker\
+  --accelerated-node-selector nodeGroup=gpu-worker \
   --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
+  --accelerated-node-toleration dedicated=worker-workload:NoExecute \
+  --system-node-toleration dedicated=system-workload:NoSchedule \
+  --system-node-toleration dedicated=system-workload:NoExecute \
   --output bundle
 ```
 

--- a/demos/cuj2.md
+++ b/demos/cuj2.md
@@ -72,9 +72,11 @@ phases:
 ```shell
 eidos bundle \
   --recipe recipe.yaml \
-  --system-node-selector nodeGroup=system-pool \
   --accelerated-node-selector nodeGroup=gpu-worker \
-  --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule \
+  --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
+  --accelerated-node-toleration dedicated=worker-workload:NoExecute \
+  --system-node-toleration dedicated=system-workload:NoSchedule \
+  --system-node-toleration dedicated=system-workload:NoExecute \
   --output bundle
 ```
 


### PR DESCRIPTION
## Summary

Update `eidos bundle` commands in CUJ1 and CUJ2 demos with correct tolerations for clusters with both NoSchedule and NoExecute taints.

## Motivation / Context

The demo bundle commands were missing `NoExecute` tolerations and `--system-node-toleration` flags. On clusters where GPU nodes have both `dedicated=worker-workload:NoSchedule` and `NoExecute` taints, components like NFD workers and GPU operator DaemonSets couldn't schedule.

Fixes: N/A
Related: #165

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Testing

Verified on `aicr-demo` EKS cluster — full training stack deployed successfully with the updated bundle command.

## Risk Assessment

- [x] **Low** — Documentation-only change

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)