### PR TITLE
Add atif1996 to copy-pr-bot trusted users

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -14,6 +14,7 @@
 
 enabled: true
 additional_trustees:
+  - atif1996
   - ayuskauskas
   - coffeepac
   - cullenmcdermott


### PR DESCRIPTION
## Summary

- Adds `atif1996` to the `additional_trustees` list in `.github/copy-pr-bot.yaml`