### PR TITLE
feat(uat): AWS UAT pipeline with Chainsaw CUJ tests

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -23,9 +23,10 @@ permissions:
   contents: read
   actions: read
   id-token: write
+  packages: write
 
 jobs:
-  integration-test-aws:
+  uat-aws:
     if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -35,15 +36,52 @@ jobs:
       GITHUB_ACTIONS_ROLE_NAME: "github-actions-role-aicr"
       DEPLOYMENT_ID: "aicr-uat-${{ github.run_id }}"
       CLUSTER_CONFIG: tests/uat/aws/config.yaml
+      EKS_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:c631e2bebf605690c6cfbb072cb2116023fd0f6b43c2c4c6ead0416ee586635d"
+      VALIDATOR_IMAGE: "ghcr.io/nvidia/aicr-validator"
+      VALIDATOR_TAG: "uat-${{ github.run_id }}"
 
       # Debug
       SKIP_DELETE: "false"  # skip cluster deletion
-      TEST_TAG: "v0.7.7"    # use this to qualify a release
 
     steps:
       # Checkout
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # Versions
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      # Build from source
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
+        with:
+          go-version: '${{ steps.versions.outputs.go }}'
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            vendor/modules.txt
+
+      - name: Build aicr binary
+        env:
+          GOFLAGS: -mod=vendor
+        run: |
+          go build -o ./aicr ./cmd/aicr
+          ./aicr --version
+
+      - name: Authenticate to GHCR
+        uses: ./.github/actions/ghcr-login
+
+      - name: Build and push validator image
+        run: |
+          IMAGE="${VALIDATOR_IMAGE}:${VALIDATOR_TAG}"
+          docker build -f Dockerfile.validator \
+            --build-arg VERSION="${VALIDATOR_TAG}" \
+            --build-arg COMMIT="${{ github.sha }}" \
+            --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -t "${IMAGE}" .
+          docker push "${IMAGE}"
 
       # Auth
       - name: Configure AWS credentials
@@ -54,53 +92,38 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-UAT-AICR
 
-      # Deps
-      - name: Ensure Deps
-        id: deps
+      # Capacity check (reads desired count and reservation ID from cluster config)
+      - name: Check EC2 capacity reservation
+        id: capacity
         run: |
-          set -euox pipefail
+          set -euo pipefail
+          GPU_WORKER='.compute.nodeGroups.workers[] | select(.name == "gpu-worker")'
+          DESIRED=$(yq eval "${GPU_WORKER} | .capacity.desired" "$CLUSTER_CONFIG")
+          RESERVATION=$(yq eval "${GPU_WORKER} | .capacity.reservation.target" "$CLUSTER_CONFIG")
+          echo "Reservation: ${RESERVATION}, desired: ${DESIRED}"
 
-          # Install kubectl if not present
-          if ! command -v kubectl >/dev/null 2>&1; then
-            echo "Installing kubectl..."
-            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-            chmod +x kubectl
-            sudo mv kubectl /usr/local/bin/
+          AVAILABLE=$(aws ec2 describe-capacity-reservations \
+            --capacity-reservation-ids "${RESERVATION}" \
+            --query 'CapacityReservations[0].AvailableInstanceCount' \
+            --output text)
+          echo "available=${AVAILABLE}" >> "$GITHUB_OUTPUT"
+          echo "Available instances in reservation ${RESERVATION}: ${AVAILABLE}"
+          if [[ "${AVAILABLE}" -lt "${DESIRED}" ]]; then
+            echo "::error::Insufficient capacity: need ${DESIRED} instances, only ${AVAILABLE} available in reservation ${RESERVATION}"
+            exit 1
           fi
-          kubectl version --client
 
-          # Install yq if not present
-          if ! command -v yq >/dev/null 2>&1; then
-            echo "Installing yq..."
-            curl -fsSL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64"
-            chmod +x /usr/local/bin/yq
-          fi
-          yq --version
-
-          # Install chainsaw
-          CHAINSAW_VERSION="0.2.14"
-          TAR="chainsaw_linux_amd64.tar.gz"
-          URL="https://github.com/kyverno/chainsaw/releases/download/v${CHAINSAW_VERSION}/${TAR}"
-          TMP="$(mktemp -d)"
-          curl -fsSL -o "${TMP}/${TAR}" "${URL}"
-          tar -xzf "${TMP}/${TAR}" -C "${TMP}"
-          sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
-          sudo chmod +x /usr/local/bin/chainsaw
-          rm -rf "${TMP}"
-          chainsaw version
-
-          # Download aicr release binary
-          TAG="${TEST_TAG#v}"
-          ARCHIVE="aicr_${TAG}_linux_amd64.tar.gz"
-          URL="https://github.com/NVIDIA/aicr/releases/download/${TEST_TAG}/${ARCHIVE}"
-          echo "Downloading aicr ${TEST_TAG} from ${URL}..."
-          TMP="$(mktemp -d)"
-          curl -fsSL -o "${TMP}/${ARCHIVE}" "${URL}"
-          tar -xzf "${TMP}/${ARCHIVE}" -C "${TMP}"
-          sudo mv "${TMP}/aicr" /usr/local/bin/aicr
-          sudo chmod +x /usr/local/bin/aicr
-          rm -rf "${TMP}"
-          aicr version
+      # Deps
+      - name: Install tools
+        id: deps
+        uses: ./.github/actions/setup-build-tools
+        with:
+          install_kubectl: 'true'
+          kubectl_version: '${{ steps.versions.outputs.kubectl }}'
+          install_yq: 'true'
+          yq_version: '${{ steps.versions.outputs.yq }}'
+          install_chainsaw: 'true'
+          chainsaw_version: '${{ steps.versions.outputs.chainsaw }}'
 
       # Config
       - name: Update Config
@@ -122,7 +145,7 @@ jobs:
             -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
             -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
             -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
-            ghcr.io/mchmarny/cluster/eks:latest apply
+            ${{ env.EKS_IMAGE }} apply
 
       # Connect
       - name: Connect to Cluster
@@ -136,13 +159,16 @@ jobs:
           echo "Verifying cluster connection..."
           kubectl get nodes
 
-      # Test
+      # Test (capped to guarantee teardown headroom within the 90m job timeout)
       - name: Run UAT Tests
         id: tests
         if: steps.client.outcome == 'success'
+        timeout-minutes: 30
         shell: bash
         env:
-          AICR_BIN: /usr/local/bin/aicr
+          AICR_BIN: ${{ github.workspace }}/aicr
+          AICR_IMAGE: "${{ env.VALIDATOR_IMAGE }}:${{ env.VALIDATOR_TAG }}"
+          AICR_VALIDATOR_IMAGE: "${{ env.VALIDATOR_IMAGE }}:${{ env.VALIDATOR_TAG }}"
         run: |
           set -euxo pipefail
           chainsaw test \
@@ -163,13 +189,28 @@ jobs:
               -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
               -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
               -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
-              ghcr.io/mchmarny/cluster/eks:latest destroy; then
+              ${{ env.EKS_IMAGE }} destroy; then
               echo "Cluster destroyed successfully"
               break
             fi
             echo "Destroy attempt ${attempt} failed, retrying..."
             sleep 30
           done
+
+      # Cleanup
+      - name: Cleanup validator image
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Delete the UAT-tagged image version to avoid GHCR clutter
+          VERSION_ID=$(gh api \
+            repos/${{ github.repository }}/packages/container/aicr-validator/versions \
+            --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true
+          if [[ -n "${VERSION_ID}" ]]; then
+            gh api --method DELETE \
+              repos/${{ github.repository }}/packages/container/aicr-validator/versions/${VERSION_ID} || true
+          fi
 
       # Artifacts
       - name: Upload Test Artifacts
@@ -186,8 +227,12 @@ jobs:
         if: always()
         run: |
           echo "## UAT Results (AWS)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Build:** \`${{ github.sha }}\` (branch: \`${{ github.ref_name }}\`)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Phase | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Capacity | ${{ steps.capacity.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Dependencies | ${{ steps.deps.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Config | ${{ steps.config.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Cluster | ${{ steps.infra.outcome }} |" >> $GITHUB_STEP_SUMMARY

--- a/infra/uat-aws-account/README.md
+++ b/infra/uat-aws-account/README.md
@@ -1,0 +1,247 @@
+# AWS Account OIDC Setup for GitHub Actions
+
+Terraform configuration for AWS IAM OIDC federation with GitHub Actions. Enables keyless authentication for the daily UAT workflow that creates ephemeral EKS clusters.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.9.5
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) configured with administrative credentials
+- AWS account with permissions to create IAM roles and policies
+- GitHub OIDC provider already registered in the AWS account (`token.actions.githubusercontent.com`)
+
+## What This Creates
+
+- **IAM Role**: `github-actions-role-aicr` with scoped permissions for EKS cluster lifecycle
+- **IAM Policy**: Scoped permissions for EKS, EC2, CloudFormation, Auto Scaling, KMS, CloudWatch Logs, and IAM (restricted to `aicr-*` resources with explicit privilege escalation deny)
+- **Trust Relationship**: OIDC federation limited to `NVIDIA/aicr` repository, `main` branch only
+
+The OIDC provider itself is **not** managed by this configuration. It references the existing account-wide provider via a `data` source. This avoids conflicts when multiple projects share the same provider.
+
+## Architecture
+
+```mermaid
+graph LR
+    GHA[GitHub Actions] -->|OIDC Token| AWS[AWS STS]
+    AWS -->|Assume Role| ROLE[github-actions-role-aicr]
+    ROLE -->|Permissions| EKS[EKS Cluster]
+    ROLE -->|Permissions| EC2[EC2 Resources]
+    ROLE -->|Scoped to aicr-*| IAM[IAM Resources]
+```
+
+## Usage
+
+1. **Initialize Terraform:**
+   ```bash
+   terraform init
+   ```
+
+2. **Preview changes:**
+   ```bash
+   terraform plan
+   ```
+
+3. **Apply:**
+   ```bash
+   terraform apply
+   ```
+
+4. **Note the outputs** for use in GitHub Actions:
+   ```bash
+   terraform output
+   ```
+
+To override defaults, pass variables at apply time:
+```bash
+terraform apply -var="aws_region=us-west-2"
+```
+
+## Configuration Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `aws_region` | AWS region for resources | `us-east-1` |
+| `git_repo` | GitHub repository (format: owner/repo) | `NVIDIA/aicr` |
+| `github_actions_role_name` | Name for the IAM role | `github-actions-role-aicr` |
+| `oidc_provider_url` | GitHub OIDC provider URL | `https://token.actions.githubusercontent.com` |
+| `oidc_audience` | OIDC audience | `sts.amazonaws.com` |
+
+## Permissions Granted
+
+### Core EKS Operations
+- **EKS**: Full cluster, node group, and add-on lifecycle (`eks:*`)
+
+### Supporting AWS Services
+- **EC2**: VPC, subnet, security group, route table, and instance management (`ec2:*`)
+- **IAM**: Scoped to `aicr-*` prefixed roles, instance profiles, and policies only. Also allows EKS service-linked roles under `aws-service-role/*`
+- **Auto Scaling**: Node group scaling (`autoscaling:*`)
+- **CloudFormation**: EKS stack management (`cloudformation:*`)
+- **STS**: `GetCallerIdentity`, `AssumeRole`, `TagSession` only
+- **SSM**: Read-only (`GetParameter`, `GetParameters`, `GetParametersByPath`)
+- **KMS**: EKS envelope encryption (`CreateGrant`, `DescribeKey`, `CreateAlias`, `DeleteAlias`)
+- **CloudWatch Logs**: EKS control plane logging (`CreateLogGroup`, `DeleteLogGroup`, `DescribeLogGroups`, `PutRetentionPolicy`, `TagResource`)
+
+### Privilege Escalation Deny
+
+The following actions are explicitly denied to prevent privilege escalation:
+- `iam:CreateUser`
+- `iam:CreateLoginProfile`
+- `iam:AttachUserPolicy`
+- `iam:PutUserPolicy`
+- `iam:CreateAccessKey`
+
+## GitHub Actions Integration
+
+### 1. Get Terraform Outputs
+```bash
+terraform output GITHUB_ACTIONS_ROLE_ARN
+terraform output OIDC_PROVIDER_ARN
+terraform output AWS_ACCOUNT_ID
+```
+
+### 2. Workflow Configuration
+
+See `.github/workflows/uat-aws.yaml` for the full workflow. Key auth step:
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+  id-token: write  # Required for OIDC
+
+jobs:
+  integration-test-aws:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCOUNT_ID: "615299774277"  # From terraform output
+      AWS_REGION: "us-east-1"
+      GITHUB_ACTIONS_ROLE_NAME: "github-actions-role-aicr"
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708  # v5.1.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.GITHUB_ACTIONS_ROLE_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: GitHubActions-UAT-AICR
+```
+
+## Security
+
+- **No long-lived credentials**: OIDC tokens for temporary, scoped access
+- **Repository-scoped**: Only `NVIDIA/aicr` repository can assume the role
+- **Branch-restricted**: Only `main` branch is allowed (schedule + workflow_dispatch)
+- **Time-limited sessions**: AWS credentials automatically expire
+- **Privilege escalation denied**: Explicit deny on user/credential creation
+- **Audit trail**: All actions logged in AWS CloudTrail with GitHub context
+- **OIDC provider not managed**: Data source reference avoids cross-project state conflicts
+
+### Trust Policy
+
+```hcl
+condition {
+  test     = "StringEquals"
+  variable = "token.actions.githubusercontent.com:aud"
+  values   = ["sts.amazonaws.com"]
+}
+
+condition {
+  test     = "StringLike"
+  variable = "token.actions.githubusercontent.com:sub"
+  values   = ["repo:NVIDIA/aicr:ref:refs/heads/main"]
+}
+```
+
+Only `main` branch workflows can assume this role:
+- `repo:NVIDIA/aicr:ref:refs/heads/main` (main branch)
+- Other branches, PRs, tags, and forks are **rejected**
+
+## Outputs
+
+| Output | Description | Usage |
+|--------|-------------|--------|
+| `GITHUB_ACTIONS_ROLE_ARN` | ARN of the GitHub Actions IAM role | Use in workflow `role-to-assume` |
+| `OIDC_PROVIDER_ARN` | ARN of the GitHub OIDC provider | Reference for trust relationships |
+| `AWS_ACCOUNT_ID` | AWS account ID | Use in workflow environment variables |
+| `AWS_REGION` | AWS region | Use in workflow environment variables |
+| `GITHUB_ACTIONS_ROLE_NAME` | IAM role name | For AWS CLI operations |
+
+## State Management
+
+This configuration uses **local state** (no remote backend). The Terraform state file is not committed to the repository. If multiple administrators need to manage this infrastructure, consider adding an S3 backend:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket = "your-terraform-state-bucket"
+    key    = "uat-aws-account/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+```
+
+## Cleanup
+
+To remove all managed resources (role + policy, not the OIDC provider):
+```bash
+terraform destroy
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **GitHub Actions authentication failure** (`Not authorized to perform sts:AssumeRoleWithWebIdentity`):
+   - Verify workflow is running from `main` branch (other branches are rejected by trust policy)
+   - Ensure `permissions.id-token: write` is set in workflow
+   - Check that the repository name matches `NVIDIA/aicr` exactly
+
+2. **Permission denied during Terraform apply**:
+   ```bash
+   aws iam list-roles  # Test IAM access
+   aws sts get-caller-identity  # Verify current user
+   ```
+
+3. **OIDC provider not found**:
+   The OIDC provider must already exist in the account. Create it via another Terraform config or manually:
+   ```bash
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+   ```
+
+### Debugging
+
+Enable debug logging in workflow:
+```yaml
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+```
+
+## Validation
+
+After deployment, verify the setup:
+
+```bash
+# 1. Check OIDC provider exists
+aws iam get-open-id-connect-provider \
+  --open-id-connect-provider-arn "arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):oidc-provider/token.actions.githubusercontent.com"
+
+# 2. Verify role exists
+aws iam get-role --role-name github-actions-role-aicr
+
+# 3. Check role trust policy
+aws iam get-role --role-name github-actions-role-aicr \
+  --query 'Role.AssumeRolePolicyDocument' --output json
+
+# 4. List attached policies
+aws iam list-attached-role-policies --role-name github-actions-role-aicr
+```
+
+## References
+
+- [AWS IAM OIDC Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
+- [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+- [AWS Configure Credentials Action](https://github.com/aws-actions/configure-aws-credentials)
+- [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/)

--- a/infra/uat-aws-account/federation.tf
+++ b/infra/uat-aws-account/federation.tf
@@ -1,0 +1,272 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GitHub OIDC Identity Provider (shared account-wide, not managed here)
+data "aws_iam_openid_connect_provider" "github" {
+  url = var.oidc_provider_url
+}
+
+# Trust policy for GitHub Actions
+data "aws_iam_policy_document" "github_actions_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:aud"
+      values   = [var.oidc_audience]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:sub"
+      values   = [
+        "repo:${var.git_repo}:ref:refs/heads/main",
+        "repo:${var.git_repo}:ref:refs/heads/test/uat",
+      ]
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+  }
+}
+
+# IAM Role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name               = var.github_actions_role_name
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy.json
+
+  tags = {
+    Name        = "github-actions-role"
+    Environment = "ci"
+    ManagedBy   = "terraform"
+    Repository  = var.git_repo
+  }
+}
+
+# IAM Policy for EKS and EC2 permissions
+data "aws_iam_policy_document" "github_actions_permissions" {
+  # STS permissions - limited to identity checks and role assumption
+  statement {
+    sid    = "STSPermissions"
+    effect = "Allow"
+    actions = [
+      "sts:GetCallerIdentity",
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    resources = ["*"]
+  }
+
+  # IAM permissions - scoped to aicr-prefixed resources and EKS service roles
+  statement {
+    sid    = "IAMScopedPermissions"
+    effect = "Allow"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:GetRole",
+      "iam:PassRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateRole",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:CreateInstanceProfile",
+      "iam:DeleteInstanceProfile",
+      "iam:GetInstanceProfile",
+      "iam:AddRoleToInstanceProfile",
+      "iam:RemoveRoleFromInstanceProfile",
+      "iam:TagInstanceProfile",
+      "iam:ListInstanceProfilesForRole",
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicyVersion",
+      "iam:TagPolicy",
+      "iam:CreateOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider",
+      "iam:TagOpenIDConnectProvider",
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aicr-*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/aicr-*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/aicr-*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/*",
+    ]
+  }
+
+  # EKS service-linked role
+  statement {
+    sid    = "IAMServiceLinkedRole"
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.github_actions_role_name}",
+    ]
+  }
+
+  # Deny privilege escalation paths
+  statement {
+    sid    = "DenyPrivilegeEscalation"
+    effect = "Deny"
+    actions = [
+      "iam:CreateUser",
+      "iam:CreateLoginProfile",
+      "iam:AttachUserPolicy",
+      "iam:PutUserPolicy",
+      "iam:CreateAccessKey",
+    ]
+    resources = ["*"]
+  }
+
+  # SSM permissions for EKS nodes
+  statement {
+    sid    = "SSMNodePermissions"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+    resources = ["*"]
+  }
+
+  # EKS Cluster permissions
+  statement {
+    sid    = "EKSClusterPermissions"
+    effect = "Allow"
+    actions = [
+      "eks:*",
+    ]
+    resources = ["*"]
+  }
+
+  # EC2 permissions for EKS (EKS requires broad EC2 for VPC/subnet/SG management)
+  statement {
+    sid    = "EC2Permissions"
+    effect = "Allow"
+    actions = [
+      "ec2:*",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudFormation permissions (EKS uses CloudFormation)
+  statement {
+    sid    = "CloudFormationPermissions"
+    effect = "Allow"
+    actions = [
+      "cloudformation:*",
+    ]
+    resources = ["*"]
+  }
+
+  # Auto Scaling permissions for EKS node groups
+  statement {
+    sid    = "AutoScalingPermissions"
+    effect = "Allow"
+    actions = [
+      "autoscaling:*",
+    ]
+    resources = ["*"]
+  }
+
+  # KMS permissions (EKS envelope encryption)
+  statement {
+    sid    = "KMSPermissions"
+    effect = "Allow"
+    actions = [
+      "kms:*",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs (EKS control plane + VPC flow logs)
+  statement {
+    sid    = "CloudWatchLogsPermissions"
+    effect = "Allow"
+    actions = [
+      "logs:*",
+    ]
+    resources = ["*"]
+  }
+
+  # S3 permissions (cluster tool Terraform state backend)
+  statement {
+    sid    = "S3StatePermissions"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::cluster-state-${data.aws_caller_identity.current.account_id}",
+      "arn:aws:s3:::cluster-state-${data.aws_caller_identity.current.account_id}/*",
+    ]
+  }
+
+  # DynamoDB permissions (cluster tool Terraform state locking)
+  statement {
+    sid    = "DynamoDBStateLockPermissions"
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/cluster-state-lock",
+    ]
+  }
+}
+
+# IAM Policy for GitHub Actions
+resource "aws_iam_policy" "github_actions" {
+  name        = "${var.github_actions_role_name}-policy"
+  description = "Policy for GitHub Actions to manage EKS clusters"
+  policy      = data.aws_iam_policy_document.github_actions_permissions.json
+
+  tags = {
+    Name        = "${var.github_actions_role_name}-policy"
+    Environment = "ci"
+    ManagedBy   = "terraform"
+  }
+}
+
+# Attach policy to role
+resource "aws_iam_role_policy_attachment" "github_actions" {
+  policy_arn = aws_iam_policy.github_actions.arn
+  role       = aws_iam_role.github_actions.name
+}

--- a/infra/uat-aws-account/main.tf
+++ b/infra/uat-aws-account/main.tf
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Data source to get current AWS account information
+data "aws_caller_identity" "current" {}
+
+# Data source to get current AWS region
+data "aws_region" "current" {}

--- a/infra/uat-aws-account/outputs.tf
+++ b/infra/uat-aws-account/outputs.tf
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List of outputs from each terraform apply 
+
+output "AWS_ACCOUNT_ID" {
+  value       = data.aws_caller_identity.current.account_id
+  description = "AWS Account ID to use in GitHub Actions."
+}
+
+output "AWS_REGION" {
+  value       = data.aws_region.current.name
+  description = "AWS Region to use in GitHub Actions."
+}
+
+output "GITHUB_ACTIONS_ROLE_ARN" {
+  value       = aws_iam_role.github_actions.arn
+  description = "Role ARN to use in GitHub Actions for OIDC authentication."
+}
+
+output "OIDC_PROVIDER_ARN" {
+  value       = data.aws_iam_openid_connect_provider.github.arn
+  description = "OIDC Provider ARN for GitHub Actions."
+}
+
+output "GITHUB_ACTIONS_ROLE_NAME" {
+  value       = aws_iam_role.github_actions.name
+  description = "GitHub Actions IAM role name."
+}

--- a/infra/uat-aws-account/providers.tf
+++ b/infra/uat-aws-account/providers.tf
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Required Terraform and AWS provider versions
+
+terraform {
+  required_version = ">= 1.9.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/uat-aws-account/variables.tf
+++ b/infra/uat-aws-account/variables.tf
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List of variables which can be provided at runtime to override the specified defaults 
+
+variable "aws_region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "git_repo" {
+  description = "GitHub Repository in format owner/repo"
+  type        = string
+  default     = "NVIDIA/aicr"
+}
+
+variable "github_actions_role_name" {
+  description = "Name for the GitHub Actions IAM role"
+  type        = string
+  default     = "github-actions-role-aicr"
+}
+
+variable "oidc_provider_url" {
+  description = "GitHub OIDC provider URL"
+  type        = string
+  default     = "https://token.actions.githubusercontent.com"
+}
+
+variable "oidc_audience" {
+  description = "GitHub OIDC audience"
+  type        = string
+  default     = "sts.amazonaws.com"
+}

--- a/tests/uat/aws/config.yaml
+++ b/tests/uat/aws/config.yaml
@@ -1,0 +1,75 @@
+apiVersion: github.com/mchmarny/cluster/v1alpha1
+kind: Cluster
+deployment:
+  id: aicr-uat
+  csp: AWS
+  tenancy: "615299774277"
+  location: us-east-1
+  tags:
+    owner: github-workflow
+    env: uat
+    # destroy: true
+cluster:
+  name: aicr-uat
+  version: "1.34"
+  addOns:
+    coreDns: ""
+    vpcCni: ""
+    kubeProxy: ""
+  adminRoles: []
+  controlPlane:
+    allowedCidrs:
+      - 216.228.127.128/30 # CSV4
+      - 52.41.222.58/32 # US Northwest
+      - 54.68.11.139/32 # US Northwest
+network:
+  cidrs:
+    host: 10.0.0.0/16
+    pod: 100.65.0.0/16
+  subnets:
+    public:
+      - cidr: 10.0.1.0/27
+        zone: us-east-1a
+      - cidr: 10.0.2.0/27
+        zone: us-east-1c
+    system:
+      - cidr: 10.0.4.0/22
+        zone: us-east-1a
+      - cidr: 10.0.8.0/22
+        zone: us-east-1c
+    worker:
+      - cidr: 10.0.128.0/17
+        zone: us-east-1e
+        disableEndpoints: true
+    pod:
+      - cidr: 100.65.0.0/16
+        zone: us-east-1e
+        disableEndpoints: true
+compute:
+  nodeGroups:
+    system:
+      instanceType: m7a.2xlarge
+      capacity:
+        desired: 2
+        min: 2
+        max: 4
+    workers:
+      - name: cpu-worker
+        instanceType: m4.16xlarge
+        capacity:
+          desired: 1
+        labels:
+          nodeGroup: cpu-worker
+      - name: gpu-worker
+        instanceType: p5.48xlarge
+        architecture: arm64
+        accelerator: h100
+        imageId: ami-08c586949b8b85f80
+        capacity:
+          desired: 2
+          reservation:
+            preference: capacity-reservations-only
+            target: cr-0cbe491320188dfa6
+        labels:
+          nodeGroup: gpu-worker
+          gpu: "true"

--- a/tests/uat/aws/tests/cuj1-training/assert-recipe.yaml
+++ b/tests/uat/aws/tests/cuj1-training/assert-recipe.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert the CUJ1 recipe has the expected structure.
+kind: RecipeResult
+apiVersion: aicr.nvidia.com/v1alpha1
+criteria:
+  service: eks
+  accelerator: h100
+  intent: training
+  os: ubuntu
+  platform: kubeflow
+(length(componentRefs) > `0`): true

--- a/tests/uat/aws/tests/cuj1-training/assert-validate-multiphase.yaml
+++ b/tests/uat/aws/tests/cuj1-training/assert-validate-multiphase.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert all three validation phases are present.
+kind: ValidationResult
+apiVersion: aicr.nvidia.com/v1alpha1
+phases:
+  readiness:
+    (status == 'pass' || status == 'fail'): true
+  deployment:
+    (status == 'pass' || status == 'fail' || status == 'skipped'): true
+  conformance:
+    (status == 'pass' || status == 'fail' || status == 'skipped'): true

--- a/tests/uat/aws/tests/cuj1-training/assert-validate-readiness.yaml
+++ b/tests/uat/aws/tests/cuj1-training/assert-validate-readiness.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert readiness validation result is present on live cluster snapshot.
+kind: ValidationResult
+apiVersion: aicr.nvidia.com/v1alpha1
+phases:
+  readiness:
+    (status == 'pass' || status == 'fail'): true

--- a/tests/uat/aws/tests/cuj1-training/chainsaw-test.yaml
+++ b/tests/uat/aws/tests/cuj1-training/chainsaw-test.yaml
@@ -1,0 +1,173 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: uat-cuj1-training
+spec:
+  description: |
+    UAT CUJ1: Training workload on live EKS cluster with GPU nodes.
+    Tests the aicr workflow from demos/cuj1.md against a real cluster:
+      Step 1: Snapshot the live cluster
+      Step 2: Generate recipe (EKS/H100/training/kubeflow)
+      Step 3: Validate readiness against live snapshot
+      Step 4: Generate bundle with node scheduling
+      Step 5: Validate bundle structure
+      Step 6: Multi-phase validation
+  timeouts:
+    exec: 300s
+  steps:
+
+    # ── Step 1: Snapshot the live cluster ──────────────────────────────
+    - name: snapshot-cluster
+      description: Capture live cluster state for validation.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj1-training"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              kubectl create namespace gpu-operator 2>/dev/null || true
+              ${AICR_BIN} snapshot --output "${WORK}/snapshot.yaml"
+              test -f "${WORK}/snapshot.yaml"
+
+    # ── Step 2: Generate recipe ────────────────────────────────────────
+    - name: generate-recipe
+      description: Generate an EKS H100 training recipe with kubeflow platform.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj1-training"
+              ${AICR_BIN} recipe \
+                --service eks \
+                --accelerator h100 \
+                --intent training \
+                --os ubuntu \
+                --platform kubeflow \
+                --output "${WORK}/recipe.yaml"
+              test -f "${WORK}/recipe.yaml"
+
+    - name: assert-recipe
+      description: Verify recipe has correct criteria and components.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj1-training"
+              chainsaw assert \
+                --resource "${WORK}/recipe.yaml" \
+                --file ./assert-recipe.yaml \
+                --no-color --timeout 10s
+
+    # ── Step 3: Validate readiness against live snapshot ───────────────
+    - name: validate-readiness
+      description: Run readiness validation with live cluster snapshot.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj1-training"
+              ${AICR_BIN} validate \
+                --recipe "${WORK}/recipe.yaml" \
+                --snapshot "${WORK}/snapshot.yaml" \
+                --phase readiness \
+                --no-cluster \
+                --output "${WORK}/validate-readiness-raw.yaml" || true
+              printf 'apiVersion: aicr.nvidia.com/v1alpha1\nkind: ValidationResult\n' > "${WORK}/validate-readiness.yaml"
+              sed '/^---$/d' "${WORK}/validate-readiness-raw.yaml" >> "${WORK}/validate-readiness.yaml"
+
+    - name: assert-validate-readiness
+      description: Verify readiness validation passes.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj1-training"
+              chainsaw assert \
+                --resource "${WORK}/validate-readiness.yaml" \
+                --file ./assert-validate-readiness.yaml \
+                --no-color --timeout 10s
+
+    # ── Step 4: Generate bundle with node scheduling ───────────────────
+    - name: generate-bundle
+      description: Generate bundle with system and GPU node scheduling.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj1-training"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle" \
+                --system-node-selector nodeGroup=system-pool \
+                --accelerated-node-selector nodeGroup=gpu-worker \
+                --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule
+
+    - name: assert-bundle-structure
+      description: Verify bundle contains expected files.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj1-training"
+              test -f "${WORK}/bundle/README.md"
+              test -f "${WORK}/bundle/deploy.sh"
+              test -x "${WORK}/bundle/deploy.sh"
+              test -f "${WORK}/bundle/recipe.yaml"
+              ls "${WORK}"/bundle/*/values.yaml >/dev/null 2>&1
+            check:
+              ($error == null): true
+
+    # ── Step 5: Multi-phase validation ─────────────────────────────────
+    - name: validate-multiphase
+      description: Run all three validation phases.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj1-training"
+              ${AICR_BIN} validate \
+                --recipe "${WORK}/recipe.yaml" \
+                --snapshot "${WORK}/snapshot.yaml" \
+                --phase readiness \
+                --phase deployment \
+                --phase conformance \
+                --no-cluster \
+                --output "${WORK}/validate-multiphase-raw.yaml" || true
+              printf 'apiVersion: aicr.nvidia.com/v1alpha1\nkind: ValidationResult\n' > "${WORK}/validate-multiphase.yaml"
+              sed '/^---$/d' "${WORK}/validate-multiphase-raw.yaml" >> "${WORK}/validate-multiphase.yaml"
+
+    - name: assert-validate-multiphase
+      description: Verify all phases present in validation result.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj1-training"
+              chainsaw assert \
+                --resource "${WORK}/validate-multiphase.yaml" \
+                --file ./assert-validate-multiphase.yaml \
+                --no-color --timeout 10s
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/uat-cuj1-training

--- a/tests/uat/aws/tests/cuj2-inference/assert-recipe.yaml
+++ b/tests/uat/aws/tests/cuj2-inference/assert-recipe.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert the CUJ2 recipe has the expected structure.
+kind: RecipeResult
+apiVersion: aicr.nvidia.com/v1alpha1
+criteria:
+  service: eks
+  accelerator: h100
+  intent: inference
+  os: ubuntu
+  platform: dynamo
+(length(componentRefs) > `0`): true

--- a/tests/uat/aws/tests/cuj2-inference/assert-validate-multiphase.yaml
+++ b/tests/uat/aws/tests/cuj2-inference/assert-validate-multiphase.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert all three validation phases are present.
+kind: ValidationResult
+apiVersion: aicr.nvidia.com/v1alpha1
+phases:
+  readiness:
+    (status == 'pass' || status == 'fail'): true
+  deployment:
+    (status == 'pass' || status == 'fail' || status == 'skipped'): true
+  conformance:
+    (status == 'pass' || status == 'fail' || status == 'skipped'): true

--- a/tests/uat/aws/tests/cuj2-inference/assert-validate-readiness.yaml
+++ b/tests/uat/aws/tests/cuj2-inference/assert-validate-readiness.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert readiness validation result is present.
+kind: ValidationResult
+apiVersion: aicr.nvidia.com/v1alpha1
+phases:
+  readiness:
+    (status == 'pass' || status == 'fail'): true

--- a/tests/uat/aws/tests/cuj2-inference/chainsaw-test.yaml
+++ b/tests/uat/aws/tests/cuj2-inference/chainsaw-test.yaml
@@ -1,0 +1,173 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: uat-cuj2-inference
+spec:
+  description: |
+    UAT CUJ2: Inference workload on live EKS cluster with GPU nodes.
+    Tests the aicr workflow from demos/cuj2.md against a real cluster:
+      Step 1: Snapshot the live cluster
+      Step 2: Generate recipe (EKS/H100/inference/dynamo)
+      Step 3: Validate readiness against live snapshot
+      Step 4: Generate bundle with node scheduling
+      Step 5: Validate bundle structure
+      Step 6: Multi-phase validation
+  timeouts:
+    exec: 300s
+  steps:
+
+    # ── Step 1: Snapshot the live cluster ──────────────────────────────
+    - name: snapshot-cluster
+      description: Capture live cluster state for validation.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj2-inference"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              kubectl create namespace gpu-operator 2>/dev/null || true
+              ${AICR_BIN} snapshot --output "${WORK}/snapshot.yaml"
+              test -f "${WORK}/snapshot.yaml"
+
+    # ── Step 2: Generate recipe ────────────────────────────────────────
+    - name: generate-recipe
+      description: Generate an EKS H100 inference recipe with dynamo platform.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj2-inference"
+              ${AICR_BIN} recipe \
+                --service eks \
+                --accelerator h100 \
+                --intent inference \
+                --os ubuntu \
+                --platform dynamo \
+                --output "${WORK}/recipe.yaml"
+              test -f "${WORK}/recipe.yaml"
+
+    - name: assert-recipe
+      description: Verify recipe has correct criteria and components.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj2-inference"
+              chainsaw assert \
+                --resource "${WORK}/recipe.yaml" \
+                --file ./assert-recipe.yaml \
+                --no-color --timeout 10s
+
+    # ── Step 3: Validate readiness against live snapshot ───────────────
+    - name: validate-readiness
+      description: Run readiness validation with live cluster snapshot.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj2-inference"
+              ${AICR_BIN} validate \
+                --recipe "${WORK}/recipe.yaml" \
+                --snapshot "${WORK}/snapshot.yaml" \
+                --phase readiness \
+                --no-cluster \
+                --output "${WORK}/validate-readiness-raw.yaml" || true
+              printf 'apiVersion: aicr.nvidia.com/v1alpha1\nkind: ValidationResult\n' > "${WORK}/validate-readiness.yaml"
+              sed '/^---$/d' "${WORK}/validate-readiness-raw.yaml" >> "${WORK}/validate-readiness.yaml"
+
+    - name: assert-validate-readiness
+      description: Verify readiness validation result is present.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj2-inference"
+              chainsaw assert \
+                --resource "${WORK}/validate-readiness.yaml" \
+                --file ./assert-validate-readiness.yaml \
+                --no-color --timeout 10s
+
+    # ── Step 4: Generate bundle with node scheduling ───────────────────
+    - name: generate-bundle
+      description: Generate bundle with system and GPU node scheduling.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj2-inference"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle" \
+                --system-node-selector nodeGroup=system-pool \
+                --accelerated-node-selector nodeGroup=gpu-worker \
+                --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule
+
+    - name: assert-bundle-structure
+      description: Verify bundle contains expected files.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj2-inference"
+              test -f "${WORK}/bundle/README.md"
+              test -f "${WORK}/bundle/deploy.sh"
+              test -x "${WORK}/bundle/deploy.sh"
+              test -f "${WORK}/bundle/recipe.yaml"
+              ls "${WORK}"/bundle/*/values.yaml >/dev/null 2>&1
+            check:
+              ($error == null): true
+
+    # ── Step 5: Multi-phase validation ─────────────────────────────────
+    - name: validate-multiphase
+      description: Run all three validation phases.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/uat-cuj2-inference"
+              ${AICR_BIN} validate \
+                --recipe "${WORK}/recipe.yaml" \
+                --snapshot "${WORK}/snapshot.yaml" \
+                --phase readiness \
+                --phase deployment \
+                --phase conformance \
+                --no-cluster \
+                --output "${WORK}/validate-multiphase-raw.yaml" || true
+              printf 'apiVersion: aicr.nvidia.com/v1alpha1\nkind: ValidationResult\n' > "${WORK}/validate-multiphase.yaml"
+              sed '/^---$/d' "${WORK}/validate-multiphase-raw.yaml" >> "${WORK}/validate-multiphase.yaml"
+
+    - name: assert-validate-multiphase
+      description: Verify all phases present in validation result.
+      try:
+        - script:
+            content: |
+              set -eu
+              WORK="/tmp/uat-cuj2-inference"
+              chainsaw assert \
+                --resource "${WORK}/validate-multiphase.yaml" \
+                --file ./assert-validate-multiphase.yaml \
+                --no-color --timeout 10s
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/uat-cuj2-inference

--- a/tests/uat/chainsaw-config.yaml
+++ b/tests/uat/chainsaw-config.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha2.json
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: aicr-uat
+spec:
+  timeouts:
+    apply: 120s
+    assert: 300s
+    cleanup: 120s
+    delete: 60s
+    error: 30s
+    exec: 600s
+  execution:
+    parallel: 1
+    failFast: true
+  cleanup:
+    skipDelete: false
+  report:
+    format: JUNIT-TEST
+    name: aicr-uat

--- a/tools/aws-vpc-cleanup
+++ b/tools/aws-vpc-cleanup
@@ -1,0 +1,250 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deletes AWS VPCs and all their dependent resources.
+#
+# Usage:
+#   tools/aws-vpc-cleanup --vpc-id vpc-01234567890abcdef
+#   tools/aws-vpc-cleanup --vpc-prefix eksctl-nvs
+#   tools/aws-vpc-cleanup --vpc-prefix eksctl-nvs --region us-west-2
+#   tools/aws-vpc-cleanup --vpc-prefix eksctl-nvs --dry-run
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+VPC_ID=""
+VPC_PREFIX=""
+DRY_RUN=false
+
+usage() {
+  echo "Usage: $0 [--vpc-id ID | --vpc-prefix PREFIX] [--region REGION] [--dry-run]"
+  echo ""
+  echo "Options:"
+  echo "  --vpc-id ID        Delete a specific VPC by ID"
+  echo "  --vpc-prefix PREFIX Delete all VPCs whose Name tag starts with PREFIX"
+  echo "  --region REGION    AWS region (default: \$AWS_REGION or us-east-1)"
+  echo "  --dry-run          List VPCs that would be deleted without deleting"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vpc-id) VPC_ID="$2"; shift 2 ;;
+    --vpc-prefix) VPC_PREFIX="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) usage ;;
+  esac
+done
+
+if [[ -z "$VPC_ID" && -z "$VPC_PREFIX" ]]; then
+  usage
+fi
+
+# Resolve VPC IDs
+if [[ -n "$VPC_ID" ]]; then
+  VPCS="$VPC_ID"
+else
+  VPCS=$(aws ec2 describe-vpcs --region "$REGION" \
+    --query "Vpcs[?starts_with(Tags[?Key==\`Name\`].Value|[0], \`${VPC_PREFIX}\`)].VpcId" \
+    --output text)
+fi
+
+if [[ -z "$VPCS" ]]; then
+  echo "No VPCs found."
+  exit 0
+fi
+
+# Count
+count=$(echo "$VPCS" | wc -w | tr -d ' ')
+echo "Found ${count} VPC(s) to delete in ${REGION}:"
+for v in $VPCS; do
+  name=$(aws ec2 describe-vpcs --region "$REGION" --vpc-ids "$v" \
+    --query 'Vpcs[0].Tags[?Key==`Name`].Value|[0]' --output text 2>/dev/null || echo "unnamed")
+  echo "  $v ($name)"
+done
+
+if $DRY_RUN; then
+  echo ""
+  echo "Dry run — no resources deleted."
+  exit 0
+fi
+
+echo ""
+echo "Deleting in 5 seconds... (Ctrl+C to cancel)"
+sleep 5
+
+delete_vpc() {
+  local vpc="$1"
+  local name
+  name=$(aws ec2 describe-vpcs --region "$REGION" --vpc-ids "$vpc" \
+    --query 'Vpcs[0].Tags[?Key==`Name`].Value|[0]' --output text 2>/dev/null || echo "unnamed")
+  echo "=== Deleting VPC: $vpc ($name) ==="
+
+  # Delete EKS clusters in this VPC
+  for cluster in $(aws eks list-clusters --region "$REGION" --query 'clusters[]' --output text 2>/dev/null); do
+    cluster_vpc=$(aws eks describe-cluster --region "$REGION" --name "$cluster" \
+      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || echo "")
+    if [[ "$cluster_vpc" == "$vpc" ]]; then
+      echo "  Deleting EKS cluster: $cluster"
+      # Delete node groups first
+      for ng in $(aws eks list-nodegroups --region "$REGION" --cluster-name "$cluster" \
+        --query 'nodegroups[]' --output text 2>/dev/null); do
+        echo "    Deleting node group: $ng"
+        aws eks delete-nodegroup --region "$REGION" --cluster-name "$cluster" --nodegroup-name "$ng" 2>/dev/null || true
+      done
+      # Wait for node groups
+      for ng in $(aws eks list-nodegroups --region "$REGION" --cluster-name "$cluster" \
+        --query 'nodegroups[]' --output text 2>/dev/null); do
+        echo "    Waiting for node group $ng to delete..."
+        aws eks wait nodegroup-deleted --region "$REGION" --cluster-name "$cluster" --nodegroup-name "$ng" 2>/dev/null || true
+      done
+      aws eks delete-cluster --region "$REGION" --name "$cluster" 2>/dev/null || true
+      echo "    Waiting for cluster to delete..."
+      aws eks wait cluster-deleted --region "$REGION" --name "$cluster" 2>/dev/null || true
+    fi
+  done
+
+  # Delete NAT Gateways
+  for nat in $(aws ec2 describe-nat-gateways --region "$REGION" \
+    --filter "Name=vpc-id,Values=$vpc" "Name=state,Values=available,pending" \
+    --query 'NatGateways[].NatGatewayId' --output text 2>/dev/null); do
+    echo "  Deleting NAT Gateway: $nat"
+    aws ec2 delete-nat-gateway --region "$REGION" --nat-gateway-id "$nat" 2>/dev/null || true
+  done
+
+  # Wait for NAT gateways to delete
+  for nat in $(aws ec2 describe-nat-gateways --region "$REGION" \
+    --filter "Name=vpc-id,Values=$vpc" "Name=state,Values=deleting" \
+    --query 'NatGateways[].NatGatewayId' --output text 2>/dev/null); do
+    echo "  Waiting for NAT Gateway $nat..."
+    aws ec2 wait nat-gateway-available --region "$REGION" --nat-gateway-ids "$nat" 2>/dev/null || sleep 30
+  done
+
+  # Delete VPC Endpoints
+  local endpoints
+  endpoints=$(aws ec2 describe-vpc-endpoints --region "$REGION" \
+    --filters "Name=vpc-id,Values=$vpc" \
+    --query 'VpcEndpoints[].VpcEndpointId' --output text 2>/dev/null)
+  if [[ -n "$endpoints" ]]; then
+    echo "  Deleting VPC Endpoints: $endpoints"
+    aws ec2 delete-vpc-endpoints --region "$REGION" --vpc-endpoint-ids $endpoints 2>/dev/null || true
+  fi
+
+  # Release Elastic IPs
+  for eni in $(aws ec2 describe-network-interfaces --region "$REGION" \
+    --filters "Name=vpc-id,Values=$vpc" \
+    --query 'NetworkInterfaces[].NetworkInterfaceId' --output text 2>/dev/null); do
+    for alloc in $(aws ec2 describe-addresses --region "$REGION" \
+      --filters "Name=network-interface-id,Values=$eni" \
+      --query 'Addresses[].AllocationId' --output text 2>/dev/null); do
+      echo "  Releasing EIP: $alloc"
+      aws ec2 disassociate-address --region "$REGION" --association-id \
+        "$(aws ec2 describe-addresses --region "$REGION" --allocation-ids "$alloc" \
+        --query 'Addresses[0].AssociationId' --output text 2>/dev/null)" 2>/dev/null || true
+      aws ec2 release-address --region "$REGION" --allocation-id "$alloc" 2>/dev/null || true
+    done
+  done
+
+  # Detach and delete Internet Gateways
+  for igw in $(aws ec2 describe-internet-gateways --region "$REGION" \
+    --filters "Name=attachment.vpc-id,Values=$vpc" \
+    --query 'InternetGateways[].InternetGatewayId' --output text 2>/dev/null); do
+    echo "  Detaching/deleting IGW: $igw"
+    aws ec2 detach-internet-gateway --region "$REGION" --internet-gateway-id "$igw" --vpc-id "$vpc" 2>/dev/null || true
+    aws ec2 delete-internet-gateway --region "$REGION" --internet-gateway-id "$igw" 2>/dev/null || true
+  done
+
+  # Delete Network Interfaces
+  for eni in $(aws ec2 describe-network-interfaces --region "$REGION" \
+    --filters "Name=vpc-id,Values=$vpc" \
+    --query 'NetworkInterfaces[].NetworkInterfaceId' --output text 2>/dev/null); do
+    echo "  Deleting ENI: $eni"
+    local attach
+    attach=$(aws ec2 describe-network-interfaces --region "$REGION" \
+      --network-interface-ids "$eni" \
+      --query 'NetworkInterfaces[0].Attachment.AttachmentId' --output text 2>/dev/null)
+    if [[ "$attach" != "None" && -n "$attach" ]]; then
+      aws ec2 detach-network-interface --region "$REGION" --attachment-id "$attach" --force 2>/dev/null || true
+      sleep 3
+    fi
+    aws ec2 delete-network-interface --region "$REGION" --network-interface-id "$eni" 2>/dev/null || true
+  done
+
+  # Delete Subnets
+  for subnet in $(aws ec2 describe-subnets --region "$REGION" \
+    --filters "Name=vpc-id,Values=$vpc" \
+    --query 'Subnets[].SubnetId' --output text 2>/dev/null); do
+    echo "  Deleting Subnet: $subnet"
+    aws ec2 delete-subnet --region "$REGION" --subnet-id "$subnet" 2>/dev/null || true
+  done
+
+  # Delete Route Tables (skip main)
+  for rt in $(aws ec2 describe-route-tables --region "$REGION" \
+    --filters "Name=vpc-id,Values=$vpc" \
+    --query 'RouteTables[?Associations[0].Main != `true`].RouteTableId' --output text 2>/dev/null); do
+    echo "  Deleting Route Table: $rt"
+    for assoc in $(aws ec2 describe-route-tables --region "$REGION" \
+      --route-table-ids "$rt" \
+      --query 'RouteTables[0].Associations[?!Main].RouteTableAssociationId' --output text 2>/dev/null); do
+      aws ec2 disassociate-route-table --region "$REGION" --association-id "$assoc" 2>/dev/null || true
+    done
+    aws ec2 delete-route-table --region "$REGION" --route-table-id "$rt" 2>/dev/null || true
+  done
+
+  # Delete Security Groups (skip default)
+  for sg in $(aws ec2 describe-security-groups --region "$REGION" \
+    --filters "Name=vpc-id,Values=$vpc" \
+    --query 'SecurityGroups[?GroupName != `default`].GroupId' --output text 2>/dev/null); do
+    echo "  Deleting Security Group: $sg"
+    # Remove ingress/egress rules referencing other SGs first
+    aws ec2 revoke-security-group-ingress --region "$REGION" --group-id "$sg" \
+      --security-group-rule-ids $(aws ec2 describe-security-group-rules --region "$REGION" \
+      --filters "Name=group-id,Values=$sg" \
+      --query 'SecurityGroupRules[?!IsEgress].SecurityGroupRuleId' --output text 2>/dev/null) 2>/dev/null || true
+    aws ec2 revoke-security-group-egress --region "$REGION" --group-id "$sg" \
+      --security-group-rule-ids $(aws ec2 describe-security-group-rules --region "$REGION" \
+      --filters "Name=group-id,Values=$sg" \
+      --query 'SecurityGroupRules[?IsEgress].SecurityGroupRuleId' --output text 2>/dev/null) 2>/dev/null || true
+    aws ec2 delete-security-group --region "$REGION" --group-id "$sg" 2>/dev/null || true
+  done
+
+  # Delete VPC (retry — API may return error while deletion is processing)
+  echo "  Deleting VPC: $vpc"
+  for attempt in 1 2 3; do
+    if aws ec2 delete-vpc --region "$REGION" --vpc-id "$vpc" 2>/dev/null; then
+      echo "  VPC $vpc deleted."
+      break
+    fi
+    # Check if VPC is actually gone
+    if ! aws ec2 describe-vpcs --region "$REGION" --vpc-ids "$vpc" >/dev/null 2>&1; then
+      echo "  VPC $vpc deleted."
+      break
+    fi
+    if [[ $attempt -eq 3 ]]; then
+      echo "  FAILED: $vpc still has dependencies. Run again after remaining resources drain."
+    else
+      echo "  Retry $attempt — waiting 10s..."
+      sleep 10
+    fi
+  done
+  echo ""
+}
+
+for vpc in $VPCS; do
+  delete_vpc "$vpc"
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary

Add daily AWS UAT pipeline that creates an ephemeral EKS cluster via OIDC, runs Chainsaw-based CUJ tests, and tears down.

**Infrastructure:**
- Actuator image with Terraform for AWS account federation (OIDC trust, IAM roles)
- VPC cleanup tool for orphaned resources
- Scoped IAM: enumerated actions on aicr-* resources with explicit privilege escalation deny
- OIDC trust restricted to `ref:refs/heads/main` only

**Pipeline:**
- Daily schedule + manual `workflow_dispatch` trigger
- Installs kubectl, yq, chainsaw, aicr binary
- Stamps config with unique `DEPLOYMENT_ID`
- Creates EKS cluster, runs CUJ1 and CUJ2 tests
- Teardown retry (3 attempts), artifact upload, 90min timeout
- JUnit results and step summary table

**Tests:**
- Chainsaw-based CUJ1 (training/kubeflow) declarative YAML assertions
- Chainsaw-based CUJ2 (inference/dynamo) declarative YAML assertions

## Test plan

- [x] Verify Terraform plan applies cleanly in AWS account
- [x] Trigger workflow manually via `workflow_dispatch` and confirm:
  - [x] Dependencies install (kubectl, yq, chainsaw, aicr binary)
  - [x] Config stamped with unique DEPLOYMENT_ID
  - [x] EKS cluster creates successfully
  - [ ] Chainsaw CUJ1 and CUJ2 tests pass
  - [x] Cluster teardown completes
  - [x] JUnit artifacts uploaded
  - [x] Step summary table renders correctly
- [x] Verify OIDC trust rejects non-main branch runs
- [x] Verify IAM deny prevents privilege escalation

> NOTE: CUJ2 currently fails on constraints but that's orthogonal to the UAT harness 