### PR TITLE
feat(validator): add Go-based CNCF AI conformance checks

### DIFF
--- a/.github/actions/aicr-build/action.yml
+++ b/.github/actions/aicr-build/action.yml
@@ -13,20 +13,22 @@
 # limitations under the License.
 
 name: 'AICR Build'
-description: 'Builds the aicr container image (via ko) and CLI binary, and loads the image into kind.'
+description: 'Builds the aicr validator image (via Dockerfile) and CLI binary, and loads the image into kind.'
 
 runs:
   using: 'composite'
   steps:
 
-    - name: Build aicr image and load into kind
+    - name: Install ko
       shell: bash
-      env:
-        GOFLAGS: -mod=vendor
       run: |
         KO_VERSION=$(yq eval '.build_tools.ko' .settings.yaml)
         GOFLAGS= go install "github.com/google/ko@${KO_VERSION}"
-        KO_DOCKER_REPO=ko.local ko build --bare --sbom=none --tags=smoke-test ./cmd/aicr
+
+    - name: Build aicr validator image and load into kind
+      shell: bash
+      run: |
+        docker build -f Dockerfile.validator -t ko.local:smoke-test .
         kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}"
 
     - name: Build aicr binary

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -25,6 +25,8 @@ on:
       - '.github/actions/gpu-cluster-setup/**'
       - '.github/actions/gpu-operator-install/**'
       - '.github/actions/aicr-build/**'
+      - 'Dockerfile.validator'
+      - 'pkg/validator/checks/conformance/**'
       - '.github/actions/gpu-test-cleanup/**'
       - '.github/actions/load-versions/**'
       - 'tests/manifests/**'
@@ -107,6 +109,39 @@ jobs:
           fi
           echo "Snapshot correctly detected ${GPU_COUNT}x ${GPU_MODEL}"
 
+      # --- Deploy DRA test pod (prerequisite for secure-accelerator-access check) ---
+
+      - name: Deploy DRA GPU test
+        run: |
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
+            -f docs/conformance/cncf/manifests/dra-gpu-test.yaml
+
+          echo "Waiting for DRA GPU test pod to complete..."
+          if kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
+            wait --for=jsonpath='{.status.phase}'=Succeeded pod/dra-gpu-test --timeout=120s; then
+            echo "DRA GPU allocation test passed."
+          else
+            echo "::error::DRA GPU test pod did not succeed"
+            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
+              logs pod/dra-gpu-test 2>/dev/null || true
+            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
+              get pod/dra-gpu-test -o yaml 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "=== DRA GPU test logs ==="
+          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
+            logs pod/dra-gpu-test
+
+      # --- Install Karpenter before validation so cluster-autoscaling check passes ---
+
+      - name: Install Karpenter + KWOK (setup)
+        run: bash kwok/scripts/validate-cluster-autoscaling.sh --setup
+
+      # --- Validate cluster (Go conformance checks run inside K8s Jobs) ---
+      # Replaces previous bash assertion steps for: inference-gateway,
+      # accelerator-metrics, pod-autoscaling, secure-accelerator-access.
+
       - name: Validate cluster
         run: |
           ./aicr validate \
@@ -130,43 +165,6 @@ jobs:
           chainsaw test \
             --test-dir tests/chainsaw/ai-conformance/kind \
             --config tests/chainsaw/chainsaw-config.yaml
-
-      # --- Inference Gateway validation (CNCF AI Conformance #6) ---
-
-      - name: Validate inference gateway
-        run: |
-          echo "=== GatewayClass ==="
-          GC_STATUS=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-            get gatewayclass kgateway \
-            -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null)
-          echo "GatewayClass accepted: ${GC_STATUS}"
-          if [[ "${GC_STATUS}" != "True" ]]; then
-            echo "::error::GatewayClass 'kgateway' not accepted"
-            kubectl --context="kind-${KIND_CLUSTER_NAME}" get gatewayclass -o yaml 2>/dev/null || true
-            exit 1
-          fi
-
-          echo "=== Gateway ==="
-          GW_STATUS=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-            get gateway inference-gateway -n kgateway-system \
-            -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null)
-          echo "Gateway programmed: ${GW_STATUS}"
-          if [[ "${GW_STATUS}" != "True" ]]; then
-            echo "::error::Gateway 'inference-gateway' not programmed"
-            kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-              get gateway inference-gateway -n kgateway-system -o yaml 2>/dev/null || true
-            exit 1
-          fi
-
-          echo "=== Gateway API CRDs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" get crds 2>/dev/null | \
-            grep -E "gateway\.networking\.k8s\.io" || true
-
-          echo "=== Inference extension CRDs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" get crds 2>/dev/null | \
-            grep -E "inference\.networking" || true
-
-          echo "Inference gateway validation passed."
 
       # --- Dynamo vLLM inference smoke test ---
 
@@ -255,209 +253,10 @@ jobs:
           fi
           echo "Dynamo vLLM inference smoke test passed."
 
-      # --- Accelerator & AI Service Metrics validation (CNCF AI Conformance #4/#5) ---
-
-      - name: Validate accelerator metrics
-
-        run: |
-          echo "=== DCGM Exporter pod ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator \
-            get pods -l app=nvidia-dcgm-exporter -o wide
-          DCGM_POD=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator \
-            get pods -l app=nvidia-dcgm-exporter -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-          if [[ -z "${DCGM_POD}" ]]; then
-            echo "::error::DCGM Exporter pod not found"
-            exit 1
-          fi
-          echo "DCGM Exporter pod: ${DCGM_POD}"
-
-          echo "=== Query DCGM metrics endpoint ==="
-          METRICS=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" run dcgm-probe \
-            --rm -i --restart=Never --image=curlimages/curl \
-            -- curl -sf http://nvidia-dcgm-exporter.gpu-operator.svc:9400/metrics 2>/dev/null)
-
-          for METRIC in DCGM_FI_DEV_GPU_UTIL DCGM_FI_DEV_FB_USED DCGM_FI_DEV_GPU_TEMP DCGM_FI_DEV_POWER_USAGE; do
-            if echo "${METRICS}" | grep -q "^${METRIC}"; then
-              echo "${METRIC}: $(echo "${METRICS}" | grep "^${METRIC}" | head -1)"
-            else
-              echo "::warning::Metric ${METRIC} not found in DCGM output"
-            fi
-          done
-
-          echo "=== Prometheus scraping GPU metrics ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n monitoring \
-            port-forward svc/kube-prometheus-prometheus 9090:9090 &
-          PF_PID=$!
-          sleep 3
-
-          cleanup_pf() { kill "${PF_PID}" 2>/dev/null || true; }
-          trap cleanup_pf EXIT
-
-          for METRIC in DCGM_FI_DEV_GPU_UTIL DCGM_FI_DEV_FB_USED DCGM_FI_DEV_GPU_TEMP DCGM_FI_DEV_POWER_USAGE; do
-            RESULT=$(curl -sf "http://localhost:9090/api/v1/query?query=${METRIC}" 2>/dev/null)
-            COUNT=$(echo "${RESULT}" | jq -r '.data.result | length' 2>/dev/null)
-            if [[ "${COUNT}" -gt 0 ]]; then
-              echo "${METRIC}: ${COUNT} time series in Prometheus"
-            else
-              echo "::warning::${METRIC} not found in Prometheus (may need more scrape time)"
-            fi
-          done
-
-          kill "${PF_PID}" 2>/dev/null || true
-          trap - EXIT
-
-          echo "=== Custom Metrics API ==="
-          CUSTOM_METRICS=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-            get --raw /apis/custom.metrics.k8s.io/v1beta1 2>/dev/null)
-          if [[ -n "${CUSTOM_METRICS}" ]]; then
-            echo "Custom metrics API is available"
-            echo "${CUSTOM_METRICS}" | jq -r '.resources[].name' 2>/dev/null | head -20 || true
-          else
-            echo "::warning::Custom metrics API not available (prometheus-adapter may need time)"
-          fi
-
-          echo "Accelerator metrics validation passed."
-
-      # --- Pod Autoscaling readiness validation (CNCF AI Conformance #8b) ---
-      # Validates the custom metrics pipeline (DCGM → Prometheus → prometheus-adapter
-      # → custom metrics API) that HPA consumes. Dynamo uses PodCliqueSets (not
-      # Deployments), so we validate the API directly rather than creating an HPA.
-      #
-      # DCGM exporter pod-mapping relabels metrics with the GPU workload's
-      # namespace/pod when a GPU is in use. Metrics may appear in gpu-operator
-      # (idle GPU) or dynamo-system (active workload). prometheus-adapter also
-      # needs relist cycles (30s each) to discover new label combinations, so
-      # we poll with retries.
-
-      - name: Validate custom metrics for pod autoscaling
-
-        run: |
-          echo "=== Custom metrics API availability ==="
-          RESOURCES=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-            get --raw /apis/custom.metrics.k8s.io/v1beta1 2>/dev/null)
-          if [[ -z "${RESOURCES}" ]]; then
-            echo "::error::Custom metrics API not available"
-            exit 1
-          fi
-          echo "Custom metrics API is available"
-          echo "${RESOURCES}" | jq -r '.resources[].name' 2>/dev/null | head -20
-
-          NAMESPACES="gpu-operator dynamo-system"
-          METRICS="gpu_utilization gpu_memory_used gpu_power_usage"
-
-          # Poll for up to 3 minutes — prometheus-adapter relists every 30s and
-          # avg_over_time(...[2m]) queries need sufficient data points.
-          HAS_METRICS=false
-          for ATTEMPT in $(seq 1 18); do
-            for METRIC in ${METRICS}; do
-              for NS in ${NAMESPACES}; do
-                RESULT=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" get --raw \
-                  "/apis/custom.metrics.k8s.io/v1beta1/namespaces/${NS}/pods/*/${METRIC}" 2>/dev/null || true)
-                if [[ -n "${RESULT}" ]] && echo "${RESULT}" | jq -e '.items | length > 0' >/dev/null 2>&1; then
-                  echo "${METRIC} metrics available in ${NS}:"
-                  echo "${RESULT}" | jq '.items[] | {pod: .describedObject.name, value: .value}' 2>/dev/null
-                  HAS_METRICS=true
-                  break 3
-                fi
-              done
-            done
-            echo "Waiting for custom metrics to appear... (${ATTEMPT}/18)"
-            sleep 10
-          done
-
-          if [[ "${HAS_METRICS}" != "true" ]]; then
-            echo "::error::No GPU custom metrics available via custom metrics API (prometheus-adapter pipeline broken)"
-            exit 1
-          fi
-
-          echo "Custom metrics pipeline validated — GPU metrics available for HPA consumption."
-
       # --- Cluster Autoscaling validation ---
 
       - name: Cluster Autoscaling (Karpenter + KWOK)
-
-        run: bash kwok/scripts/validate-cluster-autoscaling.sh
-
-      # --- DRA GPU allocation test ---
-
-      - name: Deploy DRA GPU test
-
-        run: |
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
-            -f docs/conformance/cncf/manifests/dra-gpu-test.yaml
-
-          echo "Waiting for DRA GPU test pod to complete..."
-          if kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            wait --for=jsonpath='{.status.phase}'=Succeeded pod/dra-gpu-test --timeout=120s; then
-            echo "DRA GPU allocation test passed."
-          else
-            echo "::error::DRA GPU test pod did not succeed"
-            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-              logs pod/dra-gpu-test 2>/dev/null || true
-            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-              get pod/dra-gpu-test -o yaml 2>/dev/null || true
-            exit 1
-          fi
-
-          echo "=== DRA GPU test logs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            logs pod/dra-gpu-test
-
-      # --- Secure Accelerator Access validation (CNCF AI Conformance #3) ---
-
-      - name: Validate secure accelerator access
-
-        run: |
-          echo "=== Verify DRA-mediated access (no hostPath, no device plugin) ==="
-
-          # Check pod uses resourceClaims (DRA), not resources.limits (device plugin)
-          RESOURCE_CLAIMS=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            get pod/dra-gpu-test -o jsonpath='{.spec.resourceClaims}' 2>/dev/null)
-          if [[ -z "${RESOURCE_CLAIMS}" || "${RESOURCE_CLAIMS}" == "null" ]]; then
-            echo "::error::Pod does not use DRA resourceClaims"
-            exit 1
-          fi
-          echo "Pod uses DRA resourceClaims: ${RESOURCE_CLAIMS}"
-
-          # Verify no nvidia.com/gpu in resources.limits (device plugin pattern)
-          GPU_LIMITS=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            get pod/dra-gpu-test \
-            -o jsonpath='{.spec.containers[0].resources.limits.nvidia\.com/gpu}' 2>/dev/null)
-          if [[ -n "${GPU_LIMITS}" && "${GPU_LIMITS}" != "null" ]]; then
-            echo "::error::Pod uses device plugin (nvidia.com/gpu limits) instead of DRA"
-            exit 1
-          fi
-          echo "No device plugin resources.limits — GPU access via DRA only"
-
-          # Verify no hostPath volumes to /dev/nvidia*
-          VOLUMES=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            get pod/dra-gpu-test -o jsonpath='{.spec.volumes}' 2>/dev/null)
-          if echo "${VOLUMES}" | grep -q "hostPath" && echo "${VOLUMES}" | grep -q "/dev/nvidia"; then
-            echo "::error::Pod has hostPath volume mount to /dev/nvidia*"
-            exit 1
-          fi
-          echo "No hostPath volumes to /dev/nvidia* — access is DRA-mediated"
-
-          # Verify container security (no privilege escalation)
-          PRIV_ESC=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            get pod/dra-gpu-test \
-            -o jsonpath='{.spec.containers[0].securityContext.allowPrivilegeEscalation}' 2>/dev/null)
-          echo "allowPrivilegeEscalation: ${PRIV_ESC}"
-
-          # Verify only 1 GPU visible (allocated count matches)
-          GPU_COUNT=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            logs pod/dra-gpu-test 2>/dev/null | grep -c "/dev/nvidia[0-9]" || echo "0")
-          echo "GPU devices visible in container: ${GPU_COUNT}"
-          if [[ "${GPU_COUNT}" -lt 1 ]]; then
-            echo "::error::No GPU devices visible in container"
-            exit 1
-          fi
-
-          echo "=== ResourceClaim allocation ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dra-test \
-            get resourceclaim gpu-claim -o wide
-
-          echo "Secure accelerator access validation passed."
+        run: bash kwok/scripts/validate-cluster-autoscaling.sh --exercise
 
       - name: DRA GPU test cleanup
         if: always()

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -25,6 +25,8 @@ on:
       - '.github/actions/gpu-cluster-setup/**'
       - '.github/actions/gpu-operator-install/**'
       - '.github/actions/aicr-build/**'
+      - 'Dockerfile.validator'
+      - 'pkg/validator/checks/conformance/**'
       - '.github/actions/gpu-test-cleanup/**'
       - '.github/actions/load-versions/**'
       - 'docs/conformance/cncf/manifests/gang-scheduling-test.yaml'
@@ -104,19 +106,12 @@ jobs:
           fi
           echo "Snapshot correctly detected ${GPU_COUNT}x ${GPU_MODEL}"
 
-      - name: Validate cluster
-        run: |
-          ./aicr validate \
-            --recipe recipe.yaml \
-            --phase readiness \
-            --phase deployment \
-            --phase conformance \
-            --namespace gpu-operator \
-            --kubeconfig="${HOME}/.kube/config" \
-            --require-gpu \
-            --image=ko.local:smoke-test
+      # --- Install Karpenter before validation so cluster-autoscaling check passes ---
 
-      # --- Health checks ---
+      - name: Install Karpenter + KWOK (setup)
+        run: bash kwok/scripts/validate-cluster-autoscaling.sh --setup
+
+      # --- Health checks (run before conformance to give metrics pipeline time) ---
 
       - name: Install chainsaw
         run: |
@@ -129,6 +124,22 @@ jobs:
           chainsaw test \
             --test-dir tests/chainsaw/ai-conformance/kind-training \
             --config tests/chainsaw/chainsaw-config.yaml
+
+      # --- Validate cluster (Go conformance checks run inside K8s Jobs) ---
+      # Runs after chainsaw to ensure the DCGM → Prometheus → adapter pipeline
+      # has had time to bootstrap (pod-autoscaling check needs live metric data).
+
+      - name: Validate cluster
+        run: |
+          ./aicr validate \
+            --recipe recipe.yaml \
+            --phase readiness \
+            --phase deployment \
+            --phase conformance \
+            --namespace gpu-operator \
+            --kubeconfig="${HOME}/.kube/config" \
+            --require-gpu \
+            --image=ko.local:smoke-test
 
       # --- Gang scheduling test with PodGroup + KAI scheduler ---
 
@@ -179,8 +190,7 @@ jobs:
       # --- Cluster Autoscaling validation ---
 
       - name: Cluster Autoscaling (Karpenter + KWOK)
-
-        run: bash kwok/scripts/validate-cluster-autoscaling.sh
+        run: bash kwok/scripts/validate-cluster-autoscaling.sh --exercise
 
       # --- Evidence collection ---
 

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -50,7 +50,8 @@ RUN set -e; \
 
 # Pre-compile test binaries for in-cluster validation Jobs
 RUN CGO_ENABLED=0 go test -c -o /out/readiness.test ./pkg/validator/checks/readiness && \
-    CGO_ENABLED=0 go test -c -o /out/deployment.test ./pkg/validator/checks/deployment
+    CGO_ENABLED=0 go test -c -o /out/deployment.test ./pkg/validator/checks/deployment && \
+    CGO_ENABLED=0 go test -c -o /out/conformance.test ./pkg/validator/checks/conformance
 
 # Build test2json tool — converts verbose test output to JSON event stream.
 # Compiled test binaries don't support -test.json; they require piping through
@@ -70,6 +71,7 @@ LABEL org.opencontainers.image.title="aicr-validator" \
 COPY --from=builder /out/aicr /usr/local/bin/aicr
 COPY --from=builder /out/readiness.test /usr/local/bin/readiness.test
 COPY --from=builder /out/deployment.test /usr/local/bin/deployment.test
+COPY --from=builder /out/conformance.test /usr/local/bin/conformance.test
 COPY --from=builder /out/test2json /usr/local/bin/test2json
 
 # Copy testdata needed by deployment tests at runtime (loaded via os.ReadFile

--- a/kwok/scripts/validate-cluster-autoscaling.sh
+++ b/kwok/scripts/validate-cluster-autoscaling.sh
@@ -32,7 +32,9 @@
 #
 # Usage:
 #   export KIND_CLUSTER_NAME=gpu-inference-test
-#   ./validate-cluster-autoscaling.sh
+#   ./validate-cluster-autoscaling.sh              # Run everything (default)
+#   ./validate-cluster-autoscaling.sh --setup      # Install Karpenter + create NodePool only
+#   ./validate-cluster-autoscaling.sh --exercise   # Run metrics + autoscaling exercise only
 
 set -euo pipefail
 
@@ -295,17 +297,31 @@ test_consolidation() {
 # Main
 # -------------------------------------------------------------------
 main() {
-    log_info "=== Cluster Autoscaling ==="
+    local mode="all"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --setup)    mode="setup"; shift ;;
+            --exercise) mode="exercise"; shift ;;
+            *)          echo "Unknown option: $1"; exit 1 ;;
+        esac
+    done
+
+    log_info "=== Cluster Autoscaling (mode=${mode}) ==="
     log_info "Kind cluster: ${KIND_CLUSTER_NAME}"
 
-    install_karpenter
-    create_nodepool
-    verify_external_metrics
-    deploy_test_workload
-    wait_for_hpa_scale
-    wait_for_kwok_nodes
-    verify_pods_scheduled
-    test_consolidation
+    if [[ "${mode}" == "all" || "${mode}" == "setup" ]]; then
+        install_karpenter
+        create_nodepool
+    fi
+
+    if [[ "${mode}" == "all" || "${mode}" == "exercise" ]]; then
+        verify_external_metrics
+        deploy_test_workload
+        wait_for_hpa_scale
+        wait_for_kwok_nodes
+        verify_pods_scheduled
+        test_consolidation
+    fi
 
     log_info "=== Cluster autoscaling validation PASSED ==="
 }

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -118,6 +118,70 @@ func (d *Deployer) ensureClusterRole(ctx context.Context) error {
 				Resources: []string{"pods", "services", "nodes"},
 				Verbs:     []string{"get", "list"},
 			},
+			// Conformance: cluster-wide core resources (platform-health, robust-controller)
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "endpoints"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: CRD discovery (inference-gateway, dra-support, gang-scheduling, robust-controller)
+			{
+				APIGroups: []string{"apiextensions.k8s.io"},
+				Resources: []string{"customresourcedefinitions"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: DRA support validation (resource.k8s.io/v1 — GA)
+			{
+				APIGroups: []string{"resource.k8s.io"},
+				Resources: []string{"resourceslices", "resourceclaims"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: GPU operator ClusterPolicy
+			{
+				APIGroups: []string{"nvidia.com"},
+				Resources: []string{"clusterpolicies"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: Gateway API validation
+			{
+				APIGroups: []string{"gateway.networking.k8s.io"},
+				Resources: []string{"gatewayclasses", "gateways"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: Gang scheduling (KAI scheduler)
+			{
+				APIGroups: []string{"scheduling.run.ai"},
+				Resources: []string{"queues", "podgroups"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: Cluster autoscaling (Karpenter)
+			{
+				APIGroups: []string{"karpenter.sh"},
+				Resources: []string{"nodepools"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: Aggregated metrics APIs (pod-autoscaling, ai-service-metrics)
+			{
+				APIGroups: []string{"custom.metrics.k8s.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"external.metrics.k8s.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list"},
+			},
+			// Conformance: Robust controller — webhook configurations and endpoint health
+			{
+				APIGroups: []string{"admissionregistration.k8s.io"},
+				Resources: []string{"validatingwebhookconfigurations"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"get", "list"},
+			},
 		},
 	}
 

--- a/pkg/validator/checks/conformance/accelerator_metrics_check.go
+++ b/pkg/validator/checks/conformance/accelerator_metrics_check.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+// requiredDCGMMetrics are the DCGM metrics required by CNCF AI Conformance requirement #4.
+var requiredDCGMMetrics = []string{
+	"DCGM_FI_DEV_GPU_UTIL",
+	"DCGM_FI_DEV_FB_USED",
+	"DCGM_FI_DEV_GPU_TEMP",
+	"DCGM_FI_DEV_POWER_USAGE",
+}
+
+const dcgmExporterURL = "http://nvidia-dcgm-exporter.gpu-operator.svc:9400/metrics"
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "accelerator-metrics",
+		Description: "Verify DCGM exporter exposes required GPU metrics (utilization, memory, temperature, power)",
+		Phase:       phaseConformance,
+		Func:        CheckAcceleratorMetrics,
+		TestName:    "TestAcceleratorMetrics",
+	})
+}
+
+// CheckAcceleratorMetrics validates CNCF requirement #4: Accelerator Metrics.
+// Calls the DCGM exporter metrics endpoint directly via in-cluster DNS and verifies
+// that all required GPU metrics are present.
+func CheckAcceleratorMetrics(ctx *checks.ValidationContext) error {
+	return checkAcceleratorMetricsWithURL(ctx, dcgmExporterURL)
+}
+
+// checkAcceleratorMetricsWithURL is the testable implementation that accepts a configurable URL.
+func checkAcceleratorMetricsWithURL(ctx *checks.ValidationContext, url string) error {
+	body, err := httpGet(ctx.Context, url)
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeUnavailable,
+			"DCGM exporter metrics endpoint unreachable", err)
+	}
+
+	missing := containsAllMetrics(string(body), requiredDCGMMetrics)
+	if len(missing) > 0 {
+		return errors.New(errors.ErrCodeNotFound,
+			fmt.Sprintf("DCGM metrics missing: %s", strings.Join(missing, ", ")))
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/accelerator_metrics_check_test.go
+++ b/pkg/validator/checks/conformance/accelerator_metrics_check_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestAcceleratorMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "accelerator-metrics") {
+		t.Skip("Check accelerator-metrics not enabled in recipe")
+	}
+
+	t.Logf("Running check: accelerator-metrics")
+
+	ctx := runner.Context()
+	err = CheckAcceleratorMetrics(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: accelerator-metrics")
+	}
+}

--- a/pkg/validator/checks/conformance/accelerator_metrics_check_unit_test.go
+++ b/pkg/validator/checks/conformance/accelerator_metrics_check_unit_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestCheckAcceleratorMetrics(t *testing.T) {
+	allMetrics := `# HELP DCGM_FI_DEV_GPU_UTIL GPU utilization
+# TYPE DCGM_FI_DEV_GPU_UTIL gauge
+DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-abc"} 42
+# HELP DCGM_FI_DEV_FB_USED Framebuffer memory used
+# TYPE DCGM_FI_DEV_FB_USED gauge
+DCGM_FI_DEV_FB_USED{gpu="0",UUID="GPU-abc"} 1024
+# HELP DCGM_FI_DEV_GPU_TEMP GPU temperature
+# TYPE DCGM_FI_DEV_GPU_TEMP gauge
+DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-abc"} 65
+# HELP DCGM_FI_DEV_POWER_USAGE Power draw
+# TYPE DCGM_FI_DEV_POWER_USAGE gauge
+DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-abc"} 200
+`
+
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "all metrics present",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, allMetrics)
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing one metric",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				// Only 3 of 4 metrics
+				fmt.Fprint(w, `DCGM_FI_DEV_GPU_UTIL{gpu="0"} 42
+DCGM_FI_DEV_FB_USED{gpu="0"} 1024
+DCGM_FI_DEV_GPU_TEMP{gpu="0"} 65
+`)
+			},
+			wantErr:     true,
+			errContains: "DCGM_FI_DEV_POWER_USAGE",
+		},
+		{
+			name: "missing all metrics",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "# no metrics here\n")
+			},
+			wantErr:     true,
+			errContains: "DCGM metrics missing",
+		},
+		{
+			name: "server returns 500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr:     true,
+			errContains: "HTTP 500",
+		},
+		{
+			name:        "server unreachable",
+			handler:     nil, // No server started
+			wantErr:     true,
+			errContains: "DCGM exporter metrics endpoint unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var url string
+			if tt.handler != nil {
+				server := httptest.NewServer(tt.handler)
+				defer server.Close()
+				url = server.URL + "/metrics"
+			} else {
+				// Use an unreachable URL
+				url = "http://127.0.0.1:1/metrics"
+			}
+
+			ctx := &checks.ValidationContext{
+				Context: context.Background(),
+			}
+
+			err := checkAcceleratorMetricsWithURL(ctx, url)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkAcceleratorMetricsWithURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("checkAcceleratorMetricsWithURL() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckAcceleratorMetricsRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("accelerator-metrics")
+	if !ok {
+		t.Fatal("accelerator-metrics check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+func TestContainsAllMetrics(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		required []string
+		want     []string
+	}{
+		{
+			name:     "all present",
+			text:     "DCGM_FI_DEV_GPU_UTIL 42\nDCGM_FI_DEV_FB_USED 1024",
+			required: []string{"DCGM_FI_DEV_GPU_UTIL", "DCGM_FI_DEV_FB_USED"},
+			want:     nil,
+		},
+		{
+			name:     "one missing",
+			text:     "DCGM_FI_DEV_GPU_UTIL 42",
+			required: []string{"DCGM_FI_DEV_GPU_UTIL", "DCGM_FI_DEV_FB_USED"},
+			want:     []string{"DCGM_FI_DEV_FB_USED"},
+		},
+		{
+			name:     "all missing",
+			text:     "no metrics here",
+			required: []string{"DCGM_FI_DEV_GPU_UTIL", "DCGM_FI_DEV_FB_USED"},
+			want:     []string{"DCGM_FI_DEV_GPU_UTIL", "DCGM_FI_DEV_FB_USED"},
+		},
+		{
+			name:     "empty text",
+			text:     "",
+			required: []string{"DCGM_FI_DEV_GPU_UTIL"},
+			want:     []string{"DCGM_FI_DEV_GPU_UTIL"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsAllMetrics(tt.text, tt.required)
+			if len(got) != len(tt.want) {
+				t.Errorf("containsAllMetrics() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("containsAllMetrics()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/validator/checks/conformance/ai_service_metrics_check.go
+++ b/pkg/validator/checks/conformance/ai_service_metrics_check.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+const prometheusBaseURL = "http://kube-prometheus-prometheus.monitoring.svc:9090"
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "ai-service-metrics",
+		Description: "Verify GPU metrics flow through Prometheus and custom metrics API is available",
+		Phase:       phaseConformance,
+		Func:        CheckAIServiceMetrics,
+		TestName:    "TestAIServiceMetrics",
+	})
+}
+
+// CheckAIServiceMetrics validates CNCF requirement #5: AI Service Metrics.
+// Verifies that GPU metric time series exist in Prometheus and that the
+// custom metrics API is available.
+func CheckAIServiceMetrics(ctx *checks.ValidationContext) error {
+	return checkAIServiceMetricsWithURL(ctx, prometheusBaseURL)
+}
+
+// checkAIServiceMetricsWithURL is the testable implementation that accepts a configurable URL.
+func checkAIServiceMetricsWithURL(ctx *checks.ValidationContext, promBaseURL string) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. Query Prometheus for GPU metric time series
+	queryURL := fmt.Sprintf("%s/api/v1/query?query=DCGM_FI_DEV_GPU_UTIL", promBaseURL)
+	body, err := httpGet(ctx.Context, queryURL)
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeUnavailable, "Prometheus unreachable", err)
+	}
+
+	var promResp struct {
+		Data struct {
+			Result []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &promResp); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to parse Prometheus response", err)
+	}
+	if len(promResp.Data.Result) == 0 {
+		return errors.New(errors.ErrCodeNotFound,
+			"no DCGM_FI_DEV_GPU_UTIL time series in Prometheus")
+	}
+
+	// 2. Custom metrics API available
+	rawURL := "/apis/custom.metrics.k8s.io/v1beta1"
+	restClient := ctx.Clientset.Discovery().RESTClient()
+	if restClient == nil {
+		return errors.New(errors.ErrCodeInternal, "discovery REST client is not available")
+	}
+	result := restClient.Get().AbsPath(rawURL).Do(ctx.Context)
+	if err := result.Error(); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"custom metrics API not available", err)
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/ai_service_metrics_check_test.go
+++ b/pkg/validator/checks/conformance/ai_service_metrics_check_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestAIServiceMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "ai-service-metrics") {
+		t.Skip("Check ai-service-metrics not enabled in recipe")
+	}
+
+	t.Logf("Running check: ai-service-metrics")
+
+	ctx := runner.Context()
+	err = CheckAIServiceMetrics(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: ai-service-metrics")
+	}
+}

--- a/pkg/validator/checks/conformance/ai_service_metrics_check_unit_test.go
+++ b/pkg/validator/checks/conformance/ai_service_metrics_check_unit_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckAIServiceMetrics(t *testing.T) {
+	promResponseWithData := `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [
+				{"metric": {"__name__": "DCGM_FI_DEV_GPU_UTIL", "gpu": "0"}, "value": [1700000000, "42"]}
+			]
+		}
+	}`
+
+	promResponseEmpty := `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": []
+		}
+	}`
+
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		clientset   bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "prometheus has data but fake client lacks REST client",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, promResponseWithData)
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "discovery REST client is not available",
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name: "prometheus has no data",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, promResponseEmpty)
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "no DCGM_FI_DEV_GPU_UTIL time series",
+		},
+		{
+			name: "prometheus returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Prometheus unreachable",
+		},
+		{
+			name: "prometheus returns invalid JSON",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "not json")
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "failed to parse Prometheus response",
+		},
+		{
+			name:        "prometheus unreachable",
+			handler:     nil,
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Prometheus unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset()
+				ctx = &checks.ValidationContext{
+					Context:   context.Background(),
+					Clientset: clientset,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			var promURL string
+			if tt.handler != nil {
+				server := httptest.NewServer(tt.handler)
+				defer server.Close()
+				promURL = server.URL
+			} else {
+				promURL = "http://127.0.0.1:1"
+			}
+
+			// Note: We only test the Prometheus part of the check.
+			// The custom metrics API part uses Discovery().RESTClient() which is
+			// harder to mock with fake.NewSimpleClientset. The fake discovery client
+			// returns success for unknown paths, so the happy path test covers it.
+			err := checkAIServiceMetricsWithURL(ctx, promURL)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkAIServiceMetricsWithURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("checkAIServiceMetricsWithURL() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckAIServiceMetricsRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("ai-service-metrics")
+	if !ok {
+		t.Fatal("ai-service-metrics check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}

--- a/pkg/validator/checks/conformance/cluster_autoscaling_check.go
+++ b/pkg/validator/checks/conformance/cluster_autoscaling_check.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "cluster-autoscaling",
+		Description: "Verify Karpenter controller is deployed and a GPU-aware NodePool exists",
+		Phase:       phaseConformance,
+		Func:        CheckClusterAutoscaling,
+		TestName:    "TestClusterAutoscaling",
+	})
+}
+
+// CheckClusterAutoscaling validates CNCF requirement #8a: Cluster Autoscaling.
+// Verifies the Karpenter controller deployment is running and at least one
+// NodePool has nvidia.com/gpu limits configured.
+func CheckClusterAutoscaling(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. Karpenter controller deployment running
+	if err := verifyDeploymentAvailable(ctx, "karpenter", "karpenter"); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "Karpenter controller check failed", err)
+	}
+
+	// 2. GPU NodePool exists with nvidia.com/gpu limits
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+	npGVR := schema.GroupVersionResource{
+		Group: "karpenter.sh", Version: "v1", Resource: "nodepools",
+	}
+	nps, err := dynClient.Resource(npGVR).List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "failed to list NodePools", err)
+	}
+
+	var hasGPUPool bool
+	for _, np := range nps.Items {
+		limits, found, _ := unstructured.NestedMap(np.Object, "spec", "limits")
+		if found {
+			if _, hasGPU := limits["nvidia.com/gpu"]; hasGPU {
+				hasGPUPool = true
+				break
+			}
+		}
+	}
+	if !hasGPUPool {
+		return errors.New(errors.ErrCodeNotFound,
+			"no NodePool with nvidia.com/gpu limits found")
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/cluster_autoscaling_check_test.go
+++ b/pkg/validator/checks/conformance/cluster_autoscaling_check_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestClusterAutoscaling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "cluster-autoscaling") {
+		t.Skip("Check cluster-autoscaling not enabled in recipe")
+	}
+
+	// Exercise-dependent: requires Karpenter installed with GPU NodePool
+	t.Logf("Running check: cluster-autoscaling")
+
+	ctx := runner.Context()
+	err = CheckClusterAutoscaling(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: cluster-autoscaling")
+	}
+}

--- a/pkg/validator/checks/conformance/cluster_autoscaling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/cluster_autoscaling_check_unit_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckClusterAutoscaling(t *testing.T) {
+	tests := []struct {
+		name           string
+		k8sObjects     []runtime.Object
+		dynamicObjects []runtime.Object
+		clientset      bool
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name: "all healthy",
+			k8sObjects: []runtime.Object{
+				createDeployment("karpenter", "karpenter", 1),
+			},
+			dynamicObjects: []runtime.Object{
+				createNodePool("gpu-pool", true),
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name:       "Karpenter not deployed",
+			k8sObjects: []runtime.Object{
+				// No karpenter deployment
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Karpenter controller check failed",
+		},
+		{
+			name: "Karpenter not available",
+			k8sObjects: []runtime.Object{
+				createDeployment("karpenter", "karpenter", 0),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Karpenter controller check failed",
+		},
+		{
+			name: "no NodePools",
+			k8sObjects: []runtime.Object{
+				createDeployment("karpenter", "karpenter", 1),
+			},
+			dynamicObjects: nil,
+			clientset:      true,
+			wantErr:        true,
+			errContains:    "no NodePool with nvidia.com/gpu limits found",
+		},
+		{
+			name: "NodePool without GPU limits",
+			k8sObjects: []runtime.Object{
+				createDeployment("karpenter", "karpenter", 1),
+			},
+			dynamicObjects: []runtime.Object{
+				createNodePool("cpu-pool", false),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "no NodePool with nvidia.com/gpu limits found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+
+				scheme := runtime.NewScheme()
+				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+					map[schema.GroupVersionResource]string{
+						{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}: "NodePoolList",
+					},
+					tt.dynamicObjects...)
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					Clientset:     clientset,
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckClusterAutoscaling(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckClusterAutoscaling() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckClusterAutoscaling() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckClusterAutoscalingRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("cluster-autoscaling")
+	if !ok {
+		t.Fatal("cluster-autoscaling check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createNodePool creates an unstructured Karpenter NodePool for testing.
+func createNodePool(name string, hasGPULimits bool) *unstructured.Unstructured {
+	limits := map[string]interface{}{
+		"cpu": "100",
+	}
+	if hasGPULimits {
+		limits["nvidia.com/gpu"] = "8"
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "karpenter.sh/v1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"spec": map[string]interface{}{
+				"limits": limits,
+			},
+		},
+	}
+}

--- a/pkg/validator/checks/conformance/dra_support_check.go
+++ b/pkg/validator/checks/conformance/dra_support_check.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "dra-support",
+		Description: "Verify DRA driver controller, kubelet plugin, and ResourceSlices exist",
+		Phase:       phaseConformance,
+		Func:        CheckDRASupport,
+		TestName:    "TestDRASupport",
+	})
+}
+
+// CheckDRASupport validates CNCF requirement #2: DRA Support.
+// Verifies DRA driver controller deployment, kubelet plugin DaemonSet,
+// and that ResourceSlices (resource.k8s.io/v1 GA) exist advertising GPU resources.
+func CheckDRASupport(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. DRA driver controller Deployment available
+	if err := verifyDeploymentAvailable(ctx, "nvidia-dra-driver", "nvidia-dra-driver-gpu-controller"); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "DRA driver controller check failed", err)
+	}
+
+	// 2. DRA kubelet plugin DaemonSet ready
+	if err := verifyDaemonSetReady(ctx, "nvidia-dra-driver", "nvidia-dra-driver-gpu-kubelet-plugin"); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "DRA kubelet plugin check failed", err)
+	}
+
+	// 3. ResourceSlices exist (GPU resources advertised via resource.k8s.io/v1 — GA)
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices",
+	}
+	slices, err := dynClient.Resource(gvr).List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to list ResourceSlices", err)
+	}
+	if len(slices.Items) == 0 {
+		return errors.New(errors.ErrCodeNotFound, "no ResourceSlices found (GPU resources not advertised)")
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/dra_support_check_test.go
+++ b/pkg/validator/checks/conformance/dra_support_check_test.go
@@ -12,18 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package conformance
 
 import (
-	"github.com/NVIDIA/aicr/pkg/cli"
+	"testing"
 
-	// Import check packages for side-effect registration.
-	// Each package's init() function registers its validators.
-	_ "github.com/NVIDIA/aicr/pkg/validator/checks/conformance"
-	_ "github.com/NVIDIA/aicr/pkg/validator/checks/deployment"
-	_ "github.com/NVIDIA/aicr/pkg/validator/checks/readiness"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
 )
 
-func main() {
-	cli.Execute()
+func TestDRASupport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "dra-support") {
+		t.Skip("Check dra-support not enabled in recipe")
+	}
+
+	t.Logf("Running check: dra-support")
+
+	ctx := runner.Context()
+	err = CheckDRASupport(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: dra-support")
+	}
 }

--- a/pkg/validator/checks/conformance/dra_support_check_unit_test.go
+++ b/pkg/validator/checks/conformance/dra_support_check_unit_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckDRASupport(t *testing.T) {
+	tests := []struct {
+		name           string
+		k8sObjects     []runtime.Object
+		dynamicObjects []runtime.Object
+		clientset      bool
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name: "all healthy",
+			k8sObjects: []runtime.Object{
+				createDeployment("nvidia-dra-driver", "nvidia-dra-driver-gpu-controller", 1),
+				createDaemonSet("nvidia-dra-driver", "nvidia-dra-driver-gpu-kubelet-plugin", 1),
+			},
+			dynamicObjects: []runtime.Object{
+				createResourceSlice("gpu-slice-0"),
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name: "controller deployment not available",
+			k8sObjects: []runtime.Object{
+				createDeployment("nvidia-dra-driver", "nvidia-dra-driver-gpu-controller", 0),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "DRA driver controller check failed",
+		},
+		{
+			name: "controller deployment missing",
+			k8sObjects: []runtime.Object{
+				// No controller deployment
+				createDaemonSet("nvidia-dra-driver", "nvidia-dra-driver-gpu-kubelet-plugin", 1),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "DRA driver controller check failed",
+		},
+		{
+			name: "kubelet plugin not ready",
+			k8sObjects: []runtime.Object{
+				createDeployment("nvidia-dra-driver", "nvidia-dra-driver-gpu-controller", 1),
+				createDaemonSet("nvidia-dra-driver", "nvidia-dra-driver-gpu-kubelet-plugin", 0),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "DRA kubelet plugin check failed",
+		},
+		{
+			name: "no ResourceSlices",
+			k8sObjects: []runtime.Object{
+				createDeployment("nvidia-dra-driver", "nvidia-dra-driver-gpu-controller", 1),
+				createDaemonSet("nvidia-dra-driver", "nvidia-dra-driver-gpu-kubelet-plugin", 1),
+			},
+			dynamicObjects: nil, // empty but registered via custom list kinds
+			clientset:      true,
+			wantErr:        true,
+			errContains:    "no ResourceSlices found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+
+				scheme := runtime.NewScheme()
+				// Always register custom list kinds so List() works even with 0 objects.
+				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+					map[schema.GroupVersionResource]string{
+						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices"}: "ResourceSliceList",
+					},
+					tt.dynamicObjects...)
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					Clientset:     clientset,
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckDRASupport(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckDRASupport() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckDRASupport() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckDRASupportRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("dra-support")
+	if !ok {
+		t.Fatal("dra-support check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createResourceSlice creates an unstructured ResourceSlice for testing.
+func createResourceSlice(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "resource.k8s.io/v1",
+			"kind":       "ResourceSlice",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"spec": map[string]interface{}{
+				"driver":   "gpu.nvidia.com",
+				"nodeName": "gpu-node-0",
+			},
+		},
+	}
+}
+
+// Note: createDeployment is defined in platform_health_check_unit_test.go,
+// and createDaemonSet is in gpu_operator_health_check_unit_test.go.
+// They all live in the same test package so they're accessible here.

--- a/pkg/validator/checks/conformance/gang_scheduling_check.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// kaiSchedulerDeployments are the required KAI scheduler components.
+var kaiSchedulerDeployments = []string{
+	"kai-scheduler-default",
+	"admission",
+	"binder",
+	"kai-operator",
+	"pod-grouper",
+	"podgroup-controller",
+	"queue-controller",
+}
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "gang-scheduling",
+		Description: "Verify KAI scheduler components and gang scheduling CRDs",
+		Phase:       phaseConformance,
+		Func:        CheckGangScheduling,
+		TestName:    "TestGangScheduling",
+	})
+}
+
+// CheckGangScheduling validates CNCF requirement #7: Gang Scheduling.
+// Verifies all KAI scheduler component deployments are running and
+// the required gang scheduling CRDs exist.
+func CheckGangScheduling(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. All KAI scheduler deployments available
+	for _, name := range kaiSchedulerDeployments {
+		if err := verifyDeploymentAvailable(ctx, "kai-scheduler", name); err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound,
+				fmt.Sprintf("KAI scheduler component %s check failed", name), err)
+		}
+	}
+
+	// 2. Required CRDs for gang scheduling
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+	crdGVR := schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+	requiredCRDs := []string{
+		"queues.scheduling.run.ai",
+		"podgroups.scheduling.run.ai",
+	}
+	for _, crd := range requiredCRDs {
+		_, err := dynClient.Resource(crdGVR).Get(ctx.Context, crd, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound,
+				fmt.Sprintf("gang scheduling CRD %s not found", crd), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/gang_scheduling_check_test.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestGangScheduling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "gang-scheduling") {
+		t.Skip("Check gang-scheduling not enabled in recipe")
+	}
+
+	t.Logf("Running check: gang-scheduling")
+
+	ctx := runner.Context()
+	err = CheckGangScheduling(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: gang-scheduling")
+	}
+}

--- a/pkg/validator/checks/conformance/gang_scheduling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check_unit_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckGangScheduling(t *testing.T) {
+	// Build the full set of KAI scheduler deployments for the happy path.
+	allDeployments := []runtime.Object{
+		createDeployment("kai-scheduler", "kai-scheduler-default", 1),
+		createDeployment("kai-scheduler", "admission", 1),
+		createDeployment("kai-scheduler", "binder", 1),
+		createDeployment("kai-scheduler", "kai-operator", 1),
+		createDeployment("kai-scheduler", "pod-grouper", 1),
+		createDeployment("kai-scheduler", "podgroup-controller", 1),
+		createDeployment("kai-scheduler", "queue-controller", 1),
+	}
+
+	tests := []struct {
+		name           string
+		k8sObjects     []runtime.Object
+		dynamicObjects []runtime.Object
+		clientset      bool
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:       "all healthy",
+			k8sObjects: allDeployments,
+			dynamicObjects: []runtime.Object{
+				createCRD("queues.scheduling.run.ai"),
+				createCRD("podgroups.scheduling.run.ai"),
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name: "missing one deployment",
+			k8sObjects: []runtime.Object{
+				// Only first 6 — missing queue-controller
+				createDeployment("kai-scheduler", "kai-scheduler-default", 1),
+				createDeployment("kai-scheduler", "admission", 1),
+				createDeployment("kai-scheduler", "binder", 1),
+				createDeployment("kai-scheduler", "kai-operator", 1),
+				createDeployment("kai-scheduler", "pod-grouper", 1),
+				createDeployment("kai-scheduler", "podgroup-controller", 1),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "queue-controller check failed",
+		},
+		{
+			name: "deployment not available",
+			k8sObjects: []runtime.Object{
+				createDeployment("kai-scheduler", "kai-scheduler-default", 0), // 0 available
+				createDeployment("kai-scheduler", "admission", 1),
+				createDeployment("kai-scheduler", "binder", 1),
+				createDeployment("kai-scheduler", "kai-operator", 1),
+				createDeployment("kai-scheduler", "pod-grouper", 1),
+				createDeployment("kai-scheduler", "podgroup-controller", 1),
+				createDeployment("kai-scheduler", "queue-controller", 1),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "kai-scheduler-default check failed",
+		},
+		{
+			name:       "missing CRD",
+			k8sObjects: allDeployments,
+			dynamicObjects: []runtime.Object{
+				createCRD("queues.scheduling.run.ai"),
+				// Missing podgroups CRD
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "podgroups.scheduling.run.ai not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+
+				scheme := runtime.NewScheme()
+				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+					map[schema.GroupVersionResource]string{
+						{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+					},
+					tt.dynamicObjects...)
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					Clientset:     clientset,
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckGangScheduling(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckGangScheduling() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckGangScheduling() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckGangSchedulingRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("gang-scheduling")
+	if !ok {
+		t.Fatal("gang-scheduling check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}

--- a/pkg/validator/checks/conformance/gpu_operator_health_check.go
+++ b/pkg/validator/checks/conformance/gpu_operator_health_check.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "gpu-operator-health",
+		Description: "Verify GPU operator deployment, ClusterPolicy, and DCGM exporter are healthy",
+		Phase:       phaseConformance,
+		Func:        CheckGPUOperatorHealth,
+		TestName:    "TestGPUOperatorHealth",
+	})
+}
+
+// CheckGPUOperatorHealth validates CNCF requirement #1: GPU Management.
+// Verifies GPU operator deployment, ClusterPolicy state=ready, and DCGM exporter DaemonSet.
+func CheckGPUOperatorHealth(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. GPU Operator Deployment running
+	if err := verifyDeploymentAvailable(ctx, "gpu-operator", "gpu-operator"); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "GPU operator deployment check failed", err)
+	}
+
+	// 2. ClusterPolicy state = ready (dynamic client — CRD type)
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group: "nvidia.com", Version: "v1", Resource: "clusterpolicies",
+	}
+	cp, err := dynClient.Resource(gvr).Get(ctx.Context, "cluster-policy", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "ClusterPolicy not found", err)
+	}
+	state, found, err := unstructured.NestedString(cp.Object, "status", "state")
+	if err != nil || !found {
+		return errors.New(errors.ErrCodeInternal, "ClusterPolicy status.state not found")
+	}
+	if state != "ready" {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("ClusterPolicy state=%s (want ready)", state))
+	}
+
+	// 3. DCGM exporter DaemonSet running
+	if err := verifyDaemonSetReady(ctx, "gpu-operator", "nvidia-dcgm-exporter"); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "DCGM exporter check failed", err)
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/gpu_operator_health_check_test.go
+++ b/pkg/validator/checks/conformance/gpu_operator_health_check_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestGPUOperatorHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "gpu-operator-health") {
+		t.Skip("Check gpu-operator-health not enabled in recipe")
+	}
+
+	t.Logf("Running check: gpu-operator-health")
+
+	ctx := runner.Context()
+	err = CheckGPUOperatorHealth(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: gpu-operator-health")
+	}
+}

--- a/pkg/validator/checks/conformance/gpu_operator_health_check_unit_test.go
+++ b/pkg/validator/checks/conformance/gpu_operator_health_check_unit_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckGPUOperatorHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		k8sObjects     []runtime.Object
+		dynamicObjects []runtime.Object
+		clientset      bool
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name: "all healthy",
+			k8sObjects: []runtime.Object{
+				createDeployment("gpu-operator", "gpu-operator", 1),
+				createDaemonSet("gpu-operator", "nvidia-dcgm-exporter", 1),
+			},
+			dynamicObjects: []runtime.Object{
+				createClusterPolicy("ready"),
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name: "operator deployment not available",
+			k8sObjects: []runtime.Object{
+				createDeployment("gpu-operator", "gpu-operator", 0),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "not available",
+		},
+		{
+			name: "ClusterPolicy not ready",
+			k8sObjects: []runtime.Object{
+				createDeployment("gpu-operator", "gpu-operator", 1),
+			},
+			dynamicObjects: []runtime.Object{
+				createClusterPolicy("notReady"),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "ClusterPolicy state=notReady",
+		},
+		{
+			name: "DCGM exporter not ready",
+			k8sObjects: []runtime.Object{
+				createDeployment("gpu-operator", "gpu-operator", 1),
+				createDaemonSet("gpu-operator", "nvidia-dcgm-exporter", 0),
+			},
+			dynamicObjects: []runtime.Object{
+				createClusterPolicy("ready"),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "not ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+
+				scheme := runtime.NewScheme()
+				var dynClient *dynamicfake.FakeDynamicClient
+				if len(tt.dynamicObjects) > 0 {
+					dynClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+						map[schema.GroupVersionResource]string{
+							{Group: "nvidia.com", Version: "v1", Resource: "clusterpolicies"}: "ClusterPolicyList",
+						},
+						tt.dynamicObjects...)
+				} else {
+					dynClient = dynamicfake.NewSimpleDynamicClient(scheme)
+				}
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					Clientset:     clientset,
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckGPUOperatorHealth(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckGPUOperatorHealth() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckGPUOperatorHealth() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckGPUOperatorHealthRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("gpu-operator-health")
+	if !ok {
+		t.Fatal("gpu-operator-health check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createDaemonSet creates a test DaemonSet with 1 desired and the given ready count.
+func createDaemonSet(namespace, name string, ready int32) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 1,
+			NumberReady:            ready,
+		},
+	}
+}
+
+// createClusterPolicy creates an unstructured ClusterPolicy with the given state.
+func createClusterPolicy(state string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nvidia.com/v1",
+			"kind":       "ClusterPolicy",
+			"metadata": map[string]interface{}{
+				"name": "cluster-policy",
+			},
+			"status": map[string]interface{}{
+				"state": state,
+			},
+		},
+	}
+}

--- a/pkg/validator/checks/conformance/helpers.go
+++ b/pkg/validator/checks/conformance/helpers.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// phaseConformance is the phase identifier for conformance checks.
+const phaseConformance = "conformance"
+
+// getDynamicClient returns the dynamic client from context, or creates one from RESTConfig.
+func getDynamicClient(ctx *checks.ValidationContext) (dynamic.Interface, error) {
+	if ctx.DynamicClient != nil {
+		return ctx.DynamicClient, nil
+	}
+	if ctx.RESTConfig == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "RESTConfig is not available")
+	}
+	dc, err := dynamic.NewForConfig(ctx.RESTConfig)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create dynamic client", err)
+	}
+	return dc, nil
+}
+
+// httpGet performs an HTTP GET to an in-cluster service URL with context timeout.
+func httpGet(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create request", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeUnavailable,
+			fmt.Sprintf("failed to reach %s", url), err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("HTTP %d from %s", resp.StatusCode, url))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// checkCondition verifies a status condition on an unstructured object.
+func checkCondition(obj *unstructured.Unstructured, condType, expectedStatus string) error {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return errors.New(errors.ErrCodeInternal, "status.conditions not found")
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cond["type"] == condType {
+			if cond["status"] == expectedStatus {
+				return nil
+			}
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("condition %s=%v (want %s)", condType, cond["status"], expectedStatus))
+		}
+	}
+	return errors.New(errors.ErrCodeNotFound,
+		fmt.Sprintf("condition %s not found", condType))
+}
+
+// verifyDeploymentAvailable checks that a Deployment has at least one available replica.
+func verifyDeploymentAvailable(ctx *checks.ValidationContext, namespace, name string) error {
+	deploy, err := ctx.Clientset.AppsV1().Deployments(namespace).Get(
+		ctx.Context, name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, fmt.Sprintf("deployment %s/%s not found", namespace, name), err)
+	}
+	if deploy.Status.AvailableReplicas < 1 {
+		expected := int32(1)
+		if deploy.Spec.Replicas != nil {
+			expected = *deploy.Spec.Replicas
+		}
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("deployment %s/%s not available: %d/%d replicas",
+				namespace, name, deploy.Status.AvailableReplicas, expected))
+	}
+	return nil
+}
+
+// verifyDaemonSetReady checks that a DaemonSet has at least one ready pod.
+func verifyDaemonSetReady(ctx *checks.ValidationContext, namespace, name string) error {
+	ds, err := ctx.Clientset.AppsV1().DaemonSets(namespace).Get(
+		ctx.Context, name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, fmt.Sprintf("daemonset %s/%s not found", namespace, name), err)
+	}
+	if ds.Status.NumberReady < 1 {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("daemonset %s/%s not ready: %d/%d pods",
+				namespace, name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled))
+	}
+	return nil
+}
+
+// containsAllMetrics checks that all required metric names appear in the given text.
+// Returns the list of missing metrics.
+func containsAllMetrics(text string, required []string) []string {
+	var missing []string
+	for _, metric := range required {
+		if !strings.Contains(text, metric) {
+			missing = append(missing, metric)
+		}
+	}
+	return missing
+}

--- a/pkg/validator/checks/conformance/inference_gateway_check.go
+++ b/pkg/validator/checks/conformance/inference_gateway_check.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "inference-gateway",
+		Description: "Verify Gateway API for AI/ML inference routing (GatewayClass, Gateway, CRDs)",
+		Phase:       phaseConformance,
+		Func:        CheckInferenceGateway,
+		TestName:    "TestInferenceGateway",
+	})
+}
+
+// CheckInferenceGateway validates CNCF requirement #6: Inference Gateway.
+// Verifies GatewayClass "kgateway" is accepted, Gateway "inference-gateway" is programmed,
+// and required Gateway API + InferencePool CRDs exist.
+func CheckInferenceGateway(ctx *checks.ValidationContext) error {
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// 1. GatewayClass "kgateway" accepted
+	gcGVR := schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses",
+	}
+	gc, err := dynClient.Resource(gcGVR).Get(ctx.Context, "kgateway", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "GatewayClass 'kgateway' not found", err)
+	}
+	if condErr := checkCondition(gc, "Accepted", "True"); condErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "GatewayClass not accepted", condErr)
+	}
+
+	// 2. Gateway "inference-gateway" programmed
+	gwGVR := schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways",
+	}
+	gw, err := dynClient.Resource(gwGVR).Namespace("kgateway-system").Get(
+		ctx.Context, "inference-gateway", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "Gateway 'inference-gateway' not found", err)
+	}
+	if condErr := checkCondition(gw, "Programmed", "True"); condErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "Gateway not programmed", condErr)
+	}
+
+	// 3. Required CRDs exist
+	crdGVR := schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+	requiredCRDs := []string{
+		"gateways.gateway.networking.k8s.io",
+		"httproutes.gateway.networking.k8s.io",
+		"inferencepools.inference.networking.x-k8s.io",
+	}
+	for _, crdName := range requiredCRDs {
+		_, err := dynClient.Resource(crdGVR).Get(ctx.Context, crdName, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound,
+				fmt.Sprintf("CRD %s not found", crdName), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/inference_gateway_check_test.go
+++ b/pkg/validator/checks/conformance/inference_gateway_check_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestInferenceGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "inference-gateway") {
+		t.Skip("Check inference-gateway not enabled in recipe")
+	}
+
+	t.Logf("Running check: inference-gateway")
+
+	ctx := runner.Context()
+	err = CheckInferenceGateway(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: inference-gateway")
+	}
+}

--- a/pkg/validator/checks/conformance/inference_gateway_check_unit_test.go
+++ b/pkg/validator/checks/conformance/inference_gateway_check_unit_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestCheckInferenceGateway(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(*dynamicfake.FakeDynamicClient) // populate objects via Create
+		hasDynClient bool
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name: "all healthy",
+			setup: func(dc *dynamicfake.FakeDynamicClient) {
+				createDynObject(t, dc, gcGVR, "", createGatewayClass("True"))
+				createDynObject(t, dc, gwGVR, "kgateway-system", createGateway("kgateway-system", "inference-gateway", "Programmed", "True"))
+				createDynObject(t, dc, crdGVR, "", createCRD("gateways.gateway.networking.k8s.io"))
+				createDynObject(t, dc, crdGVR, "", createCRD("httproutes.gateway.networking.k8s.io"))
+				createDynObject(t, dc, crdGVR, "", createCRD("inferencepools.inference.networking.x-k8s.io"))
+			},
+			hasDynClient: true,
+			wantErr:      false,
+		},
+		{
+			name:         "no dynamic client",
+			hasDynClient: false,
+			wantErr:      true,
+			errContains:  "RESTConfig is not available",
+		},
+		{
+			name:         "GatewayClass missing",
+			setup:        func(dc *dynamicfake.FakeDynamicClient) {},
+			hasDynClient: true,
+			wantErr:      true,
+			errContains:  "GatewayClass 'kgateway' not found",
+		},
+		{
+			name: "GatewayClass not accepted",
+			setup: func(dc *dynamicfake.FakeDynamicClient) {
+				createDynObject(t, dc, gcGVR, "", createGatewayClass("False"))
+			},
+			hasDynClient: true,
+			wantErr:      true,
+			errContains:  "GatewayClass not accepted",
+		},
+		{
+			name: "Gateway missing",
+			setup: func(dc *dynamicfake.FakeDynamicClient) {
+				createDynObject(t, dc, gcGVR, "", createGatewayClass("True"))
+			},
+			hasDynClient: true,
+			wantErr:      true,
+			errContains:  "Gateway 'inference-gateway' not found",
+		},
+		{
+			name: "Gateway not programmed",
+			setup: func(dc *dynamicfake.FakeDynamicClient) {
+				createDynObject(t, dc, gcGVR, "", createGatewayClass("True"))
+				createDynObject(t, dc, gwGVR, "kgateway-system", createGateway("kgateway-system", "inference-gateway", "Programmed", "False"))
+			},
+			hasDynClient: true,
+			wantErr:      true,
+			errContains:  "Gateway not programmed",
+		},
+		{
+			name: "missing CRD",
+			setup: func(dc *dynamicfake.FakeDynamicClient) {
+				createDynObject(t, dc, gcGVR, "", createGatewayClass("True"))
+				createDynObject(t, dc, gwGVR, "kgateway-system", createGateway("kgateway-system", "inference-gateway", "Programmed", "True"))
+				createDynObject(t, dc, crdGVR, "", createCRD("gateways.gateway.networking.k8s.io"))
+			},
+			hasDynClient: true,
+			wantErr:      true,
+			errContains:  "CRD httproutes.gateway.networking.k8s.io not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.hasDynClient {
+				scheme := runtime.NewScheme()
+				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+					map[schema.GroupVersionResource]string{
+						gcGVR:  "GatewayClassList",
+						gwGVR:  "GatewayList",
+						crdGVR: "CustomResourceDefinitionList",
+					})
+				if tt.setup != nil {
+					tt.setup(dynClient)
+				}
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckInferenceGateway(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckInferenceGateway() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckInferenceGateway() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+// GVRs used in inference gateway tests.
+var (
+	gcGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses",
+	}
+	gwGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways",
+	}
+	crdGVR = schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+)
+
+// createDynObject adds an unstructured object to the fake dynamic client via Create.
+// This avoids the scheme.ObjectKinds collision that happens with tracker.Add
+// when multiple unstructured types are registered in the same scheme.
+func createDynObject(t *testing.T, dc *dynamicfake.FakeDynamicClient, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) {
+	t.Helper()
+	var err error
+	if namespace != "" {
+		_, err = dc.Resource(gvr).Namespace(namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+	} else {
+		_, err = dc.Resource(gvr).Create(context.Background(), obj, metav1.CreateOptions{})
+	}
+	if err != nil {
+		t.Fatalf("failed to create dynamic object %s: %v", obj.GetName(), err)
+	}
+}
+
+func TestCheckInferenceGatewayRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("inference-gateway")
+	if !ok {
+		t.Fatal("inference-gateway check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createGatewayClass creates an unstructured GatewayClass "kgateway" with Accepted condition.
+func createGatewayClass(condStatus string) *unstructured.Unstructured {
+	condType := "Accepted"
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "GatewayClass",
+			"metadata": map[string]interface{}{
+				"name": "kgateway",
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   condType,
+						"status": condStatus,
+					},
+				},
+			},
+		},
+	}
+}
+
+// createGateway creates an unstructured Gateway with the given condition.
+func createGateway(namespace, name, condType, condStatus string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   condType,
+						"status": condStatus,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/validator/checks/conformance/platform_health_check.go
+++ b/pkg/validator/checks/conformance/platform_health_check.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "platform-health",
+		Description: "Verify all expected platform components are deployed and healthy",
+		Phase:       phaseConformance,
+		Func:        CheckPlatformHealth,
+		TestName:    "TestPlatformHealth",
+	})
+}
+
+// CheckPlatformHealth validates that all expected platform components from the recipe
+// are deployed and healthy. It checks namespace existence and expectedResources health
+// for each componentRef in the recipe.
+func CheckPlatformHealth(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+	if ctx.Recipe == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "recipe is not available")
+	}
+
+	var failures []string
+
+	// 1. Verify all expected namespaces are Active
+	seen := make(map[string]bool)
+	for _, ref := range ctx.Recipe.ComponentRefs {
+		if ref.Namespace != "" && !seen[ref.Namespace] {
+			seen[ref.Namespace] = true
+			ns, err := ctx.Clientset.CoreV1().Namespaces().Get(
+				ctx.Context, ref.Namespace, metav1.GetOptions{})
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("namespace %s: not found", ref.Namespace))
+				continue
+			}
+			if ns.Status.Phase != corev1.NamespaceActive {
+				failures = append(failures, fmt.Sprintf("namespace %s: phase=%s (want Active)",
+					ref.Namespace, ns.Status.Phase))
+			}
+		}
+	}
+
+	// 2. Verify all expectedResources are healthy
+	for _, ref := range ctx.Recipe.ComponentRefs {
+		for _, er := range ref.ExpectedResources {
+			if err := verifyExpectedResource(ctx.Context, ctx.Clientset, er); err != nil {
+				failures = append(failures, fmt.Sprintf("%s %s/%s (%s): %s",
+					er.Kind, er.Namespace, er.Name, ref.Name, err.Error()))
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		return errors.New(errors.ErrCodeNotFound,
+			fmt.Sprintf("platform health check failed (%d issues):\n  %s",
+				len(failures), strings.Join(failures, "\n  ")))
+	}
+	return nil
+}
+
+// verifyExpectedResource checks that a single expected resource exists and is healthy.
+// This mirrors the logic in deployment/expected_resources_check.go:verifyResource.
+func verifyExpectedResource(ctx context.Context, clientset kubernetes.Interface, er recipe.ExpectedResource) error {
+	ctx, cancel := context.WithTimeout(ctx, defaults.ResourceVerificationTimeout)
+	defer cancel()
+
+	switch er.Kind {
+	case "Deployment":
+		deploy, err := clientset.AppsV1().Deployments(er.Namespace).Get(ctx, er.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "not found", err)
+		}
+		expected := int32(1)
+		if deploy.Spec.Replicas != nil {
+			expected = *deploy.Spec.Replicas
+		}
+		if deploy.Status.AvailableReplicas < expected {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("not healthy: %d/%d replicas available",
+					deploy.Status.AvailableReplicas, expected))
+		}
+
+	case "DaemonSet":
+		ds, err := clientset.AppsV1().DaemonSets(er.Namespace).Get(ctx, er.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "not found", err)
+		}
+		if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("not healthy: %d/%d pods ready",
+					ds.Status.NumberReady, ds.Status.DesiredNumberScheduled))
+		}
+
+	case "StatefulSet":
+		ss, err := clientset.AppsV1().StatefulSets(er.Namespace).Get(ctx, er.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "not found", err)
+		}
+		expected := int32(1)
+		if ss.Spec.Replicas != nil {
+			expected = *ss.Spec.Replicas
+		}
+		if ss.Status.ReadyReplicas < expected {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("not healthy: %d/%d replicas ready",
+					ss.Status.ReadyReplicas, expected))
+		}
+
+	case "Service":
+		_, err := clientset.CoreV1().Services(er.Namespace).Get(ctx, er.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "not found", err)
+		}
+
+	case "ConfigMap":
+		_, err := clientset.CoreV1().ConfigMaps(er.Namespace).Get(ctx, er.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "not found", err)
+		}
+
+	case "Secret":
+		_, err := clientset.CoreV1().Secrets(er.Namespace).Get(ctx, er.Name, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "not found", err)
+		}
+
+	default:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported resource kind %q", er.Kind))
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/platform_health_check_test.go
+++ b/pkg/validator/checks/conformance/platform_health_check_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+// TestPlatformHealth is the integration test for platform-health.
+// This runs inside validator Jobs and invokes the validator.
+func TestPlatformHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "platform-health") {
+		t.Skip("Check platform-health not enabled in recipe")
+	}
+
+	t.Logf("Running check: platform-health")
+
+	ctx := runner.Context()
+	err = CheckPlatformHealth(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: platform-health")
+	}
+}

--- a/pkg/validator/checks/conformance/platform_health_check_unit_test.go
+++ b/pkg/validator/checks/conformance/platform_health_check_unit_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckPlatformHealth(t *testing.T) {
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		recipe      *recipe.RecipeResult
+		clientset   bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "all healthy - namespace active and deployment available",
+			objects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-operator"},
+					Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+				},
+				createDeployment("gpu-operator", "gpu-operator", 1),
+			},
+			recipe: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:      "gpu-operator",
+						Namespace: "gpu-operator",
+						ExpectedResources: []recipe.ExpectedResource{
+							{Kind: "Deployment", Namespace: "gpu-operator", Name: "gpu-operator"},
+						},
+					},
+				},
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset available",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name:      "no recipe available",
+			objects:   []runtime.Object{},
+			clientset: true,
+			recipe:    nil,
+			wantErr:   true,
+
+			errContains: "recipe is not available",
+		},
+		{
+			name:    "missing namespace",
+			objects: []runtime.Object{},
+			recipe: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:      "gpu-operator",
+						Namespace: "gpu-operator",
+					},
+				},
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "namespace gpu-operator: not found",
+		},
+		{
+			name: "deployment not available",
+			objects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-operator"},
+					Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+				},
+				createDeployment("gpu-operator", "gpu-operator", 0),
+			},
+			recipe: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:      "gpu-operator",
+						Namespace: "gpu-operator",
+						ExpectedResources: []recipe.ExpectedResource{
+							{Kind: "Deployment", Namespace: "gpu-operator", Name: "gpu-operator"},
+						},
+					},
+				},
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "not healthy",
+		},
+		{
+			name:    "empty recipe with no components - passes",
+			objects: []runtime.Object{},
+			recipe: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{},
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name: "namespace terminating",
+			objects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-operator"},
+					Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+				},
+			},
+			recipe: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:      "gpu-operator",
+						Namespace: "gpu-operator",
+					},
+				},
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "phase=Terminating",
+		},
+		{
+			name: "daemonset not ready",
+			objects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-operator"},
+					Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+				},
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "nvidia-dcgm-exporter", Namespace: "gpu-operator"},
+					Status: appsv1.DaemonSetStatus{
+						DesiredNumberScheduled: 2,
+						NumberReady:            0,
+					},
+				},
+			},
+			recipe: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:      "dcgm-exporter",
+						Namespace: "gpu-operator",
+						ExpectedResources: []recipe.ExpectedResource{
+							{Kind: "DaemonSet", Namespace: "gpu-operator", Name: "nvidia-dcgm-exporter"},
+						},
+					},
+				},
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "not healthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.objects...)
+				ctx = &checks.ValidationContext{
+					Context:   context.Background(),
+					Clientset: clientset,
+					Recipe:    tt.recipe,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context:   context.Background(),
+					Clientset: nil,
+					Recipe:    tt.recipe,
+				}
+			}
+
+			err := CheckPlatformHealth(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPlatformHealth() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckPlatformHealth() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckPlatformHealthRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("platform-health")
+	if !ok {
+		t.Fatal("platform-health check not registered")
+	}
+
+	if check.Name != "platform-health" {
+		t.Errorf("Name = %v, want platform-health", check.Name)
+	}
+
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+
+	if check.Description == "" {
+		t.Error("Description is empty")
+	}
+
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createDeployment creates a test Deployment with 1 desired replica and the given available count.
+func createDeployment(namespace, name string, available int32) *appsv1.Deployment {
+	var replicas int32 = 1
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: available,
+		},
+	}
+}

--- a/pkg/validator/checks/conformance/pod_autoscaling_check.go
+++ b/pkg/validator/checks/conformance/pod_autoscaling_check.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "pod-autoscaling",
+		Description: "Verify custom and external metrics APIs expose GPU metrics for HPA",
+		Phase:       phaseConformance,
+		Func:        CheckPodAutoscaling,
+		TestName:    "TestPodAutoscaling",
+	})
+}
+
+// CheckPodAutoscaling validates CNCF requirement #8b: Pod Autoscaling.
+// Verifies that the custom metrics API is available, GPU custom metrics have data
+// (with retries to account for prometheus-adapter relist delay), and the external
+// metrics API exposes GPU metrics.
+func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. Custom metrics API available
+	restClient := ctx.Clientset.Discovery().RESTClient()
+	if restClient == nil {
+		return errors.New(errors.ErrCodeInternal, "discovery REST client is not available")
+	}
+	rawURL := "/apis/custom.metrics.k8s.io/v1beta1"
+	result := restClient.Get().AbsPath(rawURL).Do(ctx.Context)
+	if err := result.Error(); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"custom metrics API not available (prometheus-adapter not ready)", err)
+	}
+
+	// 2. GPU custom metrics have data (poll with retries — adapter relist is 30s)
+	metrics := []string{"gpu_utilization", "gpu_memory_used", "gpu_power_usage"}
+	namespaces := []string{"gpu-operator", "dynamo-system"}
+
+	var found bool
+	maxAttempts := 12 // 2 minutes with 10s intervals
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		for _, metric := range metrics {
+			for _, ns := range namespaces {
+				path := fmt.Sprintf(
+					"/apis/custom.metrics.k8s.io/v1beta1/namespaces/%s/pods/*/%s",
+					ns, metric)
+				raw, err := restClient.Get().AbsPath(path).DoRaw(ctx.Context)
+				if err != nil {
+					continue
+				}
+
+				var metricsResp struct {
+					Items []json.RawMessage `json:"items"`
+				}
+				if json.Unmarshal(raw, &metricsResp) == nil && len(metricsResp.Items) > 0 {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if found {
+			break
+		}
+
+		// Wait before retry (respect context cancellation)
+		select {
+		case <-ctx.Context.Done():
+			return errors.Wrap(errors.ErrCodeTimeout,
+				"timed out waiting for GPU custom metrics", ctx.Context.Err())
+		case <-time.After(10 * time.Second):
+		}
+	}
+
+	if !found {
+		return errors.New(errors.ErrCodeNotFound,
+			"no GPU custom metrics available (DCGM → Prometheus → adapter pipeline broken)")
+	}
+
+	// 3. External metrics API has GPU metrics
+	extPath := "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage"
+	raw, err := restClient.Get().AbsPath(extPath).DoRaw(ctx.Context)
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"external metric dcgm_gpu_power_usage not available", err)
+	}
+	var extResp struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if json.Unmarshal(raw, &extResp) == nil && len(extResp.Items) == 0 {
+		return errors.New(errors.ErrCodeNotFound,
+			"external metric dcgm_gpu_power_usage has no data")
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/pod_autoscaling_check_test.go
+++ b/pkg/validator/checks/conformance/pod_autoscaling_check_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestPodAutoscaling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "pod-autoscaling") {
+		t.Skip("Check pod-autoscaling not enabled in recipe")
+	}
+
+	// Exercise-dependent: requires GPU workloads running to produce metrics
+	t.Logf("Running check: pod-autoscaling")
+
+	ctx := runner.Context()
+	err = CheckPodAutoscaling(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: pod-autoscaling")
+	}
+}

--- a/pkg/validator/checks/conformance/pod_autoscaling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/pod_autoscaling_check_unit_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckPodAutoscaling(t *testing.T) {
+	tests := []struct {
+		name        string
+		clientset   bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name:        "fake client lacks REST client",
+			clientset:   true,
+			wantErr:     true,
+			errContains: "discovery REST client is not available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset()
+				ctx = &checks.ValidationContext{
+					Context:   context.Background(),
+					Clientset: clientset,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckPodAutoscaling(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPodAutoscaling() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckPodAutoscaling() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckPodAutoscalingRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("pod-autoscaling")
+	if !ok {
+		t.Fatal("pod-autoscaling check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}

--- a/pkg/validator/checks/conformance/robust_controller_check.go
+++ b/pkg/validator/checks/conformance/robust_controller_check.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "robust-controller",
+		Description: "Verify Dynamo operator deployment, validating webhook, and DynamoGraphDeployment CRD",
+		Phase:       phaseConformance,
+		Func:        CheckRobustController,
+		TestName:    "TestRobustController",
+	})
+}
+
+// CheckRobustController validates CNCF requirement #9: Robust Controller.
+// Verifies the Dynamo operator is deployed, its validating webhook is operational,
+// and the DynamoGraphDeployment CRD exists.
+func CheckRobustController(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. Dynamo operator controller-manager deployment running
+	// Name from: tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml:29
+	if err := verifyDeploymentAvailable(ctx, "dynamo-system", "dynamo-platform-dynamo-operator-controller-manager"); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "Dynamo operator controller-manager check failed", err)
+	}
+
+	// 2. Validating webhook operational
+	webhooks, err := ctx.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(
+		ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to list validating webhook configurations", err)
+	}
+	var foundDynamoWebhook bool
+	for _, wh := range webhooks.Items {
+		if strings.Contains(wh.Name, "dynamo") {
+			foundDynamoWebhook = true
+			// Verify webhook service endpoint exists via EndpointSlice
+			for _, w := range wh.Webhooks {
+				if w.ClientConfig.Service != nil {
+					svcName := w.ClientConfig.Service.Name
+					svcNs := w.ClientConfig.Service.Namespace
+					slices, listErr := ctx.Clientset.DiscoveryV1().EndpointSlices(svcNs).List(
+						ctx.Context, metav1.ListOptions{
+							LabelSelector: "kubernetes.io/service-name=" + svcName,
+						})
+					if listErr != nil {
+						return errors.Wrap(errors.ErrCodeNotFound,
+							fmt.Sprintf("webhook endpoint %s/%s not found", svcNs, svcName), listErr)
+					}
+					if len(slices.Items) == 0 {
+						return errors.New(errors.ErrCodeNotFound,
+							fmt.Sprintf("no EndpointSlice for webhook service %s/%s", svcNs, svcName))
+					}
+				}
+			}
+			break
+		}
+	}
+	if !foundDynamoWebhook {
+		return errors.New(errors.ErrCodeNotFound,
+			"Dynamo validating webhook configuration not found")
+	}
+
+	// 3. DynamoGraphDeployment CRD exists (proves operator manages CRs)
+	// API group: nvidia.com (v1alpha1) — from tests/manifests/dynamo-vllm-smoke-test.yaml:28
+	// CRD name: dynamographdeployments.nvidia.com — from docs/conformance/cncf/evidence/robust-operator.md:57
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+	crdGVR := schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+	_, err = dynClient.Resource(crdGVR).Get(ctx.Context,
+		"dynamographdeployments.nvidia.com", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"DynamoGraphDeployment CRD not found", err)
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/robust_controller_check_test.go
+++ b/pkg/validator/checks/conformance/robust_controller_check_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestRobustController(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "robust-controller") {
+		t.Skip("Check robust-controller not enabled in recipe")
+	}
+
+	t.Logf("Running check: robust-controller")
+
+	ctx := runner.Context()
+	err = CheckRobustController(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: robust-controller")
+	}
+}

--- a/pkg/validator/checks/conformance/robust_controller_check_unit_test.go
+++ b/pkg/validator/checks/conformance/robust_controller_check_unit_test.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckRobustController(t *testing.T) {
+	tests := []struct {
+		name           string
+		k8sObjects     []runtime.Object
+		dynamicObjects []runtime.Object
+		clientset      bool
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name: "all healthy",
+			k8sObjects: []runtime.Object{
+				createDeployment("dynamo-system", "dynamo-platform-dynamo-operator-controller-manager", 1),
+				createDynamoWebhookConfig("dynamo-system", "dynamo-webhook-service"),
+				createEndpointSlice("dynamo-system", "dynamo-webhook-service"),
+			},
+			dynamicObjects: []runtime.Object{
+				createCRD("dynamographdeployments.nvidia.com"),
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name: "operator deployment not available",
+			k8sObjects: []runtime.Object{
+				createDeployment("dynamo-system", "dynamo-platform-dynamo-operator-controller-manager", 0),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Dynamo operator controller-manager check failed",
+		},
+		{
+			name:       "operator deployment missing",
+			k8sObjects: []runtime.Object{
+				// No operator deployment
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Dynamo operator controller-manager check failed",
+		},
+		{
+			name: "webhook missing",
+			k8sObjects: []runtime.Object{
+				createDeployment("dynamo-system", "dynamo-platform-dynamo-operator-controller-manager", 1),
+				// No webhook configuration
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "Dynamo validating webhook configuration not found",
+		},
+		{
+			name: "webhook endpoint missing",
+			k8sObjects: []runtime.Object{
+				createDeployment("dynamo-system", "dynamo-platform-dynamo-operator-controller-manager", 1),
+				createDynamoWebhookConfig("dynamo-system", "dynamo-webhook-service"),
+				// No endpoints for the webhook service
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "EndpointSlice for webhook service",
+		},
+		{
+			name: "CRD missing",
+			k8sObjects: []runtime.Object{
+				createDeployment("dynamo-system", "dynamo-platform-dynamo-operator-controller-manager", 1),
+				createDynamoWebhookConfig("dynamo-system", "dynamo-webhook-service"),
+				createEndpointSlice("dynamo-system", "dynamo-webhook-service"),
+			},
+			dynamicObjects: []runtime.Object{
+				// No CRD
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "DynamoGraphDeployment CRD not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+
+				scheme := runtime.NewScheme()
+				var dynClient *dynamicfake.FakeDynamicClient
+				if len(tt.dynamicObjects) > 0 {
+					dynClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+						map[schema.GroupVersionResource]string{
+							{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+						},
+						tt.dynamicObjects...)
+				} else {
+					dynClient = dynamicfake.NewSimpleDynamicClient(scheme)
+				}
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					Clientset:     clientset,
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckRobustController(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckRobustController() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckRobustController() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckRobustControllerRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("robust-controller")
+	if !ok {
+		t.Fatal("robust-controller check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createDynamoWebhookConfig creates a ValidatingWebhookConfiguration for testing.
+func createDynamoWebhookConfig(namespace, serviceName string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	sideEffectsNone := admissionregistrationv1.SideEffectClassNone
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dynamo-validating-webhook",
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name:                    "validate.dynamo.nvidia.com",
+				SideEffects:             &sideEffectsNone,
+				AdmissionReviewVersions: []string{"v1"},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Name:      serviceName,
+						Namespace: namespace,
+					},
+				},
+			},
+		},
+	}
+}
+
+// createEndpointSlice creates a minimal EndpointSlice for a service.
+func createEndpointSlice(namespace, serviceName string) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName + "-abc",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": serviceName,
+			},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}},
+		},
+	}
+}
+
+// createCRD creates an unstructured CustomResourceDefinition for testing.
+func createCRD(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}
+}

--- a/pkg/validator/checks/conformance/secure_access_check.go
+++ b/pkg/validator/checks/conformance/secure_access_check.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	checks.RegisterCheck(&checks.Check{
+		Name:        "secure-accelerator-access",
+		Description: "Verify DRA-mediated GPU access (no device plugin, no hostPath)",
+		Phase:       phaseConformance,
+		Func:        CheckSecureAcceleratorAccess,
+		TestName:    "TestSecureAcceleratorAccess",
+	})
+}
+
+// CheckSecureAcceleratorAccess validates CNCF requirement #3: Secure Accelerator Access.
+// Verifies that a DRA-based GPU workload uses proper access patterns:
+// resourceClaims instead of device plugin, no hostPath to GPU devices,
+// and ResourceClaim is allocated.
+func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
+
+	// 1. Get the DRA test pod (deployed by workflow before aicr validate runs)
+	pod, err := ctx.Clientset.CoreV1().Pods("dra-test").Get(
+		ctx.Context, "dra-gpu-test", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"DRA test pod not found (deploy dra-gpu-test.yaml first)", err)
+	}
+
+	// 2. Pod uses resourceClaims (DRA pattern)
+	if len(pod.Spec.ResourceClaims) == 0 {
+		return errors.New(errors.ErrCodeInternal,
+			"pod does not use DRA resourceClaims")
+	}
+
+	// 3. No nvidia.com/gpu in resources.limits (device plugin pattern)
+	for _, c := range pod.Spec.Containers {
+		if c.Resources.Limits != nil {
+			if _, hasGPU := c.Resources.Limits["nvidia.com/gpu"]; hasGPU {
+				return errors.New(errors.ErrCodeInternal,
+					"pod uses device plugin (nvidia.com/gpu in limits) instead of DRA")
+			}
+		}
+	}
+
+	// 4. No hostPath volumes to /dev/nvidia*
+	for _, vol := range pod.Spec.Volumes {
+		if vol.HostPath != nil && strings.Contains(vol.HostPath.Path, "/dev/nvidia") {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("pod has hostPath volume to %s", vol.HostPath.Path))
+		}
+	}
+
+	// 5. ResourceClaim exists
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims",
+	}
+	_, err = dynClient.Resource(gvr).Namespace("dra-test").Get(
+		ctx.Context, "gpu-claim", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "ResourceClaim gpu-claim not found", err)
+	}
+
+	// 6. Pod completed successfully — proves DRA allocation worked.
+	// Note: status.allocation may be cleared after pod completion, so we verify
+	// success via the pod phase rather than the claim's allocation status.
+	if pod.Status.Phase != corev1.PodSucceeded {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("DRA test pod phase=%s (want Succeeded), GPU allocation may have failed",
+				pod.Status.Phase))
+	}
+
+	return nil
+}

--- a/pkg/validator/checks/conformance/secure_access_check_test.go
+++ b/pkg/validator/checks/conformance/secure_access_check_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestSecureAcceleratorAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	if !runner.HasCheck("conformance", "secure-accelerator-access") {
+		t.Skip("Check secure-accelerator-access not enabled in recipe")
+	}
+
+	// Exercise-dependent: requires DRA test pod deployed by workflow
+	t.Logf("Running check: secure-accelerator-access")
+
+	ctx := runner.Context()
+	err = CheckSecureAcceleratorAccess(ctx)
+
+	if err != nil {
+		t.Errorf("Check failed: %v", err)
+	} else {
+		t.Logf("Check passed: secure-accelerator-access")
+	}
+}

--- a/pkg/validator/checks/conformance/secure_access_check_unit_test.go
+++ b/pkg/validator/checks/conformance/secure_access_check_unit_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCheckSecureAcceleratorAccess(t *testing.T) {
+	tests := []struct {
+		name           string
+		k8sObjects     []runtime.Object
+		dynamicObjects []runtime.Object
+		clientset      bool
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name: "valid DRA pod succeeded with claim",
+			k8sObjects: []runtime.Object{
+				createDRAPod(true, false, false, corev1.PodSucceeded),
+			},
+			dynamicObjects: []runtime.Object{
+				createResourceClaim("dra-test", "gpu-claim"),
+			},
+			clientset: true,
+			wantErr:   false,
+		},
+		{
+			name:        "no clientset",
+			clientset:   false,
+			wantErr:     true,
+			errContains: "kubernetes client is not available",
+		},
+		{
+			name:        "pod not found",
+			k8sObjects:  []runtime.Object{},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "DRA test pod not found",
+		},
+		{
+			name: "pod without resourceClaims",
+			k8sObjects: []runtime.Object{
+				createDRAPod(false, false, false, corev1.PodSucceeded),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "does not use DRA resourceClaims",
+		},
+		{
+			name: "pod uses device plugin",
+			k8sObjects: []runtime.Object{
+				createDRAPod(true, true, false, corev1.PodSucceeded),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "uses device plugin",
+		},
+		{
+			name: "pod has hostPath to GPU device",
+			k8sObjects: []runtime.Object{
+				createDRAPod(true, false, true, corev1.PodSucceeded),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "hostPath volume to /dev/nvidia0",
+		},
+		{
+			name: "ResourceClaim not found",
+			k8sObjects: []runtime.Object{
+				createDRAPod(true, false, false, corev1.PodSucceeded),
+			},
+			dynamicObjects: []runtime.Object{
+				// No ResourceClaim
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "ResourceClaim gpu-claim not found",
+		},
+		{
+			name: "pod not succeeded",
+			k8sObjects: []runtime.Object{
+				createDRAPod(true, false, false, corev1.PodFailed),
+			},
+			dynamicObjects: []runtime.Object{
+				createResourceClaim("dra-test", "gpu-claim"),
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "GPU allocation may have failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx *checks.ValidationContext
+
+			if tt.clientset {
+				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+
+				scheme := runtime.NewScheme()
+				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+					map[schema.GroupVersionResource]string{
+						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}: "ResourceClaimList",
+					},
+					tt.dynamicObjects...)
+
+				ctx = &checks.ValidationContext{
+					Context:       context.Background(),
+					Clientset:     clientset,
+					DynamicClient: dynClient,
+				}
+			} else {
+				ctx = &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			}
+
+			err := CheckSecureAcceleratorAccess(ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckSecureAcceleratorAccess() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CheckSecureAcceleratorAccess() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckSecureAcceleratorAccessRegistration(t *testing.T) {
+	check, ok := checks.GetCheck("secure-accelerator-access")
+	if !ok {
+		t.Fatal("secure-accelerator-access check not registered")
+	}
+	if check.Phase != phaseConformance {
+		t.Errorf("Phase = %v, want conformance", check.Phase)
+	}
+	if check.Func == nil {
+		t.Fatal("Func is nil")
+	}
+}
+
+// createDRAPod creates a test pod simulating DRA-based GPU access.
+func createDRAPod(hasResourceClaims, hasDevicePlugin, hasHostPath bool, phase corev1.PodPhase) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dra-gpu-test",
+			Namespace: "dra-test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "gpu-workload",
+					Image: "nvidia/cuda:12.0-base",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+
+	if hasResourceClaims {
+		pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+			{
+				Name:              "gpu",
+				ResourceClaimName: strPtr("gpu-claim"),
+			},
+		}
+	}
+
+	if hasDevicePlugin {
+		pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("1"),
+			},
+		}
+	}
+
+	if hasHostPath {
+		hostPathType := corev1.HostPathCharDev
+		pod.Spec.Volumes = []corev1.Volume{
+			{
+				Name: "gpu-device",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/dev/nvidia0",
+						Type: &hostPathType,
+					},
+				},
+			},
+		}
+	}
+
+	return pod
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+// createResourceClaim creates an unstructured ResourceClaim.
+func createResourceClaim(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "resource.k8s.io/v1",
+			"kind":       "ResourceClaim",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}

--- a/pkg/validator/checks/registry.go
+++ b/pkg/validator/checks/registry.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -42,6 +43,10 @@ type ValidationContext struct {
 
 	// RESTConfig provides Kubernetes API access for cluster queries (used for e.g. remote command execution)
 	RESTConfig *rest.Config
+
+	// DynamicClient provides dynamic Kubernetes API access for reading custom resources (CRDs).
+	// If nil, checks should create one from RESTConfig. Set this in unit tests for injection.
+	DynamicClient dynamic.Interface
 
 	// RecipeData contains recipe metadata that may be needed for validation
 	RecipeData map[string]interface{}

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -738,6 +738,9 @@ func (v *Validator) validateConformance(
 					// Validate that all recipe constraints/checks are registered (logs warnings for missing)
 					v.validateRecipeRegistrations(recipeResult, "conformance")
 
+					// Build test pattern from recipe (check/constraint names -> test names)
+					patternResult := v.buildTestPattern(recipeResult, "conformance")
+
 					// Deploy ONE Job for ALL conformance checks and constraints in this phase
 					jobConfig := agent.Config{
 						Namespace:          v.Namespace,
@@ -748,7 +751,8 @@ func (v *Validator) validateConformance(
 						SnapshotConfigMap:  snapshotCMName,
 						RecipeConfigMap:    recipeCMName,
 						TestPackage:        "./pkg/validator/checks/conformance",
-						TestPattern:        "", // Run all tests in package
+						TestPattern:        patternResult.Pattern,
+						ExpectedTests:      patternResult.ExpectedTests,
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Conformance, DefaultConformanceTimeout),
 					}
 
@@ -949,7 +953,30 @@ func (v *Validator) buildTestPattern(recipeResult *recipe.RecipeResult, phase st
 	case string(PhasePerformance):
 		// TODO(#140): Implement for performance phase
 	case string(PhaseConformance):
-		// TODO(#141): Implement for conformance phase
+		if recipeResult.Validation != nil && recipeResult.Validation.Conformance != nil {
+			// Add tests for constraints
+			for _, constraint := range recipeResult.Validation.Conformance.Constraints {
+				testName, ok := checks.GetTestNameForConstraint(constraint.Name)
+				if ok && !uniqueTests[testName] {
+					testNames = append(testNames, testName)
+					uniqueTests[testName] = true
+					slog.Debug("constraint mapped to test", "constraint", constraint.Name, "test", testName)
+				}
+			}
+
+			// Add tests for explicit checks
+			for _, checkName := range recipeResult.Validation.Conformance.Checks {
+				testName, ok := checks.GetTestNameForCheck(checkName)
+				if !ok {
+					testName = checkNameToTestName(checkName)
+				}
+				if !uniqueTests[testName] {
+					testNames = append(testNames, testName)
+					uniqueTests[testName] = true
+					slog.Debug("check mapped to test", "check", checkName, "test", testName)
+				}
+			}
+		}
 	}
 
 	if len(testNames) == 0 {

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -1156,7 +1156,7 @@ func TestBuildTestPattern(t *testing.T) {
 			wantExpectedTests: 0,
 		},
 		{
-			name: "conformance phase not implemented returns empty",
+			name: "conformance phase builds pattern from checks",
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Conformance: &recipe.ValidationPhase{
@@ -1165,8 +1165,8 @@ func TestBuildTestPattern(t *testing.T) {
 				},
 			},
 			phase:             "conformance",
-			wantPattern:       "",
-			wantExpectedTests: 0,
+			wantPattern:       "^(TestConformanceCheck)$",
+			wantExpectedTests: 1,
 		},
 		{
 			name: "deployment with registered check uses registry test name",

--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -60,3 +60,17 @@ spec:
               fileStore:
                 pvc:
                   storageClassName: standard
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - robust-controller
+        - secure-accelerator-access
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/recipes/overlays/h100-kind-inference.yaml
+++ b/recipes/overlays/h100-kind-inference.yaml
@@ -32,3 +32,15 @@ spec:
   # 2-node kind cluster. The skyhook-operator deployment itself is inherited
   # from the base kind recipe.
   componentRefs: []
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - secure-accelerator-access
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - pod-autoscaling

--- a/recipes/overlays/h100-kind-training.yaml
+++ b/recipes/overlays/h100-kind-training.yaml
@@ -60,3 +60,16 @@ spec:
               fileStore:
                 pvc:
                   storageClassName: standard
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - robust-controller
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -35,6 +35,18 @@ spec:
     # Assumes host has NVIDIA drivers and container toolkit pre-configured
     - name: gpu-operator
       type: Helm
+      # Override base expectedResources to exclude nvidia-driver-daemonset —
+      # Kind uses pre-installed host drivers (driver.enabled: false).
+      expectedResources:
+        - kind: Deployment
+          name: gpu-operator
+          namespace: gpu-operator
+        - kind: DaemonSet
+          name: nvidia-device-plugin-daemonset
+          namespace: gpu-operator
+        - kind: DaemonSet
+          name: nvidia-dcgm-exporter
+          namespace: gpu-operator
       overrides:
         driver:
           # Disable driver installation - use pre-installed host drivers
@@ -194,3 +206,12 @@ spec:
       valuesFile: components/network-operator/values.yaml
       dependencyRefs:
         - cert-manager
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,548 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	unstructuredScheme := runtime.NewScheme()
+	for gvk := range scheme.AllKnownTypes() {
+		if unstructuredScheme.Recognizes(gvk) {
+			continue
+		}
+		if strings.HasSuffix(gvk.Kind, "List") {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+			continue
+		}
+		unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+
+	objects, err := convertObjectsToUnstructured(scheme, objects)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, obj := range objects {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+		gvk.Kind += "List"
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		}
+	}
+
+	return NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme, nil, objects...)
+}
+
+// NewSimpleDynamicClientWithCustomListKinds try not to use this.  In general you want to have the scheme have the List types registered
+// and allow the default guessing for resources match.  Sometimes that doesn't work, so you can specify a custom mapping here.
+func NewSimpleDynamicClientWithCustomListKinds(scheme *runtime.Scheme, gvrToListKind map[schema.GroupVersionResource]string, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have your lists registered so that the object tracker will find them
+	// in the scheme to support the t.scheme.New(listGVK) call when it's building the return value.
+	// Since the base fake client needs the listGVK passed through the action (in cases where there are no instances, it
+	// cannot look up the actual hits), we need to know a mapping of GVR to listGVK here.  For GETs and other types of calls,
+	// there is no return value that contains a GVK, so it doesn't have to know the mapping in advance.
+
+	// first we attempt to invert known List types from the scheme to auto guess the resource with unsafe guesses
+	// this covers common usage of registering types in scheme and passing them
+	completeGVRToListKind := map[schema.GroupVersionResource]string{}
+	for listGVK := range scheme.AllKnownTypes() {
+		if !strings.HasSuffix(listGVK.Kind, "List") {
+			continue
+		}
+		nonListGVK := listGVK.GroupVersion().WithKind(listGVK.Kind[:len(listGVK.Kind)-4])
+		plural, _ := meta.UnsafeGuessKindToResource(nonListGVK)
+		completeGVRToListKind[plural] = listGVK.Kind
+	}
+
+	for gvr, listKind := range gvrToListKind {
+		if !strings.HasSuffix(listKind, "List") {
+			panic("coding error, listGVK must end in List or this fake client doesn't work right")
+		}
+		listGVK := gvr.GroupVersion().WithKind(listKind)
+
+		// if we already have this type registered, just skip it
+		if _, err := scheme.New(listGVK); err == nil {
+			completeGVRToListKind[gvr] = listKind
+			continue
+		}
+
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		completeGVRToListKind[gvr] = listKind
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme, gvrToListKind: completeGVRToListKind, tracker: o}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme        *runtime.Scheme
+	gvrToListKind map[schema.GroupVersionResource]string
+	tracker       testing.ObjectTracker
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+	listKind  string
+}
+
+var (
+	_ dynamic.Interface  = &FakeDynamicClient{}
+	_ testing.FakeClient = &FakeDynamicClient{}
+)
+
+func (c *FakeDynamicClient) Tracker() testing.ObjectTracker {
+	return c.tracker
+}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, listKind: c.gvrToListKind[resource]}
+}
+
+func (c *FakeDynamicClient) IsWatchListSemanticsUnSupported() bool {
+	return true
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateActionWithOptions(c.resource, obj, opts), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceActionWithOptions(c.resource, name, strings.Join(subresources, "/"), obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateActionWithOptions(c.resource, c.namespace, obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceActionWithOptions(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateActionWithOptions(c.resource, obj, opts), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateActionWithOptions(c.resource, c.namespace, obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceActionWithOptions(c.resource, "status", obj, opts), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceActionWithOptions(c.resource, "status", c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionActionWithOptions(c.resource, opts, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionActionWithOptions(c.resource, c.namespace, opts, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceActionWithOptions(c.resource, c.namespace, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if len(c.listKind) == 0 {
+		panic(fmt.Sprintf("coding error: you must register resource to list kind for every resource you're going to LIST when creating the client.  See NewSimpleDynamicClientWithCustomListKinds or register the list into the scheme: %v out of %v", c.resource, c.client.gvrToListKind))
+	}
+	listGVK := c.resource.GroupVersion().WithKind(c.listKind)
+	listForFakeClientGVK := c.resource.GroupVersion().WithKind(c.listKind[:len(c.listKind)-4]) /*base library appends List*/
+
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListActionWithOptions(c.resource, listForFakeClientGVK, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListActionWithOptions(c.resource, listForFakeClientGVK, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetRemainingItemCount(entireList.GetRemainingItemCount())
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	list.SetContinue(entireList.GetContinue())
+	list.GetObjectKind().SetGroupVersionKind(listGVK)
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchActionWithOptions(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchActionWithOptions(c.resource, c.namespace, opts))
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchActionWithOptions(c.resource, name, pt, data, opts), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceActionWithOptions(c.resource, name, pt, data, opts, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchActionWithOptions(c.resource, c.namespace, name, pt, data, opts), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceActionWithOptions(c.resource, c.namespace, name, pt, data, opts, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	patchOptions := metav1.PatchOptions{
+		Force:        &options.Force,
+		DryRun:       options.DryRun,
+		FieldManager: options.FieldManager,
+	}
+	var uncastRet runtime.Object
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchActionWithOptions(c.resource, name, types.ApplyPatchType, outBytes, patchOptions), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceActionWithOptions(c.resource, name, types.ApplyPatchType, outBytes, patchOptions, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchActionWithOptions(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, patchOptions), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceActionWithOptions(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, patchOptions, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (c *dynamicResourceClient) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return c.Apply(ctx, name, obj, options, "status")
+}
+
+func convertObjectsToUnstructured(s *runtime.Scheme, objs []runtime.Object) ([]runtime.Object, error) {
+	ul := make([]runtime.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		u, err := convertToUnstructured(s, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		ul = append(ul, u)
+	}
+	return ul, nil
+}
+
+func convertToUnstructured(s *runtime.Scheme, obj runtime.Object) (runtime.Object, error) {
+	var (
+		err error
+		u   unstructured.Unstructured
+	)
+
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group == "" || gvk.Kind == "" {
+		gvks, _, err := s.ObjectKinds(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured - unable to get GVK %w", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		u.SetAPIVersion(apiv)
+		u.SetKind(k)
+	}
+	return &u, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,6 +455,7 @@ k8s.io/client-go/applyconfigurations/storagemigration/v1beta1
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/features
 k8s.io/client-go/gentype
 k8s.io/client-go/kubernetes


### PR DESCRIPTION
## Summary

Implement 11 Go-based conformance checks for `aicr validate --phase conformance`, mapping to CNCF AI Conformance v1.35 MUST requirements. Each check runs inside a K8s Job with in-cluster service access (DNS-based), replacing ~250 lines of bash assertion steps with structured, testable Go code.

### Conformance checks

| Check | CNCF Requirement | What it validates |
|-------|-----------------|-------------------|
| `platform-health` | Prerequisite | All expected namespaces active, all `expectedResources` healthy |
| `gpu-operator-health` | #1 GPU Management | Operator deployment, ClusterPolicy ready, DCGM exporter running |
| `dra-support` | #2 DRA Support | DRA driver controller, kubelet plugin, ResourceSlices advertised |
| `secure-accelerator-access` | #3 Secure Access | DRA resourceClaims, no device plugin/hostPath, pod succeeded |
| `accelerator-metrics` | #4 Accelerator Metrics | DCGM exports GPU util/memory/temp/power metrics |
| `ai-service-metrics` | #5 AI Service Metrics | Prometheus has GPU time series, custom metrics API available |
| `inference-gateway` | #6 Inference Gateway | GatewayClass accepted, Gateway programmed, required CRDs |
| `gang-scheduling` | #7 Gang Scheduling | KAI scheduler deployments (7), Queue/PodGroup CRDs |
| `robust-controller` | #9 Robust Controller | Dynamo operator, validating webhook with endpoints, DGD CRD |
| `pod-autoscaling` | #8b Pod Autoscaling | Custom + external metrics APIs with GPU metric data |
| `cluster-autoscaling` | #8a Cluster Autoscaling | Karpenter controller, GPU-aware NodePool |

### Infrastructure

- Wire `buildTestPattern` for conformance phase in `phases.go`
- Add `DynamicClient` field to `ValidationContext` for CRD reads (unit-testable)
- Add 11 read-only RBAC rules to validator ClusterRole
- Add `conformance.test` compilation to `Dockerfile.validator`
- Switch `aicr-build` CI action from `ko build` to `docker build -f Dockerfile.validator` (includes all test binaries + test2json + shell)
- Update 4 recipe overlays (`kind`, `h100-kind-inference`, `h100-kind-inference-dynamo`, `h100-kind-training`) with per-intent conformance check lists
- Add `expectedResources` override in kind overlay for gpu-operator (excludes `nvidia-driver-daemonset` since Kind uses host drivers)

### CI workflow changes

- Remove 4 redundant bash assertion steps from inference workflow (~207 lines) now covered by Go conformance checks:
  - Validate inference gateway
  - Validate accelerator metrics
  - Validate custom metrics for pod autoscaling
  - Validate secure accelerator access
- Move DRA test pod deployment before `aicr validate` (prerequisite for `secure-accelerator-access` check)

### What stays in bash

Exercise steps that deploy workloads and test dynamic behavior remain in bash:
- Dynamo vLLM inference smoke test (deploy model, send chat completion)
- Gang scheduling exercise (deploy 2 workers, verify both succeed)
- Karpenter + KWOK autoscaling (install, scale up/down cycle)

## Test plan

- [x] `make test` passes (73.3% coverage, conformance 75.4%)
- [x] 11 unit test files with table-driven tests using `fake.NewSimpleClientset` and `dynamicfake`
- [x] GPU Inference Test (H100): 9/9 conformance checks pass, Dynamo + autoscaling exercises pass
- [x] GPU Training Test (H100 x2): 8/8 conformance checks pass, gang scheduling + autoscaling exercises pass
- [x] GPU Smoke Test (T4): pass
- [x] All 17 KWOK recipe tests: pass
- [x] Unit, Integration, Conformance, E2E tests: pass
- [x] Security scans (Trivy, ClamAV, CodeQL): pass