### PR TITLE
feat(skyhook): update to nvidia-tuned 0.2.1 and set h100 overlays back

### DIFF
--- a/recipes/components/skyhook-customizations/manifests/tuning.yaml
+++ b/recipes/components/skyhook-customizations/manifests/tuning.yaml
@@ -63,7 +63,7 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/skyhook-packages/nvidia-tuned
-      version: "0.2.0"
+      version: "0.2.1"
       interrupt:
         type: reboot
       env:

--- a/recipes/overlays/h100-eks-inference.yaml
+++ b/recipes/overlays/h100-eks-inference.yaml
@@ -37,8 +37,7 @@ spec:
     - name: skyhook-customizations
       type: Helm
       manifestFiles:
-        # Temporarily disabled until skyhook-customizations is fixed
-        - components/skyhook-customizations/manifests/no-op.yaml
+        - components/skyhook-customizations/manifests/tuning.yaml
       overrides:
         service: aws
         accelerator: h100

--- a/recipes/overlays/h100-eks-training.yaml
+++ b/recipes/overlays/h100-eks-training.yaml
@@ -45,8 +45,7 @@ spec:
     - name: skyhook-customizations
       type: Helm
       manifestFiles:
-        # Temporarily disabled until skyhook-customizations is fixed
-        - components/skyhook-customizations/manifests/no-op.yaml
+        - components/skyhook-customizations/manifests/tuning.yaml
       overrides:
         service: aws
         accelerator: h100


### PR DESCRIPTION
## Summary

Update nvidia-tuned to 0.2.1 and set h100 overlays back to using tuning instead of no-op

## Motivation / Context

<!-- Why is this change needed? Link issues/discussions. -->

Fixes: <!-- #123 or N/A -->
Related: <!-- #123 or N/A -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: ___recipes_________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
