### PR TITLE
fix: remove trailing quote from skyhook no-op package version

### DIFF
--- a/recipes/components/skyhook-customizations/manifests/no-op.yaml
+++ b/recipes/components/skyhook-customizations/manifests/no-op.yaml
@@ -57,7 +57,7 @@ spec:
   packages:
     no-op:
       image: ghcr.io/nvidia/skyhook-packages/shellscript
-      version: 1.1.1"
+      version: 1.1.1
       configMap:
         apply.sh: |
           #!/bin/bash


### PR DESCRIPTION
## Summary

Fix a trailing double quote in the skyhook no-op manifest version string that caused the skyhook webhook to reject it.

## Motivation / Context

During CUJ1 training deployment on the `aicr-demo` cluster, the skyhook-customizations manifest apply failed:

```
admission webhook "validate-skyhook.nvidia.com" denied the request:
error version string for no-op is invalid: 1.1.1"
```

The version field had `1.1.1"` instead of `1.1.1`.

Fixes: #165
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: `recipes/components/skyhook-customizations`

## Testing

One character fix — removed trailing `"` from line 60 of `no-op.yaml`.

## Risk Assessment

- [x] **Low** — Typo fix

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)