### PR TITLE
fix(recipes): exclude NFD worker nodeSelector from accelerated scheduling

### DIFF
--- a/demos/cuj2-demo.md
+++ b/demos/cuj2-demo.md
@@ -28,7 +28,9 @@
   │  $ aicr bundle --recipe recipe.yaml \                                  │
   │      --accelerated-node-selector nodeGroup=gpu-worker \                │
   │      --accelerated-node-toleration dedicated=worker-workload:NoSchedule│
+  │      --accelerated-node-toleration dedicated=worker-workload:NoExecute │
   │      --system-node-toleration dedicated=system-workload:NoSchedule     │
+  │      --system-node-toleration dedicated=system-workload:NoExecute      │
   │                                                                        │
   │  recipe.yaml ──▶ bundle/                                               │
   │    ├── deploy.sh                                                       │
@@ -143,11 +145,13 @@
       --output recipe.yaml
 ```
 ```
-aicr bundle --recipe recipe.yaml \
-       --accelerated-node-selector nodeGroup=gpu-worker \
-       --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
-       --system-node-toleration dedicated=system-workload:NoSchedule \
-       --output bundle
+   aicr bundle --recipe recipe.yaml \
+    --accelerated-node-selector nodeGroup=gpu-worker \
+    --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
+    --accelerated-node-toleration dedicated=worker-workload:NoExecute \
+    --system-node-toleration dedicated=system-workload:NoSchedule \
+    --system-node-toleration dedicated=system-workload:NoExecute \
+    --output bundle
 ```
 
 ## Dynamo Platform — Components & Deployment

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -663,6 +663,38 @@ aicr bundle [flags]
 | `--workload-gate` | | string | Taint for skyhook-operator runtime required (format: key=value:effect or key:effect). This is a day 2 option for cluster scaling operations. |
 | `--workload-selector` | | string[] | Label selector for skyhook-customizations to prevent eviction of running training jobs (format: key=value, repeatable). Required when skyhook-customizations is enabled with training intent. |
 
+**Node Scheduling:**
+
+The `--accelerated-node-selector` and `--accelerated-node-toleration` flags control scheduling for GPU-specific components:
+
+| Flag | GPU Daemonsets | NFD Workers |
+|------|---------------|-------------|
+| `--accelerated-node-selector` | Applied (restricts to GPU nodes) | **Not applied** (NFD runs on all nodes) |
+| `--accelerated-node-toleration` | Applied | Applied |
+| `--system-node-selector` | Not applied | Not applied |
+| `--system-node-toleration` | Not applied | Not applied |
+
+NFD (Node Feature Discovery) workers must run on **all nodes** (GPU, CPU, and system) to detect hardware features. This matches the gpu-operator default behavior where NFD workers also run on control-plane nodes. The `--accelerated-node-selector` is intentionally not applied to NFD workers so they are not restricted to GPU nodes.
+
+> **Note:** When no `--accelerated-node-toleration` is specified, a default toleration (`operator: Exists`) is applied to both GPU daemonsets and NFD workers, allowing them to run on nodes with any taint.
+
+**Example:**
+
+```bash
+aicr bundle --recipe recipe.yaml \
+  --accelerated-node-selector nodeGroup=gpu-worker \
+  --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
+  --accelerated-node-toleration dedicated=worker-workload:NoExecute \
+  --system-node-toleration dedicated=system-workload:NoSchedule \
+  --system-node-toleration dedicated=system-workload:NoExecute \
+  --output bundle
+```
+
+This results in:
+- **GPU daemonsets** (driver, device-plugin, toolkit, dcgm): `nodeSelector=nodeGroup=gpu-worker` + tolerations for `dedicated=worker-workload` with both `NoSchedule` and `NoExecute`
+- **NFD workers**: no nodeSelector (runs on all nodes) + tolerations for `dedicated=worker-workload` with both `NoSchedule` and `NoExecute`
+- **System components** (gpu-operator controller, NFD gc/master): tolerations for `dedicated=system-workload` with both `NoSchedule` and `NoExecute`
+
 **Behavior:**
 - All components from the recipe are bundled automatically
 - Each component creates a subdirectory in the output directory

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -62,7 +62,12 @@ components:
       accelerated:
         nodeSelectorPaths:
           - daemonsets.nodeSelector
-          - node-feature-discovery.worker.nodeSelector
+          # Note: NFD worker nodeSelector is intentionally excluded from
+          # accelerated scheduling. NFD must run on all nodes (GPU, CPU,
+          # and system) to detect hardware features — this matches the
+          # gpu-operator default behavior where NFD workers also run on
+          # control-plane nodes. NFD worker tolerations remain here so
+          # it inherits the same tolerations as GPU daemonsets.
         tolerationPaths:
           - daemonsets.tolerations
           - node-feature-discovery.worker.tolerations

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
@@ -63,7 +63,8 @@ toolkit:
   enabled: true
 
 # ── Node Feature Discovery scheduling ───────────────────────────────
-# NFD master/gc run on system nodes, worker runs on GPU nodes
+# NFD master/gc run on system nodes, worker runs on all worker nodes
+# (no accelerated nodeSelector — NFD must discover features everywhere)
 node-feature-discovery:
   master:
     nodeSelector:
@@ -71,6 +72,3 @@ node-feature-discovery:
   gc:
     nodeSelector:
       nodeGroup: system-pool
-  worker:
-    nodeSelector:
-      nodeGroup: gpu-worker


### PR DESCRIPTION
## Summary

Remove NFD worker nodeSelector from accelerated scheduling paths so NFD runs on all nodes regardless of `--accelerated-node-selector`. This matches the gpu-operator default behavior where NFD workers run on all nodes including control-plane.

## Motivation / Context

NFD (Node Feature Discovery) workers must run on **all nodes** (GPU, CPU, and system) to detect hardware features. The gpu-operator chart defaults already configure NFD workers to run on control-plane nodes.

Previously, the NFD worker `nodeSelector` was wired to the accelerated scheduling paths in the registry. When using `--accelerated-node-selector` during bundle generation, this restricted NFD workers to GPU nodes only, preventing hardware discovery on other nodes.

**Why this wasn't caught sooner:** On existing clusters, NFD labels persist on node objects from previous runs even after NFD workers stop. GPU operator daemonsets, validators, and conformance tests all continued to work because they relied on stale labels. On a **fresh cluster** where NFD workers never ran, the GPU operator wouldn't discover GPU nodes and nothing GPU-related would schedule.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Other: Recipe registry
- [x] Docs/examples (`docs/`)

## Changes

| # | Change | File |
|---|--------|------|
| 1 | Remove `node-feature-discovery.worker.nodeSelector` from accelerated `nodeSelectorPaths` | `recipes/registry.yaml` |
| 2 | Document node scheduling behavior for GPU daemonsets vs NFD workers | `docs/user/cli-reference.md` |

NFD worker tolerations remain in `accelerated.tolerationPaths` so it inherits the same tolerations as GPU daemonsets.

## Node Scheduling Behavior

| Flag | GPU Daemonsets | NFD Workers |
|------|---------------|-------------|
| `--accelerated-node-selector` | Applied (restricts to GPU nodes) | **Not applied** (NFD runs on all nodes) |
| `--accelerated-node-toleration` | Applied | Applied |
| `--system-node-selector` | Not applied | Not applied |
| `--system-node-toleration` | Not applied | Not applied |

## Testing

- Verified NFD worker daemonset gets no nodeSelector from `--accelerated-node-selector`
- Verified GPU daemonsets still respect `--accelerated-node-selector`
- Verified NFD worker still inherits `--accelerated-node-toleration`

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)