### PR TITLE
feat(validator): auto-discover expected resources from kustomize sources via krusty SDK

### DIFF
--- a/pkg/validator/resource_discovery.go
+++ b/pkg/validator/resource_discovery.go
@@ -39,6 +39,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Workload resource kinds used for auto-discovery and summary reporting.
+const (
+	kindDeployment  = "Deployment"
+	kindDaemonSet   = "DaemonSet"
+	kindStatefulSet = "StatefulSet"
+)
+
 // componentDiscovery tracks the discovery results for a single component.
 type componentDiscovery struct {
 	name      string
@@ -213,7 +220,7 @@ func countByKind(resources []recipe.ExpectedResource) string {
 	}
 
 	var parts []string
-	for _, kind := range []string{"Deployment", "DaemonSet", "StatefulSet"} { //nolint:goconst // workload kinds are clearer as literals in switch/range
+	for _, kind := range []string{kindDeployment, kindDaemonSet, kindStatefulSet} {
 		if n, ok := counts[kind]; ok {
 			label := kind + "s"
 			if n == 1 {
@@ -335,6 +342,9 @@ func renderKustomizeTemplate(ctx context.Context, ref recipe.ComponentRef) ([]re
 
 	select {
 	case <-ctx.Done():
+		// On timeout the goroutine above keeps running but is bounded:
+		// krusty's internal git clone has a hard 27s timeout, after which
+		// the goroutine writes to the buffered channel and exits.
 		return nil, errors.Wrap(errors.ErrCodeTimeout, "kustomize build timed out", ctx.Err())
 	case r := <-ch:
 		return r.resources, r.err
@@ -346,7 +356,7 @@ func renderKustomizeTemplate(ctx context.Context, ref recipe.ComponentRef) ([]re
 // The double-slash separates the repo root from the kustomization root path,
 // and ?ref= sets the git ref (tag, branch, or commit).
 func buildKustomizeURL(source, path, tag string) string {
-	url := source
+	url := strings.TrimSuffix(source, "/")
 	if path != "" {
 		url += "//" + path
 	}
@@ -452,7 +462,7 @@ func extractWorkloadResources(manifestContent string, defaultNamespace string) [
 
 		// Only extract workload resources
 		switch meta.Kind {
-		case "Deployment", "DaemonSet", "StatefulSet": //nolint:goconst // workload kinds are clearer as literals in switch/range
+		case kindDeployment, kindDaemonSet, kindStatefulSet:
 			ns := meta.Metadata.Namespace
 			if ns == "" {
 				ns = defaultNamespace

--- a/pkg/validator/resource_discovery.go
+++ b/pkg/validator/resource_discovery.go
@@ -34,6 +34,8 @@ import (
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/registry"
 	"helm.sh/helm/v4/pkg/release"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/yaml"
 )
 
@@ -87,19 +89,20 @@ func resolveHealthCheckAsserts(ctx context.Context, recipeResult *recipe.RecipeR
 	}
 }
 
-// resolveExpectedResources discovers expected workload resources from two sources
+// resolveExpectedResources discovers expected workload resources from three sources
 // and merges them with any manually declared expectedResources:
 //
 //  1. Helm chart rendering via the Helm Go SDK (equivalent to `helm template`)
-//  2. Manifest file rendering via shared pkg/manifest.Render() — same logic as the bundler
+//  2. Kustomize build via the krusty Go SDK (equivalent to `kustomize build`)
+//  3. Manifest file rendering via shared pkg/manifest.Render() — same logic as the bundler
 //
 // Manual expectedResources take precedence over auto-discovered ones.
 // Rendering failures for individual components are logged as warnings and do not
 // block other components.
 //
-// Note: Phase 1 (helm template) requires network access for chart downloads
-// (HTTP repos and OCI registries). Offline/air-gapped environments will see
-// warnings for components with chart coordinates but can still use manually
+// Note: Phases 1 and 2 require network access — Helm for chart downloads
+// (HTTP repos and OCI registries), Kustomize for git clones (requires system git).
+// Offline/air-gapped environments will see warnings but can still use manually
 // declared expectedResources.
 func resolveExpectedResources(ctx context.Context, recipeResult *recipe.RecipeResult, kubeVersion string) error {
 	summaries := make([]componentDiscovery, 0, len(recipeResult.ComponentRefs))
@@ -145,9 +148,21 @@ func resolveExpectedResources(ctx context.Context, recipeResult *recipe.RecipeRe
 			} else {
 				discovered = append(discovered, chartResources...)
 			}
+		} else if ref.Type == recipe.ComponentTypeKustomize && ref.Source != "" {
+			// Phase 2: Build kustomization from remote source (equivalent to `kustomize build`).
+			slog.Debug("auto-discovering expected resources via kustomize build",
+				"component", ref.Name, "source", ref.Source, "path", ref.Path)
+
+			kustomizeResources, err := renderKustomizeTemplate(ctx, *ref)
+			if err != nil {
+				slog.Warn("failed to build kustomization for expected resource discovery",
+					"component", ref.Name, "error", err)
+			} else {
+				discovered = append(discovered, kustomizeResources...)
+			}
 		}
 
-		// Phase 2: Render manifestFiles (Go templates bundled alongside the chart).
+		// Phase 3: Render manifestFiles (Go templates bundled alongside the chart).
 		// Uses the same rendering logic as the bundler (pkg/manifest.Render).
 		if len(ref.ManifestFiles) > 0 {
 			manifestResources := renderManifestFiles(ctx, *ref, values)
@@ -198,7 +213,7 @@ func countByKind(resources []recipe.ExpectedResource) string {
 	}
 
 	var parts []string
-	for _, kind := range []string{"Deployment", "DaemonSet", "StatefulSet"} {
+	for _, kind := range []string{"Deployment", "DaemonSet", "StatefulSet"} { //nolint:goconst // workload kinds are clearer as literals in switch/range
 		if n, ok := counts[kind]; ok {
 			label := kind + "s"
 			if n == 1 {
@@ -270,6 +285,75 @@ func renderHelmTemplate(ctx context.Context, ref recipe.ComponentRef, values map
 	}
 
 	return extractWorkloadResources(accessor.Manifest(), ref.Namespace), nil
+}
+
+// renderKustomizeTemplate uses the krusty Go SDK to build a kustomization
+// (equivalent to `kustomize build`), then extracts workload resources from the output.
+// Supports remote git sources (cloned via system git) and local directories.
+//
+// The kustomize URL is constructed from ComponentRef fields:
+//
+//	{Source}//{Path}?ref={Tag}
+//
+// For example: "https://github.com/org/repo//deploy/prod?ref=v1.0.0"
+//
+// Note: krusty.Run is not context-aware, so the timeout bounds only the
+// goroutine wrapper. The internal git clone has its own 27s default timeout.
+func renderKustomizeTemplate(ctx context.Context, ref recipe.ComponentRef) ([]recipe.ExpectedResource, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaults.ComponentRenderTimeout)
+	defer cancel()
+
+	kustomizeURL := buildKustomizeURL(ref.Source, ref.Path, ref.Tag)
+
+	// krusty.Run is synchronous and not context-aware, so run it in a
+	// goroutine and select on context cancellation.
+	type result struct {
+		resources []recipe.ExpectedResource
+		err       error
+	}
+	ch := make(chan result, 1)
+
+	go func() {
+		opts := krusty.MakeDefaultOptions()
+		k := krusty.MakeKustomizer(opts)
+		fSys := filesys.MakeFsOnDisk()
+
+		resMap, err := k.Run(fSys, kustomizeURL)
+		if err != nil {
+			ch <- result{err: errors.Wrap(errors.ErrCodeInternal, "kustomize build failed", err)}
+			return
+		}
+
+		yamlBytes, err := resMap.AsYaml()
+		if err != nil {
+			ch <- result{err: errors.Wrap(errors.ErrCodeInternal, "failed to convert kustomize output to YAML", err)}
+			return
+		}
+
+		ch <- result{resources: extractWorkloadResources(string(yamlBytes), ref.Namespace)}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "kustomize build timed out", ctx.Err())
+	case r := <-ch:
+		return r.resources, r.err
+	}
+}
+
+// buildKustomizeURL constructs a kustomize-style URL from source, path, and tag.
+// Format: {source}//{path}?ref={tag}
+// The double-slash separates the repo root from the kustomization root path,
+// and ?ref= sets the git ref (tag, branch, or commit).
+func buildKustomizeURL(source, path, tag string) string {
+	url := source
+	if path != "" {
+		url += "//" + path
+	}
+	if tag != "" {
+		url += "?ref=" + tag
+	}
+	return url
 }
 
 // locateChart resolves a chart reference to a local path by downloading it.
@@ -368,7 +452,7 @@ func extractWorkloadResources(manifestContent string, defaultNamespace string) [
 
 		// Only extract workload resources
 		switch meta.Kind {
-		case "Deployment", "DaemonSet", "StatefulSet":
+		case "Deployment", "DaemonSet", "StatefulSet": //nolint:goconst // workload kinds are clearer as literals in switch/range
 			ns := meta.Metadata.Namespace
 			if ns == "" {
 				ns = defaultNamespace

--- a/pkg/validator/resource_discovery_test.go
+++ b/pkg/validator/resource_discovery_test.go
@@ -58,7 +58,7 @@ metadata:
 `,
 			defaultNamespace: "default",
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "my-deploy", Namespace: "gpu-operator"},
+				{Kind: kindDeployment, Name: "my-deploy", Namespace: "gpu-operator"},
 			},
 		},
 		{
@@ -84,9 +84,9 @@ metadata:
 `,
 			defaultNamespace: "default",
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "controller", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "agent", Namespace: "ns1"},
-				{Kind: "StatefulSet", Name: "db", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "controller", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "agent", Namespace: "ns1"},
+				{Kind: kindStatefulSet, Name: "db", Namespace: "ns1"},
 			},
 		},
 		{
@@ -117,7 +117,7 @@ metadata:
 `,
 			defaultNamespace: "default",
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "my-deploy", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "my-deploy", Namespace: "ns1"},
 			},
 		},
 		{
@@ -130,7 +130,7 @@ metadata:
 `,
 			defaultNamespace: "gpu-operator",
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "no-ns-deploy", Namespace: "gpu-operator"},
+				{Kind: kindDeployment, Name: "no-ns-deploy", Namespace: "gpu-operator"},
 			},
 		},
 		{
@@ -156,7 +156,7 @@ metadata:
 `,
 			defaultNamespace: "default",
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "good-deploy", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "good-deploy", Namespace: "ns1"},
 			},
 		},
 		{
@@ -169,7 +169,7 @@ metadata:
 `,
 			defaultNamespace: "default",
 			want: []recipe.ExpectedResource{
-				{Kind: "DaemonSet", Name: "my-ds", Namespace: "kube-system"},
+				{Kind: kindDaemonSet, Name: "my-ds", Namespace: "kube-system"},
 			},
 		},
 	}
@@ -201,49 +201,49 @@ func TestMergeExpectedResources(t *testing.T) {
 			name:   "no manual, only discovered",
 			manual: nil,
 			discovered: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "b", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "a", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "b", Namespace: "ns1"},
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "b", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "a", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "b", Namespace: "ns1"},
 			},
 		},
 		{
 			name: "only manual, no discovered",
 			manual: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "a", Namespace: "ns1"},
 			},
 			discovered: nil,
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "a", Namespace: "ns1"},
 			},
 		},
 		{
 			name: "manual takes precedence on conflict",
 			manual: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "overlap", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "overlap", Namespace: "ns1"},
 			},
 			discovered: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "overlap", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "new", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "overlap", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "new", Namespace: "ns1"},
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "overlap", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "new", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "overlap", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "new", Namespace: "ns1"},
 			},
 		},
 		{
 			name: "different namespaces are not conflicts",
 			manual: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "app", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "app", Namespace: "ns1"},
 			},
 			discovered: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "app", Namespace: "ns2"},
+				{Kind: kindDeployment, Name: "app", Namespace: "ns2"},
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "app", Namespace: "ns1"},
-				{Kind: "Deployment", Name: "app", Namespace: "ns2"},
+				{Kind: kindDeployment, Name: "app", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "app", Namespace: "ns2"},
 			},
 		},
 		{
@@ -337,26 +337,26 @@ func TestCountByKind(t *testing.T) {
 		{
 			name: "single deployment",
 			resources: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a"},
+				{Kind: kindDeployment, Name: "a"},
 			},
 			want: "1 Deployment",
 		},
 		{
 			name: "multiple types",
 			resources: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a"},
-				{Kind: "Deployment", Name: "b"},
-				{Kind: "DaemonSet", Name: "c"},
+				{Kind: kindDeployment, Name: "a"},
+				{Kind: kindDeployment, Name: "b"},
+				{Kind: kindDaemonSet, Name: "c"},
 			},
 			want: "2 Deployments, 1 DaemonSet",
 		},
 		{
 			name: "all three types",
 			resources: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "a"},
-				{Kind: "DaemonSet", Name: "b"},
-				{Kind: "StatefulSet", Name: "c"},
-				{Kind: "StatefulSet", Name: "d"},
+				{Kind: kindDeployment, Name: "a"},
+				{Kind: kindDaemonSet, Name: "b"},
+				{Kind: kindStatefulSet, Name: "c"},
+				{Kind: kindStatefulSet, Name: "d"},
 			},
 			want: "1 Deployment, 1 DaemonSet, 2 StatefulSets",
 		},
@@ -402,7 +402,7 @@ func TestResolveExpectedResources_ManualOnly(t *testing.T) {
 				Namespace: "ns1",
 				Type:      recipe.ComponentTypeHelm,
 				ExpectedResources: []recipe.ExpectedResource{
-					{Kind: "Deployment", Name: "manual-deploy", Namespace: "ns1"},
+					{Kind: kindDeployment, Name: "manual-deploy", Namespace: "ns1"},
 				},
 			},
 		},
@@ -447,7 +447,7 @@ func TestResolveExpectedResources_MultipleComponents(t *testing.T) {
 				Namespace: "ns3",
 				Type:      recipe.ComponentTypeHelm,
 				ExpectedResources: []recipe.ExpectedResource{
-					{Kind: "Deployment", Name: "manual-only", Namespace: "ns3"},
+					{Kind: kindDeployment, Name: "manual-only", Namespace: "ns3"},
 				},
 			},
 		},
@@ -494,7 +494,7 @@ func TestRenderManifestFiles(t *testing.T) {
 				"manifests/deploy.yaml": []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-deploy\n  namespace: test-ns\n"),
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "my-deploy", Namespace: "test-ns"},
+				{Kind: kindDeployment, Name: "my-deploy", Namespace: "test-ns"},
 			},
 		},
 		{
@@ -509,8 +509,8 @@ func TestRenderManifestFiles(t *testing.T) {
 				"manifests/multi.yaml": []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: controller\n  namespace: ns1\n---\napiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: agent\n  namespace: ns1\n"),
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "controller", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "agent", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "controller", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "agent", Namespace: "ns1"},
 			},
 		},
 		{
@@ -527,7 +527,7 @@ func TestRenderManifestFiles(t *testing.T) {
 				"manifests/templated.yaml": []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: {{ index .Values \"mycomp\" \"appName\" }}\n  namespace: {{ .Release.Namespace }}\n"),
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "web-server", Namespace: "prod-ns"},
+				{Kind: kindDeployment, Name: "web-server", Namespace: "prod-ns"},
 			},
 		},
 		{
@@ -579,7 +579,7 @@ func TestRenderManifestFiles(t *testing.T) {
 				"manifests/no-ns.yaml": []byte("apiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: my-db\n"),
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "StatefulSet", Name: "my-db", Namespace: "fallback-ns"},
+				{Kind: kindStatefulSet, Name: "my-db", Namespace: "fallback-ns"},
 			},
 		},
 		{
@@ -595,8 +595,8 @@ func TestRenderManifestFiles(t *testing.T) {
 				"manifests/b.yaml": []byte("apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: ds-b\n  namespace: ns1\n"),
 			},
 			want: []recipe.ExpectedResource{
-				{Kind: "Deployment", Name: "deploy-a", Namespace: "ns1"},
-				{Kind: "DaemonSet", Name: "ds-b", Namespace: "ns1"},
+				{Kind: kindDeployment, Name: "deploy-a", Namespace: "ns1"},
+				{Kind: kindDaemonSet, Name: "ds-b", Namespace: "ns1"},
 			},
 		},
 	}
@@ -644,7 +644,7 @@ func TestResolveExpectedResources_ManifestFileAutoDetect(t *testing.T) {
 
 	got := recipeResult.ComponentRefs[0].ExpectedResources
 	want := []recipe.ExpectedResource{
-		{Kind: "Deployment", Name: "auto-detected", Namespace: "test-ns"},
+		{Kind: kindDeployment, Name: "auto-detected", Namespace: "test-ns"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d resources, got %d: %+v", len(want), len(got), got)
@@ -671,7 +671,7 @@ func TestResolveExpectedResources_ManualOverridesManifestFile(t *testing.T) {
 				Type:          recipe.ComponentTypeHelm,
 				ManifestFiles: []string{"manifests/workloads.yaml"},
 				ExpectedResources: []recipe.ExpectedResource{
-					{Kind: "Deployment", Name: "overlap", Namespace: "ns1"},
+					{Kind: kindDeployment, Name: "overlap", Namespace: "ns1"},
 				},
 			},
 		},
@@ -681,8 +681,8 @@ func TestResolveExpectedResources_ManualOverridesManifestFile(t *testing.T) {
 
 	got := recipeResult.ComponentRefs[0].ExpectedResources
 	want := []recipe.ExpectedResource{
-		{Kind: "Deployment", Name: "overlap", Namespace: "ns1"},
-		{Kind: "DaemonSet", Name: "discovered-only", Namespace: "ns1"},
+		{Kind: kindDeployment, Name: "overlap", Namespace: "ns1"},
+		{Kind: kindDaemonSet, Name: "discovered-only", Namespace: "ns1"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d resources, got %d: %+v", len(want), len(got), got)
@@ -807,9 +807,9 @@ spec:
 	foundDaemonSet := false
 	for _, r := range resources {
 		switch {
-		case r.Kind == "Deployment" && r.Name == "my-release-server" && r.Namespace == "test-ns":
+		case r.Kind == kindDeployment && r.Name == "my-release-server" && r.Namespace == "test-ns":
 			foundDeployment = true
-		case r.Kind == "DaemonSet" && r.Name == "my-release-agent" && r.Namespace == "test-ns":
+		case r.Kind == kindDaemonSet && r.Name == "my-release-agent" && r.Namespace == "test-ns":
 			foundDaemonSet = true
 		}
 	}
@@ -890,7 +890,7 @@ spec:
 		t.Fatalf("expected 1 resource, got %d: %v", len(resources), resources)
 	}
 
-	if resources[0].Kind != "StatefulSet" || resources[0].Name != "my-database" || resources[0].Namespace != "db-ns" {
+	if resources[0].Kind != kindStatefulSet || resources[0].Name != "my-database" || resources[0].Namespace != "db-ns" {
 		t.Errorf("expected StatefulSet my-database in db-ns, got %v", resources[0])
 	}
 
@@ -1166,6 +1166,13 @@ func TestBuildKustomizeURL(t *testing.T) {
 			tag:    "main",
 			want:   "git@github.com:org/repo.git//overlays/prod?ref=main",
 		},
+		{
+			name:   "trailing slash in source is trimmed",
+			source: "https://github.com/org/repo/",
+			path:   "deploy/production",
+			tag:    "v1.0.0",
+			want:   "https://github.com/org/repo//deploy/production?ref=v1.0.0",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1259,9 +1266,9 @@ spec:
 	foundDaemonSet := false
 	for _, r := range resources {
 		switch {
-		case r.Kind == "Deployment" && r.Name == "controller" && r.Namespace == "my-ns":
+		case r.Kind == kindDeployment && r.Name == "controller" && r.Namespace == "my-ns":
 			foundDeployment = true
-		case r.Kind == "DaemonSet" && r.Name == "agent" && r.Namespace == "my-ns":
+		case r.Kind == kindDaemonSet && r.Name == "agent" && r.Namespace == "my-ns":
 			foundDaemonSet = true
 		}
 	}
@@ -1342,7 +1349,7 @@ spec:
 	if len(resources) != 1 {
 		t.Fatalf("expected 1 workload resource, got %d: %v", len(resources), resources)
 	}
-	if resources[0].Kind != "Deployment" || resources[0].Name != "only-workload" {
+	if resources[0].Kind != kindDeployment || resources[0].Name != "only-workload" {
 		t.Errorf("expected Deployment only-workload, got %v", resources[0])
 	}
 }
@@ -1403,7 +1410,7 @@ spec:
 	if len(got) != 1 {
 		t.Fatalf("expected 1 resource, got %d: %v", len(got), got)
 	}
-	if got[0].Kind != "Deployment" || got[0].Name != "kust-deploy" || got[0].Namespace != "kust-ns" {
+	if got[0].Kind != kindDeployment || got[0].Name != "kust-deploy" || got[0].Namespace != "kust-ns" {
 		t.Errorf("expected Deployment kust-deploy in kust-ns, got %v", got[0])
 	}
 }
@@ -1427,6 +1434,40 @@ func TestRenderKustomizeTemplate_InvalidSource(t *testing.T) {
 }
 
 func TestRenderKustomizeTemplate_CancelledContext(t *testing.T) {
+	// Use a valid temp kustomization directory so the only failure path
+	// is the canceled context, not a missing filesystem path.
+	kustDir := t.TempDir()
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "kustomization.yaml"), []byte(kustomizationYAML), 0o644); err != nil {
+		t.Fatalf("failed to write kustomization.yaml: %v", err)
+	}
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: ns1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - name: test
+          image: nginx:latest
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "deployment.yaml"), []byte(deploymentYAML), 0o644); err != nil {
+		t.Fatalf("failed to write deployment.yaml: %v", err)
+	}
+
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
@@ -1434,7 +1475,7 @@ func TestRenderKustomizeTemplate_CancelledContext(t *testing.T) {
 		Name:      "cancelled-comp",
 		Namespace: "ns1",
 		Type:      recipe.ComponentTypeKustomize,
-		Source:    "/some/path",
+		Source:    kustDir,
 	}
 
 	_, err := renderKustomizeTemplate(ctx, ref)

--- a/pkg/validator/resource_discovery_test.go
+++ b/pkg/validator/resource_discovery_test.go
@@ -1123,6 +1123,349 @@ func TestResolveExpectedResources_SkipsChainsawComponents(t *testing.T) {
 	}
 }
 
+func TestBuildKustomizeURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		path   string
+		tag    string
+		want   string
+	}{
+		{
+			name:   "full URL with source, path, and tag",
+			source: "https://github.com/org/repo",
+			path:   "deploy/production",
+			tag:    "v1.0.0",
+			want:   "https://github.com/org/repo//deploy/production?ref=v1.0.0",
+		},
+		{
+			name:   "source and tag, no path",
+			source: "https://github.com/org/repo",
+			path:   "",
+			tag:    "v2.0.0",
+			want:   "https://github.com/org/repo?ref=v2.0.0",
+		},
+		{
+			name:   "source and path, no tag",
+			source: "https://github.com/org/repo",
+			path:   "config/base",
+			tag:    "",
+			want:   "https://github.com/org/repo//config/base",
+		},
+		{
+			name:   "source only",
+			source: "https://github.com/org/repo",
+			path:   "",
+			tag:    "",
+			want:   "https://github.com/org/repo",
+		},
+		{
+			name:   "ssh-style source",
+			source: "git@github.com:org/repo.git",
+			path:   "overlays/prod",
+			tag:    "main",
+			want:   "git@github.com:org/repo.git//overlays/prod?ref=main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildKustomizeURL(tt.source, tt.path, tt.tag)
+			if got != tt.want {
+				t.Errorf("buildKustomizeURL(%q, %q, %q) = %q, want %q",
+					tt.source, tt.path, tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderKustomizeTemplate_LocalDirectory(t *testing.T) {
+	// Build a minimal kustomization in a temp directory to test the krusty
+	// rendering path without network access.
+	kustDir := t.TempDir()
+
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - daemonset.yaml
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "kustomization.yaml"), []byte(kustomizationYAML), 0o644); err != nil {
+		t.Fatalf("failed to write kustomization.yaml: %v", err)
+	}
+
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: my-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller
+  template:
+    metadata:
+      labels:
+        app: controller
+    spec:
+      containers:
+        - name: controller
+          image: nginx:latest
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "deployment.yaml"), []byte(deploymentYAML), 0o644); err != nil {
+		t.Fatalf("failed to write deployment.yaml: %v", err)
+	}
+
+	daemonsetYAML := `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent
+  namespace: my-ns
+spec:
+  selector:
+    matchLabels:
+      app: agent
+  template:
+    metadata:
+      labels:
+        app: agent
+    spec:
+      containers:
+        - name: agent
+          image: busybox:latest
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "daemonset.yaml"), []byte(daemonsetYAML), 0o644); err != nil {
+		t.Fatalf("failed to write daemonset.yaml: %v", err)
+	}
+
+	ref := recipe.ComponentRef{
+		Name:      "kust-comp",
+		Namespace: "my-ns",
+		Type:      recipe.ComponentTypeKustomize,
+		Source:    kustDir,
+	}
+
+	resources, err := renderKustomizeTemplate(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("renderKustomizeTemplate() error = %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d: %v", len(resources), resources)
+	}
+
+	foundDeployment := false
+	foundDaemonSet := false
+	for _, r := range resources {
+		switch {
+		case r.Kind == "Deployment" && r.Name == "controller" && r.Namespace == "my-ns":
+			foundDeployment = true
+		case r.Kind == "DaemonSet" && r.Name == "agent" && r.Namespace == "my-ns":
+			foundDaemonSet = true
+		}
+	}
+
+	if !foundDeployment {
+		t.Errorf("expected Deployment controller in my-ns, got %v", resources)
+	}
+	if !foundDaemonSet {
+		t.Errorf("expected DaemonSet agent in my-ns, got %v", resources)
+	}
+}
+
+func TestRenderKustomizeTemplate_NonWorkloadFiltered(t *testing.T) {
+	// Verify that non-workload resources (Service, ConfigMap) are filtered out.
+	kustDir := t.TempDir()
+
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resources.yaml
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "kustomization.yaml"), []byte(kustomizationYAML), 0o644); err != nil {
+		t.Fatalf("failed to write kustomization.yaml: %v", err)
+	}
+
+	resourcesYAML := `apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+  namespace: ns1
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: ns1
+data:
+  key: value
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: only-workload
+  namespace: ns1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - name: test
+          image: nginx:latest
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "resources.yaml"), []byte(resourcesYAML), 0o644); err != nil {
+		t.Fatalf("failed to write resources.yaml: %v", err)
+	}
+
+	ref := recipe.ComponentRef{
+		Name:      "filtered-comp",
+		Namespace: "ns1",
+		Type:      recipe.ComponentTypeKustomize,
+		Source:    kustDir,
+	}
+
+	resources, err := renderKustomizeTemplate(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("renderKustomizeTemplate() error = %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 workload resource, got %d: %v", len(resources), resources)
+	}
+	if resources[0].Kind != "Deployment" || resources[0].Name != "only-workload" {
+		t.Errorf("expected Deployment only-workload, got %v", resources[0])
+	}
+}
+
+func TestResolveExpectedResources_KustomizeComponent(t *testing.T) {
+	// Verify that kustomize components get auto-discovered resources.
+	kustDir := t.TempDir()
+
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "kustomization.yaml"), []byte(kustomizationYAML), 0o644); err != nil {
+		t.Fatalf("failed to write kustomization.yaml: %v", err)
+	}
+
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kust-deploy
+  namespace: kust-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - name: test
+          image: nginx:latest
+`
+	if err := os.WriteFile(filepath.Join(kustDir, "deployment.yaml"), []byte(deploymentYAML), 0o644); err != nil {
+		t.Fatalf("failed to write deployment.yaml: %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:      "kust-comp",
+				Namespace: "kust-ns",
+				Type:      recipe.ComponentTypeKustomize,
+				Source:    kustDir,
+			},
+		},
+	}
+
+	err := resolveExpectedResources(t.Context(), recipeResult, "")
+	if err != nil {
+		t.Fatalf("resolveExpectedResources() error = %v", err)
+	}
+
+	got := recipeResult.ComponentRefs[0].ExpectedResources
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource, got %d: %v", len(got), got)
+	}
+	if got[0].Kind != "Deployment" || got[0].Name != "kust-deploy" || got[0].Namespace != "kust-ns" {
+		t.Errorf("expected Deployment kust-deploy in kust-ns, got %v", got[0])
+	}
+}
+
+func TestRenderKustomizeTemplate_InvalidSource(t *testing.T) {
+	// Verify that an invalid source produces a wrapped error, not a panic.
+	ref := recipe.ComponentRef{
+		Name:      "bad-comp",
+		Namespace: "ns1",
+		Type:      recipe.ComponentTypeKustomize,
+		Source:    "/nonexistent/path/to/kustomization",
+	}
+
+	resources, err := renderKustomizeTemplate(t.Context(), ref)
+	if err == nil {
+		t.Fatalf("expected error for invalid source, got %d resources", len(resources))
+	}
+	if resources != nil {
+		t.Errorf("expected nil resources on error, got %v", resources)
+	}
+}
+
+func TestRenderKustomizeTemplate_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	ref := recipe.ComponentRef{
+		Name:      "cancelled-comp",
+		Namespace: "ns1",
+		Type:      recipe.ComponentTypeKustomize,
+		Source:    "/some/path",
+	}
+
+	_, err := renderKustomizeTemplate(ctx, ref)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}
+
+func TestResolveExpectedResources_KustomizeSkipsEmptySource(t *testing.T) {
+	// Kustomize components without Source should skip discovery without error.
+	recipeResult := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name: "no-source",
+				Type: recipe.ComponentTypeKustomize,
+				// Source is empty — skips kustomize build
+			},
+		},
+	}
+
+	err := resolveExpectedResources(t.Context(), recipeResult, "")
+	if err != nil {
+		t.Errorf("resolveExpectedResources() error = %v", err)
+	}
+
+	if len(recipeResult.ComponentRefs[0].ExpectedResources) != 0 {
+		t.Errorf("expected no resources for kustomize component without source, got %d",
+			len(recipeResult.ComponentRefs[0].ExpectedResources))
+	}
+}
+
 func TestResolveExpectedResources_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately


### PR DESCRIPTION
## Summary

- Add kustomize expected resource auto-discovery to `resolveExpectedResources()`, matching the existing Helm `helm template` auto-discovery
- Kustomize components now get workload resources (Deployment, DaemonSet, StatefulSet) discovered automatically from their git source via the krusty Go SDK
- Previously, kustomize components silently passed health checks with zero resource verifications unless `expectedResources` were manually declared

## Design

```
resolveExpectedResources() phases:
  Phase 1: Helm → renderHelmTemplate()       (existing)
  Phase 2: Kustomize → renderKustomizeTemplate()  (NEW)
  Phase 3: ManifestFiles → renderManifestFiles()  (existing)

Kustomize URL construction:
  ComponentRef.Source  = "https://github.com/org/repo"
  ComponentRef.Path    = "deploy/production"
  ComponentRef.Tag     = "v1.0.0"
  → "https://github.com/org/repo//deploy/production?ref=v1.0.0"

krusty.Run(fSys, url) handles git clone + kustomize build internally.
extractWorkloadResources() is reused from the Helm path.
```

## Files changed

| File | Change |
|------|--------|
| `pkg/validator/resource_discovery.go` | Add `renderKustomizeTemplate()`, `buildKustomizeURL()`, Phase 2 condition in `resolveExpectedResources()`, update docstring |
| `pkg/validator/resource_discovery_test.go` | Add 7 tests: URL construction, local kustomization rendering, non-workload filtering, invalid source, cancelled context, integration, empty source skip |

## Test plan

- [x] `go test -race ./pkg/validator/...` -- 77.3% coverage
  - `renderKustomizeTemplate` 90.5%
  - `buildKustomizeURL` 100%
  - `resolveExpectedResources` 78.4%
- [x] `golangci-lint run` -- 0 issues
- [x] `make test` -- all packages pass
