### PR TITLE
chore: upgrade Go to 1.26.0

### DIFF
--- a/.github/actions/chainsaw/action.yml
+++ b/.github/actions/chainsaw/action.yml
@@ -38,7 +38,19 @@ runs:
 
     - name: Install Chainsaw
       shell: bash
-      run: go install github.com/kyverno/chainsaw@${{ inputs.chainsaw_version }}
+      run: |
+        set -euo pipefail
+        VERSION="${{ inputs.chainsaw_version }}"
+        VERSION="${VERSION#v}"
+        TAR="chainsaw_linux_amd64.tar.gz"
+        URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
+        TMP="$(mktemp -d)"
+        curl -fsSL -o "${TMP}/${TAR}" "${URL}"
+        tar -xzf "${TMP}/${TAR}" -C "${TMP}"
+        sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
+        sudo chmod +x /usr/local/bin/chainsaw
+        rm -rf "${TMP}"
+        chainsaw version
 
     - name: Build aicr binary
       shell: bash

--- a/.github/actions/integration/action.yml
+++ b/.github/actions/integration/action.yml
@@ -72,7 +72,18 @@ runs:
     - name: Install Chainsaw
       shell: bash
       run: |
-        go install github.com/kyverno/chainsaw@${{ inputs.chainsaw_version }}
+        set -euo pipefail
+        VERSION="${{ inputs.chainsaw_version }}"
+        VERSION="${VERSION#v}"
+        TAR="chainsaw_linux_amd64.tar.gz"
+        URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
+        TMP="$(mktemp -d)"
+        curl -fsSL -o "${TMP}/${TAR}" "${URL}"
+        tar -xzf "${TMP}/${TAR}" -C "${TMP}"
+        sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
+        sudo chmod +x /usr/local/bin/chainsaw
+        rm -rf "${TMP}"
+        chainsaw version
 
     - name: Run Integration Tests
       shell: bash

--- a/.github/actions/security-scan/action.yml
+++ b/.github/actions/security-scan/action.yml
@@ -45,7 +45,7 @@ runs:
   using: 'composite'
   steps:
     - name: Run Trivy Security Scan
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
+      uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518  # v0.34.1
       with:
         scan-type: ${{ inputs.scan_type }}
         scan-ref: ${{ inputs.scan_ref }}

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -115,8 +115,17 @@ jobs:
 
       - name: Install chainsaw
         run: |
-          CHAINSAW_VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
-          GOFLAGS= go install "github.com/kyverno/chainsaw@${CHAINSAW_VERSION}"
+          set -euo pipefail
+          VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
+          VERSION="${VERSION#v}"
+          TAR="chainsaw_linux_amd64.tar.gz"
+          URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
+          TMP="$(mktemp -d)"
+          curl -fsSL -o "${TMP}/${TAR}" "${URL}"
+          tar -xzf "${TMP}/${TAR}" -C "${TMP}"
+          sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
+          sudo chmod +x /usr/local/bin/chainsaw
+          rm -rf "${TMP}"
           chainsaw version
 
       - name: Run chainsaw health checks

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -96,8 +96,17 @@ jobs:
 
       - name: Install chainsaw
         run: |
-          CHAINSAW_VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
-          GOFLAGS= go install "github.com/kyverno/chainsaw@${CHAINSAW_VERSION}"
+          set -euo pipefail
+          VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
+          VERSION="${VERSION#v}"
+          TAR="chainsaw_linux_amd64.tar.gz"
+          URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
+          TMP="$(mktemp -d)"
+          curl -fsSL -o "${TMP}/${TAR}" "${URL}"
+          tar -xzf "${TMP}/${TAR}" -C "${TMP}"
+          sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
+          sudo chmod +x /usr/local/bin/chainsaw
+          rm -rf "${TMP}"
           chainsaw version
 
       - name: Run chainsaw health checks

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -221,7 +221,7 @@ jobs:
         uses: ./.github/actions/ghcr-login
 
       - name: Scan container image
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518  # v0.34.1
         with:
           scan-type: 'image'
           image-ref: '${{ matrix.image }}:${{ github.ref_name }}'

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Scan Repo
         continue-on-error: true
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518  # v0.34.1
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,7 @@ version: "2"
 
 # Run configuration
 run:
-  go: "1.25"
+  go: "1.26"
   timeout: 5m
   tests: true
   modules-download-mode: readonly

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ignore:
-  - vulnerability: CVE-2025-61732
-    package:
-      name: stdlib
-      version: go1.24.12
-    until: "2025-12-31"
-  - vulnerability: CVE-2025-68121
-    package:
-      name: stdlib
-      version: go1.24.12
-    until: "2025-12-31"
+ignore: []
+
+exclude:
+  - '**/.terraform/**'

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -14,19 +14,19 @@
 
 # Language Versions
 languages:
-  go: '1.25.7'
+  go: '1.26.0'
 
 # Build Tools
 build_tools:
   goreleaser: 'v2'
   ko: 'v0.18.0'
-  crane: 'v0.20.6'
+  crane: 'v0.21.0'
   git_cliff: '2.12.0'
 
 # Linting
 linting:
   golangci_lint: 'v2.10.1'
-  yamllint: '1.35.0'
+  yamllint: '1.38.0'
   addlicense: 'v1.1.1'
   go_licenses: 'v1.6.0'
 
@@ -38,9 +38,9 @@ security_tools:
 testing_tools:
   kubectl: 'v1.35.0'
   kind: '0.31.0'
-  ctlptl: '0.8.43'
-  tilt: '0.35.0'
-  helm: 'v4.1.0'
+  ctlptl: '0.9.0'
+  tilt: '0.36.3'
+  helm: 'v4.1.1'
   kwok: 'v0.7.0'
   chainsaw: 'v0.2.14'
   yq: 'v4.52.4'

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -18,7 +18,7 @@
 # ---------------------------------------------------------------------------
 # Builder stage: compile aicr CLI and pre-compiled test binaries
 # ---------------------------------------------------------------------------
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /workspace
 

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -1071,7 +1071,7 @@ go build -ldflags="$(LDFLAGS)" -o bin/aicrd ./cmd/aicrd
 Production images are built with ko (automated in CI/CD). For local development:
 
 ```dockerfile
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN go build -ldflags="-X github.com/NVIDIA/aicr/pkg/api.version=v1.0.0" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/aicr
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -365,11 +365,21 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
     else
         log_info "Installing Chainsaw ${CHAINSAW_VERSION}..."
         if prompt_continue; then
-            if command_exists go; then
-                go install github.com/kyverno/chainsaw@"${CHAINSAW_VERSION}"
-            else
-                log_warning "Install chainsaw manually: go install github.com/kyverno/chainsaw@${CHAINSAW_VERSION}"
-            fi
+            local ver="${CHAINSAW_VERSION#v}"
+            local os_name; os_name="$(uname -s | tr '[:upper:]' '[:lower:]')"
+            local arch; arch="$(uname -m)"
+            case "${arch}" in
+                x86_64) arch="amd64" ;;
+                aarch64|arm64) arch="arm64" ;;
+            esac
+            local tar="chainsaw_${os_name}_${arch}.tar.gz"
+            local url="https://github.com/kyverno/chainsaw/releases/download/v${ver}/${tar}"
+            local tmp; tmp="$(mktemp -d)"
+            curl -fsSL -o "${tmp}/${tar}" "${url}"
+            tar -xzf "${tmp}/${tar}" -C "${tmp}"
+            sudo mv "${tmp}/chainsaw" /usr/local/bin/chainsaw
+            sudo chmod +x /usr/local/bin/chainsaw
+            rm -rf "${tmp}"
             log_success "Chainsaw installed"
         fi
     fi

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -365,21 +365,21 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
     else
         log_info "Installing Chainsaw ${CHAINSAW_VERSION}..."
         if prompt_continue; then
-            local ver="${CHAINSAW_VERSION#v}"
-            local os_name; os_name="$(uname -s | tr '[:upper:]' '[:lower:]')"
-            local arch; arch="$(uname -m)"
-            case "${arch}" in
-                x86_64) arch="amd64" ;;
-                aarch64|arm64) arch="arm64" ;;
+            CHAINSAW_VER="${CHAINSAW_VERSION#v}"
+            CHAINSAW_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+            CHAINSAW_ARCH="$(uname -m)"
+            case "${CHAINSAW_ARCH}" in
+                x86_64) CHAINSAW_ARCH="amd64" ;;
+                aarch64|arm64) CHAINSAW_ARCH="arm64" ;;
             esac
-            local tar="chainsaw_${os_name}_${arch}.tar.gz"
-            local url="https://github.com/kyverno/chainsaw/releases/download/v${ver}/${tar}"
-            local tmp; tmp="$(mktemp -d)"
-            curl -fsSL -o "${tmp}/${tar}" "${url}"
-            tar -xzf "${tmp}/${tar}" -C "${tmp}"
-            sudo mv "${tmp}/chainsaw" /usr/local/bin/chainsaw
+            CHAINSAW_TAR="chainsaw_${CHAINSAW_OS}_${CHAINSAW_ARCH}.tar.gz"
+            CHAINSAW_URL="https://github.com/kyverno/chainsaw/releases/download/v${CHAINSAW_VER}/${CHAINSAW_TAR}"
+            CHAINSAW_TMP="$(mktemp -d)"
+            curl -fsSL -o "${CHAINSAW_TMP}/${CHAINSAW_TAR}" "${CHAINSAW_URL}"
+            tar -xzf "${CHAINSAW_TMP}/${CHAINSAW_TAR}" -C "${CHAINSAW_TMP}"
+            sudo mv "${CHAINSAW_TMP}/chainsaw" /usr/local/bin/chainsaw
             sudo chmod +x /usr/local/bin/chainsaw
-            rm -rf "${tmp}"
+            rm -rf "${CHAINSAW_TMP}"
             log_success "Chainsaw installed"
         fi
     fi


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.7 to 1.26.0 in `go.mod`, `.settings.yaml`, `Dockerfile.validator`, `.golangci.yaml`, and `docs/contributor/api-server.md`
- Remove 2 stdlib CVE ignores (CVE-2025-61732, CVE-2025-68121) from `.grype.yaml` — fixed in Go 1.26.0
- Add `.terraform` directory exclusion in `.grype.yaml` to skip gitignored Terraform provider binaries
- Bump tool versions via `make upgrade` (trivy-action v0.34.1, crane v0.21.0, yamllint 1.38.0, ctlptl 0.9.0, tilt 0.36.3, helm v4.1.1)

## Test plan
- [x] `make test` — all 46 packages pass with race detector (73.4% coverage)
- [x] `make lint` — 0 issues
- [x] `make scan` — no vulnerabilities found