### PR TITLE
fix: pipeline issues around forked repos

### DIFF
--- a/.github/actions/cli-e2e/action.yml
+++ b/.github/actions/cli-e2e/action.yml
@@ -56,6 +56,7 @@ runs:
         rm -rf "${TMP}"
 
     - name: Generate SLSA predicate
+      if: github.event.pull_request.head.repo.fork == false
       uses: ./.github/actions/generate-slsa-predicate
       with:
         workflow_file: qualification.yaml
@@ -97,7 +98,21 @@ runs:
           echo "::warning::No binary attestation found (attestation tests will skip)"
         fi
 
+    ## skipping attestation tests for forked repository because
+    ## OIDC authentication is not available in forked repositories
+    - name: Run CLI chainsaw tests (forked repository)
+      if: github.event.pull_request.head.repo.fork == true
+      shell: bash
+      run: |
+        set -euo pipefail
+        chainsaw test \
+          --no-cluster \
+          --config tests/chainsaw/chainsaw-config.yaml \
+          --test-dir tests/chainsaw/cli/ \
+          --selector 'ci!=true'
+
     - name: Run CLI chainsaw tests
+      if: github.event.pull_request.head.repo.fork == false
       shell: bash
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary

fix pipelines on forks to skip attestation tests since oidc is missing.

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [ ] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
