### PR TITLE
fix(bundler): add type-aware routing for kustomize components

### DIFF
--- a/pkg/bundler/deployer/argocd/argocd.go
+++ b/pkg/bundler/deployer/argocd/argocd.go
@@ -40,12 +40,15 @@ var readmeTemplate string
 
 // ApplicationData contains data for rendering an ArgoCD Application.
 type ApplicationData struct {
-	Name       string
-	Namespace  string
-	Repository string
-	Chart      string
-	Version    string
-	SyncWave   int
+	Name        string
+	Namespace   string
+	Repository  string
+	Chart       string
+	Version     string
+	SyncWave    int
+	IsKustomize bool   // True when the component uses Kustomize instead of Helm
+	Tag         string // Git ref for Kustomize components (tag, branch, or commit)
+	Path        string // Path within the repository to the kustomization
 }
 
 // AppOfAppsData contains data for rendering the App of Apps manifest.
@@ -138,18 +141,24 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", comp.Name))
 		}
+
+		isKustomize := comp.Type == recipe.ComponentTypeKustomize
+
 		chartName := comp.Chart
 		if chartName == "" {
 			chartName = comp.Name
 		}
 
 		appData := ApplicationData{
-			Name:       comp.Name,
-			Namespace:  comp.Namespace,
-			Repository: comp.Source,
-			Chart:      chartName,
-			Version:    shared.NormalizeVersion(comp.Version),
-			SyncWave:   i, // Use index as sync wave
+			Name:        comp.Name,
+			Namespace:   comp.Namespace,
+			Repository:  comp.Source,
+			Chart:       chartName,
+			Version:     shared.NormalizeVersion(comp.Version),
+			SyncWave:    i, // Use index as sync wave
+			IsKustomize: isKustomize,
+			Tag:         comp.Tag,
+			Path:        comp.Path,
 		}
 		appDataList = append(appDataList, appData)
 	}
@@ -180,18 +189,20 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		output.Files = append(output.Files, appPath)
 		output.TotalSize += appSize
 
-		// Generate values.yaml
-		values := input.ComponentValues[appData.Name]
-		if values == nil {
-			values = make(map[string]any)
+		// Generate values.yaml only for Helm components (kustomize uses source directly)
+		if !appData.IsKustomize {
+			values := input.ComponentValues[appData.Name]
+			if values == nil {
+				values = make(map[string]any)
+			}
+			valuesPath, valuesSize, err := shared.WriteValuesFile(values, componentDir, "values.yaml")
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInternal,
+					fmt.Sprintf("failed to generate values.yaml for %s", appData.Name), err)
+			}
+			output.Files = append(output.Files, valuesPath)
+			output.TotalSize += valuesSize
 		}
-		valuesPath, valuesSize, err := shared.WriteValuesFile(values, componentDir, "values.yaml")
-		if err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal,
-				fmt.Sprintf("failed to generate values.yaml for %s", appData.Name), err)
-		}
-		output.Files = append(output.Files, valuesPath)
-		output.TotalSize += valuesSize
 	}
 
 	// Generate app-of-apps.yaml

--- a/pkg/bundler/deployer/argocd/argocd_test.go
+++ b/pkg/bundler/deployer/argocd/argocd_test.go
@@ -540,6 +540,162 @@ func TestNormalizeVersion(t *testing.T) {
 	}
 }
 
+func TestGenerate_KustomizeOnly(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{
+		{
+			Name:      "my-kustomize-app",
+			Namespace: "my-app",
+			Type:      recipe.ComponentTypeKustomize,
+			Source:    "https://github.com/example/repo",
+			Tag:       "v2.0.0",
+			Path:      "deploy/production",
+		},
+	}
+	recipeResult.DeploymentOrder = []string{"my-kustomize-app"}
+
+	input := &GeneratorInput{
+		RecipeResult:    recipeResult,
+		ComponentValues: map[string]map[string]any{},
+		Version:         "v0.9.0",
+	}
+
+	output, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Verify application.yaml uses source (not sources) with path
+	appPath := filepath.Join(outputDir, "my-kustomize-app", "application.yaml")
+	content, err := os.ReadFile(appPath)
+	if err != nil {
+		t.Fatalf("failed to read application.yaml: %v", err)
+	}
+	appContent := string(content)
+
+	if !strings.Contains(appContent, "path: deploy/production") {
+		t.Error("application.yaml should contain kustomize path")
+	}
+	if !strings.Contains(appContent, "targetRevision: v2.0.0") {
+		t.Error("application.yaml should contain kustomize tag as targetRevision")
+	}
+	if strings.Contains(appContent, "chart:") {
+		t.Error("application.yaml should not contain chart for kustomize component")
+	}
+	if strings.Contains(appContent, "helm:") {
+		t.Error("application.yaml should not contain helm section for kustomize component")
+	}
+	// Kustomize uses single source, not multi-source
+	if strings.Contains(appContent, "sources:") {
+		t.Error("application.yaml should use source (singular) for kustomize, not sources")
+	}
+	if !strings.Contains(appContent, "source:") {
+		t.Error("application.yaml should contain source for kustomize component")
+	}
+
+	// values.yaml should NOT exist for kustomize components
+	valuesPath := filepath.Join(outputDir, "my-kustomize-app", "values.yaml")
+	if _, statErr := os.Stat(valuesPath); !os.IsNotExist(statErr) {
+		t.Error("values.yaml should not exist for kustomize component")
+	}
+
+	// app-of-apps.yaml and README should still exist
+	for _, f := range []string{"app-of-apps.yaml", "README.md"} {
+		if _, statErr := os.Stat(filepath.Join(outputDir, f)); os.IsNotExist(statErr) {
+			t.Errorf("expected %s to exist", f)
+		}
+	}
+
+	if len(output.Files) == 0 {
+		t.Error("Generate() returned no files")
+	}
+}
+
+func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{
+		{
+			Name:      "cert-manager",
+			Namespace: "cert-manager",
+			Chart:     "cert-manager",
+			Version:   "v1.17.2",
+			Type:      recipe.ComponentTypeHelm,
+			Source:    "https://charts.jetstack.io",
+		},
+		{
+			Name:      "my-kustomize-app",
+			Namespace: "my-app",
+			Type:      recipe.ComponentTypeKustomize,
+			Source:    "https://github.com/example/repo",
+			Tag:       "v2.0.0",
+			Path:      "deploy/production",
+		},
+	}
+	recipeResult.DeploymentOrder = []string{"cert-manager", "my-kustomize-app"}
+
+	input := &GeneratorInput{
+		RecipeResult: recipeResult,
+		ComponentValues: map[string]map[string]any{
+			"cert-manager":     {"installCRDs": true},
+			"my-kustomize-app": {},
+		},
+		Version: "v0.9.0",
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Helm component should have chart-based application.yaml
+	certApp, err := os.ReadFile(filepath.Join(outputDir, "cert-manager", "application.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cert-manager application.yaml: %v", err)
+	}
+	certAppStr := string(certApp)
+	if !strings.Contains(certAppStr, "chart:") {
+		t.Error("cert-manager application.yaml should contain chart")
+	}
+	if !strings.Contains(certAppStr, "helm:") {
+		t.Error("cert-manager application.yaml should contain helm section")
+	}
+
+	// Helm component should have values.yaml
+	certValues := filepath.Join(outputDir, "cert-manager", "values.yaml")
+	if _, statErr := os.Stat(certValues); os.IsNotExist(statErr) {
+		t.Error("cert-manager should have values.yaml")
+	}
+
+	// Kustomize component should have path-based application.yaml
+	kustApp, err := os.ReadFile(filepath.Join(outputDir, "my-kustomize-app", "application.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read my-kustomize-app application.yaml: %v", err)
+	}
+	kustAppStr := string(kustApp)
+	if !strings.Contains(kustAppStr, "path: deploy/production") {
+		t.Error("kustomize application.yaml should contain path")
+	}
+	if strings.Contains(kustAppStr, "chart:") {
+		t.Error("kustomize application.yaml should not contain chart")
+	}
+
+	// Kustomize component should NOT have values.yaml
+	kustValues := filepath.Join(outputDir, "my-kustomize-app", "values.yaml")
+	if _, statErr := os.Stat(kustValues); !os.IsNotExist(statErr) {
+		t.Error("kustomize component should not have values.yaml")
+	}
+}
+
 // TestGenerate_Reproducible verifies that ArgoCD bundle generation is deterministic.
 // Running Generate() twice with the same input should produce identical output files.
 func TestGenerate_Reproducible(t *testing.T) {

--- a/pkg/bundler/deployer/argocd/templates/README.md.tmpl
+++ b/pkg/bundler/deployer/argocd/templates/README.md.tmpl
@@ -11,10 +11,14 @@ This bundle contains ArgoCD Application manifests for deploying NVIDIA Cloud Nat
 
 The following components are included in deployment order:
 
-| Component | Version | Sync Wave | Namespace |
-|-----------|---------|-----------|-----------|
+| Component | Type | Version | Sync Wave | Namespace |
+|-----------|------|---------|-----------|-----------|
 {{- range .Components }}
-| {{ .Name }} | {{ .Version }} | {{ .SyncWave }} | {{ .Namespace }} |
+{{ if .IsKustomize -}}
+| {{ .Name }} | Kustomize | {{ .Tag }} | {{ .SyncWave }} | {{ .Namespace }} |
+{{- else -}}
+| {{ .Name }} | Helm | {{ .Version }} | {{ .SyncWave }} | {{ .Namespace }} |
+{{- end }}
 {{- end }}
 
 ## Prerequisites
@@ -76,7 +80,9 @@ argocd app sync nvidia-stack --watch
 {{- range .Components }}
 ├── {{ .Name }}/
 │   ├── application.yaml       # ArgoCD Application (sync-wave: {{ .SyncWave }})
+{{- if not .IsKustomize }}
 │   └── values.yaml            # Helm values
+{{- end }}
 {{- end }}
 ```
 
@@ -92,7 +98,7 @@ Components are deployed in order using ArgoCD sync-waves:
 
 ### Modifying Values
 
-Edit the `values.yaml` file in each component directory to customize the deployment.
+Edit the `values.yaml` file in each Helm component directory to customize the deployment.
 
 ### Changing Deployment Order
 

--- a/pkg/bundler/deployer/argocd/templates/application.yaml.tmpl
+++ b/pkg/bundler/deployer/argocd/templates/application.yaml.tmpl
@@ -7,6 +7,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "{{ .SyncWave }}"
 spec:
   project: default
+{{ if .IsKustomize -}}
+  source:
+    repoURL: {{ .Repository }}
+    targetRevision: {{ .Tag }}
+    path: {{ .Path }}
+{{ else -}}
   sources:
     - repoURL: {{ .Repository }}
       chart: {{ .Chart }}
@@ -17,6 +23,7 @@ spec:
     - repoURL: '{{ `{{ .RepoURL }}` }}'
       targetRevision: main
       ref: values
+{{ end -}}
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Namespace }}

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -58,6 +58,9 @@ type ComponentData struct {
 	HasManifests bool
 	HasChart     bool
 	IsOCI        bool
+	IsKustomize  bool   // True when the component uses Kustomize instead of Helm
+	Tag          string // Git ref for Kustomize components (tag, branch, or commit)
+	Path         string // Path within the repository to the kustomization
 }
 
 // GeneratorInput contains all data needed to generate a per-component Helm bundle.
@@ -223,6 +226,8 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 			}
 		}
 
+		isKustomize := ref.Type == recipe.ComponentTypeKustomize
+
 		chartName := ref.Chart
 		if chartName == "" {
 			chartName = ref.Name
@@ -241,8 +246,11 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 			Version:      version,
 			ChartVersion: shared.NormalizeVersionWithDefault(ref.Version),
 			HasManifests: hasManifests,
-			HasChart:     ref.Source != "",
+			HasChart:     !isKustomize && ref.Source != "",
 			IsOCI:        isOCI,
+			IsKustomize:  isKustomize,
+			Tag:          ref.Tag,
+			Path:         ref.Path,
 		})
 	}
 

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -660,7 +660,332 @@ func TestBuildComponentDataList_NamespaceAndChart(t *testing.T) {
 	}
 }
 
+func TestGenerate_KustomizeOnly(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	input := &GeneratorInput{
+		RecipeResult: createKustomizeRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"my-kustomize-app": {},
+		},
+		Version: "v1.0.0",
+	}
+
+	output, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify root files exist
+	for _, f := range []string{"README.md", "deploy.sh", "undeploy.sh"} {
+		path := filepath.Join(outputDir, f)
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			t.Errorf("expected root file %s does not exist", f)
+		}
+	}
+
+	// Verify component directory exists with README
+	readmePath := filepath.Join(outputDir, "my-kustomize-app", "README.md")
+	if _, statErr := os.Stat(readmePath); os.IsNotExist(statErr) {
+		t.Error("expected my-kustomize-app/README.md does not exist")
+	}
+
+	// deploy.sh should contain kustomize build, NOT helm upgrade
+	deployContent, err := os.ReadFile(filepath.Join(outputDir, "deploy.sh"))
+	if err != nil {
+		t.Fatalf("failed to read deploy.sh: %v", err)
+	}
+	deployScript := string(deployContent)
+
+	if !strings.Contains(deployScript, "kustomize build") {
+		t.Error("deploy.sh missing kustomize build command")
+	}
+	if strings.Contains(deployScript, "helm upgrade") {
+		t.Error("deploy.sh should not contain helm upgrade for kustomize-only bundle")
+	}
+	if !strings.Contains(deployScript, "via kustomize") {
+		t.Error("deploy.sh should indicate kustomize deployment")
+	}
+	if !strings.Contains(deployScript, "ref=v1.0.0") {
+		t.Error("deploy.sh should contain kustomize tag ref")
+	}
+	if !strings.Contains(deployScript, "deploy/production") {
+		t.Error("deploy.sh should contain kustomize path")
+	}
+
+	// undeploy.sh should contain kustomize build for deletion
+	undeployContent, err := os.ReadFile(filepath.Join(outputDir, "undeploy.sh"))
+	if err != nil {
+		t.Fatalf("failed to read undeploy.sh: %v", err)
+	}
+	undeployScript := string(undeployContent)
+
+	if !strings.Contains(undeployScript, "kustomize build") {
+		t.Error("undeploy.sh missing kustomize build command")
+	}
+	if strings.Contains(undeployScript, "helm uninstall") {
+		t.Error("undeploy.sh should not contain helm uninstall for kustomize-only bundle")
+	}
+
+	// Component README should show kustomize instructions
+	compReadme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("failed to read component README: %v", err)
+	}
+	compReadmeStr := string(compReadme)
+	if !strings.Contains(compReadmeStr, "kustomize build") {
+		t.Error("component README should contain kustomize build instructions")
+	}
+	if strings.Contains(compReadmeStr, "helm upgrade") {
+		t.Error("component README should not contain helm commands for kustomize component")
+	}
+
+	if len(output.Files) < 4 {
+		t.Errorf("expected at least 4 files, got %d", len(output.Files))
+	}
+}
+
+func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	input := &GeneratorInput{
+		RecipeResult: createMixedRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager":     {"installCRDs": true},
+			"my-kustomize-app": {},
+		},
+		Version: "v1.0.0",
+	}
+
+	output, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify both component directories exist
+	for _, comp := range []string{"cert-manager", "my-kustomize-app"} {
+		readmePath := filepath.Join(outputDir, comp, "README.md")
+		if _, statErr := os.Stat(readmePath); os.IsNotExist(statErr) {
+			t.Errorf("expected %s/README.md does not exist", comp)
+		}
+	}
+
+	// deploy.sh should contain BOTH helm and kustomize commands
+	deployContent, err := os.ReadFile(filepath.Join(outputDir, "deploy.sh"))
+	if err != nil {
+		t.Fatalf("failed to read deploy.sh: %v", err)
+	}
+	deployScript := string(deployContent)
+
+	if !strings.Contains(deployScript, "helm upgrade") {
+		t.Error("deploy.sh missing helm upgrade for Helm component")
+	}
+	if !strings.Contains(deployScript, "kustomize build") {
+		t.Error("deploy.sh missing kustomize build for Kustomize component")
+	}
+
+	// undeploy.sh should contain BOTH helm and kustomize commands
+	undeployContent, err := os.ReadFile(filepath.Join(outputDir, "undeploy.sh"))
+	if err != nil {
+		t.Fatalf("failed to read undeploy.sh: %v", err)
+	}
+	undeployScript := string(undeployContent)
+
+	if !strings.Contains(undeployScript, "helm uninstall") {
+		t.Error("undeploy.sh missing helm uninstall for Helm component")
+	}
+	if !strings.Contains(undeployScript, "kustomize build") {
+		t.Error("undeploy.sh missing kustomize build for Kustomize component")
+	}
+
+	// Root README should show both types
+	rootReadme, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
+	if err != nil {
+		t.Fatalf("failed to read README.md: %v", err)
+	}
+	rootReadmeStr := string(rootReadme)
+	if !strings.Contains(rootReadmeStr, "Helm") {
+		t.Error("root README should indicate Helm type")
+	}
+	if !strings.Contains(rootReadmeStr, "Kustomize") {
+		t.Error("root README should indicate Kustomize type")
+	}
+
+	if len(output.Files) < 7 {
+		t.Errorf("expected at least 7 files, got %d", len(output.Files))
+	}
+}
+
+func TestBuildComponentDataList_Kustomize(t *testing.T) {
+	g := NewGenerator()
+
+	input := &GeneratorInput{
+		RecipeResult: &recipe.RecipeResult{
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:      "my-kustomize-app",
+					Namespace: "my-app",
+					Type:      recipe.ComponentTypeKustomize,
+					Source:    "https://github.com/example/repo",
+					Tag:       "v2.0.0",
+					Path:      "deploy/production",
+				},
+			},
+		},
+	}
+
+	components, err := g.buildComponentDataList(input)
+	if err != nil {
+		t.Fatalf("buildComponentDataList failed: %v", err)
+	}
+
+	if len(components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(components))
+	}
+
+	comp := components[0]
+	if !comp.IsKustomize {
+		t.Error("expected IsKustomize to be true")
+	}
+	if comp.HasChart {
+		t.Error("expected HasChart to be false for kustomize component")
+	}
+	if comp.Tag != "v2.0.0" {
+		t.Errorf("expected Tag v2.0.0, got %s", comp.Tag)
+	}
+	if comp.Path != "deploy/production" {
+		t.Errorf("expected Path deploy/production, got %s", comp.Path)
+	}
+	if comp.Repository != "https://github.com/example/repo" {
+		t.Errorf("expected Repository https://github.com/example/repo, got %s", comp.Repository)
+	}
+}
+
+func TestBuildComponentDataList_MixedTypes(t *testing.T) {
+	g := NewGenerator()
+
+	input := &GeneratorInput{
+		RecipeResult: &recipe.RecipeResult{
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+					Chart:     "cert-manager",
+					Type:      recipe.ComponentTypeHelm,
+					Version:   "v1.17.2",
+					Source:    "https://charts.jetstack.io",
+				},
+				{
+					Name:      "my-kustomize-app",
+					Namespace: "my-app",
+					Type:      recipe.ComponentTypeKustomize,
+					Source:    "https://github.com/example/repo",
+					Tag:       "v2.0.0",
+					Path:      "deploy/production",
+				},
+			},
+		},
+	}
+
+	components, err := g.buildComponentDataList(input)
+	if err != nil {
+		t.Fatalf("buildComponentDataList failed: %v", err)
+	}
+
+	if len(components) != 2 {
+		t.Fatalf("expected 2 components, got %d", len(components))
+	}
+
+	for _, comp := range components {
+		switch comp.Name {
+		case "cert-manager":
+			if comp.IsKustomize {
+				t.Error("cert-manager should not be kustomize")
+			}
+			if !comp.HasChart {
+				t.Error("cert-manager should have HasChart=true")
+			}
+		case "my-kustomize-app":
+			if !comp.IsKustomize {
+				t.Error("my-kustomize-app should be kustomize")
+			}
+			if comp.HasChart {
+				t.Error("my-kustomize-app should have HasChart=false")
+			}
+		}
+	}
+}
+
 // Helper functions
+
+func createKustomizeRecipeResult() *recipe.RecipeResult {
+	return &recipe.RecipeResult{
+		Kind:       "RecipeResult",
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Metadata: struct {
+			Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
+			AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
+			ExcludedOverlays   []string                   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+			ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
+		}{
+			Version: "v0.1.0",
+		},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:      "my-kustomize-app",
+				Namespace: "my-app",
+				Type:      recipe.ComponentTypeKustomize,
+				Source:    "https://github.com/example/repo",
+				Tag:       "v1.0.0",
+				Path:      "deploy/production",
+			},
+		},
+		DeploymentOrder: []string{"my-kustomize-app"},
+	}
+}
+
+func createMixedRecipeResult() *recipe.RecipeResult {
+	return &recipe.RecipeResult{
+		Kind:       "RecipeResult",
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Metadata: struct {
+			Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
+			AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
+			ExcludedOverlays   []string                   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+			ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
+		}{
+			Version: "v0.1.0",
+		},
+		Criteria: &recipe.Criteria{
+			Service:     "eks",
+			Accelerator: "h100",
+			Intent:      "training",
+		},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:      "cert-manager",
+				Namespace: "cert-manager",
+				Chart:     "cert-manager",
+				Type:      recipe.ComponentTypeHelm,
+				Version:   "v1.17.2",
+				Source:    "https://charts.jetstack.io",
+			},
+			{
+				Name:      "my-kustomize-app",
+				Namespace: "my-app",
+				Type:      recipe.ComponentTypeKustomize,
+				Source:    "https://github.com/example/repo",
+				Tag:       "v1.0.0",
+				Path:      "deploy/production",
+			},
+		},
+		DeploymentOrder: []string{"cert-manager", "my-kustomize-app"},
+	}
+}
 
 func createTestRecipeResult() *recipe.RecipeResult {
 	return &recipe.RecipeResult{

--- a/pkg/bundler/deployer/helm/templates/README.md.tmpl
+++ b/pkg/bundler/deployer/helm/templates/README.md.tmpl
@@ -3,7 +3,7 @@
 Recipe Version: {{ .RecipeVersion }}
 Bundler Version: {{ .BundlerVersion }}
 
-Per-component Helm bundle for deploying NVIDIA Cloud Native Stack components
+Per-component bundle for deploying NVIDIA Cloud Native Stack components
 for GPU-accelerated Kubernetes workloads.
 
 ## Configuration
@@ -19,10 +19,14 @@ for GPU-accelerated Kubernetes workloads.
 
 The following components are included (deployed in order):
 
-| Component | Version | Namespace | Chart |
-|-----------|---------|-----------|-------|
+| Component | Type | Version | Namespace | Source |
+|-----------|------|---------|-----------|--------|
 {{ range .Components -}}
-| {{ .Name }} | {{ .Version }} | {{ .Namespace }} | {{ .ChartName }} ({{ .Repository }}) |
+{{ if .IsKustomize -}}
+| {{ .Name }} | Kustomize | {{ .Tag }} | {{ .Namespace }} | {{ .Repository }} ({{ .Path }}) |
+{{ else -}}
+| {{ .Name }} | Helm | {{ .Version }} | {{ .Namespace }} | {{ .ChartName }} ({{ .Repository }}) |
+{{ end -}}
 {{ end }}
 
 {{ if .Constraints }}
@@ -59,6 +63,13 @@ Install components individually in order:
 {{ range .Components }}
 ### {{ .Name }}
 
+{{ if .IsKustomize -}}
+```bash
+kubectl create namespace {{ .Namespace }} --dry-run=client -o yaml | kubectl apply -f -
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl apply -n {{ .Namespace }} -f -
+```
+{{ else -}}
 ```bash
 {{ if .IsOCI -}}
 helm upgrade --install {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
@@ -75,6 +86,7 @@ helm upgrade --install {{ .Name }} {{ .ChartName }} \
   --wait --timeout 10m
 {{ end -}}
 ```
+{{ end -}}
 {{ if .HasManifests }}
 ```bash
 kubectl apply -f {{ .Name }}/manifests/
@@ -84,7 +96,7 @@ kubectl apply -f {{ .Name }}/manifests/
 
 ## Customization
 
-Each component has its own `values.yaml` in its directory.
+Each Helm component has its own `values.yaml` in its directory.
 Edit the file before deploying to customize component configuration:
 
 ```bash
@@ -93,7 +105,7 @@ vim gpu-operator/values.yaml
 
 ## Upgrade
 
-To upgrade a specific component:
+To upgrade a specific Helm component:
 
 ```bash
 helm upgrade <component> <chart> --version <version> -n <namespace> -f <component>/values.yaml --wait --timeout 10m
@@ -104,9 +116,16 @@ helm upgrade <component> <chart> --version <version> -n <namespace> -f <componen
 To remove components (reverse order):
 
 {{ range .ComponentsReversed -}}
+{{ if .IsKustomize -}}
+```bash
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl delete -n {{ .Namespace }} --ignore-not-found -f -
+```
+{{ else -}}
 ```bash
 helm uninstall {{ .Name }} -n {{ .Namespace }}
 ```
+{{ end -}}
 {{ end }}
 
 ## Troubleshooting

--- a/pkg/bundler/deployer/helm/templates/component-README.md.tmpl
+++ b/pkg/bundler/deployer/helm/templates/component-README.md.tmpl
@@ -1,5 +1,39 @@
 # {{ .Name }}
 
+{{ if .IsKustomize -}}
+Source: {{ .Repository }}
+Path: {{ .Path }}
+{{ if .Tag -}}Tag: {{ .Tag }}{{ end }}
+Namespace: {{ .Namespace }}
+
+## Install
+
+```bash
+kubectl create namespace {{ .Namespace }} --dry-run=client -o yaml | kubectl apply -f -
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl apply -n {{ .Namespace }} -f -
+```
+{{ if .HasManifests }}
+After the kustomization is applied, apply additional manifests:
+
+```bash
+kubectl apply -f manifests/
+```
+{{ end }}
+## Upgrade
+
+```bash
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl apply -n {{ .Namespace }} -f -
+```
+
+## Uninstall
+
+```bash
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl delete -n {{ .Namespace }} --ignore-not-found -f -
+```
+{{ else -}}
 Chart: {{ .Repository }}/{{ .ChartName }}
 Version: {{ .Version }}
 Namespace: {{ .Namespace }}
@@ -53,3 +87,4 @@ helm upgrade {{ .Name }} {{ .ChartName }} \
 ```bash
 helm uninstall {{ .Name }} -n {{ .Namespace }}
 ```
+{{ end -}}

--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -45,7 +45,13 @@ echo "Deploying Cloud Native Stack components..."
 
 # Install components in order
 {{ range .Components -}}
-{{ if .HasChart -}}
+{{ if .IsKustomize -}}
+echo "Installing {{ .Name }} ({{ .Namespace }}) via kustomize..."
+kubectl create namespace {{ .Namespace }} --dry-run=client -o yaml | kubectl apply -f -
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl apply -n {{ .Namespace }} -f - \
+  || helm_failed "{{ .Name }}"
+{{ else if .HasChart -}}
 echo "Installing {{ .Name }} ({{ .Namespace }})..."
 COMPONENT_WAIT_ARGS="${WAIT_ARGS}"
 if echo "${ASYNC_COMPONENTS}" | grep -qw "{{ .Name }}"; then

--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -25,7 +25,15 @@ PROTECTED_NS="kube-system kube-public kube-node-lease default"
 echo "Deleting manifests for {{ .Name }}..."
 kubectl delete -f "${SCRIPT_DIR}/{{ .Name }}/manifests/" --ignore-not-found
 {{ end -}}
-{{ if .HasChart -}}
+{{ if .IsKustomize -}}
+echo "Uninstalling {{ .Name }} ({{ .Namespace }}) via kustomize..."
+kustomize build '{{ .Repository }}//{{ .Path }}{{ if .Tag }}?ref={{ .Tag }}{{ end }}' \
+  | kubectl delete -n {{ .Namespace }} --ignore-not-found -f - || true
+if [[ "${KEEP_NS}" == "false" ]] && ! echo " ${PROTECTED_NS} " | grep -q " {{ .Namespace }} " && kubectl get namespace {{ .Namespace }} &>/dev/null; then
+  echo "Deleting namespace {{ .Namespace }}..."
+  kubectl delete namespace {{ .Namespace }} --ignore-not-found
+fi
+{{ else if .HasChart -}}
 echo "Uninstalling {{ .Name }} ({{ .Namespace }})..."
 helm uninstall {{ .Name }} -n {{ .Namespace }} --ignore-not-found || true
 if [[ "${KEEP_NS}" == "false" ]] && ! echo " ${PROTECTED_NS} " | grep -q " {{ .Namespace }} " && kubectl get namespace {{ .Namespace }} &>/dev/null; then


### PR DESCRIPTION
## Summary
- Bundler deployers now check `ComponentRef.Type` to generate appropriate output for Kustomize components instead of routing everything through Helm templates
- Helm deployer generates `kustomize build` commands in deploy/undeploy scripts for Kustomize components, with kustomize-specific README docs
- ArgoCD deployer generates single-source Application manifests with `path` + `targetRevision` for Kustomize components instead of `chart` + `helm` multi-source; skips `values.yaml` for Kustomize components
- Mixed bundles (Helm + Kustomize in same recipe) are fully supported

Fixes #219

## Changes
- `pkg/bundler/deployer/helm/helm.go` — Added `IsKustomize`, `Tag`, `Path` fields to `ComponentData`; `buildComponentDataList` populates them from `ComponentRef.Type`
- `pkg/bundler/deployer/helm/templates/deploy.sh.tmpl` — Conditional `kustomize build` vs `helm upgrade` per component type
- `pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl` — Conditional `kustomize build | kubectl delete` vs `helm uninstall`
- `pkg/bundler/deployer/helm/templates/component-README.md.tmpl` — Kustomize-specific install/upgrade/uninstall instructions
- `pkg/bundler/deployer/helm/templates/README.md.tmpl` — Type column in component table; kustomize manual install commands
- `pkg/bundler/deployer/argocd/argocd.go` — Added `IsKustomize`, `Tag`, `Path` fields to `ApplicationData`; skip `values.yaml` for kustomize components
- `pkg/bundler/deployer/argocd/templates/application.yaml.tmpl` — Single `source` with `path`/`targetRevision` for kustomize vs multi-source `chart`/`helm` for Helm
- `pkg/bundler/deployer/argocd/templates/README.md.tmpl` — Type column in component table

## Test plan
- [x] `TestGenerate_KustomizeOnly` — Kustomize-only Helm bundle generates `kustomize build` (not `helm upgrade`)
- [x] `TestGenerate_MixedHelmAndKustomize` — Mixed bundle contains both helm and kustomize commands
- [x] `TestBuildComponentDataList_Kustomize` — Kustomize ComponentRef produces correct ComponentData fields
- [x] `TestBuildComponentDataList_MixedTypes` — Mixed types set `HasChart`/`IsKustomize` correctly
- [x] ArgoCD `TestGenerate_KustomizeOnly` — Kustomize Application uses `source`/`path`, no `chart`/`helm`, no `values.yaml`
- [x] ArgoCD `TestGenerate_MixedHelmAndKustomize` — Mixed bundle: Helm gets `chart`+`values.yaml`, Kustomize gets `path`, no `values.yaml`
- [x] All existing tests continue to pass
- [x] `make qualify` passes (test + lint + e2e + scan)