### PR TITLE
fix: pass cluster K8s version to Helm SDK chart rendering

### DIFF
--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -1473,7 +1473,7 @@ func (v *Validator) ensureDataConfigMaps(
 	// NOTE: This intentionally mutates recipeResult.ComponentRefs[].ExpectedResources
 	// in place *before* serialization below, so the check pod sees the full
 	// expected resources list (manual + auto-discovered) in the deployed ConfigMap.
-	if resolveErr := resolveExpectedResources(ctx, recipeResult); resolveErr != nil {
+	if resolveErr := resolveExpectedResources(ctx, recipeResult, kubeVersionFromSnapshot(snap)); resolveErr != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to resolve expected resources", resolveErr)
 	}
 

--- a/pkg/validator/resource_discovery.go
+++ b/pkg/validator/resource_discovery.go
@@ -25,9 +25,12 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/manifest"
+	"github.com/NVIDIA/aicr/pkg/measurement"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
 	"sigs.k8s.io/yaml"
@@ -53,7 +56,7 @@ type componentDiscovery struct {
 // (HTTP repos and OCI registries). Offline/air-gapped environments will see
 // warnings for components with chart coordinates but can still use manually
 // declared expectedResources.
-func resolveExpectedResources(ctx context.Context, recipeResult *recipe.RecipeResult) error {
+func resolveExpectedResources(ctx context.Context, recipeResult *recipe.RecipeResult, kubeVersion string) error {
 	summaries := make([]componentDiscovery, 0, len(recipeResult.ComponentRefs))
 
 	for i := range recipeResult.ComponentRefs {
@@ -82,7 +85,7 @@ func resolveExpectedResources(ctx context.Context, recipeResult *recipe.RecipeRe
 			slog.Debug("auto-discovering expected resources via helm template",
 				"component", ref.Name, "chart", ref.Chart, "version", ref.Version)
 
-			chartResources, err := renderHelmTemplate(ctx, *ref, values)
+			chartResources, err := renderHelmTemplate(ctx, *ref, values, kubeVersion)
 			if err != nil {
 				slog.Warn("failed to render helm chart for expected resource discovery",
 					"component", ref.Name, "error", err)
@@ -160,7 +163,7 @@ func countByKind(resources []recipe.ExpectedResource) string {
 // renderHelmTemplate uses the Helm Go SDK to render a chart (equivalent to
 // `helm template`), then extracts workload resources from the output.
 // Supports both HTTP repos and OCI registries (oci:// prefix in source).
-func renderHelmTemplate(ctx context.Context, ref recipe.ComponentRef, values map[string]any) ([]recipe.ExpectedResource, error) {
+func renderHelmTemplate(ctx context.Context, ref recipe.ComponentRef, values map[string]any, kubeVersion string) ([]recipe.ExpectedResource, error) {
 	ctx, cancel := context.WithTimeout(ctx, defaults.ComponentRenderTimeout)
 	defer cancel()
 
@@ -188,6 +191,13 @@ func renderHelmTemplate(ctx context.Context, ref recipe.ComponentRef, values map
 	install.Replace = true
 	if ref.Version != "" {
 		install.Version = ref.Version
+	}
+
+	if kubeVersion != "" {
+		kv, parseErr := chartutil.ParseKubeVersion(kubeVersion)
+		if parseErr == nil {
+			install.KubeVersion = kv
+		}
 	}
 
 	chartPath, err := locateChart(install, ref, settings)
@@ -350,6 +360,28 @@ func mergeExpectedResources(manual, discovered []recipe.ExpectedResource) []reci
 	}
 
 	return result
+}
+
+// kubeVersionFromSnapshot extracts the Kubernetes server version from a snapshot.
+// Returns empty string if not found.
+func kubeVersionFromSnapshot(snap *snapshotter.Snapshot) string {
+	if snap == nil {
+		return ""
+	}
+	for _, m := range snap.Measurements {
+		if m == nil || m.Type != measurement.TypeK8s {
+			continue
+		}
+		for _, st := range m.Subtypes {
+			if st.Name != "server" {
+				continue
+			}
+			if reading, ok := st.Data[measurement.KeyVersion]; ok {
+				return reading.String()
+			}
+		}
+	}
+	return ""
 }
 
 // splitYAMLDocuments splits a multi-document YAML string on "---" separators.

--- a/pkg/validator/resource_discovery_test.go
+++ b/pkg/validator/resource_discovery_test.go
@@ -383,7 +383,7 @@ func TestResolveExpectedResources_NoManifestFiles(t *testing.T) {
 		},
 	}
 
-	err := resolveExpectedResources(t.Context(), recipeResult)
+	err := resolveExpectedResources(t.Context(), recipeResult, "")
 	if err != nil {
 		t.Fatalf("resolveExpectedResources() error = %v", err)
 	}
@@ -408,7 +408,7 @@ func TestResolveExpectedResources_ManualOnly(t *testing.T) {
 		},
 	}
 
-	_ = resolveExpectedResources(t.Context(), recipeResult)
+	_ = resolveExpectedResources(t.Context(), recipeResult, "")
 
 	got := recipeResult.ComponentRefs[0].ExpectedResources
 	if len(got) != 1 {
@@ -453,7 +453,7 @@ func TestResolveExpectedResources_MultipleComponents(t *testing.T) {
 		},
 	}
 
-	_ = resolveExpectedResources(t.Context(), recipeResult)
+	_ = resolveExpectedResources(t.Context(), recipeResult, "")
 
 	// comp-a: should have 1 discovered resource from manifestFiles
 	if got := len(recipeResult.ComponentRefs[0].ExpectedResources); got != 1 {
@@ -640,7 +640,7 @@ func TestResolveExpectedResources_ManifestFileAutoDetect(t *testing.T) {
 		},
 	}
 
-	_ = resolveExpectedResources(t.Context(), recipeResult)
+	_ = resolveExpectedResources(t.Context(), recipeResult, "")
 
 	got := recipeResult.ComponentRefs[0].ExpectedResources
 	want := []recipe.ExpectedResource{
@@ -677,7 +677,7 @@ func TestResolveExpectedResources_ManualOverridesManifestFile(t *testing.T) {
 		},
 	}
 
-	_ = resolveExpectedResources(t.Context(), recipeResult)
+	_ = resolveExpectedResources(t.Context(), recipeResult, "")
 
 	got := recipeResult.ComponentRefs[0].ExpectedResources
 	want := []recipe.ExpectedResource{
@@ -707,7 +707,7 @@ func TestResolveExpectedResources_SkipsEmptyChartCoordinates(t *testing.T) {
 		},
 	}
 
-	err := resolveExpectedResources(t.Context(), recipeResult)
+	err := resolveExpectedResources(t.Context(), recipeResult, "")
 	if err != nil {
 		t.Errorf("resolveExpectedResources() error = %v", err)
 	}
@@ -793,7 +793,7 @@ spec:
 		Version:   "0.1.0",
 	}
 
-	resources, err := renderHelmTemplate(t.Context(), ref, nil)
+	resources, err := renderHelmTemplate(t.Context(), ref, nil, "")
 	if err != nil {
 		t.Fatalf("renderHelmTemplate() error = %v", err)
 	}
@@ -881,7 +881,7 @@ spec:
 		},
 	}
 
-	resources, err := renderHelmTemplate(t.Context(), ref, values)
+	resources, err := renderHelmTemplate(t.Context(), ref, values, "")
 	if err != nil {
 		t.Fatalf("renderHelmTemplate() error = %v", err)
 	}
@@ -923,7 +923,7 @@ spec:
 		"statefulset": map[string]any{"enabled": false},
 	}
 
-	resources, err = renderHelmTemplate(t.Context(), ref2, disabledValues)
+	resources, err = renderHelmTemplate(t.Context(), ref2, disabledValues, "")
 	if err != nil {
 		t.Fatalf("renderHelmTemplate() with disabled error = %v", err)
 	}
@@ -949,7 +949,7 @@ func TestResolveExpectedResources_ContextCancelled(t *testing.T) {
 		},
 	}
 
-	err := resolveExpectedResources(ctx, recipeResult)
+	err := resolveExpectedResources(ctx, recipeResult, "")
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}


### PR DESCRIPTION
## Summary

- Extract K8s server version from snapshot and pass to Helm SDK's `install.KubeVersion` during chart rendering
- Fixes `chart requires kubeVersion: >= X which is incompatible with Kubernetes v1.20.0` errors in validation

## Root cause

PR #186 replaced the `helm` CLI subprocess with the Helm Go SDK for chart rendering. In client-only mode, the SDK copies `chartutil.DefaultCapabilities` which hardcodes `k8sVersionMajor=1, k8sVersionMinor=20` (Kubernetes v1.20.0). The `install.KubeVersion` override was never set, so charts with `kubeVersion` constraints (cert-manager, network-operator, skyhook-operator, etc.) fail rendering.

## Fix

- Add `kubeVersion` parameter to `resolveExpectedResources()` and `renderHelmTemplate()`
- New `kubeVersionFromSnapshot()` helper extracts the version from the K8s server subtype
- Set `install.KubeVersion` via `chartutil.ParseKubeVersion()` before `RunWithContext()`
- When no snapshot is available (tests), empty string preserves existing default behavior

## Test plan
- [x] `go test -race ./pkg/validator/...` — all tests pass
- [x] `make test` — full suite passes
- [x] `make lint` — 0 issues
- [ ] CI GPU Inference Test should now render all charts successfully