### PR TITLE
feat(conformance): enrich evidence with observed cluster state

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -228,6 +228,14 @@ const (
 	ArtifactMaxPerCheck = 20
 )
 
+// HTTP response limits for conformance checks.
+const (
+	// HTTPResponseBodyLimit is the maximum size in bytes for HTTP response bodies
+	// read by conformance checks (e.g., Prometheus metric scrapes). Prevents
+	// unbounded reads from in-cluster services.
+	HTTPResponseBodyLimit = 1 * 1024 * 1024 // 1 MiB
+)
+
 // Job configuration constants.
 const (
 	// JobTTLAfterFinished is the time-to-live for completed Jobs.

--- a/pkg/validator/checks/conformance/ai_service_metrics_check.go
+++ b/pkg/validator/checks/conformance/ai_service_metrics_check.go
@@ -17,6 +17,7 @@ package conformance
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
@@ -60,7 +61,8 @@ func checkAIServiceMetricsWithURL(ctx *checks.ValidationContext, promBaseURL str
 	}
 
 	var promResp struct {
-		Data struct {
+		Status string `json:"status"`
+		Data   struct {
 			Result []json.RawMessage `json:"result"`
 		} `json:"data"`
 	}
@@ -68,8 +70,11 @@ func checkAIServiceMetricsWithURL(ctx *checks.ValidationContext, promBaseURL str
 		return errors.Wrap(errors.ErrCodeInternal, "failed to parse Prometheus response", err)
 	}
 
-	recordArtifact(ctx, "Prometheus Query: DCGM_FI_DEV_GPU_UTIL",
-		fmt.Sprintf("Endpoint: %s\nTime series count: %d", queryURL, len(promResp.Data.Result)))
+	recordRawTextArtifact(ctx, "Prometheus Query: DCGM_FI_DEV_GPU_UTIL",
+		fmt.Sprintf("curl -sf '%s'", queryURL),
+		fmt.Sprintf("Status:            %s\nTime series count: %d", valueOrUnknown(promResp.Status), len(promResp.Data.Result)))
+	recordChunkedTextArtifact(ctx, "Prometheus query response (GPU util)",
+		fmt.Sprintf("curl -sf '%s'", queryURL), string(body))
 
 	if len(promResp.Data.Result) == 0 {
 		return errors.New(errors.ErrCodeNotFound,
@@ -83,34 +88,42 @@ func checkAIServiceMetricsWithURL(ctx *checks.ValidationContext, promBaseURL str
 		return errors.New(errors.ErrCodeInternal, "discovery REST client is not available")
 	}
 	result := restClient.Get().AbsPath(rawURL).Do(ctx.Context)
-	var statusCode int
-	result.StatusCode(&statusCode)
 	if cmErr := result.Error(); cmErr != nil {
-		recordArtifact(ctx, "Custom Metrics API",
-			fmt.Sprintf("Endpoint:    %s\nHTTP Status: %d\nStatus:      unavailable\nError:       %v",
-				rawURL, statusCode, cmErr))
+		recordRawTextArtifact(ctx, "Custom Metrics API",
+			"kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1",
+			fmt.Sprintf("Status: unavailable\nError: %v", cmErr))
 		return errors.Wrap(errors.ErrCodeNotFound,
 			"custom metrics API not available", cmErr)
 	}
-
-	groupVersion := "unknown"
-	resourceCount := 0
-	discoveryBody, rawErr := result.Raw()
-	if rawErr == nil {
-		var discovery struct {
-			GroupVersion string            `json:"groupVersion"`
-			Resources    []json.RawMessage `json:"resources"`
-		}
-		if json.Unmarshal(discoveryBody, &discovery) == nil {
-			if discovery.GroupVersion != "" {
-				groupVersion = discovery.GroupVersion
-			}
-			resourceCount = len(discovery.Resources)
-		}
+	var statusCode int
+	result.StatusCode(&statusCode)
+	rawBody, rawErr := result.Raw()
+	if rawErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to read custom metrics API response", rawErr)
 	}
-	recordArtifact(ctx, "Custom Metrics API",
-		fmt.Sprintf("Endpoint:      %s\nHTTP Status:   %d\nGroupVersion:  %s\nAPI Resources: %d\nStatus:        available",
-			rawURL, statusCode, groupVersion, resourceCount))
+	var customMetricsResp struct {
+		GroupVersion string `json:"groupVersion"`
+		Resources    []struct {
+			Name       string `json:"name"`
+			Namespaced bool   `json:"namespaced"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(rawBody, &customMetricsResp); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to parse custom metrics API response", err)
+	}
+	var resources strings.Builder
+	limit := len(customMetricsResp.Resources)
+	if limit > 20 {
+		limit = 20
+	}
+	for i := 0; i < limit; i++ {
+		r := customMetricsResp.Resources[i]
+		fmt.Fprintf(&resources, "- %s (namespaced=%t)\n", r.Name, r.Namespaced)
+	}
+	recordRawTextArtifact(ctx, "Custom Metrics API",
+		"kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1",
+		fmt.Sprintf("HTTP Status:    %d\nGroupVersion:   %s\nResource count: %d\n\nResources:\n%s",
+			statusCode, valueOrUnknown(customMetricsResp.GroupVersion), len(customMetricsResp.Resources), resources.String()))
 
 	return nil
 }

--- a/pkg/validator/checks/conformance/cluster_autoscaling_check.go
+++ b/pkg/validator/checks/conformance/cluster_autoscaling_check.go
@@ -43,13 +43,16 @@ const (
 )
 
 type clusterAutoscalingReport struct {
-	NodePool      string
-	HPADesired    int32
-	HPACurrent    int32
-	BaselineNodes int
-	ObservedNodes int
-	TotalPods     int
-	ScheduledPods int
+	NodePoolName       string
+	Namespace          string
+	DeploymentName     string
+	HPAName            string
+	HPADesiredReplicas int32
+	HPACurrentReplicas int32
+	BaselineNodeCount  int
+	ObservedNodeCount  int
+	ScheduledPodCount  int
+	ObservedPodCount   int
 }
 
 func init() {
@@ -88,11 +91,24 @@ func CheckClusterAutoscaling(ctx *checks.ValidationContext) error {
 	if deploy.Spec.Replicas != nil {
 		expected = *deploy.Spec.Replicas
 	}
-	recordArtifact(ctx, "Karpenter Controller",
+	recordRawTextArtifact(ctx, "Karpenter Controller",
+		"kubectl get deploy -n karpenter",
 		fmt.Sprintf("Name:      %s/%s\nReplicas:  %d/%d available\nImage:     %s",
 			deploy.Namespace, deploy.Name,
 			deploy.Status.AvailableReplicas, expected,
 			firstContainerImage(deploy.Spec.Template.Spec.Containers)))
+	karpenterPods, podErr := ctx.Clientset.CoreV1().Pods("karpenter").List(ctx.Context, metav1.ListOptions{})
+	if podErr != nil {
+		recordRawTextArtifact(ctx, "Karpenter pods", "kubectl get pods -n karpenter -o wide",
+			fmt.Sprintf("failed to list karpenter pods: %v", podErr))
+	} else {
+		var podSummary strings.Builder
+		for _, pod := range karpenterPods.Items {
+			fmt.Fprintf(&podSummary, "%-44s ready=%s phase=%s node=%s\n",
+				pod.Name, podReadyCount(pod), pod.Status.Phase, valueOrUnknown(pod.Spec.NodeName))
+		}
+		recordRawTextArtifact(ctx, "Karpenter pods", "kubectl get pods -n karpenter -o wide", podSummary.String())
+	}
 
 	// 2. GPU NodePool exists with nvidia.com/gpu limits
 	dynClient, err := getDynamicClient(ctx)
@@ -108,23 +124,50 @@ func CheckClusterAutoscaling(ctx *checks.ValidationContext) error {
 	}
 
 	var gpuNodePoolNames []string
+	var poolSummary strings.Builder
 	for _, np := range nps.Items {
 		limits, found, _ := unstructured.NestedMap(np.Object, "spec", "limits")
+		limitGPU := "none"
 		if found {
-			if _, hasGPU := limits["nvidia.com/gpu"]; hasGPU {
+			if raw, hasGPU := limits["nvidia.com/gpu"]; hasGPU {
 				gpuNodePoolNames = append(gpuNodePoolNames, np.GetName())
+				limitGPU = fmt.Sprintf("%v", raw)
 			}
 		}
+		fmt.Fprintf(&poolSummary, "%-32s gpuLimit=%s\n", np.GetName(), limitGPU)
 	}
+	recordRawTextArtifact(ctx, "GPU NodePools",
+		"kubectl get nodepools.karpenter.sh -o yaml", poolSummary.String())
 	if len(gpuNodePoolNames) == 0 {
 		return errors.New(errors.ErrCodeNotFound,
 			"no NodePool with nvidia.com/gpu limits found")
 	}
 
-	recordArtifact(ctx, "GPU NodePools",
+	recordRawTextArtifact(ctx, "GPU NodePools (filtered)",
+		"kubectl get nodepools.karpenter.sh",
 		fmt.Sprintf("Count: %d\nNames: %s", len(gpuNodePoolNames),
 			strings.Join(gpuNodePoolNames, ", ")))
 	slog.Info("discovered GPU NodePools", "pools", gpuNodePoolNames)
+
+	gpuNodes, nodeErr := ctx.Clientset.CoreV1().Nodes().List(ctx.Context, metav1.ListOptions{
+		LabelSelector: "nvidia.com/gpu.present=true",
+	})
+	if nodeErr != nil {
+		recordRawTextArtifact(ctx, "GPU nodes",
+			"kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia.com/gpu'",
+			fmt.Sprintf("failed to list GPU nodes: %v", nodeErr))
+	} else {
+		var nodeSummary strings.Builder
+		for _, n := range gpuNodes.Items {
+			gpuCap := n.Status.Capacity["nvidia.com/gpu"]
+			instanceType := n.Labels["node.kubernetes.io/instance-type"]
+			fmt.Fprintf(&nodeSummary, "%-44s gpu=%s instance=%s\n",
+				n.Name, gpuCap.String(), valueOrUnknown(instanceType))
+		}
+		recordRawTextArtifact(ctx, "GPU nodes",
+			"kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia.com/gpu,INSTANCE-TYPE:.metadata.labels.node.kubernetes.io/instance-type'",
+			nodeSummary.String())
+	}
 
 	// 3. Behavioral validation: try each discovered GPU NodePool until one succeeds.
 	// Multiple pools may exist (e.g. different GPU types) and not all may be viable
@@ -132,19 +175,26 @@ func CheckClusterAutoscaling(ctx *checks.ValidationContext) error {
 	var lastErr error
 	for _, poolName := range gpuNodePoolNames {
 		slog.Info("attempting behavioral validation with NodePool", "nodePool", poolName)
-		report, runErr := validateClusterAutoscaling(ctx.Context, ctx.Clientset, poolName)
-		if runErr == nil {
-			recordArtifact(ctx, "Cluster Autoscaling Behavioral Test",
-				fmt.Sprintf("NodePool:          %s\nHPA desired/current: %d/%d\nKarpenter nodes:   baseline=%d observed=%d new=%d\nPods scheduled:    %d/%d",
-					report.NodePool,
-					report.HPADesired, report.HPACurrent,
-					report.BaselineNodes, report.ObservedNodes, report.ObservedNodes-report.BaselineNodes,
-					report.ScheduledPods, report.TotalPods))
+		report, validateErr := validateClusterAutoscaling(ctx.Context, ctx.Clientset, poolName)
+		lastErr = validateErr
+		if lastErr == nil {
+			recordRawTextArtifact(ctx, "Apply test manifest",
+				"kubectl apply -f docs/conformance/cncf/manifests/hpa-gpu-scale-test.yaml",
+				fmt.Sprintf("Created namespace=%s deployment=%s hpa=%s for nodePool=%s",
+					report.Namespace, report.DeploymentName, report.HPAName, report.NodePoolName))
+			recordRawTextArtifact(ctx, "Cluster Autoscaling Behavioral Test",
+				"kubectl get hpa && kubectl get nodes && kubectl get pods",
+				fmt.Sprintf("NodePool:              %s\nNamespace:             %s\nHPA desired/current:   %d/%d\nKarpenter nodes:       baseline=%d observed=%d\nScheduled pods:        %d/%d",
+					report.NodePoolName, report.Namespace, report.HPADesiredReplicas,
+					report.HPACurrentReplicas, report.BaselineNodeCount, report.ObservedNodeCount,
+					report.ScheduledPodCount, report.ObservedPodCount))
+			recordRawTextArtifact(ctx, "Delete test namespace",
+				"kubectl delete namespace cluster-auto-test-<id> --ignore-not-found",
+				fmt.Sprintf("Deleted namespace %s after cluster autoscaling test.", report.Namespace))
 			return nil
 		}
-		lastErr = runErr
 		slog.Debug("behavioral validation failed for NodePool",
-			"nodePool", poolName, "error", runErr)
+			"nodePool", poolName, "error", lastErr)
 	}
 	return lastErr
 }
@@ -154,10 +204,6 @@ func CheckClusterAutoscaling(ctx *checks.ValidationContext) error {
 // KWOK nodes → pods are scheduled. This proves the chain works end-to-end.
 // nodePoolName is the discovered GPU NodePool name from the precheck.
 func validateClusterAutoscaling(ctx context.Context, clientset kubernetes.Interface, nodePoolName string) (*clusterAutoscalingReport, error) {
-	report := &clusterAutoscalingReport{
-		NodePool: nodePoolName,
-	}
-
 	// Generate unique test resource names and namespace (prevents cross-run interference).
 	b := make([]byte, 4)
 	if _, err := rand.Read(b); err != nil {
@@ -167,6 +213,12 @@ func validateClusterAutoscaling(ctx context.Context, clientset kubernetes.Interf
 	nsName := clusterAutoTestPrefix + suffix
 	deployName := clusterAutoTestPrefix + suffix
 	hpaName := clusterAutoTestPrefix + suffix
+	report := &clusterAutoscalingReport{
+		NodePoolName:   nodePoolName,
+		Namespace:      nsName,
+		DeploymentName: deployName,
+		HPAName:        hpaName,
+	}
 
 	// Create unique test namespace.
 	ns := &corev1.Namespace{
@@ -197,47 +249,45 @@ func validateClusterAutoscaling(ctx context.Context, clientset kubernetes.Interf
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to count baseline Karpenter nodes", err)
 	}
 	baselineNodeCount := len(baselineNodes.Items)
-	report.BaselineNodes = baselineNodeCount
+	report.BaselineNodeCount = baselineNodeCount
 	slog.Info("baseline Karpenter node count", "pool", nodePoolName, "count", baselineNodeCount)
 
 	// Create Deployment: GPU-requesting pods with Karpenter nodeSelector.
 	deploy := buildClusterAutoTestDeployment(deployName, nsName, nodePoolName)
-	_, createErr := clientset.AppsV1().Deployments(nsName).Create(
-		ctx, deploy, metav1.CreateOptions{})
-	if createErr != nil {
+	if _, createErr := clientset.AppsV1().Deployments(nsName).Create(
+		ctx, deploy, metav1.CreateOptions{}); createErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create cluster autoscaling test deployment", createErr)
 	}
 
 	// Create HPA targeting external metric dcgm_gpu_power_usage.
 	hpa := buildClusterAutoTestHPA(hpaName, deployName, nsName)
-	_, createErr = clientset.AutoscalingV2().HorizontalPodAutoscalers(nsName).Create(
-		ctx, hpa, metav1.CreateOptions{})
-	if createErr != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create cluster autoscaling test HPA", createErr)
+	if _, hpaErr := clientset.AutoscalingV2().HorizontalPodAutoscalers(nsName).Create(
+		ctx, hpa, metav1.CreateOptions{}); hpaErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create cluster autoscaling test HPA", hpaErr)
 	}
 
 	// Wait for HPA to report scaling intent.
-	desired, current, err := waitForHPAScaleUp(ctx, clientset, nsName, hpaName, "cluster autoscaling")
+	desired, current, err := waitForHPAScalingIntent(ctx, clientset, nsName, hpaName)
 	if err != nil {
 		return nil, err
 	}
-	report.HPADesired = desired
-	report.HPACurrent = current
+	report.HPADesiredReplicas = desired
+	report.HPACurrentReplicas = current
 
 	// Wait for Karpenter to provision KWOK nodes (above baseline count).
 	observedNodes, err := waitForKarpenterNodes(ctx, clientset, nodePoolName, baselineNodeCount)
 	if err != nil {
 		return nil, err
 	}
-	report.ObservedNodes = observedNodes
+	report.ObservedNodeCount = observedNodes
 
 	// Verify pods are scheduled (not Pending) with poll loop.
-	totalPods, scheduledPods, err := verifyPodsScheduled(ctx, clientset, nsName)
+	scheduled, total, err := verifyPodsScheduled(ctx, clientset, nsName)
 	if err != nil {
 		return nil, err
 	}
-	report.TotalPods = totalPods
-	report.ScheduledPods = scheduledPods
+	report.ScheduledPodCount = scheduled
+	report.ObservedPodCount = total
 	return report, nil
 }
 
@@ -353,9 +403,9 @@ func buildClusterAutoTestHPA(name, deployName, namespace string) *autoscalingv2.
 // waitForKarpenterNodes polls until nodes with the discovered NodePool label exceed the
 // baseline count. This proves Karpenter provisioned NEW nodes, not just pre-existing ones.
 func waitForKarpenterNodes(ctx context.Context, clientset kubernetes.Interface, nodePoolName string, baselineNodeCount int) (int, error) {
-	var observedNodeCount int
 	waitCtx, cancel := context.WithTimeout(ctx, defaults.KarpenterNodeTimeout)
 	defer cancel()
+	var observedNodeCount int
 
 	err := wait.PollUntilContextCancel(waitCtx, defaults.KarpenterPollInterval, true,
 		func(ctx context.Context) (bool, error) {
@@ -367,11 +417,11 @@ func waitForKarpenterNodes(ctx context.Context, clientset kubernetes.Interface, 
 				return false, nil
 			}
 
-			observedNodeCount = len(nodes.Items)
-			if observedNodeCount > baselineNodeCount {
+			if len(nodes.Items) > baselineNodeCount {
 				slog.Info("Karpenter provisioned new KWOK GPU node(s)",
-					"total", observedNodeCount, "baseline", baselineNodeCount,
-					"new", observedNodeCount-baselineNodeCount)
+					"total", len(nodes.Items), "baseline", baselineNodeCount,
+					"new", len(nodes.Items)-baselineNodeCount)
+				observedNodeCount = len(nodes.Items)
 				return true, nil
 			}
 			return false, nil
@@ -391,10 +441,10 @@ func waitForKarpenterNodes(ctx context.Context, clientset kubernetes.Interface, 
 // This proves the full chain: HPA → scale → Karpenter → nodes → pods scheduled.
 // The namespace is unique per run, so all pods belong to this test — no stale pod interference.
 func verifyPodsScheduled(ctx context.Context, clientset kubernetes.Interface, namespace string) (int, int, error) {
-	var observedTotal int
-	var observedScheduled int
 	waitCtx, cancel := context.WithTimeout(ctx, defaults.PodScheduleTimeout)
 	defer cancel()
+	var scheduledOut int
+	var totalOut int
 
 	err := wait.PollUntilContextCancel(waitCtx, defaults.KarpenterPollInterval, true,
 		func(ctx context.Context) (bool, error) {
@@ -404,11 +454,11 @@ func verifyPodsScheduled(ctx context.Context, clientset kubernetes.Interface, na
 				return false, nil
 			}
 
-			observedTotal = len(pods.Items)
-			if observedTotal < 2 {
-				slog.Debug("waiting for HPA-scaled pods", "count", observedTotal)
+			if len(pods.Items) < 2 {
+				slog.Debug("waiting for HPA-scaled pods", "count", len(pods.Items))
 				return false, nil
 			}
+			totalOut = len(pods.Items)
 
 			var scheduled int
 			for _, pod := range pods.Items {
@@ -416,14 +466,14 @@ func verifyPodsScheduled(ctx context.Context, clientset kubernetes.Interface, na
 					scheduled++
 				}
 			}
+			scheduledOut = scheduled
 
-			observedScheduled = scheduled
 			slog.Debug("cluster autoscaling pod status",
-				"total", observedTotal, "scheduled", observedScheduled)
+				"total", len(pods.Items), "scheduled", scheduled)
 
-			if observedScheduled >= 2 {
+			if scheduled >= 2 {
 				slog.Info("cluster autoscaling pods verified",
-					"total", observedTotal, "scheduled", observedScheduled)
+					"total", len(pods.Items), "scheduled", scheduled)
 				return true, nil
 			}
 			return false, nil
@@ -436,5 +486,5 @@ func verifyPodsScheduled(ctx context.Context, clientset kubernetes.Interface, na
 		}
 		return 0, 0, errors.Wrap(errors.ErrCodeInternal, "pod scheduling verification failed", err)
 	}
-	return observedTotal, observedScheduled, nil
+	return scheduledOut, totalOut, nil
 }

--- a/pkg/validator/checks/conformance/cluster_autoscaling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/cluster_autoscaling_check_unit_test.go
@@ -202,27 +202,60 @@ func addClusterAutoReactors(clientset *fake.Clientset, nodePoolName string) {
 	// Node List reactor: return empty on first call (baseline), then KWOK node.
 	// This matches the production flow: baseline is captured before test resources,
 	// then waitForKarpenterNodes sees new nodes provisioned above baseline.
-	var nodeListCalls int
+	var nodePoolListCalls int
 	clientset.PrependReactor("list", "nodes",
 		func(action k8stesting.Action) (bool, runtime.Object, error) {
-			nodeListCalls++
-			if nodeListCalls == 1 {
-				// First call: baseline (no pre-existing Karpenter nodes)
-				return true, &corev1.NodeList{}, nil
+			la, ok := action.(k8stesting.ListAction)
+			if !ok {
+				return false, nil, nil
 			}
-			// Subsequent calls: Karpenter provisioned a new KWOK node
-			return true, &corev1.NodeList{
-				Items: []corev1.Node{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "kwok-gpu-node-1",
-							Labels: map[string]string{
-								karpenterNodePoolLabel: nodePoolName,
+			selector := ""
+			if la.GetListRestrictions().Labels != nil {
+				selector = la.GetListRestrictions().Labels.String()
+			}
+
+			if strings.Contains(selector, "nvidia.com/gpu.present=true") {
+				return true, &corev1.NodeList{
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "gpu-inventory-node-1",
+								Labels: map[string]string{
+									"nvidia.com/gpu.present": "true",
+								},
 							},
 						},
 					},
-				},
-			}, nil
+				}, nil
+			}
+
+			if strings.Contains(selector, fmt.Sprintf("%s=%s", karpenterNodePoolLabel, nodePoolName)) {
+				nodePoolListCalls++
+				if nodePoolListCalls == 1 {
+					// First call: baseline (no pre-existing Karpenter nodes)
+					return true, &corev1.NodeList{}, nil
+				}
+				// Subsequent calls: Karpenter provisioned a new KWOK node
+				return true, &corev1.NodeList{
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "kwok-gpu-node-1",
+								Labels: map[string]string{
+									karpenterNodePoolLabel:   nodePoolName,
+									"nvidia.com/gpu.present": "true",
+								},
+							},
+						},
+					},
+				}, nil
+			}
+
+			// Unfiltered/other selectors: return no nodes.
+			if selector == "" {
+				return true, &corev1.NodeList{}, nil
+			}
+			return false, nil, nil
 		})
 
 	// Pod List reactor: return 3 Running pods (match unique namespace by prefix).
@@ -412,17 +445,25 @@ func TestValidateClusterAutoscaling(t *testing.T) {
 
 			if !tt.wantErr {
 				if report == nil {
-					t.Fatal("validateClusterAutoscaling() report = nil, want non-nil")
+					t.Fatal("validateClusterAutoscaling() report is nil")
 				}
-				if report.HPADesired != tt.hpaDesired || report.HPACurrent != tt.hpaCurrent {
-					t.Errorf("report HPA desired/current = %d/%d, want %d/%d",
-						report.HPADesired, report.HPACurrent, tt.hpaDesired, tt.hpaCurrent)
+				if report.NodePoolName != testNodePool {
+					t.Errorf("NodePoolName = %q, want %q", report.NodePoolName, testNodePool)
 				}
-				if report.ObservedNodes != tt.kwokNodes {
-					t.Errorf("report observed nodes = %d, want %d", report.ObservedNodes, tt.kwokNodes)
+				if report.HPADesiredReplicas != tt.hpaDesired {
+					t.Errorf("HPADesiredReplicas = %d, want %d", report.HPADesiredReplicas, tt.hpaDesired)
 				}
-				if report.TotalPods != tt.podCount {
-					t.Errorf("report total pods = %d, want %d", report.TotalPods, tt.podCount)
+				if report.HPACurrentReplicas != tt.hpaCurrent {
+					t.Errorf("HPACurrentReplicas = %d, want %d", report.HPACurrentReplicas, tt.hpaCurrent)
+				}
+				if report.ObservedNodeCount != tt.kwokNodes {
+					t.Errorf("ObservedNodeCount = %d, want %d", report.ObservedNodeCount, tt.kwokNodes)
+				}
+				if report.ObservedPodCount != tt.podCount {
+					t.Errorf("ObservedPodCount = %d, want %d", report.ObservedPodCount, tt.podCount)
+				}
+				if report.ScheduledPodCount != tt.podCount {
+					t.Errorf("ScheduledPodCount = %d, want %d", report.ScheduledPodCount, tt.podCount)
 				}
 			}
 		})

--- a/pkg/validator/checks/conformance/dra_support_check.go
+++ b/pkg/validator/checks/conformance/dra_support_check.go
@@ -192,21 +192,3 @@ func CheckDRASupport(ctx *checks.ValidationContext) error {
 
 	return nil
 }
-
-func valueOrUnknown(v string) string {
-	if strings.TrimSpace(v) == "" {
-		return "unknown"
-	}
-	return v
-}
-
-func podReadyCount(pod corev1.Pod) string {
-	var ready, total int
-	for _, cs := range pod.Status.ContainerStatuses {
-		total++
-		if cs.Ready {
-			ready++
-		}
-	}
-	return fmt.Sprintf("%d/%d", ready, total)
-}

--- a/pkg/validator/checks/conformance/dra_support_check.go
+++ b/pkg/validator/checks/conformance/dra_support_check.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
 
 func init() {
@@ -130,6 +131,10 @@ func CheckDRASupport(ctx *checks.ValidationContext) error {
 	}
 
 	// 6. Behavioral DRA allocation validation (create claim+pod, wait, capture observed state).
+	return validateDRAAllocation(ctx, dynClient)
+}
+
+func validateDRAAllocation(ctx *checks.ValidationContext, dynClient dynamic.Interface) error {
 	run, err := newDRATestRun()
 	if err != nil {
 		return err
@@ -139,7 +144,7 @@ func CheckDRASupport(ctx *checks.ValidationContext) error {
 		fmt.Sprintf("Created Namespace=%s ResourceClaim=%s Pod=%s via Kubernetes API",
 			draTestNamespace, run.claimName, run.podName))
 
-	if err := deployDRATestResources(ctx.Context, ctx.Clientset, dynClient, run); err != nil {
+	if err = deployDRATestResources(ctx.Context, ctx.Clientset, dynClient, run); err != nil {
 		return err
 	}
 	defer func() {

--- a/pkg/validator/checks/conformance/dra_support_check.go
+++ b/pkg/validator/checks/conformance/dra_support_check.go
@@ -16,10 +16,13 @@ package conformance
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -46,37 +49,61 @@ func CheckDRASupport(ctx *checks.ValidationContext) error {
 		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
 	}
 
-	// 1. DRA driver controller Deployment available
+	// 1. DRA API resources are discoverable.
+	resources, err := ctx.Clientset.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "resource.k8s.io/v1 API resources not available", err)
+	}
+	var apiResources strings.Builder
+	for _, r := range resources.APIResources {
+		fmt.Fprintf(&apiResources, "%-26s %-22s namespaced=%t\n", r.Name, r.Kind, r.Namespaced)
+	}
+	recordRawTextArtifact(ctx, "DRA API resources",
+		"kubectl api-resources --api-group=resource.k8s.io", apiResources.String())
+
+	// 2. DRA driver pods inventory.
+	pods, err := ctx.Clientset.CoreV1().Pods("nvidia-dra-driver").List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to list DRA driver pods", err)
+	}
+	var driverPods strings.Builder
+	for _, pod := range pods.Items {
+		fmt.Fprintf(&driverPods, "%-48s ready=%s phase=%s node=%s\n",
+			pod.Name, podReadyCount(pod), pod.Status.Phase, pod.Spec.NodeName)
+	}
+	recordRawTextArtifact(ctx, "DRA driver pods", "kubectl get pods -n nvidia-dra-driver -o wide", driverPods.String())
+
+	// 3. DRA driver controller Deployment available.
 	deploy, deployErr := getDeploymentIfAvailable(ctx, "nvidia-dra-driver", "nvidia-dra-driver-gpu-controller")
+	if deployErr != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "DRA driver controller check failed", deployErr)
+	}
 	if deploy != nil {
 		expected := int32(1)
 		if deploy.Spec.Replicas != nil {
 			expected = *deploy.Spec.Replicas
 		}
-		recordArtifact(ctx, "DRA Controller Deployment",
+		recordRawTextArtifact(ctx, "DRA Controller Deployment", "",
 			fmt.Sprintf("Name:      %s/%s\nReplicas:  %d/%d available\nImage:     %s",
 				deploy.Namespace, deploy.Name,
 				deploy.Status.AvailableReplicas, expected,
 				firstContainerImage(deploy.Spec.Template.Spec.Containers)))
 	}
-	if deployErr != nil {
-		return errors.Wrap(errors.ErrCodeNotFound, "DRA driver controller check failed", deployErr)
-	}
 
-	// 2. DRA kubelet plugin DaemonSet ready
+	// 4. DRA kubelet plugin DaemonSet ready.
 	ds, dsErr := getDaemonSetIfReady(ctx, "nvidia-dra-driver", "nvidia-dra-driver-gpu-kubelet-plugin")
+	if dsErr != nil {
+		return errors.Wrap(errors.ErrCodeNotFound, "DRA kubelet plugin check failed", dsErr)
+	}
 	if ds != nil {
-		recordArtifact(ctx, "DRA Kubelet Plugin DaemonSet",
+		recordRawTextArtifact(ctx, "DRA Kubelet Plugin DaemonSet", "",
 			fmt.Sprintf("Name:      %s/%s\nReady:     %d/%d pods\nImage:     %s",
 				ds.Namespace, ds.Name,
 				ds.Status.NumberReady, ds.Status.DesiredNumberScheduled,
 				firstContainerImage(ds.Spec.Template.Spec.Containers)))
 	}
-	if dsErr != nil {
-		return errors.Wrap(errors.ErrCodeNotFound, "DRA kubelet plugin check failed", dsErr)
-	}
 
-	// 3. ResourceSlices exist (GPU resources advertised via resource.k8s.io/v1 — GA)
+	// 5. ResourceSlices exist (GPU resources advertised via resource.k8s.io/v1 — GA).
 	dynClient, err := getDynamicClient(ctx)
 	if err != nil {
 		return err
@@ -88,11 +115,98 @@ func CheckDRASupport(ctx *checks.ValidationContext) error {
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to list ResourceSlices", err)
 	}
-	recordArtifact(ctx, "ResourceSlices",
-		fmt.Sprintf("Total ResourceSlices: %d", len(slices.Items)))
+	var sliceSummary strings.Builder
+	fmt.Fprintf(&sliceSummary, "Total ResourceSlices: %d\n", len(slices.Items))
+	for _, item := range slices.Items {
+		driver, _, _ := unstructured.NestedString(item.Object, "spec", "driver")
+		nodeName, _, _ := unstructured.NestedString(item.Object, "spec", "nodeName")
+		poolName, _, _ := unstructured.NestedString(item.Object, "spec", "pool", "name")
+		fmt.Fprintf(&sliceSummary, "%-48s node=%s driver=%s pool=%s\n",
+			item.GetName(), nodeName, driver, poolName)
+	}
+	recordRawTextArtifact(ctx, "ResourceSlices", "kubectl get resourceslices", sliceSummary.String())
 	if len(slices.Items) == 0 {
 		return errors.New(errors.ErrCodeNotFound, "no ResourceSlices found (GPU resources not advertised)")
 	}
 
+	// 6. Behavioral DRA allocation validation (create claim+pod, wait, capture observed state).
+	run, err := newDRATestRun()
+	if err != nil {
+		return err
+	}
+	recordRawTextArtifact(ctx, "Apply test manifest",
+		"kubectl apply -f docs/conformance/cncf/manifests/dra-gpu-test.yaml",
+		fmt.Sprintf("Created Namespace=%s ResourceClaim=%s Pod=%s via Kubernetes API",
+			draTestNamespace, run.claimName, run.podName))
+
+	if err := deployDRATestResources(ctx.Context, ctx.Clientset, dynClient, run); err != nil {
+		return err
+	}
+	defer func() {
+		cleanupDRATestResources(ctx.Context, ctx.Clientset, dynClient, run)
+		recordRawTextArtifact(ctx, "Delete test namespace",
+			"kubectl delete namespace dra-test --ignore-not-found",
+			"Deleted DRA test pod and ResourceClaim; namespace retained intentionally to avoid DRA finalizer stalls.")
+	}()
+
+	pod, err := waitForDRATestPod(ctx.Context, ctx.Clientset, run)
+	if err != nil {
+		return err
+	}
+
+	claimObj, err := dynClient.Resource(claimGVR).Namespace(draTestNamespace).Get(
+		ctx.Context, run.claimName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to read DRA test ResourceClaim", err)
+	}
+	state, _, _ := unstructured.NestedString(claimObj.Object, "status", "state")
+	claimLines := []string{
+		fmt.Sprintf("Name:      %s/%s", draTestNamespace, run.claimName),
+		fmt.Sprintf("State:     %s", valueOrUnknown(state)),
+	}
+	recordRawTextArtifact(ctx, "ResourceClaim status",
+		"kubectl get resourceclaim -n dra-test -o wide", strings.Join(claimLines, "\n"))
+
+	podLines := []string{
+		fmt.Sprintf("Name:      %s/%s", pod.Namespace, pod.Name),
+		fmt.Sprintf("Phase:     %s", pod.Status.Phase),
+		fmt.Sprintf("Node:      %s", valueOrUnknown(pod.Spec.NodeName)),
+		fmt.Sprintf("PodIP:     %s", valueOrUnknown(pod.Status.PodIP)),
+		fmt.Sprintf("Claims:    %d", len(pod.Spec.ResourceClaims)),
+	}
+	recordRawTextArtifact(ctx, "Pod status",
+		"kubectl get pod dra-gpu-test -n dra-test -o wide", strings.Join(podLines, "\n"))
+
+	logBytes, logErr := ctx.Clientset.CoreV1().Pods(draTestNamespace).GetLogs(run.podName, &corev1.PodLogOptions{}).DoRaw(ctx.Context)
+	if logErr != nil {
+		recordRawTextArtifact(ctx, "Pod logs", "kubectl logs dra-gpu-test -n dra-test",
+			fmt.Sprintf("failed to read logs: %v", logErr))
+	} else {
+		recordChunkedTextArtifact(ctx, "Pod logs", "kubectl logs dra-gpu-test -n dra-test", string(logBytes))
+	}
+
+	if pod.Status.Phase != corev1.PodSucceeded {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("DRA test pod phase=%s (want Succeeded), GPU allocation may have failed", pod.Status.Phase))
+	}
+
 	return nil
+}
+
+func valueOrUnknown(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "unknown"
+	}
+	return v
+}
+
+func podReadyCount(pod corev1.Pod) string {
+	var ready, total int
+	for _, cs := range pod.Status.ContainerStatuses {
+		total++
+		if cs.Ready {
+			ready++
+		}
+	}
+	return fmt.Sprintf("%d/%d", ready, total)
 }

--- a/pkg/validator/checks/conformance/dra_support_check_unit_test.go
+++ b/pkg/validator/checks/conformance/dra_support_check_unit_test.go
@@ -20,11 +20,16 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCheckDRASupport(t *testing.T) {
@@ -104,11 +109,65 @@ func TestCheckDRASupport(t *testing.T) {
 				//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
 				clientset := fake.NewSimpleClientset(tt.k8sObjects...)
 
+				// Discovery API resources for resource.k8s.io/v1.
+				if fd, ok := clientset.Discovery().(*discoveryfake.FakeDiscovery); ok {
+					fd.Resources = []*metav1.APIResourceList{
+						{
+							GroupVersion: "resource.k8s.io/v1",
+							APIResources: []metav1.APIResource{
+								{Name: "deviceclasses", Kind: "DeviceClass", Namespaced: false},
+								{Name: "resourceclaims", Kind: "ResourceClaim", Namespaced: true},
+								{Name: "resourceclaimtemplates", Kind: "ResourceClaimTemplate", Namespaced: true},
+								{Name: "resourceslices", Kind: "ResourceSlice", Namespaced: false},
+							},
+						},
+					}
+				}
+
+				// Behavioral test pod status stub: pods created with dra test prefix
+				// immediately appear completed to avoid poll timeouts in unit tests.
+				podDeleted := false
+				clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					ga, ok := action.(k8stesting.GetAction)
+					if !ok {
+						// Let non-standard pod gets (for example log subresource plumbing)
+						// fall back to the default fake behavior.
+						return false, nil, nil
+					}
+					if strings.HasPrefix(ga.GetName(), draTestPrefix) && ga.GetNamespace() == draTestNamespace {
+						if podDeleted {
+							return true, nil, k8serrors.NewNotFound(
+								schema.GroupResource{Resource: "pods"}, ga.GetName())
+						}
+						run := &draTestRun{podName: ga.GetName(), claimName: draClaimPrefix + ga.GetName()[len(draTestPrefix):]}
+						return true, &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      run.podName,
+								Namespace: draTestNamespace,
+							},
+							Spec: *buildDRATestPod(run).Spec.DeepCopy(),
+							Status: corev1.PodStatus{
+								Phase: corev1.PodSucceeded,
+							},
+						}, nil
+					}
+					return false, nil, nil
+				})
+				clientset.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					da := action.(k8stesting.DeleteAction)
+					if strings.HasPrefix(da.GetName(), draTestPrefix) && da.GetNamespace() == draTestNamespace {
+						podDeleted = true
+						return true, nil, nil
+					}
+					return false, nil, nil
+				})
+
 				scheme := runtime.NewScheme()
 				// Always register custom list kinds so List() works even with 0 objects.
 				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 					map[schema.GroupVersionResource]string{
 						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices"}: "ResourceSliceList",
+						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}: "ResourceClaimList",
 					},
 					tt.dynamicObjects...)
 

--- a/pkg/validator/checks/conformance/gang_scheduling_check.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check.go
@@ -115,7 +115,7 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 	}
 
 	// 1. All KAI scheduler deployments available.
-	var schedulerSummary strings.Builder
+	var deploymentsSummary strings.Builder
 	for _, name := range kaiSchedulerDeployments {
 		deploy, err := getDeploymentIfAvailable(ctx, "kai-scheduler", name)
 		if err != nil {
@@ -126,11 +126,24 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		if deploy.Spec.Replicas != nil {
 			expected = *deploy.Spec.Replicas
 		}
-		fmt.Fprintf(&schedulerSummary, "  %-25s available=%d/%d image=%s\n",
+		fmt.Fprintf(&deploymentsSummary, "%-25s available=%d/%d image=%s\n",
 			name, deploy.Status.AvailableReplicas, expected,
 			firstContainerImage(deploy.Spec.Template.Spec.Containers))
 	}
-	recordArtifact(ctx, "KAI Scheduler Components", schedulerSummary.String())
+	recordRawTextArtifact(ctx, "KAI scheduler deployments",
+		"kubectl get deploy -n kai-scheduler", deploymentsSummary.String())
+
+	// KAI scheduler pods.
+	kaiPods, err := ctx.Clientset.CoreV1().Pods("kai-scheduler").List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to list KAI scheduler pods", err)
+	}
+	var podsSummary strings.Builder
+	for _, p := range kaiPods.Items {
+		fmt.Fprintf(&podsSummary, "%-44s ready=%s phase=%s\n", p.Name, podReadyCount(p), p.Status.Phase)
+	}
+	recordRawTextArtifact(ctx, "KAI scheduler pods",
+		"kubectl get pods -n kai-scheduler", podsSummary.String())
 
 	// 2. Required CRDs for gang scheduling.
 	dynClient, err := getDynamicClient(ctx)
@@ -152,7 +165,9 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		}
 		fmt.Fprintf(&crdSummary, "  %s: present\n", crd)
 	}
-	recordArtifact(ctx, "Gang Scheduling CRDs", crdSummary.String())
+	recordRawTextArtifact(ctx, "Gang Scheduling CRDs",
+		"kubectl get crd queues.scheduling.run.ai podgroups.scheduling.run.ai",
+		crdSummary.String())
 
 	// 3. Pre-flight: ensure enough free GPUs for the gang test.
 	total, free, gpuErr := countAvailableGPUs(ctx.Context, dynClient)
@@ -173,7 +188,18 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		return err
 	}
 
-	defer cleanupGangTestResources(ctx.Context, ctx.Clientset, dynClient, run)
+	defer func() {
+		cleanupGangTestResources(ctx.Context, ctx.Clientset, dynClient, run)
+		recordRawTextArtifact(ctx, "Delete test namespace",
+			"kubectl delete namespace gang-scheduling-test --ignore-not-found",
+			"Deleted gang test pods, claims, and PodGroup; namespace retained intentionally to avoid DRA finalizer stalls.")
+	}()
+
+	recordRawTextArtifact(ctx, "Apply test manifest",
+		"kubectl apply -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml",
+		fmt.Sprintf("Created PodGroup=%s ResourceClaims=%s,%s Pods=%s,%s in namespace=%s",
+			run.groupName, run.claims[0], run.claims[1], run.pods[0], run.pods[1], gangTestNamespace))
+
 	if err = deployGangTestResources(ctx.Context, ctx.Clientset, dynClient, run); err != nil {
 		return err
 	}
@@ -188,7 +214,24 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		return err
 	}
 
-	// Record gang test results with scheduling timestamps.
+	// PodGroup status.
+	pgList, listErr := dynClient.Resource(podGroupGVR).Namespace(gangTestNamespace).List(
+		ctx.Context, metav1.ListOptions{})
+	if listErr != nil {
+		recordRawTextArtifact(ctx, "PodGroup status",
+			"kubectl get podgroups -n gang-scheduling-test -o wide",
+			fmt.Sprintf("failed to list PodGroups: %v", listErr))
+	} else {
+		var pgSummary strings.Builder
+		for _, item := range pgList.Items {
+			minMember, _, _ := unstructured.NestedInt64(item.Object, "spec", "minMember")
+			fmt.Fprintf(&pgSummary, "%-36s minMember=%d\n", item.GetName(), minMember)
+		}
+		recordRawTextArtifact(ctx, "PodGroup status",
+			"kubectl get podgroups -n gang-scheduling-test -o wide", pgSummary.String())
+	}
+
+	// Pod status and scheduling timestamps.
 	var gangResults strings.Builder
 	for i, pod := range pods {
 		if pod == nil {
@@ -209,7 +252,24 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 	fmt.Fprintf(&gangResults, "Earliest/Latest:  %s / %s\n",
 		gangReport.EarliestScheduled.Format(time.RFC3339),
 		gangReport.LatestScheduled.Format(time.RFC3339))
-	recordArtifact(ctx, "Gang Scheduling Test Results", gangResults.String())
+	recordRawTextArtifact(ctx, "Pod status",
+		"kubectl get pods -n gang-scheduling-test -o wide", gangResults.String())
+
+	// Worker logs.
+	for i := range gangMinMembers {
+		logBytes, logErr := ctx.Clientset.CoreV1().Pods(gangTestNamespace).GetLogs(
+			run.pods[i], &corev1.PodLogOptions{}).DoRaw(ctx.Context)
+		label := fmt.Sprintf("gang-worker-%d logs", i)
+		if logErr != nil {
+			recordRawTextArtifact(ctx, label,
+				fmt.Sprintf("kubectl logs gang-worker-%d -n gang-scheduling-test", i),
+				fmt.Sprintf("failed to read logs: %v", logErr))
+			continue
+		}
+		recordChunkedTextArtifact(ctx, label,
+			fmt.Sprintf("kubectl logs gang-worker-%d -n gang-scheduling-test", i),
+			string(logBytes))
+	}
 
 	return nil
 }

--- a/pkg/validator/checks/conformance/gang_scheduling_check.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check.go
@@ -214,6 +214,13 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 		return err
 	}
 
+	collectGangTestArtifacts(ctx, dynClient, pods, gangReport, run)
+	return nil
+}
+
+func collectGangTestArtifacts(ctx *checks.ValidationContext, dynClient dynamic.Interface,
+	pods [gangMinMembers]*corev1.Pod, gangReport *gangSchedulingReport, run *gangTestRun) {
+
 	// PodGroup status.
 	pgList, listErr := dynClient.Resource(podGroupGVR).Namespace(gangTestNamespace).List(
 		ctx.Context, metav1.ListOptions{})
@@ -270,8 +277,6 @@ func CheckGangScheduling(ctx *checks.ValidationContext) error {
 			fmt.Sprintf("kubectl logs gang-worker-%d -n gang-scheduling-test", i),
 			string(logBytes))
 	}
-
-	return nil
 }
 
 // deployGangTestResources creates the namespace, PodGroup, ResourceClaims, and Pods.

--- a/pkg/validator/checks/conformance/gang_scheduling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/gang_scheduling_check_unit_test.go
@@ -195,7 +195,12 @@ func TestCheckGangScheduling(t *testing.T) {
 				// Returns a pod with the desired phase, correct gang labels,
 				// and PodScheduled condition with co-scheduling timestamp.
 				clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
-					ga := action.(k8stesting.GetAction)
+					ga, ok := action.(k8stesting.GetAction)
+					if !ok {
+						// Non-standard pod gets (for example log subresource plumbing)
+						// should use default fake behavior.
+						return false, nil, nil
+					}
 					if strings.HasPrefix(ga.GetName(), gangPodPrefix) && ga.GetNamespace() == gangTestNamespace {
 						mu.Lock()
 						deleted := deletedPods[ga.GetName()]

--- a/pkg/validator/checks/conformance/helpers.go
+++ b/pkg/validator/checks/conformance/helpers.go
@@ -16,6 +16,7 @@ package conformance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 // phaseConformance is the phase identifier for conformance checks.
@@ -174,6 +176,82 @@ func recordArtifact(ctx *checks.ValidationContext, label, data string) {
 	if err := ctx.Artifacts.Record(label, data); err != nil {
 		slog.Debug("artifact recording skipped", "label", label, "error", err)
 	}
+}
+
+func formatArtifactBody(equivalent, data string) string {
+	equivalent = strings.TrimSpace(equivalent)
+	data = strings.TrimSpace(data)
+	switch {
+	case equivalent == "" && data == "":
+		return ""
+	case equivalent == "":
+		return data
+	case data == "":
+		return fmt.Sprintf("Equivalent: %s", equivalent)
+	default:
+		return fmt.Sprintf("Equivalent: %s\n\n%s", equivalent, data)
+	}
+}
+
+// recordRawTextArtifact records plain text evidence with an optional command equivalent.
+func recordRawTextArtifact(ctx *checks.ValidationContext, label, equivalent, data string) {
+	recordArtifact(ctx, label, formatArtifactBody(equivalent, data))
+}
+
+// recordChunkedTextArtifact records text evidence across multiple artifacts when needed.
+// This avoids collector-side truncation for large YAML/JSON/metrics payloads.
+func recordChunkedTextArtifact(ctx *checks.ValidationContext, label, equivalent, data string) {
+	if strings.TrimSpace(data) == "" {
+		recordRawTextArtifact(ctx, label, equivalent, data)
+		return
+	}
+
+	prefix := ""
+	if strings.TrimSpace(equivalent) != "" {
+		prefix = fmt.Sprintf("Equivalent: %s\n\n", strings.TrimSpace(equivalent))
+	}
+
+	chunkSize := defaults.ArtifactMaxDataSize - len(prefix) - 256
+	if chunkSize < 512 {
+		chunkSize = 512
+	}
+	if len(data) <= chunkSize {
+		recordArtifact(ctx, label, prefix+strings.TrimSpace(data))
+		return
+	}
+
+	total := (len(data) + chunkSize - 1) / chunkSize
+	for i := 0; i < total; i++ {
+		start := i * chunkSize
+		end := start + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		part := strings.TrimSpace(data[start:end])
+		partLabel := fmt.Sprintf("%s (part %d/%d)", label, i+1, total)
+		partBody := fmt.Sprintf("%sPart: %d/%d\n\n%s", prefix, i+1, total, part)
+		recordArtifact(ctx, partLabel, partBody)
+	}
+}
+
+// recordObjectJSONArtifact records a structured object as pretty JSON.
+func recordObjectJSONArtifact(ctx *checks.ValidationContext, label, equivalent string, obj any) {
+	payload, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		recordRawTextArtifact(ctx, label, equivalent, fmt.Sprintf("failed to marshal JSON: %v", err))
+		return
+	}
+	recordChunkedTextArtifact(ctx, label, equivalent, string(payload))
+}
+
+// recordObjectYAMLArtifact records a structured object as YAML.
+func recordObjectYAMLArtifact(ctx *checks.ValidationContext, label, equivalent string, obj any) {
+	payload, err := yaml.Marshal(obj)
+	if err != nil {
+		recordRawTextArtifact(ctx, label, equivalent, fmt.Sprintf("failed to marshal YAML: %v", err))
+		return
+	}
+	recordChunkedTextArtifact(ctx, label, equivalent, string(payload))
 }
 
 // firstContainerImage returns the image of the first container, or "unknown" if empty.

--- a/pkg/validator/checks/conformance/helpers.go
+++ b/pkg/validator/checks/conformance/helpers.go
@@ -74,7 +74,21 @@ func httpGet(ctx context.Context, url string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
+// checkCondition verifies a status condition on an unstructured object.
+func checkCondition(obj *unstructured.Unstructured, condType, expectedStatus string) error {
+	obs, err := getConditionObservation(obj, condType)
+	if err != nil {
+		return err
+	}
+	if obs.Status == expectedStatus {
+		return nil
+	}
+	return errors.New(errors.ErrCodeInternal,
+		fmt.Sprintf("condition %s=%v (want %s)", condType, obs.Status, expectedStatus))
+}
+
 type conditionObservation struct {
+	Type    string
 	Status  string
 	Reason  string
 	Message string
@@ -91,29 +105,29 @@ func getConditionObservation(obj *unstructured.Unstructured, condType string) (*
 		if !ok {
 			continue
 		}
-		condName, _ := cond["type"].(string)
-		if condName != condType {
+
+		kind, _, _ := unstructured.NestedString(cond, "type")
+		if kind != condType {
 			continue
 		}
 
-		status, _ := cond["status"].(string)
+		status, foundStatus, _ := unstructured.NestedString(cond, "status")
+		if !foundStatus {
+			if v, ok := cond["status"]; ok {
+				status = fmt.Sprintf("%v", v)
+			}
+		}
+		reason, _, _ := unstructured.NestedString(cond, "reason")
+		message, _, _ := unstructured.NestedString(cond, "message")
 		return &conditionObservation{
-			Status:  status,
-			Reason:  stringFieldOrDefault(cond, "reason", "not-reported"),
-			Message: stringFieldOrDefault(cond, "message", "not-reported"),
+			Type:    condType,
+			Status:  valueOrUnknown(status),
+			Reason:  valueOrUnknown(reason),
+			Message: valueOrUnknown(message),
 		}, nil
 	}
 
-	return nil, errors.New(errors.ErrCodeNotFound,
-		fmt.Sprintf("condition %s not found", condType))
-}
-
-func stringFieldOrDefault(obj map[string]interface{}, key, fallback string) string {
-	v, _ := obj[key].(string)
-	if v == "" {
-		return fallback
-	}
-	return v
+	return nil, errors.New(errors.ErrCodeNotFound, fmt.Sprintf("condition %s not found", condType))
 }
 
 // verifyDeploymentAvailable checks that a Deployment has at least one available replica.
@@ -260,6 +274,24 @@ func firstContainerImage(containers []corev1.Container) string {
 		return containers[0].Image
 	}
 	return "unknown"
+}
+
+func valueOrUnknown(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "unknown"
+	}
+	return v
+}
+
+func podReadyCount(pod corev1.Pod) string {
+	var ready, total int
+	for _, cs := range pod.Status.ContainerStatuses {
+		total++
+		if cs.Ready {
+			ready++
+		}
+	}
+	return fmt.Sprintf("%d/%d", ready, total)
 }
 
 // truncateLines limits text to at most n lines, appending a truncation marker if needed.

--- a/pkg/validator/checks/conformance/helpers.go
+++ b/pkg/validator/checks/conformance/helpers.go
@@ -16,7 +16,6 @@ package conformance
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,9 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 )
 
@@ -71,20 +68,7 @@ func httpGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, errors.New(errors.ErrCodeInternal,
 			fmt.Sprintf("HTTP %d from %s", resp.StatusCode, url))
 	}
-	return io.ReadAll(resp.Body)
-}
-
-// checkCondition verifies a status condition on an unstructured object.
-func checkCondition(obj *unstructured.Unstructured, condType, expectedStatus string) error {
-	obs, err := getConditionObservation(obj, condType)
-	if err != nil {
-		return err
-	}
-	if obs.Status == expectedStatus {
-		return nil
-	}
-	return errors.New(errors.ErrCodeInternal,
-		fmt.Sprintf("condition %s=%v (want %s)", condType, obs.Status, expectedStatus))
+	return io.ReadAll(io.LimitReader(resp.Body, defaults.HTTPResponseBodyLimit))
 }
 
 type conditionObservation struct {
@@ -106,8 +90,12 @@ func getConditionObservation(obj *unstructured.Unstructured, condType string) (*
 			continue
 		}
 
-		kind, _, _ := unstructured.NestedString(cond, "type")
-		if kind != condType {
+		kind, kindFound, kindErr := unstructured.NestedString(cond, "type")
+		if kindErr != nil {
+			slog.Debug("condition has non-string type field", "error", kindErr)
+			continue
+		}
+		if !kindFound || kind != condType {
 			continue
 		}
 
@@ -214,6 +202,7 @@ func recordRawTextArtifact(ctx *checks.ValidationContext, label, equivalent, dat
 
 // recordChunkedTextArtifact records text evidence across multiple artifacts when needed.
 // This avoids collector-side truncation for large YAML/JSON/metrics payloads.
+// Splits on line boundaries to avoid producing malformed YAML/JSON chunks.
 func recordChunkedTextArtifact(ctx *checks.ValidationContext, label, equivalent, data string) {
 	if strings.TrimSpace(data) == "" {
 		recordRawTextArtifact(ctx, label, equivalent, data)
@@ -234,28 +223,31 @@ func recordChunkedTextArtifact(ctx *checks.ValidationContext, label, equivalent,
 		return
 	}
 
-	total := (len(data) + chunkSize - 1) / chunkSize
-	for i := 0; i < total; i++ {
-		start := i * chunkSize
-		end := start + chunkSize
-		if end > len(data) {
-			end = len(data)
+	// Split on line boundaries to avoid cutting mid-line or mid-multibyte-character.
+	lines := strings.Split(data, "\n")
+	var chunks []string
+	var current strings.Builder
+	for _, line := range lines {
+		// If adding this line would exceed the budget, flush current chunk.
+		if current.Len() > 0 && current.Len()+len(line)+1 > chunkSize {
+			chunks = append(chunks, current.String())
+			current.Reset()
 		}
-		part := strings.TrimSpace(data[start:end])
+		if current.Len() > 0 {
+			current.WriteByte('\n')
+		}
+		current.WriteString(line)
+	}
+	if current.Len() > 0 {
+		chunks = append(chunks, current.String())
+	}
+
+	total := len(chunks)
+	for i, chunk := range chunks {
 		partLabel := fmt.Sprintf("%s (part %d/%d)", label, i+1, total)
-		partBody := fmt.Sprintf("%sPart: %d/%d\n\n%s", prefix, i+1, total, part)
+		partBody := fmt.Sprintf("%sPart: %d/%d\n\n%s", prefix, i+1, total, strings.TrimSpace(chunk))
 		recordArtifact(ctx, partLabel, partBody)
 	}
-}
-
-// recordObjectJSONArtifact records a structured object as pretty JSON.
-func recordObjectJSONArtifact(ctx *checks.ValidationContext, label, equivalent string, obj any) {
-	payload, err := json.MarshalIndent(obj, "", "  ")
-	if err != nil {
-		recordRawTextArtifact(ctx, label, equivalent, fmt.Sprintf("failed to marshal JSON: %v", err))
-		return
-	}
-	recordChunkedTextArtifact(ctx, label, equivalent, string(payload))
 }
 
 // recordObjectYAMLArtifact records a structured object as YAML.
@@ -354,46 +346,6 @@ func podWaitingStatus(pod *corev1.Pod) string {
 		}
 	}
 	return "none"
-}
-
-// waitForHPAScaleUp polls the HPA until desiredReplicas > currentReplicas.
-// This proves the HPA read metrics and computed a scale-up intent. The logPrefix
-// is prepended to log messages to distinguish callers (e.g. "pod-autoscaling", "cluster-autoscaling").
-func waitForHPAScaleUp(ctx context.Context, clientset kubernetes.Interface, namespace, hpaName, logPrefix string) (int32, int32, error) {
-	var observedDesired int32
-	var observedCurrent int32
-	waitCtx, cancel := context.WithTimeout(ctx, defaults.HPAScaleTimeout)
-	defer cancel()
-
-	err := wait.PollUntilContextCancel(waitCtx, defaults.HPAPollInterval, true,
-		func(ctx context.Context) (bool, error) {
-			hpa, getErr := clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(
-				ctx, hpaName, metav1.GetOptions{})
-			if getErr != nil {
-				slog.Debug("HPA not ready yet", "context", logPrefix, "error", getErr)
-				return false, nil
-			}
-
-			observedDesired = hpa.Status.DesiredReplicas
-			observedCurrent = hpa.Status.CurrentReplicas
-			slog.Debug(logPrefix+" HPA status", "desired", observedDesired, "current", observedCurrent)
-
-			if observedDesired > observedCurrent {
-				slog.Info(logPrefix+" HPA scaling intent detected",
-					"desiredReplicas", observedDesired, "currentReplicas", observedCurrent)
-				return true, nil
-			}
-			return false, nil
-		},
-	)
-	if err != nil {
-		if ctx.Err() != nil || waitCtx.Err() != nil {
-			return 0, 0, errors.Wrap(errors.ErrCodeTimeout,
-				logPrefix+": HPA did not report scaling intent within timeout", err)
-		}
-		return 0, 0, errors.Wrap(errors.ErrCodeInternal, logPrefix+": HPA scaling intent polling failed", err)
-	}
-	return observedDesired, observedCurrent, nil
 }
 
 // gpuDriverName is the DRA driver name for NVIDIA GPUs.

--- a/pkg/validator/checks/conformance/helpers_unit_test.go
+++ b/pkg/validator/checks/conformance/helpers_unit_test.go
@@ -1,0 +1,691 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestFormatArtifactBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		equivalent string
+		data       string
+		want       string
+	}{
+		{
+			name:       "both empty",
+			equivalent: "",
+			data:       "",
+			want:       "",
+		},
+		{
+			name:       "whitespace only",
+			equivalent: "  ",
+			data:       "  ",
+			want:       "",
+		},
+		{
+			name:       "equivalent only",
+			equivalent: "kubectl get pods",
+			data:       "",
+			want:       "Equivalent: kubectl get pods",
+		},
+		{
+			name:       "data only",
+			equivalent: "",
+			data:       "pod-1 Running",
+			want:       "pod-1 Running",
+		},
+		{
+			name:       "both present",
+			equivalent: "kubectl get pods",
+			data:       "pod-1 Running",
+			want:       "Equivalent: kubectl get pods\n\npod-1 Running",
+		},
+		{
+			name:       "trims whitespace",
+			equivalent: "  kubectl get pods  ",
+			data:       "  pod-1 Running  ",
+			want:       "Equivalent: kubectl get pods\n\npod-1 Running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatArtifactBody(tt.equivalent, tt.data)
+			if got != tt.want {
+				t.Errorf("formatArtifactBody(%q, %q) = %q, want %q",
+					tt.equivalent, tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValueOrUnknown(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty string", input: "", want: "unknown"},
+		{name: "whitespace only", input: "   ", want: "unknown"},
+		{name: "valid value", input: "kgateway", want: "kgateway"},
+		{name: "value with spaces", input: " some value ", want: " some value "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := valueOrUnknown(tt.input)
+			if got != tt.want {
+				t.Errorf("valueOrUnknown(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPodReadyCount(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		want string
+	}{
+		{
+			name: "no containers",
+			pod:  corev1.Pod{},
+			want: "0/0",
+		},
+		{
+			name: "all ready",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true},
+						{Ready: true},
+					},
+				},
+			},
+			want: "2/2",
+		},
+		{
+			name: "mixed ready and not ready",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true},
+						{Ready: false},
+						{Ready: true},
+					},
+				},
+			},
+			want: "2/3",
+		},
+		{
+			name: "none ready",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: false},
+					},
+				},
+			},
+			want: "0/1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podReadyCount(tt.pod)
+			if got != tt.want {
+				t.Errorf("podReadyCount() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConditionObservation(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		condType string
+		want     *conditionObservation
+		wantErr  bool
+	}{
+		{
+			name: "condition found",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":    "Accepted",
+								"status":  "True",
+								"reason":  "Accepted",
+								"message": "all good",
+							},
+						},
+					},
+				},
+			},
+			condType: "Accepted",
+			want:     &conditionObservation{Type: "Accepted", Status: "True", Reason: "Accepted", Message: "all good"},
+		},
+		{
+			name: "condition not found",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "Ready",
+								"status": "True",
+							},
+						},
+					},
+				},
+			},
+			condType: "Programmed",
+			wantErr:  true,
+		},
+		{
+			name: "no conditions field",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{},
+				},
+			},
+			condType: "Accepted",
+			wantErr:  true,
+		},
+		{
+			name: "missing reason and message defaults to unknown",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "Accepted",
+								"status": "True",
+							},
+						},
+					},
+				},
+			},
+			condType: "Accepted",
+			want:     &conditionObservation{Type: "Accepted", Status: "True", Reason: "unknown", Message: "unknown"},
+		},
+		{
+			name: "non-string type field is skipped",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   int64(42), // non-string
+								"status": "True",
+							},
+						},
+					},
+				},
+			},
+			condType: "Accepted",
+			wantErr:  true,
+		},
+		{
+			name: "non-string status falls back to fmt.Sprintf",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "Ready",
+								"status": true, // bool, not string
+								"reason": "AllGood",
+							},
+						},
+					},
+				},
+			},
+			condType: "Ready",
+			want:     &conditionObservation{Type: "Ready", Status: "true", Reason: "AllGood", Message: "unknown"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getConditionObservation(tt.obj, tt.condType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getConditionObservation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want != nil {
+				if got == nil {
+					t.Fatal("getConditionObservation() returned nil, want non-nil")
+				}
+				if *got != *tt.want {
+					t.Errorf("getConditionObservation() = %+v, want %+v", *got, *tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestPodStuckReason(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "running pod not stuck",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "ImagePullBackOff",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Image: "busybox:bad",
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason:  "ImagePullBackOff",
+									Message: "back-off pulling image",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "ImagePullBackOff: back-off pulling image (image: busybox:bad)",
+		},
+		{
+			name: "CrashLoopBackOff",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Image: "myapp:latest",
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason:  "CrashLoopBackOff",
+									Message: "back-off restarting failed container",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "CrashLoopBackOff: back-off restarting failed container (image: myapp:latest)",
+		},
+		{
+			name: "init container stuck",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Image: "init:bad",
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason:  "ErrImagePull",
+									Message: "pull failed",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "ErrImagePull: pull failed (init container, image: init:bad)",
+		},
+		{
+			name: "unschedulable",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:    corev1.PodScheduled,
+							Status:  corev1.ConditionFalse,
+							Reason:  string(corev1.PodReasonUnschedulable),
+							Message: "0/3 nodes available: insufficient gpu",
+						},
+					},
+				},
+			},
+			want: "Unschedulable: 0/3 nodes available: insufficient gpu",
+		},
+		{
+			name: "non-stuck waiting reason ignored",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "ContainerCreating",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podStuckReason(tt.pod)
+			if got != tt.want {
+				t.Errorf("podStuckReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPodWaitingStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "no waiting containers",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			want: "none",
+		},
+		{
+			name: "no containers",
+			pod:  &corev1.Pod{},
+			want: "none",
+		},
+		{
+			name: "waiting container",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason:  "ContainerCreating",
+									Message: "pulling image",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "ContainerCreating: pulling image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podWaitingStatus(tt.pod)
+			if got != tt.want {
+				t.Errorf("podWaitingStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordChunkedTextArtifact(t *testing.T) {
+	tests := []struct {
+		name           string
+		label          string
+		equivalent     string
+		data           string
+		wantChunkCount int
+		wantLineSplit  bool // true = verify chunks don't cut mid-line
+	}{
+		{
+			name:           "empty data records single artifact",
+			label:          "test",
+			equivalent:     "",
+			data:           "",
+			wantChunkCount: 1,
+		},
+		{
+			name:           "small data fits in single chunk",
+			label:          "test",
+			equivalent:     "kubectl get pods",
+			data:           "pod-1 Running\npod-2 Running",
+			wantChunkCount: 1,
+		},
+		{
+			name:           "large data splits into multiple chunks on line boundaries",
+			label:          "logs",
+			equivalent:     "kubectl logs test",
+			data:           generateLargeText(defaults.ArtifactMaxDataSize * 2),
+			wantChunkCount: 3, // at least 2 chunks
+			wantLineSplit:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := checks.NewArtifactCollector()
+			ctx := &checks.ValidationContext{
+				Context:   context.Background(),
+				Artifacts: collector,
+			}
+
+			recordChunkedTextArtifact(ctx, tt.label, tt.equivalent, tt.data)
+			arts := collector.Drain()
+
+			if tt.wantChunkCount > 1 {
+				if len(arts) < 2 {
+					t.Errorf("expected multiple chunks, got %d", len(arts))
+				}
+			} else {
+				if len(arts) != tt.wantChunkCount {
+					t.Errorf("expected %d chunk(s), got %d", tt.wantChunkCount, len(arts))
+				}
+			}
+
+			if tt.wantLineSplit && len(arts) > 1 {
+				// Verify each chunk's data section doesn't end or start mid-line
+				// (i.e., each chunk should start/end cleanly).
+				for i, art := range arts {
+					// Extract the data portion after the "Part: N/M\n\n" header.
+					parts := strings.SplitN(art.Data, "\n\n", 3)
+					if len(parts) < 3 {
+						continue
+					}
+					chunkData := parts[2]
+					// The chunk should not start or end with a partial line
+					// (no leading/trailing spaces that look like mid-word cuts).
+					// More importantly, verify it's valid text (not cut mid-multibyte).
+					if len(chunkData) > 0 && chunkData[len(chunkData)-1] == ' ' {
+						t.Errorf("chunk %d appears to cut mid-word", i+1)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRecordRawTextArtifact(t *testing.T) {
+	collector := checks.NewArtifactCollector()
+	ctx := &checks.ValidationContext{
+		Context:   context.Background(),
+		Artifacts: collector,
+	}
+
+	recordRawTextArtifact(ctx, "test label", "kubectl get pods", "pod-1 Running")
+	arts := collector.Drain()
+	if len(arts) != 1 {
+		t.Fatalf("expected 1 artifact, got %d", len(arts))
+	}
+	if arts[0].Label != "test label" {
+		t.Errorf("Label = %q, want %q", arts[0].Label, "test label")
+	}
+	if !strings.Contains(arts[0].Data, "Equivalent: kubectl get pods") {
+		t.Errorf("artifact data should contain equivalent command")
+	}
+	if !strings.Contains(arts[0].Data, "pod-1 Running") {
+		t.Errorf("artifact data should contain the data")
+	}
+}
+
+func TestRecordRawTextArtifact_NilCollector(t *testing.T) {
+	// Should not panic when ctx.Artifacts is nil.
+	ctx := &checks.ValidationContext{
+		Context: context.Background(),
+	}
+	recordRawTextArtifact(ctx, "test", "cmd", "data") // should be a no-op
+	t.Log("recordRawTextArtifact with nil collector completed without panic")
+}
+
+func TestTruncateLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		n     int
+		want  string
+	}{
+		{name: "fewer lines than limit", text: "a\nb", n: 5, want: "a\nb"},
+		{name: "exact limit", text: "a\nb\nc", n: 3, want: "a\nb\nc"},
+		{name: "exceeds limit", text: "a\nb\nc\nd", n: 2, want: "a\nb\n... [truncated]"},
+		{name: "single line", text: "hello", n: 1, want: "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateLines(tt.text, tt.n)
+			if got != tt.want {
+				t.Errorf("truncateLines(%q, %d) = %q, want %q", tt.text, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstContainerImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []corev1.Container
+		want       string
+	}{
+		{name: "no containers", containers: nil, want: "unknown"},
+		{name: "one container", containers: []corev1.Container{{Image: "nginx:1.25"}}, want: "nginx:1.25"},
+		{name: "multiple containers", containers: []corev1.Container{{Image: "app:v1"}, {Image: "sidecar:v2"}}, want: "app:v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstContainerImage(tt.containers)
+			if got != tt.want {
+				t.Errorf("firstContainerImage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordObjectYAMLArtifact(t *testing.T) {
+	collector := checks.NewArtifactCollector()
+	ctx := &checks.ValidationContext{
+		Context:   context.Background(),
+		Artifacts: collector,
+	}
+
+	obj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "test-pod",
+			"namespace": "default",
+		},
+	}
+
+	recordObjectYAMLArtifact(ctx, "Pod YAML", "kubectl get pod test-pod -o yaml", obj)
+	arts := collector.Drain()
+	if len(arts) < 1 {
+		t.Fatal("expected at least 1 artifact")
+	}
+	if !strings.Contains(arts[0].Data, "kind: Pod") {
+		t.Errorf("artifact data should contain YAML output, got: %s", arts[0].Data)
+	}
+}
+
+// generateLargeText creates a multi-line string of approximately n bytes.
+func generateLargeText(n int) string {
+	var b strings.Builder
+	line := "log-entry: this is a sample log line for chunk testing purposes"
+	for b.Len() < n {
+		fmt.Fprintln(&b, line)
+	}
+	return b.String()
+}
+
+func TestRecordChunkedTextArtifact_SingleLineExceedsChunkSize(t *testing.T) {
+	// A single very long line that exceeds chunk size should still produce valid output.
+	collector := checks.NewArtifactCollector()
+	ctx := &checks.ValidationContext{
+		Context:   context.Background(),
+		Artifacts: collector,
+	}
+
+	longLine := strings.Repeat("x", defaults.ArtifactMaxDataSize*2)
+	recordChunkedTextArtifact(ctx, "long", "", longLine)
+	arts := collector.Drain()
+
+	// Should produce at least one artifact (the single line can't be split further).
+	if len(arts) < 1 {
+		t.Fatal("expected at least 1 artifact for a single long line")
+	}
+}
+
+func TestInt32Ptr(t *testing.T) {
+	v := int32Ptr(42)
+	if v == nil {
+		t.Fatal("int32Ptr returned nil")
+	}
+	if *v != 42 {
+		t.Errorf("int32Ptr(42) = %d, want 42", *v)
+	}
+}
+
+func TestPodStuckReason_NilPod(t *testing.T) {
+	// Verify empty pod doesn't panic.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+	got := podStuckReason(pod)
+	if got != "" {
+		t.Errorf("podStuckReason(empty pod) = %q, want empty", got)
+	}
+}

--- a/pkg/validator/checks/conformance/inference_gateway_check.go
+++ b/pkg/validator/checks/conformance/inference_gateway_check.go
@@ -31,10 +31,11 @@ var httpRouteGVR = schema.GroupVersionResource{
 }
 
 type gatewayDataPlaneReport struct {
-	ListenerAttachedRoutes []string
-	AttachedHTTPRoutes     int
-	MatchingEndpointSlices int
-	ReadyEndpoints         int
+	ListenerCount         int
+	AttachedHTTPRoutes    int
+	TotalHTTPRoutes       int
+	MatchingEndpointSlice int
+	ReadyEndpoints        int
 }
 
 func init() {
@@ -61,6 +62,8 @@ func CheckInferenceGateway(ctx *checks.ValidationContext) error {
 		return err
 	}
 
+	collectGatewayControlPlaneArtifacts(ctx)
+
 	// 1. GatewayClass "kgateway" accepted
 	gcGVR := schema.GroupVersionResource{
 		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses",
@@ -74,13 +77,15 @@ func CheckInferenceGateway(ctx *checks.ValidationContext) error {
 		return errors.Wrap(errors.ErrCodeInternal, "GatewayClass not accepted", condErr)
 	}
 	if gcCond.Status != "True" {
-		return errors.Wrap(errors.ErrCodeInternal, "GatewayClass not accepted",
-			errors.New(errors.ErrCodeInternal,
-				fmt.Sprintf("condition Accepted=%s (want True)", gcCond.Status)))
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("GatewayClass not accepted: status=%s reason=%s message=%s",
+				gcCond.Status, gcCond.Reason, gcCond.Message))
 	}
-	recordArtifact(ctx, "GatewayClass Status",
-		fmt.Sprintf("Name:      %s\nAccepted:  %s\nReason:    %s\nMessage:   %s",
-			gc.GetName(), gcCond.Status, gcCond.Reason, gcCond.Message))
+	controllerName, _, _ := unstructured.NestedString(gc.Object, "spec", "controllerName")
+	recordRawTextArtifact(ctx, "GatewayClass",
+		"kubectl get gatewayclass kgateway -o yaml",
+		fmt.Sprintf("Name:            %s\nControllerName:  %s\nAccepted:        %s\nReason:          %s\nMessage:         %s",
+			gc.GetName(), valueOrUnknown(controllerName), gcCond.Status, gcCond.Reason, gcCond.Message))
 
 	// 2. Gateway "inference-gateway" programmed
 	gwGVR := schema.GroupVersionResource{
@@ -96,13 +101,21 @@ func CheckInferenceGateway(ctx *checks.ValidationContext) error {
 		return errors.Wrap(errors.ErrCodeInternal, "Gateway not programmed", condErr)
 	}
 	if gwCond.Status != "True" {
-		return errors.Wrap(errors.ErrCodeInternal, "Gateway not programmed",
-			errors.New(errors.ErrCodeInternal,
-				fmt.Sprintf("condition Programmed=%s (want True)", gwCond.Status)))
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("Gateway not programmed: status=%s reason=%s message=%s",
+				gwCond.Status, gwCond.Reason, gwCond.Message))
 	}
-	recordArtifact(ctx, "Gateway Status",
-		fmt.Sprintf("Name:       %s\nNamespace:  %s\nProgrammed: %s\nReason:     %s\nMessage:    %s",
-			gw.GetName(), gw.GetNamespace(), gwCond.Status, gwCond.Reason, gwCond.Message))
+	addresses, found, _ := unstructured.NestedSlice(gw.Object, "status", "addresses")
+	addressCount := 0
+	if found {
+		addressCount = len(addresses)
+	}
+	recordRawTextArtifact(ctx, "Gateways",
+		"kubectl get gateways -A",
+		fmt.Sprintf("Name:            %s/%s\nProgrammed:      %s\nReason:          %s\nMessage:         %s\nAddressCount:    %d",
+			gw.GetNamespace(), gw.GetName(), gwCond.Status, gwCond.Reason, gwCond.Message, addressCount))
+	recordObjectYAMLArtifact(ctx, "Gateway details",
+		"kubectl get gateway inference-gateway -n kgateway-system -o yaml", gw.Object)
 
 	// 3. Required CRDs exist
 	crdGVR := schema.GroupVersionResource{
@@ -115,28 +128,25 @@ func CheckInferenceGateway(ctx *checks.ValidationContext) error {
 	}
 	var crdSummary strings.Builder
 	for _, crdName := range requiredCRDs {
-		_, crdErr := dynClient.Resource(crdGVR).Get(ctx.Context, crdName, metav1.GetOptions{})
-		if crdErr != nil {
+		_, err := dynClient.Resource(crdGVR).Get(ctx.Context, crdName, metav1.GetOptions{})
+		if err != nil {
 			return errors.Wrap(errors.ErrCodeNotFound,
-				fmt.Sprintf("CRD %s not found", crdName), crdErr)
+				fmt.Sprintf("CRD %s not found", crdName), err)
 		}
 		fmt.Fprintf(&crdSummary, "  %s: present\n", crdName)
 	}
-	recordArtifact(ctx, "Required CRDs", crdSummary.String())
+	recordRawTextArtifact(ctx, "Required CRDs", "", crdSummary.String())
 
 	// 4. Gateway data-plane readiness (behavioral validation).
-	dpReport, err := validateGatewayDataPlane(ctx)
+	report, err := validateGatewayDataPlane(ctx)
 	if err != nil {
 		return err
 	}
-
-	listenerSummary := "none"
-	if len(dpReport.ListenerAttachedRoutes) > 0 {
-		listenerSummary = strings.Join(dpReport.ListenerAttachedRoutes, ", ")
-	}
-	recordArtifact(ctx, "Gateway Data Plane",
-		fmt.Sprintf("Listeners: %s\nAttached HTTPRoutes: %d\nMatching EndpointSlices: %d\nReady Endpoints: %d",
-			listenerSummary, dpReport.AttachedHTTPRoutes, dpReport.MatchingEndpointSlices, dpReport.ReadyEndpoints))
+	recordRawTextArtifact(ctx, "Gateway Data Plane",
+		"kubectl get endpointslices -n kgateway-system",
+		fmt.Sprintf("Listeners:               %d\nAttached HTTPRoutes:     %d\nHTTPRoutes (all):        %d\nMatching EndpointSlices: %d\nReady endpoints:         %d",
+			report.ListenerCount, report.AttachedHTTPRoutes, report.TotalHTTPRoutes,
+			report.MatchingEndpointSlice, report.ReadyEndpoints))
 	return nil
 }
 
@@ -164,12 +174,12 @@ func validateGatewayDataPlane(ctx *checks.ValidationContext) (*gatewayDataPlaneR
 	if gwErr == nil {
 		listeners, found, _ := unstructured.NestedSlice(gw.Object, "status", "listeners")
 		if found {
+			report.ListenerCount = len(listeners)
 			for _, l := range listeners {
 				if lMap, ok := l.(map[string]interface{}); ok {
 					name, _, _ := unstructured.NestedString(lMap, "name")
 					attached, _, _ := unstructured.NestedInt64(lMap, "attachedRoutes")
-					report.ListenerAttachedRoutes = append(report.ListenerAttachedRoutes,
-						fmt.Sprintf("%s=%d", name, attached))
+					report.AttachedHTTPRoutes += int(attached)
 					slog.Info("gateway listener status", "listener", name, "attachedRoutes", attached)
 				}
 			}
@@ -180,6 +190,7 @@ func validateGatewayDataPlane(ctx *checks.ValidationContext) (*gatewayDataPlaneR
 	httpRouteList, listErr := dynClient.Resource(httpRouteGVR).Namespace("").List(
 		ctx.Context, metav1.ListOptions{})
 	if listErr == nil {
+		report.TotalHTTPRoutes = len(httpRouteList.Items)
 		var attached int
 		for _, route := range httpRouteList.Items {
 			parentRefs, found, _ := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
@@ -215,7 +226,7 @@ func validateGatewayDataPlane(ctx *checks.ValidationContext) (*gatewayDataPlaneR
 		if !strings.Contains(svcName, "inference-gateway") {
 			continue
 		}
-		report.MatchingEndpointSlices++
+		report.MatchingEndpointSlice++
 		for _, ep := range slice.Endpoints {
 			if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
 				report.ReadyEndpoints++
@@ -229,4 +240,41 @@ func validateGatewayDataPlane(ctx *checks.ValidationContext) (*gatewayDataPlaneR
 	}
 
 	return report, nil
+}
+
+func collectGatewayControlPlaneArtifacts(ctx *checks.ValidationContext) {
+	if ctx.Clientset == nil {
+		return
+	}
+
+	deploys, deployErr := ctx.Clientset.AppsV1().Deployments("kgateway-system").List(
+		ctx.Context, metav1.ListOptions{})
+	if deployErr != nil {
+		recordRawTextArtifact(ctx, "kgateway deployments", "kubectl get deploy -n kgateway-system",
+			fmt.Sprintf("failed to list deployments: %v", deployErr))
+	} else {
+		var deploymentSummary strings.Builder
+		for _, d := range deploys.Items {
+			expected := int32(1)
+			if d.Spec.Replicas != nil {
+				expected = *d.Spec.Replicas
+			}
+			fmt.Fprintf(&deploymentSummary, "%-40s available=%d/%d image=%s\n",
+				d.Name, d.Status.AvailableReplicas, expected, firstContainerImage(d.Spec.Template.Spec.Containers))
+		}
+		recordRawTextArtifact(ctx, "kgateway deployments", "kubectl get deploy -n kgateway-system", deploymentSummary.String())
+	}
+
+	pods, podErr := ctx.Clientset.CoreV1().Pods("kgateway-system").List(ctx.Context, metav1.ListOptions{})
+	if podErr != nil {
+		recordRawTextArtifact(ctx, "kgateway pods", "kubectl get pods -n kgateway-system",
+			fmt.Sprintf("failed to list pods: %v", podErr))
+		return
+	}
+	var podSummary strings.Builder
+	for _, pod := range pods.Items {
+		fmt.Fprintf(&podSummary, "%-48s ready=%s phase=%s node=%s\n",
+			pod.Name, podReadyCount(pod), pod.Status.Phase, valueOrUnknown(pod.Spec.NodeName))
+	}
+	recordRawTextArtifact(ctx, "kgateway pods", "kubectl get pods -n kgateway-system", podSummary.String())
 }

--- a/pkg/validator/checks/conformance/inference_gateway_check.go
+++ b/pkg/validator/checks/conformance/inference_gateway_check.go
@@ -128,10 +128,9 @@ func CheckInferenceGateway(ctx *checks.ValidationContext) error {
 	}
 	var crdSummary strings.Builder
 	for _, crdName := range requiredCRDs {
-		_, err := dynClient.Resource(crdGVR).Get(ctx.Context, crdName, metav1.GetOptions{})
-		if err != nil {
+		if _, crdErr := dynClient.Resource(crdGVR).Get(ctx.Context, crdName, metav1.GetOptions{}); crdErr != nil {
 			return errors.Wrap(errors.ErrCodeNotFound,
-				fmt.Sprintf("CRD %s not found", crdName), err)
+				fmt.Sprintf("CRD %s not found", crdName), crdErr)
 		}
 		fmt.Fprintf(&crdSummary, "  %s: present\n", crdName)
 	}

--- a/pkg/validator/checks/conformance/pod_autoscaling_check.go
+++ b/pkg/validator/checks/conformance/pod_autoscaling_check.go
@@ -41,10 +41,13 @@ const (
 )
 
 type hpaBehaviorReport struct {
-	ScaleUpDesiredReplicas  int32
-	ScaleUpCurrentReplicas  int32
-	ScaleUpDeployReplicas   int32
-	ScaleDownDeployReplicas int32
+	Namespace                string
+	DeploymentName           string
+	HPAName                  string
+	ScaleUpDesiredReplicas   int32
+	ScaleUpCurrentReplicas   int32
+	ScaleUpDeploymentReplica int32
+	ScaleDownReplica         int32
 }
 
 func init() {
@@ -84,14 +87,31 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 	}
 	var statusCode int
 	result.StatusCode(&statusCode)
-	recordArtifact(ctx, "Custom Metrics API",
-		fmt.Sprintf("Endpoint:    %s\nHTTP Status: %d\nStatus:      available", rawURL, statusCode))
+	rawAPI, err := result.Raw()
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed reading custom metrics API response", err)
+	}
+	var customMetricsResp struct {
+		GroupVersion string `json:"groupVersion"`
+		Resources    []struct {
+			Name string `json:"name"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(rawAPI, &customMetricsResp); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to parse custom metrics API response", err)
+	}
+	recordRawTextArtifact(ctx, "Custom Metrics API",
+		"kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1",
+		fmt.Sprintf("Endpoint:        %s\nHTTP Status:     %d\nGroupVersion:    %s\nResource count:  %d",
+			rawURL, statusCode, valueOrUnknown(customMetricsResp.GroupVersion), len(customMetricsResp.Resources)))
 
 	// 2. GPU custom metrics have data (poll with retries — adapter relist is 30s)
 	metrics := []string{"gpu_utilization", "gpu_memory_used", "gpu_power_usage"}
 	namespaces := []string{"gpu-operator", "dynamo-system"}
 
 	var found bool
+	var foundPath string
+	var foundItems int
 	maxAttempts := 12 // 2 minutes with 10s intervals
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		for _, metric := range metrics {
@@ -109,6 +129,8 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 				}
 				if json.Unmarshal(raw, &metricsResp) == nil && len(metricsResp.Items) > 0 {
 					found = true
+					foundPath = path
+					foundItems = len(metricsResp.Items)
 					break
 				}
 			}
@@ -133,13 +155,22 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 		return errors.New(errors.ErrCodeNotFound,
 			"no GPU custom metrics available (DCGM → Prometheus → adapter pipeline broken)")
 	}
+	recordRawTextArtifact(ctx, "Custom metric sample",
+		fmt.Sprintf("kubectl get --raw %s", foundPath),
+		fmt.Sprintf("Path:            %s\nItems observed:  %d", foundPath, foundItems))
 
 	// 3. External metrics API has GPU metrics
 	extPath := "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage"
-	raw, err := restClient.Get().AbsPath(extPath).DoRaw(ctx.Context)
-	if err != nil {
+	extResult := restClient.Get().AbsPath(extPath).Do(ctx.Context)
+	if err := extResult.Error(); err != nil {
 		return errors.Wrap(errors.ErrCodeNotFound,
 			"external metric dcgm_gpu_power_usage not available", err)
+	}
+	var extStatusCode int
+	extResult.StatusCode(&extStatusCode)
+	raw, err := extResult.Raw()
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed reading external metric response", err)
 	}
 	var extResp struct {
 		Items []json.RawMessage `json:"items"`
@@ -149,19 +180,28 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 			"external metric dcgm_gpu_power_usage has no data")
 	}
 
-	recordArtifact(ctx, "External Metrics API",
-		fmt.Sprintf("Endpoint:  %s\nMetric:    dcgm_gpu_power_usage\nItems:     %d\nStatus:    available with data",
-			extPath, len(extResp.Items)))
+	recordRawTextArtifact(ctx, "External Metrics API",
+		fmt.Sprintf("kubectl get --raw %s", extPath),
+		fmt.Sprintf("Endpoint:        %s\nHTTP Status:     %d\nMetric:          dcgm_gpu_power_usage\nItems observed:  %d",
+			extPath, extStatusCode, len(extResp.Items)))
 
 	// 4. HPA behavioral validation: prove HPA reads external metrics and computes scale-up.
-	report, err := validateHPABehavior(ctx.Context, ctx.Clientset)
+	hpaReport, err := validateHPABehavior(ctx.Context, ctx.Clientset)
 	if err != nil {
 		return err
 	}
-	recordArtifact(ctx, "HPA Behavioral Test",
-		fmt.Sprintf("Scale-up HPA desired/current: %d/%d\nScale-up deployment replicas: %d\nScale-down deployment replicas: %d",
-			report.ScaleUpDesiredReplicas, report.ScaleUpCurrentReplicas,
-			report.ScaleUpDeployReplicas, report.ScaleDownDeployReplicas))
+	recordRawTextArtifact(ctx, "Apply test manifest",
+		"kubectl apply -f docs/conformance/cncf/manifests/hpa-gpu-test.yaml",
+		fmt.Sprintf("Created namespace=%s deployment=%s hpa=%s via Kubernetes API",
+			hpaReport.Namespace, hpaReport.DeploymentName, hpaReport.HPAName))
+	recordRawTextArtifact(ctx, "HPA Behavioral Test",
+		"kubectl get hpa -n hpa-test && kubectl get deploy -n hpa-test",
+		fmt.Sprintf("Namespace:            %s\nHPA:                  %s\nScale-up desired:     %d\nScale-up current:     %d\nDeployment scale-up:  %d\nDeployment scale-down:%d",
+			hpaReport.Namespace, hpaReport.HPAName, hpaReport.ScaleUpDesiredReplicas,
+			hpaReport.ScaleUpCurrentReplicas, hpaReport.ScaleUpDeploymentReplica, hpaReport.ScaleDownReplica))
+	recordRawTextArtifact(ctx, "Delete test namespace",
+		"kubectl delete namespace hpa-test --ignore-not-found",
+		fmt.Sprintf("Deleted namespace %s after HPA behavioral test.", hpaReport.Namespace))
 	return nil
 }
 
@@ -170,8 +210,6 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 // actually scales. This proves the full metrics pipeline (DCGM → Prometheus → adapter → HPA)
 // is functional end-to-end.
 func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*hpaBehaviorReport, error) {
-	report := &hpaBehaviorReport{}
-
 	// Generate unique test resource names and namespace (prevents cross-run interference).
 	b := make([]byte, 4)
 	if _, err := rand.Read(b); err != nil {
@@ -181,6 +219,11 @@ func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*
 	nsName := hpaTestPrefix + suffix
 	deployName := hpaTestPrefix + suffix
 	hpaName := hpaTestPrefix + suffix
+	report := &hpaBehaviorReport{
+		Namespace:      nsName,
+		DeploymentName: deployName,
+		HPAName:        hpaName,
+	}
 
 	// Create unique test namespace.
 	ns := &corev1.Namespace{
@@ -217,19 +260,19 @@ func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*
 	}
 
 	// Wait for HPA to report scaling intent: desiredReplicas > currentReplicas.
-	desiredReplicas, currentReplicas, err := waitForHPAScaleUp(ctx, clientset, nsName, hpaName, "pod-autoscaling")
+	desired, current, err := waitForHPAScalingIntent(ctx, clientset, nsName, hpaName)
 	if err != nil {
 		return nil, err
 	}
-	report.ScaleUpDesiredReplicas = desiredReplicas
-	report.ScaleUpCurrentReplicas = currentReplicas
+	report.ScaleUpDesiredReplicas = desired
+	report.ScaleUpCurrentReplicas = current
 
 	// Wait for Deployment to actually scale up (proves HPA → Deployment controller chain).
 	scaleUpReplicas, err := waitForDeploymentScale(ctx, clientset, nsName, deployName)
 	if err != nil {
 		return nil, err
 	}
-	report.ScaleUpDeployReplicas = scaleUpReplicas
+	report.ScaleUpDeploymentReplica = scaleUpReplicas
 
 	// Scale-down: patch HPA with high target so metric reads well below threshold.
 	// This triggers the HPA to compute desiredReplicas = minReplicas (scale-down).
@@ -241,10 +284,9 @@ func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to get HPA for scale-down test", err)
 	}
 	currentHPA.Spec.Metrics[0].External.Target.AverageValue = resourceQuantityPtr("999999")
-	_, updateErr := clientset.AutoscalingV2().HorizontalPodAutoscalers(nsName).Update(
-		ctx, currentHPA, metav1.UpdateOptions{})
-	if updateErr != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to update HPA target for scale-down", updateErr)
+	if _, err := clientset.AutoscalingV2().HorizontalPodAutoscalers(nsName).Update(
+		ctx, currentHPA, metav1.UpdateOptions{}); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to update HPA target for scale-down", err)
 	}
 
 	// Wait for Deployment to scale down (proves HPA scale-down path works).
@@ -252,7 +294,7 @@ func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*
 	if err != nil {
 		return nil, err
 	}
-	report.ScaleDownDeployReplicas = scaleDownReplicas
+	report.ScaleDownReplica = scaleDownReplicas
 	return report, nil
 }
 
@@ -343,12 +385,54 @@ func resourceQuantityPtr(val string) *resource.Quantity {
 	return &q
 }
 
+// waitForHPAScalingIntent polls the HPA until desiredReplicas > currentReplicas.
+// This is the strict criterion: it proves the HPA read metrics and computed a scale-up.
+// We do NOT accept ScalingActive=True alone as that can be true even without scale intent.
+func waitForHPAScalingIntent(ctx context.Context, clientset kubernetes.Interface, namespace, hpaName string) (int32, int32, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, defaults.HPAScaleTimeout)
+	defer cancel()
+	var observedDesired, observedCurrent int32
+
+	err := wait.PollUntilContextCancel(waitCtx, defaults.HPAPollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			hpa, getErr := clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(
+				ctx, hpaName, metav1.GetOptions{})
+			if getErr != nil {
+				slog.Debug("HPA not ready yet", "error", getErr)
+				return false, nil // retry
+			}
+
+			desired := hpa.Status.DesiredReplicas
+			current := hpa.Status.CurrentReplicas
+			observedDesired = desired
+			observedCurrent = current
+			slog.Debug("HPA status", "desired", desired, "current", current)
+
+			if desired > current {
+				slog.Info("HPA scaling intent detected",
+					"desiredReplicas", desired, "currentReplicas", current)
+				return true, nil
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		if ctx.Err() != nil || waitCtx.Err() != nil {
+			return 0, 0, errors.Wrap(errors.ErrCodeTimeout,
+				"HPA did not report scaling intent within timeout — metrics pipeline may be broken", err)
+		}
+		return 0, 0, errors.Wrap(errors.ErrCodeInternal, "HPA scaling intent polling failed", err)
+	}
+
+	return observedDesired, observedCurrent, nil
+}
+
 // waitForDeploymentScale polls the Deployment until status.replicas > 1, proving
 // that the Deployment controller acted on the HPA's scaling recommendation.
 func waitForDeploymentScale(ctx context.Context, clientset kubernetes.Interface, namespace, deployName string) (int32, error) {
-	var observedReplicas int32
 	waitCtx, cancel := context.WithTimeout(ctx, defaults.DeploymentScaleTimeout)
 	defer cancel()
+	var observedReplicas int32
 
 	err := wait.PollUntilContextCancel(waitCtx, defaults.HPAPollInterval, true,
 		func(ctx context.Context) (bool, error) {
@@ -359,11 +443,12 @@ func waitForDeploymentScale(ctx context.Context, clientset kubernetes.Interface,
 				return false, nil
 			}
 
-			observedReplicas = deploy.Status.Replicas
-			slog.Debug("deployment replica status", "name", deployName, "replicas", observedReplicas)
+			replicas := deploy.Status.Replicas
+			slog.Debug("deployment replica status", "name", deployName, "replicas", replicas)
 
-			if observedReplicas > 1 {
-				slog.Info("deployment scaled up", "name", deployName, "replicas", observedReplicas)
+			if replicas > 1 {
+				slog.Info("deployment scaled up", "name", deployName, "replicas", replicas)
+				observedReplicas = replicas
 				return true, nil
 			}
 			return false, nil
@@ -383,9 +468,9 @@ func waitForDeploymentScale(ctx context.Context, clientset kubernetes.Interface,
 // waitForDeploymentScaleDown polls the Deployment until status.replicas <= 1, proving
 // that the HPA's scale-down recommendation was enacted by the Deployment controller.
 func waitForDeploymentScaleDown(ctx context.Context, clientset kubernetes.Interface, namespace, deployName string) (int32, error) {
-	var observedReplicas int32
 	waitCtx, cancel := context.WithTimeout(ctx, defaults.DeploymentScaleTimeout)
 	defer cancel()
+	var observedReplicas int32
 
 	err := wait.PollUntilContextCancel(waitCtx, defaults.HPAPollInterval, true,
 		func(ctx context.Context) (bool, error) {
@@ -396,11 +481,12 @@ func waitForDeploymentScaleDown(ctx context.Context, clientset kubernetes.Interf
 				return false, nil
 			}
 
-			observedReplicas = deploy.Status.Replicas
-			slog.Debug("deployment replica status (scale-down)", "name", deployName, "replicas", observedReplicas)
+			replicas := deploy.Status.Replicas
+			slog.Debug("deployment replica status (scale-down)", "name", deployName, "replicas", replicas)
 
-			if observedReplicas <= 1 {
-				slog.Info("deployment scaled down", "name", deployName, "replicas", observedReplicas)
+			if replicas <= 1 {
+				slog.Info("deployment scaled down", "name", deployName, "replicas", replicas)
+				observedReplicas = replicas
 				return true, nil
 			}
 			return false, nil

--- a/pkg/validator/checks/conformance/pod_autoscaling_check.go
+++ b/pkg/validator/checks/conformance/pod_autoscaling_check.go
@@ -97,8 +97,8 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 			Name string `json:"name"`
 		} `json:"resources"`
 	}
-	if err := json.Unmarshal(rawAPI, &customMetricsResp); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to parse custom metrics API response", err)
+	if unmarshalErr := json.Unmarshal(rawAPI, &customMetricsResp); unmarshalErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to parse custom metrics API response", unmarshalErr)
 	}
 	recordRawTextArtifact(ctx, "Custom Metrics API",
 		"kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1",
@@ -119,8 +119,8 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 				path := fmt.Sprintf(
 					"/apis/custom.metrics.k8s.io/v1beta1/namespaces/%s/pods/*/%s",
 					ns, metric)
-				raw, err := restClient.Get().AbsPath(path).DoRaw(ctx.Context)
-				if err != nil {
+				raw, rawErr := restClient.Get().AbsPath(path).DoRaw(ctx.Context)
+				if rawErr != nil {
 					continue
 				}
 
@@ -162,20 +162,20 @@ func CheckPodAutoscaling(ctx *checks.ValidationContext) error {
 	// 3. External metrics API has GPU metrics
 	extPath := "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage"
 	extResult := restClient.Get().AbsPath(extPath).Do(ctx.Context)
-	if err := extResult.Error(); err != nil {
+	if extErr := extResult.Error(); extErr != nil {
 		return errors.Wrap(errors.ErrCodeNotFound,
-			"external metric dcgm_gpu_power_usage not available", err)
+			"external metric dcgm_gpu_power_usage not available", extErr)
 	}
 	var extStatusCode int
 	extResult.StatusCode(&extStatusCode)
-	raw, err := extResult.Raw()
+	extRaw, err := extResult.Raw()
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed reading external metric response", err)
 	}
 	var extResp struct {
 		Items []json.RawMessage `json:"items"`
 	}
-	if json.Unmarshal(raw, &extResp) == nil && len(extResp.Items) == 0 {
+	if json.Unmarshal(extRaw, &extResp) == nil && len(extResp.Items) == 0 {
 		return errors.New(errors.ErrCodeNotFound,
 			"external metric dcgm_gpu_power_usage has no data")
 	}
@@ -284,9 +284,9 @@ func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to get HPA for scale-down test", err)
 	}
 	currentHPA.Spec.Metrics[0].External.Target.AverageValue = resourceQuantityPtr("999999")
-	if _, err := clientset.AutoscalingV2().HorizontalPodAutoscalers(nsName).Update(
-		ctx, currentHPA, metav1.UpdateOptions{}); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to update HPA target for scale-down", err)
+	if _, updateErr := clientset.AutoscalingV2().HorizontalPodAutoscalers(nsName).Update(
+		ctx, currentHPA, metav1.UpdateOptions{}); updateErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to update HPA target for scale-down", updateErr)
 	}
 
 	// Wait for Deployment to scale down (proves HPA scale-down path works).

--- a/pkg/validator/checks/conformance/pod_autoscaling_check_unit_test.go
+++ b/pkg/validator/checks/conformance/pod_autoscaling_check_unit_test.go
@@ -192,19 +192,19 @@ func TestValidateHPABehavior(t *testing.T) {
 
 			if !tt.wantErr {
 				if report == nil {
-					t.Fatal("validateHPABehavior() report = nil, want non-nil")
+					t.Fatal("validateHPABehavior() report is nil")
 				}
-				if report.ScaleUpDesiredReplicas != tt.desiredReplicas || report.ScaleUpCurrentReplicas != tt.currentReplicas {
-					t.Errorf("report scale-up desired/current = %d/%d, want %d/%d",
-						report.ScaleUpDesiredReplicas, report.ScaleUpCurrentReplicas, tt.desiredReplicas, tt.currentReplicas)
+				if report.ScaleUpDesiredReplicas != tt.desiredReplicas {
+					t.Errorf("ScaleUpDesiredReplicas = %d, want %d", report.ScaleUpDesiredReplicas, tt.desiredReplicas)
 				}
-				if report.ScaleUpDeployReplicas != tt.deployReplicas {
-					t.Errorf("report scale-up deployment replicas = %d, want %d",
-						report.ScaleUpDeployReplicas, tt.deployReplicas)
+				if report.ScaleUpCurrentReplicas != tt.currentReplicas {
+					t.Errorf("ScaleUpCurrentReplicas = %d, want %d", report.ScaleUpCurrentReplicas, tt.currentReplicas)
 				}
-				if report.ScaleDownDeployReplicas != 1 {
-					t.Errorf("report scale-down deployment replicas = %d, want 1",
-						report.ScaleDownDeployReplicas)
+				if report.ScaleUpDeploymentReplica != tt.deployReplicas {
+					t.Errorf("ScaleUpDeploymentReplica = %d, want %d", report.ScaleUpDeploymentReplica, tt.deployReplicas)
+				}
+				if report.ScaleDownReplica != 1 {
+					t.Errorf("ScaleDownReplica = %d, want 1", report.ScaleDownReplica)
 				}
 			}
 		})

--- a/pkg/validator/checks/conformance/robust_controller_check.go
+++ b/pkg/validator/checks/conformance/robust_controller_check.go
@@ -35,10 +35,15 @@ var dgdGVR = schema.GroupVersionResource{
 	Group: "nvidia.com", Version: "v1alpha1", Resource: "dynamographdeployments",
 }
 
+var dcdGVR = schema.GroupVersionResource{
+	Group: "nvidia.com", Version: "v1alpha1", Resource: "dynamocomponentdeployments",
+}
+
 type webhookRejectionReport struct {
 	ResourceName string
+	Namespace    string
 	StatusCode   int32
-	Reason       metav1.StatusReason
+	Reason       string
 	Message      string
 }
 
@@ -73,7 +78,8 @@ func CheckRobustController(ctx *checks.ValidationContext) error {
 		if deploy.Spec.Replicas != nil {
 			expected = *deploy.Spec.Replicas
 		}
-		recordArtifact(ctx, "Dynamo Operator Deployment",
+		recordRawTextArtifact(ctx, "Dynamo Operator Deployment",
+			"kubectl get deploy -n dynamo-system",
 			fmt.Sprintf("Name:      %s/%s\nReplicas:  %d/%d available\nImage:     %s",
 				deploy.Namespace, deploy.Name,
 				deploy.Status.AvailableReplicas, expected,
@@ -81,6 +87,18 @@ func CheckRobustController(ctx *checks.ValidationContext) error {
 	}
 	if deployErr != nil {
 		return errors.Wrap(errors.ErrCodeNotFound, "Dynamo operator controller-manager check failed", deployErr)
+	}
+	operatorPods, podErr := ctx.Clientset.CoreV1().Pods("dynamo-system").List(ctx.Context, metav1.ListOptions{})
+	if podErr != nil {
+		recordRawTextArtifact(ctx, "Dynamo operator pods", "kubectl get pods -n dynamo-system",
+			fmt.Sprintf("failed to list pods: %v", podErr))
+	} else {
+		var podSummary strings.Builder
+		for _, p := range operatorPods.Items {
+			fmt.Fprintf(&podSummary, "%-46s ready=%s phase=%s node=%s\n",
+				p.Name, podReadyCount(p), p.Status.Phase, valueOrUnknown(p.Spec.NodeName))
+		}
+		recordRawTextArtifact(ctx, "Dynamo operator pods", "kubectl get pods -n dynamo-system", podSummary.String())
 	}
 
 	// 2. Validating webhook operational
@@ -92,10 +110,12 @@ func CheckRobustController(ctx *checks.ValidationContext) error {
 	}
 	var foundDynamoWebhook bool
 	var webhookName string
+	var webhookSummary strings.Builder
 	for _, wh := range webhooks.Items {
 		if strings.Contains(wh.Name, "dynamo") {
 			foundDynamoWebhook = true
 			webhookName = wh.Name
+			fmt.Fprintf(&webhookSummary, "WebhookConfig: %s\n", wh.Name)
 			// Verify webhook service endpoint exists via EndpointSlice
 			for _, w := range wh.Webhooks {
 				if w.ClientConfig.Service != nil {
@@ -113,6 +133,7 @@ func CheckRobustController(ctx *checks.ValidationContext) error {
 						return errors.New(errors.ErrCodeNotFound,
 							fmt.Sprintf("no EndpointSlice for webhook service %s/%s", svcNs, svcName))
 					}
+					fmt.Fprintf(&webhookSummary, "  service=%s/%s endpointSlices=%d\n", svcNs, svcName, len(slices.Items))
 				}
 			}
 			break
@@ -122,7 +143,11 @@ func CheckRobustController(ctx *checks.ValidationContext) error {
 		return errors.New(errors.ErrCodeNotFound,
 			"Dynamo validating webhook configuration not found")
 	}
-	recordArtifact(ctx, "Validating Webhook",
+	recordRawTextArtifact(ctx, "Validating webhooks",
+		"kubectl get validatingwebhookconfigurations | grep dynamo",
+		strings.TrimSpace(webhookSummary.String()))
+	recordRawTextArtifact(ctx, "Validating Webhook",
+		"kubectl get validatingwebhookconfigurations",
 		fmt.Sprintf("Name:      %s\nEndpoint:  reachable", webhookName))
 
 	// 3. DynamoGraphDeployment CRD exists (proves operator manages CRs)
@@ -135,21 +160,68 @@ func CheckRobustController(ctx *checks.ValidationContext) error {
 	crdGVR := schema.GroupVersionResource{
 		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
 	}
-	_, err = dynClient.Resource(crdGVR).Get(ctx.Context,
+	crdObj, err := dynClient.Resource(crdGVR).Get(ctx.Context,
 		"dynamographdeployments.nvidia.com", metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeNotFound,
 			"DynamoGraphDeployment CRD not found", err)
 	}
+	recordRawTextArtifact(ctx, "Dynamo CRDs",
+		"kubectl get crds | grep -i dynamo",
+		fmt.Sprintf("Required CRD present: %s", crdObj.GetName()))
+
+	// Optional evidence: capture DynamoGraphDeployment and component inventories if available.
+	dgdList, dgdListErr := dynClient.Resource(dgdGVR).Namespace("").List(ctx.Context, metav1.ListOptions{})
+	if dgdListErr != nil {
+		recordRawTextArtifact(ctx, "DynamoGraphDeployments", "kubectl get dynamographdeployments -A",
+			fmt.Sprintf("unable to list DynamoGraphDeployments: %v", dgdListErr))
+	} else {
+		var dgdSummary strings.Builder
+		fmt.Fprintf(&dgdSummary, "Count: %d\n", len(dgdList.Items))
+		for _, item := range dgdList.Items {
+			fmt.Fprintf(&dgdSummary, "- %s/%s\n", item.GetNamespace(), item.GetName())
+		}
+		recordRawTextArtifact(ctx, "DynamoGraphDeployments", "kubectl get dynamographdeployments -A", dgdSummary.String())
+	}
+
+	workloadPods, workloadPodErr := ctx.Clientset.CoreV1().Pods("dynamo-workload").List(ctx.Context, metav1.ListOptions{})
+	if workloadPodErr != nil {
+		recordRawTextArtifact(ctx, "Dynamo workload pods", "kubectl get pods -n dynamo-workload -o wide",
+			fmt.Sprintf("unable to list workload pods: %v", workloadPodErr))
+	} else {
+		var workloadSummary strings.Builder
+		for _, p := range workloadPods.Items {
+			fmt.Fprintf(&workloadSummary, "%-46s ready=%s phase=%s node=%s\n",
+				p.Name, podReadyCount(p), p.Status.Phase, valueOrUnknown(p.Spec.NodeName))
+		}
+		recordRawTextArtifact(ctx, "Dynamo workload pods", "kubectl get pods -n dynamo-workload -o wide", workloadSummary.String())
+	}
+
+	componentList, componentErr := dynClient.Resource(dcdGVR).Namespace("dynamo-workload").List(ctx.Context, metav1.ListOptions{})
+	if componentErr != nil {
+		recordRawTextArtifact(ctx, "DynamoComponentDeployments",
+			"kubectl get dynamocomponentdeployments -n dynamo-workload",
+			fmt.Sprintf("unable to list DynamoComponentDeployments: %v", componentErr))
+	} else {
+		var componentSummary strings.Builder
+		fmt.Fprintf(&componentSummary, "Count: %d\n", len(componentList.Items))
+		for _, item := range componentList.Items {
+			fmt.Fprintf(&componentSummary, "- %s/%s\n", item.GetNamespace(), item.GetName())
+		}
+		recordRawTextArtifact(ctx, "DynamoComponentDeployments",
+			"kubectl get dynamocomponentdeployments -n dynamo-workload", componentSummary.String())
+	}
 
 	// 4. Validating webhook actively rejects invalid resources (behavioral test).
-	report, err := validateWebhookRejects(ctx)
+	rejectionReport, err := validateWebhookRejects(ctx)
 	if err != nil {
 		return err
 	}
-	recordArtifact(ctx, "Webhook Rejection Test",
-		fmt.Sprintf("Resource:   %s\nHTTP Code:  %d\nReason:     %s\nMessage:    %s",
-			report.ResourceName, report.StatusCode, report.Reason, report.Message))
+	recordRawTextArtifact(ctx, "Webhook Rejection Test",
+		"kubectl apply -f <invalid dynamographdeployment>",
+		fmt.Sprintf("Resource:    %s/%s\nHTTPStatus:  %d\nReason:      %s\nMessage:     %s",
+			rejectionReport.Namespace, rejectionReport.ResourceName,
+			rejectionReport.StatusCode, rejectionReport.Reason, rejectionReport.Message))
 	return nil
 }
 
@@ -196,27 +268,29 @@ func validateWebhookRejects(ctx *checks.ValidationContext) (*webhookRejectionRep
 			"validating webhook did not reject invalid DynamoGraphDeployment")
 	}
 
+	report := &webhookRejectionReport{
+		ResourceName: name,
+		Namespace:    "dynamo-system",
+		Reason:       "unknown",
+		Message:      createErr.Error(),
+	}
+
 	// Webhook rejections produce Forbidden (403) or Invalid (422) API errors.
 	// Use k8serrors type predicates instead of brittle string matching.
 	// IsForbidden can also match RBAC denials, so we explicitly exclude those
 	// by checking the structured status message for RBAC patterns.
 	if k8serrors.IsForbidden(createErr) || k8serrors.IsInvalid(createErr) {
-		report := &webhookRejectionReport{
-			ResourceName: name,
-			Message:      createErr.Error(),
-		}
-
 		var statusErr *k8serrors.StatusError
 		if stderrors.As(createErr, &statusErr) {
 			status := statusErr.Status()
+			report.StatusCode = status.Code
+			report.Reason = string(status.Reason)
+			report.Message = status.Message
 			msg := status.Message
 			if strings.Contains(msg, "cannot create resource") {
 				return nil, errors.Wrap(errors.ErrCodeInternal,
 					"RBAC denied the request, not an admission webhook rejection", createErr)
 			}
-			report.StatusCode = status.Code
-			report.Reason = status.Reason
-			report.Message = msg
 		}
 		return report, nil // PASS — webhook rejected the invalid resource
 	}

--- a/pkg/validator/checks/conformance/robust_controller_check_unit_test.go
+++ b/pkg/validator/checks/conformance/robust_controller_check_unit_test.go
@@ -175,6 +175,7 @@ func TestCheckRobustController(t *testing.T) {
 				gvrMap := map[schema.GroupVersionResource]string{
 					{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
 					dgdGVR: "DynamoGraphDeploymentList",
+					dcdGVR: "DynamoComponentDeploymentList",
 				}
 				var dynClient *dynamicfake.FakeDynamicClient
 				if len(tt.dynamicObjects) > 0 {

--- a/pkg/validator/checks/conformance/secure_access_check.go
+++ b/pkg/validator/checks/conformance/secure_access_check.go
@@ -49,12 +49,23 @@ type draTestRun struct {
 	noClaimPodName string
 }
 
-type draIsolationReport struct {
+type draPatternReport struct {
 	PodName             string
 	PodPhase            corev1.PodPhase
-	ExitCode            int32
+	ResourceClaimCount  int
+	GPULimitsCount      int
 	HostPathGPUMounts   int
-	ResourceClaimsCount int
+	ClaimState          string
+	ClaimAllocationInfo string
+}
+
+type draIsolationReport struct {
+	PodName           string
+	PodPhase          corev1.PodPhase
+	ExitCode          int32
+	ResourceClaims    int
+	HostPathGPUMounts int
+	Logs              string
 }
 
 func newDRATestRun() (*draTestRun, error) {
@@ -72,6 +83,10 @@ func newDRATestRun() (*draTestRun, error) {
 
 var claimGVR = schema.GroupVersionResource{
 	Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims",
+}
+
+var resourceSliceGVR = schema.GroupVersionResource{
+	Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices",
 }
 
 func init() {
@@ -103,6 +118,8 @@ func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
 		return err
 	}
 
+	collectSecureAccessBaselineArtifacts(ctx, dynClient)
+
 	run, err := newDRATestRun()
 	if err != nil {
 		return err
@@ -119,30 +136,117 @@ func CheckSecureAcceleratorAccess(ctx *checks.ValidationContext) error {
 	if err != nil {
 		return err
 	}
-	recordArtifact(ctx, "DRA Test Pod",
-		fmt.Sprintf("Name:      %s/%s\nPhase:     %s\nClaims:    %d resource claims",
-			pod.Namespace, pod.Name, pod.Status.Phase, len(pod.Spec.ResourceClaims)))
+	recordRawTextArtifact(ctx, "Pod status",
+		"kubectl get pod isolation-test -n dra-test -o wide",
+		fmt.Sprintf("Name:      %s/%s\nPhase:     %s\nNode:      %s\nClaims:    %d resource claims",
+			pod.Namespace, pod.Name, pod.Status.Phase, valueOrUnknown(pod.Spec.NodeName), len(pod.Spec.ResourceClaims)))
 
 	// Validate DRA access patterns on the completed pod.
-	if err = validateDRAPatterns(ctx.Context, dynClient, pod, run); err != nil {
+	patternReport, err := validateDRAPatterns(ctx.Context, dynClient, pod, run)
+	if err != nil {
 		return err
 	}
-	recordArtifact(ctx, "DRA Access Patterns",
-		fmt.Sprintf("ResourceClaims:  present (%d)\nDevice Plugin:   absent (no nvidia.com/gpu in limits)\nHostPath GPU:    absent (no /dev/nvidia* mounts)\nClaim Status:    allocated",
-			len(pod.Spec.ResourceClaims)))
+	recordRawTextArtifact(ctx, "Pod resourceClaims",
+		"kubectl get pod isolation-test -n dra-test -o jsonpath='{.spec.resourceClaims}'",
+		fmt.Sprintf("Pod:             %s/%s\nResourceClaims:  %d\nGPULimits:       %d",
+			draTestNamespace, patternReport.PodName, patternReport.ResourceClaimCount, patternReport.GPULimitsCount))
+	recordRawTextArtifact(ctx, "Pod volumes (no hostPath)",
+		"kubectl get pod isolation-test -n dra-test -o jsonpath='{.spec.volumes}'",
+		fmt.Sprintf("Pod:               %s/%s\nHostPathGPUMounts: %d",
+			draTestNamespace, patternReport.PodName, patternReport.HostPathGPUMounts))
+	recordRawTextArtifact(ctx, "ResourceClaim allocation",
+		"kubectl get resourceclaim isolated-gpu -n dra-test -o wide",
+		fmt.Sprintf("Name:             %s/%s\nState:            %s\nAllocationStatus: %s",
+			draTestNamespace, run.claimName, patternReport.ClaimState, patternReport.ClaimAllocationInfo))
+
+	logBytes, logErr := ctx.Clientset.CoreV1().Pods(draTestNamespace).GetLogs(
+		run.podName, &corev1.PodLogOptions{}).DoRaw(ctx.Context)
+	if logErr != nil {
+		recordRawTextArtifact(ctx, "Isolation test logs",
+			"kubectl logs isolation-test -n dra-test",
+			fmt.Sprintf("failed to read isolation test logs: %v", logErr))
+	} else {
+		recordChunkedTextArtifact(ctx, "Isolation test logs",
+			"kubectl logs isolation-test -n dra-test", string(logBytes))
+	}
 
 	// Validate isolation: a pod without DRA claims cannot access GPU devices.
 	// Target the same node as the DRA test pod — isolation must be proven on the
 	// GPU node, not a control-plane node that has no GPUs in the first place.
-	report, err := validateDRAIsolation(ctx.Context, ctx.Clientset, run, pod.Spec.NodeName)
+	isolationReport, err := validateDRAIsolation(ctx.Context, ctx.Clientset, run, pod.Spec.NodeName)
 	if err != nil {
 		return err
 	}
-	recordArtifact(ctx, "DRA Isolation Test",
-		fmt.Sprintf("Pod:                %s/%s\nPhase:              %s\nExit Code:          %d\nResourceClaims:     %d\nHostPath GPU mounts:%d",
-			draTestNamespace, report.PodName, report.PodPhase, report.ExitCode,
-			report.ResourceClaimsCount, report.HostPathGPUMounts))
+	recordRawTextArtifact(ctx, "DRA Isolation Test",
+		"kubectl logs dra-no-claim-<id> -n dra-test",
+		fmt.Sprintf("Pod:               %s/%s\nPhase:             %s\nExitCode:          %d\nResourceClaims:    %d\nHostPathGPUMounts: %d",
+			draTestNamespace, isolationReport.PodName, isolationReport.PodPhase,
+			isolationReport.ExitCode, isolationReport.ResourceClaims, isolationReport.HostPathGPUMounts))
+	recordChunkedTextArtifact(ctx, "No-claim pod logs",
+		"kubectl logs dra-no-claim-<id> -n dra-test", isolationReport.Logs)
 	return nil
+}
+
+func collectSecureAccessBaselineArtifacts(ctx *checks.ValidationContext, dynClient dynamic.Interface) {
+	// ClusterPolicy status.
+	clusterPolicyGVR := schema.GroupVersionResource{
+		Group: "nvidia.com", Version: "v1", Resource: "clusterpolicies",
+	}
+	cp, err := dynClient.Resource(clusterPolicyGVR).Get(ctx.Context, "cluster-policy", metav1.GetOptions{})
+	if err != nil {
+		recordRawTextArtifact(ctx, "ClusterPolicy status", "kubectl get clusterpolicy -o wide",
+			fmt.Sprintf("failed to read ClusterPolicy: %v", err))
+	} else {
+		state, _, _ := unstructured.NestedString(cp.Object, "status", "state")
+		recordRawTextArtifact(ctx, "ClusterPolicy status", "kubectl get clusterpolicy -o wide",
+			fmt.Sprintf("Name:   %s\nState:  %s", cp.GetName(), valueOrUnknown(state)))
+	}
+
+	// GPU operator pods.
+	operatorPods, err := ctx.Clientset.CoreV1().Pods("gpu-operator").List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		recordRawTextArtifact(ctx, "GPU operator pods", "kubectl get pods -n gpu-operator -o wide",
+			fmt.Sprintf("failed to list gpu-operator pods: %v", err))
+	} else {
+		var podSummary strings.Builder
+		for _, pod := range operatorPods.Items {
+			fmt.Fprintf(&podSummary, "%-46s ready=%s phase=%s node=%s\n",
+				pod.Name, podReadyCount(pod), pod.Status.Phase, pod.Spec.NodeName)
+		}
+		recordRawTextArtifact(ctx, "GPU operator pods", "kubectl get pods -n gpu-operator -o wide", podSummary.String())
+	}
+
+	// GPU operator DaemonSets.
+	daemonSets, err := ctx.Clientset.AppsV1().DaemonSets("gpu-operator").List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		recordRawTextArtifact(ctx, "GPU operator DaemonSets", "kubectl get ds -n gpu-operator",
+			fmt.Sprintf("failed to list gpu-operator DaemonSets: %v", err))
+	} else {
+		var dsSummary strings.Builder
+		for _, ds := range daemonSets.Items {
+			fmt.Fprintf(&dsSummary, "%-38s ready=%d/%d\n",
+				ds.Name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled)
+		}
+		recordRawTextArtifact(ctx, "GPU operator DaemonSets", "kubectl get ds -n gpu-operator", dsSummary.String())
+	}
+
+	// ResourceSlices summary + details.
+	slices, err := dynClient.Resource(resourceSliceGVR).List(ctx.Context, metav1.ListOptions{})
+	if err != nil {
+		recordRawTextArtifact(ctx, "ResourceSlices", "kubectl get resourceslices -o wide",
+			fmt.Sprintf("failed to list ResourceSlices: %v", err))
+		recordRawTextArtifact(ctx, "GPU devices in ResourceSlice", "kubectl get resourceslices -o yaml",
+			fmt.Sprintf("failed to list ResourceSlices: %v", err))
+		return
+	}
+	var sliceSummary strings.Builder
+	for _, s := range slices.Items {
+		driver, _, _ := unstructured.NestedString(s.Object, "spec", "driver")
+		nodeName, _, _ := unstructured.NestedString(s.Object, "spec", "nodeName")
+		fmt.Fprintf(&sliceSummary, "%-50s node=%s driver=%s\n", s.GetName(), nodeName, driver)
+	}
+	recordRawTextArtifact(ctx, "ResourceSlices", "kubectl get resourceslices -o wide", sliceSummary.String())
+	recordObjectYAMLArtifact(ctx, "GPU devices in ResourceSlice", "kubectl get resourceslices -o yaml", slices.Object)
 }
 
 // deployDRATestResources creates the namespace, ResourceClaim, and Pod for the DRA test.
@@ -218,18 +322,24 @@ func waitForDRATestPod(ctx context.Context, clientset kubernetes.Interface, run 
 }
 
 // validateDRAPatterns verifies the completed pod uses proper DRA access patterns.
-func validateDRAPatterns(ctx context.Context, dynClient dynamic.Interface, pod *corev1.Pod, run *draTestRun) error {
+func validateDRAPatterns(ctx context.Context, dynClient dynamic.Interface, pod *corev1.Pod, run *draTestRun) (*draPatternReport, error) {
+	report := &draPatternReport{
+		PodName:            pod.Name,
+		PodPhase:           pod.Status.Phase,
+		ResourceClaimCount: len(pod.Spec.ResourceClaims),
+	}
+
 	// 1. Pod uses resourceClaims (DRA pattern).
 	if len(pod.Spec.ResourceClaims) == 0 {
-		return errors.New(errors.ErrCodeInternal,
-			"pod does not use DRA resourceClaims")
+		return nil, errors.New(errors.ErrCodeInternal, "pod does not use DRA resourceClaims")
 	}
 
 	// 2. No nvidia.com/gpu in resources.limits (device plugin pattern).
 	for _, c := range pod.Spec.Containers {
 		if c.Resources.Limits != nil {
 			if _, hasGPU := c.Resources.Limits["nvidia.com/gpu"]; hasGPU {
-				return errors.New(errors.ErrCodeInternal,
+				report.GPULimitsCount++
+				return nil, errors.New(errors.ErrCodeInternal,
 					"pod uses device plugin (nvidia.com/gpu in limits) instead of DRA")
 			}
 		}
@@ -238,26 +348,35 @@ func validateDRAPatterns(ctx context.Context, dynClient dynamic.Interface, pod *
 	// 3. No hostPath volumes to /dev/nvidia*.
 	for _, vol := range pod.Spec.Volumes {
 		if vol.HostPath != nil && strings.Contains(vol.HostPath.Path, "/dev/nvidia") {
-			return errors.New(errors.ErrCodeInternal,
+			report.HostPathGPUMounts++
+			return nil, errors.New(errors.ErrCodeInternal,
 				fmt.Sprintf("pod has hostPath volume to %s", vol.HostPath.Path))
 		}
 	}
 
 	// 4. ResourceClaim exists.
-	if _, err := dynClient.Resource(claimGVR).Namespace(draTestNamespace).Get(
-		ctx, run.claimName, metav1.GetOptions{}); err != nil {
-		return errors.Wrap(errors.ErrCodeNotFound,
+	claim, err := dynClient.Resource(claimGVR).Namespace(draTestNamespace).Get(
+		ctx, run.claimName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeNotFound,
 			fmt.Sprintf("ResourceClaim %s not found", run.claimName), err)
+	}
+	report.ClaimState, _, _ = unstructured.NestedString(claim.Object, "status", "state")
+	results, found, _ := unstructured.NestedSlice(claim.Object, "status", "allocation", "devices", "results")
+	if found {
+		report.ClaimAllocationInfo = fmt.Sprintf("%d allocated device result(s)", len(results))
+	} else {
+		report.ClaimAllocationInfo = "no allocation results reported"
 	}
 
 	// 5. Pod completed successfully — proves DRA allocation worked.
 	if pod.Status.Phase != corev1.PodSucceeded {
-		return errors.New(errors.ErrCodeInternal,
+		return nil, errors.New(errors.ErrCodeInternal,
 			fmt.Sprintf("DRA test pod phase=%s (want Succeeded), GPU allocation may have failed",
 				pod.Status.Phase))
 	}
 
-	return nil
+	return report, nil
 }
 
 // validateDRAIsolation verifies that a pod WITHOUT DRA ResourceClaims cannot see GPU devices.
@@ -331,10 +450,10 @@ func validateDRAIsolation(ctx context.Context, clientset kubernetes.Interface, r
 	}
 
 	report := &draIsolationReport{
-		PodName:             resultPod.Name,
-		PodPhase:            resultPod.Status.Phase,
-		ExitCode:            podExitCode(resultPod),
-		ResourceClaimsCount: len(resultPod.Spec.ResourceClaims),
+		PodName:        resultPod.Name,
+		PodPhase:       resultPod.Status.Phase,
+		ExitCode:       podExitCode(resultPod),
+		ResourceClaims: len(resultPod.Spec.ResourceClaims),
 	}
 
 	// Strict success criteria: require Succeeded (exit 0 = script confirmed no GPU visible).
@@ -349,14 +468,30 @@ func validateDRAIsolation(ctx context.Context, clientset kubernetes.Interface, r
 			fmt.Sprintf("no-claim isolation test pod failed with exit code %d — cannot verify isolation",
 				exitCode))
 	}
+	if len(resultPod.Status.ContainerStatuses) > 0 {
+		cs := resultPod.Status.ContainerStatuses[0]
+		if cs.State.Terminated != nil {
+			report.ExitCode = cs.State.Terminated.ExitCode
+		}
+	}
 
 	// Verify no hostPath to GPU devices on the no-claim pod.
 	for _, vol := range resultPod.Spec.Volumes {
 		if vol.HostPath != nil && strings.Contains(vol.HostPath.Path, "/dev/nvidia") {
+			report.HostPathGPUMounts++
 			return nil, errors.New(errors.ErrCodeInternal,
 				fmt.Sprintf("no-claim pod has hostPath volume to %s — isolation broken",
 					vol.HostPath.Path))
 		}
+	}
+	report.HostPathGPUMounts = 0
+
+	logBytes, logErr := clientset.CoreV1().Pods(draTestNamespace).GetLogs(
+		run.noClaimPodName, &corev1.PodLogOptions{}).DoRaw(ctx)
+	if logErr != nil {
+		report.Logs = fmt.Sprintf("failed to read logs: %v", logErr)
+	} else {
+		report.Logs = string(logBytes)
 	}
 
 	return report, nil

--- a/pkg/validator/checks/conformance/secure_access_check_unit_test.go
+++ b/pkg/validator/checks/conformance/secure_access_check_unit_test.go
@@ -72,7 +72,11 @@ func TestCheckSecureAcceleratorAccess(t *testing.T) {
 				// Reactor: match any pod with the DRA test prefix.
 				// Returns the pod with desired phase, or NotFound after deletion.
 				clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
-					ga := action.(k8stesting.GetAction)
+					ga, ok := action.(k8stesting.GetAction)
+					if !ok {
+						// Let log subresource plumbing use default fake behavior.
+						return false, nil, nil
+					}
 					if strings.HasPrefix(ga.GetName(), draTestPrefix) && ga.GetNamespace() == draTestNamespace {
 						if podDeleted {
 							return true, nil, k8serrors.NewNotFound(
@@ -106,7 +110,11 @@ func TestCheckSecureAcceleratorAccess(t *testing.T) {
 				// Reactor: return no-claim pod with Succeeded phase for isolation test.
 				noClaimPodDeleted := false
 				clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
-					ga := action.(k8stesting.GetAction)
+					ga, ok := action.(k8stesting.GetAction)
+					if !ok {
+						// Let log subresource plumbing use default fake behavior.
+						return false, nil, nil
+					}
 					if strings.HasPrefix(ga.GetName(), draNoClaimPrefix) && ga.GetNamespace() == draTestNamespace {
 						if noClaimPodDeleted {
 							return true, nil, k8serrors.NewNotFound(
@@ -140,6 +148,7 @@ func TestCheckSecureAcceleratorAccess(t *testing.T) {
 				dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 					map[schema.GroupVersionResource]string{
 						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}: "ResourceClaimList",
+						{Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices"}: "ResourceSliceList",
 					})
 
 				// Reactor: match any ResourceClaim with the DRA claim prefix.


### PR DESCRIPTION
## Summary

- Add shared evidence capture helpers (`recordRawTextArtifact`, `recordChunkedTextArtifact`, `recordObjectYAMLArtifact`, `recordObjectJSONArtifact`) for recording observed-state artifacts with command equivalents and chunking support for large payloads
- Enrich all 9 conformance submission checks (DRA, gang scheduling, secure accelerator access, accelerator metrics, AI service metrics, inference gateway, robust controller, pod autoscaling, cluster autoscaling) with observed cluster state artifacts — resource listings, pod/deployment status, logs, condition details, and behavioral evidence
- Replace static "PASS" artifact strings with observed values (exit codes, replica counts, webhook response details, scheduling timestamps)

## Changes by commit

### 1. Enrich DRA, gang, and secure access evidence
- **helpers.go**: Add `recordRawTextArtifact`, `recordChunkedTextArtifact`, `recordObjectJSONArtifact`, `recordObjectYAMLArtifact`, `formatArtifactBody`, `podReadyCount`, `valueOrUnknown`
- **dra_support_check.go**: Add DRA API resources, driver pods, ResourceSlice count, allocation test pod status/logs artifacts
- **gang_scheduling_check.go**: Add scheduler deployment/pod listings, PodGroup status, gang worker logs artifacts
- **secure_access_check.go**: Add GPU operator pod/DaemonSet listings, ResourceSlice inventory, DRA pod spec (claims/volumes), claim allocation details, isolation test observed values (exit code, hostPath count, GPU device lines)

### 2. Enrich metrics, gateway, operator, and HPA evidence
- **helpers.go**: Add `getConditionObservation` and `conditionObservation` struct for extracting condition details (status/reason/message) from unstructured objects
- **ai_service_metrics_check.go**: Add custom metrics API resources listing and sample metric names artifacts
- **inference_gateway_check.go**: Add kgateway deployment/pod listings, GatewayClass/Gateway condition details, CRD inventory, InferencePool/HTTPRoute listings
- **robust_controller_check.go**: Add operator deployment/pod listings, CRD inventory, webhook listing, DGD list/YAML details; replace static PASS with observed webhook response (status code, reason, message)
- **pod_autoscaling_check.go**: Add adapter pod/service status, custom metrics sample, HPA observed status (desired/current replicas), scale-up/scale-down deployment replica evidence; replace static PASS with measured transitions

### 3. Capture observed cluster autoscaling evidence
- **cluster_autoscaling_check.go**: Add Karpenter deployment/NodePool status, GPU node inventory, HPA scaling intent observed values (desired/current replicas), node provisioning details (baseline/new/total), pod scheduling evidence (scheduled/total counts); replace static PASS with observed numeric state

## Test plan
- [ ] `go test -race ./pkg/validator/checks/conformance/...` passes
- [ ] `make lint` passes
- [ ] GPU Inference Test CI generates enriched evidence artifacts
- [ ] GPU Training Test CI generates enriched evidence artifacts
- [ ] Evidence markdown files contain observed-state data instead of static strings