### PR TITLE
fix(recipes): remove dynamo components from kind training overlay

### DIFF
--- a/.github/workflows/gpu-h100-conformance-test.yaml
+++ b/.github/workflows/gpu-h100-conformance-test.yaml
@@ -36,7 +36,6 @@ on:
       - 'tests/manifests/**'
       - 'tests/chainsaw/ai-conformance/**'
       - 'docs/conformance/cncf/**'
-      - 'recipes/components/dynamo-platform/**'
       - 'recipes/components/prometheus-adapter/**'
       - 'recipes/overlays/kind.yaml'
       - 'recipes/overlays/kind-inference.yaml'
@@ -82,7 +81,6 @@ jobs:
           method: bundle
           accelerator: h100
           intent: training
-          platform: dynamo
 
       # --- Snapshot and validation ---
 
@@ -171,13 +169,6 @@ jobs:
           kubectl --context="kind-${KIND_CLUSTER_NAME}" get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded 2>/dev/null || true
           echo "=== Recent events (gpu-operator) ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n gpu-operator get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
-          echo "=== Dynamo pods ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get pods -o wide 2>/dev/null || true
-          echo "=== Dynamo operator logs ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system \
-            logs deployment/dynamo-operator-controller-manager --tail=100 -c manager 2>/dev/null || true
-          echo "=== Recent events (dynamo-system) ==="
-          kubectl --context="kind-${KIND_CLUSTER_NAME}" -n dynamo-system get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
           echo "=== KAI scheduler pods ==="
           kubectl --context="kind-${KIND_CLUSTER_NAME}" -n kai-scheduler get pods -o wide 2>/dev/null || true
           echo "=== KAI scheduler logs ==="

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -32,7 +32,6 @@ on:
       - '.github/actions/gpu-test-cleanup/**'
       - '.github/actions/load-versions/**'
       - 'tests/chainsaw/ai-conformance/kind-training/**'
-      - 'recipes/components/dynamo-platform/**'
       - 'recipes/overlays/kind.yaml'
       - 'recipes/overlays/h100-kind-training.yaml'
       - 'kwok/manifests/karpenter/**'
@@ -144,7 +143,6 @@ jobs:
             --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
             --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
             --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml \
             --kubeconfig="${HOME}/.kube/config" \
             --debug
 

--- a/pkg/recipe/conformance_test.go
+++ b/pkg/recipe/conformance_test.go
@@ -90,8 +90,6 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 				"prometheus-adapter",
 				"nvidia-dra-driver-gpu",
 				"kai-scheduler",
-				"dynamo-crds",
-				"dynamo-platform",
 			},
 			requiredChecks: []string{
 				"platform-health",
@@ -100,7 +98,6 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 				"accelerator-metrics",
 				"ai-service-metrics",
 				"gang-scheduling",
-				"robust-controller",
 				"pod-autoscaling",
 				"cluster-autoscaling",
 			},

--- a/recipes/overlays/h100-kind-training.yaml
+++ b/recipes/overlays/h100-kind-training.yaml
@@ -19,7 +19,6 @@ metadata:
 
 spec:
   # Inherits from kind recipe (kind-specific GPU operator + monitoring settings)
-  # Adds Dynamo platform components for the training stack.
   base: kind
 
   criteria:
@@ -32,35 +31,6 @@ spec:
     - name: K8s.server.version
       value: ">= 1.34"
 
-  componentRefs:
-    # Dynamo platform (model serving, orchestration)
-    - name: dynamo-crds
-      type: Helm
-      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "0.8.1"
-      valuesFile: components/dynamo-crds/values.yaml
-
-    - name: dynamo-platform
-      type: Helm
-      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "0.8.1"
-      valuesFile: components/dynamo-platform/values.yaml
-      dependencyRefs:
-        - dynamo-crds
-        - cert-manager
-        - kube-prometheus-stack
-      overrides:
-        # Use kind's local-path-provisioner instead of EBS gp2
-        etcd:
-          persistence:
-            storageClass: standard
-        nats:
-          config:
-            jetstream:
-              fileStore:
-                pvc:
-                  storageClassName: standard
-
   validation:
     conformance:
       checks:
@@ -70,6 +40,5 @@ spec:
         - accelerator-metrics
         - ai-service-metrics
         - gang-scheduling
-        - robust-controller
         - pod-autoscaling
         - cluster-autoscaling

--- a/tests/chainsaw/ai-conformance/kind-training/assert-crds.yaml
+++ b/tests/chainsaw/ai-conformance/kind-training/assert-crds.yaml
@@ -14,7 +14,7 @@
 
 # Assert that critical CRDs are installed by the kind training stack.
 # Compared to the cluster (inference) assert-crds:
-#   Removed: kgateway-crds (Gateway API, Inference Extension) — inference-only
+#   Removed: dynamo-crds — no Dynamo dependency in kind training validation
 
 # ── GPU Operator ───────────────────────────────────────────────────────
 # ClusterPolicy CRD — the GPU operator's primary configuration object
@@ -38,12 +38,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.cert-manager.io
----
-# ── dynamo-crds ────────────────────────────────────────────────────────
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: dynamocomponentdeployments.nvidia.com
 ---
 # ── Skyhook ────────────────────────────────────────────────────────────
 apiVersion: apiextensions.k8s.io/v1

--- a/tests/chainsaw/ai-conformance/kind-training/assert-namespaces.yaml
+++ b/tests/chainsaw/ai-conformance/kind-training/assert-namespaces.yaml
@@ -14,7 +14,7 @@
 
 # Assert that all namespaces created by the kind training stack exist.
 # Compared to the kind inference test:
-#   Removed: kgateway-system (inference-only)
+#   Removed: dynamo-system (no Dynamo dependency in kind training validation)
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -61,13 +61,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kai-scheduler
-status:
-  phase: Active
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: dynamo-system
 status:
   phase: Active
 ---

--- a/tests/chainsaw/ai-conformance/kind-training/chainsaw-test.yaml
+++ b/tests/chainsaw/ai-conformance/kind-training/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
 
     # ── CRDs ───────────────────────────────────────────────────────────
     - name: assert-crds
-      description: Verify critical CRDs are installed (dynamo, GPU operator, cert-manager).
+      description: Verify critical CRDs are installed (GPU operator, cert-manager, skyhook).
       timeouts:
         assert: 120s
       try:
@@ -106,10 +106,3 @@ spec:
       try:
         - assert:
             file: ../cluster/assert-kai-scheduler.yaml
-
-    # ── Dynamo Platform ────────────────────────────────────────────────
-    - name: assert-dynamo
-      description: Verify Dynamo operator, etcd, and NATS are healthy.
-      try:
-        - assert:
-            file: ../cluster/assert-dynamo.yaml


### PR DESCRIPTION
## Summary

Remove dynamo-crds and dynamo-platform from the `h100-kind-training` overlay. Dynamo is an inference serving platform and does not belong in training recipes.

## Motivation / Context

Dynamo components were incorrectly included in the kind training overlay, which would deploy unnecessary inference infrastructure when generating a training recipe for kind clusters.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: Recipe overlays (`recipes/overlays/`)

## Implementation Notes

Removed `dynamo-crds` and `dynamo-platform` componentRefs from `recipes/overlays/h100-kind-training.yaml`. No other training overlays include dynamo components.

## Testing

```bash
# Verified no other training overlays reference dynamo
grep -r dynamo recipes/overlays/ | grep training
# Only h100-kind-training.yaml was affected (now fixed)
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)