### PR TITLE
feat: adding nccl test

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -23,6 +23,9 @@ ignore: |
   dist/
   node_modules/
 
+  # Generated snapshot output files (machine-generated, not hand-written)
+  snapshot.yaml
+
   # Examples (generated/reference files with varying styles)
   examples/
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -236,12 +236,12 @@ aicr/
 - **Phases**:
   - **Readiness**: Evaluates constraints inline against snapshot (K8s version, OS, kernel) — no checks or Jobs
   - **Deployment**: Validates component deployment health and expected resources
-  - **Performance**: Validates system performance and network fabric health
+  - **Performance**: Validates system performance and network fabric health (e.g. NCCL all-reduce bus bandwidth via Kubeflow Trainer)
   - **Conformance**: Validates workload-specific requirements and conformance
 - **Features**:
   - Phase-based validation with dependency logic (fail → skip subsequent)
   - Constraint evaluation against snapshots using version comparison operators
-  - Check execution framework (skeleton implementation)
+  - Check execution framework with in-cluster Job dispatch and result collection
   - Structured validation results with per-phase status
 - **CLI**: `aicr validate --phase <phase>` (default: readiness)
 - **Implementation**: `pkg/validator/phases.go` contains phase validation logic

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -50,7 +50,9 @@ RUN set -e; \
 
 # Pre-compile test binaries for in-cluster validation Jobs
 RUN CGO_ENABLED=0 go test -c -o /out/deployment.test ./pkg/validator/checks/deployment && \
+    CGO_ENABLED=0 go test -c -o /out/performance.test ./pkg/validator/checks/performance && \
     CGO_ENABLED=0 go test -c -o /out/conformance.test ./pkg/validator/checks/conformance
+    
 
 # Build test2json tool — converts verbose test output to JSON event stream.
 # Compiled test binaries don't support -test.json; they require piping through
@@ -69,12 +71,14 @@ LABEL org.opencontainers.image.title="aicr-validator" \
 # Copy compiled binaries
 COPY --from=builder /out/aicr /usr/local/bin/aicr
 COPY --from=builder /out/deployment.test /usr/local/bin/deployment.test
+COPY --from=builder /out/performance.test /usr/local/bin/performance.test
 COPY --from=builder /out/conformance.test /usr/local/bin/conformance.test
 COPY --from=builder /out/test2json /usr/local/bin/test2json
 
 # Copy testdata needed by deployment tests at runtime (loaded via os.ReadFile
 # relative to CWD, e.g. testdata/nvidia-smi-verify-pod.yaml)
 COPY --from=builder /workspace/pkg/validator/checks/deployment/testdata /app/testdata
+COPY --from=builder /workspace/pkg/validator/checks/performance/testdata /app/testdata
 
 WORKDIR /app
 

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -52,7 +52,6 @@ RUN set -e; \
 RUN CGO_ENABLED=0 go test -c -o /out/deployment.test ./pkg/validator/checks/deployment && \
     CGO_ENABLED=0 go test -c -o /out/performance.test ./pkg/validator/checks/performance && \
     CGO_ENABLED=0 go test -c -o /out/conformance.test ./pkg/validator/checks/conformance
-    
 
 # Build test2json tool — converts verbose test output to JSON event stream.
 # Compiled test binaries don't support -test.json; they require piping through

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -74,8 +74,11 @@ COPY --from=builder /out/performance.test /usr/local/bin/performance.test
 COPY --from=builder /out/conformance.test /usr/local/bin/conformance.test
 COPY --from=builder /out/test2json /usr/local/bin/test2json
 
-# Copy testdata needed by deployment tests at runtime (loaded via os.ReadFile
-# relative to CWD, e.g. testdata/nvidia-smi-verify-pod.yaml)
+# Copy testdata for each phase into /app/testdata (CWD at runtime).
+# Docker merges directory contents on successive COPYs. The two trees have
+# non-overlapping paths (deployment: flat files; performance: h100/eks/*)
+# so there is no risk of silent overwrites. Add a new phase here if it also
+# reads templates via os.ReadFile relative to testdata/.
 COPY --from=builder /workspace/pkg/validator/checks/deployment/testdata /app/testdata
 COPY --from=builder /workspace/pkg/validator/checks/performance/testdata /app/testdata
 

--- a/cmd/aicr/main.go
+++ b/cmd/aicr/main.go
@@ -21,6 +21,7 @@ import (
 	// Each package's init() function registers its validators.
 	_ "github.com/NVIDIA/aicr/pkg/validator/checks/conformance"
 	_ "github.com/NVIDIA/aicr/pkg/validator/checks/deployment"
+	_ "github.com/NVIDIA/aicr/pkg/validator/checks/performance"
 )
 
 func main() {

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -219,6 +219,11 @@ const (
 
 	// NCCLLauncherPodTimeout is the maximum time to wait for the NCCL launcher pod to be created.
 	NCCLLauncherPodTimeout = 5 * time.Minute
+
+	// NCCLTrainerArchiveDownloadTimeout is the timeout for downloading the Kubeflow Trainer
+	// source archive from GitHub. The archive is several MB, so a longer timeout than the
+	// standard HTTPClientTimeout is appropriate.
+	NCCLTrainerArchiveDownloadTimeout = 5 * time.Minute
 )
 
 // Deployment and pod scheduling test timeouts for conformance validation.

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -213,6 +213,12 @@ const (
 	// TrainerCRDEstablishedTimeout is the time to wait for Kubeflow Trainer CRDs
 	// to reach the Established condition after installation.
 	TrainerCRDEstablishedTimeout = 2 * time.Minute
+
+	// NCCLTrainJobTimeout is the maximum time to wait for the NCCL all-reduce TrainJob to complete.
+	NCCLTrainJobTimeout = 30 * time.Minute
+
+	// NCCLLauncherPodTimeout is the maximum time to wait for the NCCL launcher pod to be created.
+	NCCLLauncherPodTimeout = 5 * time.Minute
 )
 
 // Deployment and pod scheduling test timeouts for conformance validation.

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -208,6 +208,13 @@ const (
 	EvidenceRenderTimeout = 30 * time.Second
 )
 
+// Kubeflow Trainer install timeouts for NCCL performance validation.
+const (
+	// TrainerCRDEstablishedTimeout is the time to wait for Kubeflow Trainer CRDs
+	// to reach the Established condition after installation.
+	TrainerCRDEstablishedTimeout = 2 * time.Minute
+)
+
 // Deployment and pod scheduling test timeouts for conformance validation.
 const (
 	// DeploymentScaleTimeout is the timeout for waiting for Deployment controller

--- a/pkg/validator/agent/deployer_test.go
+++ b/pkg/validator/agent/deployer_test.go
@@ -87,8 +87,8 @@ func TestDeployer_EnsureRBAC(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Role not found: %v", err)
 		}
-		if len(role.Rules) != 5 {
-			t.Errorf("expected 5 rules, got %d", len(role.Rules))
+		if len(role.Rules) != 6 {
+			t.Errorf("expected 6 rules, got %d", len(role.Rules))
 		}
 
 		// Verify RoleBinding

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -27,7 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ensureServiceAccount creates the ServiceAccount if it doesn't exist.
+// ensureServiceAccount creates or updates the ServiceAccount so changes across
+// releases are always applied even when the resource already exists in the cluster.
 func (d *Deployer) ensureServiceAccount(ctx context.Context) error {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -37,7 +38,14 @@ func (d *Deployer) ensureServiceAccount(ctx context.Context) error {
 	}
 
 	_, err := d.clientset.CoreV1().ServiceAccounts(d.config.Namespace).Create(ctx, sa, metav1.CreateOptions{})
-	return k8s.IgnoreAlreadyExists(err)
+	if errors.IsAlreadyExists(err) {
+		_, err = d.clientset.CoreV1().ServiceAccounts(d.config.Namespace).Update(ctx, sa, metav1.UpdateOptions{})
+		if err != nil {
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to update ServiceAccount", err)
+		}
+		return nil
+	}
+	return err
 }
 
 // deleteServiceAccount deletes the ServiceAccount.
@@ -333,7 +341,10 @@ func (d *Deployer) deleteClusterRoleBinding(ctx context.Context) error {
 	return k8s.IgnoreNotFound(err)
 }
 
-// ensureRoleBinding creates the RoleBinding if it doesn't exist.
+// ensureRoleBinding creates or updates the RoleBinding so Subject changes across
+// releases are always applied even when the resource already exists in the cluster.
+// Note: RoleRef is immutable in Kubernetes — the RoleRef here is stable (always
+// references d.config.ServiceAccountName), so updates will never be rejected.
 func (d *Deployer) ensureRoleBinding(ctx context.Context) error {
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -81,6 +81,11 @@ func (d *Deployer) ensureRole(ctx context.Context) error {
 				Resources: []string{"jobs"},
 				Verbs:     []string{"get", "list"},
 			},
+			{
+				APIGroups: []string{"trainer.kubeflow.org"},
+				Resources: []string{"trainingruntimes", "trainjobs"},
+				Verbs:     []string{"get", "list", "create", "update", "delete"},
+			},
 		},
 	}
 
@@ -132,10 +137,11 @@ func (d *Deployer) ensureClusterRole(ctx context.Context) error {
 				Verbs:     []string{"get", "list"},
 			},
 			// Conformance: CRD discovery (inference-gateway, dra-support, gang-scheduling, robust-controller)
+			// Performance: Kubeflow Trainer install/uninstall creates and watches CRDs.
 			{
 				APIGroups: []string{"apiextensions.k8s.io"},
 				Resources: []string{"customresourcedefinitions"},
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
 			},
 			// Conformance: DRA support validation (resource.k8s.io/v1 — GA)
 			{
@@ -229,6 +235,18 @@ func (d *Deployer) ensureClusterRole(ctx context.Context) error {
 				APIGroups: []string{"apps"},
 				Resources: []string{"deployments"},
 				Verbs:     []string{"create", "delete"},
+			},
+			// Performance: Kubeflow Trainer install/uninstall lifecycle.
+			// installTrainer creates Namespace, ServiceAccount, RBAC, Deployment, Service, ConfigMap.
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "serviceaccounts", "services", "configmaps"},
+				Verbs:     []string{"create", "delete"},
+			},
+			{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterroles", "clusterrolebindings", "roles", "rolebindings"},
+				Verbs:     []string{"get", "list", "create", "delete"},
 			},
 		},
 	}

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -45,7 +45,10 @@ func (d *Deployer) ensureServiceAccount(ctx context.Context) error {
 		}
 		return nil
 	}
-	return err
+	if err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to create ServiceAccount", err)
+	}
+	return nil
 }
 
 // deleteServiceAccount deletes the ServiceAccount.
@@ -83,7 +86,7 @@ func (d *Deployer) ensureRole(ctx context.Context) error {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods/log", "pods/status"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{"batch"},
@@ -106,7 +109,10 @@ func (d *Deployer) ensureRole(ctx context.Context) error {
 		}
 		return nil
 	}
-	return err
+	if err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to create Role", err)
+	}
+	return nil
 }
 
 // deleteRole deletes the Role.
@@ -373,7 +379,10 @@ func (d *Deployer) ensureRoleBinding(ctx context.Context) error {
 		}
 		return nil
 	}
-	return err
+	if err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to create RoleBinding", err)
+	}
+	return nil
 }
 
 // deleteRoleBinding deletes the RoleBinding.

--- a/pkg/validator/agent/rbac.go
+++ b/pkg/validator/agent/rbac.go
@@ -46,8 +46,9 @@ func (d *Deployer) deleteServiceAccount(ctx context.Context) error {
 	return k8s.IgnoreNotFound(err)
 }
 
-// ensureRole creates the Role if it doesn't exist.
-// The Role grants permissions to read cluster state and write result ConfigMaps.
+// ensureRole creates or updates the Role so the current policy rules are always applied.
+// Using create-or-update ensures that RBAC changes in new releases take effect even when
+// the Role already exists in the cluster from a previous run.
 // Note: This is namespace-scoped. For cluster-wide resources, see ensureClusterRole.
 func (d *Deployer) ensureRole(ctx context.Context) error {
 	role := &rbacv1.Role{
@@ -69,12 +70,12 @@ func (d *Deployer) ensureRole(ctx context.Context) error {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list", "create", "update", "patch", "delete"},
+				Verbs:     []string{"get", "list", "create", "update", "patch", "delete", "watch"},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods/log", "pods/status"},
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"batch"},
@@ -84,7 +85,7 @@ func (d *Deployer) ensureRole(ctx context.Context) error {
 			{
 				APIGroups: []string{"trainer.kubeflow.org"},
 				Resources: []string{"trainingruntimes", "trainjobs"},
-				Verbs:     []string{"get", "list", "create", "update", "delete"},
+				Verbs:     []string{"get", "list", "create", "update", "delete", "watch"},
 			},
 		},
 	}
@@ -253,12 +254,19 @@ func (d *Deployer) ensureClusterRole(ctx context.Context) error {
 
 	slog.Debug("creating ClusterRole", "name", clusterRoleName)
 	_, err := d.clientset.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		slog.Error("failed to create ClusterRole", "name", clusterRoleName, "error", err)
-		return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to create ClusterRole", err)
-	}
-	if errors.IsAlreadyExists(err) {
-		slog.Debug("ClusterRole already exists", "name", clusterRoleName)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			slog.Error("failed to create ClusterRole", "name", clusterRoleName, "error", err)
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to create ClusterRole", err)
+		}
+		// Update: enforce the latest rules even when the ClusterRole already exists from a prior run.
+		slog.Debug("ClusterRole already exists, updating", "name", clusterRoleName)
+		_, err = d.clientset.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
+		if err != nil {
+			slog.Error("failed to update ClusterRole", "name", clusterRoleName, "error", err)
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to update ClusterRole", err)
+		}
+		slog.Info("ClusterRole updated successfully", "name", clusterRoleName)
 	} else {
 		slog.Info("ClusterRole created successfully", "name", clusterRoleName)
 	}

--- a/pkg/validator/agent/rbac_test.go
+++ b/pkg/validator/agent/rbac_test.go
@@ -120,8 +120,8 @@ func TestEnsureRole(t *testing.T) {
 		}
 
 		// Verify policy rules
-		if len(role.Rules) != 5 {
-			t.Errorf("expected 5 rules, got %d", len(role.Rules))
+		if len(role.Rules) != 6 {
+			t.Errorf("expected 6 rules, got %d", len(role.Rules))
 		}
 
 		// Rule 0: namespaces, events, services, endpoints, nodes (get, list)
@@ -178,6 +178,21 @@ func TestEnsureRole(t *testing.T) {
 		}
 		if !containsResource(rule4.Resources, "jobs") {
 			t.Errorf("expected jobs in fifth rule, got %v", rule4.Resources)
+		}
+
+		// Rule 5: trainer.kubeflow.org trainingruntimes/trainjobs (get, list, create, update, delete)
+		rule5 := role.Rules[5]
+		if rule5.APIGroups[0] != "trainer.kubeflow.org" {
+			t.Errorf("expected trainer.kubeflow.org API group in sixth rule, got %v", rule5.APIGroups)
+		}
+		if !containsResource(rule5.Resources, "trainingruntimes") || !containsResource(rule5.Resources, "trainjobs") {
+			t.Errorf("expected trainingruntimes and trainjobs in sixth rule, got %v", rule5.Resources)
+		}
+		if !containsVerb(rule5.Verbs, "get") || !containsVerb(rule5.Verbs, "list") ||
+			!containsVerb(rule5.Verbs, "create") || !containsVerb(rule5.Verbs, "update") ||
+			!containsVerb(rule5.Verbs, "delete") {
+
+			t.Errorf("expected get/list/create/update/delete verbs for Trainer resources, got %v", rule5.Verbs)
 		}
 	})
 

--- a/pkg/validator/agent/rbac_test.go
+++ b/pkg/validator/agent/rbac_test.go
@@ -164,13 +164,16 @@ func TestEnsureRole(t *testing.T) {
 			t.Errorf("expected get/list/watch/create/update/patch/delete verbs for pods, got %v", rule2.Verbs)
 		}
 
-		// Rule 3: pods/log, pods/status (get, list)
+		// Rule 3: pods/log, pods/status (get, list — no watch needed for subresources)
 		rule3 := role.Rules[3]
 		if !containsResource(rule3.Resources, "pods/log") || !containsResource(rule3.Resources, "pods/status") {
 			t.Errorf("expected pods/log and pods/status in fourth rule, got %v", rule3.Resources)
 		}
 		if !containsVerb(rule3.Verbs, "get") || !containsVerb(rule3.Verbs, "list") {
 			t.Errorf("expected get/list verbs for pod subresources, got %v", rule3.Verbs)
+		}
+		if containsVerb(rule3.Verbs, "watch") {
+			t.Error("pods/log and pods/status should not have watch verb (least privilege)")
 		}
 
 		// Rule 4: batch/jobs (get, list)

--- a/pkg/validator/agent/rbac_test.go
+++ b/pkg/validator/agent/rbac_test.go
@@ -150,16 +150,18 @@ func TestEnsureRole(t *testing.T) {
 			t.Errorf("expected get/list/create/update/patch verbs for configmaps, got %v", rule1.Verbs)
 		}
 
-		// Rule 2: pods (get, list, create, update, patch, delete)
+		// Rule 2: pods (get, list, watch, create, update, patch, delete)
+		// watch is required by WaitForPodSuccess which uses the Kubernetes Watch API.
 		rule2 := role.Rules[2]
 		if len(rule2.Resources) != 1 || rule2.Resources[0] != "pods" {
 			t.Errorf("expected pods in third rule, got %v", rule2.Resources)
 		}
 		if !containsVerb(rule2.Verbs, "get") || !containsVerb(rule2.Verbs, "list") ||
-			!containsVerb(rule2.Verbs, "create") || !containsVerb(rule2.Verbs, "update") ||
-			!containsVerb(rule2.Verbs, "patch") || !containsVerb(rule2.Verbs, "delete") {
+			!containsVerb(rule2.Verbs, "watch") || !containsVerb(rule2.Verbs, "create") ||
+			!containsVerb(rule2.Verbs, "update") || !containsVerb(rule2.Verbs, "patch") ||
+			!containsVerb(rule2.Verbs, "delete") {
 
-			t.Errorf("expected get/list/create/update/patch/delete verbs for pods, got %v", rule2.Verbs)
+			t.Errorf("expected get/list/watch/create/update/patch/delete verbs for pods, got %v", rule2.Verbs)
 		}
 
 		// Rule 3: pods/log, pods/status (get, list)

--- a/pkg/validator/checks/README.md
+++ b/pkg/validator/checks/README.md
@@ -92,6 +92,13 @@ pkg/validator/checks/
 │   ├── gpu_operator_version_constraint_test.go      # Integration test
 │   └── gpu_operator_version_constraint_unit_test.go # Unit test
 ├── performance/                 # Performance phase checks + constraints
+│   ├── nccl_all_reduce_bw_constraint.go           # NCCL all-reduce BW constraint + registration
+│   ├── nccl_all_reduce_bw_constraint_test.go      # Integration test (TestNcclAllReduceBw — runs in Jobs)
+│   ├── nccl_all_reduce_bw_constraint_unit_test.go # Unit test (runs locally without cluster)
+│   ├── trainer_lifecycle.go                       # Kubeflow Trainer install/uninstall lifecycle
+│   └── testdata/h100/eks/                         # EKS+H100 TrainingRuntime/TrainJob templates
+│       ├── runtime.yaml
+│       └── trainjob.yaml
 └── conformance/                 # Conformance phase checks + constraints
 ```
 

--- a/pkg/validator/checks/README.md
+++ b/pkg/validator/checks/README.md
@@ -733,24 +733,31 @@ cm, _ := ctx.Clientset.CoreV1().ConfigMaps(ns).Get(ctx.Context, name, metav1.Get
 #### Performance Phase
 
 **Typical validations:**
-- NCCL bandwidth measurements
+- NCCL all-reduce bus bandwidth (EW fabric between GPU nodes)
 - Network fabric health
 - GPU-to-GPU communication latency
 - Storage I/O performance
 
 **Example constraint names:**
-- `Performance.nccl.bandwidth`
+- `nccl-all-reduce-bw` (implemented — EKS + H100)
 - `Performance.network.latency`
 - `Performance.gpu.peer-access`
 
+**Implemented constraints:**
+- `nccl-all-reduce-bw` — Runs a Kubeflow Trainer `TrainJob` with NCCL `all_reduce_perf`, parses the 16 GB bus bandwidth from launcher logs, and validates it is within 10% of the recipe threshold. Skips gracefully when fewer than 2 GPU nodes are available (requires EKS + H100 to run). Auto-installs Kubeflow Trainer if not already present and tears it down on exit.
+
 **Access patterns:**
 ```go
-// Run Jobs for performance tests
-job, _ := ctx.Clientset.BatchV1().Jobs(ns).Create(ctx.Context, perfJob, metav1.CreateOptions{})
+// Dynamic client for CRD and TrainJob operations
+dynamicClient, _ := dynamic.NewForConfig(ctx.RESTConfig)
 
-// Wait for completion and read results from logs
-pods, _ := ctx.Clientset.CoreV1().Pods(ns).List(ctx.Context, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s", jobName)})
-logs, _ := ctx.Clientset.CoreV1().Pods(ns).GetLogs(podName, &corev1.PodLogOptions{}).Stream(ctx.Context)
+// List schedulable GPU nodes
+nodes, _ := ctx.Clientset.CoreV1().Nodes().List(ctx.Context, metav1.ListOptions{})
+
+// Watch launcher pod for completion
+watcher, _ := ctx.Clientset.CoreV1().Pods(ns).Watch(ctx.Context, metav1.ListOptions{
+    FieldSelector: "metadata.name=" + podName,
+})
 ```
 
 #### Conformance Phase

--- a/pkg/validator/checks/deployment/check_nvidia_smi_check.go
+++ b/pkg/validator/checks/deployment/check_nvidia_smi_check.go
@@ -122,7 +122,6 @@ func verifySingleNode(ctx *checks.ValidationContext, t *testing.T, nodeName stri
 		ClientSet:  ctx.Clientset,
 		RESTConfig: ctx.RESTConfig,
 		Namespace:  ctx.Namespace,
-		T:          t,
 	}
 
 	// Create verification pod

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -42,6 +42,10 @@ const (
 	testType       = "all_reduce_perf"
 	minMessageSize = "1K"
 	maxMessageSize = "16G"
+
+	// ncclTrainJobName is the name used for both the TrainJob resource and the label
+	// selector when waiting for the launcher pod. Must stay in sync with trainjob.yaml.
+	ncclTrainJobName = "nccl-all-reduce-tj"
 )
 
 // templatePath returns the path to a testdata template file for the given
@@ -330,7 +334,7 @@ func waitForLauncherPodAndGetLogs(ctx *checks.ValidationContext, podHelper *help
 		ctx.Context,
 		ctx.Clientset,
 		ctx.Namespace,
-		"jobset.sigs.k8s.io/jobset-name=nccl-all-reduce-tj,jobset.sigs.k8s.io/replicatedjob-name=launcher",
+		fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s,jobset.sigs.k8s.io/replicatedjob-name=launcher", ncclTrainJobName),
 		defaults.NCCLLauncherPodTimeout,
 	)
 	if err != nil {
@@ -399,7 +403,9 @@ func parseBandwidthFromLogs(logs string) (float64, error) {
 	// #        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
 	//  17179869184    4294967296     float     sum      -1   123456   139.2   450.3      0   123456   139.2   450.3      0
 
-	// Look for the line with the max message size (16G = 17179869184 bytes)
+	// Look for the row corresponding to maxMessageSize (16G = 17179869184 bytes).
+	// NCCL output has two measurement sets (in-place and out-of-place); we capture the
+	// first busbw column (in-place), which is the standard benchmark metric for NCCL.
 	re := regexp.MustCompile(`\s+17179869184\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+[\d.]+\s+([\d.]+)`)
 	matches := re.FindStringSubmatch(logs)
 
@@ -436,7 +442,7 @@ func cleanupNCCLResources(dynamicClient dynamic.Interface, namespace string) {
 	}
 
 	// Delete trainjob
-	err := dynamicClient.Resource(trainJobGVR).Namespace(namespace).Delete(cleanupCtx, "nccl-all-reduce-tj", metav1.DeleteOptions{})
+	err := dynamicClient.Resource(trainJobGVR).Namespace(namespace).Delete(cleanupCtx, ncclTrainJobName, metav1.DeleteOptions{})
 	if err != nil {
 		slog.Error("Warning: Failed to delete TrainJob", "error", err)
 	} else {

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -39,11 +39,9 @@ import (
 )
 
 const (
-	trainJobTimeout    = 30 * time.Minute
-	launcherPodTimeout = 5 * time.Minute
-	testType           = "all_reduce_perf"
-	minMessageSize     = "1K"
-	maxMessageSize     = "16G"
+	testType       = "all_reduce_perf"
+	minMessageSize = "1K"
+	maxMessageSize = "16G"
 )
 
 // templatePath returns the path to a testdata template file for the given
@@ -207,7 +205,7 @@ func parseThreshold(value string) (float64, error) {
 
 	threshold, err := strconv.ParseFloat(numStr, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid threshold format: %w", err)
+		return 0, aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest, "invalid threshold format", err)
 	}
 
 	return threshold, nil
@@ -333,7 +331,7 @@ func waitForLauncherPodAndGetLogs(ctx *checks.ValidationContext, podHelper *help
 		ctx.Clientset,
 		ctx.Namespace,
 		"jobset.sigs.k8s.io/jobset-name=nccl-all-reduce-tj,jobset.sigs.k8s.io/replicatedjob-name=launcher",
-		launcherPodTimeout,
+		defaults.NCCLLauncherPodTimeout,
 	)
 	if err != nil {
 		return "", aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "failed to find launcher pod", err)
@@ -342,7 +340,7 @@ func waitForLauncherPodAndGetLogs(ctx *checks.ValidationContext, podHelper *help
 	slog.Info("Found launcher pod", "name", launcherPod.Name)
 
 	// Wait for pod to complete using helper method
-	err = podHelper.WaitForPodSuccess(ctx.Context, launcherPod, trainJobTimeout)
+	err = podHelper.WaitForPodSuccess(ctx.Context, launcherPod, defaults.NCCLTrainJobTimeout)
 	if err != nil {
 		// Get logs even if pod failed for debugging
 		slog.Info("Pod did not succeed, retrieving logs for debugging...")
@@ -402,12 +400,12 @@ func parseBandwidthFromLogs(logs string) (float64, error) {
 	matches := re.FindStringSubmatch(logs)
 
 	if len(matches) < 2 {
-		return 0, fmt.Errorf("could not find bandwidth value in logs")
+		return 0, aicrErrors.New(aicrErrors.ErrCodeInternal, "could not find bandwidth value in logs")
 	}
 
 	bandwidth, err := strconv.ParseFloat(matches[1], 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse bandwidth value: %w", err)
+		return 0, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse bandwidth value", err)
 	}
 
 	return bandwidth, nil

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -46,12 +47,36 @@ const (
 	// ncclTrainJobName is the name used for both the TrainJob resource and the label
 	// selector when waiting for the launcher pod. Must stay in sync with trainjob.yaml.
 	ncclTrainJobName = "nccl-all-reduce-tj"
+
+	// ncclTrainingRuntimeName is the name of the TrainingRuntime resource.
+	// Must stay in sync with runtime.yaml.
+	ncclTrainingRuntimeName = "nccl-all-reduce-runtime"
 )
+
+// Package-level GVR definitions for Kubeflow Trainer CRDs used by both
+// applyNCCLResources and cleanupNCCLResources.
+var (
+	trainJobGVR = schema.GroupVersionResource{
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
+		Resource: "trainjobs",
+	}
+
+	trainingRuntimeGVR = schema.GroupVersionResource{
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
+		Resource: "trainingruntimes",
+	}
+)
+
+// ncclBandwidthRe matches the 16G (17179869184 bytes) row in NCCL all-reduce output
+// and captures the first busbw column (in-place measurement).
+var ncclBandwidthRe = regexp.MustCompile(`\s+17179869184\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+[\d.]+\s+([\d.]+)`)
 
 // templatePath returns the path to a testdata template file for the given
 // accelerator and service combination: testdata/{accelerator}/{service}/{filename}
 func templatePath(accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, filename string) string {
-	return fmt.Sprintf("testdata/%s/%s/%s", accelerator, service, filename)
+	return filepath.Join("testdata", string(accelerator), string(service), filename)
 }
 
 func init() {
@@ -265,19 +290,6 @@ func applyNCCLResources(ctx *checks.ValidationContext, dynamicClient dynamic.Int
 		"MAX_MESSAGE_SIZE":   maxMessageSize,
 	}
 
-	// Define GVRs for TrainingRuntime and TrainJob
-	trainingRuntimeGVR := schema.GroupVersionResource{
-		Group:    "trainer.kubeflow.org",
-		Version:  "v1alpha1",
-		Resource: "trainingruntimes",
-	}
-
-	trainJobGVR := schema.GroupVersionResource{
-		Group:    "trainer.kubeflow.org",
-		Version:  "v1alpha1",
-		Resource: "trainjobs",
-	}
-
 	// Apply runtime first
 	if err := applyYAMLWithDynamicClient(ctx.Context, dynamicClient, trainingRuntimeGVR, config.Namespace, templatePath(accelerator, service, "runtime.yaml"), templateData); err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply training runtime", err)
@@ -406,8 +418,7 @@ func parseBandwidthFromLogs(logs string) (float64, error) {
 	// Look for the row corresponding to maxMessageSize (16G = 17179869184 bytes).
 	// NCCL output has two measurement sets (in-place and out-of-place); we capture the
 	// first busbw column (in-place), which is the standard benchmark metric for NCCL.
-	re := regexp.MustCompile(`\s+17179869184\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+[\d.]+\s+([\d.]+)`)
-	matches := re.FindStringSubmatch(logs)
+	matches := ncclBandwidthRe.FindStringSubmatch(logs)
 
 	if len(matches) < 2 {
 		return 0, aicrErrors.New(aicrErrors.ErrCodeInternal, "could not find bandwidth value in logs")
@@ -428,19 +439,6 @@ func cleanupNCCLResources(dynamicClient dynamic.Interface, namespace string) {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
 	defer cancel()
 
-	// Define GVRs
-	trainJobGVR := schema.GroupVersionResource{
-		Group:    "trainer.kubeflow.org",
-		Version:  "v1alpha1",
-		Resource: "trainjobs",
-	}
-
-	trainingRuntimeGVR := schema.GroupVersionResource{
-		Group:    "trainer.kubeflow.org",
-		Version:  "v1alpha1",
-		Resource: "trainingruntimes",
-	}
-
 	// Delete trainjob
 	err := dynamicClient.Resource(trainJobGVR).Namespace(namespace).Delete(cleanupCtx, ncclTrainJobName, metav1.DeleteOptions{})
 	if err != nil {
@@ -450,7 +448,7 @@ func cleanupNCCLResources(dynamicClient dynamic.Interface, namespace string) {
 	}
 
 	// Delete runtime
-	err = dynamicClient.Resource(trainingRuntimeGVR).Namespace(namespace).Delete(cleanupCtx, "nccl-all-reduce-runtime", metav1.DeleteOptions{})
+	err = dynamicClient.Resource(trainingRuntimeGVR).Namespace(namespace).Delete(cleanupCtx, ncclTrainingRuntimeName, metav1.DeleteOptions{})
 	if err != nil {
 		slog.Error("Warning: Failed to delete TrainingRuntime", "error", err)
 	} else {

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -1,0 +1,443 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	"github.com/NVIDIA/aicr/pkg/validator/helper"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	trainJobTimeout    = 30 * time.Minute
+	launcherPodTimeout = 5 * time.Minute
+	testType           = "all_reduce_perf"
+	minMessageSize     = "1K"
+	maxMessageSize     = "16G"
+)
+
+// templatePath returns the path to a testdata template file for the given
+// accelerator and service combination: testdata/{accelerator}/{service}/{filename}
+func templatePath(accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, filename string) string {
+	return fmt.Sprintf("testdata/%s/%s/%s", accelerator, service, filename)
+}
+
+func init() {
+	// Register this constraint validator
+	checks.RegisterConstraintValidator(&checks.ConstraintValidator{
+		Pattern:     "nccl-all-reduce-bw",
+		Description: "Verify NCCL All Reduce Bus Bandwidth within 10% of threshold",
+		Func:        validateNcclAllReduceBw,
+		TestName:    "TestNcclAllReduceBw",
+		Phase:       "performance",
+	})
+}
+
+// supportedNCCLCombinations maps each supported cloud service to the accelerator
+// types for which the NCCL all-reduce test has been implemented. The test uses
+// p5.48xlarge-specific templates with EFA networking and NVSwitch topology, so
+// only EKS+H100 is currently supported.
+var supportedNCCLCombinations = map[recipe.CriteriaServiceType][]recipe.CriteriaAcceleratorType{
+	recipe.CriteriaServiceEKS: {recipe.CriteriaAcceleratorH100},
+}
+
+// validateNcclAllReduceBw validates NCCL All Reduce bandwidth by running a TrainJob.
+// It applies the runtime and trainjob YAML templates, waits for completion,
+// and extracts bandwidth metrics from the launcher pod logs.
+// Returns actual bandwidth value, whether it passed the threshold, and any error.
+func validateNcclAllReduceBw(ctx *checks.ValidationContext, constraint recipe.Constraint) (string, bool, error) {
+	slog.Info("Starting NCCL All Reduce bandwidth validation")
+
+	// Skip unless the recipe targets a supported service + accelerator combination.
+	if ctx.Recipe == nil || ctx.Recipe.Criteria == nil {
+		slog.Info("Skipping NCCL All Reduce bandwidth validation: no recipe criteria")
+		return "skipped - requires Service + Accelerator", true, nil
+	}
+
+	service := ctx.Recipe.Criteria.Service
+	accelerator := ctx.Recipe.Criteria.Accelerator
+	supported := false
+	if supportedAccelerators, ok := supportedNCCLCombinations[service]; ok {
+		for _, a := range supportedAccelerators {
+			if accelerator == a {
+				supported = true
+				break
+			}
+		}
+	}
+
+	if !supported {
+		slog.Info("Skipping NCCL All Reduce bandwidth validation: unsupported service/accelerator combination",
+			"service", service, "accelerator", accelerator)
+		return "skipped - requires Service + Accelerator to be implemented", true, nil
+	}
+
+	// Extract threshold from constraint
+	threshold, err := parseThreshold(constraint.Value)
+	if err != nil {
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest, "invalid threshold", err)
+	}
+	slog.Info("Target bandwidth threshold", "threshold", threshold, "tolerance", "10%")
+
+	// Create dynamic client for CRD operations (needed for trainer check and NCCL resources).
+	dynamicClient, err := dynamic.NewForConfig(ctx.RESTConfig)
+	if err != nil {
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create dynamic client", err)
+	}
+
+	// Ensure Kubeflow Trainer is installed.  If it is already present we leave it
+	// alone; if we install it we clean it up after the test completes.
+	trainerInstalled, err := isTrainerInstalled(ctx.Context, dynamicClient)
+	if err != nil {
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check Kubeflow Trainer installation", err)
+	}
+	if !trainerInstalled {
+		slog.Info("Kubeflow Trainer not found, installing...")
+		var installedResources []trainerResourceRef
+		installedResources, err = installTrainer(ctx.Context, dynamicClient, ctx.Clientset.Discovery())
+		if err != nil {
+			return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to install Kubeflow Trainer", err)
+		}
+		defer deleteTrainer(dynamicClient, installedResources)
+		slog.Info("Kubeflow Trainer installed", "resources", len(installedResources))
+	} else {
+		slog.Info("Kubeflow Trainer already installed, proceeding")
+	}
+
+	// Determine GPU configuration from snapshot
+	gpuConfig, err := determineGPUConfig(ctx)
+	if err != nil {
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to determine GPU configuration", err)
+	}
+	slog.Info("GPU Configuration", "nodes", gpuConfig.WorkerCount, ", GPUs/node", gpuConfig.GPUCountPerNode, ", total GPUs", gpuConfig.TotalGPUCount)
+
+	// Apply runtime and trainjob resources
+	if applyErr := applyNCCLResources(ctx, dynamicClient, gpuConfig, accelerator, service); applyErr != nil {
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply NCCL resources", applyErr)
+	}
+
+	// Ensure cleanup
+	defer cleanupNCCLResources(dynamicClient, gpuConfig.Namespace)
+
+	// Create pod helper for launcher pod operations
+	podHelper := &helper.PodLifecycle{
+		ClientSet:  ctx.Clientset,
+		RESTConfig: ctx.RESTConfig,
+		Namespace:  ctx.Namespace,
+	}
+
+	// Wait for launcher pod and get logs
+	logs, err := waitForLauncherPodAndGetLogs(ctx, podHelper)
+	if err != nil {
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get launcher logs", err)
+	}
+
+	// Parse bandwidth from logs
+	bandwidth, err := parseBandwidthFromLogs(logs)
+	if err != nil {
+		return logs, false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse bandwidth from logs", err)
+	}
+
+	slog.Info("Measured bandwidth", "bandwidth", bandwidth)
+
+	// Check if bandwidth meets threshold (within 10% tolerance)
+	passed := bandwidth >= (threshold * 0.9)
+	actualValue := fmt.Sprintf("%.2f GB/s", bandwidth)
+
+	if passed {
+		slog.Info("Bandwidth validation passed", "bandwidth", bandwidth, "threshold", threshold*0.9, "tolerance", "90%")
+	} else {
+		slog.Info("Bandwidth validation failed", "bandwidth", bandwidth, "threshold", threshold*0.9, "tolerance", "90%")
+	}
+
+	return actualValue, passed, nil
+}
+
+// gpuConfiguration holds GPU node and count information
+type gpuConfiguration struct {
+	WorkerCount     int
+	GPUCountPerNode int
+	TotalGPUCount   int
+	Namespace       string
+}
+
+// parseThreshold extracts the numeric threshold value from constraint
+func parseThreshold(value string) (float64, error) {
+	// Remove units and parse (e.g., "450 GB/s" -> 450)
+	numStr := strings.TrimSpace(value)
+	numStr = strings.Split(numStr, " ")[0]
+
+	threshold, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid threshold format: %w", err)
+	}
+
+	return threshold, nil
+}
+
+// determineGPUConfig analyzes the snapshot to determine GPU node configuration
+func determineGPUConfig(ctx *checks.ValidationContext) (*gpuConfiguration, error) {
+	slog.Info("Analyzing GPU node configuration...")
+
+	// Find schedulable GPU nodes
+	gpuNodes, err := helper.FindSchedulableGpuNodes(ctx)
+	if err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to find GPU nodes", err)
+	}
+
+	if len(gpuNodes) == 0 {
+		return nil, aicrErrors.New(aicrErrors.ErrCodeInternal, "no schedulable GPU nodes found")
+	}
+
+	slog.Info("Found GPU nodes", "count", len(gpuNodes))
+
+	// Get GPU count from first node (assuming homogeneous cluster)
+	firstNode := gpuNodes[0]
+	gpuResource := v1.ResourceName("nvidia.com/gpu")
+	gpuQuantity := firstNode.Status.Allocatable[gpuResource]
+	gpuCountPerNode := int(gpuQuantity.Value())
+
+	if gpuCountPerNode == 0 {
+		return nil, aicrErrors.New(aicrErrors.ErrCodeInternal, "no GPUs found on nodes")
+	}
+
+	totalGPUs := len(gpuNodes) * gpuCountPerNode
+
+	return &gpuConfiguration{
+		WorkerCount:     len(gpuNodes),
+		GPUCountPerNode: gpuCountPerNode,
+		TotalGPUCount:   totalGPUs,
+		Namespace:       ctx.Namespace,
+	}, nil
+}
+
+// applyNCCLResources applies the runtime and trainjob YAML files with template substitution using dynamic client
+func applyNCCLResources(ctx *checks.ValidationContext, dynamicClient dynamic.Interface, config *gpuConfiguration, accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType) error {
+	slog.Info("Applying NCCL test resources...")
+
+	templateData := map[string]string{
+		"NAMESPACE":          config.Namespace,
+		"WORKER_COUNT":       strconv.Itoa(config.WorkerCount),
+		"GPU_COUNT_PER_NODE": strconv.Itoa(config.GPUCountPerNode),
+		"GPU_COUNT":          strconv.Itoa(config.TotalGPUCount),
+		"TEST_TYPE":          testType,
+		"MIN_MESSAGE_SIZE":   minMessageSize,
+		"MAX_MESSAGE_SIZE":   maxMessageSize,
+	}
+
+	// Define GVRs for TrainingRuntime and TrainJob
+	trainingRuntimeGVR := schema.GroupVersionResource{
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
+		Resource: "trainingruntimes",
+	}
+
+	trainJobGVR := schema.GroupVersionResource{
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
+		Resource: "trainjobs",
+	}
+
+	// Apply runtime first
+	if err := applyYAMLWithDynamicClient(ctx.Context, dynamicClient, trainingRuntimeGVR, config.Namespace, templatePath(accelerator, service, "runtime.yaml"), templateData); err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply training runtime", err)
+	}
+	slog.Info("Applied TrainingRuntime")
+
+	// Apply trainjob
+	if err := applyYAMLWithDynamicClient(ctx.Context, dynamicClient, trainJobGVR, config.Namespace, templatePath(accelerator, service, "trainjob.yaml"), templateData); err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply train job", err)
+	}
+	slog.Info("Applied TrainJob")
+
+	return nil
+}
+
+// applyYAMLWithDynamicClient reads a YAML template, performs substitution, and applies it using dynamic client
+func applyYAMLWithDynamicClient(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, templatePath string, data map[string]string) error {
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read template", err)
+	}
+
+	// Perform template substitution
+	yamlContent := string(content)
+	for key, value := range data {
+		yamlContent = strings.ReplaceAll(yamlContent, "${"+key+"}", value)
+	}
+
+	// Parse YAML to unstructured object
+	obj := &unstructured.Unstructured{}
+	if unmarshalErr := yaml.Unmarshal([]byte(yamlContent), obj); unmarshalErr != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse YAML", unmarshalErr)
+	}
+
+	// Apply with timeout
+	applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+
+	// Create the resource
+	_, err = dynamicClient.Resource(gvr).Namespace(namespace).Create(applyCtx, obj, metav1.CreateOptions{})
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create resource", err)
+	}
+
+	return nil
+}
+
+// waitForLauncherPodAndGetLogs waits for the launcher pod to be created and retrieves logs
+func waitForLauncherPodAndGetLogs(ctx *checks.ValidationContext, podHelper *helper.PodLifecycle) (string, error) {
+	slog.Info("Waiting for launcher pod to be created...")
+
+	// Wait for launcher pod to be created (pattern: nccl-all-reduce-tj-launcher-*)
+	launcherPod, err := waitForPodByLabelSelector(
+		ctx.Context,
+		ctx.Clientset,
+		ctx.Namespace,
+		"jobset.sigs.k8s.io/jobset-name=nccl-all-reduce-tj,jobset.sigs.k8s.io/replicatedjob-name=launcher",
+		launcherPodTimeout,
+	)
+	if err != nil {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "failed to find launcher pod", err)
+	}
+
+	slog.Info("Found launcher pod", "name", launcherPod.Name)
+
+	// Wait for pod to complete using helper method
+	err = podHelper.WaitForPodSuccess(ctx.Context, launcherPod, trainJobTimeout)
+	if err != nil {
+		// Get logs even if pod failed for debugging
+		slog.Info("Pod did not succeed, retrieving logs for debugging...")
+		logs, _ := podHelper.GetPodLogs(ctx.Context, launcherPod)
+		return logs, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "pod failed to complete successfully", err)
+	}
+
+	// Get logs from completed pod using helper method
+	slog.Info("Retrieving logs from successful pod...")
+	logs, err := podHelper.GetPodLogs(ctx.Context, launcherPod)
+	if err != nil {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get pod logs", err)
+	}
+
+	return logs, nil
+}
+
+// waitForPodByLabelSelector waits for a pod matching the label selector to be created
+func waitForPodByLabelSelector(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector string, timeout time.Duration) (*v1.Pod, error) {
+	slog.Info("Polling for pod with selector", "selector", labelSelector)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(defaults.PodPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "timeout waiting for pod", ctx.Err())
+		case <-ticker.C:
+			pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
+			if err != nil {
+				slog.Error("Error listing pods, retrying...", "error", err)
+				continue
+			}
+			if len(pods.Items) > 0 {
+				return &pods.Items[0], nil
+			}
+			slog.Info("Pod not found yet, continuing to poll...")
+		}
+	}
+}
+
+// parseBandwidthFromLogs extracts the bus bandwidth value from NCCL test logs
+func parseBandwidthFromLogs(logs string) (float64, error) {
+	// NCCL test output format example:
+	// #       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
+	// #        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
+	//  17179869184    4294967296     float     sum      -1   123456   139.2   450.3      0   123456   139.2   450.3      0
+
+	// Look for the line with the max message size (16G = 17179869184 bytes)
+	re := regexp.MustCompile(`\s+17179869184\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+[\d.]+\s+([\d.]+)`)
+	matches := re.FindStringSubmatch(logs)
+
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("could not find bandwidth value in logs")
+	}
+
+	bandwidth, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse bandwidth value: %w", err)
+	}
+
+	return bandwidth, nil
+}
+
+// cleanupNCCLResources removes the trainjob and runtime resources using dynamic client
+func cleanupNCCLResources(dynamicClient dynamic.Interface, namespace string) {
+	slog.Info("Cleaning up NCCL test resources...")
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
+	defer cancel()
+
+	// Define GVRs
+	trainJobGVR := schema.GroupVersionResource{
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
+		Resource: "trainjobs",
+	}
+
+	trainingRuntimeGVR := schema.GroupVersionResource{
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
+		Resource: "trainingruntimes",
+	}
+
+	// Delete trainjob
+	err := dynamicClient.Resource(trainJobGVR).Namespace(namespace).Delete(cleanupCtx, "nccl-all-reduce-tj", metav1.DeleteOptions{})
+	if err != nil {
+		slog.Error("Warning: Failed to delete TrainJob", "error", err)
+	} else {
+		slog.Info("Deleted TrainJob")
+	}
+
+	// Delete runtime
+	err = dynamicClient.Resource(trainingRuntimeGVR).Namespace(namespace).Delete(cleanupCtx, "nccl-all-reduce-runtime", metav1.DeleteOptions{})
+	if err != nil {
+		slog.Error("Warning: Failed to delete TrainingRuntime", "error", err)
+	} else {
+		slog.Info("Deleted TrainingRuntime")
+	}
+}

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -141,6 +141,14 @@ func validateNcclAllReduceBw(ctx *checks.ValidationContext, constraint recipe.Co
 	}
 	slog.Info("GPU Configuration", "nodes", gpuConfig.WorkerCount, ", GPUs/node", gpuConfig.GPUCountPerNode, ", total GPUs", gpuConfig.TotalGPUCount)
 
+	// NCCL all-reduce tests EW (East-West) fabric between nodes and requires at least
+	// two GPU nodes. Skip gracefully rather than fail when only one node is available.
+	if gpuConfig.WorkerCount < 2 {
+		slog.Info("Skipping NCCL All Reduce bandwidth validation: requires at least 2 GPU nodes for EW fabric test",
+			"nodes", gpuConfig.WorkerCount)
+		return "skipped - requires at least 2 GPU nodes for EW fabric test", true, nil
+	}
+
 	// Apply runtime and trainjob resources
 	if applyErr := applyNCCLResources(ctx, dynamicClient, gpuConfig, accelerator, service); applyErr != nil {
 		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply NCCL resources", applyErr)

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -358,32 +358,36 @@ func waitForLauncherPodAndGetLogs(ctx *checks.ValidationContext, podHelper *help
 	return logs, nil
 }
 
-// waitForPodByLabelSelector waits for a pod matching the label selector to be created
+// waitForPodByLabelSelector waits for a pod matching the label selector to be created.
+// Uses the Watch API for efficiency instead of polling.
 func waitForPodByLabelSelector(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector string, timeout time.Duration) (*v1.Pod, error) {
-	slog.Info("Polling for pod with selector", "selector", labelSelector)
+	slog.Info("Watching for pod with selector", "selector", labelSelector)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(defaults.PodPollInterval)
-	defer ticker.Stop()
+	watcher, err := clientset.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to watch pods", err)
+	}
+	defer watcher.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "timeout waiting for pod", ctx.Err())
-		case <-ticker.C:
-			pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-				LabelSelector: labelSelector,
-			})
-			if err != nil {
-				slog.Error("Error listing pods, retrying...", "error", err)
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return nil, aicrErrors.New(aicrErrors.ErrCodeInternal, "pod watch channel closed unexpectedly")
+			}
+			pod, ok := event.Object.(*v1.Pod)
+			if !ok {
 				continue
 			}
-			if len(pods.Items) > 0 {
-				return &pods.Items[0], nil
-			}
-			slog.Info("Pod not found yet, continuing to poll...")
+			slog.Info("Found launcher pod", "name", pod.Name)
+			return pod, nil
 		}
 	}
 }

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+// TestNcclAllReduceBw validates the nccl-all-reduce-bw constraint.
+// This integration test runs inside validator Jobs and invokes the validator.
+func TestNcclAllReduceBw(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Load Job environment
+	runner, err := checks.NewTestRunner(t)
+	if err != nil {
+		t.Skipf("Not in Job environment: %v", err)
+	}
+	defer runner.Cancel()
+
+	// Get constraint from recipe
+	constraint := runner.GetConstraint("performance", "nccl-all-reduce-bw")
+	if constraint == nil {
+		t.Skip("Constraint nccl-all-reduce-bw not defined in recipe")
+	}
+
+	t.Logf("Validating constraint: %s = %s", constraint.Name, constraint.Value)
+
+	// Run the validator
+	ctx := runner.Context()
+	actual, passed, err := validateNcclAllReduceBw(ctx, *constraint)
+	if err != nil {
+		t.Fatalf("Validation failed: %v", err)
+	}
+
+	t.Logf("CONSTRAINT_RESULT: name=%s expected=%s actual=%s passed=%v",
+		constraint.Name, constraint.Value, actual, passed)
+
+	if !passed {
+		t.Errorf("Constraint not satisfied: expected %s, got %s", constraint.Value, actual)
+	} else {
+		t.Logf("✓ Constraint satisfied: %s = %s", constraint.Name, actual)
+	}
+}

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/checks"
+)
+
+func TestValidateNcclAllReduceBw(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func() *checks.ValidationContext
+		constraint recipe.Constraint
+		wantActual string
+		wantPassed bool
+		wantErr    bool
+	}{
+		{
+			name: "skipped when recipe is nil",
+			setup: func() *checks.ValidationContext {
+				return &checks.ValidationContext{
+					Context: context.Background(),
+				}
+			},
+			constraint: recipe.Constraint{
+				Name:  "nccl-all-reduce-bw",
+				Value: "450 GB/s",
+			},
+			wantActual: "skipped - requires Service + Accelerator",
+			wantPassed: true,
+			wantErr:    false,
+		},
+		{
+			name: "skipped when service is not EKS",
+			setup: func() *checks.ValidationContext {
+				return &checks.ValidationContext{
+					Context: context.Background(),
+					Recipe: &recipe.RecipeResult{
+						Criteria: &recipe.Criteria{
+							Service:     recipe.CriteriaServiceGKE,
+							Accelerator: recipe.CriteriaAcceleratorH100,
+						},
+					},
+				}
+			},
+			constraint: recipe.Constraint{
+				Name:  "nccl-all-reduce-bw",
+				Value: "450 GB/s",
+			},
+			wantActual: "skipped - requires Service + Accelerator to be implemented",
+			wantPassed: true,
+			wantErr:    false,
+		},
+		{
+			name: "skipped when accelerator is not H100",
+			setup: func() *checks.ValidationContext {
+				return &checks.ValidationContext{
+					Context: context.Background(),
+					Recipe: &recipe.RecipeResult{
+						Criteria: &recipe.Criteria{
+							Service:     recipe.CriteriaServiceEKS,
+							Accelerator: recipe.CriteriaAcceleratorA100,
+						},
+					},
+				}
+			},
+			constraint: recipe.Constraint{
+				Name:  "nccl-all-reduce-bw",
+				Value: "450 GB/s",
+			},
+			wantActual: "skipped - requires Service + Accelerator to be implemented",
+			wantPassed: true,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setup()
+			actual, passed, err := validateNcclAllReduceBw(ctx, tt.constraint)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateNcclAllReduceBw() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if actual != tt.wantActual {
+				t.Errorf("validateNcclAllReduceBw() actual = %v, want %v", actual, tt.wantActual)
+			}
+
+			if passed != tt.wantPassed {
+				t.Errorf("validateNcclAllReduceBw() passed = %v, want %v", passed, tt.wantPassed)
+			}
+		})
+	}
+}
+
+func TestSupportedNCCLCombinations(t *testing.T) {
+	tests := []struct {
+		name        string
+		service     recipe.CriteriaServiceType
+		accelerator recipe.CriteriaAcceleratorType
+		wantFound   bool
+	}{
+		{
+			name:        "EKS + H100 is supported",
+			service:     recipe.CriteriaServiceEKS,
+			accelerator: recipe.CriteriaAcceleratorH100,
+			wantFound:   true,
+		},
+		{
+			name:        "GKE + H100 is not supported",
+			service:     recipe.CriteriaServiceGKE,
+			accelerator: recipe.CriteriaAcceleratorH100,
+			wantFound:   false,
+		},
+		{
+			name:        "EKS + A100 is not supported",
+			service:     recipe.CriteriaServiceEKS,
+			accelerator: recipe.CriteriaAcceleratorA100,
+			wantFound:   false,
+		},
+		{
+			name:        "EKS + GB200 is not supported",
+			service:     recipe.CriteriaServiceEKS,
+			accelerator: recipe.CriteriaAcceleratorGB200,
+			wantFound:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found := false
+			if accelerators, ok := supportedNCCLCombinations[tt.service]; ok {
+				for _, a := range accelerators {
+					if a == tt.accelerator {
+						found = true
+						break
+					}
+				}
+			}
+			if found != tt.wantFound {
+				t.Errorf("combination %s+%s: found=%v, want %v", tt.service, tt.accelerator, found, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestValidateNcclAllReduceBwRegistration(t *testing.T) {
+	// Verify the constraint validator is registered
+	validator, ok := checks.GetConstraintValidator("nccl-all-reduce-bw")
+	if !ok {
+		t.Fatal("nccl-all-reduce-bw constraint validator not registered")
+	}
+
+	if validator.Pattern != "nccl-all-reduce-bw" {
+		t.Errorf("Pattern = %v, want nccl-all-reduce-bw", validator.Pattern)
+	}
+
+	if validator.Description == "" {
+		t.Error("Description is empty")
+	}
+
+	if validator.TestName == "" {
+		t.Error("TestName is empty")
+	}
+}

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
@@ -20,6 +20,11 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestValidateNcclAllReduceBw(t *testing.T) {
@@ -161,6 +166,103 @@ func TestSupportedNCCLCombinations(t *testing.T) {
 			}
 			if found != tt.wantFound {
 				t.Errorf("combination %s+%s: found=%v, want %v", tt.service, tt.accelerator, found, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestDetermineGPUConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		nodes           []v1.Node
+		wantWorkerCount int
+		wantGPUPerNode  int
+		wantTotalGPU    int
+		wantErr         bool
+	}{
+		{
+			name: "single GPU node yields WorkerCount=1 (triggers < 2 node skip)",
+			nodes: []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-node-1"},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			wantWorkerCount: 1,
+			wantGPUPerNode:  8,
+			wantTotalGPU:    8,
+			wantErr:         false,
+		},
+		{
+			name: "two GPU nodes yields WorkerCount=2",
+			nodes: []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-node-1"},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("8"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu-node-2"},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			wantWorkerCount: 2,
+			wantGPUPerNode:  8,
+			wantTotalGPU:    16,
+			wantErr:         false,
+		},
+		{
+			name:    "no GPU nodes returns error",
+			nodes:   []v1.Node{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]runtime.Object, 0, len(tt.nodes))
+			for i := range tt.nodes {
+				objects = append(objects, &tt.nodes[i])
+			}
+
+			//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+			clientset := fake.NewSimpleClientset(objects...)
+
+			ctx := &checks.ValidationContext{
+				Context:   context.Background(),
+				Clientset: clientset,
+				Namespace: "default",
+			}
+
+			gpuConfig, err := determineGPUConfig(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("determineGPUConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if gpuConfig.WorkerCount != tt.wantWorkerCount {
+				t.Errorf("WorkerCount = %d, want %d", gpuConfig.WorkerCount, tt.wantWorkerCount)
+			}
+			if gpuConfig.GPUCountPerNode != tt.wantGPUPerNode {
+				t.Errorf("GPUCountPerNode = %d, want %d", gpuConfig.GPUCountPerNode, tt.wantGPUPerNode)
+			}
+			if gpuConfig.TotalGPUCount != tt.wantTotalGPU {
+				t.Errorf("TotalGPUCount = %d, want %d", gpuConfig.TotalGPUCount, tt.wantTotalGPU)
 			}
 		})
 	}

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
@@ -16,7 +16,10 @@ package performance
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
@@ -24,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -69,6 +74,43 @@ func TestValidateNcclAllReduceBw(t *testing.T) {
 				Value: "450 GB/s",
 			},
 			wantActual: "skipped - requires Service + Accelerator to be implemented",
+			wantPassed: true,
+			wantErr:    false,
+		},
+		{
+			name: "error on invalid threshold for supported combination",
+			setup: func() *checks.ValidationContext {
+				return &checks.ValidationContext{
+					Context: context.Background(),
+					Recipe: &recipe.RecipeResult{
+						Criteria: &recipe.Criteria{
+							Service:     recipe.CriteriaServiceEKS,
+							Accelerator: recipe.CriteriaAcceleratorH100,
+						},
+					},
+				}
+			},
+			constraint: recipe.Constraint{
+				Name:  "nccl-all-reduce-bw",
+				Value: "not-a-number",
+			},
+			wantActual: "",
+			wantPassed: false,
+			wantErr:    true,
+		},
+		{
+			name: "skipped when criteria is nil",
+			setup: func() *checks.ValidationContext {
+				return &checks.ValidationContext{
+					Context: context.Background(),
+					Recipe:  &recipe.RecipeResult{},
+				}
+			},
+			constraint: recipe.Constraint{
+				Name:  "nccl-all-reduce-bw",
+				Value: "450 GB/s",
+			},
+			wantActual: "skipped - requires Service + Accelerator",
 			wantPassed: true,
 			wantErr:    false,
 		},
@@ -285,5 +327,312 @@ func TestValidateNcclAllReduceBwRegistration(t *testing.T) {
 
 	if validator.TestName == "" {
 		t.Error("TestName is empty")
+	}
+}
+
+func TestParseBandwidthFromLogs(t *testing.T) {
+	tests := []struct {
+		name    string
+		logs    string
+		want    float64
+		wantErr bool
+	}{
+		{
+			name: "valid NCCL output with 16G row",
+			logs: `#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
+   1073741824     268435456     float     sum      -1   12345    86.9   283.1      0   12345    86.9   283.1      0
+  17179869184    4294967296     float     sum      -1  123456   139.2   450.3      0  123456   139.2   450.3      0`,
+			want:    450.3,
+			wantErr: false,
+		},
+		{
+			name:    "no matching row in output",
+			logs:    "some random log output without NCCL data",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "empty logs",
+			logs:    "",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "row with negative root value",
+			logs:    `  17179869184    4294967296     float     sum      -1   98765   200.5   651.2      0   98765   200.5   651.2      0`,
+			want:    651.2,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBandwidthFromLogs(tt.logs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseBandwidthFromLogs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseBandwidthFromLogs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseThreshold(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    float64
+		wantErr bool
+	}{
+		{
+			name:    "value with units",
+			value:   "450 GB/s",
+			want:    450,
+			wantErr: false,
+		},
+		{
+			name:    "plain numeric value",
+			value:   "300",
+			want:    300,
+			wantErr: false,
+		},
+		{
+			name:    "value with leading/trailing spaces",
+			value:   "  500 GB/s  ",
+			want:    500,
+			wantErr: false,
+		},
+		{
+			name:    "decimal value",
+			value:   "450.5 GB/s",
+			want:    450.5,
+			wantErr: false,
+		},
+		{
+			name:    "invalid non-numeric",
+			value:   "abc",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			value:   "",
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseThreshold(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseThreshold() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseThreshold() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTemplatePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		accelerator recipe.CriteriaAcceleratorType
+		service     recipe.CriteriaServiceType
+		filename    string
+		want        string
+	}{
+		{
+			name:        "EKS H100 runtime",
+			accelerator: recipe.CriteriaAcceleratorH100,
+			service:     recipe.CriteriaServiceEKS,
+			filename:    "runtime.yaml",
+			want:        "testdata/h100/eks/runtime.yaml",
+		},
+		{
+			name:        "EKS H100 trainjob",
+			accelerator: recipe.CriteriaAcceleratorH100,
+			service:     recipe.CriteriaServiceEKS,
+			filename:    "trainjob.yaml",
+			want:        "testdata/h100/eks/trainjob.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := templatePath(tt.accelerator, tt.service, tt.filename)
+			if got != tt.want {
+				t.Errorf("templatePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyYAMLWithDynamicClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvr := trainingRuntimeGVR
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			gvr: "TrainingRuntimeList",
+		})
+
+	// Create a temp YAML file to apply
+	tmpDir := t.TempDir()
+	yamlContent := `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: test-runtime
+  namespace: ${NAMESPACE}
+spec:
+  replicas: ${WORKER_COUNT}`
+
+	yamlPath := filepath.Join(tmpDir, "test-runtime.yaml")
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0640); err != nil {
+		t.Fatalf("Failed to write test YAML: %v", err)
+	}
+
+	data := map[string]string{
+		"NAMESPACE":    "test-ns",
+		"WORKER_COUNT": "2",
+	}
+
+	err := applyYAMLWithDynamicClient(context.Background(), client, gvr, "test-ns", yamlPath, data)
+	if err != nil {
+		t.Fatalf("applyYAMLWithDynamicClient() error = %v", err)
+	}
+
+	// Verify resource was created
+	obj, err := client.Resource(gvr).Namespace("test-ns").Get(context.Background(), "test-runtime", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Resource not created: %v", err)
+	}
+	if obj.GetName() != "test-runtime" {
+		t.Errorf("Expected name test-runtime, got %v", obj.GetName())
+	}
+}
+
+func TestApplyYAMLWithDynamicClientFileNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	err := applyYAMLWithDynamicClient(context.Background(), client, trainJobGVR, "test-ns", "/nonexistent/path.yaml", nil)
+	if err == nil {
+		t.Error("applyYAMLWithDynamicClient() expected error for missing file, got nil")
+	}
+}
+
+func TestApplyNCCLResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			trainJobGVR:        "TrainJobList",
+			trainingRuntimeGVR: "TrainingRuntimeList",
+		})
+
+	config := &gpuConfiguration{
+		WorkerCount:     2,
+		GPUCountPerNode: 8,
+		TotalGPUCount:   16,
+		Namespace:       "test-ns",
+	}
+
+	ctx := &checks.ValidationContext{
+		Context:   context.Background(),
+		Namespace: "test-ns",
+	}
+
+	// Uses real testdata files (h100/eks)
+	err := applyNCCLResources(ctx, client, config, recipe.CriteriaAcceleratorH100, recipe.CriteriaServiceEKS)
+	if err != nil {
+		t.Fatalf("applyNCCLResources() error = %v", err)
+	}
+
+	// Verify both resources were created
+	_, err = client.Resource(trainingRuntimeGVR).Namespace("test-ns").Get(context.Background(), ncclTrainingRuntimeName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("TrainingRuntime not created: %v", err)
+	}
+	_, err = client.Resource(trainJobGVR).Namespace("test-ns").Get(context.Background(), ncclTrainJobName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("TrainJob not created: %v", err)
+	}
+}
+
+func TestApplyNCCLResourcesUnsupportedTemplate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	config := &gpuConfiguration{
+		WorkerCount:     2,
+		GPUCountPerNode: 8,
+		TotalGPUCount:   16,
+		Namespace:       "test-ns",
+	}
+
+	ctx := &checks.ValidationContext{
+		Context:   context.Background(),
+		Namespace: "test-ns",
+	}
+
+	// Use a non-existent accelerator/service combo to trigger file-not-found
+	err := applyNCCLResources(ctx, client, config, "nonexistent", "nosvc")
+	if err == nil {
+		t.Error("applyNCCLResources() expected error for missing template, got nil")
+	}
+}
+
+func TestApplyYAMLWithDynamicClientInvalidYAML(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "invalid.yaml")
+	if err := os.WriteFile(yamlPath, []byte("not: valid: yaml: [broken"), 0640); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	err := applyYAMLWithDynamicClient(context.Background(), client, trainJobGVR, "test-ns", yamlPath, nil)
+	if err == nil {
+		t.Error("applyYAMLWithDynamicClient() expected error for invalid YAML, got nil")
+	}
+}
+
+func TestWaitForPodByLabelSelectorTimeout(t *testing.T) {
+	//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+	clientset := fake.NewSimpleClientset()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := waitForPodByLabelSelector(ctx, clientset, "test-ns", "app=nonexistent", 100*time.Millisecond)
+	if err == nil {
+		t.Error("waitForPodByLabelSelector() expected timeout error, got nil")
+	}
+}
+
+func TestConstants(t *testing.T) {
+	if ncclTrainJobName == "" {
+		t.Error("ncclTrainJobName is empty")
+	}
+	if ncclTrainingRuntimeName == "" {
+		t.Error("ncclTrainingRuntimeName is empty")
+	}
+	if trainJobGVR.Resource == "" {
+		t.Error("trainJobGVR.Resource is empty")
+	}
+	if trainingRuntimeGVR.Resource == "" {
+		t.Error("trainingRuntimeGVR.Resource is empty")
+	}
+	if trainJobGVR.Group != "trainer.kubeflow.org" {
+		t.Errorf("trainJobGVR.Group = %v, want trainer.kubeflow.org", trainJobGVR.Group)
+	}
+	if trainingRuntimeGVR.Group != "trainer.kubeflow.org" {
+		t.Errorf("trainingRuntimeGVR.Group = %v, want trainer.kubeflow.org", trainingRuntimeGVR.Group)
 	}
 }

--- a/pkg/validator/checks/performance/testdata/h100/eks/runtime.yaml
+++ b/pkg/validator/checks/performance/testdata/h100/eks/runtime.yaml
@@ -1,0 +1,197 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: nccl-all-reduce-runtime
+  namespace: ${NAMESPACE}
+  labels:
+    trainer.kubeflow.org/framework: mpi
+spec:
+  mlPolicy:
+    mpi:
+      mpiImplementation: OpenMPI
+      numProcPerNode: ${GPU_COUNT_PER_NODE}
+      runLauncherAsNode: false
+      # Mount the SSH secret to /tmp/mpi-keys (not /root/.ssh) so that init containers
+      # can copy the private key to /root/.ssh with chmod 600. Kubernetes secret volumes
+      # default to 0644, and SSH refuses to use a private key with permissions > 0600.
+      sshAuthMountPath: /tmp/mpi-keys
+  template:
+    spec:
+      network:
+        # Required: JobSet sets spec.subdomain on pods and creates the headless service
+        # that makes pod FQDNs (e.g. nccl-all-reduce-tj-node-0-0.nccl-all-reduce-tj) resolvable.
+        enableDNSHostnames: true
+        # Required: publish DNS records for pods not yet Ready so mpirun can resolve
+        # workers before they finish initialization.
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - name: launcher
+        replicas: 1
+        template:
+          spec:
+            template:
+              spec:
+                initContainers:
+                # Fix SSH key permissions: the MPI plugin mounts the secret at /tmp/mpi-keys
+                # with default 0644 permissions. SSH refuses to use id_rsa with > 0600.
+                # This init container copies the key to a writable emptyDir (/root/.ssh)
+                # with correct permissions before mpirun starts.
+                - name: fix-ssh-perms
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/id_rsa /root/.ssh/id_rsa
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys
+                  volumeMounts:
+                  # mpi-ssh-auth is injected by the MPI plugin into the pod volumes list
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                # Container must be named "node" — the MPI plugin only processes containers
+                # with this name (constants.Node) to inject: SSH auth mount, hostfile mount,
+                # and OpenMPI env vars (OMPI_MCA_orte_default_hostfile, OMPI_MCA_plm_rsh_args,
+                # OMPI_MCA_orte_default_slots, OMPI_MCA_orte_keep_fqdn_hostnames).
+                - name: node
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  env:
+                  # /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu is where libnccl-net.so
+                  # (the aws-ofi-nccl EFA plugin) is installed in the hpc-cloud/nccl-tests image.
+                  # mpirun propagates this path to workers via -x LD_LIBRARY_PATH below.
+                  - name: LD_LIBRARY_PATH
+                    value: "/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/usr/local/nvidia/lib"
+                  - name: PATH
+                    value: "$PATH:/opt/amazon/efa/bin:/usr/bin"
+                  command:
+                  - /opt/amazon/openmpi/bin/mpirun
+                  - -np
+                  - "${GPU_COUNT}"
+                  - --allow-run-as-root
+                  - -bind-to
+                  - none
+                  - --mca
+                  - plm_rsh_agent
+                  - ssh
+                  # Override plm_rsh_args to suppress host-key checking (known_hosts is empty
+                  # on fresh pods) and include retry count so mpirun waits for worker sshd.
+                  - --mca
+                  - plm_rsh_args
+                  - -o StrictHostKeyChecking=no -o ConnectionAttempts=10
+                  - -x
+                  - LD_LIBRARY_PATH
+                  - -x
+                  - PATH
+                  - -x
+                  - NCCL_DEBUG=INFO
+                  - -x
+                  - FI_PROVIDER=efa
+                  - -x
+                  - FI_EFA_USE_DEVICE_RDMA=1
+                  - -x
+                  - FI_EFA_FORK_SAFE=1
+                  - -x
+                  - NCCL_SOCKET_IFNAME=eth0
+                  - -x
+                  - NCCL_IGNORE_DISABLED_P2P=1
+                  - /opt/nccl-tests/build/${TEST_TYPE}
+                  - -b
+                  - ${MIN_MESSAGE_SIZE}
+                  - -e
+                  - ${MAX_MESSAGE_SIZE}
+                  - -f
+                  - "2"
+                  - -g
+                  - "1"
+                  resources:
+                    limits:
+                      cpu: "2"
+                      memory: 128Mi
+                  volumeMounts:
+                  # ssh-config emptyDir holds the chmod-fixed keys from the init container.
+                  # The plugin will also mount mpi-ssh-auth at /tmp/mpi-keys on this container.
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+      # This replicatedJob must be named "node" — the MPI plugin identifies the training
+      # workers by constants.Node ("node") to override replicas from TrainJob.spec.trainer.numNodes
+      # and to mount SSH auth credentials so the launcher can SSH in.
+      - name: node
+        template:
+          spec:
+            template:
+              spec:
+                nodeSelector:
+                  node.kubernetes.io/instance-type: p5.48xlarge
+                initContainers:
+                # Fix authorized_keys permissions so sshd accepts incoming connections.
+                # The MPI plugin mounts the secret at /tmp/mpi-keys with 0644; sshd
+                # with StrictModes requires authorized_keys to not be group/world writable,
+                # and requires the .ssh directory to be 0700.
+                - name: fix-ssh-perms
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/authorized_keys
+                  volumeMounts:
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                # Container must be named "node" for the MPI plugin to mount SSH auth volume.
+                - name: node
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  # Run sshd in foreground so the launcher can SSH in and run the NCCL test.
+                  command: ["/usr/sbin/sshd", "-De"]
+                  resources:
+                    limits:
+                      nvidia.com/gpu: "8"
+                      vpc.amazonaws.com/efa: "32"
+                    requests:
+                      nvidia.com/gpu: "8"
+                      vpc.amazonaws.com/efa: "32"
+                  securityContext:
+                    capabilities:
+                      add: ["IPC_LOCK"]
+                  volumeMounts:
+                  # ssh-config holds the chmod-fixed authorized_keys from the init container.
+                  # The plugin will also mount mpi-ssh-auth at /tmp/mpi-keys on this container.
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                  - name: dshm
+                    mountPath: /dev/shm
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+                - name: dshm
+                  emptyDir:
+                    medium: Memory

--- a/pkg/validator/checks/performance/testdata/h100/eks/trainjob.yaml
+++ b/pkg/validator/checks/performance/testdata/h100/eks/trainjob.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: nccl-all-reduce-tj
+  namespace: ${NAMESPACE}
+spec:
+  runtimeRef:
+    name: nccl-all-reduce-runtime
+    apiGroup: trainer.kubeflow.org
+    kind: TrainingRuntime
+
+  # High-level abstraction: The operator injects these into the Runtime
+  trainer:
+    # Override node replica count (maps to replicatedJobs[node].replicas in the JobSet)
+    numNodes: ${WORKER_COUNT}
+        

--- a/pkg/validator/checks/performance/testdata/h100/eks/trainjob.yaml
+++ b/pkg/validator/checks/performance/testdata/h100/eks/trainjob.yaml
@@ -27,4 +27,3 @@ spec:
   trainer:
     # Override node replica count (maps to replicatedJobs[node].replicas in the JobSet)
     numNodes: ${WORKER_COUNT}
-        

--- a/pkg/validator/checks/performance/trainer_lifecycle.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle.go
@@ -346,9 +346,12 @@ func extractTarGz(r io.Reader, targetDir string) error {
 				return fmt.Errorf("failed to create file %s: %w", path, err)
 			}
 			_, copyErr := io.Copy(f, io.LimitReader(tr, maxExtractedFileSize))
-			f.Close()
+			closeErr := f.Close()
 			if copyErr != nil {
 				return fmt.Errorf("failed to write file %s: %w", path, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("failed to close file %s: %w", path, closeErr)
 			}
 		}
 	}

--- a/pkg/validator/checks/performance/trainer_lifecycle.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle.go
@@ -280,8 +280,8 @@ func downloadAndExtractGitHubArchive(ctx context.Context, archiveURL string) (st
 	}
 
 	// Use a bounded HTTP client — http.DefaultClient has no timeout.
-	client := &http.Client{Timeout: defaults.NCCLTrainerArchiveDownloadTimeout} //nolint:gosec // archiveURL is a compile-time constant, not user input
-	resp, err := client.Do(req)
+	client := &http.Client{Timeout: defaults.NCCLTrainerArchiveDownloadTimeout}
+	resp, err := client.Do(req) //nolint:gosec // archiveURL is a compile-time constant, not user input
 	if err != nil {
 		return "", nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to download archive from %s", archiveURL), err)
 	}

--- a/pkg/validator/checks/performance/trainer_lifecycle.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle.go
@@ -1,0 +1,366 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// trainerArchiveURL is the GitHub tar.gz archive for Kubeflow Trainer v2.1.0.
+	trainerArchiveURL = "https://github.com/kubeflow/trainer/archive/refs/tags/v2.1.0.tar.gz"
+
+	// trainerKustomizePath is the path within the extracted archive to the manager overlay.
+	trainerKustomizePath = "manifests/overlays/manager"
+
+	// trainerCRDName is the CRD that signals the Trainer operator is installed.
+	trainerCRDName = "trainjobs.trainer.kubeflow.org"
+
+	// maxExtractedFileSize caps individual file sizes during tar extraction (50 MB).
+	maxExtractedFileSize = 50 * 1024 * 1024
+)
+
+// trainerResourceRef identifies a Kubernetes resource applied during Trainer installation,
+// so it can be deleted during cleanup.
+type trainerResourceRef struct {
+	GVR       schema.GroupVersionResource
+	Namespace string
+	Name      string
+}
+
+// isTrainerInstalled returns true when the Kubeflow Trainer CRD is present in the cluster.
+func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (bool, error) {
+	crdGVR := schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+	_, err := dynamicClient.Resource(crdGVR).Get(ctx, trainerCRDName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check for Kubeflow Trainer CRD", err)
+	}
+	return true, nil
+}
+
+// installTrainer downloads the Kubeflow Trainer v2.1.0 archive from GitHub, builds the
+// kustomize manager overlay entirely in Go (no CLI), and applies every resource to the
+// cluster via the dynamic client.  It returns the list of resources it created so the
+// caller can defer deleteTrainer for cleanup.
+func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discoveryClient discovery.DiscoveryInterface) ([]trainerResourceRef, error) {
+	slog.Info("Downloading Kubeflow Trainer archive", "url", trainerArchiveURL)
+
+	extractedDir, cleanup, err := downloadAndExtractGitHubArchive(ctx, trainerArchiveURL)
+	if err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to download Trainer archive", err)
+	}
+	defer cleanup()
+
+	kustomizePath := filepath.Join(extractedDir, trainerKustomizePath)
+	slog.Info("Building Trainer kustomize manifests", "path", kustomizePath)
+
+	// LoadRestrictionsNone lets krusty follow the ../../base references in the overlay.
+	opts := krusty.MakeDefaultOptions()
+	opts.LoadRestrictions = types.LoadRestrictionsNone
+
+	k := krusty.MakeKustomizer(opts)
+	fSys := filesys.MakeFsOnDisk()
+
+	resMap, err := k.Run(fSys, kustomizePath)
+	if err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to build Trainer manifests", err)
+	}
+
+	// Build a REST mapper from live discovery so we can resolve GVK → GVR for each resource.
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
+
+	applied := make([]trainerResourceRef, 0, len(resMap.Resources()))
+	for _, res := range resMap.Resources() {
+		// Convert to unstructured via YAML round-trip (guarantees plain Go types).
+		yamlBytes, err := res.AsYAML()
+		if err != nil {
+			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to marshal Trainer resource to YAML", err)
+		}
+
+		obj := &unstructured.Unstructured{}
+		if unmarshalErr := yaml.Unmarshal(yamlBytes, obj); unmarshalErr != nil {
+			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse Trainer resource YAML", unmarshalErr)
+		}
+
+		gvk := obj.GroupVersionKind()
+		if gvk.Kind == "" {
+			continue
+		}
+
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+				fmt.Sprintf("failed to resolve REST mapping for %s", gvk), err)
+		}
+
+		ref := trainerResourceRef{GVR: mapping.Resource, Name: obj.GetName()}
+
+		applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+		if mapping.Scope.Name() == apimeta.RESTScopeNameNamespace {
+			ref.Namespace = obj.GetNamespace()
+			_, err = dynamicClient.Resource(mapping.Resource).Namespace(ref.Namespace).Create(applyCtx, obj, metav1.CreateOptions{})
+		} else {
+			_, err = dynamicClient.Resource(mapping.Resource).Create(applyCtx, obj, metav1.CreateOptions{})
+		}
+		cancel()
+
+		if err != nil {
+			if k8serrors.IsAlreadyExists(err) {
+				slog.Info("Trainer resource already exists, skipping", "kind", gvk.Kind, "name", obj.GetName())
+				continue
+			}
+			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+				fmt.Sprintf("failed to create %s %q", gvk.Kind, obj.GetName()), err)
+		}
+
+		applied = append(applied, ref)
+		slog.Info("Applied Trainer resource", "kind", gvk.Kind, "name", obj.GetName(), "namespace", ref.Namespace)
+	}
+
+	// Wait for the CRDs the NCCL test needs before returning.
+	if err := waitForTrainerCRDsEstablished(ctx, dynamicClient); err != nil {
+		return applied, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "Trainer CRDs not ready after install", err)
+	}
+
+	return applied, nil
+}
+
+// deleteTrainer removes every resource that was created by installTrainer, in reverse
+// application order so dependents are deleted before their owners.
+// Uses context.Background() because the parent context may already be canceled at
+// defer time; cleanup must still complete.
+func deleteTrainer(dynamicClient dynamic.Interface, resources []trainerResourceRef) {
+	slog.Info("Deleting installed Kubeflow Trainer resources", "count", len(resources))
+	for i := len(resources) - 1; i >= 0; i-- {
+		ref := resources[i]
+		deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
+
+		var err error
+		if ref.Namespace != "" {
+			err = dynamicClient.Resource(ref.GVR).Namespace(ref.Namespace).Delete(deleteCtx, ref.Name, metav1.DeleteOptions{})
+		} else {
+			err = dynamicClient.Resource(ref.GVR).Delete(deleteCtx, ref.Name, metav1.DeleteOptions{})
+		}
+		cancel()
+
+		if err != nil && !k8serrors.IsNotFound(err) {
+			slog.Error("Failed to delete Trainer resource", "gvr", ref.GVR.Resource, "name", ref.Name, "error", err)
+		} else {
+			slog.Info("Deleted Trainer resource", "gvr", ref.GVR.Resource, "name", ref.Name)
+		}
+	}
+}
+
+// waitForTrainerCRDsEstablished waits for the two CRDs that the NCCL test requires
+// to reach the Established condition after Trainer installation.
+func waitForTrainerCRDsEstablished(ctx context.Context, dynamicClient dynamic.Interface) error {
+	crds := []string{
+		"trainjobs.trainer.kubeflow.org",
+		"trainingruntimes.trainer.kubeflow.org",
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, defaults.TrainerCRDEstablishedTimeout)
+	defer cancel()
+
+	for _, crd := range crds {
+		slog.Info("Waiting for Trainer CRD to be established", "crd", crd)
+		if err := waitForCRDEstablished(waitCtx, dynamicClient, crd); err != nil {
+			return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, fmt.Sprintf("CRD %s not established", crd), err)
+		}
+	}
+	return nil
+}
+
+// waitForCRDEstablished watches a CRD until its Established condition is True.
+// It checks the current state first so the fast path (already established) returns
+// immediately without starting a watch.
+func waitForCRDEstablished(ctx context.Context, dynamicClient dynamic.Interface, crdName string) error {
+	crdGVR := schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+
+	existing, err := dynamicClient.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
+	if err == nil && isCRDEstablished(existing) {
+		return nil
+	}
+
+	watcher, err := dynamicClient.Resource(crdGVR).Watch(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + crdName,
+	})
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to watch CRD", err)
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "timed out waiting for CRD to be established", ctx.Err())
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return aicrErrors.New(aicrErrors.ErrCodeInternal, "CRD watch channel closed unexpectedly")
+			}
+			obj, ok := event.Object.(*unstructured.Unstructured)
+			if !ok {
+				continue
+			}
+			if isCRDEstablished(obj) {
+				slog.Info("CRD established", "crd", crdName)
+				return nil
+			}
+		}
+	}
+}
+
+// isCRDEstablished returns true when the CRD's status contains an Established condition
+// with status "True".
+func isCRDEstablished(obj *unstructured.Unstructured) bool {
+	conditions, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, c := range conditions {
+		condition, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if condition["type"] == "Established" && condition["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+// downloadAndExtractGitHubArchive fetches a GitHub tar.gz release archive over HTTP and
+// extracts it to a temp directory.  Returns the path to the top-level directory inside
+// the archive and a cleanup function to remove the temp dir.
+func downloadAndExtractGitHubArchive(ctx context.Context, archiveURL string) (string, func(), error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // archiveURL is a compile-time constant, not user input
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to download archive from %s: %w", archiveURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", nil, fmt.Errorf("unexpected HTTP %d downloading %s", resp.StatusCode, archiveURL)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "aicr-trainer-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+
+	if extractErr := extractTarGz(resp.Body, tmpDir); extractErr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to extract archive: %w", extractErr)
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil || len(entries) == 0 {
+		cleanup()
+		return "", nil, fmt.Errorf("extracted archive is empty or unreadable")
+	}
+
+	return filepath.Join(tmpDir, entries[0].Name()), cleanup, nil
+}
+
+// extractTarGz decompresses and extracts a gzipped tar stream into targetDir.
+func extractTarGz(r io.Reader, targetDir string) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read error: %w", err)
+		}
+
+		path, err := sanitizeTarPath(targetDir, header.Name)
+		if err != nil {
+			return err
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(path, 0750); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", path, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+				return fmt.Errorf("failed to create parent dir for %s: %w", path, err)
+			}
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
+			if err != nil {
+				return fmt.Errorf("failed to create file %s: %w", path, err)
+			}
+			_, copyErr := io.Copy(f, io.LimitReader(tr, maxExtractedFileSize))
+			f.Close()
+			if copyErr != nil {
+				return fmt.Errorf("failed to write file %s: %w", path, copyErr)
+			}
+		}
+	}
+	return nil
+}
+
+// sanitizeTarPath validates a tar entry path against the target directory to prevent
+// path traversal attacks.
+func sanitizeTarPath(targetDir, entryPath string) (string, error) {
+	cleanPath := filepath.Join(targetDir, filepath.FromSlash(entryPath))
+	if !strings.HasPrefix(cleanPath, filepath.Clean(targetDir)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid tar entry %q: potential path traversal", entryPath)
+	}
+	return cleanPath, nil
+}

--- a/pkg/validator/checks/performance/trainer_lifecycle.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle.go
@@ -276,34 +276,36 @@ func isCRDEstablished(obj *unstructured.Unstructured) bool {
 func downloadAndExtractGitHubArchive(ctx context.Context, archiveURL string) (string, func(), error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to build request: %w", err)
+		return "", nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to build request", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // archiveURL is a compile-time constant, not user input
+	// Use a bounded HTTP client — http.DefaultClient has no timeout.
+	client := &http.Client{Timeout: defaults.NCCLTrainerArchiveDownloadTimeout} //nolint:gosec // archiveURL is a compile-time constant, not user input
+	resp, err := client.Do(req)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to download archive from %s: %w", archiveURL, err)
+		return "", nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to download archive from %s", archiveURL), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("unexpected HTTP %d downloading %s", resp.StatusCode, archiveURL)
+		return "", nil, aicrErrors.New(aicrErrors.ErrCodeInternal, fmt.Sprintf("unexpected HTTP %d downloading %s", resp.StatusCode, archiveURL))
 	}
 
 	tmpDir, err := os.MkdirTemp("", "aicr-trainer-*")
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+		return "", nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create temp dir", err)
 	}
 	cleanup := func() { os.RemoveAll(tmpDir) }
 
 	if extractErr := extractTarGz(resp.Body, tmpDir); extractErr != nil {
 		cleanup()
-		return "", nil, fmt.Errorf("failed to extract archive: %w", extractErr)
+		return "", nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to extract archive", extractErr)
 	}
 
 	entries, err := os.ReadDir(tmpDir)
 	if err != nil || len(entries) == 0 {
 		cleanup()
-		return "", nil, fmt.Errorf("extracted archive is empty or unreadable")
+		return "", nil, aicrErrors.New(aicrErrors.ErrCodeInternal, "extracted archive is empty or unreadable")
 	}
 
 	return filepath.Join(tmpDir, entries[0].Name()), cleanup, nil
@@ -313,7 +315,7 @@ func downloadAndExtractGitHubArchive(ctx context.Context, archiveURL string) (st
 func extractTarGz(r io.Reader, targetDir string) error {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
-		return fmt.Errorf("failed to create gzip reader: %w", err)
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create gzip reader", err)
 	}
 	defer gzr.Close()
 
@@ -324,7 +326,7 @@ func extractTarGz(r io.Reader, targetDir string) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("tar read error: %w", err)
+			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "tar read error", err)
 		}
 
 		path, err := sanitizeTarPath(targetDir, header.Name)
@@ -335,23 +337,23 @@ func extractTarGz(r io.Reader, targetDir string) error {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(path, 0750); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", path, err)
+				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to create directory %s", path), err)
 			}
 		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
-				return fmt.Errorf("failed to create parent dir for %s: %w", path, err)
+				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to create parent dir for %s", path), err)
 			}
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
 			if err != nil {
-				return fmt.Errorf("failed to create file %s: %w", path, err)
+				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to create file %s", path), err)
 			}
 			_, copyErr := io.Copy(f, io.LimitReader(tr, maxExtractedFileSize))
 			closeErr := f.Close()
 			if copyErr != nil {
-				return fmt.Errorf("failed to write file %s: %w", path, copyErr)
+				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to write file %s", path), copyErr)
 			}
 			if closeErr != nil {
-				return fmt.Errorf("failed to close file %s: %w", path, closeErr)
+				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to close file %s", path), closeErr)
 			}
 		}
 	}
@@ -363,7 +365,7 @@ func extractTarGz(r io.Reader, targetDir string) error {
 func sanitizeTarPath(targetDir, entryPath string) (string, error) {
 	cleanPath := filepath.Join(targetDir, filepath.FromSlash(entryPath))
 	if !strings.HasPrefix(cleanPath, filepath.Clean(targetDir)+string(os.PathSeparator)) {
-		return "", fmt.Errorf("invalid tar entry %q: potential path traversal", entryPath)
+		return "", aicrErrors.New(aicrErrors.ErrCodeInvalidRequest, fmt.Sprintf("invalid tar entry %q: potential path traversal", entryPath))
 	}
 	return cleanPath, nil
 }

--- a/pkg/validator/checks/performance/trainer_lifecycle.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle.go
@@ -149,7 +149,19 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 
 		if err != nil {
 			if k8serrors.IsAlreadyExists(err) {
-				slog.Info("Trainer resource already exists, skipping", "kind", gvk.Kind, "name", obj.GetName())
+				// Update: enforce current resource state even when left from a prior partial install.
+				updateCtx, updateCancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+				if mapping.Scope.Name() == apimeta.RESTScopeNameNamespace {
+					_, err = dynamicClient.Resource(mapping.Resource).Namespace(ref.Namespace).Update(updateCtx, obj, metav1.UpdateOptions{})
+				} else {
+					_, err = dynamicClient.Resource(mapping.Resource).Update(updateCtx, obj, metav1.UpdateOptions{})
+				}
+				updateCancel()
+				if err != nil {
+					slog.Warn("Failed to update existing Trainer resource, continuing", "kind", gvk.Kind, "name", obj.GetName(), "error", err)
+				} else {
+					slog.Info("Updated existing Trainer resource", "kind", gvk.Kind, "name", obj.GetName())
+				}
 				continue
 			}
 			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
@@ -336,14 +348,14 @@ func extractTarGz(r io.Reader, targetDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(path, 0750); err != nil {
+			if err := os.MkdirAll(path, 0750); err != nil { //nolint:gosec // G703 -- path sanitized by sanitizeTarPath above
 				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to create directory %s", path), err)
 			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+			if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil { //nolint:gosec // G703 -- path sanitized by sanitizeTarPath above
 				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to create parent dir for %s", path), err)
 			}
-			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640) //nolint:gosec // G703 -- path sanitized by sanitizeTarPath above
 			if err != nil {
 				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, fmt.Sprintf("failed to create file %s", path), err)
 			}

--- a/pkg/validator/checks/performance/trainer_lifecycle_test.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle_test.go
@@ -1,0 +1,462 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestSanitizeTarPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		targetDir string
+		entryPath string
+		wantErr   bool
+	}{
+		{
+			name:      "valid path inside target",
+			targetDir: tmpDir,
+			entryPath: "trainer-2.1.0/manifests/base/kustomization.yaml",
+			wantErr:   false,
+		},
+		{
+			name:      "path traversal attempt",
+			targetDir: tmpDir,
+			entryPath: "../../../etc/passwd",
+			wantErr:   true,
+		},
+		{
+			name:      "path with double dots in middle",
+			targetDir: tmpDir,
+			entryPath: "foo/../../etc/passwd",
+			wantErr:   true,
+		},
+		{
+			name:      "simple filename",
+			targetDir: tmpDir,
+			entryPath: "README.md",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeTarPath(tt.targetDir, tt.entryPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sanitizeTarPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == "" {
+					t.Error("sanitizeTarPath() returned empty path for valid input")
+				}
+				// Verify the returned path is under targetDir
+				rel, err := filepath.Rel(tt.targetDir, got)
+				if err != nil || rel == ".." || rel[:3] == "../" {
+					t.Errorf("sanitizeTarPath() returned path outside target: %v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestIsCRDEstablished(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *unstructured.Unstructured
+		want bool
+	}{
+		{
+			name: "CRD with Established=True",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "Established",
+								"status": "True",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "CRD with Established=False",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "Established",
+								"status": "False",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "CRD without Established condition",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "NamesAccepted",
+								"status": "True",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "CRD with no status",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			want: false,
+		},
+		{
+			name: "CRD with empty conditions",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"conditions": []interface{}{},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isCRDEstablished(tt.obj)
+			if got != tt.want {
+				t.Errorf("isCRDEstablished() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrainerConstants(t *testing.T) {
+	if trainerArchiveURL == "" {
+		t.Error("trainerArchiveURL is empty")
+	}
+	if trainerKustomizePath == "" {
+		t.Error("trainerKustomizePath is empty")
+	}
+	if trainerCRDName == "" {
+		t.Error("trainerCRDName is empty")
+	}
+	if maxExtractedFileSize <= 0 {
+		t.Errorf("maxExtractedFileSize = %d, want > 0", maxExtractedFileSize)
+	}
+}
+
+func TestIsTrainerInstalled(t *testing.T) {
+	crdGVR := schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "trainer CRD exists",
+			objects: []runtime.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "apiextensions.k8s.io/v1",
+						"kind":       "CustomResourceDefinition",
+						"metadata": map[string]interface{}{
+							"name": trainerCRDName,
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "trainer CRD not found",
+			objects: []runtime.Object{},
+			want:    false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+				map[schema.GroupVersionResource]string{
+					crdGVR: "CustomResourceDefinitionList",
+				},
+				tt.objects...)
+
+			got, err := isTrainerInstalled(context.Background(), client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isTrainerInstalled() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isTrainerInstalled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteTrainer(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group: "", Version: "v1", Resource: "configmaps",
+	}
+
+	scheme := runtime.NewScheme()
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "test-ns",
+			},
+		},
+	}
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			gvr: "ConfigMapList",
+		},
+		obj)
+
+	refs := []trainerResourceRef{
+		{GVR: gvr, Namespace: "test-ns", Name: "test-cm"},
+	}
+
+	// Verify resource exists
+	_, err := client.Resource(gvr).Namespace("test-ns").Get(context.Background(), "test-cm", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Resource should exist before delete: %v", err)
+	}
+
+	deleteTrainer(client, refs)
+
+	// Verify resource is deleted
+	_, err = client.Resource(gvr).Namespace("test-ns").Get(context.Background(), "test-cm", metav1.GetOptions{})
+	if err == nil {
+		t.Error("Resource should be deleted after deleteTrainer")
+	}
+}
+
+func TestDeleteTrainerClusterScoped(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles",
+	}
+
+	scheme := runtime.NewScheme()
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": "test-role",
+			},
+		},
+	}
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			gvr: "ClusterRoleList",
+		},
+		obj)
+
+	refs := []trainerResourceRef{
+		{GVR: gvr, Namespace: "", Name: "test-role"},
+	}
+
+	deleteTrainer(client, refs)
+
+	_, err := client.Resource(gvr).Get(context.Background(), "test-role", metav1.GetOptions{})
+	if err == nil {
+		t.Error("Cluster-scoped resource should be deleted")
+	}
+}
+
+func TestDeleteTrainerEmpty(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	// Should not panic with empty slice
+	deleteTrainer(client, nil)
+	deleteTrainer(client, []trainerResourceRef{})
+}
+
+func TestCleanupNCCLResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	tj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "trainer.kubeflow.org/v1alpha1",
+			"kind":       "TrainJob",
+			"metadata": map[string]interface{}{
+				"name":      ncclTrainJobName,
+				"namespace": "test-ns",
+			},
+		},
+	}
+
+	rt := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "trainer.kubeflow.org/v1alpha1",
+			"kind":       "TrainingRuntime",
+			"metadata": map[string]interface{}{
+				"name":      ncclTrainingRuntimeName,
+				"namespace": "test-ns",
+			},
+		},
+	}
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			trainJobGVR:        "TrainJobList",
+			trainingRuntimeGVR: "TrainingRuntimeList",
+		},
+		tj, rt)
+
+	// Should not panic, should delete both resources
+	cleanupNCCLResources(client, "test-ns")
+
+	// Verify both deleted
+	_, err := client.Resource(trainJobGVR).Namespace("test-ns").Get(context.Background(), ncclTrainJobName, metav1.GetOptions{})
+	if err == nil {
+		t.Error("TrainJob should be deleted")
+	}
+	_, err = client.Resource(trainingRuntimeGVR).Namespace("test-ns").Get(context.Background(), ncclTrainingRuntimeName, metav1.GetOptions{})
+	if err == nil {
+		t.Error("TrainingRuntime should be deleted")
+	}
+}
+
+func TestCleanupNCCLResourcesNotFound(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			trainJobGVR:        "TrainJobList",
+			trainingRuntimeGVR: "TrainingRuntimeList",
+		})
+
+	// Should not panic when resources don't exist
+	cleanupNCCLResources(client, "test-ns")
+}
+
+func TestExtractTarGzValid(t *testing.T) {
+	// Create a valid tar.gz in memory
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	// Add a directory
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "test-dir/",
+		Typeflag: tar.TypeDir,
+		Mode:     0750,
+	}); err != nil {
+		t.Fatalf("Failed to write dir header: %v", err)
+	}
+
+	// Add a file
+	content := []byte("hello world")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "test-dir/test.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0640,
+		Size:     int64(len(content)),
+	}); err != nil {
+		t.Fatalf("Failed to write file header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("Failed to write file content: %v", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Failed to close tar writer: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	err := extractTarGz(&buf, tmpDir)
+	if err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+
+	// Verify extracted file
+	extracted, err := os.ReadFile(filepath.Join(tmpDir, "test-dir", "test.txt"))
+	if err != nil {
+		t.Fatalf("Failed to read extracted file: %v", err)
+	}
+	if string(extracted) != "hello world" {
+		t.Errorf("Extracted content = %q, want %q", string(extracted), "hello world")
+	}
+}
+
+func TestExtractTarGzInvalidInput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Test with invalid gzip data
+	invalidGzip := filepath.Join(tmpDir, "bad.tar.gz")
+	if err := os.WriteFile(invalidGzip, []byte("not a gzip file"), 0640); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	f, err := os.Open(filepath.Clean(invalidGzip))
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	defer f.Close()
+
+	err = extractTarGz(f, tmpDir)
+	if err == nil {
+		t.Error("extractTarGz() expected error for invalid gzip data, got nil")
+	}
+}

--- a/pkg/validator/checks/runner.go
+++ b/pkg/validator/checks/runner.go
@@ -25,11 +25,10 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	k8sclient "github.com/NVIDIA/aicr/pkg/k8s/client"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // testingT is a minimal interface that matches the testing.T methods we use.
@@ -197,52 +196,35 @@ func (r *TestRunner) HasCheck(phase, checkName string) bool {
 	return false
 }
 
-// LoadValidationContext loads the validation context from the Job environment.
-// This function is called inside Kubernetes Jobs to reconstruct the context needed for validation.
+// LoadValidationContext loads the validation context for running checks.
+// Works both inside Kubernetes Jobs (in-cluster config) and locally (KUBECONFIG).
 //
-// Context loading process:
-//  1. Creates in-cluster Kubernetes client using rest.InClusterConfig()
-//  2. Loads snapshot from mounted file (auto-detects YAML/JSON format)
-//  3. Parses optional recipe metadata from environment variable
-//  4. Returns fully initialized ValidationContext
+// Kubernetes client discovery: KUBECONFIG env → ~/.kube/config → in-cluster service account.
+// Namespace resolution: service account file → AICR_VALIDATION_NAMESPACE env → "default".
 //
-// Environment variables used:
+// Environment variables:
+//   - KUBECONFIG: Path to kubeconfig file (for local development)
+//   - AICR_VALIDATION_NAMESPACE: Validation namespace (for local development)
 //   - AICR_SNAPSHOT_PATH: Path to snapshot file (default: /data/snapshot/snapshot.yaml)
+//   - AICR_RECIPE_PATH: Path to recipe file (default: /data/recipe/recipe.yaml)
 //   - AICR_RECIPE_DATA: Optional JSON-encoded recipe metadata
-//
-// Mounted volumes expected:
-//   - /data/snapshot/snapshot.yaml: Snapshot ConfigMap
-//   - /data/recipe/recipe.yaml: Recipe ConfigMap (not currently used)
-//
-// Returns error if:
-//   - In-cluster config cannot be created (not running in Kubernetes)
-//   - Kubernetes client creation fails
-//   - Snapshot file cannot be read or parsed
 //
 // IMPORTANT: The caller is responsible for calling the returned cancel function
 // when the validation context is no longer needed.
 func LoadValidationContext() (*ValidationContext, context.CancelFunc, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaults.CheckExecutionTimeout)
 
-	// Create in-cluster Kubernetes client
-	config, err := rest.InClusterConfig()
+	// Create Kubernetes client using the standard fallback chain:
+	// KUBECONFIG env → ~/.kube/config → in-cluster service account.
+	// This allows running checks locally (go test with KUBECONFIG) or in-cluster (Jobs).
+	clientset, config, err := k8sclient.BuildKubeClient("")
 	if err != nil {
 		cancel()
-		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to create in-cluster config", err)
+		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to create kubernetes client", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		cancel()
-		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to create kubernetes clientset", err)
-	}
-
-	// Get the validation namespace
-	namespace, err := getNamespaceFromServiceAccount()
-	if err != nil {
-		cancel()
-		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to get namespace from service account", err)
-	}
+	// Resolve namespace: in-cluster service account file → AICR_VALIDATION_NAMESPACE env → "default".
+	namespace := resolveNamespace()
 
 	// Load snapshot from mounted file using serializer (auto-detects YAML/JSON format)
 	snapshotPath := os.Getenv("AICR_SNAPSHOT_PATH")
@@ -291,11 +273,18 @@ func LoadValidationContext() (*ValidationContext, context.CancelFunc, error) {
 	}, cancel, nil
 }
 
-// getNamespaceFromServiceAccount gets the namespace from the service account
-func getNamespaceFromServiceAccount() (string, error) {
-	namespaceBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to read namespace from service account", err)
+// resolveNamespace returns the validation namespace using a fallback chain:
+//  1. In-cluster service account file (when running as a Kubernetes Pod)
+//  2. AICR_VALIDATION_NAMESPACE environment variable (for local development)
+//  3. "default" as a last resort
+func resolveNamespace() string {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			return ns
+		}
 	}
-	return strings.TrimSpace(string(namespaceBytes)), nil
+	if ns := os.Getenv("AICR_VALIDATION_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return "default"
 }

--- a/pkg/validator/checks/runner_test.go
+++ b/pkg/validator/checks/runner_test.go
@@ -42,23 +42,21 @@ func mockCheckFailure(ctx *ValidationContext) error {
 	return testCheckError
 }
 
-func TestNewTestRunner_FailsOutsideKubernetes(t *testing.T) {
-	// This test verifies that NewTestRunner fails gracefully when not in Kubernetes
-	// (which is the expected behavior during local testing)
+func TestNewTestRunner_FailsWithoutSnapshot(t *testing.T) {
+	// This test verifies that NewTestRunner fails gracefully when snapshot is missing
+	// (which is the expected behavior during local testing without env setup)
 
 	runner, err := NewTestRunner(t)
 
 	if err == nil {
-		t.Error("NewTestRunner() should fail when not in Kubernetes cluster")
+		if runner != nil {
+			defer runner.Cancel()
+		}
+		t.Skip("NewTestRunner() succeeded — likely running with KUBECONFIG and snapshot available")
 	}
 
 	if runner != nil {
 		t.Error("NewTestRunner() should return nil runner on error")
-	}
-
-	// Error should mention in-cluster config
-	if err != nil && !strings.Contains(err.Error(), "in-cluster") {
-		t.Errorf("Error should mention in-cluster config, got: %v", err)
 	}
 }
 
@@ -241,25 +239,26 @@ measurements:
 
 	os.Setenv("AICR_SNAPSHOT_PATH", snapshotPath)
 
-	// Attempt to load context
-	// This will still fail on in-cluster config, but we can verify it tries to load the snapshot
+	// Attempt to load context — succeeds if KUBECONFIG is available, fails otherwise
 	ctx, cancel, err := LoadValidationContext()
 	if cancel != nil {
 		defer cancel()
 	}
 
-	// Should fail on in-cluster config (not on snapshot loading)
-	if err == nil {
-		t.Error("LoadValidationContext should fail when not in Kubernetes")
+	if err != nil {
+		// If it failed, it should NOT be about the snapshot file (we provided a valid one)
+		if strings.Contains(err.Error(), "no such file") && strings.Contains(err.Error(), "snapshot") {
+			t.Errorf("Should not fail on snapshot file, got: %v", err)
+		}
+		return
 	}
 
-	// Error should be about in-cluster config, not snapshot file
-	if err != nil && strings.Contains(err.Error(), "no such file") {
-		t.Errorf("Should fail on in-cluster config, not snapshot file, got: %v", err)
+	// If it succeeded (KUBECONFIG available), verify context is populated
+	if ctx == nil {
+		t.Error("LoadValidationContext should return non-nil context on success")
 	}
-
-	if ctx != nil {
-		t.Error("LoadValidationContext should return nil context on error")
+	if ctx != nil && ctx.Snapshot == nil {
+		t.Error("LoadValidationContext should populate snapshot")
 	}
 }
 
@@ -276,23 +275,18 @@ func TestLoadValidationContext_DefaultSnapshotPath(t *testing.T) {
 
 	os.Unsetenv("AICR_SNAPSHOT_PATH")
 
-	// Should use default path /data/snapshot/snapshot.yaml
+	// Should fail because /data/snapshot/snapshot.yaml doesn't exist locally
 	ctx, cancel, err := LoadValidationContext()
 	if cancel != nil {
 		defer cancel()
 	}
 
 	if err == nil {
-		t.Error("LoadValidationContext should fail when not in Kubernetes")
+		t.Skip("LoadValidationContext succeeded — default snapshot path exists")
 	}
 
 	if ctx != nil {
 		t.Error("LoadValidationContext should return nil context on error")
-	}
-
-	// Error should be about in-cluster config or default snapshot path
-	if err != nil && !strings.Contains(err.Error(), "in-cluster") && !strings.Contains(err.Error(), "/data/snapshot") {
-		t.Logf("Error: %v", err)
 	}
 }
 
@@ -310,31 +304,53 @@ func TestLoadValidationContext_WithRecipeData(t *testing.T) {
 	recipeJSON := `{"key":"value","number":42}`
 	os.Setenv("AICR_RECIPE_DATA", recipeJSON)
 
-	// Will fail on in-cluster config, but that's expected
-	// This test verifies the recipe data parsing logic
+	// Will fail on snapshot (not available locally), but that's expected.
+	// This test verifies that recipe data parsing itself doesn't cause the error.
 	ctx, cancel, err := LoadValidationContext()
 	if cancel != nil {
 		defer cancel()
 	}
 
 	if err == nil {
-		t.Error("LoadValidationContext should fail when not in Kubernetes")
+		if ctx != nil {
+			t.Log("LoadValidationContext succeeded with recipe data")
+		}
+		return
 	}
 
-	if ctx != nil {
-		t.Error("LoadValidationContext should return nil context on error")
-	}
-
-	// The error should be about in-cluster config, not recipe parsing
-	if err != nil && strings.Contains(err.Error(), "recipe") && strings.Contains(err.Error(), "unmarshal") {
+	// The error should NOT be about recipe parsing
+	if strings.Contains(err.Error(), "recipe") && strings.Contains(err.Error(), "unmarshal") {
 		t.Errorf("Recipe data parsing failed, got: %v", err)
 	}
 }
 
 func TestLoadValidationContext_InvalidRecipeData(t *testing.T) {
-	// Set invalid recipe data
+	// Set invalid recipe data and a valid snapshot so parsing reaches the recipe step
+	tmpDir := t.TempDir()
+	snapshotPath := filepath.Join(tmpDir, "snapshot.yaml")
+	snapshotYAML := `apiVersion: aicr.nvidia.com/v1alpha1
+kind: Snapshot
+metadata:
+  version: test
+measurements:
+  - type: OS
+    subtypes:
+      - name: release
+        data:
+          ID: ubuntu
+`
+	if err := os.WriteFile(snapshotPath, []byte(snapshotYAML), 0644); err != nil {
+		t.Fatalf("Failed to create test snapshot file: %v", err)
+	}
+
+	originalSnapshot := os.Getenv("AICR_SNAPSHOT_PATH")
 	originalRecipe := os.Getenv("AICR_RECIPE_DATA")
 	defer func() {
+		if originalSnapshot != "" {
+			os.Setenv("AICR_SNAPSHOT_PATH", originalSnapshot)
+		} else {
+			os.Unsetenv("AICR_SNAPSHOT_PATH")
+		}
 		if originalRecipe != "" {
 			os.Setenv("AICR_RECIPE_DATA", originalRecipe)
 		} else {
@@ -342,14 +358,15 @@ func TestLoadValidationContext_InvalidRecipeData(t *testing.T) {
 		}
 	}()
 
+	os.Setenv("AICR_SNAPSHOT_PATH", snapshotPath)
 	os.Setenv("AICR_RECIPE_DATA", "invalid json{")
 
-	// Will fail on in-cluster config first, but we're testing recipe parsing
 	ctx, cancel, err := LoadValidationContext()
 	if cancel != nil {
 		defer cancel()
 	}
 
+	// May fail on K8s client (no KUBECONFIG) before reaching recipe parsing
 	if err == nil {
 		t.Error("LoadValidationContext should fail with invalid recipe JSON")
 	}

--- a/pkg/validator/checks/runner_test.go
+++ b/pkg/validator/checks/runner_test.go
@@ -479,6 +479,35 @@ func TestTestRunner_HasCheck(t *testing.T) {
 	})
 }
 
+func TestResolveNamespace(t *testing.T) {
+	// Save and restore env
+	originalNS := os.Getenv("AICR_VALIDATION_NAMESPACE")
+	defer func() {
+		if originalNS != "" {
+			os.Setenv("AICR_VALIDATION_NAMESPACE", originalNS)
+		} else {
+			os.Unsetenv("AICR_VALIDATION_NAMESPACE")
+		}
+	}()
+
+	t.Run("uses env var when set", func(t *testing.T) {
+		os.Setenv("AICR_VALIDATION_NAMESPACE", "custom-ns")
+		ns := resolveNamespace()
+		if ns != "custom-ns" {
+			t.Errorf("resolveNamespace() = %v, want custom-ns", ns)
+		}
+	})
+
+	t.Run("falls back to default", func(t *testing.T) {
+		os.Unsetenv("AICR_VALIDATION_NAMESPACE")
+		ns := resolveNamespace()
+		// In CI/local, the service account file won't exist, so it falls back to "default"
+		if ns != "default" && ns == "" {
+			t.Errorf("resolveNamespace() = %v, want non-empty", ns)
+		}
+	})
+}
+
 // Helper types for testing
 
 type testError struct {

--- a/pkg/validator/helper/pod.go
+++ b/pkg/validator/helper/pod.go
@@ -151,6 +151,8 @@ func (p *PodLifecycle) WaitForPodSuccess(ctx context.Context, pod *v1.Pod, timeo
 }
 
 // GetPodLogs retrieves logs from a pod
+//
+//nolint:unparam // string return used by callers in performance and deployment packages
 func (p *PodLifecycle) GetPodLogs(ctx context.Context, pod *v1.Pod) (string, error) {
 	// Check if pod has containers
 	if len(pod.Spec.Containers) == 0 {

--- a/pkg/validator/helper/pod.go
+++ b/pkg/validator/helper/pod.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
@@ -42,7 +42,6 @@ type PodLifecycle struct {
 	ClientSet  kubernetes.Interface
 	RESTConfig *rest.Config
 	Namespace  string
-	T          *testing.T
 }
 
 // CreatePodFromTemplate creates a pod from a YAML template file
@@ -60,14 +59,14 @@ func (p *PodLifecycle) CreatePodFromTemplate(ctx context.Context, templatePath s
 		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create pod", err)
 	}
 
-	p.T.Logf("Successfully created pod %s/%s", createdPod.Namespace, createdPod.Name)
+	slog.Info("Successfully created pod", "namespace", createdPod.Namespace, "name", createdPod.Name)
 	return createdPod, nil
 }
 
 // WaitForPodByName waits for a pod with the given name to be created in the namespace
 // and returns the pod object when found or an error if the timeout is reached
 func (p *PodLifecycle) WaitForPodByName(ctx context.Context, podName string, timeout time.Duration) (*v1.Pod, error) {
-	p.T.Logf("Waiting for pod %s to be created...", podName)
+	slog.Info("Waiting for pod to be created", "name", podName)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -86,7 +85,7 @@ func (p *PodLifecycle) WaitForPodByName(ctx context.Context, podName string, tim
 		case <-ticker.C:
 			foundPod, err = p.ClientSet.CoreV1().Pods(p.Namespace).Get(ctx, podName, metav1.GetOptions{})
 			if err == nil {
-				p.T.Logf("Found pod %s (status: %s)", podName, foundPod.Status.Phase)
+				slog.Info("Found pod", "name", podName, "status", foundPod.Status.Phase)
 				return foundPod, nil
 			}
 			// Continue polling only if pod not found; fail fast on other errors
@@ -102,7 +101,7 @@ func (p *PodLifecycle) WaitForPodSuccess(ctx context.Context, pod *v1.Pod, timeo
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	p.T.Logf("Waiting for pod %s to reach Succeeded state...", pod.Name)
+	slog.Info("Waiting for pod to reach Succeeded state", "name", pod.Name)
 
 	// Use watch API for efficient monitoring
 	watcher, err := p.ClientSet.CoreV1().Pods(pod.Namespace).Watch(
@@ -130,11 +129,11 @@ func (p *PodLifecycle) WaitForPodSuccess(ctx context.Context, pod *v1.Pod, timeo
 				continue
 			}
 
-			p.T.Logf("Pod %s current phase: %s", watchedPod.Name, watchedPod.Status.Phase)
+			slog.Info("Pod current phase", "name", watchedPod.Name, "status", watchedPod.Status.Phase)
 
 			// Check for success
 			if watchedPod.Status.Phase == v1.PodSucceeded {
-				p.T.Logf("Pod %s successfully completed", watchedPod.Name)
+				slog.Info("Pod successfully completed", "name", watchedPod.Name)
 				return nil
 			}
 
@@ -168,7 +167,7 @@ func (p *PodLifecycle) GetPodLogs(ctx context.Context, pod *v1.Pod) (string, err
 	}
 	defer func() {
 		if closeErr := logsReader.Close(); closeErr != nil {
-			p.T.Logf("Error closing logs reader: %v", closeErr)
+			slog.Error("Error closing logs reader", "error", closeErr)
 		}
 	}()
 
@@ -185,7 +184,7 @@ func (p *PodLifecycle) CleanupPod(ctx context.Context, pod *v1.Pod) error {
 	cleanupCtx, cancel := context.WithTimeout(ctx, defaults.K8sJobCompletionTimeout)
 	defer cancel()
 
-	p.T.Logf("Cleaning up pod %s/%s", pod.Namespace, pod.Name)
+	slog.Info("Cleaning up pod", "namespace", pod.Namespace, "name", pod.Name)
 	return p.ClientSet.CoreV1().Pods(p.Namespace).Delete(cleanupCtx, pod.Name, metav1.DeleteOptions{})
 }
 
@@ -233,7 +232,7 @@ func (p *PodLifecycle) WaitForPodRunning(ctx context.Context, pod *v1.Pod, timeo
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	p.T.Logf("Waiting for pod %s to reach Running state...", pod.Name)
+	slog.Info("Waiting for pod to reach Running state", "name", pod.Name)
 
 	ticker := time.NewTicker(defaults.PodPollInterval)
 	defer ticker.Stop()
@@ -250,7 +249,7 @@ func (p *PodLifecycle) WaitForPodRunning(ctx context.Context, pod *v1.Pod, timeo
 
 			switch foundPod.Status.Phase {
 			case v1.PodRunning:
-				p.T.Logf("Pod %s is now in Running state", pod.Name)
+				slog.Info("Pod is now in Running state", "name", pod.Name)
 				return nil
 			case v1.PodFailed:
 				return aicrErrors.New(aicrErrors.ErrCodeInternal, "pod entered Failed phase while waiting for Running")

--- a/pkg/validator/helper/pod_test.go
+++ b/pkg/validator/helper/pod_test.go
@@ -15,9 +15,14 @@
 package helper
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestLoadPodFromTemplate(t *testing.T) {
@@ -109,6 +114,90 @@ invalid: [unclosed`,
 				}
 			}
 		})
+	}
+}
+
+func TestPodLifecycleCleanupPod(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: "test", Image: "test:latest"}},
+		},
+	}
+
+	//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+	clientset := fake.NewSimpleClientset(pod)
+
+	p := &PodLifecycle{
+		ClientSet: clientset,
+		Namespace: "test-ns",
+	}
+
+	err := p.CleanupPod(context.Background(), pod)
+	if err != nil {
+		t.Fatalf("CleanupPod() error = %v", err)
+	}
+
+	// Verify pod is deleted
+	_, err = clientset.CoreV1().Pods("test-ns").Get(context.Background(), "test-pod", metav1.GetOptions{})
+	if err == nil {
+		t.Error("Pod should be deleted after CleanupPod")
+	}
+}
+
+func TestPodLifecycleGetPodLogs(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: "test", Image: "test:latest"}},
+		},
+	}
+
+	//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+	clientset := fake.NewSimpleClientset(pod)
+
+	p := &PodLifecycle{
+		ClientSet: clientset,
+		Namespace: "test-ns",
+	}
+
+	// The fake clientset returns empty logs but no error
+	logs, err := p.GetPodLogs(context.Background(), pod)
+	if err != nil {
+		t.Fatalf("GetPodLogs() error = %v", err)
+	}
+	// Fake client returns empty logs
+	_ = logs
+}
+
+func TestPodLifecycleGetPodLogsNoContainers(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{},
+		},
+	}
+
+	//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+	clientset := fake.NewSimpleClientset(pod)
+
+	p := &PodLifecycle{
+		ClientSet: clientset,
+		Namespace: "test-ns",
+	}
+
+	_, err := p.GetPodLogs(context.Background(), pod)
+	if err == nil {
+		t.Error("GetPodLogs() should error for pod with no containers")
 	}
 }
 

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -543,6 +543,10 @@ func (v *Validator) validatePerformance(
 					// Validate that all recipe constraints/checks are registered (logs warnings for missing)
 					v.validateRecipeRegistrations(recipeResult, "performance")
 
+					// Build a test pattern so only the tests required by the recipe run,
+					// not every test in the package (including unit tests).
+					patternResult := v.buildTestPattern(recipeResult, "performance")
+
 					// Deploy ONE Job for ALL performance checks and constraints in this phase
 					// Performance tests may need GPU nodes
 					jobConfig := agent.Config{
@@ -554,7 +558,7 @@ func (v *Validator) validatePerformance(
 						SnapshotConfigMap:  snapshotCMName,
 						RecipeConfigMap:    recipeCMName,
 						TestPackage:        "./pkg/validator/checks/performance",
-						TestPattern:        "", // Run all tests in package
+						TestPattern:        patternResult.Pattern,
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Performance, DefaultPerformanceTimeout),
 						NodeSelector:       nil, // Will be set below if GPU required
 					}
@@ -900,7 +904,30 @@ func (v *Validator) buildTestPattern(recipeResult *recipe.RecipeResult, phase st
 			}
 		}
 	case string(PhasePerformance):
-		// TODO(#140): Implement for performance phase
+		if recipeResult.Validation != nil && recipeResult.Validation.Performance != nil {
+			// Add tests for constraints
+			for _, constraint := range recipeResult.Validation.Performance.Constraints {
+				testName, ok := checks.GetTestNameForConstraint(constraint.Name)
+				if ok && !uniqueTests[testName] {
+					testNames = append(testNames, testName)
+					uniqueTests[testName] = true
+					slog.Debug("constraint mapped to test", "constraint", constraint.Name, "test", testName)
+				}
+			}
+
+			// Add tests for explicit checks
+			for _, checkName := range recipeResult.Validation.Performance.Checks {
+				testName, ok := checks.GetTestNameForCheck(checkName)
+				if !ok {
+					testName = checkNameToTestName(checkName)
+				}
+				if !uniqueTests[testName] {
+					testNames = append(testNames, testName)
+					uniqueTests[testName] = true
+					slog.Debug("check mapped to test", "check", checkName, "test", testName)
+				}
+			}
+		}
 	case string(PhaseConformance):
 		if recipeResult.Validation != nil && recipeResult.Validation.Conformance != nil {
 			// Add tests for constraints

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -27,13 +27,19 @@ import (
 )
 
 func init() {
-	// Register a test-only check for buildTestPattern tests.
-	// Cannot import deployment checks due to import cycle, so register directly.
+	// Register test-only checks/constraints for buildTestPattern tests.
+	// Cannot import phase-specific check packages due to import cycles, so register directly.
 	checks.RegisterCheck(&checks.Check{
 		Name:        "test-registered-check",
 		Description: "Test-only check for buildTestPattern coverage",
 		Phase:       "deployment",
 		TestName:    "TestRegisteredCheck",
+	})
+	checks.RegisterConstraintValidator(&checks.ConstraintValidator{
+		Pattern:     "test-perf-constraint",
+		Description: "Test-only performance constraint for buildTestPattern coverage",
+		Phase:       "performance",
+		TestName:    "TestPerfConstraint",
 	})
 }
 
@@ -1119,11 +1125,40 @@ func TestBuildTestPattern(t *testing.T) {
 			wantExpectedTests: 0,
 		},
 		{
-			name: "performance phase not implemented returns empty",
+			name: "performance phase with unregistered check falls back to generated name",
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Performance: &recipe.ValidationPhase{
 						Checks: []string{"perf-check"},
+					},
+				},
+			},
+			phase:             "performance",
+			wantPattern:       "^(TestPerfCheck)$",
+			wantExpectedTests: 1,
+		},
+		{
+			name: "performance phase with registered constraint uses registry test name",
+			recipe: &recipe.RecipeResult{
+				Validation: &recipe.ValidationConfig{
+					Performance: &recipe.ValidationPhase{
+						Constraints: []recipe.Constraint{
+							{Name: "test-perf-constraint", Value: "200"},
+						},
+					},
+				},
+			},
+			phase:             "performance",
+			wantPattern:       "^(TestPerfConstraint)$",
+			wantExpectedTests: 1,
+		},
+		{
+			name: "performance phase with empty checks returns empty pattern",
+			recipe: &recipe.RecipeResult{
+				Validation: &recipe.ValidationConfig{
+					Performance: &recipe.ValidationPhase{
+						Checks:      []string{},
+						Constraints: []recipe.Constraint{},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Adds the first performance-phase validator: NCCL all-reduce bus bandwidth (`nccl-all-reduce-bw`). Includes the supporting infrastructure fixes required to make performance-phase Jobs work end-to-end: RBAC idempotency, missing RBAC verbs, `buildTestPattern` stub for performance phase, `PodLifecycle` decoupled from `testing.T`, and `LoadValidationContext` generalized to support both in-cluster and local kubeconfig.

## Motivation / Context

Performance-phase validation was wired into the framework but had no implemented checks. GPU clusters running EKS + H100 (p5.48xlarge) need EW-fabric bandwidth verified as part of AI-readiness validation. Several operational bugs were discovered and fixed while wiring up the first real performance check.

Fixes: N/A
Related: #140

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `Dockerfile.validator`, `pkg/defaults`

## Implementation Notes

**New: NCCL all-reduce bandwidth constraint (`nccl-all-reduce-bw`)**
Registered under the `performance` phase; maps to `TestNcclAllReduceBw` in the compiled test binary. Skips gracefully when the recipe lacks EKS + H100 criteria or when fewer than 2 GPU nodes are available (EW fabric requires ≥ 2 nodes). Auto-installs Kubeflow Trainer v2.1.0 via kustomize if not present and defers full teardown on exit. Parses bus bandwidth from the 16 G all-reduce row in NCCL output logs and validates it is within 10% of the recipe threshold. Templates in `testdata/{accelerator}/{service}/` allow new hardware/cloud combinations to be added without code changes.

**Bug fix: RBAC create-or-update idempotency**
`ensureRole` and `ensureClusterRole` previously used `IgnoreAlreadyExists` — on a cluster with a stale Role from a prior run, RBAC changes in a new image were silently ignored. Both functions now use create-or-update semantics so the current policy rules are always enforced on every run.

**Bug fix: Missing RBAC verbs**
Added `watch` to the pods rule in the namespace-scoped Role (required by `WaitForPodSuccess` which uses the Watch API). Added `trainer.kubeflow.org` rules for `TrainJob`/`TrainingRuntime` lifecycle. Extended the cluster-scoped CRD rule from `get/list` to `get/list/watch/create/delete` and added cluster-scoped rules for all resources created by Trainer install (namespaces, serviceaccounts, services, configmaps, RBAC types).

**Bug fix: `buildTestPattern` stub for performance phase**
`phases.go` had a `// TODO(#140)` stub returning an empty test pattern for the performance phase, causing the compiled binary to run all tests in the package (unit tests included) instead of only the tests required by the recipe. Implemented the full constraint + check mapping.

**Bug fix: `LoadValidationContext` in-cluster-only restriction**
Switched from `rest.InClusterConfig()` to `k8sclient.BuildKubeClient("")` (KUBECONFIG → `~/.kube/config` → in-cluster) and replaced `getNamespaceFromServiceAccount` with a graceful `resolveNamespace` fallback chain (service account file → `AICR_VALIDATION_NAMESPACE` env → `"default"`).

**Refactor: `PodLifecycle` decoupled from `testing.T`**
Removed the `T *testing.T` field and replaced all `t.Logf` calls with `slog`. `PodLifecycle` is now usable from production validator code, which is required by the NCCL constraint.

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

Unit tests added/updated:
- `TestValidateNcclAllReduceBw` — 3 early-exit skip cases (nil recipe, unsupported service, unsupported accelerator)
- `TestDetermineGPUConfig` — single node (WorkerCount=1, triggers `<2` skip), two nodes, no GPU nodes (error path)
- `TestSupportedNCCLCombinations` — matrix of supported/unsupported service+accelerator pairs
- `TestValidateNcclAllReduceBwRegistration` — verifies constraint is registered with correct metadata
- `TestEnsureRole` — updated to assert 6 rules including new Trainer rule; asserts `watch` verb on pods
- `TestBuildTestPattern` — replaced stub test with 3 new performance-phase cases

Integration test added: `TestNcclAllReduceBw` — compiled into `performance.test` in `Dockerfile.validator`, dispatched in-cluster when recipe contains `nccl-all-reduce-bw`.

## Risk Assessment

<!-- Select one and explain -->

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** The RBAC create-or-update change means existing `aicr-validator` Roles and ClusterRoles in the cluster will be updated on the next run rather than silently left as-is. This is intentional and additive — no existing rules are removed. The `performance.test` binary is new and only dispatched when the recipe contains a `nccl-all-reduce-bw` constraint.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
