### PR TITLE
fix(recipes): correct component deployment ordering

### DIFF
--- a/pkg/recipe/deployment_order_guard_test.go
+++ b/pkg/recipe/deployment_order_guard_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestDeploymentOrderGuards(t *testing.T) {
+	tests := []struct {
+		name             string
+		criteria         func() *Criteria
+		requiredDeps     map[string][]string
+		requiredOrdering [][2]string
+	}{
+		{
+			name: "h100-eks-inference",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorH100
+				c.Intent = CriteriaIntentInference
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"gpu-operator": {"cert-manager", "kube-prometheus-stack", "skyhook-customizations"},
+			},
+			requiredOrdering: [][2]string{
+				{"skyhook-customizations", "gpu-operator"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+		{
+			name: "h100-eks-training",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorH100
+				c.Intent = CriteriaIntentTraining
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"gpu-operator": {"cert-manager", "kube-prometheus-stack", "skyhook-customizations"},
+			},
+			requiredOrdering: [][2]string{
+				{"skyhook-customizations", "gpu-operator"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+		{
+			name: "h100-eks-ubuntu-inference-dynamo",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorH100
+				c.Intent = CriteriaIntentInference
+				c.OS = CriteriaOSUbuntu
+				c.Platform = CriteriaPlatformDynamo
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"dynamo-platform": {"dynamo-crds", "cert-manager", "kube-prometheus-stack", "kai-scheduler"},
+			},
+			requiredOrdering: [][2]string{
+				{"kai-scheduler", "dynamo-platform"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+		{
+			name: "h100-kind-inference-dynamo",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceKind
+				c.Accelerator = CriteriaAcceleratorH100
+				c.Intent = CriteriaIntentInference
+				c.Platform = CriteriaPlatformDynamo
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"dynamo-platform": {"dynamo-crds", "cert-manager", "kube-prometheus-stack", "kai-scheduler"},
+			},
+			requiredOrdering: [][2]string{
+				{"kai-scheduler", "dynamo-platform"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewBuilder()
+			result, err := builder.BuildFromCriteria(context.Background(), tt.criteria())
+			if err != nil {
+				t.Fatalf("BuildFromCriteria failed: %v", err)
+			}
+
+			orderIndex := make(map[string]int, len(result.DeploymentOrder))
+			for i, name := range result.DeploymentOrder {
+				orderIndex[name] = i
+			}
+
+			for compName, deps := range tt.requiredDeps {
+				comp := result.GetComponentRef(compName)
+				if comp == nil {
+					t.Fatalf("required component %q not found", compName)
+				}
+				for _, dep := range deps {
+					if !slices.Contains(comp.DependencyRefs, dep) {
+						t.Errorf("component %q missing dependency %q (got %v)", compName, dep, comp.DependencyRefs)
+					}
+				}
+			}
+
+			for _, pair := range tt.requiredOrdering {
+				before, after := pair[0], pair[1]
+				beforeIdx, ok := orderIndex[before]
+				if !ok {
+					t.Fatalf("component %q not found in deploymentOrder (%v)", before, result.DeploymentOrder)
+				}
+				afterIdx, ok := orderIndex[after]
+				if !ok {
+					t.Fatalf("component %q not found in deploymentOrder (%v)", after, result.DeploymentOrder)
+				}
+				if beforeIdx >= afterIdx {
+					t.Errorf("deployment order regression: %q (idx=%d) must be before %q (idx=%d); order=%v",
+						before, beforeIdx, after, afterIdx, result.DeploymentOrder)
+				}
+			}
+		})
+	}
+}

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -61,6 +61,7 @@ spec:
         - components/nvsentinel/manifests/allow-intra-namespace.yaml
       dependencyRefs:
         - cert-manager
+        - gpu-operator
 
     - name: skyhook-operator
       type: Helm

--- a/recipes/overlays/h100-eks-inference.yaml
+++ b/recipes/overlays/h100-eks-inference.yaml
@@ -33,6 +33,12 @@ spec:
       value: ">= 1.32.4"
 
   componentRefs:
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - skyhook-customizations
 
     - name: skyhook-customizations
       type: Helm

--- a/recipes/overlays/h100-eks-training.yaml
+++ b/recipes/overlays/h100-eks-training.yaml
@@ -36,6 +36,10 @@ spec:
     # H100-specific GPU Operator overrides (inherits valuesFile from eks-training)
     - name: gpu-operator
       type: Helm
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - skyhook-customizations
       overrides:
         cdi:
           enabled: true

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -79,6 +79,7 @@ spec:
         - dynamo-crds
         - cert-manager
         - kube-prometheus-stack
+        - kai-scheduler
       overrides:
         etcd:
           persistence:

--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -49,6 +49,7 @@ spec:
         - dynamo-crds
         - cert-manager
         - kube-prometheus-stack
+        - kai-scheduler
       overrides:
         # Use kind's local-path-provisioner instead of EBS gp2
         etcd:

--- a/tests/chainsaw/ai-conformance/offline/assert-recipe.yaml
+++ b/tests/chainsaw/ai-conformance/offline/assert-recipe.yaml
@@ -60,12 +60,12 @@ deploymentOrder:
   - kgateway-crds
   - kgateway
   - kube-prometheus-stack
-  - dynamo-platform
-  - gpu-operator
   - k8s-ephemeral-storage-metrics
-  - kai-scheduler
-  - nvidia-dra-driver-gpu
-  - nvsentinel
   - prometheus-adapter
   - skyhook-operator
   - skyhook-customizations
+  - gpu-operator
+  - kai-scheduler
+  - dynamo-platform
+  - nvidia-dra-driver-gpu
+  - nvsentinel

--- a/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
@@ -53,12 +53,12 @@ deploymentOrder:
   - aws-efa
   - cert-manager
   - kube-prometheus-stack
-  - gpu-operator
   - k8s-ephemeral-storage-metrics
-  - kai-scheduler
   - kubeflow-trainer
-  - nvidia-dra-driver-gpu
-  - nvsentinel
   - prometheus-adapter
   - skyhook-operator
   - skyhook-customizations
+  - gpu-operator
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel


### PR DESCRIPTION
## Summary

Add dependency refs to ensure correct component deployment ordering in EKS and kind recipes.

## Motivation / Context

During EKS cluster deployment, skyhook-customizations (GPU node tuning) deploys last and triggers node reboots, disrupting all already-running pods. Additionally, dynamo-platform deploys before kai-scheduler is ready, and nvsentinel deploys before gpu-operator.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

- **gpu-operator → skyhook-customizations**: Added in `h100-eks-training` and `h100-eks-inference` overlays so node reboots complete before GPU operator starts.
- **nvsentinel → gpu-operator**: Added in `base.yaml` since nvsentinel requires GPU operator CRDs.
- **dynamo-platform → kai-scheduler**: Added in both EKS and kind dynamo overlays.
- `dependencyRefs` are replacing (not additive), so overlay changes include all deps for that component.
- `kgateway` dep for dynamo-platform was omitted because the test framework only validates deps against `base.yaml` + the current file, not the full inheritance chain. At runtime, kgateway deploys early via its own deps so ordering is not an issue.

## Testing

```bash
make test  # recipe tests pass
```

All recipe dependency and cycle tests pass.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)