### PR TITLE
fix(ci): deduplicate tool installs and fix broken workflows

### DIFF
--- a/.github/actions/chainsaw/action.yml
+++ b/.github/actions/chainsaw/action.yml
@@ -36,21 +36,11 @@ runs:
           vendor/modules.txt
         check-latest: true
 
-    - name: Install Chainsaw
-      shell: bash
-      run: |
-        set -euo pipefail
-        VERSION="${{ inputs.chainsaw_version }}"
-        VERSION="${VERSION#v}"
-        TAR="chainsaw_linux_amd64.tar.gz"
-        URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
-        TMP="$(mktemp -d)"
-        curl -fsSL -o "${TMP}/${TAR}" "${URL}"
-        tar -xzf "${TMP}/${TAR}" -C "${TMP}"
-        sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
-        sudo chmod +x /usr/local/bin/chainsaw
-        rm -rf "${TMP}"
-        chainsaw version
+    - name: Setup build tools
+      uses: ./.github/actions/setup-build-tools
+      with:
+        install_chainsaw: 'true'
+        chainsaw_version: '${{ inputs.chainsaw_version }}'
 
     - name: Build aicr binary
       shell: bash

--- a/.github/actions/cloud-run-deploy/action.yml
+++ b/.github/actions/cloud-run-deploy/action.yml
@@ -47,7 +47,7 @@ inputs:
   crane_version:
     description: 'crane version (e.g. v0.20.6)'
     required: false
-    default: 'v0.20.6'
+    default: 'v0.21.0'
 
 runs:
   using: 'composite'

--- a/.github/actions/gpu-cluster-setup/action.yml
+++ b/.github/actions/gpu-cluster-setup/action.yml
@@ -40,30 +40,15 @@ runs:
           go.sum
           vendor/modules.txt
 
-    - name: Install kind
-      shell: bash
-      run: |
-        KIND_VERSION="${{ steps.versions.outputs.kind }}"
-        sudo curl -fsSL -o /usr/local/bin/kind \
-          "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64"
-        sudo chmod +x /usr/local/bin/kind
-        kind version
-
-    - name: Install kubectl
-      shell: bash
-      run: |
-        KUBECTL_VERSION="${{ steps.versions.outputs.kubectl }}"
-        sudo curl -fsSL -o /usr/local/bin/kubectl \
-          "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-        sudo chmod +x /usr/local/bin/kubectl
-        kubectl version --client
-
-    - name: Install Helm
-      shell: bash
-      run: |
-        curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | \
-          DESIRED_VERSION=${{ steps.versions.outputs.helm }} bash
-        helm version
+    - name: Setup build tools
+      uses: ./.github/actions/setup-build-tools
+      with:
+        install_kind: 'true'
+        kind_version: '${{ steps.versions.outputs.kind }}'
+        install_kubectl: 'true'
+        kubectl_version: '${{ steps.versions.outputs.kubectl }}'
+        install_helm: 'true'
+        helm_version: '${{ steps.versions.outputs.helm }}'
 
     - name: Install nvkind
       shell: bash

--- a/.github/actions/integration/action.yml
+++ b/.github/actions/integration/action.yml
@@ -22,7 +22,7 @@ inputs:
   helm_version:
     description: 'Helm version to install (e.g., v4.1.0)'
     required: false
-    default: 'v4.1.0'
+    default: 'v4.1.1'
   chainsaw_version:
     description: 'Chainsaw version to install (e.g., v0.2.14)'
     required: false
@@ -45,45 +45,10 @@ runs:
       uses: ./.github/actions/setup-build-tools
       with:
         install_goreleaser: 'true'
-
-    - name: Install Helm
-      shell: bash
-      run: |
-        set -euo pipefail
-        HELM_VERSION="${{ inputs.helm_version }}"
-        HELM_VERSION="${HELM_VERSION#v}"
-        HELM_BASE="https://get.helm.sh"
-        HELM_TAR="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
-        HELM_TMP="$(mktemp -d)"
-        curl -fsSL -o "${HELM_TMP}/${HELM_TAR}" "${HELM_BASE}/${HELM_TAR}"
-        curl -fsSL -o "${HELM_TMP}/${HELM_TAR}.sha256sum" "${HELM_BASE}/${HELM_TAR}.sha256sum"
-        EXPECTED=$(awk '{print $1}' "${HELM_TMP}/${HELM_TAR}.sha256sum")
-        ACTUAL=$(sha256sum "${HELM_TMP}/${HELM_TAR}" | awk '{print $1}')
-        if [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
-          echo "::error::helm checksum mismatch: expected ${EXPECTED}, got ${ACTUAL}"
-          exit 1
-        fi
-        tar -xzf "${HELM_TMP}/${HELM_TAR}" -C "${HELM_TMP}"
-        sudo mv "${HELM_TMP}/linux-amd64/helm" /usr/local/bin/helm
-        sudo chmod +x /usr/local/bin/helm
-        rm -rf "${HELM_TMP}"
-        helm version
-
-    - name: Install Chainsaw
-      shell: bash
-      run: |
-        set -euo pipefail
-        VERSION="${{ inputs.chainsaw_version }}"
-        VERSION="${VERSION#v}"
-        TAR="chainsaw_linux_amd64.tar.gz"
-        URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
-        TMP="$(mktemp -d)"
-        curl -fsSL -o "${TMP}/${TAR}" "${URL}"
-        tar -xzf "${TMP}/${TAR}" -C "${TMP}"
-        sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
-        sudo chmod +x /usr/local/bin/chainsaw
-        rm -rf "${TMP}"
-        chainsaw version
+        install_helm: 'true'
+        helm_version: '${{ inputs.helm_version }}'
+        install_chainsaw: 'true'
+        chainsaw_version: '${{ inputs.chainsaw_version }}'
 
     - name: Run Integration Tests
       shell: bash

--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -29,7 +29,7 @@ inputs:
   helm_version:
     description: 'Helm version to install'
     required: false
-    default: 'v4.1.0'
+    default: 'v4.1.1'
   kwok_version:
     description: 'KWOK version to install'
     required: false
@@ -82,58 +82,18 @@ runs:
         sudo rm -rf /opt/ghc
         docker system prune -f
 
-    - name: Install Kind
-      shell: bash
-      run: |
-        if [[ -x /usr/local/bin/kind ]]; then echo "kind already installed"; kind version; exit 0; fi
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${{ inputs.kind_version }}/kind-linux-amd64
-        chmod +x ./kind
-        sudo mv ./kind /usr/local/bin/kind
-        kind version
-
-    - name: Install Helm
-      shell: bash
-      run: |
-        if [[ -x /usr/local/bin/helm ]]; then echo "helm already installed"; helm version; exit 0; fi
-        set -euo pipefail
-        HELM_VERSION="${{ inputs.helm_version }}"
-        HELM_VERSION="${HELM_VERSION#v}"
-        HELM_BASE="https://get.helm.sh"
-        HELM_TAR="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
-        HELM_TMP="$(mktemp -d)"
-        curl -fsSL -o "${HELM_TMP}/${HELM_TAR}" "${HELM_BASE}/${HELM_TAR}"
-        curl -fsSL -o "${HELM_TMP}/${HELM_TAR}.sha256sum" "${HELM_BASE}/${HELM_TAR}.sha256sum"
-        EXPECTED=$(awk '{print $1}' "${HELM_TMP}/${HELM_TAR}.sha256sum")
-        ACTUAL=$(sha256sum "${HELM_TMP}/${HELM_TAR}" | awk '{print $1}')
-        if [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
-          echo "::error::helm checksum mismatch: expected ${EXPECTED}, got ${ACTUAL}"
-          exit 1
-        fi
-        tar -xzf "${HELM_TMP}/${HELM_TAR}" -C "${HELM_TMP}"
-        sudo mv "${HELM_TMP}/linux-amd64/helm" /usr/local/bin/helm
-        sudo chmod +x /usr/local/bin/helm
-        rm -rf "${HELM_TMP}"
-        helm version
-
-    - name: Install kubectl
-      shell: bash
-      run: |
-        if [[ -x /usr/local/bin/kubectl ]]; then echo "kubectl already installed"; kubectl version --client; exit 0; fi
-        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-        curl -fsSL -o kubectl "https://dl.k8s.io/release/${{ inputs.kubectl_version }}/bin/linux/${ARCH}/kubectl"
-        chmod +x kubectl
-        sudo mv kubectl /usr/local/bin/kubectl
-        kubectl version --client
-
-    - name: Install yq
-      shell: bash
-      run: |
-        if [[ -x /usr/local/bin/yq ]]; then echo "yq already installed"; yq --version; exit 0; fi
-        YQ_VERSION="${{ inputs.yq_version }}"
-        sudo wget -qO /usr/local/bin/yq \
-          "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
-        sudo chmod +x /usr/local/bin/yq
-        yq --version
+    - name: Setup build tools
+      uses: ./.github/actions/setup-build-tools
+      with:
+        install_kind: 'true'
+        kind_version: '${{ inputs.kind_version }}'
+        install_helm: 'true'
+        helm_version: '${{ inputs.helm_version }}'
+        install_kubectl: 'true'
+        kubectl_version: '${{ inputs.kubectl_version }}'
+        install_yq: 'true'
+        yq_version: '${{ inputs.yq_version }}'
+        install_goreleaser: 'true'
 
     - name: Prep system for Kind cluster
       shell: bash
@@ -141,11 +101,6 @@ runs:
         sudo sysctl -w net.ipv4.ip_forward=1
         sudo sysctl -w fs.inotify.max_user_watches=524288
         sudo sysctl -w fs.inotify.max_user_instances=1024
-
-    - name: Install GoReleaser
-      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6.4.0
-      with:
-        install-only: true
 
     - name: Build aicr binary
       shell: bash

--- a/.github/actions/setup-build-tools/action.yml
+++ b/.github/actions/setup-build-tools/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: 'Setup Build Tools'
-description: 'Install container build and release tools (ko, syft, crane, goreleaser)'
+description: 'Install build, release, and testing tools (ko, syft, crane, goreleaser, chainsaw, helm, kubectl, kind, yq)'
 
 inputs:
   install_ko:
@@ -33,13 +33,53 @@ inputs:
     required: false
     default: 'false'
   crane_version:
-    description: 'crane version (e.g. v0.20.6)'
+    description: 'crane version (e.g. v0.21.0)'
     required: false
-    default: 'v0.20.6'
+    default: 'v0.21.0'
   install_goreleaser:
     description: 'Install goreleaser (true/false)'
     required: false
     default: 'false'
+  install_chainsaw:
+    description: 'Install chainsaw (true/false)'
+    required: false
+    default: 'false'
+  chainsaw_version:
+    description: 'Chainsaw version (e.g. v0.2.14)'
+    required: false
+    default: 'v0.2.14'
+  install_helm:
+    description: 'Install helm (true/false)'
+    required: false
+    default: 'false'
+  helm_version:
+    description: 'Helm version (e.g. v4.1.1)'
+    required: false
+    default: 'v4.1.1'
+  install_kubectl:
+    description: 'Install kubectl (true/false)'
+    required: false
+    default: 'false'
+  kubectl_version:
+    description: 'kubectl version (e.g. v1.35.0)'
+    required: false
+    default: 'v1.35.0'
+  install_kind:
+    description: 'Install kind (true/false)'
+    required: false
+    default: 'false'
+  kind_version:
+    description: 'Kind version (e.g. 0.31.0)'
+    required: false
+    default: '0.31.0'
+  install_yq:
+    description: 'Install yq (true/false)'
+    required: false
+    default: 'false'
+  yq_version:
+    description: 'yq version (e.g. v4.52.4)'
+    required: false
+    default: 'v4.52.4'
 
 runs:
   using: 'composite'
@@ -105,3 +145,81 @@ runs:
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6.4.0
       with:
         install-only: true
+
+    - name: Install Chainsaw
+      if: inputs.install_chainsaw == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -x /usr/local/bin/chainsaw ]]; then echo "chainsaw already installed"; chainsaw version; exit 0; fi
+        VERSION="${{ inputs.chainsaw_version }}"
+        VERSION="${VERSION#v}"
+        TAR="chainsaw_linux_amd64.tar.gz"
+        URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
+        TMP="$(mktemp -d)"
+        curl -fsSL -o "${TMP}/${TAR}" "${URL}"
+        tar -xzf "${TMP}/${TAR}" -C "${TMP}"
+        sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
+        sudo chmod +x /usr/local/bin/chainsaw
+        rm -rf "${TMP}"
+        chainsaw version
+
+    - name: Install Helm
+      if: inputs.install_helm == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -x /usr/local/bin/helm ]]; then echo "helm already installed"; helm version; exit 0; fi
+        HELM_VERSION="${{ inputs.helm_version }}"
+        HELM_VERSION="${HELM_VERSION#v}"
+        HELM_BASE="https://get.helm.sh"
+        HELM_TAR="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+        HELM_TMP="$(mktemp -d)"
+        curl -fsSL -o "${HELM_TMP}/${HELM_TAR}" "${HELM_BASE}/${HELM_TAR}"
+        curl -fsSL -o "${HELM_TMP}/${HELM_TAR}.sha256sum" "${HELM_BASE}/${HELM_TAR}.sha256sum"
+        EXPECTED=$(awk '{print $1}' "${HELM_TMP}/${HELM_TAR}.sha256sum")
+        ACTUAL=$(sha256sum "${HELM_TMP}/${HELM_TAR}" | awk '{print $1}')
+        if [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
+          echo "::error::helm checksum mismatch: expected ${EXPECTED}, got ${ACTUAL}"
+          exit 1
+        fi
+        tar -xzf "${HELM_TMP}/${HELM_TAR}" -C "${HELM_TMP}"
+        sudo mv "${HELM_TMP}/linux-amd64/helm" /usr/local/bin/helm
+        sudo chmod +x /usr/local/bin/helm
+        rm -rf "${HELM_TMP}"
+        helm version
+
+    - name: Install kubectl
+      if: inputs.install_kubectl == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -x /usr/local/bin/kubectl ]]; then echo "kubectl already installed"; kubectl version --client; exit 0; fi
+        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+        curl -fsSL -o kubectl "https://dl.k8s.io/release/${{ inputs.kubectl_version }}/bin/linux/${ARCH}/kubectl"
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/kubectl
+        kubectl version --client
+
+    - name: Install Kind
+      if: inputs.install_kind == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -x /usr/local/bin/kind ]]; then echo "kind already installed"; kind version; exit 0; fi
+        curl -fsSL -o kind "https://kind.sigs.k8s.io/dl/v${{ inputs.kind_version }}/kind-linux-amd64"
+        chmod +x kind
+        sudo mv kind /usr/local/bin/kind
+        kind version
+
+    - name: Install yq
+      if: inputs.install_yq == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -x /usr/local/bin/yq ]]; then echo "yq already installed"; yq --version; exit 0; fi
+        YQ_VERSION="${{ inputs.yq_version }}"
+        sudo curl -fsSL -o /usr/local/bin/yq \
+          "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+        sudo chmod +x /usr/local/bin/yq
+        yq --version

--- a/.github/workflows/build-attested.yaml
+++ b/.github/workflows/build-attested.yaml
@@ -32,9 +32,12 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-attest:
-    needs: [tests, security-scan]
     name: Build and Attest Binaries
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -45,10 +48,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ steps.versions.outputs.go }}
           cache: true
 
       - name: Install Cosign

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Deploy API Server
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (e.g., v0.1.4)'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy API Server
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    env:
+      IDENTITY_PROVIDER: 'projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+      SERVICE_ACCOUNT: 'github-actions'
+      PROJECT_ID: 'eidosx'
+      RUN_REGION: 'us-west1'
+      RUN_SERVICE: 'api'
+      SOURCE_IMAGE: 'ghcr.io/nvidia/aicrd'
+      TARGET_REGISTRY: 'us-docker.pkg.dev/eidosx/demo'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Deploy Demo API Server
+        uses: ./.github/actions/cloud-run-deploy
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: ${{ env.IDENTITY_PROVIDER }}
+          service_account: "${{ env.SERVICE_ACCOUNT }}@${{ env.PROJECT_ID }}.iam.gserviceaccount.com"
+          region: ${{ env.RUN_REGION }}
+          service: ${{ env.RUN_SERVICE }}
+          source_image: "${{ env.SOURCE_IMAGE }}:${{ inputs.image_tag }}"
+          target_registry: ${{ env.TARGET_REGISTRY }}
+          image_name: 'aicrd'
+          ghcr_token: ${{ github.token }}
+          crane_version: ${{ steps.versions.outputs.crane }}

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -113,20 +113,15 @@ jobs:
             --output=validation-result.yaml \
             --evidence-dir=conformance-evidence
 
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
       - name: Install chainsaw
-        run: |
-          set -euo pipefail
-          VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
-          VERSION="${VERSION#v}"
-          TAR="chainsaw_linux_amd64.tar.gz"
-          URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
-          TMP="$(mktemp -d)"
-          curl -fsSL -o "${TMP}/${TAR}" "${URL}"
-          tar -xzf "${TMP}/${TAR}" -C "${TMP}"
-          sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
-          sudo chmod +x /usr/local/bin/chainsaw
-          rm -rf "${TMP}"
-          chainsaw version
+        uses: ./.github/actions/setup-build-tools
+        with:
+          install_chainsaw: 'true'
+          chainsaw_version: '${{ steps.versions.outputs.chainsaw }}'
 
       - name: Run chainsaw health checks
         run: |

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -94,20 +94,15 @@ jobs:
 
       # --- Health checks (run before conformance to give metrics pipeline time) ---
 
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
       - name: Install chainsaw
-        run: |
-          set -euo pipefail
-          VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml)
-          VERSION="${VERSION#v}"
-          TAR="chainsaw_linux_amd64.tar.gz"
-          URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
-          TMP="$(mktemp -d)"
-          curl -fsSL -o "${TMP}/${TAR}" "${URL}"
-          tar -xzf "${TMP}/${TAR}" -C "${TMP}"
-          sudo mv "${TMP}/chainsaw" /usr/local/bin/chainsaw
-          sudo chmod +x /usr/local/bin/chainsaw
-          rm -rf "${TMP}"
-          chainsaw version
+        uses: ./.github/actions/setup-build-tools
+        with:
+          install_chainsaw: 'true'
+          chainsaw_version: '${{ steps.versions.outputs.chainsaw }}'
 
       - name: Run chainsaw health checks
         run: |

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -45,25 +45,6 @@ jobs:
     permissions:
       actions: read
       contents: read
+      security-events: write
     with:
       coverage_report: 'true'
-
-  security-scan:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      actions: read
-      contents: read
-      security-events: write  # required by codeql-action/upload-sarif in security-scan
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Security Scan
-        uses: ./.github/actions/security-scan
-        with:
-          severity: 'MEDIUM'
-          category: 'trivy-fs'

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -40,25 +40,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-
-  security-scan:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Security Scan
-        uses: ./.github/actions/security-scan
-        with:
-          severity: 'MEDIUM'
-          category: 'trivy-fs'
+      security-events: write
 
   # =============================================================================
   # Build Job: GoReleaser (binaries, ko images, draft GitHub release)
@@ -67,7 +49,7 @@ jobs:
   build:
     name: Build and Release (Draft)
     runs-on: ubuntu-latest
-    needs: [tests, security-scan]
+    needs: [tests]
     timeout-minutes: 30
     outputs:
       release_outcome: ${{ steps.release.outputs.release_outcome }}
@@ -123,7 +105,7 @@ jobs:
   docker-validator:
     name: Docker Validator (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    needs: [tests, security-scan]
+    needs: [tests]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -364,44 +346,11 @@ jobs:
   # =============================================================================
 
   deploy:
-    name: Deploy API Server
-    runs-on: ubuntu-latest
     needs: [publish, release-check]
-    timeout-minutes: 10
+    uses: ./.github/workflows/deploy.yaml
     permissions:
       contents: read
       packages: read
       id-token: write
-    env:
-      IDENTITY_PROVIDER: 'projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
-      SERVICE_ACCOUNT: 'github-actions'
-      PROJECT_ID: 'eidosx'
-      RUN_REGION: 'us-west1'
-      RUN_SERVICE: 'api'
-      # Source: GHCR image built by GoReleaser
-      SOURCE_IMAGE: 'ghcr.io/nvidia/aicrd'
-      # Target: Artifact Registry demo repository
-      TARGET_REGISTRY: 'us-docker.pkg.dev/eidosx/demo'
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Load versions
-        id: versions
-        uses: ./.github/actions/load-versions
-
-      - name: Deploy Demo API Server
-        uses: ./.github/actions/cloud-run-deploy
-        with:
-          project_id: ${{ env.PROJECT_ID }}
-          workload_identity_provider: ${{ env.IDENTITY_PROVIDER }}
-          service_account: "${{ env.SERVICE_ACCOUNT }}@${{ env.PROJECT_ID }}.iam.gserviceaccount.com"
-          region: ${{ env.RUN_REGION }}
-          service: ${{ env.RUN_SERVICE }}
-          source_image: "${{ env.SOURCE_IMAGE }}:${{ github.ref_name }}"
-          target_registry: ${{ env.TARGET_REGISTRY }}
-          image_name: 'aicrd'
-          ghcr_token: ${{ github.token }}
-          crane_version: ${{ steps.versions.outputs.crane }}
+    with:
+      image_tag: ${{ github.ref_name }}

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -124,3 +124,23 @@ jobs:
         uses: ./.github/actions/e2e
         with:
           go_version: ${{ steps.versions.outputs.go }}
+
+  security-scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Security Scan
+        uses: ./.github/actions/security-scan
+        with:
+          severity: 'MEDIUM'
+          category: 'trivy-fs'

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -27,36 +27,10 @@ permissions:
 
 jobs:
   deploy:
-    name: Test Deploy
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/deploy.yaml
     permissions:
       contents: read
-      id-token: write
       packages: read
-    env:
-      IDENTITY_PROVIDER: 'projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
-      SERVICE_ACCOUNT: 'github-actions'
-      PROJECT_ID: 'eidosx'
-      RUN_REGION: 'us-west1'
-      RUN_SERVICE: 'api'
-      SOURCE_IMAGE: 'ghcr.io/nvidia/aicrd'
-      TARGET_REGISTRY: 'us-docker.pkg.dev/eidosx/demo'
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Deploy Demo API Server
-        uses: ./.github/actions/cloud-run-deploy
-        with:
-          project_id: ${{ env.PROJECT_ID }}
-          workload_identity_provider: ${{ env.IDENTITY_PROVIDER }}
-          service_account: "${{ env.SERVICE_ACCOUNT }}@${{ env.PROJECT_ID }}.iam.gserviceaccount.com"
-          region: ${{ env.RUN_REGION }}
-          service: ${{ env.RUN_SERVICE }}
-          source_image: "${{ env.SOURCE_IMAGE }}:${{ inputs.image_tag }}"
-          target_registry: ${{ env.TARGET_REGISTRY }}
-          image_name: 'aicrd'
-          ghcr_token: ${{ github.token }}
+      id-token: write
+    with:
+      image_tag: ${{ inputs.image_tag }}


### PR DESCRIPTION
## Summary
- Centralize 5 tool installs (chainsaw, helm, kubectl, kind, yq) into `setup-build-tools` composite action, eliminating duplicated install scripts across 6 actions/workflows
- Extract deploy job as reusable `deploy.yaml` workflow, removing duplicated config from `on-tag.yaml` and `test-deploy.yaml`
- Move `security-scan` job into `qualification.yaml` so it runs as part of the shared test suite instead of being copy-pasted in `on-push.yaml` and `on-tag.yaml`
- Fix `build-attested.yaml`: remove broken `needs: [tests, security-scan]` (those jobs don't exist in this file), add `load-versions` step for `.settings.yaml` consistency, add missing concurrency group
- Align stale version defaults (`crane v0.21.0`, `helm v4.1.1`) with `.settings.yaml`

## Changes

| Area | Files | What changed |
|------|-------|-------------|
| Shared action | `setup-build-tools/action.yml` | +5 tools with boolean flags, cache guards, checksum verification (helm) |
| Consumers | `chainsaw/`, `integration/`, `kwok-test/`, `gpu-cluster-setup/` actions | Replace inline installs with `setup-build-tools` calls |
| GPU workflows | `gpu-h100-inference-test.yaml`, `gpu-h100-training-test.yaml` | Add `load-versions`, replace inline chainsaw install |
| Security scan | `qualification.yaml`, `on-push.yaml`, `on-tag.yaml` | Move job into qualification, remove from callers |
| Deploy | `deploy.yaml` (new), `on-tag.yaml`, `test-deploy.yaml` | Extract reusable workflow |
| Build attested | `build-attested.yaml` | Fix broken needs, add load-versions + concurrency |
| Version drift | `cloud-run-deploy/`, `integration/`, `kwok-test/` | Align defaults with `.settings.yaml` |

Net: **+277 -276 lines** across 14 files (1 new)

## Test plan
- [ ] `on-push.yaml` triggers qualification (unit + integration + conformance + e2e + security-scan)
- [ ] `on-tag.yaml` build/release pipeline runs with updated needs graph
- [ ] `build-attested.yaml` runs via `workflow_dispatch` without failing on missing jobs
- [ ] `test-deploy.yaml` deploys correctly via reusable workflow
- [x] KWOK recipe tests pass with tools installed via `setup-build-tools`
- [x] GPU H100 inference/training tests install chainsaw via shared action