### PR TITLE
ci: consolidate qualification jobs and remove duplicate tests

### DIFF
--- a/.github/actions/cli-e2e/action.yml
+++ b/.github/actions/cli-e2e/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: 'CLI E2E Tests'
-description: 'Build attested aicr binary and run CLI chainsaw tests'
+description: 'Build attested aicr binary and run CLI + conformance chainsaw tests'
 
 inputs:
   go_version:
@@ -105,3 +105,12 @@ runs:
           --no-cluster \
           --config tests/chainsaw/chainsaw-config.yaml \
           --test-dir tests/chainsaw/cli/
+
+    - name: Run AI-conformance offline tests
+      shell: bash
+      run: |
+        set -euo pipefail
+        chainsaw test \
+          --no-cluster \
+          --config tests/chainsaw/chainsaw-config.yaml \
+          --test-dir tests/chainsaw/ai-conformance/offline/

--- a/.github/actions/go-lint/action.yml
+++ b/.github/actions/go-lint/action.yml
@@ -1,0 +1,73 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Go Lint'
+description: 'Run Go linter, YAML linter, and license header checks'
+
+inputs:
+  go_version:
+    description: 'Go version to install (e.g., 1.25)'
+    required: true
+  golangci_lint_version:
+    description: 'golangci-lint version to use (e.g., v2.6)'
+    required: true
+  addlicense_version:
+    description: 'addlicense version to use (e.g., v1.1.1)'
+    required: false
+    default: 'v1.1.1'
+  lint_timeout:
+    description: 'Lint timeout duration'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
+      with:
+        go-version: '${{ inputs.go_version }}'
+        cache: true
+        cache-dependency-path: |
+          go.sum
+          vendor/modules.txt
+        check-latest: true
+
+    - name: Lint Go
+      if: hashFiles('.golangci.yaml') != ''
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+      with:
+        version: ${{ inputs.golangci_lint_version }}
+        args: --timeout=${{ inputs.lint_timeout || '5m' }}
+      env:
+        GOFLAGS: -mod=vendor
+
+    - name: Lint YAML
+      if: hashFiles('.yamllint.yaml') != ''
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y yamllint
+        make lint-yaml
+
+    - name: Install addlicense
+      shell: bash
+      run: |
+        ADDLICENSE_VERSION="${{ inputs.addlicense_version }}"
+        ADDLICENSE_VERSION_NUM="${ADDLICENSE_VERSION#v}"
+        go install github.com/google/addlicense@${ADDLICENSE_VERSION}
+        echo "addlicense installed: $(addlicense -version 2>&1 || echo ${ADDLICENSE_VERSION_NUM})"
+
+    - name: Ensure License Headers
+      shell: bash
+      run: make license

--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -1,0 +1,59 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Go Test'
+description: 'Setup Go, verify vendor, run unit tests with race detector and coverage'
+
+inputs:
+  go_version:
+    description: 'Go version to install (e.g., 1.25)'
+    required: true
+  coverage_report:
+    description: 'Whether to generate coverage report (true/false)'
+    required: false
+    default: 'false'
+  coverage_threshold:
+    description: 'Minimum coverage percentage required'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
+      with:
+        go-version: '${{ inputs.go_version }}'
+        cache: true
+        cache-dependency-path: |
+          go.sum
+          vendor/modules.txt
+        check-latest: true
+
+    - name: Verify vendor is in sync
+      shell: bash
+      run: |
+        go mod vendor
+        git diff --exit-code vendor/ || (echo "vendor/ is out of sync with go.mod/go.sum; run 'make tidy' and commit go.mod, go.sum, and vendor/" && exit 1)
+
+    - name: Run Tests with Coverage
+      shell: bash
+      run: make test
+
+    - name: Coverage Report
+      if: inputs.coverage_report == 'true'
+      uses: ./.github/actions/go-coverage
+      with:
+        coverage_file: ./coverage.out
+        threshold: ${{ inputs.coverage_threshold }}

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -28,8 +28,8 @@ permissions:
 
 jobs:
 
-  unit:
-    name: Unit
+  test:
+    name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -46,67 +46,42 @@ jobs:
         id: versions
         uses: ./.github/actions/load-versions
 
-      - name: Run Go CI (setup, test, lint)
-        uses: ./.github/actions/go-ci
+      - name: Run Go Tests
+        uses: ./.github/actions/go-test
+        with:
+          go_version: ${{ steps.versions.outputs.go }}
+          coverage_report: ${{ inputs.coverage_report }}
+          coverage_threshold: ${{ steps.versions.outputs.coverage_threshold }}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Run Linters
+        uses: ./.github/actions/go-lint
         with:
           go_version: ${{ steps.versions.outputs.go }}
           golangci_lint_version: ${{ steps.versions.outputs.golangci_lint }}
           addlicense_version: ${{ steps.versions.outputs.addlicense }}
-          coverage_report: ${{ inputs.coverage_report }}
-          coverage_threshold: ${{ steps.versions.outputs.coverage_threshold }}
           lint_timeout: ${{ steps.versions.outputs.lint_timeout }}
-
-  integration:
-    name: Integration
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    steps:
-
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Load versions
-        id: versions
-        uses: ./.github/actions/load-versions
-
-      - name: Run Integration Tests
-        uses: ./.github/actions/integration
-        with:
-          go_version: ${{ steps.versions.outputs.go }}
-          helm_version: ${{ steps.versions.outputs.helm }}
-          chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
-
-  chainsaw:
-    name: Conformance
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    steps:
-
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Load versions
-        id: versions
-        uses: ./.github/actions/load-versions
-
-      - name: Run Conformance Tests
-        uses: ./.github/actions/chainsaw
-        with:
-          go_version: ${{ steps.versions.outputs.go }}
-          chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
 
   cli-e2e:
     name: CLI E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -729,13 +729,13 @@ func (b *DefaultBundler) attestBundle(ctx context.Context, dir string, dataFiles
 
 	// Create attestation subdirectory
 	attestDir := filepath.Join(dir, attestation.AttestationDir)
-	if mkdirErr := os.MkdirAll(attestDir, 0755); mkdirErr != nil {
+	if mkdirErr := os.MkdirAll(attestDir, 0755); mkdirErr != nil { //nolint:gosec // dir is filepath.Clean'd on entry; attestDir uses constant subpath
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create attestation directory", mkdirErr)
 	}
 
 	// Write bundle attestation
 	bundleAttestPath := filepath.Join(dir, attestation.BundleAttestationFile)
-	if writeErr := os.WriteFile(bundleAttestPath, bundleJSON, 0600); writeErr != nil {
+	if writeErr := os.WriteFile(bundleAttestPath, bundleJSON, 0600); writeErr != nil { //nolint:gosec // path built from filepath.Clean'd dir + constant filename
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write bundle attestation", writeErr)
 	}
 	attestFiles = append(attestFiles, attestation.BundleAttestationFile)
@@ -790,7 +790,7 @@ func (b *DefaultBundler) attestBundle(ctx context.Context, dir string, dataFiles
 	}
 
 	destPath := filepath.Join(dir, attestation.BinaryAttestationFile)
-	if copyErr := os.WriteFile(destPath, binaryAttestData, 0600); copyErr != nil {
+	if copyErr := os.WriteFile(destPath, binaryAttestData, 0600); copyErr != nil { //nolint:gosec // path built from filepath.Clean'd dir + constant filename
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to copy binary attestation into bundle", copyErr)
 	}

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -186,77 +186,6 @@ check_api_health() {
 # CLI Recipe Tests (from e2e.md)
 # =============================================================================
 
-test_cli_recipe() {
-  msg "=========================================="
-  msg "Testing CLI recipe generation"
-  msg "=========================================="
-
-  local recipe_dir="${OUTPUT_DIR}/recipes"
-  mkdir -p "$recipe_dir"
-
-  # Test 1: Basic recipe with query parameters
-  msg "--- Test: Recipe with query parameters ---"
-  local basic_recipe="${recipe_dir}/basic.yaml"
-  echo -e "${DIM}  \$ aicr recipe --service eks --accelerator h100 --os ubuntu --intent training -o basic.yaml${NC}"
-  if "${AICR_BIN}" recipe \
-    --service eks \
-    --accelerator h100 \
-    --os ubuntu \
-    --intent training \
-    --output "$basic_recipe" 2>&1; then
-    if [ -f "$basic_recipe" ] && grep -q "kind: RecipeResult" "$basic_recipe"; then
-      # Show components from recipe
-      local components
-      components=$(grep "^  - name:" "$basic_recipe" 2>/dev/null | wc -l | tr -d ' ')
-      detail "Generated recipe with ${components} components"
-      pass "cli/recipe/query-params"
-    else
-      fail "cli/recipe/query-params" "Recipe file invalid"
-    fi
-  else
-    fail "cli/recipe/query-params" "Command failed"
-  fi
-
-  # Test 2: Recipe from criteria file
-  msg "--- Test: Recipe from criteria file ---"
-  local criteria_file="${recipe_dir}/criteria.yaml"
-  cat > "$criteria_file" << 'EOF'
-kind: RecipeCriteria
-apiVersion: aicr.nvidia.com/v1alpha1
-metadata:
-  name: h100-eks-ubuntu-training
-spec:
-  service: eks
-  accelerator: h100
-  os: ubuntu
-  intent: training
-EOF
-
-  local criteria_recipe="${recipe_dir}/from-criteria.yaml"
-  if "${AICR_BIN}" recipe --criteria "$criteria_file" --output "$criteria_recipe" 2>&1; then
-    if [ -f "$criteria_recipe" ]; then
-      pass "cli/recipe/criteria-file"
-    else
-      fail "cli/recipe/criteria-file" "Recipe file not created"
-    fi
-  else
-    fail "cli/recipe/criteria-file" "Command failed"
-  fi
-
-  # Test 3: CLI flags override criteria file
-  msg "--- Test: CLI flags override criteria file ---"
-  local override_recipe="${recipe_dir}/override.yaml"
-  if "${AICR_BIN}" recipe --criteria "$criteria_file" --service gke --output "$override_recipe" 2>&1; then
-    if grep -q "service: gke" "$override_recipe" 2>/dev/null; then
-      pass "cli/recipe/override"
-    else
-      fail "cli/recipe/override" "Override not applied"
-    fi
-  else
-    fail "cli/recipe/override" "Command failed"
-  fi
-}
-
 # =============================================================================
 # API Recipe Tests (from e2e.md)
 # =============================================================================
@@ -309,122 +238,6 @@ spec:
 # =============================================================================
 # CLI Bundle Tests (from e2e.md)
 # =============================================================================
-
-test_cli_bundle() {
-  msg "=========================================="
-  msg "Testing CLI bundle generation"
-  msg "=========================================="
-
-  # First generate a recipe to use
-  local recipe_file="${OUTPUT_DIR}/bundle-test-recipe.yaml"
-  "${AICR_BIN}" recipe \
-    --service eks \
-    --accelerator h100 \
-    --os ubuntu \
-    --intent training \
-    --output "$recipe_file" 2>&1 || true
-
-  if [ ! -f "$recipe_file" ]; then
-    fail "cli/bundle/prerequisite" "Could not generate recipe for bundle tests"
-    return 1
-  fi
-
-  # Test 1: Basic bundle generation
-  msg "--- Test: Basic bundle ---"
-  local basic_bundle="${OUTPUT_DIR}/bundles/basic"
-  mkdir -p "$basic_bundle"
-  echo -e "${DIM}  \$ aicr bundle --recipe recipe.yaml --output bundles/basic${NC}"
-  if "${AICR_BIN}" bundle \
-    --recipe "$recipe_file" \
-    --output "$basic_bundle" 2>&1; then
-    if [ -f "${basic_bundle}/deploy.sh" ] && [ -f "${basic_bundle}/README.md" ]; then
-      local file_count
-      file_count=$(find "$basic_bundle" -type f | wc -l | tr -d ' ')
-      detail "Generated ${file_count} files in bundle"
-      # Verify at least one component directory has values.yaml
-      local comp_count
-      comp_count=$(find "$basic_bundle" -mindepth 2 -name "values.yaml" | wc -l | tr -d ' ')
-      if [ "$comp_count" -gt 0 ]; then
-        detail "Found ${comp_count} component directories"
-        pass "cli/bundle/basic"
-      else
-        fail "cli/bundle/basic" "No component directories with values.yaml"
-      fi
-    else
-      fail "cli/bundle/basic" "Missing deploy.sh or README.md"
-    fi
-  else
-    fail "cli/bundle/basic" "Command failed"
-  fi
-
-  # Test 2: Bundle with node selectors and tolerations
-  msg "--- Test: Bundle with scheduling options ---"
-  local sched_bundle="${OUTPUT_DIR}/bundles/scheduling"
-  mkdir -p "$sched_bundle"
-  if "${AICR_BIN}" bundle \
-    --recipe "$recipe_file" \
-    --output "$sched_bundle" \
-    --system-node-selector nodeGroup=system-pool \
-    --accelerated-node-selector nodeGroup=customer-gpu \
-    --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule 2>&1; then
-    # Search across all component values files for the node selector
-    local found_selector=false
-    for vfile in "${sched_bundle}"/*/values.yaml; do
-      if [ -f "$vfile" ] && grep -q "system-pool" "$vfile" 2>/dev/null; then
-        found_selector=true
-        break
-      fi
-    done
-    if [ "$found_selector" = true ]; then
-      pass "cli/bundle/scheduling"
-    else
-      fail "cli/bundle/scheduling" "Node selector not found in component values"
-    fi
-  else
-    fail "cli/bundle/scheduling" "Command failed"
-  fi
-
-  # Test 3: Bundle with ArgoCD deployer
-  msg "--- Test: Bundle with ArgoCD deployer ---"
-  local argocd_bundle="${OUTPUT_DIR}/bundles/argocd"
-  mkdir -p "$argocd_bundle"
-  if "${AICR_BIN}" bundle \
-    --recipe "$recipe_file" \
-    --output "$argocd_bundle" \
-    --deployer argocd 2>&1; then
-    if [ -f "${argocd_bundle}/app-of-apps.yaml" ]; then
-      pass "cli/bundle/argocd"
-    else
-      fail "cli/bundle/argocd" "app-of-apps.yaml not found"
-    fi
-  else
-    fail "cli/bundle/argocd" "Command failed"
-  fi
-
-  # Test 4: Verify bundle integrity (checksums)
-  msg "--- Test: Bundle integrity ---"
-  if [ -f "${basic_bundle}/checksums.txt" ]; then
-    cd "$basic_bundle"
-    if shasum -a 256 -c checksums.txt > /dev/null 2>&1; then
-      pass "cli/bundle/integrity"
-    else
-      fail "cli/bundle/integrity" "Checksum verification failed"
-    fi
-    cd - > /dev/null
-  else
-    skip "cli/bundle/integrity" "No checksums.txt"
-  fi
-
-  # Test 5: deploy.sh is executable
-  msg "--- Test: deploy.sh executable ---"
-  if [ -x "${basic_bundle}/deploy.sh" ]; then
-    pass "cli/bundle/deploy-script"
-  elif [ -f "${basic_bundle}/deploy.sh" ]; then
-    fail "cli/bundle/deploy-script" "deploy.sh exists but is not executable"
-  else
-    fail "cli/bundle/deploy-script" "deploy.sh not found"
-  fi
-}
 
 # =============================================================================
 # API Bundle Tests (from e2e.md)
@@ -484,28 +297,6 @@ test_api_bundle() {
 # =============================================================================
 # CLI Help Test
 # =============================================================================
-
-test_cli_help() {
-  msg "=========================================="
-  msg "Testing CLI help"
-  msg "=========================================="
-
-  # Test: aicr -h
-  msg "--- Test: aicr -h ---"
-  if "${AICR_BIN}" -h > /dev/null 2>&1; then
-    pass "cli/help"
-  else
-    fail "cli/help" "aicr -h failed"
-  fi
-
-  # Test: aicr --version
-  msg "--- Test: aicr --version ---"
-  if "${AICR_BIN}" --version > /dev/null 2>&1; then
-    pass "cli/version"
-  else
-    fail "cli/version" "aicr --version failed"
-  fi
-}
 
 # =============================================================================
 # Fake GPU Setup (for snapshot tests)
@@ -1677,69 +1468,6 @@ test_validate_job_deployment() {
 }
 
 
-test_external_data() {
-  msg "=========================================="
-  msg "Testing external data directory (--data flag)"
-  msg "=========================================="
-
-  local data_dir="${ROOT_DIR}/examples/data"
-  local external_dir="${OUTPUT_DIR}/external-data"
-  mkdir -p "$external_dir"
-
-  # Check if examples/data exists
-  if [ ! -d "$data_dir" ]; then
-    skip "cli/external-data" "examples/data directory not found"
-    return 0
-  fi
-
-  # Test 1: Recipe with external data (should include dgxc-teleport)
-  msg "--- Test: Recipe with external data ---"
-  local recipe_file="${external_dir}/recipe-with-external.yaml"
-  echo -e "${DIM}  \$ aicr recipe --service eks --accelerator h100 --os ubuntu --intent training --data ./examples/data${NC}"
-  if "${AICR_BIN}" recipe \
-    --service eks \
-    --accelerator h100 \
-    --os ubuntu \
-    --intent training \
-    --data "$data_dir" \
-    --output "$recipe_file" 2>&1; then
-    if [ -f "$recipe_file" ]; then
-      # Check if dgxc-teleport component is included (from external registry)
-      if grep -q "dgxc-teleport" "$recipe_file" 2>/dev/null; then
-        detail "External component 'dgxc-teleport' included in recipe"
-        pass "cli/external-data/recipe"
-      else
-        # May not be included if overlay doesn't match exactly
-        warn "dgxc-teleport not in recipe (overlay may not match)"
-        pass "cli/external-data/recipe"
-      fi
-    else
-      fail "cli/external-data/recipe" "Recipe file not created"
-    fi
-  else
-    fail "cli/external-data/recipe" "Command failed"
-  fi
-
-  # Test 2: Bundle with external data
-  msg "--- Test: Bundle with external data ---"
-  local bundle_dir="${external_dir}/bundle"
-  mkdir -p "$bundle_dir"
-  echo -e "${DIM}  \$ aicr bundle --recipe recipe.yaml --data ./examples/data --output ./bundle${NC}"
-  if "${AICR_BIN}" bundle \
-    --recipe "$recipe_file" \
-    --data "$data_dir" \
-    --output "$bundle_dir" 2>&1; then
-    if [ -f "${bundle_dir}/deploy.sh" ]; then
-      detail "Bundle generated with external data"
-      pass "cli/external-data/bundle"
-    else
-      fail "cli/external-data/bundle" "deploy.sh not found"
-    fi
-  else
-    fail "cli/external-data/bundle" "Command failed"
-  fi
-}
-
 # =============================================================================
 # API Metrics Tests
 # =============================================================================
@@ -1781,175 +1509,6 @@ test_api_metrics() {
 # =============================================================================
 # Output Format Tests (--format json/table)
 # =============================================================================
-
-test_output_formats() {
-  msg "=========================================="
-  msg "Testing output format variations"
-  msg "=========================================="
-
-  local format_dir="${OUTPUT_DIR}/formats"
-  mkdir -p "$format_dir"
-
-  # Test 1: Recipe with JSON format
-  msg "--- Test: Recipe with --format json ---"
-  local json_recipe="${format_dir}/recipe.json"
-  echo -e "${DIM}  \$ aicr recipe --service eks --accelerator h100 --intent inference --format json${NC}"
-  if "${AICR_BIN}" recipe \
-    --service eks \
-    --accelerator h100 \
-    --intent inference \
-    --format json \
-    --output "$json_recipe" 2>&1; then
-    if [ -f "$json_recipe" ]; then
-      # Verify it's valid JSON
-      if command -v jq &> /dev/null; then
-        if jq -e . "$json_recipe" > /dev/null 2>&1; then
-          local component_count
-          component_count=$(jq '.spec.components | length' "$json_recipe" 2>/dev/null || echo "?")
-          detail "Valid JSON with ${component_count} components"
-          pass "cli/format/json"
-        else
-          fail "cli/format/json" "Invalid JSON output"
-        fi
-      else
-        # No jq, just check it starts with { or [
-        if head -c1 "$json_recipe" | grep -q '[{[]'; then
-          detail "JSON format detected (jq not available for validation)"
-          pass "cli/format/json"
-        else
-          fail "cli/format/json" "Output doesn't look like JSON"
-        fi
-      fi
-    else
-      fail "cli/format/json" "Output file not created"
-    fi
-  else
-    fail "cli/format/json" "Command failed"
-  fi
-
-  # Test 2: Recipe with table format
-  msg "--- Test: Recipe with --format table ---"
-  local table_recipe="${format_dir}/recipe.txt"
-  echo -e "${DIM}  \$ aicr recipe --service eks --accelerator h100 --intent inference --format table${NC}"
-  if "${AICR_BIN}" recipe \
-    --service eks \
-    --accelerator h100 \
-    --intent inference \
-    --format table \
-    --output "$table_recipe" 2>&1; then
-    if [ -f "$table_recipe" ] && [ -s "$table_recipe" ]; then
-      # Table format should have human-readable output (not YAML/JSON)
-      # Check it doesn't start with typical YAML/JSON markers
-      if ! head -c1 "$table_recipe" | grep -q '[{[]' && ! head -1 "$table_recipe" | grep -q "^kind:"; then
-        local line_count
-        line_count=$(wc -l < "$table_recipe" | tr -d ' ')
-        detail "Table format output (${line_count} lines)"
-        pass "cli/format/table"
-      else
-        fail "cli/format/table" "Output appears to be YAML/JSON, not table"
-      fi
-    else
-      fail "cli/format/table" "Output file empty or not created"
-    fi
-  else
-    fail "cli/format/table" "Command failed"
-  fi
-
-  # Test 3: Snapshot format (if available)
-  if [ "$FAKE_GPU_ENABLED" = "true" ] && kubectl get cm "$SNAPSHOT_CM" -n "$SNAPSHOT_NAMESPACE" > /dev/null 2>&1; then
-    msg "--- Test: Validate with --format json ---"
-    local json_validate="${format_dir}/validate.json"
-
-    # Generate recipe first
-    local recipe_for_validate="${format_dir}/recipe-for-validate.yaml"
-    "${AICR_BIN}" recipe \
-      --snapshot "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}" \
-      --intent training \
-      --output "$recipe_for_validate" 2>&1 || true
-
-    if [ -f "$recipe_for_validate" ]; then
-      echo -e "${DIM}  \$ aicr validate --recipe recipe.yaml --snapshot cm://... --format json${NC}"
-      if "${AICR_BIN}" validate \
-        --recipe "$recipe_for_validate" \
-        --snapshot "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}" \
-        --format json \
-        --output "$json_validate" 2>&1; then
-        if [ -f "$json_validate" ] && [ -s "$json_validate" ]; then
-          detail "Validation output in JSON format"
-          pass "cli/format/validate-json"
-        else
-          warn "Validation JSON output empty (may be expected)"
-          pass "cli/format/validate-json"
-        fi
-      else
-        warn "Validate with JSON format had issues"
-        pass "cli/format/validate-json"
-      fi
-    else
-      skip "cli/format/validate-json" "Could not generate recipe"
-    fi
-  else
-    skip "cli/format/validate-json" "Snapshot not available"
-  fi
-}
-
-# =============================================================================
-# Deploy Agent CLI Tests
-# =============================================================================
-
-test_deploy_agent_cli() {
-  msg "=========================================="
-  msg "Testing snapshot agent CLI flags"
-  msg "=========================================="
-
-  # The snapshot command always deploys an agent Job.
-  # This test verifies the agent-related CLI flags are present and accepted.
-
-  local help_output
-  help_output=$("${AICR_BIN}" snapshot --help 2>&1)
-
-  # Test 1: Help shows agent-related flags
-  msg "--- Test: snapshot --help shows agent flags ---"
-  local missing_flags=()
-  for flag in "--namespace" "--image" "--node-selector" "--toleration" "--timeout" "--cleanup"; do
-    if ! echo "$help_output" | grep -q -- "$flag"; then
-      missing_flags+=("$flag")
-    fi
-  done
-
-  if [ ${#missing_flags[@]} -eq 0 ]; then
-    detail "All agent flags documented"
-    pass "cli/agent-flags/help"
-  else
-    fail "cli/agent-flags/help" "Missing flags: ${missing_flags[*]}"
-  fi
-
-  # Test 2: Agent flags are accepted (should fail with cluster error, not parse error)
-  msg "--- Test: agent flags accepted ---"
-  echo -e "${DIM}  \$ aicr snapshot --namespace test-ns --image test:latest (dry-run check)${NC}"
-
-  local deploy_output
-  deploy_output=$("${AICR_BIN}" snapshot --namespace nonexistent-test-ns --image "test:latest" 2>&1) || true
-
-  if echo "$deploy_output" | grep -qi "not found\|connection refused\|forbidden\|unauthorized\|cannot\|failed"; then
-    detail "Flags accepted (expected cluster error)"
-    pass "cli/agent-flags/accepted"
-  elif echo "$deploy_output" | grep -qi "unknown flag\|invalid\|usage"; then
-    fail "cli/agent-flags/accepted" "Flag parsing error"
-  else
-    detail "Command executed (output: ${deploy_output:0:50}...)"
-    pass "cli/agent-flags/accepted"
-  fi
-
-  # Test 3: Verify --image flag is supported
-  msg "--- Test: --image flag ---"
-  if echo "$help_output" | grep -q -- "--image"; then
-    detail "--image flag documented"
-    pass "cli/agent-flags/image-flag"
-  else
-    fail "cli/agent-flags/image-flag" "--image not in help output"
-  fi
-}
 
 # =============================================================================
 # OCI Bundle Tests (from e2e.md)
@@ -2062,9 +1621,6 @@ main() {
   # Build binaries
   build_binaries
 
-  # Run CLI help tests (always works)
-  test_cli_help
-
   # Check API is available
   if ! check_api_health; then
     warn "API not available, skipping API tests"
@@ -2073,14 +1629,10 @@ main() {
     API_AVAILABLE=true
   fi
 
-  # Run CLI tests (always)
-  test_cli_recipe
-  test_cli_bundle
-  test_external_data
-  test_output_formats
-  test_deploy_agent_cli
-
   # Run API tests (if available)
+  # NOTE: Pure CLI tests (recipe, bundle, help, output formats, external data,
+  # deploy agent flags) are covered by chainsaw CLI tests in the CLI E2E job.
+  # This script focuses on cluster-dependent tests only.
   if [ "$API_AVAILABLE" = true ]; then
     test_api_recipe
     test_api_bundle


### PR DESCRIPTION
## Summary

- **Eliminate Integration job** — CLI E2E already runs all 16 chainsaw CLI tests (Integration ran 15/16 with a separate binary build)
- **Merge Conformance into CLI E2E** — AI-conformance offline tests now run in the same job, removing one binary build and runner
- **Split Unit into parallel Test + Lint** — Go tests and linting now run concurrently instead of sequentially (~4 min wall-clock improvement)
- **Remove 6 CLI-overlap test functions from `tests/e2e/run.sh`** — `test_cli_recipe`, `test_cli_bundle`, `test_cli_help`, `test_external_data`, `test_output_formats`, `test_deploy_agent_cli` are already covered by chainsaw CLI tests; E2E script now focuses exclusively on cluster-dependent tests

### Before (6 jobs)
| Job | Timeout | Scope |
|-----|---------|-------|
| Unit | 15m | go test + lint + license + YAML lint |
| Integration | 15m | chainsaw CLI (15/16 tests) |
| Conformance | 15m | chainsaw ai-conformance/offline |
| CLI E2E | 10m | chainsaw CLI (16/16 tests) + attestation |
| E2E | 30m | Kind cluster + API + snapshot + validation |
| Security Scan | 10m | Trivy filesystem scan |

### After (5 jobs)
| Job | Timeout | Scope |
|-----|---------|-------|
| Test | 15m | go test + coverage |
| Lint | 10m | golangci-lint + YAML lint + license |
| CLI E2E | 15m | chainsaw CLI (all) + conformance/offline + attestation |
| E2E | 30m | Kind cluster + API + snapshot + validation |
| Security Scan | 10m | Trivy filesystem scan |

**Estimated savings:** ~17 min total CI compute, ~4 min wall-clock (Test and Lint parallel vs sequential Unit).

## Test plan
- [x] Verify `Test` job passes (go test with race detector)
- [x] Verify `Lint` job passes (golangci-lint, yamllint, license headers)
- [x] Verify `CLI E2E` job passes (all 16 CLI tests + conformance offline tests)
- [x] Verify `E2E` job passes (cluster-dependent tests still work without removed CLI tests)
- [x] Verify `Security Scan` job passes (unchanged)