### PR TITLE
feat: integrate CNCF submission evidence collection into aicr validate

### DIFF
--- a/docs/conformance/cncf/README.md
+++ b/docs/conformance/cncf/README.md
@@ -19,11 +19,9 @@ recipe meets the Must-have requirements for Kubernetes v1.34.
 ```
 docs/conformance/cncf/
 ├── README.md
-├── collect-evidence.sh
-├── manifests/
-│   ├── dra-gpu-test.yaml
-│   ├── gang-scheduling-test.yaml
-│   └── hpa-gpu-test.yaml
+├── submission/
+│   ├── PRODUCT.yaml
+│   └── README.md
 └── evidence/
     ├── index.md
     ├── dra-support.md
@@ -34,76 +32,68 @@ docs/conformance/cncf/
     ├── robust-operator.md
     ├── pod-autoscaling.md
     └── cluster-autoscaling.md
+
+pkg/evidence/scripts/             # Evidence collection script + test manifests
+├── collect-evidence.sh
+└── manifests/
+    ├── dra-gpu-test.yaml
+    ├── gang-scheduling-test.yaml
+    └── hpa-gpu-test.yaml
 ```
 
 ## Usage
 
 Evidence collection has two steps:
 
-### Step 1: Structural Validation Evidence
+### Structural Validation (CI)
 
-`aicr validate` checks component health, CRDs, constraints, and generates
-structural evidence:
+`aicr validate` checks component health, CRDs, and constraints for CI:
 
 ```bash
-# Generate evidence during validation
-aicr validate -r recipe.yaml -s snapshot.yaml \
+# Structural validation + evidence rendering
+aicr validate -r recipe.yaml \
   --phase conformance --evidence-dir ./evidence
-
-# Or use a saved result file
-aicr validate -r recipe.yaml -s snapshot.yaml \
-  --phase conformance --evidence-dir ./evidence \
-  --result validation-result.yaml
 ```
 
-### Step 2: Behavioral Test Evidence
+### CNCF Submission Evidence
 
-`collect-evidence.sh` deploys test workloads and collects behavioral evidence
-(DRA GPU allocation, gang scheduling, HPA autoscaling, etc.) that requires
-running actual GPU workloads on the cluster:
+Add `--cncf-submission` to collect detailed behavioral evidence for CNCF AI
+Conformance submission. This deploys GPU workloads, captures command outputs,
+workload logs, nvidia-smi output, and Prometheus queries:
 
 ```bash
 # Collect all behavioral evidence
-./docs/conformance/cncf/collect-evidence.sh all
+aicr validate --phase conformance \
+  --evidence-dir ./evidence --cncf-submission
 
-# Collect evidence for a single feature
-./docs/conformance/cncf/collect-evidence.sh dra
-./docs/conformance/cncf/collect-evidence.sh gang
-./docs/conformance/cncf/collect-evidence.sh secure
-./docs/conformance/cncf/collect-evidence.sh metrics
-./docs/conformance/cncf/collect-evidence.sh gateway
-./docs/conformance/cncf/collect-evidence.sh operator
-./docs/conformance/cncf/collect-evidence.sh hpa
-./docs/conformance/cncf/collect-evidence.sh cluster-autoscaling
+# Collect specific features
+aicr validate --phase conformance \
+  --evidence-dir ./evidence --cncf-submission -f dra -f hpa
 ```
 
-> **Note:** The HPA test (`hpa`) deploys a GPU stress workload (nbody) and waits
-> for HPA to scale up, then verifies scale-down. This takes ~5 minutes due to
-> metric propagation through the DCGM → Prometheus → prometheus-adapter → HPA pipeline.
+Alternatively, run the evidence collection script directly:
+```bash
+./pkg/evidence/scripts/collect-evidence.sh all
+./pkg/evidence/scripts/collect-evidence.sh dra
+```
 
-### Why Two Steps?
+> **Note:** The `--cncf-submission` flag deploys GPU workloads and takes ~15
+> minutes. The HPA test uses CUDA N-Body Simulation to stress GPUs and verifies
+> both scale-up and scale-down.
 
-| Evidence Type | `aicr validate` | `collect-evidence.sh` |
+### Two Modes
+
+| | `aicr validate --phase conformance` | `--cncf-submission` |
 |---|---|---|
-| Component health (pods, CRDs) | Yes | Yes |
-| Constraint validation (K8s version, OS) | Yes | No |
-| DRA GPU allocation test | No | Yes |
-| Gang scheduling test | No | Yes |
-| Device isolation verification | No | Yes |
-| Gateway condition checks (Accepted, Programmed) | No | Yes |
-| Webhook rejection test | No | Yes |
-| HPA scale-up and scale-down with GPU load | No | Yes |
-| Prometheus query results | No | Yes |
-| Cluster autoscaling (ASG config) | No | Yes |
-
-`aicr validate` checks that components are deployed correctly. `collect-evidence.sh`
-verifies they work correctly by running actual workloads. Both are needed for
-complete conformance evidence.
-
-> **Future:** Behavioral tests are inherently long-running (e.g., HPA test deploys
-> CUDA N-Body Simulation and waits ~5 minutes for metric propagation and scaling) and are better
-> suited as a separate step than blocking `aicr validate`. A follow-up integration
-> is tracked in [#192](https://github.com/NVIDIA/aicr/issues/192).
+| **Purpose** | CI pass/fail | CNCF submission evidence |
+| **Speed** | ~3 minutes | ~15 minutes |
+| **Deploys workloads** | No | Yes |
+| **Output** | Structural evidence (pass/fail + artifacts) | Behavioral evidence (command outputs, logs, queries) |
+| **DRA GPU allocation test** | Status check only | Deploys pod, verifies GPU access |
+| **Gang scheduling test** | Component check only | Deploys PodGroup, verifies co-scheduling |
+| **HPA autoscaling** | Metrics API check | Scale-up + scale-down with GPU load |
+| **Gateway** | Status check | Condition verification (Accepted, Programmed) |
+| **Webhook test** | No | Rejection test with invalid CR |
 
 ## Evidence
 

--- a/docs/conformance/cncf/evidence/dra-support.md
+++ b/docs/conformance/cncf/evidence/dra-support.md
@@ -47,7 +47,7 @@ ip-100-64-171-120.ec2.internal-gpu.nvidia.com-75xvv              ip-100-64-171-1
 
 Deploy a test pod that requests 1 GPU via ResourceClaim and verifies device access.
 
-**Test manifest:** `docs/conformance/cncf/manifests/dra-gpu-test.yaml`
+**Test manifest:** `pkg/evidence/scripts/manifests/dra-gpu-test.yaml`
 
 ```yaml
 ---
@@ -99,7 +99,7 @@ spec:
 
 **Apply test manifest**
 ```
-$ kubectl apply -f docs/conformance/cncf/manifests/dra-gpu-test.yaml
+$ kubectl apply -f pkg/evidence/scripts/manifests/dra-gpu-test.yaml
 namespace/dra-test created
 resourceclaim.resource.k8s.io/gpu-claim created
 pod/dra-gpu-test created

--- a/docs/conformance/cncf/evidence/gang-scheduling.md
+++ b/docs/conformance/cncf/evidence/gang-scheduling.md
@@ -52,7 +52,7 @@ podgroups.scheduling.run.ai   2026-02-12T20:42:05Z
 Deploy a PodGroup with minMember=2 and two GPU pods. KAI scheduler ensures both
 pods are scheduled atomically.
 
-**Test manifest:** `docs/conformance/cncf/manifests/gang-scheduling-test.yaml`
+**Test manifest:** `pkg/evidence/scripts/manifests/gang-scheduling-test.yaml`
 
 ```yaml
 ---
@@ -81,18 +81,21 @@ metadata:
 spec:
   schedulerName: kai-scheduler
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault
   tolerations:
     - operator: Exists
   containers:
     - name: worker
       image: nvidia/cuda:12.9.0-base-ubuntu24.04
       command: ["bash", "-c", "nvidia-smi && echo 'Gang worker 0 completed successfully'"]
+      securityContext:
+        allowPrivilegeEscalation: false
       resources:
-        claims:
-          - name: gpu
-  resourceClaims:
-    - name: gpu
-      resourceClaimName: gang-gpu-claim-0
+        limits:
+          nvidia.com/gpu: 1
 ---
 apiVersion: v1
 kind: Pod
@@ -105,38 +108,21 @@ metadata:
 spec:
   schedulerName: kai-scheduler
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault
   tolerations:
     - operator: Exists
   containers:
     - name: worker
       image: nvidia/cuda:12.9.0-base-ubuntu24.04
       command: ["bash", "-c", "nvidia-smi && echo 'Gang worker 1 completed successfully'"]
+      securityContext:
+        allowPrivilegeEscalation: false
       resources:
-        claims:
-          - name: gpu
-  resourceClaims:
-    - name: gpu
-      resourceClaimName: gang-gpu-claim-1
----
-apiVersion: resource.k8s.io/v1
-kind: ResourceClaim
-metadata:
-  name: gang-gpu-claim-0
-  namespace: gang-scheduling-test
-spec:
-  devices:
-    requests:
-      - name: gpu
-        exactly:
-          deviceClassName: gpu.nvidia.com
-          allocationMode: ExactCount
-          count: 1
----
-apiVersion: resource.k8s.io/v1
-kind: ResourceClaim
-metadata:
-  name: gang-gpu-claim-1
-  namespace: gang-scheduling-test
+        limits:
+          nvidia.com/gpu: 1
 spec:
   devices:
     requests:
@@ -149,7 +135,7 @@ spec:
 
 **Apply test manifest**
 ```
-$ kubectl apply -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml
+$ kubectl apply -f pkg/evidence/scripts/manifests/gang-scheduling-test.yaml
 namespace/gang-scheduling-test created
 podgroup.scheduling.run.ai/gang-test-group created
 pod/gang-worker-0 created

--- a/docs/conformance/cncf/evidence/pod-autoscaling.md
+++ b/docs/conformance/cncf/evidence/pod-autoscaling.md
@@ -56,7 +56,7 @@ pods/gpu_utilization
 Deploy a GPU workload running CUDA N-Body Simulation to generate sustained GPU utilization,
 then create an HPA targeting `gpu_utilization` to demonstrate autoscaling.
 
-**Test manifest:** `docs/conformance/cncf/manifests/hpa-gpu-test.yaml`
+**Test manifest:** `pkg/evidence/scripts/manifests/hpa-gpu-test.yaml`
 
 ```yaml
 ---
@@ -91,7 +91,7 @@ spec:
         - name: gpu-worker
           image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.7.1-ubuntu18.04
           command: ["bash", "-c"]
-          args: ["while true; do /cuda-samples/nbody -benchmark -numbodies=16777216 -iterations=10000; done"]
+          args: ["/cuda-samples/nbody -benchmark -numbodies=4194304 -iterations=30 || true; exec sleep infinity"]
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -110,7 +110,10 @@ spec:
     kind: Deployment
     name: gpu-workload
   minReplicas: 1
-  maxReplicas: 4
+  maxReplicas: 2
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 30
   metrics:
     - type: Pods
       pods:
@@ -123,7 +126,7 @@ spec:
 
 **Apply test manifest**
 ```
-$ kubectl apply -f docs/conformance/cncf/manifests/hpa-gpu-test.yaml
+$ kubectl apply -f pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
 namespace/hpa-test created
 deployment.apps/gpu-workload created
 horizontalpodautoscaler.autoscaling/gpu-workload-hpa created

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -289,6 +289,37 @@ func helmNamespacesFromRecipe(rec *recipe.RecipeResult) []string {
 	return namespaces
 }
 
+// runCNCFSubmission handles --cncf-submission: validates feature names and
+// runs behavioral evidence collection.
+func runCNCFSubmission(ctx context.Context, cmd *cli.Command, evidenceDir string, features []string) error {
+	for _, f := range features {
+		if !evidence.IsValidFeature(f) {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("unknown feature %q; valid features: %v", f, evidence.ValidFeatures))
+		}
+	}
+
+	slog.Info("collecting behavioral conformance evidence",
+		"dir", evidenceDir, "features", features)
+
+	// Use a longer timeout for behavioral evidence (default 5m is too short).
+	evidenceTimeout := cmd.Duration("timeout")
+	if evidenceTimeout <= 5*time.Minute {
+		evidenceTimeout = 20 * time.Minute
+	}
+	evidenceCtx, evidenceCancel := context.WithTimeout(ctx, evidenceTimeout)
+	defer evidenceCancel()
+
+	collector := evidence.NewCollector(evidenceDir,
+		evidence.WithFeatures(features),
+	)
+	if runErr := collector.Run(evidenceCtx); runErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "evidence collection failed", runErr)
+	}
+	slog.Info("conformance evidence written", "dir", evidenceDir)
+	return nil
+}
+
 func validateCmdFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
@@ -388,6 +419,18 @@ func validateCmdFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:  "evidence-dir",
 			Usage: "Write CNCF conformance evidence markdown to this directory. Requires --phase conformance.",
+		},
+		&cli.BoolFlag{
+			Name:  "cncf-submission",
+			Usage: "Collect detailed behavioral evidence for CNCF AI Conformance submission. Deploys GPU workloads, captures nvidia-smi output, Prometheus queries, and HPA scaling tests. Requires --evidence-dir. Takes ~15 minutes.",
+		},
+		&cli.StringSliceFlag{
+			Name:    "feature",
+			Aliases: []string{"f"},
+			Usage: "Evidence feature to collect (repeatable, default: all). Only used with --cncf-submission.\n" +
+				"Available features: dra-support, gang-scheduling, secure-access, accelerator-metrics,\n" +
+				"inference-gateway, robust-operator, pod-autoscaling, cluster-autoscaling.\n" +
+				"Short aliases also accepted: dra, gang, secure, metrics, gateway, operator, hpa.",
 		},
 		&cli.StringFlag{
 			Name:  "result",
@@ -504,6 +547,18 @@ Use a saved result file for evidence instead of the live run:
 			}
 			if resultPath != "" && evidenceDir == "" {
 				return errors.New(errors.ErrCodeInvalidRequest, "--result requires --evidence-dir")
+			}
+
+			cncfSubmission := cmd.Bool("cncf-submission")
+			if cncfSubmission && evidenceDir == "" {
+				return errors.New(errors.ErrCodeInvalidRequest, "--cncf-submission requires --evidence-dir")
+			}
+			features := cmd.StringSlice("feature")
+			if len(features) > 0 && !cncfSubmission {
+				return errors.New(errors.ErrCodeInvalidRequest, "--feature requires --cncf-submission")
+			}
+			if cncfSubmission {
+				return runCNCFSubmission(ctx, cmd, evidenceDir, features)
 			}
 
 			recipeFilePath := cmd.String("recipe")

--- a/pkg/evidence/collector.go
+++ b/pkg/evidence/collector.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evidence
+
+import (
+	"context"
+	"embed"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+//go:embed scripts/collect-evidence.sh
+var collectScript []byte
+
+//go:embed scripts/manifests
+var manifestsFS embed.FS
+
+// ValidFeatures lists all supported evidence collection features.
+// These are the user-facing names shown in help text and used with --feature.
+var ValidFeatures = []string{
+	"dra-support",
+	"gang-scheduling",
+	"secure-access",
+	"accelerator-metrics",
+	"inference-gateway",
+	"robust-operator",
+	"pod-autoscaling",
+	"cluster-autoscaling",
+}
+
+// featureToScript maps user-facing feature names to script section names.
+var featureToScript = map[string]string{
+	"dra-support":          "dra",
+	"gang-scheduling":      "gang",
+	"secure-access":        "secure",
+	"accelerator-metrics":  "metrics",
+	"inference-gateway":    "gateway",
+	"robust-operator":      "operator",
+	"pod-autoscaling":      "hpa",
+	"cluster-autoscaling":  "cluster-autoscaling",
+}
+
+// featureAliases maps short names to canonical feature names for convenience.
+var featureAliases = map[string]string{
+	"dra":      "dra-support",
+	"gang":     "gang-scheduling",
+	"secure":   "secure-access",
+	"metrics":  "accelerator-metrics",
+	"gateway":  "inference-gateway",
+	"operator": "robust-operator",
+	"hpa":      "pod-autoscaling",
+}
+
+// ResolveFeature returns the canonical feature name, resolving aliases.
+func ResolveFeature(name string) string {
+	if canonical, ok := featureAliases[name]; ok {
+		return canonical
+	}
+	return name
+}
+
+// IsValidFeature returns true if the name is a valid feature or alias.
+func IsValidFeature(name string) bool {
+	if name == "all" {
+		return true
+	}
+	resolved := ResolveFeature(name)
+	for _, f := range ValidFeatures {
+		if f == resolved {
+			return true
+		}
+	}
+	return false
+}
+
+// ScriptSection returns the script section name for a feature.
+func ScriptSection(feature string) string {
+	if section, ok := featureToScript[feature]; ok {
+		return section
+	}
+	return feature
+}
+
+// FeatureDescriptions maps feature names to human-readable descriptions.
+var FeatureDescriptions = map[string]string{
+	"dra-support":          "DRA GPU allocation test",
+	"gang-scheduling":      "Gang scheduling co-scheduling test",
+	"secure-access":        "Secure accelerator access verification",
+	"accelerator-metrics":  "Accelerator & AI service metrics",
+	"inference-gateway":    "Inference API gateway conditions",
+	"robust-operator":      "Robust AI operator + webhook test",
+	"pod-autoscaling":      "HPA pod autoscaling (scale-up + scale-down)",
+	"cluster-autoscaling":  "Cluster autoscaling (ASG configuration)",
+}
+
+// CollectorOption configures the Collector.
+type CollectorOption func(*Collector)
+
+// Collector orchestrates behavioral evidence collection by invoking the
+// embedded collect-evidence.sh script against a live Kubernetes cluster.
+type Collector struct {
+	outputDir string
+	features  []string
+	noCleanup bool
+}
+
+// NewCollector creates a new evidence Collector.
+func NewCollector(outputDir string, opts ...CollectorOption) *Collector {
+	c := &Collector{
+		outputDir: outputDir,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// WithFeatures sets which features to collect evidence for.
+// If empty, all features are collected.
+func WithFeatures(features []string) CollectorOption {
+	return func(c *Collector) {
+		c.features = features
+	}
+}
+
+// WithNoCleanup skips test namespace cleanup after collection.
+func WithNoCleanup(noCleanup bool) CollectorOption {
+	return func(c *Collector) {
+		c.noCleanup = noCleanup
+	}
+}
+
+// Run executes evidence collection for the configured features.
+func (c *Collector) Run(ctx context.Context) error {
+	// Write embedded script and manifests to temp directory.
+	tmpDir, err := os.MkdirTemp("", "aicr-evidence-")
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create temp directory", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	scriptPath := filepath.Join(tmpDir, "collect-evidence.sh")
+	if err := os.WriteFile(scriptPath, collectScript, 0o700); err != nil { //nolint:gosec // script needs execute permission
+		return errors.Wrap(errors.ErrCodeInternal, "failed to write evidence script", err)
+	}
+
+	manifestDir := filepath.Join(tmpDir, "manifests")
+	if err := writeEmbeddedManifests(manifestDir); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to write manifests", err)
+	}
+
+	// Create output directory.
+	if err := os.MkdirAll(c.outputDir, 0o755); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to create output directory", err)
+	}
+
+	// Determine features to run. "all" or empty means run everything.
+	// Resolve any aliases (e.g., "gang" → "gang-scheduling").
+	features := make([]string, 0, len(c.features))
+	for _, f := range c.features {
+		features = append(features, ResolveFeature(f))
+	}
+	if len(features) == 0 {
+		features = []string{"all"}
+	}
+	for _, f := range features {
+		if f == "all" {
+			features = []string{"all"}
+			break
+		}
+	}
+
+	// Run each feature, translating to script section names.
+	var lastErr error
+	for _, feature := range features {
+		scriptSection := ScriptSection(feature)
+		slog.Info("collecting evidence", "feature", feature)
+		if err := c.runSection(ctx, scriptPath, tmpDir, scriptSection); err != nil {
+			slog.Warn("evidence collection failed for feature",
+				"feature", feature, "error", err)
+			lastErr = err
+			// Continue with remaining features.
+		}
+	}
+
+	if lastErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			"one or more evidence sections failed", lastErr)
+	}
+	return nil
+}
+
+// runSection executes the evidence script for a single section.
+func (c *Collector) runSection(ctx context.Context, scriptPath, scriptDir, section string) error {
+	cmd := exec.CommandContext(ctx, "bash", scriptPath, section)
+	cmd.Dir = scriptDir
+	cmd.Env = append(os.Environ(),
+		"EVIDENCE_DIR="+c.outputDir,
+		"SCRIPT_DIR="+scriptDir,
+	)
+	if c.noCleanup {
+		cmd.Env = append(cmd.Env, "NO_CLEANUP=true")
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// writeEmbeddedManifests extracts the embedded manifests to the target directory.
+func writeEmbeddedManifests(targetDir string) error {
+	return fs.WalkDir(manifestsFS, "scripts/manifests", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Compute relative path from "scripts/manifests" prefix.
+		relPath, _ := filepath.Rel("scripts/manifests", path)
+		targetPath := filepath.Join(targetDir, relPath)
+
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+
+		data, err := manifestsFS.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, data, 0o600)
+	})
+}

--- a/pkg/evidence/collector_test.go
+++ b/pkg/evidence/collector_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evidence
+
+import (
+	"testing"
+)
+
+func TestResolveFeature(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"canonical passthrough", "dra-support", "dra-support"},
+		{"canonical passthrough gang", "gang-scheduling", "gang-scheduling"},
+		{"canonical passthrough cluster", "cluster-autoscaling", "cluster-autoscaling"},
+		{"alias dra", "dra", "dra-support"},
+		{"alias gang", "gang", "gang-scheduling"},
+		{"alias secure", "secure", "secure-access"},
+		{"alias metrics", "metrics", "accelerator-metrics"},
+		{"alias gateway", "gateway", "inference-gateway"},
+		{"alias operator", "operator", "robust-operator"},
+		{"alias hpa", "hpa", "pod-autoscaling"},
+		{"unknown passthrough", "unknown-feature", "unknown-feature"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveFeature(tt.input)
+			if result != tt.expected {
+				t.Errorf("ResolveFeature(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestScriptSection(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"dra-support", "dra-support", "dra"},
+		{"gang-scheduling", "gang-scheduling", "gang"},
+		{"secure-access", "secure-access", "secure"},
+		{"accelerator-metrics", "accelerator-metrics", "metrics"},
+		{"inference-gateway", "inference-gateway", "gateway"},
+		{"robust-operator", "robust-operator", "operator"},
+		{"pod-autoscaling", "pod-autoscaling", "hpa"},
+		{"cluster-autoscaling", "cluster-autoscaling", "cluster-autoscaling"},
+		{"all passthrough", "all", "all"},
+		{"unknown passthrough", "unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ScriptSection(tt.input)
+			if result != tt.expected {
+				t.Errorf("ScriptSection(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidFeature(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"valid canonical", "dra-support", true},
+		{"valid canonical gang", "gang-scheduling", true},
+		{"valid canonical cluster", "cluster-autoscaling", true},
+		{"valid alias dra", "dra", true},
+		{"valid alias hpa", "hpa", true},
+		{"valid all", "all", true},
+		{"invalid", "typo", false},
+		{"invalid empty", "", false},
+		{"invalid partial", "gang-sched", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidFeature(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsValidFeature(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewCollector(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		c := NewCollector("/tmp/out")
+		if c.outputDir != "/tmp/out" {
+			t.Errorf("outputDir = %q, want %q", c.outputDir, "/tmp/out")
+		}
+		if len(c.features) != 0 {
+			t.Errorf("features = %v, want empty", c.features)
+		}
+		if c.noCleanup {
+			t.Error("noCleanup = true, want false")
+		}
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		c := NewCollector("/tmp/out",
+			WithFeatures([]string{"dra", "gang"}),
+			WithNoCleanup(true),
+		)
+		if len(c.features) != 2 {
+			t.Errorf("features length = %d, want 2", len(c.features))
+		}
+		if !c.noCleanup {
+			t.Error("noCleanup = false, want true")
+		}
+	})
+}
+
+func TestFeatureDescriptionsComplete(t *testing.T) {
+	for _, f := range ValidFeatures {
+		if _, ok := FeatureDescriptions[f]; !ok {
+			t.Errorf("ValidFeature %q missing from FeatureDescriptions", f)
+		}
+		if _, ok := featureToScript[f]; !ok {
+			t.Errorf("ValidFeature %q missing from featureToScript", f)
+		}
+	}
+}

--- a/pkg/evidence/scripts/collect-evidence.sh
+++ b/pkg/evidence/scripts/collect-evidence.sh
@@ -23,9 +23,10 @@
 # This script collects behavioral test evidence (HPA scaling, DRA allocation, etc.)
 # that requires deploying test workloads. Both are needed for full conformance evidence.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-EVIDENCE_DIR="${SCRIPT_DIR}/evidence"
+# Support invocation from aicr CLI (env vars) or standalone (defaults).
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-${SCRIPT_DIR}/evidence}"
 SECTION="${1:-all}"
 
 # Current output file — set per section
@@ -52,9 +53,12 @@ capture() {
     echo "" >> "${EVIDENCE_FILE}"
     echo "**${label}**" >> "${EVIDENCE_FILE}"
     echo '```' >> "${EVIDENCE_FILE}"
-    # Strip absolute repo path from command display to avoid leaking local paths
+    # Strip absolute paths from command display to avoid leaking local/temp paths
     local cmd_display="$*"
+    cmd_display="${cmd_display//${SCRIPT_DIR}\//}"
     cmd_display="${cmd_display//${REPO_ROOT}\//}"
+    # Strip any remaining absolute paths to manifests (e.g., temp dirs from aicr evidence)
+    cmd_display=$(echo "${cmd_display}" | sed 's|[^ ]*/manifests/|manifests/|g')
     echo "\$ ${cmd_display}" >> "${EVIDENCE_FILE}"
     if output=$("$@" 2>&1); then
         echo "${output}" >> "${EVIDENCE_FILE}"
@@ -79,6 +83,21 @@ wait_for_pod() {
     done
     echo "Timeout"
     return 1
+}
+
+# Clean up a test namespace properly: pods → resourceclaims → namespace
+# This order prevents stale DRA kubelet checkpoint issues caused by
+# orphaned ResourceClaims with delete-protection finalizers.
+cleanup_ns() {
+    local ns="$1"
+    # Skip if namespace doesn't exist
+    if ! kubectl get namespace "$ns" &>/dev/null; then return 0; fi
+    # Delete pods first so DRA driver can call NodeUnprepareResources
+    kubectl delete pods --all -n "$ns" --ignore-not-found --wait=true --timeout=30s &>/dev/null || true
+    # Delete resourceclaims (finalizer removed after pod deletion)
+    kubectl delete resourceclaims --all -n "$ns" --ignore-not-found --wait=true --timeout=30s &>/dev/null || true
+    # Now namespace can terminate cleanly
+    kubectl delete namespace "$ns" --ignore-not-found --timeout=60s &>/dev/null || true
 }
 
 # Write a per-section evidence file header
@@ -135,15 +154,14 @@ EOF
 
 Deploy a test pod that requests 1 GPU via ResourceClaim and verifies device access.
 
-**Test manifest:** `docs/conformance/cncf/manifests/dra-gpu-test.yaml`
+**Test manifest:** `pkg/evidence/scripts/manifests/dra-gpu-test.yaml`
 EOF
     echo '```yaml' >> "${EVIDENCE_FILE}"
     cat "${SCRIPT_DIR}/manifests/dra-gpu-test.yaml" >> "${EVIDENCE_FILE}"
     echo '```' >> "${EVIDENCE_FILE}"
 
     # Clean up any previous run
-    kubectl delete namespace dra-test --ignore-not-found --wait=false 2>/dev/null || true
-    sleep 5
+    cleanup_ns dra-test
 
     # Deploy test
     log_info "Deploying DRA GPU test..."
@@ -170,7 +188,7 @@ EOF
 
 ## Cleanup
 EOF
-    capture "Delete test namespace" kubectl delete namespace dra-test --ignore-not-found
+    capture "Delete test namespace" cleanup_ns dra-test
 
     log_info "DRA evidence collection complete."
 }
@@ -203,15 +221,14 @@ EOF
 Deploy a PodGroup with minMember=2 and two GPU pods. KAI scheduler ensures both
 pods are scheduled atomically.
 
-**Test manifest:** `docs/conformance/cncf/manifests/gang-scheduling-test.yaml`
+**Test manifest:** `pkg/evidence/scripts/manifests/gang-scheduling-test.yaml`
 EOF
     echo '```yaml' >> "${EVIDENCE_FILE}"
     cat "${SCRIPT_DIR}/manifests/gang-scheduling-test.yaml" >> "${EVIDENCE_FILE}"
     echo '```' >> "${EVIDENCE_FILE}"
 
     # Clean up any previous run
-    kubectl delete namespace gang-scheduling-test --ignore-not-found --wait=false 2>/dev/null || true
-    sleep 5
+    cleanup_ns gang-scheduling-test
 
     # Deploy test
     log_info "Deploying gang scheduling test..."
@@ -243,7 +260,7 @@ EOF
 
 ## Cleanup
 EOF
-    capture "Delete test namespace" kubectl delete namespace gang-scheduling-test --ignore-not-found
+    capture "Delete test namespace" cleanup_ns gang-scheduling-test
 
     log_info "Gang scheduling evidence collection complete."
 }
@@ -306,8 +323,7 @@ Deploy a test pod requesting 1 GPU via ResourceClaim and verify:
 EOF
 
     # Clean up any previous run
-    kubectl delete namespace secure-access-test --ignore-not-found --wait=false 2>/dev/null || true
-    sleep 5
+    cleanup_ns secure-access-test
 
     # Deploy DRA test for isolation verification
     cat <<'MANIFEST' | kubectl apply -f -
@@ -364,8 +380,8 @@ spec:
           - name: gpu
 MANIFEST
 
-    log_info "Waiting for isolation test pod (up to ${POD_TIMEOUT}s)..."
-    pod_phase=$(wait_for_pod "secure-access-test" "isolation-test" "${POD_TIMEOUT}")
+    log_info "Waiting for isolation test pod (up to 60s)..."
+    pod_phase=$(wait_for_pod "secure-access-test" "isolation-test" 60)
     log_info "Pod phase: ${pod_phase}"
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
@@ -394,7 +410,7 @@ EOF
 
 ## Cleanup
 EOF
-    capture "Delete test namespace" kubectl delete namespace secure-access-test --ignore-not-found
+    capture "Delete test namespace" cleanup_ns secure-access-test
 
     log_info "Secure accelerator access evidence collection complete."
 }
@@ -817,15 +833,14 @@ EOF
 Deploy a GPU workload running CUDA N-Body Simulation to generate sustained GPU utilization,
 then create an HPA targeting `gpu_utilization` to demonstrate autoscaling.
 
-**Test manifest:** `docs/conformance/cncf/manifests/hpa-gpu-test.yaml`
+**Test manifest:** `pkg/evidence/scripts/manifests/hpa-gpu-test.yaml`
 EOF
     echo '```yaml' >> "${EVIDENCE_FILE}"
     cat "${SCRIPT_DIR}/manifests/hpa-gpu-test.yaml" >> "${EVIDENCE_FILE}"
     echo '```' >> "${EVIDENCE_FILE}"
 
     # Clean up any previous run
-    kubectl delete namespace hpa-test --ignore-not-found 2>/dev/null || true
-    kubectl wait --for=delete namespace/hpa-test --timeout=60s 2>/dev/null || true
+    cleanup_ns hpa-test
 
     # Deploy test
     log_info "Deploying HPA GPU test..."
@@ -856,7 +871,7 @@ EOF
         targets=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.currentMetrics[0].pods.current.averageValue}' 2>/dev/null)
         replicas=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.currentReplicas}' 2>/dev/null)
         log_info "  Check ${i}/20: gpu_utilization=${targets:-unknown}, replicas=${replicas:-1}"
-        if [ -n "$targets" ] && [ "${replicas:-1}" -gt 1 ]; then
+        if [ "${replicas:-1}" -gt 1 ] && [ -n "$targets" ]; then
             hpa_scaled=true
             break
         fi
@@ -885,58 +900,18 @@ EOF
 EOF
     capture "Pods after scale-up" kubectl get pods -n hpa-test -o wide
 
-    # Scale-down test: delete the deployment to remove GPU load, verify HPA scales down
+    # Scale-down test: wait for N-Body to finish, verify HPA scales back to 1
     local hpa_scaled_down=false
     if [ "${hpa_scaled}" = "true" ]; then
         cat >> "${EVIDENCE_FILE}" <<'EOF'
 
 ## Scale-Down Verification
 
-Scale the deployment to 0, replace GPU workload with an idle container, then
-scale back to 1. Verify HPA detects reduced utilization and scales down.
+The N-Body simulation runs a fixed number of iterations and then exits.
+Once the workload completes, GPU utilization drops to 0 and HPA scales
+back to minReplicas (1).
 EOF
-        log_info "Stopping GPU workload for scale-down test..."
-        # Delete the GPU-intensive deployment and replace with an idle one.
-        # This cleanly stops GPU load without rollout errors or Error status.
-        kubectl delete deployment gpu-workload -n hpa-test --wait=true --timeout=30s 2>/dev/null || true
-        kubectl wait --for=delete pod -n hpa-test -l app=gpu-workload --timeout=60s 2>/dev/null || true
-
-        # Create idle deployment (no GPU, just sleep) targeting the same HPA
-        kubectl apply -n hpa-test -f - 2>/dev/null <<'IDLE_DEPLOY'
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: gpu-workload
-  namespace: hpa-test
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gpu-workload
-  template:
-    metadata:
-      labels:
-        app: gpu-workload
-    spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        seccompProfile:
-          type: RuntimeDefault
-      tolerations:
-        - operator: Exists
-      containers:
-        - name: gpu-worker
-          image: ubuntu:22.04
-          command: ["sleep", "600"]
-          securityContext:
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-          resources:
-            limits:
-              nvidia.com/gpu: 1
-IDLE_DEPLOY
-        kubectl wait --for=condition=Ready pod -n hpa-test -l app=gpu-workload --timeout=60s 2>/dev/null || true
+        log_info "Waiting for GPU workload to finish and HPA to scale down..."
 
         log_info "Waiting for HPA scale-down (up to 5 minutes)..."
         for i in $(seq 1 20); do
@@ -944,7 +919,7 @@ IDLE_DEPLOY
             replicas=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.currentReplicas}' 2>/dev/null)
             targets=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.currentMetrics[0].pods.current.averageValue}' 2>/dev/null)
             log_info "  Scale-down check ${i}/20: gpu_utilization=${targets:-unknown}, replicas=${replicas:-?}"
-            if [ "${replicas}" = "1" ] && [ -n "${targets}" ]; then
+            if [ "${replicas}" = "1" ] && [ "${targets:-unknown}" = "0" ]; then
                 hpa_scaled_down=true
                 break
             fi
@@ -969,7 +944,7 @@ IDLE_DEPLOY
 
 ## Cleanup
 EOF
-    capture "Delete test namespace" kubectl delete namespace hpa-test --ignore-not-found
+    capture "Delete test namespace" cleanup_ns hpa-test
 
     log_info "Pod autoscaling evidence collection complete."
 }

--- a/pkg/evidence/scripts/manifests/dra-gpu-test.yaml
+++ b/pkg/evidence/scripts/manifests/dra-gpu-test.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # DRA GPU allocation test
-# Usage: kubectl apply -f docs/conformance/cncf/manifests/dra-gpu-test.yaml
+# Usage: kubectl apply -f pkg/evidence/scripts/manifests/dra-gpu-test.yaml
 ---
 apiVersion: v1
 kind: Namespace

--- a/pkg/evidence/scripts/manifests/gang-scheduling-test.yaml
+++ b/pkg/evidence/scripts/manifests/gang-scheduling-test.yaml
@@ -15,7 +15,7 @@
 # Gang scheduling test with PodGroup and KAI scheduler
 # Demonstrates all-or-nothing scheduling: both pods must be scheduled together
 # Requires: KAI scheduler with PodGroup CRD
-# Usage: kubectl apply -f docs/conformance/cncf/manifests/gang-scheduling-test.yaml
+# Usage: kubectl apply -f pkg/evidence/scripts/manifests/gang-scheduling-test.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -55,11 +55,8 @@ spec:
       securityContext:
         allowPrivilegeEscalation: false
       resources:
-        claims:
-          - name: gpu
-  resourceClaims:
-    - name: gpu
-      resourceClaimName: gang-gpu-claim-0
+        limits:
+          nvidia.com/gpu: 1
 ---
 apiVersion: v1
 kind: Pod
@@ -85,36 +82,5 @@ spec:
       securityContext:
         allowPrivilegeEscalation: false
       resources:
-        claims:
-          - name: gpu
-  resourceClaims:
-    - name: gpu
-      resourceClaimName: gang-gpu-claim-1
----
-apiVersion: resource.k8s.io/v1
-kind: ResourceClaim
-metadata:
-  name: gang-gpu-claim-0
-  namespace: gang-scheduling-test
-spec:
-  devices:
-    requests:
-      - name: gpu
-        exactly:
-          deviceClassName: gpu.nvidia.com
-          allocationMode: ExactCount
-          count: 1
----
-apiVersion: resource.k8s.io/v1
-kind: ResourceClaim
-metadata:
-  name: gang-gpu-claim-1
-  namespace: gang-scheduling-test
-spec:
-  devices:
-    requests:
-      - name: gpu
-        exactly:
-          deviceClassName: gpu.nvidia.com
-          allocationMode: ExactCount
-          count: 1
+        limits:
+          nvidia.com/gpu: 1

--- a/pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
+++ b/pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
@@ -14,7 +14,7 @@
 
 # HPA Pod Autoscaling test with custom GPU metrics
 # Demonstrates HPA scaling based on gpu_utilization from prometheus-adapter
-# Usage: kubectl apply -f docs/conformance/cncf/manifests/hpa-gpu-test.yaml
+# Usage: kubectl apply -f pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -48,7 +48,7 @@ spec:
         - name: gpu-worker
           image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.7.1-ubuntu18.04
           command: ["bash", "-c"]
-          args: ["while true; do /cuda-samples/nbody -benchmark -numbodies=16777216 -iterations=10000; done"]
+          args: ["/cuda-samples/nbody -benchmark -numbodies=4194304 -iterations=30 || true; exec sleep infinity"]
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -67,7 +67,10 @@ spec:
     kind: Deployment
     name: gpu-workload
   minReplicas: 1
-  maxReplicas: 4
+  maxReplicas: 2
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 30
   metrics:
     - type: Pods
       pods:


### PR DESCRIPTION
## Summary

Integrate CNCF submission evidence collection into `aicr validate --phase conformance --cncf-submission` for CNCF AI Conformance submission.

This is a short-term solution for preparing CNCF submission. 

The next step is to port the script's detailed evidence captures into the Go checks via `recordArtifact` and deprecate the script entirely. This gives a single Go implementation for both CI validation and evidence collection.  One code path, two modes: fast CI by default, full evidence when collection for CNCF submission is required.

## Motivation / Context

The evidence collection script (`collect-evidence.sh`) deploys GPU workloads and captures behavioral evidence (DRA allocation, gang scheduling, HPA scaling, etc.) needed for CNCF AI Conformance submission. This PR embeds the script into the `aicr` binary so it can be invoked as a single command.

Related: #192

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Other: `pkg/evidence` (new package)

## Implementation Notes

- `--cncf-submission` flag on `aicr validate --phase conformance` runs behavioral evidence collection instead of structural Go checks
- `--feature` flag allows per-feature runs (e.g., `--feature dra`, `--feature hpa`); supports aliases (e.g., `--feature gang-scheduling` resolves to `gang`)
- Script and manifests embedded via `go:embed` in `pkg/evidence/collector.go`
- Auto-extends timeout to 20 minutes for behavioral tests
- `cleanup_ns` helper deletes pods → resourceclaims → namespace to prevent stale DRA kubelet checkpoint issues
- HPA test uses finite N-Body simulation (4M bodies, 30 iterations) with natural scale-down; `maxReplicas=2`, `scaleDown.stabilizationWindowSeconds=30`
- Gang scheduling test uses device plugin (`nvidia.com/gpu: 1`) instead of DRA ResourceClaims

## Testing

```bash
# Per-feature test
aicr validate --phase conformance --cncf-submission --feature hpa --evidence-dir /tmp/evidence

# Full evidence collection (all 8 features)
aicr validate --phase conformance --cncf-submission --evidence-dir /tmp/evidence
```

All 8 features pass on EKS H100 cluster: DRA, gang scheduling, secure access, metrics, inference gateway, robust operator, pod autoscaling, cluster autoscaling.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — new flag only, no changes to existing validate behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [ ] Commits are cryptographically signed (`git commit -S`) — GPG agent unavailable