### PR TITLE
feat(validator): self-contained DRA conformance check with EKS overlays

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -137,6 +137,13 @@ const (
 	ComponentRenderTimeout = 60 * time.Second
 )
 
+// DRA test timeouts for conformance validation.
+const (
+	// DRATestPodTimeout is the timeout for the DRA test pod to complete.
+	// The pod runs a simple CUDA device check but may need time for image pull.
+	DRATestPodTimeout = 5 * time.Minute
+)
+
 // Pod operation timeouts for validation and agent operations.
 const (
 	// PodWaitTimeout is the maximum time to wait for pod operations to complete.

--- a/pkg/recipe/conformance_test.go
+++ b/pkg/recipe/conformance_test.go
@@ -36,6 +36,7 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 		criteria           func() *Criteria
 		requiredComponents []string
 		requiredChecks     []string
+		wantDRAConstraint  bool // K8s >= 1.34 required for DRA GA
 	}{
 		{
 			name: "h100-kind-inference-dynamo",
@@ -71,6 +72,7 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 				"pod-autoscaling",
 				"cluster-autoscaling",
 			},
+			wantDRAConstraint: true,
 		},
 		{
 			name: "h100-kind-training",
@@ -102,6 +104,74 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 				"pod-autoscaling",
 				"cluster-autoscaling",
 			},
+			wantDRAConstraint: true,
+		},
+		{
+			name: "h100-eks-ubuntu-inference-dynamo",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorH100
+				c.OS = CriteriaOSUbuntu
+				c.Intent = CriteriaIntentInference
+				c.Platform = CriteriaPlatformDynamo
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+				"kgateway-crds",
+				"kgateway",
+				"dynamo-crds",
+				"dynamo-platform",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"inference-gateway",
+				"robust-controller",
+				"secure-accelerator-access",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+			},
+			wantDRAConstraint: true,
+		},
+		{
+			name: "h100-eks-ubuntu-training",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorH100
+				c.OS = CriteriaOSUbuntu
+				c.Intent = CriteriaIntentTraining
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"gang-scheduling",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+			},
+			wantDRAConstraint: false,
 		},
 	}
 
@@ -153,15 +223,17 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 			}
 
 			// 5. DRA constraint present (K8s >= 1.34 required for DRA GA)
-			var hasDRAConstraint bool
-			for _, c := range result.Constraints {
-				if c.Name == "K8s.server.version" && strings.Contains(c.Value, "1.34") {
-					hasDRAConstraint = true
-					break
+			if tt.wantDRAConstraint {
+				var hasDRAConstraint bool
+				for _, c := range result.Constraints {
+					if c.Name == "K8s.server.version" && strings.Contains(c.Value, "1.34") {
+						hasDRAConstraint = true
+						break
+					}
 				}
-			}
-			if !hasDRAConstraint {
-				t.Error("Missing K8s >= 1.34 constraint (required for DRA GA)")
+				if !hasDRAConstraint {
+					t.Error("Missing K8s >= 1.34 constraint (required for DRA GA)")
+				}
 			}
 
 			t.Logf("Recipe %s: %d components, %d conformance checks",

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -136,6 +136,17 @@ func (d *Deployer) ensureClusterRole(ctx context.Context) error {
 				Resources: []string{"resourceslices", "resourceclaims"},
 				Verbs:     []string{"get", "list"},
 			},
+			// Conformance: secure-accelerator-access — DRA test pod lifecycle
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "pods"},
+				Verbs:     []string{"create", "delete"},
+			},
+			{
+				APIGroups: []string{"resource.k8s.io"},
+				Resources: []string{"resourceclaims"},
+				Verbs:     []string{"create", "delete"},
+			},
 			// Conformance: GPU operator ClusterPolicy
 			{
 				APIGroups: []string{"nvidia.com"},

--- a/pkg/validator/checks/conformance/secure_access_check.go
+++ b/pkg/validator/checks/conformance/secure_access_check.go
@@ -15,15 +15,53 @@
 package conformance
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/k8s"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
+
+const (
+	draTestNamespace = "dra-test"
+	draTestPrefix    = "dra-gpu-test-"
+	draClaimPrefix   = "gpu-claim-"
+)
+
+// draTestRun holds per-invocation resource names to avoid collisions.
+type draTestRun struct {
+	podName   string
+	claimName string
+}
+
+func newDRATestRun() (*draTestRun, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate random suffix", err)
+	}
+	suffix := hex.EncodeToString(b)
+	return &draTestRun{
+		podName:   draTestPrefix + suffix,
+		claimName: draClaimPrefix + suffix,
+	}, nil
+}
+
+var claimGVR = schema.GroupVersionResource{
+	Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims",
+}
 
 func init() {
 	checks.RegisterCheck(&checks.Check{
@@ -36,29 +74,109 @@ func init() {
 }
 
 // CheckSecureAcceleratorAccess validates CNCF requirement #3: Secure Accelerator Access.
-// Verifies that a DRA-based GPU workload uses proper access patterns:
-// resourceClaims instead of device plugin, no hostPath to GPU devices,
-// and ResourceClaim is allocated.
+// Creates a DRA-based GPU test pod with unique names, waits for completion, and verifies
+// proper access patterns: resourceClaims instead of device plugin, no hostPath to GPU
+// devices, and ResourceClaim is allocated.
 func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
 	if ctx.Clientset == nil {
 		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
 	}
 
-	// 1. Get the DRA test pod (deployed by workflow before aicr validate runs)
-	pod, err := ctx.Clientset.CoreV1().Pods("dra-test").Get(
-		ctx.Context, "dra-gpu-test", metav1.GetOptions{})
+	dynClient, err := getDynamicClient(ctx)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeNotFound,
-			"DRA test pod not found (deploy dra-gpu-test.yaml first)", err)
+		return err
 	}
 
-	// 2. Pod uses resourceClaims (DRA pattern)
+	run, err := newDRATestRun()
+	if err != nil {
+		return err
+	}
+
+	// Deploy DRA test resources and ensure cleanup.
+	if err = deployDRATestResources(ctx.Context, ctx.Clientset, dynClient, run); err != nil {
+		return err
+	}
+	defer cleanupDRATestResources(ctx.Context, ctx.Clientset, dynClient, run)
+
+	// Wait for test pod to reach terminal state.
+	pod, err := waitForDRATestPod(ctx.Context, ctx.Clientset, run)
+	if err != nil {
+		return err
+	}
+
+	// Validate DRA access patterns on the completed pod.
+	return validateDRAPatterns(ctx.Context, dynClient, pod, run)
+}
+
+// deployDRATestResources creates the namespace, ResourceClaim, and Pod for the DRA test.
+func deployDRATestResources(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, run *draTestRun) error {
+	// 1. Create namespace (idempotent).
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: draTestNamespace},
+	}
+	if _, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); k8s.IgnoreAlreadyExists(err) != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
+	}
+
+	// 2. Create ResourceClaim with unique name.
+	claim := buildResourceClaim(run)
+	if _, err := dynClient.Resource(claimGVR).Namespace(draTestNamespace).Create(
+		ctx, claim, metav1.CreateOptions{}); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create ResourceClaim", err)
+	}
+
+	// 3. Create Pod with unique name.
+	pod := buildDRATestPod(run)
+	if _, err := clientset.CoreV1().Pods(draTestNamespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create DRA test pod", err)
+	}
+
+	return nil
+}
+
+// waitForDRATestPod polls until the DRA test pod reaches a terminal state.
+func waitForDRATestPod(ctx context.Context, clientset kubernetes.Interface, run *draTestRun) (*corev1.Pod, error) {
+	var resultPod *corev1.Pod
+
+	waitCtx, cancel := context.WithTimeout(ctx, defaults.DRATestPodTimeout)
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(waitCtx, defaults.PodPollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := clientset.CoreV1().Pods(draTestNamespace).Get(
+				ctx, run.podName, metav1.GetOptions{})
+			if err != nil {
+				return false, errors.Wrap(errors.ErrCodeInternal, "failed to get DRA test pod", err)
+			}
+			switch pod.Status.Phase { //nolint:exhaustive // only terminal states matter
+			case corev1.PodSucceeded, corev1.PodFailed:
+				resultPod = pod
+				return true, nil
+			default:
+				return false, nil
+			}
+		},
+	)
+	if err != nil {
+		// Distinguish timeout from other poll errors (RBAC, NotFound, etc).
+		if ctx.Err() != nil || waitCtx.Err() != nil {
+			return nil, errors.Wrap(errors.ErrCodeTimeout, "DRA test pod did not complete in time", err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeInternal, "DRA test pod polling failed", err)
+	}
+
+	return resultPod, nil
+}
+
+// validateDRAPatterns verifies the completed pod uses proper DRA access patterns.
+func validateDRAPatterns(ctx context.Context, dynClient dynamic.Interface, pod *corev1.Pod, run *draTestRun) error {
+	// 1. Pod uses resourceClaims (DRA pattern).
 	if len(pod.Spec.ResourceClaims) == 0 {
 		return errors.New(errors.ErrCodeInternal,
 			"pod does not use DRA resourceClaims")
 	}
 
-	// 3. No nvidia.com/gpu in resources.limits (device plugin pattern)
+	// 2. No nvidia.com/gpu in resources.limits (device plugin pattern).
 	for _, c := range pod.Spec.Containers {
 		if c.Resources.Limits != nil {
 			if _, hasGPU := c.Resources.Limits["nvidia.com/gpu"]; hasGPU {
@@ -68,7 +186,7 @@ func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
 		}
 	}
 
-	// 4. No hostPath volumes to /dev/nvidia*
+	// 3. No hostPath volumes to /dev/nvidia*.
 	for _, vol := range pod.Spec.Volumes {
 		if vol.HostPath != nil && strings.Contains(vol.HostPath.Path, "/dev/nvidia") {
 			return errors.New(errors.ErrCodeInternal,
@@ -76,23 +194,14 @@ func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
 		}
 	}
 
-	// 5. ResourceClaim exists
-	dynClient, err := getDynamicClient(ctx)
-	if err != nil {
-		return err
-	}
-	gvr := schema.GroupVersionResource{
-		Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims",
-	}
-	_, err = dynClient.Resource(gvr).Namespace("dra-test").Get(
-		ctx.Context, "gpu-claim", metav1.GetOptions{})
-	if err != nil {
-		return errors.Wrap(errors.ErrCodeNotFound, "ResourceClaim gpu-claim not found", err)
+	// 4. ResourceClaim exists.
+	if _, err := dynClient.Resource(claimGVR).Namespace(draTestNamespace).Get(
+		ctx, run.claimName, metav1.GetOptions{}); err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			fmt.Sprintf("ResourceClaim %s not found", run.claimName), err)
 	}
 
-	// 6. Pod completed successfully — proves DRA allocation worked.
-	// Note: status.allocation may be cleared after pod completion, so we verify
-	// success via the pod phase rather than the claim's allocation status.
+	// 5. Pod completed successfully — proves DRA allocation worked.
 	if pod.Status.Phase != corev1.PodSucceeded {
 		return errors.New(errors.ErrCodeInternal,
 			fmt.Sprintf("DRA test pod phase=%s (want Succeeded), GPU allocation may have failed",
@@ -100,4 +209,101 @@ func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
 	}
 
 	return nil
+}
+
+// cleanupDRATestResources removes test resources. Best-effort: errors are ignored
+// since cleanup failures should not mask test results.
+// The namespace is intentionally NOT deleted — it's harmless to leave and
+// namespace deletion can hang on DRA finalizers.
+func cleanupDRATestResources(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, run *draTestRun) {
+	// Delete pod first (releases claim reservation), then claim.
+	_ = k8s.IgnoreNotFound(clientset.CoreV1().Pods(draTestNamespace).Delete(
+		ctx, run.podName, metav1.DeleteOptions{}))
+	waitForDeletion(ctx, func() error {
+		_, err := clientset.CoreV1().Pods(draTestNamespace).Get(ctx, run.podName, metav1.GetOptions{})
+		return err
+	})
+	_ = k8s.IgnoreNotFound(dynClient.Resource(claimGVR).Namespace(draTestNamespace).Delete(
+		ctx, run.claimName, metav1.DeleteOptions{}))
+}
+
+// waitForDeletion polls until a resource is gone (NotFound) or the context expires.
+func waitForDeletion(ctx context.Context, getFunc func() error) {
+	pollCtx, cancel := context.WithTimeout(ctx, defaults.K8sCleanupTimeout)
+	defer cancel()
+	_ = wait.PollUntilContextCancel(pollCtx, defaults.PodPollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			err := getFunc()
+			if k8serrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
+		},
+	)
+}
+
+// buildDRATestPod returns the Pod spec for the DRA GPU allocation test.
+func buildDRATestPod(run *draTestRun) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      run.podName,
+			Namespace: draTestNamespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Tolerations: []corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
+			},
+			ResourceClaims: []corev1.PodResourceClaim{
+				{
+					Name:              "gpu",
+					ResourceClaimName: strPtr(run.claimName),
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "gpu-test",
+					Image:   "nvidia/cuda:12.9.0-base-ubuntu24.04",
+					Command: []string{"bash", "-c", "ls /dev/nvidia* && echo 'DRA GPU allocation successful'"},
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{Name: "gpu"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildResourceClaim returns the unstructured ResourceClaim for the DRA test.
+func buildResourceClaim(run *draTestRun) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "resource.k8s.io/v1",
+			"kind":       "ResourceClaim",
+			"metadata": map[string]interface{}{
+				"name":      run.claimName,
+				"namespace": draTestNamespace,
+			},
+			"spec": map[string]interface{}{
+				"devices": map[string]interface{}{
+					"requests": []interface{}{
+						map[string]interface{}{
+							"name": "gpu",
+							"exactly": map[string]interface{}{
+								"deviceClassName": "gpu.nvidia.com",
+								"allocationMode":  "ExactCount",
+								"count":           int64(1),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/pkg/validator/checks/conformance/secure_access_check_unit_test.go
+++ b/pkg/validator/checks/conformance/secure_access_check_unit_test.go
@@ -21,32 +21,27 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCheckSecureAcceleratorAccess(t *testing.T) {
 	tests := []struct {
-		name           string
-		k8sObjects     []runtime.Object
-		dynamicObjects []runtime.Object
-		clientset      bool
-		wantErr        bool
-		errContains    string
+		name        string
+		podPhase    corev1.PodPhase
+		clientset   bool
+		wantErr     bool
+		errContains string
 	}{
 		{
-			name: "valid DRA pod succeeded with claim",
-			k8sObjects: []runtime.Object{
-				createDRAPod(true, false, false, corev1.PodSucceeded),
-			},
-			dynamicObjects: []runtime.Object{
-				createResourceClaim("dra-test", "gpu-claim"),
-			},
+			name:      "DRA allocation succeeds",
+			podPhase:  corev1.PodSucceeded,
 			clientset: true,
 			wantErr:   false,
 		},
@@ -57,59 +52,8 @@ func TestCheckSecureAcceleratorAccess(t *testing.T) {
 			errContains: "kubernetes client is not available",
 		},
 		{
-			name:        "pod not found",
-			k8sObjects:  []runtime.Object{},
-			clientset:   true,
-			wantErr:     true,
-			errContains: "DRA test pod not found",
-		},
-		{
-			name: "pod without resourceClaims",
-			k8sObjects: []runtime.Object{
-				createDRAPod(false, false, false, corev1.PodSucceeded),
-			},
-			clientset:   true,
-			wantErr:     true,
-			errContains: "does not use DRA resourceClaims",
-		},
-		{
-			name: "pod uses device plugin",
-			k8sObjects: []runtime.Object{
-				createDRAPod(true, true, false, corev1.PodSucceeded),
-			},
-			clientset:   true,
-			wantErr:     true,
-			errContains: "uses device plugin",
-		},
-		{
-			name: "pod has hostPath to GPU device",
-			k8sObjects: []runtime.Object{
-				createDRAPod(true, false, true, corev1.PodSucceeded),
-			},
-			clientset:   true,
-			wantErr:     true,
-			errContains: "hostPath volume to /dev/nvidia0",
-		},
-		{
-			name: "ResourceClaim not found",
-			k8sObjects: []runtime.Object{
-				createDRAPod(true, false, false, corev1.PodSucceeded),
-			},
-			dynamicObjects: []runtime.Object{
-				// No ResourceClaim
-			},
-			clientset:   true,
-			wantErr:     true,
-			errContains: "ResourceClaim gpu-claim not found",
-		},
-		{
-			name: "pod not succeeded",
-			k8sObjects: []runtime.Object{
-				createDRAPod(true, false, false, corev1.PodFailed),
-			},
-			dynamicObjects: []runtime.Object{
-				createResourceClaim("dra-test", "gpu-claim"),
-			},
+			name:        "DRA allocation fails",
+			podPhase:    corev1.PodFailed,
 			clientset:   true,
 			wantErr:     true,
 			errContains: "GPU allocation may have failed",
@@ -122,14 +66,66 @@ func TestCheckSecureAcceleratorAccess(t *testing.T) {
 
 			if tt.clientset {
 				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
-				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
+				clientset := fake.NewSimpleClientset()
+				podDeleted := false
+
+				// Reactor: match any pod with the DRA test prefix.
+				// Returns the pod with desired phase, or NotFound after deletion.
+				clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					ga := action.(k8stesting.GetAction)
+					if strings.HasPrefix(ga.GetName(), draTestPrefix) && ga.GetNamespace() == draTestNamespace {
+						if podDeleted {
+							return true, nil, k8serrors.NewNotFound(
+								schema.GroupResource{Resource: "pods"}, ga.GetName())
+						}
+						run := &draTestRun{podName: ga.GetName(), claimName: draClaimPrefix + ga.GetName()[len(draTestPrefix):]}
+						return true, &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      run.podName,
+								Namespace: draTestNamespace,
+							},
+							Spec: *buildDRATestPod(run).Spec.DeepCopy(),
+							Status: corev1.PodStatus{
+								Phase: tt.podPhase,
+							},
+						}, nil
+					}
+					return false, nil, nil
+				})
+
+				// Reactor: mark pod as deleted so subsequent Gets return NotFound.
+				clientset.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					da := action.(k8stesting.DeleteAction)
+					if strings.HasPrefix(da.GetName(), draTestPrefix) && da.GetNamespace() == draTestNamespace {
+						podDeleted = true
+						return true, nil, nil
+					}
+					return false, nil, nil
+				})
 
 				scheme := runtime.NewScheme()
 				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 					map[schema.GroupVersionResource]string{
 						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}: "ResourceClaimList",
-					},
-					tt.dynamicObjects...)
+					})
+
+				// Reactor: match any ResourceClaim with the DRA claim prefix.
+				dynClient.PrependReactor("get", "resourceclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					ga := action.(k8stesting.GetAction)
+					if strings.HasPrefix(ga.GetName(), draClaimPrefix) && ga.GetNamespace() == draTestNamespace {
+						return true, &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "resource.k8s.io/v1",
+								"kind":       "ResourceClaim",
+								"metadata": map[string]interface{}{
+									"name":      ga.GetName(),
+									"namespace": draTestNamespace,
+								},
+							},
+						}, nil
+					}
+					return false, nil, nil
+				})
 
 				ctx = &checks.ValidationContext{
 					Context:       context.Background(),
@@ -168,78 +164,5 @@ func TestCheckSecureAcceleratorAccessRegistration(t *testing.T) {
 	}
 	if check.Func == nil {
 		t.Fatal("Func is nil")
-	}
-}
-
-// createDRAPod creates a test pod simulating DRA-based GPU access.
-func createDRAPod(hasResourceClaims, hasDevicePlugin, hasHostPath bool, phase corev1.PodPhase) *corev1.Pod {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dra-gpu-test",
-			Namespace: "dra-test",
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "gpu-workload",
-					Image: "nvidia/cuda:12.0-base",
-				},
-			},
-		},
-		Status: corev1.PodStatus{
-			Phase: phase,
-		},
-	}
-
-	if hasResourceClaims {
-		pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
-			{
-				Name:              "gpu",
-				ResourceClaimName: strPtr("gpu-claim"),
-			},
-		}
-	}
-
-	if hasDevicePlugin {
-		pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				"nvidia.com/gpu": resource.MustParse("1"),
-			},
-		}
-	}
-
-	if hasHostPath {
-		hostPathType := corev1.HostPathCharDev
-		pod.Spec.Volumes = []corev1.Volume{
-			{
-				Name: "gpu-device",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/dev/nvidia0",
-						Type: &hostPathType,
-					},
-				},
-			},
-		}
-	}
-
-	return pod
-}
-
-func strPtr(s string) *string {
-	return &s
-}
-
-// createResourceClaim creates an unstructured ResourceClaim.
-func createResourceClaim(namespace, name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "resource.k8s.io/v1",
-			"kind":       "ResourceClaim",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-			},
-		},
 	}
 }

--- a/recipes/overlays/eks.yaml
+++ b/recipes/overlays/eks.yaml
@@ -72,3 +72,12 @@ spec:
       type: Helm
       version: v0.5.3
       valuesFile: components/aws-efa/values.yaml
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -103,3 +103,17 @@ spec:
               fileStore:
                 pvc:
                   storageClassName: gp2
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - robust-controller
+        - secure-accelerator-access
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/recipes/overlays/h100-eks-ubuntu-training.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-training.yaml
@@ -51,6 +51,5 @@ spec:
         - accelerator-metrics
         - ai-service-metrics
         - gang-scheduling
-        - robust-controller
         - pod-autoscaling
         - cluster-autoscaling

--- a/recipes/overlays/h100-eks-ubuntu-training.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-training.yaml
@@ -41,3 +41,16 @@ spec:
       value: ">= 6.8"
 
   componentRefs: []
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - robust-controller
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/tests/chainsaw/cli/cuj1-training/assert-validate-multiphase.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-validate-multiphase.yaml
@@ -27,4 +27,4 @@ phases:
       - name: expected-resources
         status: pass
   conformance:
-    status: skipped
+    status: pass


### PR DESCRIPTION
## Summary
- Add conformance validation checks to EKS overlays (eks, h100-eks-ubuntu-inference-dynamo, h100-eks-ubuntu-training)
- Add EKS test cases to conformance recipe invariant tests
- Rewrite `secure-accelerator-access` check to be self-contained: programmatically creates DRA test namespace, ResourceClaim, and GPU pod, waits for completion, validates DRA access patterns, and cleans up
- Expand ClusterRole RBAC permissions for DRA check (create/delete namespaces, pods, resourceclaims)
- Add `DRATestPodTimeout` constant (5min) to handle image pull latency

## Test plan
- [x] Unit tests pass: `go test -v ./pkg/validator/checks/conformance/... -run TestCheckSecureAcceleratorAccess`
- [x] Recipe invariant tests pass: `go test -v ./pkg/recipe/... -run TestConformanceRecipeInvariants`
- [x] Full test suite passes: `make test` (73.5% coverage)
- [x] Live EKS cluster validation: `TestSecureAcceleratorAccess PASS (3.60s)` on H100 node with DRA