### PR TITLE
feat(validator): self-contained gang scheduling conformance check

### DIFF
--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -29,7 +29,6 @@ on:
       - 'pkg/validator/checks/conformance/**'
       - '.github/actions/gpu-test-cleanup/**'
       - '.github/actions/load-versions/**'
-      - 'docs/conformance/cncf/manifests/gang-scheduling-test.yaml'
       - 'tests/chainsaw/ai-conformance/kind-training/**'
       - 'recipes/components/dynamo-platform/**'
       - 'recipes/overlays/kind.yaml'
@@ -128,6 +127,8 @@ jobs:
       # --- Validate cluster (Go conformance checks run inside K8s Jobs) ---
       # Runs after chainsaw to ensure the DCGM → Prometheus → adapter pipeline
       # has had time to bootstrap (pod-autoscaling check needs live metric data).
+      # Gang scheduling (PodGroup + 2 GPU pods) is exercised by the self-contained
+      # gang-scheduling conformance check — no separate deploy step needed.
 
       - name: Validate cluster
         run: |
@@ -140,52 +141,6 @@ jobs:
             --kubeconfig="${HOME}/.kube/config" \
             --require-gpu \
             --image=ko.local:smoke-test
-
-      # --- Gang scheduling test with PodGroup + KAI scheduler ---
-
-      - name: Deploy gang scheduling test
-        run: |
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" apply \
-            -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml
-
-          echo "Waiting for gang scheduling pods to complete..."
-          for i in $(seq 1 60); do
-            PHASE_0=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-              -n gang-scheduling-test get pod gang-worker-0 \
-              -o jsonpath='{.status.phase}' 2>/dev/null)
-            PHASE_1=$(kubectl --context="kind-${KIND_CLUSTER_NAME}" \
-              -n gang-scheduling-test get pod gang-worker-1 \
-              -o jsonpath='{.status.phase}' 2>/dev/null)
-
-            if [[ "${PHASE_0}" == "Succeeded" && "${PHASE_1}" == "Succeeded" ]]; then
-              echo "Both gang scheduling pods succeeded!"
-              break
-            fi
-
-            if [[ "${PHASE_0}" == "Failed" || "${PHASE_1}" == "Failed" ]]; then
-              echo "::error::Gang scheduling pod failed (worker-0=${PHASE_0}, worker-1=${PHASE_1})"
-              kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-                describe pods 2>/dev/null || true
-              exit 1
-            fi
-
-            echo "Waiting for pod completion... worker-0=${PHASE_0}, worker-1=${PHASE_1} (${i}/60)"
-            sleep 10
-          done
-
-          if [[ "${PHASE_0}" != "Succeeded" || "${PHASE_1}" != "Succeeded" ]]; then
-            echo "::error::Gang scheduling pods did not complete within 10 minutes"
-            kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-              describe pods 2>/dev/null || true
-            exit 1
-          fi
-
-          echo "=== gang-worker-0 logs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            logs gang-worker-0 2>/dev/null || true
-          echo "=== gang-worker-1 logs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            logs gang-worker-1 2>/dev/null || true
 
       # --- Cluster Autoscaling validation ---
 
@@ -222,35 +177,14 @@ jobs:
           kubectl --context="kind-${KIND_CLUSTER_NAME}" get queues -A 2>/dev/null || true
           echo "=== KAI scheduler podgroups ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" get podgroups -A 2>/dev/null || true
-          echo "=== Gang scheduling test pods ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            describe pods 2>/dev/null || true
-          echo "=== gang-worker-0 logs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            logs gang-worker-0 --tail=50 2>/dev/null || true
-          echo "=== gang-worker-1 logs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            logs gang-worker-1 --tail=50 2>/dev/null || true
-          echo "=== ResourceClaims ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            get resourceclaims -o yaml 2>/dev/null || true
           echo "=== Non-running pods (all namespaces) ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" get pods -A \
             --field-selector=status.phase!=Running,status.phase!=Succeeded 2>/dev/null || true
-          echo "=== Recent events (gang-scheduling-test) ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gang-scheduling-test \
-            get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
           echo "=== GPU Operator pods ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator get pods -o wide 2>/dev/null || true
           echo "=== Node resources ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" describe nodes 2>/dev/null | \
             grep -A 20 "Allocated resources" || true
-
-      - name: Gang scheduling test cleanup
-        if: always()
-        run: |
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" delete \
-            -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml --ignore-not-found 2>/dev/null || true
 
       - name: GPU Test Cleanup
         if: always()

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -137,11 +137,15 @@ const (
 	ComponentRenderTimeout = 60 * time.Second
 )
 
-// DRA test timeouts for conformance validation.
+// Conformance test timeouts for DRA and gang scheduling validation.
 const (
 	// DRATestPodTimeout is the timeout for the DRA test pod to complete.
 	// The pod runs a simple CUDA device check but may need time for image pull.
 	DRATestPodTimeout = 5 * time.Minute
+
+	// GangTestPodTimeout is the timeout for gang scheduling test pods to complete.
+	// Two pods must be co-scheduled, each pulling a CUDA image and running nvidia-smi.
+	GangTestPodTimeout = 5 * time.Minute
 )
 
 // Pod operation timeouts for validation and agent operations.

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -165,6 +165,12 @@ func (d *Deployer) ensureClusterRole(ctx context.Context) error {
 				Resources: []string{"queues", "podgroups"},
 				Verbs:     []string{"get", "list"},
 			},
+			// Conformance: gang-scheduling — PodGroup lifecycle for functional test
+			{
+				APIGroups: []string{"scheduling.run.ai"},
+				Resources: []string{"podgroups"},
+				Verbs:     []string{"create", "delete"},
+			},
 			// Conformance: Cluster autoscaling (Karpenter)
 			{
 				APIGroups: []string{"karpenter.sh"},

--- a/pkg/validator/checks/conformance/gang_scheduling_check.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check.go
@@ -15,12 +15,31 @@
 package conformance
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/k8s"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	gangTestNamespace = "gang-scheduling-test"
+	gangTestPrefix    = "gang-test-"
+	gangPodPrefix     = "gang-worker-"
+	gangClaimPrefix   = "gang-gpu-claim-"
+	gangGroupPrefix   = "gang-group-"
+	gangMinMembers    = 2
 )
 
 // kaiSchedulerDeployments are the required KAI scheduler components.
@@ -34,10 +53,39 @@ var kaiSchedulerDeployments = []string{
 	"queue-controller",
 }
 
+var podGroupGVR = schema.GroupVersionResource{
+	Group: "scheduling.run.ai", Version: "v2alpha2", Resource: "podgroups",
+}
+
+// gangTestRun holds per-invocation resource names to avoid collisions.
+type gangTestRun struct {
+	suffix    string
+	groupName string
+	pods      [gangMinMembers]string
+	claims    [gangMinMembers]string
+}
+
+func newGangTestRun() (*gangTestRun, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate random suffix", err)
+	}
+	suffix := hex.EncodeToString(b)
+	run := &gangTestRun{
+		suffix:    suffix,
+		groupName: gangGroupPrefix + suffix,
+	}
+	for i := range gangMinMembers {
+		run.pods[i] = fmt.Sprintf("%s%s-%d", gangPodPrefix, suffix, i)
+		run.claims[i] = fmt.Sprintf("%s%s-%d", gangClaimPrefix, suffix, i)
+	}
+	return run, nil
+}
+
 func init() {
 	checks.RegisterCheck(&checks.Check{
 		Name:        "gang-scheduling",
-		Description: "Verify KAI scheduler components and gang scheduling CRDs",
+		Description: "Verify KAI scheduler components, CRDs, and gang scheduling with PodGroup",
 		Phase:       phaseConformance,
 		Func:        CheckGangScheduling,
 		TestName:    "TestGangScheduling",
@@ -45,14 +93,15 @@ func init() {
 }
 
 // CheckGangScheduling validates CNCF requirement #7: Gang Scheduling.
-// Verifies all KAI scheduler component deployments are running and
-// the required gang scheduling CRDs exist.
+// Verifies KAI scheduler deployments are running, required CRDs exist, and
+// exercises gang scheduling by creating a PodGroup with 2 GPU pods that must
+// be co-scheduled via the KAI scheduler.
 func CheckGangScheduling(ctx *checks.ValidationContext) error {
 	if ctx.Clientset == nil {
 		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
 	}
 
-	// 1. All KAI scheduler deployments available
+	// 1. All KAI scheduler deployments available.
 	for _, name := range kaiSchedulerDeployments {
 		if err := verifyDeploymentAvailable(ctx, "kai-scheduler", name); err != nil {
 			return errors.Wrap(errors.ErrCodeNotFound,
@@ -60,7 +109,7 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		}
 	}
 
-	// 2. Required CRDs for gang scheduling
+	// 2. Required CRDs for gang scheduling.
 	dynClient, err := getDynamicClient(ctx)
 	if err != nil {
 		return err
@@ -73,12 +122,264 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		"podgroups.scheduling.run.ai",
 	}
 	for _, crd := range requiredCRDs {
-		_, err := dynClient.Resource(crdGVR).Get(ctx.Context, crd, metav1.GetOptions{})
-		if err != nil {
+		if _, crdErr := dynClient.Resource(crdGVR).Get(ctx.Context, crd, metav1.GetOptions{}); crdErr != nil {
 			return errors.Wrap(errors.ErrCodeNotFound,
-				fmt.Sprintf("gang scheduling CRD %s not found", crd), err)
+				fmt.Sprintf("gang scheduling CRD %s not found", crd), crdErr)
+		}
+	}
+
+	// 3. Pre-flight: ensure enough free GPUs for the gang test.
+	total, free, gpuErr := countAvailableGPUs(ctx.Context, dynClient)
+	if gpuErr != nil {
+		return gpuErr
+	}
+	if free < gangMinMembers {
+		return errors.New(errors.ErrCodeUnavailable,
+			fmt.Sprintf("insufficient free GPUs for gang scheduling test: %d free of %d total (need %d)",
+				free, total, gangMinMembers))
+	}
+
+	// 4. Functional test: create PodGroup with 2 GPU pods, verify co-scheduling.
+	run, err := newGangTestRun()
+	if err != nil {
+		return err
+	}
+
+	defer cleanupGangTestResources(ctx.Context, ctx.Clientset, dynClient, run)
+	if err = deployGangTestResources(ctx.Context, ctx.Clientset, dynClient, run); err != nil {
+		return err
+	}
+
+	pods, err := waitForGangTestPods(ctx.Context, ctx.Clientset, run)
+	if err != nil {
+		return err
+	}
+
+	return validateGangPatterns(pods, run)
+}
+
+// deployGangTestResources creates the namespace, PodGroup, ResourceClaims, and Pods.
+func deployGangTestResources(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, run *gangTestRun) error {
+	// 1. Create namespace (idempotent).
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: gangTestNamespace},
+	}
+	if _, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); k8s.IgnoreAlreadyExists(err) != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
+	}
+
+	// 2. Create PodGroup.
+	podGroup := buildPodGroup(run)
+	if _, err := dynClient.Resource(podGroupGVR).Namespace(gangTestNamespace).Create(
+		ctx, podGroup, metav1.CreateOptions{}); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create PodGroup", err)
+	}
+
+	// 3. Create ResourceClaims and Pods.
+	for i := range gangMinMembers {
+		claim := buildGangResourceClaim(run, i)
+		if _, err := dynClient.Resource(claimGVR).Namespace(gangTestNamespace).Create(
+			ctx, claim, metav1.CreateOptions{}); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal,
+				fmt.Sprintf("failed to create ResourceClaim %s", run.claims[i]), err)
+		}
+
+		pod := buildGangTestPod(run, i)
+		if _, err := clientset.CoreV1().Pods(gangTestNamespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal,
+				fmt.Sprintf("failed to create gang test pod %s", run.pods[i]), err)
 		}
 	}
 
 	return nil
+}
+
+// waitForGangTestPods polls until all gang test pods reach a terminal state.
+func waitForGangTestPods(ctx context.Context, clientset kubernetes.Interface, run *gangTestRun) ([gangMinMembers]*corev1.Pod, error) {
+	var result [gangMinMembers]*corev1.Pod
+
+	waitCtx, cancel := context.WithTimeout(ctx, defaults.GangTestPodTimeout)
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(waitCtx, defaults.PodPollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			allDone := true
+			for i := range gangMinMembers {
+				if result[i] != nil {
+					continue // already terminal
+				}
+				pod, err := clientset.CoreV1().Pods(gangTestNamespace).Get(
+					ctx, run.pods[i], metav1.GetOptions{})
+				if err != nil {
+					return false, errors.Wrap(errors.ErrCodeInternal,
+						fmt.Sprintf("failed to get gang test pod %s", run.pods[i]), err)
+				}
+				switch pod.Status.Phase { //nolint:exhaustive // only terminal states matter
+				case corev1.PodSucceeded, corev1.PodFailed:
+					result[i] = pod
+				default:
+					allDone = false
+				}
+			}
+			return allDone, nil
+		},
+	)
+	if err != nil {
+		if ctx.Err() != nil || waitCtx.Err() != nil {
+			return result, errors.Wrap(errors.ErrCodeTimeout, "gang test pods did not complete in time", err)
+		}
+		return result, errors.Wrap(errors.ErrCodeInternal, "gang test pod polling failed", err)
+	}
+
+	return result, nil
+}
+
+// validateGangPatterns verifies all pods completed successfully and were scheduled by kai-scheduler.
+func validateGangPatterns(pods [gangMinMembers]*corev1.Pod, run *gangTestRun) error {
+	for i, pod := range pods {
+		if pod == nil {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("gang test pod %s result is nil", run.pods[i]))
+		}
+
+		// Pod must have succeeded.
+		if pod.Status.Phase != corev1.PodSucceeded {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("gang test pod %s phase=%s (want Succeeded), gang scheduling may have failed",
+					run.pods[i], pod.Status.Phase))
+		}
+
+		// Pod must use kai-scheduler.
+		if pod.Spec.SchedulerName != "kai-scheduler" {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("gang test pod %s schedulerName=%s (want kai-scheduler)",
+					run.pods[i], pod.Spec.SchedulerName))
+		}
+
+		// Pod must have PodGroup label.
+		if pod.Labels["pod-group.scheduling.run.ai/name"] != run.groupName {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("gang test pod %s missing PodGroup label (want %s)",
+					run.pods[i], run.groupName))
+		}
+
+		// Pod must use DRA (resourceClaims, not device plugin).
+		if len(pod.Spec.ResourceClaims) == 0 {
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("gang test pod %s does not use DRA resourceClaims", run.pods[i]))
+		}
+	}
+
+	return nil
+}
+
+// cleanupGangTestResources removes test resources. Best-effort: errors are ignored.
+// The namespace is intentionally NOT deleted — namespace deletion can hang on DRA finalizers.
+func cleanupGangTestResources(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, run *gangTestRun) {
+	// Delete pods first (releases claim reservations).
+	for i := range gangMinMembers {
+		_ = k8s.IgnoreNotFound(clientset.CoreV1().Pods(gangTestNamespace).Delete(
+			ctx, run.pods[i], metav1.DeleteOptions{}))
+	}
+	// Wait for pod deletions.
+	for i := range gangMinMembers {
+		podName := run.pods[i]
+		waitForDeletion(ctx, func() error {
+			_, err := clientset.CoreV1().Pods(gangTestNamespace).Get(ctx, podName, metav1.GetOptions{})
+			return err
+		})
+	}
+	// Delete claims.
+	for i := range gangMinMembers {
+		_ = k8s.IgnoreNotFound(dynClient.Resource(claimGVR).Namespace(gangTestNamespace).Delete(
+			ctx, run.claims[i], metav1.DeleteOptions{}))
+	}
+	// Delete PodGroup.
+	_ = k8s.IgnoreNotFound(dynClient.Resource(podGroupGVR).Namespace(gangTestNamespace).Delete(
+		ctx, run.groupName, metav1.DeleteOptions{}))
+}
+
+// buildPodGroup returns the unstructured PodGroup for the gang scheduling test.
+func buildPodGroup(run *gangTestRun) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "scheduling.run.ai/v2alpha2",
+			"kind":       "PodGroup",
+			"metadata": map[string]interface{}{
+				"name":      run.groupName,
+				"namespace": gangTestNamespace,
+			},
+			"spec": map[string]interface{}{
+				"minMember": int64(gangMinMembers),
+				"queue":     "default-queue",
+			},
+		},
+	}
+}
+
+// buildGangResourceClaim returns the unstructured ResourceClaim for a gang test pod.
+func buildGangResourceClaim(run *gangTestRun, index int) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "resource.k8s.io/v1",
+			"kind":       "ResourceClaim",
+			"metadata": map[string]interface{}{
+				"name":      run.claims[index],
+				"namespace": gangTestNamespace,
+			},
+			"spec": map[string]interface{}{
+				"devices": map[string]interface{}{
+					"requests": []interface{}{
+						map[string]interface{}{
+							"name": "gpu",
+							"exactly": map[string]interface{}{
+								"deviceClassName": "gpu.nvidia.com",
+								"allocationMode":  "ExactCount",
+								"count":           int64(1),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildGangTestPod returns the Pod spec for a gang scheduling test worker.
+func buildGangTestPod(run *gangTestRun, index int) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      run.pods[index],
+			Namespace: gangTestNamespace,
+			Labels: map[string]string{
+				"pod-group.scheduling.run.ai/name":     run.groupName,
+				"pod-group.scheduling.run.ai/group-id": run.groupName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: "kai-scheduler",
+			RestartPolicy: corev1.RestartPolicyNever,
+			Tolerations: []corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
+			},
+			ResourceClaims: []corev1.PodResourceClaim{
+				{
+					Name:              "gpu",
+					ResourceClaimName: strPtr(run.claims[index]),
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "worker",
+					Image:   "nvidia/cuda:12.9.0-base-ubuntu24.04",
+					Command: []string{"bash", "-c", fmt.Sprintf("nvidia-smi && echo 'Gang worker %d completed successfully'", index)},
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{Name: "gpu"},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/validator/checks/conformance/gang_scheduling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check_unit_test.go
@@ -16,15 +16,48 @@ package conformance
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+// createGPUResourceSlice creates an unstructured ResourceSlice with the given number of GPU devices.
+func createGPUResourceSlice(name string, numDevices int) *unstructured.Unstructured {
+	devices := make([]interface{}, numDevices)
+	for i := range numDevices {
+		devices[i] = map[string]interface{}{
+			"name": fmt.Sprintf("gpu-%d", i),
+			"basic": map[string]interface{}{
+				"attributes": map[string]interface{}{},
+			},
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "resource.k8s.io/v1",
+			"kind":       "ResourceSlice",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"spec": map[string]interface{}{
+				"driver":  gpuDriverName,
+				"devices": devices,
+			},
+		},
+	}
+}
 
 func TestCheckGangScheduling(t *testing.T) {
 	// Build the full set of KAI scheduler deployments for the happy path.
@@ -38,23 +71,30 @@ func TestCheckGangScheduling(t *testing.T) {
 		createDeployment("kai-scheduler", "queue-controller", 1),
 	}
 
+	// Common dynamic objects: CRDs + ResourceSlice with 4 GPUs.
+	fullDynamicObjects := []runtime.Object{
+		createCRD("queues.scheduling.run.ai"),
+		createCRD("podgroups.scheduling.run.ai"),
+		createGPUResourceSlice("gpu-node-0", 4),
+	}
+
 	tests := []struct {
 		name           string
 		k8sObjects     []runtime.Object
 		dynamicObjects []runtime.Object
 		clientset      bool
+		podPhase       corev1.PodPhase
+		claimsListErr  error
 		wantErr        bool
 		errContains    string
 	}{
 		{
-			name:       "all healthy",
-			k8sObjects: allDeployments,
-			dynamicObjects: []runtime.Object{
-				createCRD("queues.scheduling.run.ai"),
-				createCRD("podgroups.scheduling.run.ai"),
-			},
-			clientset: true,
-			wantErr:   false,
+			name:           "all healthy with gang scheduling",
+			k8sObjects:     allDeployments,
+			dynamicObjects: fullDynamicObjects,
+			clientset:      true,
+			podPhase:       corev1.PodSucceeded,
+			wantErr:        false,
 		},
 		{
 			name:        "no clientset",
@@ -65,7 +105,7 @@ func TestCheckGangScheduling(t *testing.T) {
 		{
 			name: "missing one deployment",
 			k8sObjects: []runtime.Object{
-				// Only first 6 — missing queue-controller
+				// Only first 6 -- missing queue-controller
 				createDeployment("kai-scheduler", "kai-scheduler-default", 1),
 				createDeployment("kai-scheduler", "admission", 1),
 				createDeployment("kai-scheduler", "binder", 1),
@@ -103,6 +143,36 @@ func TestCheckGangScheduling(t *testing.T) {
 			wantErr:     true,
 			errContains: "podgroups.scheduling.run.ai not found",
 		},
+		{
+			name:       "insufficient GPUs",
+			k8sObjects: allDeployments,
+			dynamicObjects: []runtime.Object{
+				createCRD("queues.scheduling.run.ai"),
+				createCRD("podgroups.scheduling.run.ai"),
+				createGPUResourceSlice("gpu-node-0", 1), // only 1 GPU, need 2
+			},
+			clientset:   true,
+			wantErr:     true,
+			errContains: "insufficient free GPUs",
+		},
+		{
+			name:           "gang test pod fails",
+			k8sObjects:     allDeployments,
+			dynamicObjects: fullDynamicObjects,
+			clientset:      true,
+			podPhase:       corev1.PodFailed,
+			wantErr:        true,
+			errContains:    "gang scheduling may have failed",
+		},
+		{
+			name:           "resourceclaim list fails",
+			k8sObjects:     allDeployments,
+			dynamicObjects: fullDynamicObjects,
+			clientset:      true,
+			claimsListErr:  fmt.Errorf("resourceclaims list failed"),
+			wantErr:        true,
+			errContains:    "failed to list ResourceClaims",
+		},
 	}
 
 	for _, tt := range tests {
@@ -113,12 +183,81 @@ func TestCheckGangScheduling(t *testing.T) {
 				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
 				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
 
+				// Track deleted pods to return NotFound on subsequent Gets.
+				var mu sync.Mutex
+				deletedPods := make(map[string]bool)
+
+				// Reactor: match any pod with the gang worker prefix.
+				// Returns a pod with the desired phase and correct gang labels.
+				clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					ga := action.(k8stesting.GetAction)
+					if strings.HasPrefix(ga.GetName(), gangPodPrefix) && ga.GetNamespace() == gangTestNamespace {
+						mu.Lock()
+						deleted := deletedPods[ga.GetName()]
+						mu.Unlock()
+						if deleted {
+							return true, nil, k8serrors.NewNotFound(
+								schema.GroupResource{Resource: "pods"}, ga.GetName())
+						}
+						// Extract suffix from pod name: "gang-worker-SUFFIX-N" -> SUFFIX
+						nameAfterPrefix := ga.GetName()[len(gangPodPrefix):]
+						lastDash := strings.LastIndex(nameAfterPrefix, "-")
+						suffix := nameAfterPrefix[:lastDash]
+						groupName := gangGroupPrefix + suffix
+
+						return true, &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      ga.GetName(),
+								Namespace: gangTestNamespace,
+								Labels: map[string]string{
+									"pod-group.scheduling.run.ai/name":     groupName,
+									"pod-group.scheduling.run.ai/group-id": groupName,
+								},
+							},
+							Spec: corev1.PodSpec{
+								SchedulerName: "kai-scheduler",
+								RestartPolicy: corev1.RestartPolicyNever,
+								ResourceClaims: []corev1.PodResourceClaim{
+									{Name: "gpu", ResourceClaimName: strPtr("test-claim")},
+								},
+								Containers: []corev1.Container{
+									{Name: "worker", Image: "nvidia/cuda:12.9.0-base-ubuntu24.04"},
+								},
+							},
+							Status: corev1.PodStatus{Phase: tt.podPhase},
+						}, nil
+					}
+					return false, nil, nil
+				})
+
+				// Reactor: mark pod as deleted so subsequent Gets return NotFound.
+				clientset.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					da := action.(k8stesting.DeleteAction)
+					if strings.HasPrefix(da.GetName(), gangPodPrefix) && da.GetNamespace() == gangTestNamespace {
+						mu.Lock()
+						deletedPods[da.GetName()] = true
+						mu.Unlock()
+						return true, nil, nil
+					}
+					return false, nil, nil
+				})
+
 				scheme := runtime.NewScheme()
 				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 					map[schema.GroupVersionResource]string{
 						{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+						{Group: "scheduling.run.ai", Version: "v2alpha2", Resource: "podgroups"}:              "PodGroupList",
+						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}:                 "ResourceClaimList",
+						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices"}:                 "ResourceSliceList",
 					},
 					tt.dynamicObjects...)
+				if tt.claimsListErr != nil {
+					dynClient.PrependReactor("list", "resourceclaims",
+						func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+							return true, nil, tt.claimsListErr
+						},
+					)
+				}
 
 				ctx = &checks.ValidationContext{
 					Context:       context.Background(),

--- a/pkg/validator/checks/conformance/helpers.go
+++ b/pkg/validator/checks/conformance/helpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -132,4 +133,55 @@ func containsAllMetrics(text string, required []string) []string {
 		}
 	}
 	return missing
+}
+
+// gpuDriverName is the DRA driver name for NVIDIA GPUs.
+const gpuDriverName = "gpu.nvidia.com"
+
+// countAvailableGPUs counts total GPU devices from ResourceSlices and subtracts
+// allocated devices from ResourceClaims to determine how many are free.
+func countAvailableGPUs(ctx context.Context, dynClient dynamic.Interface) (total, free int, err error) {
+	sliceGVR := schema.GroupVersionResource{
+		Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices",
+	}
+
+	// Count total GPU devices from ResourceSlices.
+	slices, err := dynClient.Resource(sliceGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, 0, errors.Wrap(errors.ErrCodeInternal, "failed to list ResourceSlices", err)
+	}
+	for _, slice := range slices.Items {
+		driver, _, _ := unstructured.NestedString(slice.Object, "spec", "driver")
+		if driver != gpuDriverName {
+			continue
+		}
+		devices, found, _ := unstructured.NestedSlice(slice.Object, "spec", "devices")
+		if found {
+			total += len(devices)
+		}
+	}
+
+	// Count allocated GPU devices from ResourceClaims.
+	var allocated int
+	claims, err := dynClient.Resource(claimGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, 0, errors.Wrap(errors.ErrCodeInternal, "failed to list ResourceClaims", err)
+	}
+	for _, claim := range claims.Items {
+		results, found, _ := unstructured.NestedSlice(claim.Object, "status", "allocation", "devices", "results")
+		if !found {
+			continue
+		}
+		for _, r := range results {
+			result, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if result["driver"] == gpuDriverName {
+				allocated++
+			}
+		}
+	}
+
+	return total, total - allocated, nil
 }


### PR DESCRIPTION
## Summary
- Make the gang-scheduling conformance check fully self-contained by programmatically creating test resources (PodGroup + 2 GPU pods with DRA ResourceClaims) instead of relying on pre-deployed manifests
- Add GPU availability pre-flight check via ResourceSlices/ResourceClaims to fail fast when fewer than 2 GPUs are free, avoiding a 5-minute timeout
- Add `countAvailableGPUs()` shared helper in `conformance/helpers.go` for reuse by other GPU-dependent checks
- Add PodGroup create/delete RBAC for the validator service account

## Test plan
- [x] Unit tests pass with race detector (8 test cases including insufficient GPUs, pod failure, missing deployments/CRDs)
- [x] Full conformance test suite passes
- [ ] CI: lint, unit tests, build
- [ ] CI: GPU workflow validates gang scheduling end-to-end