### PR TITLE
fix(evidence): performance improvement - replace fixed sleeps with polling and refresh evidence

### DIFF
--- a/docs/conformance/cncf/README.md
+++ b/docs/conformance/cncf/README.md
@@ -77,16 +77,17 @@ Alternatively, run the evidence collection script directly:
 ./pkg/evidence/scripts/collect-evidence.sh dra
 ```
 
-> **Note:** The `--cncf-submission` flag deploys GPU workloads and takes ~15
-> minutes. The HPA test uses CUDA N-Body Simulation to stress GPUs and verifies
-> both scale-up and scale-down.
+> **Note:** The `--cncf-submission` flag deploys GPU workloads and takes ~5-10
+> minutes. The evidence collection script uses polling with early exit on both
+> success and failure, minimizing wait times. The HPA test uses CUDA N-Body
+> Simulation to stress GPUs and verifies scale-up.
 
 ### Two Modes
 
 | | `aicr validate --phase conformance` | `--cncf-submission` |
 |---|---|---|
 | **Purpose** | CI pass/fail | CNCF submission evidence |
-| **Speed** | ~3 minutes | ~15 minutes |
+| **Speed** | ~3 minutes | ~5-10 minutes |
 | **Deploys workloads** | No | Yes |
 | **Output** | Structural evidence (pass/fail + artifacts) | Behavioral evidence (command outputs, logs, queries) |
 | **DRA GPU allocation test** | Status check only | Deploys pod, verifies GPU access |

--- a/docs/conformance/cncf/evidence/accelerator-metrics.md
+++ b/docs/conformance/cncf/evidence/accelerator-metrics.md
@@ -1,7 +1,7 @@
 # Accelerator & AI Service Metrics
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:22:24 UTC
+**Generated:** 2026-03-02 18:29:45 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -22,14 +22,14 @@ Demonstrates two CNCF AI Conformance observability requirements:
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus
 NAME                                      READY   STATUS    RESTARTS   AGE
-prometheus-kube-prometheus-prometheus-0   2/2     Running   0          5d20h
+prometheus-kube-prometheus-prometheus-0   2/2     Running   0          47h
 ```
 
 **Prometheus service**
 ```
 $ kubectl get svc kube-prometheus-prometheus -n monitoring
-NAME                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
-kube-prometheus-prometheus   ClusterIP   172.20.174.169   <none>        9090/TCP,8080/TCP   11d
+NAME                         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
+kube-prometheus-prometheus   ClusterIP   172.20.206.75   <none>        9090/TCP,8080/TCP   2d
 ```
 
 ### Prometheus Adapter (Custom Metrics API)
@@ -37,15 +37,15 @@ kube-prometheus-prometheus   ClusterIP   172.20.174.169   <none>        9090/TCP
 **Prometheus adapter pod**
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus-adapter
-NAME                                 READY   STATUS    RESTARTS        AGE
-prometheus-adapter-d9dbc69cb-jxgp9   1/1     Running   1 (5m57s ago)   23h
+NAME                                  READY   STATUS    RESTARTS   AGE
+prometheus-adapter-585f5dfc99-nm42j   1/1     Running   0          47h
 ```
 
 **Prometheus adapter service**
 ```
 $ kubectl get svc prometheus-adapter -n monitoring
-NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-prometheus-adapter   ClusterIP   172.20.192.109   <none>        443/TCP   11d
+NAME                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+prometheus-adapter   ClusterIP   172.20.42.196   <none>        443/TCP   2d
 ```
 
 ### Grafana
@@ -53,8 +53,8 @@ prometheus-adapter   ClusterIP   172.20.192.109   <none>        443/TCP   11d
 **Grafana pod**
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana
-NAME                      READY   STATUS    RESTARTS   AGE
-grafana-c4bf56ffd-285sl   3/3     Running   0          5d20h
+NAME                       READY   STATUS    RESTARTS   AGE
+grafana-6494c6659c-l9jsk   3/3     Running   0          47h
 ```
 
 ## Accelerator Metrics (DCGM Exporter)
@@ -67,15 +67,15 @@ temperature, power draw, and more in Prometheus exposition format.
 **DCGM exporter pod**
 ```
 $ kubectl get pods -n gpu-operator -l app=nvidia-dcgm-exporter -o wide
-NAME                         READY   STATUS    RESTARTS        AGE     IP               NODE                             NOMINATED NODE   READINESS GATES
-nvidia-dcgm-exporter-br2tz   1/1     Running   1 (3m43s ago)   5m51s   100.65.138.241   ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME                         READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+nvidia-dcgm-exporter-9v4gs   1/1     Running   0          2d    100.65.218.207   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 **DCGM exporter service**
 ```
 $ kubectl get svc -n gpu-operator -l app=nvidia-dcgm-exporter
 NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
-nvidia-dcgm-exporter   ClusterIP   172.20.144.227   <none>        9400/TCP   6d
+nvidia-dcgm-exporter   ClusterIP   172.20.145.184   <none>        9400/TCP   2d
 ```
 
 ### DCGM Metrics Endpoint
@@ -84,36 +84,36 @@ Query DCGM exporter directly to show raw GPU metrics in Prometheus format.
 
 **Key GPU metrics from DCGM exporter (sampled)**
 ```
-DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
-DCGM_FI_DEV_GPU_TEMP{gpu="1",UUID="GPU-289275cb-a907-ab73-9a95-058ae119f62d",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
-DCGM_FI_DEV_GPU_TEMP{gpu="2",UUID="GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 27
-DCGM_FI_DEV_GPU_TEMP{gpu="3",UUID="GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
-DCGM_FI_DEV_GPU_TEMP{gpu="4",UUID="GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
-DCGM_FI_DEV_GPU_TEMP{gpu="5",UUID="GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 27
-DCGM_FI_DEV_GPU_TEMP{gpu="6",UUID="GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
-DCGM_FI_DEV_GPU_TEMP{gpu="7",UUID="GPU-b60b817a-a091-c492-4211-92b276d697e6",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
-DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.351000
-DCGM_FI_DEV_POWER_USAGE{gpu="1",UUID="GPU-289275cb-a907-ab73-9a95-058ae119f62d",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.746000
-DCGM_FI_DEV_POWER_USAGE{gpu="2",UUID="GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 66.834000
-DCGM_FI_DEV_POWER_USAGE{gpu="3",UUID="GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 69.771000
-DCGM_FI_DEV_POWER_USAGE{gpu="4",UUID="GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 66.401000
-DCGM_FI_DEV_POWER_USAGE{gpu="5",UUID="GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 66.619000
-DCGM_FI_DEV_POWER_USAGE{gpu="6",UUID="GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.529000
-DCGM_FI_DEV_POWER_USAGE{gpu="7",UUID="GPU-b60b817a-a091-c492-4211-92b276d697e6",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 69.468000
-DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="1",UUID="GPU-289275cb-a907-ab73-9a95-058ae119f62d",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="2",UUID="GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="3",UUID="GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="4",UUID="GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="5",UUID="GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="6",UUID="GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="7",UUID="GPU-b60b817a-a091-c492-4211-92b276d697e6",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="1",UUID="GPU-289275cb-a907-ab73-9a95-058ae119f62d",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="2",UUID="GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="3",UUID="GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="4",UUID="GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="5",UUID="GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-171-120.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 27
+DCGM_FI_DEV_GPU_TEMP{gpu="1",UUID="GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="2",UUID="GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-dkb9q",pod_uid=""} 29
+DCGM_FI_DEV_GPU_TEMP{gpu="3",UUID="GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
+DCGM_FI_DEV_GPU_TEMP{gpu="4",UUID="GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="5",UUID="GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_GPU_TEMP{gpu="6",UUID="GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="7",UUID="GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 27
+DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.433000
+DCGM_FI_DEV_POWER_USAGE{gpu="1",UUID="GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 70.849000
+DCGM_FI_DEV_POWER_USAGE{gpu="2",UUID="GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-dkb9q",pod_uid=""} 110.786000
+DCGM_FI_DEV_POWER_USAGE{gpu="3",UUID="GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.933000
+DCGM_FI_DEV_POWER_USAGE{gpu="4",UUID="GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 69.140000
+DCGM_FI_DEV_POWER_USAGE{gpu="5",UUID="GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.033000
+DCGM_FI_DEV_POWER_USAGE{gpu="6",UUID="GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.156000
+DCGM_FI_DEV_POWER_USAGE{gpu="7",UUID="GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.495000
+DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="1",UUID="GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="2",UUID="GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-dkb9q",pod_uid=""} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="3",UUID="GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="4",UUID="GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="5",UUID="GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="6",UUID="GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="7",UUID="GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="1",UUID="GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="2",UUID="GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-dkb9q",pod_uid=""} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="3",UUID="GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="4",UUID="GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="5",UUID="GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-100-64-147-149.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
 ```
 
 ### Prometheus Querying GPU Metrics
@@ -130,184 +130,184 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia0",
           "endpoint": "gpu-metrics",
           "gpu": "0",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.215,
+          1772476205.739,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-289275cb-a907-ab73-9a95-058ae119f62d",
-          "__name__": "DCGM_FI_DEV_GPU_UTIL",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia1",
-          "endpoint": "gpu-metrics",
-          "gpu": "1",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964566.215,
-          "0"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",
-          "__name__": "DCGM_FI_DEV_GPU_UTIL",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia2",
-          "endpoint": "gpu-metrics",
-          "gpu": "2",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:75:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964566.215,
-          "0"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.215,
+          1772476205.739,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.215,
+          1772476205.739,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.215,
+          1772476205.739,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia6",
           "endpoint": "gpu-metrics",
           "gpu": "6",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.215,
+          1772476205.739,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-b60b817a-a091-c492-4211-92b276d697e6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.215,
+          1772476205.739,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia1",
+          "endpoint": "gpu-metrics",
+          "gpu": "1",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476205.739,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "main",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-dkb9q",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476205.739,
           "0"
         ]
       }
@@ -326,185 +326,185 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia0",
           "endpoint": "gpu-metrics",
           "gpu": "0",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.661,
+          1772476206.062,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-289275cb-a907-ab73-9a95-058ae119f62d",
-          "__name__": "DCGM_FI_DEV_FB_USED",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia1",
-          "endpoint": "gpu-metrics",
-          "gpu": "1",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964566.661,
-          "0"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",
-          "__name__": "DCGM_FI_DEV_FB_USED",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia2",
-          "endpoint": "gpu-metrics",
-          "gpu": "2",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:75:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964566.661,
-          "0"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.661,
+          1772476206.062,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.661,
+          1772476206.062,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.661,
+          1772476206.062,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia6",
           "endpoint": "gpu-metrics",
           "gpu": "6",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.661,
+          1772476206.062,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-b60b817a-a091-c492-4211-92b276d697e6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964566.661,
+          1772476206.062,
           "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia1",
+          "endpoint": "gpu-metrics",
+          "gpu": "1",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476206.062,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "main",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-dkb9q",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476206.062,
+          "74166"
         ]
       }
     ]
@@ -522,185 +522,185 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia0",
           "endpoint": "gpu-metrics",
           "gpu": "0",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.081,
+          1772476206.403,
           "27"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-289275cb-a907-ab73-9a95-058ae119f62d",
-          "__name__": "DCGM_FI_DEV_GPU_TEMP",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia1",
-          "endpoint": "gpu-metrics",
-          "gpu": "1",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964567.081,
-          "28"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",
-          "__name__": "DCGM_FI_DEV_GPU_TEMP",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia2",
-          "endpoint": "gpu-metrics",
-          "gpu": "2",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:75:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964567.081,
-          "27"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.081,
+          1772476206.403,
           "29"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.081,
-          "29"
+          1772476206.403,
+          "28"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.081,
+          1772476206.403,
+          "26"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia6",
+          "endpoint": "gpu-metrics",
+          "gpu": "6",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:B9:00.0",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476206.403,
+          "28"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia7",
+          "endpoint": "gpu-metrics",
+          "gpu": "7",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:CA:00.0",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476206.403,
           "27"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
-          "device": "nvidia6",
+          "device": "nvidia1",
           "endpoint": "gpu-metrics",
-          "gpu": "6",
-          "instance": "100.65.138.241:9400",
+          "gpu": "1",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.081,
-          "29"
+          1772476206.403,
+          "28"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-b60b817a-a091-c492-4211-92b276d697e6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia7",
+          "container": "main",
+          "device": "nvidia2",
           "endpoint": "gpu-metrics",
-          "gpu": "7",
-          "instance": "100.65.138.241:9400",
+          "gpu": "2",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-dkb9q",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.081,
-          "28"
+          1772476206.403,
+          "29"
         ]
       }
     ]
@@ -718,185 +718,185 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia0",
           "endpoint": "gpu-metrics",
           "gpu": "0",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.42,
-          "67.351"
+          1772476206.746,
+          "67.433"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-289275cb-a907-ab73-9a95-058ae119f62d",
-          "__name__": "DCGM_FI_DEV_POWER_USAGE",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia1",
-          "endpoint": "gpu-metrics",
-          "gpu": "1",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964567.42,
-          "67.746"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-f814846a-9bbe-469e-97c3-d037d67c3c32",
-          "__name__": "DCGM_FI_DEV_POWER_USAGE",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia2",
-          "endpoint": "gpu-metrics",
-          "gpu": "2",
-          "instance": "100.65.138.241:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:75:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1771964567.42,
-          "66.834"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.42,
-          "69.771"
+          1772476206.746,
+          "67.933"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.42,
-          "66.401"
+          1772476206.746,
+          "69.14"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.42,
-          "66.619"
+          1772476206.746,
+          "67.033"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia6",
           "endpoint": "gpu-metrics",
           "gpu": "6",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.42,
-          "68.529"
+          1772476206.746,
+          "67.156"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-100-64-171-120.ec2.internal",
-          "UUID": "GPU-b60b817a-a091-c492-4211-92b276d697e6",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "100.65.138.241:9400",
+          "instance": "100.65.218.207:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-br2tz",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1771964567.42,
-          "69.468"
+          1772476206.746,
+          "68.495"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia1",
+          "endpoint": "gpu-metrics",
+          "gpu": "1",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-9v4gs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476206.746,
+          "70.849"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-100-64-147-149.ec2.internal",
+          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "main",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "100.65.218.207:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-dkb9q",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1772476206.746,
+          "110.786"
         ]
       }
     ]
@@ -912,11 +912,11 @@ enabling HPA and other consumers to act on workload-specific metrics.
 **Custom metrics API available resources**
 ```
 $ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | jq .resources[].name
-namespaces/gpu_power_usage
-pods/gpu_utilization
 namespaces/gpu_utilization
-namespaces/gpu_memory_used
+pods/gpu_utilization
 pods/gpu_memory_used
+namespaces/gpu_memory_used
+namespaces/gpu_power_usage
 pods/gpu_power_usage
 ```
 

--- a/docs/conformance/cncf/evidence/cluster-autoscaling.md
+++ b/docs/conformance/cncf/evidence/cluster-autoscaling.md
@@ -1,7 +1,7 @@
 # Cluster Autoscaling
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:26:59 UTC
+**Generated:** 2026-03-02 18:32:08 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -70,7 +70,7 @@ up/down based on workload demand. The ASG is configured with p5.48xlarge instanc
 +---------------------------------------+-------------------------+
 |                ImageId                |      InstanceType       |
 +---------------------------------------+-------------------------+
-|  ami-XXXXXXXXXXXX                     |  p5.48xlarge            |
+|  ami-00fc69912e2e87875                |  p5.48xlarge            |
 +---------------------------------------+-------------------------+
 ||                      CapacityReservation                      ||
 |+--------------------------------+------------------------------+|
@@ -93,7 +93,7 @@ on-demand availability risk.
 |    DescribeCapacityReservations     |
 +------------+------------------------+
 |  AZ        |  us-east-1e            |
-|  Available |  0                     |
+|  Available |  3                     |
 |  ID        |  cr-0cbe491320188dfa6  |
 |  State     |  active                |
 |  Total     |  10                    |
@@ -110,7 +110,7 @@ appropriate labels and GPU resources.
 ```
 $ kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.capacity.nvidia\.com/gpu,INSTANCE-TYPE:.metadata.labels.node\.kubernetes\.io/instance-type,VERSION:.status.nodeInfo.kubeletVersion
 NAME                             GPU      INSTANCE-TYPE   VERSION
-ip-100-64-171-120.ec2.internal   8        p5.48xlarge     v1.34.1
+ip-100-64-147-149.ec2.internal   8        p5.48xlarge     v1.34.3
 ip-100-64-4-149.ec2.internal     <none>   m4.16xlarge     v1.34.2
 ip-100-64-6-88.ec2.internal      <none>   m4.16xlarge     v1.34.2
 ip-100-64-83-166.ec2.internal    <none>   m4.16xlarge     v1.34.1

--- a/docs/conformance/cncf/evidence/dra-support.md
+++ b/docs/conformance/cncf/evidence/dra-support.md
@@ -1,7 +1,7 @@
 # DRA Support (Dynamic Resource Allocation)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:20:22 UTC
+**Generated:** 2026-03-02 18:27:47 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -28,9 +28,9 @@ resourceslices                        resource.k8s.io/v1   false        Resource
 **DRA driver pods**
 ```
 $ kubectl get pods -n nvidia-dra-driver -o wide
-NAME                                                READY   STATUS    RESTARTS        AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-nvidia-dra-driver-gpu-controller-75f987ff5f-chrbn   1/1     Running   1 (3m54s ago)   47h   100.65.71.124   ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-dra-driver-gpu-kubelet-plugin-rmxdj          2/2     Running   2 (3m54s ago)   17m   100.65.2.168    ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME                                               READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+nvidia-dra-driver-gpu-controller-9d69fbdcb-kdstj   1/1     Running   0          47h   100.64.6.159     ip-100-64-4-149.ec2.internal     <none>           <none>
+nvidia-dra-driver-gpu-kubelet-plugin-gmcsz         2/2     Running   0          47h   100.65.244.134   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 ## Device Advertisement (ResourceSlices)
@@ -39,8 +39,8 @@ nvidia-dra-driver-gpu-kubelet-plugin-rmxdj          2/2     Running   2 (3m54s a
 ```
 $ kubectl get resourceslices
 NAME                                                             NODE                             DRIVER                      POOL                             AGE
-ip-100-64-171-120.ec2.internal-compute-domain.nvidia.com-76zr9   ip-100-64-171-120.ec2.internal   compute-domain.nvidia.com   ip-100-64-171-120.ec2.internal   2m12s
-ip-100-64-171-120.ec2.internal-gpu.nvidia.com-75xvv              ip-100-64-171-120.ec2.internal   gpu.nvidia.com              ip-100-64-171-120.ec2.internal   2m10s
+ip-100-64-147-149.ec2.internal-compute-domain.nvidia.com-pslfg   ip-100-64-147-149.ec2.internal   compute-domain.nvidia.com   ip-100-64-147-149.ec2.internal   47h
+ip-100-64-147-149.ec2.internal-gpu.nvidia.com-bvcfk              ip-100-64-147-149.ec2.internal   gpu.nvidia.com              ip-100-64-147-149.ec2.internal   47h
 ```
 
 ## GPU Allocation Test
@@ -48,8 +48,23 @@ ip-100-64-171-120.ec2.internal-gpu.nvidia.com-75xvv              ip-100-64-171-1
 Deploy a test pod that requests 1 GPU via ResourceClaim and verifies device access.
 
 **Test manifest:** `pkg/evidence/scripts/manifests/dra-gpu-test.yaml`
-
 ```yaml
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DRA GPU allocation test
+# Usage: kubectl apply -f pkg/evidence/scripts/manifests/dra-gpu-test.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -99,7 +114,7 @@ spec:
 
 **Apply test manifest**
 ```
-$ kubectl apply -f pkg/evidence/scripts/manifests/dra-gpu-test.yaml
+$ kubectl apply -f manifests/dra-gpu-test.yaml
 namespace/dra-test created
 resourceclaim.resource.k8s.io/gpu-claim created
 pod/dra-gpu-test created
@@ -109,14 +124,14 @@ pod/dra-gpu-test created
 ```
 $ kubectl get resourceclaim -n dra-test -o wide
 NAME        STATE     AGE
-gpu-claim   pending   10s
+gpu-claim   pending   11s
 ```
 
 **Pod status**
 ```
 $ kubectl get pod dra-gpu-test -n dra-test -o wide
-NAME           READY   STATUS      RESTARTS   AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-dra-gpu-test   0/1     Completed   0          10s   100.65.63.246   ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME           READY   STATUS      RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+dra-gpu-test   0/1     Completed   0          12s   100.65.115.146   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 **Pod logs**
@@ -125,7 +140,7 @@ $ kubectl logs dra-gpu-test -n dra-test
 /dev/nvidia-modeset
 /dev/nvidia-uvm
 /dev/nvidia-uvm-tools
-/dev/nvidia2
+/dev/nvidia0
 /dev/nvidiactl
 DRA GPU allocation successful
 ```
@@ -136,6 +151,6 @@ DRA GPU allocation successful
 
 **Delete test namespace**
 ```
-$ kubectl delete namespace dra-test --ignore-not-found
-namespace "dra-test" deleted
+$ cleanup_ns dra-test
+
 ```

--- a/docs/conformance/cncf/evidence/gang-scheduling.md
+++ b/docs/conformance/cncf/evidence/gang-scheduling.md
@@ -1,7 +1,7 @@
 # Gang Scheduling (KAI Scheduler)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:20:59 UTC
+**Generated:** 2026-03-02 18:28:23 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -16,26 +16,26 @@ scheduler with PodGroups. Both pods in the group must be scheduled together or n
 ```
 $ kubectl get deploy -n kai-scheduler
 NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
-admission               1/1     1            1           5d23h
-binder                  1/1     1            1           5d23h
-kai-operator            1/1     1            1           7d
-kai-scheduler-default   1/1     1            1           7d
-pod-grouper             1/1     1            1           5d23h
-podgroup-controller     1/1     1            1           5d23h
-queue-controller        1/1     1            1           5d23h
+admission               1/1     1            1           47h
+binder                  1/1     1            1           47h
+kai-operator            1/1     1            1           2d
+kai-scheduler-default   1/1     1            1           2d
+pod-grouper             1/1     1            1           47h
+podgroup-controller     1/1     1            1           47h
+queue-controller        1/1     1            1           47h
 ```
 
 **KAI scheduler pods**
 ```
 $ kubectl get pods -n kai-scheduler
 NAME                                     READY   STATUS    RESTARTS   AGE
-admission-669878d9d8-thrfv               1/1     Running   0          5d20h
-binder-7f67b6c8f8-qkx4v                  1/1     Running   0          5d20h
-kai-operator-6dd58c647-mhbr2             1/1     Running   0          5d20h
-kai-scheduler-default-75b48f4b9f-vq52j   1/1     Running   0          5d20h
-pod-grouper-5d5c88b6fb-fgbfn             1/1     Running   0          5d20h
-podgroup-controller-56947478b-ldphl      1/1     Running   0          5d20h
-queue-controller-5f5b6895b6-t46mz        1/1     Running   0          5d20h
+admission-7d7df8fb9c-k8nln               1/1     Running   0          47h
+binder-7c77f88c96-n4ptk                  1/1     Running   0          47h
+kai-operator-6f8c7cffdc-2gm6x            1/1     Running   0          47h
+kai-scheduler-default-57cdcbc95b-t8579   1/1     Running   0          47h
+pod-grouper-64b948697b-wx8d8             1/1     Running   0          47h
+podgroup-controller-69d7f579d4-sgkzv     1/1     Running   0          47h
+queue-controller-d9878bf9b-6q4sh         1/1     Running   0          47h
 ```
 
 ## PodGroup CRD
@@ -44,7 +44,7 @@ queue-controller-5f5b6895b6-t46mz        1/1     Running   0          5d20h
 ```
 $ kubectl get crd podgroups.scheduling.run.ai
 NAME                          CREATED AT
-podgroups.scheduling.run.ai   2026-02-12T20:42:05Z
+podgroups.scheduling.run.ai   2026-02-28T18:05:52Z
 ```
 
 ## Gang Scheduling Test
@@ -53,8 +53,25 @@ Deploy a PodGroup with minMember=2 and two GPU pods. KAI scheduler ensures both
 pods are scheduled atomically.
 
 **Test manifest:** `pkg/evidence/scripts/manifests/gang-scheduling-test.yaml`
-
 ```yaml
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Gang scheduling test with PodGroup and KAI scheduler
+# Demonstrates all-or-nothing scheduling: both pods must be scheduled together
+# Requires: KAI scheduler with PodGroup CRD
+# Usage: kubectl apply -f pkg/evidence/scripts/manifests/gang-scheduling-test.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -123,25 +140,15 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 1
-spec:
-  devices:
-    requests:
-      - name: gpu
-        exactly:
-          deviceClassName: gpu.nvidia.com
-          allocationMode: ExactCount
-          count: 1
 ```
 
 **Apply test manifest**
 ```
-$ kubectl apply -f pkg/evidence/scripts/manifests/gang-scheduling-test.yaml
+$ kubectl apply -f manifests/gang-scheduling-test.yaml
 namespace/gang-scheduling-test created
 podgroup.scheduling.run.ai/gang-test-group created
 pod/gang-worker-0 created
 pod/gang-worker-1 created
-resourceclaim.resource.k8s.io/gang-gpu-claim-0 created
-resourceclaim.resource.k8s.io/gang-gpu-claim-1 created
 ```
 
 **PodGroup status**
@@ -149,22 +156,22 @@ resourceclaim.resource.k8s.io/gang-gpu-claim-1 created
 $ kubectl get podgroups -n gang-scheduling-test -o wide
 NAME                                                    AGE
 gang-test-group                                         12s
-pg-gang-worker-0-9d788a4d-ca91-4057-8fcd-569ca994417e   12s
-pg-gang-worker-1-ac139cd5-5d46-471f-bdfb-6c52470eb405   11s
+pg-gang-worker-0-e88edf69-abce-41ce-9ca9-3dc95d1feb8d   11s
+pg-gang-worker-1-07906b8a-1863-43a7-8cac-9ab74199ee0a   10s
 ```
 
 **Pod status**
 ```
 $ kubectl get pods -n gang-scheduling-test -o wide
-NAME            READY   STATUS      RESTARTS   AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-gang-worker-0   0/1     Completed   0          13s   100.65.1.153    ip-100-64-171-120.ec2.internal   <none>           <none>
-gang-worker-1   0/1     Completed   0          12s   100.65.247.22   ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME            READY   STATUS      RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+gang-worker-0   0/1     Completed   0          13s   100.65.18.82     ip-100-64-147-149.ec2.internal   <none>           <none>
+gang-worker-1   0/1     Completed   0          12s   100.65.228.165   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 **gang-worker-0 logs**
 ```
 $ kubectl logs gang-worker-0 -n gang-scheduling-test
-Tue Feb 24 20:21:18 2026       
+Mon Mar  2 18:28:37 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
 +-----------------------------------------+------------------------+----------------------+
@@ -172,7 +179,7 @@ Tue Feb 24 20:21:18 2026
 | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
-|   0  NVIDIA H100 80GB HBM3          On  |   00000000:75:00.0 Off |                    0 |
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:B9:00.0 Off |                    0 |
 | N/A   28C    P0             67W /  700W |       0MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
@@ -190,7 +197,7 @@ Gang worker 0 completed successfully
 **gang-worker-1 logs**
 ```
 $ kubectl logs gang-worker-1 -n gang-scheduling-test
-Tue Feb 24 20:21:18 2026       
+Mon Mar  2 18:28:37 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
 +-----------------------------------------+------------------------+----------------------+
@@ -199,7 +206,7 @@ Tue Feb 24 20:21:18 2026
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
 |   0  NVIDIA H100 80GB HBM3          On  |   00000000:86:00.0 Off |                    0 |
-| N/A   29C    P0             69W /  700W |       0MiB /  81559MiB |      0%      Default |
+| N/A   29C    P0             68W /  700W |       0MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 
@@ -219,6 +226,6 @@ Gang worker 1 completed successfully
 
 **Delete test namespace**
 ```
-$ kubectl delete namespace gang-scheduling-test --ignore-not-found
-namespace "gang-scheduling-test" deleted
+$ cleanup_ns gang-scheduling-test
+
 ```

--- a/docs/conformance/cncf/evidence/inference-gateway.md
+++ b/docs/conformance/cncf/evidence/inference-gateway.md
@@ -1,7 +1,7 @@
 # Inference API Gateway (kgateway)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:22:48 UTC
+**Generated:** 2026-03-02 18:30:07 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -27,16 +27,16 @@ with an implementation for advanced traffic management for inference services.
 ```
 $ kubectl get deploy -n kgateway-system
 NAME                READY   UP-TO-DATE   AVAILABLE   AGE
-inference-gateway   1/1     1            1           11d
-kgateway            1/1     1            1           11d
+inference-gateway   1/1     1            1           2d
+kgateway            1/1     1            1           2d
 ```
 
 **kgateway pods**
 ```
 $ kubectl get pods -n kgateway-system
 NAME                                 READY   STATUS    RESTARTS   AGE
-inference-gateway-7cc77867db-pcvd6   1/1     Running   0          5d20h
-kgateway-754f8c47b-m8jbk             1/1     Running   0          5d20h
+inference-gateway-6f458cff9d-vpnhj   1/1     Running   0          47h
+kgateway-db4cf9d47-scpmv             1/1     Running   0          47h
 ```
 
 ## GatewayClass
@@ -45,8 +45,8 @@ kgateway-754f8c47b-m8jbk             1/1     Running   0          5d20h
 ```
 $ kubectl get gatewayclass
 NAME                CONTROLLER              ACCEPTED   AGE
-kgateway            kgateway.dev/kgateway   True       11d
-kgateway-waypoint   kgateway.dev/kgateway   True       11d
+kgateway            kgateway.dev/kgateway   True       2d
+kgateway-waypoint   kgateway.dev/kgateway   True       2d
 ```
 
 ## Gateway API CRDs
@@ -59,22 +59,22 @@ No resources found
 
 **All gateway-related CRDs**
 ```
-gatewayclasses.gateway.networking.k8s.io               2026-02-12T20:25:46Z
-gateways.gateway.networking.k8s.io                     2026-02-12T20:25:47Z
-grpcroutes.gateway.networking.k8s.io                   2026-02-12T20:25:47Z
-httproutes.gateway.networking.k8s.io                   2026-02-12T20:25:48Z
-referencegrants.gateway.networking.k8s.io              2026-02-12T20:25:49Z
+gatewayclasses.gateway.networking.k8s.io               2026-02-28T18:01:53Z
+gateways.gateway.networking.k8s.io                     2026-02-28T18:01:53Z
+grpcroutes.gateway.networking.k8s.io                   2026-02-28T18:01:54Z
+httproutes.gateway.networking.k8s.io                   2026-02-28T18:01:54Z
+referencegrants.gateway.networking.k8s.io              2026-02-28T18:01:55Z
 ```
 
 ## Inference Extension CRDs
 
 **Inference CRDs**
 ```
-inferencemodelrewrites.inference.networking.x-k8s.io   2026-02-13T04:02:05Z
-inferenceobjectives.inference.networking.x-k8s.io      2026-02-13T04:02:06Z
-inferencepoolimports.inference.networking.x-k8s.io     2026-02-13T04:02:06Z
-inferencepools.inference.networking.k8s.io             2026-02-13T04:02:06Z
-inferencepools.inference.networking.x-k8s.io           2026-02-13T04:02:06Z
+inferencemodelrewrites.inference.networking.x-k8s.io   2026-02-28T18:01:55Z
+inferenceobjectives.inference.networking.x-k8s.io      2026-02-28T18:01:55Z
+inferencepoolimports.inference.networking.x-k8s.io     2026-02-28T18:01:56Z
+inferencepools.inference.networking.k8s.io             2026-02-28T18:01:56Z
+inferencepools.inference.networking.x-k8s.io           2026-02-28T18:01:56Z
 ```
 
 ## Active Gateway
@@ -82,8 +82,8 @@ inferencepools.inference.networking.x-k8s.io           2026-02-13T04:02:06Z
 **Gateways**
 ```
 $ kubectl get gateways -A
-NAMESPACE         NAME                CLASS      ADDRESS                                                                 PROGRAMMED   AGE
-kgateway-system   inference-gateway   kgateway   a54ce9a4a35c046319fe83adf42874ea-40675078.us-east-1.elb.amazonaws.com   True         11d
+NAMESPACE         NAME                CLASS      ADDRESS                                                                  PROGRAMMED   AGE
+kgateway-system   inference-gateway   kgateway   a6f2d9a8d891f41d095dc1c96e933d01-794641921.us-east-1.elb.amazonaws.com   True         2d
 ```
 
 **Gateway details**
@@ -97,15 +97,20 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "10"
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"gateway.networking.k8s.io/v1","kind":"Gateway","metadata":{"annotations":{"helm.sh/hook":"post-install,post-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"10"},"name":"inference-gateway","namespace":"kgateway-system"},"spec":{"gatewayClassName":"kgateway","listeners":[{"allowedRoutes":{"namespaces":{"from":"All"}},"name":"http","port":80,"protocol":"HTTP"}]}}
-  creationTimestamp: "2026-02-12T20:26:19Z"
-  generation: 1
+      {"apiVersion":"gateway.networking.k8s.io/v1","kind":"Gateway","metadata":{"annotations":{"helm.sh/hook":"post-install,post-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"10"},"name":"inference-gateway","namespace":"kgateway-system"},"spec":{"gatewayClassName":"kgateway","infrastructure":{"parametersRef":{"group":"gateway.kgateway.dev","kind":"GatewayParameters","name":"system-proxy"}},"listeners":[{"allowedRoutes":{"namespaces":{"from":"All"}},"name":"http","port":80,"protocol":"HTTP"}]}}
+  creationTimestamp: "2026-02-28T18:02:11Z"
+  generation: 2
   name: inference-gateway
   namespace: kgateway-system
-  resourceVersion: "64362"
-  uid: 77a1da90-610a-4d2b-af39-f54d3c69828a
+  resourceVersion: "8821127"
+  uid: f56b1086-711b-48ae-951d-c228f72ceb69
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: system-proxy
   listeners:
   - allowedRoutes:
       namespaces:
@@ -116,44 +121,44 @@ spec:
 status:
   addresses:
   - type: Hostname
-    value: a54ce9a4a35c046319fe83adf42874ea-40675078.us-east-1.elb.amazonaws.com
+    value: a6f2d9a8d891f41d095dc1c96e933d01-794641921.us-east-1.elb.amazonaws.com
   conditions:
-  - lastTransitionTime: "2026-02-12T20:26:19Z"
+  - lastTransitionTime: "2026-02-28T18:02:17Z"
     message: ""
-    observedGeneration: 1
+    observedGeneration: 2
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: "2026-02-12T20:26:19Z"
+  - lastTransitionTime: "2026-02-28T18:02:17Z"
     message: ""
-    observedGeneration: 1
+    observedGeneration: 2
     reason: Programmed
     status: "True"
     type: Programmed
   listeners:
   - attachedRoutes: 0
     conditions:
-    - lastTransitionTime: "2026-02-12T20:26:19Z"
+    - lastTransitionTime: "2026-02-28T18:02:17Z"
       message: ""
-      observedGeneration: 1
+      observedGeneration: 2
       reason: Accepted
       status: "True"
       type: Accepted
-    - lastTransitionTime: "2026-02-12T20:26:19Z"
+    - lastTransitionTime: "2026-02-28T18:02:17Z"
       message: ""
-      observedGeneration: 1
+      observedGeneration: 2
       reason: NoConflicts
       status: "False"
       type: Conflicted
-    - lastTransitionTime: "2026-02-12T20:26:19Z"
+    - lastTransitionTime: "2026-02-28T18:02:17Z"
       message: ""
-      observedGeneration: 1
+      observedGeneration: 2
       reason: ResolvedRefs
       status: "True"
       type: ResolvedRefs
-    - lastTransitionTime: "2026-02-12T20:26:19Z"
+    - lastTransitionTime: "2026-02-28T18:02:17Z"
       message: ""
-      observedGeneration: 1
+      observedGeneration: 2
       reason: Programmed
       status: "True"
       type: Programmed

--- a/docs/conformance/cncf/evidence/pod-autoscaling.md
+++ b/docs/conformance/cncf/evidence/pod-autoscaling.md
@@ -1,7 +1,7 @@
 # Pod Autoscaling (HPA with GPU Metrics)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:43:33 UTC
+**Generated:** 2026-03-02 18:30:49 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -17,8 +17,7 @@ utilizing accelerators, including the ability to scale based on custom GPU metri
 3. **GPU Stress Workload** — Deployment running CUDA N-Body Simulation to generate GPU load
 4. **HPA Configuration** — Targets `gpu_utilization` with threshold of 50%
 5. **HPA Scale-Up** — Successfully scales replicas when GPU utilization exceeds target
-6. **HPA Scale-Down** — Successfully scales back down when GPU load is removed
-7. **Result: PASS**
+6. **Result: PASS**
 
 ---
 
@@ -27,15 +26,15 @@ utilizing accelerators, including the ability to scale based on custom GPU metri
 **Prometheus adapter pod**
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus-adapter
-NAME                                 READY   STATUS    RESTARTS      AGE
-prometheus-adapter-d9dbc69cb-jxgp9   1/1     Running   1 (27m ago)   23h
+NAME                                  READY   STATUS    RESTARTS   AGE
+prometheus-adapter-585f5dfc99-nm42j   1/1     Running   0          47h
 ```
 
 **Prometheus adapter service**
 ```
 $ kubectl get svc prometheus-adapter -n monitoring
-NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-prometheus-adapter   ClusterIP   172.20.192.109   <none>        443/TCP   11d
+NAME                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+prometheus-adapter   ClusterIP   172.20.42.196   <none>        443/TCP   2d
 ```
 
 ## Custom Metrics API
@@ -43,12 +42,12 @@ prometheus-adapter   ClusterIP   172.20.192.109   <none>        443/TCP   11d
 **Available custom metrics**
 ```
 $ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | jq .resources[].name
+pods/gpu_utilization
+namespaces/gpu_utilization
 pods/gpu_memory_used
 namespaces/gpu_memory_used
-pods/gpu_power_usage
 namespaces/gpu_power_usage
-namespaces/gpu_utilization
-pods/gpu_utilization
+pods/gpu_power_usage
 ```
 
 ## GPU Stress Test Deployment
@@ -57,8 +56,24 @@ Deploy a GPU workload running CUDA N-Body Simulation to generate sustained GPU u
 then create an HPA targeting `gpu_utilization` to demonstrate autoscaling.
 
 **Test manifest:** `pkg/evidence/scripts/manifests/hpa-gpu-test.yaml`
-
 ```yaml
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HPA Pod Autoscaling test with custom GPU metrics
+# Demonstrates HPA scaling based on gpu_utilization from prometheus-adapter
+# Usage: kubectl apply -f pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -80,6 +95,8 @@ spec:
       labels:
         app: gpu-workload
     spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -91,7 +108,7 @@ spec:
         - name: gpu-worker
           image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.7.1-ubuntu18.04
           command: ["bash", "-c"]
-          args: ["/cuda-samples/nbody -benchmark -numbodies=4194304 -iterations=30 || true; exec sleep infinity"]
+          args: ["/cuda-samples/nbody -benchmark -numbodies=4194304 -iterations=9999 || true"]
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -126,7 +143,7 @@ spec:
 
 **Apply test manifest**
 ```
-$ kubectl apply -f pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
+$ kubectl apply -f manifests/hpa-gpu-test.yaml
 namespace/hpa-test created
 deployment.apps/gpu-workload created
 horizontalpodautoscaler.autoscaling/gpu-workload-hpa created
@@ -135,8 +152,8 @@ horizontalpodautoscaler.autoscaling/gpu-workload-hpa created
 **GPU workload pod**
 ```
 $ kubectl get pods -n hpa-test -o wide
-NAME                           READY   STATUS    RESTARTS   AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-gpu-workload-7d7f4dbdf-9559s   1/1     Running   0          3s    100.65.30.220   ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME                           READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+gpu-workload-7bccc5b5d-vsztd   1/1     Running   0          3s    100.65.168.154   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 ## HPA Status
@@ -145,7 +162,7 @@ gpu-workload-7d7f4dbdf-9559s   1/1     Running   0          3s    100.65.30.220 
 ```
 $ kubectl get hpa -n hpa-test
 NAME               REFERENCE                 TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
-gpu-workload-hpa   Deployment/gpu-workload   100/50    1         4         2          101s
+gpu-workload-hpa   Deployment/gpu-workload   100/50    1         2         2          48s
 ```
 
 **HPA details**
@@ -155,13 +172,25 @@ Name:                         gpu-workload-hpa
 Namespace:                    hpa-test
 Labels:                       <none>
 Annotations:                  <none>
-CreationTimestamp:            Tue, 24 Feb 2026 12:43:45 -0800
+CreationTimestamp:            Mon, 02 Mar 2026 10:30:59 -0800
 Reference:                    Deployment/gpu-workload
 Metrics:                      ( current / target )
   "gpu_utilization" on pods:  100 / 50
 Min replicas:                 1
-Max replicas:                 4
-Deployment pods:              2 current / 2 desired
+Max replicas:                 2
+Behavior:
+  Scale Up:
+    Stabilization Window: 0 seconds
+    Select Policy: Max
+    Policies:
+      - Type: Pods     Value: 4    Period: 15 seconds
+      - Type: Percent  Value: 100  Period: 15 seconds
+  Scale Down:
+    Stabilization Window: 30 seconds
+    Select Policy: Max
+    Policies:
+      - Type: Percent  Value: 100  Period: 15 seconds
+Deployment pods:       2 current / 2 desired
 Conditions:
   Type            Status  Reason              Message
   ----            ------  ------              -------
@@ -169,18 +198,20 @@ Conditions:
   ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from pods metric gpu_utilization
   ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
 Events:
-  Type    Reason             Age   From                       Message
-  ----    ------             ----  ----                       -------
-  Normal  SuccessfulRescale  28s   horizontal-pod-autoscaler  New size: 2; reason: pods metric gpu_utilization above target
+  Type     Reason                        Age   From                       Message
+  ----     ------                        ----  ----                       -------
+  Warning  FailedGetPodsMetric           35s   horizontal-pod-autoscaler  unable to get metric gpu_utilization: no metrics returned from custom metrics API
+  Warning  FailedComputeMetricsReplicas  35s   horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get pods metric value: unable to get metric gpu_utilization: no metrics returned from custom metrics API
+  Normal   SuccessfulRescale             20s   horizontal-pod-autoscaler  New size: 2; reason: pods metric gpu_utilization above target
 ```
 
 ## GPU Utilization Evidence
 
 **GPU utilization (nvidia-smi)**
 ```
-$ kubectl exec -n hpa-test gpu-workload-7d7f4dbdf-9559s -- nvidia-smi --query-gpu=utilization.gpu,utilization.memory,power.draw --format=csv
+$ kubectl exec -n hpa-test gpu-workload-7bccc5b5d-vsztd -- nvidia-smi --query-gpu=utilization.gpu,utilization.memory,power.draw --format=csv
 utilization.gpu [%], utilization.memory [%], power.draw [W]
-100 %, 0 %, 592.74 W
+100 %, 0 %, 591.71 W
 ```
 
 ## Pods After Scale-Up
@@ -188,66 +219,17 @@ utilization.gpu [%], utilization.memory [%], power.draw [W]
 **Pods after scale-up**
 ```
 $ kubectl get pods -n hpa-test -o wide
-NAME                           READY   STATUS    RESTARTS   AGE    IP              NODE                             NOMINATED NODE   READINESS GATES
-gpu-workload-7d7f4dbdf-9559s   1/1     Running   0          108s   100.65.30.220   ip-100-64-171-120.ec2.internal   <none>           <none>
-gpu-workload-7d7f4dbdf-v8csq   1/1     Running   0          33s    100.65.63.246   ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME                           READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+gpu-workload-7bccc5b5d-vsztd   1/1     Running   0          54s   100.65.168.154   ip-100-64-147-149.ec2.internal   <none>           <none>
+gpu-workload-7bccc5b5d-w75hq   1/1     Running   0          24s   100.65.115.146   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
-## Scale-Down Verification
-
-Scale the deployment to 0, replace GPU workload with an idle container, then
-scale back to 1. Verify HPA detects reduced utilization and scales down.
-
-**HPA after scale-down**
-```
-$ kubectl get hpa -n hpa-test
-NAME               REFERENCE                 TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
-gpu-workload-hpa   Deployment/gpu-workload   100/50    1         4         2          3m3s
-```
-
-**Pods after scale-down**
-```
-$ kubectl get pods -n hpa-test -o wide
-NAME                            READY   STATUS    RESTARTS   AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-gpu-workload-5dbfcc64b7-lsksc   1/1     Running   0          18s   100.65.38.156   ip-100-64-171-120.ec2.internal   <none>           <none>
-gpu-workload-5dbfcc64b7-td2mg   1/1     Running   0          40s   100.65.165.86   ip-100-64-171-120.ec2.internal   <none>           <none>
-```
-
-**HPA events**
-```
-$ kubectl describe hpa gpu-workload-hpa -n hpa-test
-Name:                         gpu-workload-hpa
-Namespace:                    hpa-test
-Labels:                       <none>
-Annotations:                  <none>
-CreationTimestamp:            Tue, 24 Feb 2026 12:43:45 -0800
-Reference:                    Deployment/gpu-workload
-Metrics:                      ( current / target )
-  "gpu_utilization" on pods:  100 / 50
-Min replicas:                 1
-Max replicas:                 4
-Deployment pods:              2 current / 2 desired
-Conditions:
-  Type            Status  Reason              Message
-  ----            ------  ------              -------
-  AbleToScale     True    ReadyForNewScale    recommended size matches current size
-  ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from pods metric gpu_utilization
-  ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
-Events:
-  Type     Reason                        Age                 From                       Message
-  ----     ------                        ----                ----                       -------
-  Warning  FailedGetScale                50s (x2 over 65s)   horizontal-pod-autoscaler  deployments.apps "gpu-workload" not found
-  Warning  FailedGetPodsMetric           35s                 horizontal-pod-autoscaler  unable to get metric gpu_utilization: no metrics returned from custom metrics API
-  Warning  FailedComputeMetricsReplicas  35s                 horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get pods metric value: unable to get metric gpu_utilization: no metrics returned from custom metrics API
-  Normal   SuccessfulRescale             20s (x2 over 111s)  horizontal-pod-autoscaler  New size: 2; reason: pods metric gpu_utilization above target
-```
-
-**Result: PASS** — HPA successfully scaled up when GPU utilization exceeded target, and scaled back down when load was removed.
+**Result: PASS** — HPA successfully read gpu_utilization metric and scaled replicas when utilization exceeded target threshold.
 
 ## Cleanup
 
 **Delete test namespace**
 ```
-$ kubectl delete namespace hpa-test --ignore-not-found
-namespace "hpa-test" deleted
+$ cleanup_ns hpa-test
+
 ```

--- a/docs/conformance/cncf/evidence/robust-operator.md
+++ b/docs/conformance/cncf/evidence/robust-operator.md
@@ -1,7 +1,7 @@
 # Robust AI Operator (Dynamo Platform)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:23:11 UTC
+**Generated:** 2026-03-02 18:30:29 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -28,39 +28,30 @@ webhooks operational, and custom resources reconciled.
 ```
 $ kubectl get deploy -n dynamo-system
 NAME                                                 READY   UP-TO-DATE   AVAILABLE   AGE
-dynamo-platform-dynamo-operator-controller-manager   1/1     1            1           6d21h
-grove-operator                                       1/1     1            1           5d23h
+dynamo-platform-dynamo-operator-controller-manager   1/1     1            1           144m
+grove-operator                                       1/1     1            1           144m
 ```
 
 **Dynamo operator pods**
 ```
 $ kubectl get pods -n dynamo-system
-NAME                                                              READY   STATUS      RESTARTS   AGE
-dynamo-operator-webhook-ca-inject-1-47jd7                         0/1     Completed   0          11d
-dynamo-operator-webhook-ca-inject-2-tf49w                         0/1     Completed   0          7d1h
-dynamo-operator-webhook-ca-inject-4-lhfsc                         0/1     Completed   0          7d1h
-dynamo-operator-webhook-ca-inject-5-6hxbn                         0/1     Completed   0          7d1h
-dynamo-operator-webhook-ca-inject-6-s85wc                         0/1     Completed   0          6d22h
-dynamo-operator-webhook-cert-gen-1-g8dx6                          0/1     Completed   0          11d
-dynamo-operator-webhook-cert-gen-6-5krdc                          0/1     Completed   0          6d22h
-dynamo-platform-dynamo-operator-controller-manager-5895f7f2pn9d   2/2     Running     0          5d20h
-dynamo-platform-dynamo-operator-webhook-ca-inject-1-wmjs9         0/1     Completed   0          6d21h
-dynamo-platform-dynamo-operator-webhook-cert-gen-1-tw4c9          0/1     Completed   0          6d21h
-dynamo-platform-etcd-0                                            1/1     Running     0          5d13h
-dynamo-platform-nats-0                                            2/2     Running     0          5d13h
-grove-operator-57565844db-lfsg2                                   1/1     Running     0          5d20h
+NAME                                                              READY   STATUS      RESTARTS       AGE
+dynamo-platform-dynamo-operator-controller-manager-79b8c69nn4nd   2/2     Running     0              144m
+dynamo-platform-dynamo-operator-webhook-ca-inject-1-6wbfn         0/1     Completed   0              143m
+dynamo-platform-dynamo-operator-webhook-cert-gen-1-9fqq6          0/1     Completed   0              144m
+grove-operator-6848cc55b8-7lxt2                                   1/1     Running     1 (144m ago)   144m
 ```
 
 ## Custom Resource Definitions
 
 **Dynamo CRDs**
 ```
-dynamocomponentdeployments.nvidia.com                  2026-02-12T20:41:17Z
-dynamographdeploymentrequests.nvidia.com               2026-02-12T20:41:17Z
-dynamographdeployments.nvidia.com                      2026-02-12T20:41:17Z
-dynamographdeploymentscalingadapters.nvidia.com        2026-02-12T20:41:17Z
-dynamomodels.nvidia.com                                2026-02-12T20:41:17Z
-dynamoworkermetadatas.nvidia.com                       2026-02-12T20:41:17Z
+dynamocomponentdeployments.nvidia.com                  2026-03-02T15:57:37Z
+dynamographdeploymentrequests.nvidia.com               2026-03-02T15:57:35Z
+dynamographdeployments.nvidia.com                      2026-03-02T15:57:37Z
+dynamographdeploymentscalingadapters.nvidia.com        2026-03-02T15:57:35Z
+dynamomodels.nvidia.com                                2026-03-02T15:57:35Z
+dynamoworkermetadatas.nvidia.com                       2026-03-02T15:57:35Z
 ```
 
 ## Webhooks
@@ -69,12 +60,12 @@ dynamoworkermetadatas.nvidia.com                       2026-02-12T20:41:17Z
 ```
 $ kubectl get validatingwebhookconfigurations -l app.kubernetes.io/instance=dynamo-platform
 NAME                                         WEBHOOKS   AGE
-dynamo-platform-dynamo-operator-validating   4          6d21h
+dynamo-platform-dynamo-operator-validating   4          144m
 ```
 
 **Dynamo validating webhooks**
 ```
-dynamo-platform-dynamo-operator-validating   4          6d21h
+dynamo-platform-dynamo-operator-validating   4          144m
 ```
 
 ## Custom Resource Reconciliation
@@ -86,7 +77,7 @@ it into component deployments with pods, services, and scaling configuration.
 ```
 $ kubectl get dynamographdeployments -A
 NAMESPACE         NAME       AGE
-dynamo-workload   vllm-agg   5d23h
+dynamo-workload   vllm-agg   90m
 ```
 
 **DynamoGraphDeployment details**
@@ -97,32 +88,41 @@ kind: DynamoGraphDeployment
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoGraphDeployment","metadata":{"annotations":{},"name":"vllm-agg","namespace":"dynamo-workload"},"spec":{"services":{"Frontend":{"componentType":"frontend","envFromSecret":"hf-token-secret","envs":[{"name":"SERVED_MODEL_NAME","value":"Qwen/Qwen3-0.6B"}],"extraPodSpec":{"mainContainer":{"image":"nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1"}},"replicas":1},"VllmDecodeWorker":{"componentType":"worker","envFromSecret":"hf-token-secret","extraPodSpec":{"mainContainer":{"args":["--model","Qwen/Qwen3-0.6B"],"command":["python3","-m","dynamo.vllm"],"image":"nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1","workingDir":"/workspace/examples/backends/vllm"}},"replicas":1,"resources":{"limits":{"gpu":"1"}}}}}}
-  creationTimestamp: "2026-02-18T21:12:53Z"
+      {"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoGraphDeployment","metadata":{"annotations":{},"name":"vllm-agg","namespace":"dynamo-workload"},"spec":{"services":{"Frontend":{"componentType":"frontend","envs":[{"name":"SERVED_MODEL_NAME","value":"Qwen/Qwen3-0.6B"},{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"image":"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0"},"nodeSelector":{"nodeGroup":"cpu-worker"}},"replicas":1},"VllmDecodeWorker":{"componentType":"worker","envs":[{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"args":["--model","Qwen/Qwen3-0.6B"],"command":["python3","-m","dynamo.vllm"],"image":"nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0","workingDir":"/workspace/examples/backends/vllm"},"nodeSelector":{"nodeGroup":"gpu-worker"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"worker-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"worker-workload"}]},"replicas":1,"resources":{"limits":{"gpu":"1"}}}}}}
+  creationTimestamp: "2026-03-02T16:59:53Z"
   finalizers:
   - nvidia.com/finalizer
   generation: 2
   name: vllm-agg
   namespace: dynamo-workload
-  resourceVersion: "6642195"
-  uid: 1d5d783c-b616-404a-86e1-97a5751aa2fd
+  resourceVersion: "9854275"
+  uid: 89860009-949f-457e-9626-83853ee3d08f
 spec:
   services:
     Frontend:
       componentType: frontend
-      envFromSecret: hf-token-secret
       envs:
       - name: SERVED_MODEL_NAME
         value: Qwen/Qwen3-0.6B
+      - name: DYN_STORE_KV
+        value: mem
+      - name: DYN_EVENT_PLANE
+        value: zmq
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0
           name: ""
           resources: {}
+        nodeSelector:
+          nodeGroup: cpu-worker
       replicas: 1
     VllmDecodeWorker:
       componentType: worker
-      envFromSecret: hf-token-secret
+      envs:
+      - name: DYN_STORE_KV
+        value: mem
+      - name: DYN_EVENT_PLANE
+        value: zmq
       extraPodSpec:
         mainContainer:
           args:
@@ -132,36 +132,46 @@ spec:
           - python3
           - -m
           - dynamo.vllm
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
           name: ""
           resources: {}
           workingDir: /workspace/examples/backends/vllm
+        nodeSelector:
+          nodeGroup: gpu-worker
+        tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: worker-workload
+        - effect: NoExecute
+          key: dedicated
+          operator: Equal
+          value: worker-workload
       replicas: 1
       resources:
         limits:
           gpu: "1"
 status:
   conditions:
-  - lastTransitionTime: "2026-02-24T20:17:50Z"
-    message: 'Resources not ready: vllm-agg: podclique/vllm-agg-0-frontend: desired=1,
-      ready=0; podclique/vllm-agg-0-vllmdecodeworker: desired=1, ready=0'
-    reason: some_resources_are_not_ready
-    status: "False"
+  - lastTransitionTime: "2026-03-02T17:03:59Z"
+    message: All resources are ready
+    reason: all_resources_are_ready
+    status: "True"
     type: Ready
   services:
     Frontend:
       componentKind: PodClique
       componentName: vllm-agg-0-frontend
-      readyReplicas: 0
+      readyReplicas: 1
       replicas: 1
-      updatedReplicas: 2
+      updatedReplicas: 1
     VllmDecodeWorker:
       componentKind: PodClique
       componentName: vllm-agg-0-vllmdecodeworker
-      readyReplicas: 0
+      readyReplicas: 1
       replicas: 1
       updatedReplicas: 1
-  state: pending
+  state: successful
 ```
 
 ### Workload Pods Created by Operator
@@ -169,9 +179,9 @@ status:
 **Dynamo workload pods**
 ```
 $ kubectl get pods -n dynamo-workload -o wide
-NAME                                READY   STATUS                   RESTARTS   AGE     IP       NODE                             NOMINATED NODE   READINESS GATES
-vllm-agg-0-frontend-wfg4h           0/1     SchedulingGated          0          5m46s   <none>   <none>                           <none>           <none>
-vllm-agg-0-vllmdecodeworker-5fljt   0/1     ContainerStatusUnknown   0          5d13h   <none>   ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME                                READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+vllm-agg-0-frontend-fbbxm           1/1     Running   0          90m   100.65.57.214    ip-100-64-83-166.ec2.internal    <none>           <none>
+vllm-agg-0-vllmdecodeworker-dkb9q   1/1     Running   0          90m   100.65.180.246   ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 ### Component Deployments

--- a/docs/conformance/cncf/evidence/secure-accelerator-access.md
+++ b/docs/conformance/cncf/evidence/secure-accelerator-access.md
@@ -1,7 +1,7 @@
 # Secure Accelerator Access
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-02-24 20:21:40 UTC
+**Generated:** 2026-03-02 18:29:02 UTC
 **Kubernetes Version:** v1.34
 **Platform:** linux/amd64
 
@@ -19,7 +19,7 @@ access control, and auditability of accelerator usage.
 ```
 $ kubectl get clusterpolicy -o wide
 NAME             STATUS   AGE
-cluster-policy   ready    2026-02-18T20:16:26Z
+cluster-policy   ready    2026-02-28T18:05:28Z
 ```
 
 ### GPU Operator Pods
@@ -27,24 +27,21 @@ cluster-policy   ready    2026-02-18T20:16:26Z
 **GPU operator pods**
 ```
 $ kubectl get pods -n gpu-operator -o wide
-NAME                                            READY   STATUS      RESTARTS        AGE     IP               NODE                             NOMINATED NODE   READINESS GATES
-gpu-feature-discovery-dh2p9                     1/1     Running     0               5m2s    100.65.4.71      ip-100-64-171-120.ec2.internal   <none>           <none>
-gpu-operator-54f86f694c-wn8tz                   1/1     Running     0               5d20h   100.64.7.63      ip-100-64-4-149.ec2.internal     <none>           <none>
-node-feature-discovery-gc-559d7b578d-btpc6      1/1     Running     0               5d20h   100.65.168.24    ip-100-64-83-166.ec2.internal    <none>           <none>
-node-feature-discovery-master-75765d64b-td98v   1/1     Running     0               5d20h   100.64.4.111     ip-100-64-6-88.ec2.internal      <none>           <none>
-node-feature-discovery-worker-5mlc6             1/1     Running     0               6d      100.64.8.11      ip-100-64-9-88.ec2.internal      <none>           <none>
-node-feature-discovery-worker-6xx4q             1/1     Running     0               6d      100.64.7.203     ip-100-64-6-88.ec2.internal      <none>           <none>
-node-feature-discovery-worker-bkfmp             1/1     Running     1 (5m12s ago)   5d1h    100.65.49.189    ip-100-64-171-120.ec2.internal   <none>           <none>
-node-feature-discovery-worker-xmhs6             1/1     Running     0               6d      100.65.52.121    ip-100-64-83-166.ec2.internal    <none>           <none>
-node-feature-discovery-worker-zm4d9             1/1     Running     0               6d      100.64.5.27      ip-100-64-4-149.ec2.internal     <none>           <none>
-nvidia-container-toolkit-daemonset-fmmhr        1/1     Running     0               5m2s    100.65.145.135   ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-cuda-validator-w9nvg                     0/1     Completed   0               3m3s    100.65.63.246    ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-dcgm-exporter-br2tz                      1/1     Running     1 (2m54s ago)   5m2s    100.65.138.241   ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-dcgm-l29t6                               1/1     Running     0               5m2s    100.65.111.44    ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-device-plugin-daemonset-jzbk9            1/1     Running     0               5m2s    100.65.244.167   ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-driver-daemonset-97gpb                   3/3     Running     3 (5m12s ago)   5d1h    100.65.9.193     ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-mig-manager-hq49r                        1/1     Running     0               5m2s    100.65.254.73    ip-100-64-171-120.ec2.internal   <none>           <none>
-nvidia-operator-validator-69vkl                 1/1     Running     0               5m2s    100.65.51.102    ip-100-64-171-120.ec2.internal   <none>           <none>
+NAME                                            READY   STATUS      RESTARTS     AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
+gpu-feature-discovery-bvhgd                     1/1     Running     0            2d    100.65.255.231   ip-100-64-147-149.ec2.internal   <none>           <none>
+gpu-operator-786cd6c97d-gq9mz                   1/1     Running     0            47h   100.64.6.112     ip-100-64-6-88.ec2.internal      <none>           <none>
+node-feature-discovery-gc-bc77948b7-r4rv9       1/1     Running     0            47h   100.64.4.102     ip-100-64-6-88.ec2.internal      <none>           <none>
+node-feature-discovery-master-69bb75cbf-qvnq2   1/1     Running     0            47h   100.64.9.167     ip-100-64-9-88.ec2.internal      <none>           <none>
+node-feature-discovery-worker-cknx6             1/1     Running     1 (2d ago)   2d    100.65.191.98    ip-100-64-147-149.ec2.internal   <none>           <none>
+node-feature-discovery-worker-zg4ns             1/1     Running     0            2d    100.65.115.28    ip-100-64-83-166.ec2.internal    <none>           <none>
+nvidia-container-toolkit-daemonset-9bjkk        1/1     Running     0            2d    100.65.153.241   ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-cuda-validator-mlv2d                     0/1     Completed   0            47h   100.65.219.230   ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-dcgm-d67rc                               1/1     Running     0            2d    100.65.255.197   ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-dcgm-exporter-9v4gs                      1/1     Running     0            2d    100.65.218.207   ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-device-plugin-daemonset-nk7kw            1/1     Running     0            2d    100.65.97.81     ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-driver-daemonset-sb8r6                   3/3     Running     3 (2d ago)   2d    100.65.141.130   ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-mig-manager-84wnn                        1/1     Running     0            2d    100.65.166.98    ip-100-64-147-149.ec2.internal   <none>           <none>
+nvidia-operator-validator-kcqjk                 1/1     Running     0            47h   100.65.22.255    ip-100-64-147-149.ec2.internal   <none>           <none>
 ```
 
 ### GPU Operator DaemonSets
@@ -53,16 +50,16 @@ nvidia-operator-validator-69vkl                 1/1     Running     0           
 ```
 $ kubectl get ds -n gpu-operator
 NAME                                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                                          AGE
-gpu-feature-discovery                     1         1         1       1            1           nvidia.com/gpu.deploy.gpu-feature-discovery=true                       6d
-node-feature-discovery-worker             5         5         5       5            5           <none>                                                                 6d
-nvidia-container-toolkit-daemonset        1         1         1       1            1           nvidia.com/gpu.deploy.container-toolkit=true                           6d
-nvidia-dcgm                               1         1         1       1            1           nvidia.com/gpu.deploy.dcgm=true                                        6d
-nvidia-dcgm-exporter                      1         1         1       1            1           nvidia.com/gpu.deploy.dcgm-exporter=true                               6d
-nvidia-device-plugin-daemonset            1         1         1       1            1           nvidia.com/gpu.deploy.device-plugin=true                               6d
-nvidia-device-plugin-mps-control-daemon   0         0         0       0            0           nvidia.com/gpu.deploy.device-plugin=true,nvidia.com/mps.capable=true   6d
-nvidia-driver-daemonset                   1         1         1       1            1           nvidia.com/gpu.deploy.driver=true                                      6d
-nvidia-mig-manager                        1         1         1       1            1           nvidia.com/gpu.deploy.mig-manager=true                                 6d
-nvidia-operator-validator                 1         1         1       1            1           nvidia.com/gpu.deploy.operator-validator=true                          6d
+gpu-feature-discovery                     1         1         1       1            1           nvidia.com/gpu.deploy.gpu-feature-discovery=true                       2d
+node-feature-discovery-worker             2         2         2       2            2           <none>                                                                 2d
+nvidia-container-toolkit-daemonset        1         1         1       1            1           nvidia.com/gpu.deploy.container-toolkit=true                           2d
+nvidia-dcgm                               1         1         1       1            1           nvidia.com/gpu.deploy.dcgm=true                                        2d
+nvidia-dcgm-exporter                      1         1         1       1            1           nvidia.com/gpu.deploy.dcgm-exporter=true                               2d
+nvidia-device-plugin-daemonset            1         1         1       1            1           nvidia.com/gpu.deploy.device-plugin=true                               2d
+nvidia-device-plugin-mps-control-daemon   0         0         0       0            0           nvidia.com/gpu.deploy.device-plugin=true,nvidia.com/mps.capable=true   2d
+nvidia-driver-daemonset                   1         1         1       1            1           nvidia.com/gpu.deploy.driver=true                                      2d
+nvidia-mig-manager                        1         1         1       1            1           nvidia.com/gpu.deploy.mig-manager=true                                 2d
+nvidia-operator-validator                 1         1         1       1            1           nvidia.com/gpu.deploy.operator-validator=true                          2d
 ```
 
 ## DRA-Mediated GPU Access
@@ -77,8 +74,8 @@ GPU devices via ResourceSlices, and pods request access through ResourceClaims.
 ```
 $ kubectl get resourceslices -o wide
 NAME                                                             NODE                             DRIVER                      POOL                             AGE
-ip-100-64-171-120.ec2.internal-compute-domain.nvidia.com-76zr9   ip-100-64-171-120.ec2.internal   compute-domain.nvidia.com   ip-100-64-171-120.ec2.internal   3m32s
-ip-100-64-171-120.ec2.internal-gpu.nvidia.com-75xvv              ip-100-64-171-120.ec2.internal   gpu.nvidia.com              ip-100-64-171-120.ec2.internal   3m30s
+ip-100-64-147-149.ec2.internal-compute-domain.nvidia.com-pslfg   ip-100-64-147-149.ec2.internal   compute-domain.nvidia.com   ip-100-64-147-149.ec2.internal   47h
+ip-100-64-147-149.ec2.internal-gpu.nvidia.com-bvcfk              ip-100-64-147-149.ec2.internal   gpu.nvidia.com              ip-100-64-147-149.ec2.internal   47h
 ```
 
 ### GPU Device Details
@@ -91,18 +88,18 @@ items:
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
-    creationTimestamp: "2026-02-24T20:18:17Z"
-    generateName: ip-100-64-171-120.ec2.internal-compute-domain.nvidia.com-
+    creationTimestamp: "2026-02-28T18:29:53Z"
+    generateName: ip-100-64-147-149.ec2.internal-compute-domain.nvidia.com-
     generation: 1
-    name: ip-100-64-171-120.ec2.internal-compute-domain.nvidia.com-76zr9
+    name: ip-100-64-147-149.ec2.internal-compute-domain.nvidia.com-pslfg
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: ip-100-64-171-120.ec2.internal
-      uid: a94c3e56-9f0e-42fb-abad-32cd237c6c6b
-    resourceVersion: "6642417"
-    uid: 2e9ffac0-5bdd-49b0-8f6a-5a23764608b3
+      name: ip-100-64-147-149.ec2.internal
+      uid: 2e8f0172-e1d7-4713-9160-a9f215925a19
+    resourceVersion: "8799315"
+    uid: c9677899-dd3d-436a-925e-ea804f1a2f58
   spec:
     devices:
     - attributes:
@@ -118,190 +115,28 @@ items:
           string: daemon
       name: daemon-0
     driver: compute-domain.nvidia.com
-    nodeName: ip-100-64-171-120.ec2.internal
+    nodeName: ip-100-64-147-149.ec2.internal
     pool:
       generation: 1
-      name: ip-100-64-171-120.ec2.internal
+      name: ip-100-64-147-149.ec2.internal
       resourceSliceCount: 1
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
-    creationTimestamp: "2026-02-24T20:18:19Z"
-    generateName: ip-100-64-171-120.ec2.internal-gpu.nvidia.com-
+    creationTimestamp: "2026-02-28T18:29:55Z"
+    generateName: ip-100-64-147-149.ec2.internal-gpu.nvidia.com-
     generation: 1
-    name: ip-100-64-171-120.ec2.internal-gpu.nvidia.com-75xvv
+    name: ip-100-64-147-149.ec2.internal-gpu.nvidia.com-bvcfk
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: ip-100-64-171-120.ec2.internal
-      uid: a94c3e56-9f0e-42fb-abad-32cd237c6c6b
-    resourceVersion: "6642429"
-    uid: 83776fa9-badc-49b5-8204-6135190dfd88
+      name: ip-100-64-147-149.ec2.internal
+      uid: 2e8f0172-e1d7-4713-9160-a9f215925a19
+    resourceVersion: "8799324"
+    uid: f6681459-442a-4a14-832e-99b9ea9cba3d
   spec:
     devices:
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:75:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:66
-        type:
-          string: gpu
-        uuid:
-          string: GPU-f814846a-9bbe-469e-97c3-d037d67c3c32
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-2
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:86:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:77
-        type:
-          string: gpu
-        uuid:
-          string: GPU-3cc59718-d7df-49ac-07a3-a6cedfe263c6
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-3
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:97:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:88
-        type:
-          string: gpu
-        uuid:
-          string: GPU-71fc8f21-7800-5bb9-53ad-7e6fc93ef15f
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-4
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:a8:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:99
-        type:
-          string: gpu
-        uuid:
-          string: GPU-dee5c16e-1d0a-cec8-a9ea-f878a4be1b3d
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-5
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:b9:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:aa
-        type:
-          string: gpu
-        uuid:
-          string: GPU-ca1b8386-093b-60cc-349d-c4a38b9124c0
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-6
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:ca:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:bb
-        type:
-          string: gpu
-        uuid:
-          string: GPU-b60b817a-a091-c492-4211-92b276d697e6
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-7
     - attributes:
         addressingMode:
           string: HMM
@@ -324,7 +159,7 @@ items:
         type:
           string: gpu
         uuid:
-          string: GPU-22dbdd79-f55a-92a8-aa39-322198e72ed6
+          string: GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138
       capacity:
         memory:
           value: 81559Mi
@@ -351,16 +186,178 @@ items:
         type:
           string: gpu
         uuid:
-          string: GPU-289275cb-a907-ab73-9a95-058ae119f62d
+          string: GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7
       capacity:
         memory:
           value: 81559Mi
       name: gpu-1
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:75:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:66
+        type:
+          string: gpu
+        uuid:
+          string: GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-2
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:86:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:77
+        type:
+          string: gpu
+        uuid:
+          string: GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-3
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:97:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:88
+        type:
+          string: gpu
+        uuid:
+          string: GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-4
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:a8:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:99
+        type:
+          string: gpu
+        uuid:
+          string: GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-5
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:b9:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:aa
+        type:
+          string: gpu
+        uuid:
+          string: GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-6
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:ca:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:bb
+        type:
+          string: gpu
+        uuid:
+          string: GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-7
     driver: gpu.nvidia.com
-    nodeName: ip-100-64-171-120.ec2.internal
+    nodeName: ip-100-64-147-149.ec2.internal
     pool:
       generation: 1
-      name: ip-100-64-171-120.ec2.internal
+      name: ip-100-64-147-149.ec2.internal
       resourceSliceCount: 1
 kind: List
 metadata:
@@ -385,14 +382,14 @@ $ kubectl get pod isolation-test -n secure-access-test -o jsonpath={.spec.resour
 **Pod volumes (no hostPath)**
 ```
 $ kubectl get pod isolation-test -n secure-access-test -o jsonpath={.spec.volumes}
-[{"name":"kube-api-access-xsvnl","projected":{"defaultMode":420,"sources":[{"serviceAccountToken":{"expirationSeconds":3607,"path":"token"}},{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kube-root-ca.crt"}},{"downwardAPI":{"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"},"path":"namespace"}]}}]}}]
+[{"name":"kube-api-access-ls9pc","projected":{"defaultMode":420,"sources":[{"serviceAccountToken":{"expirationSeconds":3607,"path":"token"}},{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kube-root-ca.crt"}},{"downwardAPI":{"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"},"path":"namespace"}]}}]}}]
 ```
 
 **ResourceClaim allocation**
 ```
 $ kubectl get resourceclaim isolated-gpu -n secure-access-test -o wide
 NAME           STATE     AGE
-isolated-gpu   pending   13s
+isolated-gpu   pending   15s
 ```
 
 ### Container GPU Visibility (only allocated GPU visible)
@@ -401,17 +398,17 @@ isolated-gpu   pending   13s
 ```
 $ kubectl logs isolation-test -n secure-access-test
 === Visible NVIDIA devices ===
-crw-rw-rw- 1 root root 195, 254 Feb 24 20:22 /dev/nvidia-modeset
-crw-rw-rw- 1 root root 508,   0 Feb 24 20:22 /dev/nvidia-uvm
-crw-rw-rw- 1 root root 508,   1 Feb 24 20:22 /dev/nvidia-uvm-tools
-crw-rw-rw- 1 root root 195,   2 Feb 24 20:22 /dev/nvidia2
-crw-rw-rw- 1 root root 195, 255 Feb 24 20:22 /dev/nvidiactl
+crw-rw-rw- 1 root root 195, 254 Mar  2 18:29 /dev/nvidia-modeset
+crw-rw-rw- 1 root root 507,   0 Mar  2 18:29 /dev/nvidia-uvm
+crw-rw-rw- 1 root root 507,   1 Mar  2 18:29 /dev/nvidia-uvm-tools
+crw-rw-rw- 1 root root 195,   0 Mar  2 18:29 /dev/nvidia0
+crw-rw-rw- 1 root root 195, 255 Mar  2 18:29 /dev/nvidiactl
 
 === nvidia-smi output ===
-GPU 0: NVIDIA H100 80GB HBM3 (UUID: GPU-f814846a-9bbe-469e-97c3-d037d67c3c32)
+GPU 0: NVIDIA H100 80GB HBM3 (UUID: GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138)
 
 === GPU count ===
-0, NVIDIA H100 80GB HBM3, GPU-f814846a-9bbe-469e-97c3-d037d67c3c32
+0, NVIDIA H100 80GB HBM3, GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138
 
 Secure accelerator access test completed
 ```
@@ -422,6 +419,6 @@ Secure accelerator access test completed
 
 **Delete test namespace**
 ```
-$ kubectl delete namespace secure-access-test --ignore-not-found
-namespace "secure-access-test" deleted
+$ cleanup_ns secure-access-test
+
 ```

--- a/docs/conformance/cncf/submission/PRODUCT.yaml
+++ b/docs/conformance/cncf/submission/PRODUCT.yaml
@@ -15,7 +15,7 @@
 metadata:
   kubernetesVersion: v1.34
   platformName: "Kubernetes Platforms Powered by NVIDIA AI Cluster Runtime (AICR)"
-  platformVersion: "0.7.7"
+  platformVersion: "0.8.0"
   vendorName: "NVIDIA"
   websiteUrl: "https://github.com/NVIDIA/aicr"
   repoUrl: "https://github.com/NVIDIA/aicr"

--- a/pkg/evidence/scripts/collect-evidence.sh
+++ b/pkg/evidence/scripts/collect-evidence.sh
@@ -69,7 +69,8 @@ capture() {
     echo '```' >> "${EVIDENCE_FILE}"
 }
 
-# Wait for a pod to reach a terminal phase (Succeeded or Failed)
+# Wait for a pod to reach a terminal phase (Succeeded or Failed).
+# Exits early on unrecoverable container errors (ImagePullBackOff, CrashLoopBackOff, etc.)
 wait_for_pod() {
     local ns="$1" name="$2" timeout="$3"
     local elapsed=0
@@ -78,10 +79,34 @@ wait_for_pod() {
         case "$phase" in
             Succeeded|Failed) echo "$phase"; return 0 ;;
         esac
+        # Check for unrecoverable container errors to fail early
+        local waiting_reason
+        waiting_reason=$(kubectl get pod "$name" -n "$ns" -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null)
+        case "$waiting_reason" in
+            ErrImagePull|ImagePullBackOff|CrashLoopBackOff|InvalidImageName|CreateContainerConfigError)
+                log_error "Pod $name failed early: $waiting_reason" >&2
+                echo "Failed"
+                return 1
+                ;;
+        esac
         sleep 5
         elapsed=$((elapsed + 5))
     done
     echo "Timeout"
+    return 1
+}
+
+# Wait for a local port to accept connections (e.g., after kubectl port-forward).
+# Exits early if the background process dies.
+wait_for_port() {
+    local port="$1" timeout="$2" pid="$3"
+    local elapsed=0
+    while [ $elapsed -lt "$timeout" ]; do
+        if curl -sf "http://localhost:${port}/-/ready" &>/dev/null; then return 0; fi
+        if ! kill -0 "$pid" 2>/dev/null; then return 1; fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
     return 1
 }
 
@@ -495,9 +520,8 @@ EOF
     # Port-forward to Prometheus and query
     kubectl port-forward svc/kube-prometheus-prometheus -n monitoring 9090:9090 &>/dev/null &
     local pf_pid=$!
-    sleep 3
 
-    if kill -0 "${pf_pid}" 2>/dev/null; then
+    if wait_for_port 9090 30 "${pf_pid}"; then
         # GPU Utilization
         echo "" >> "${EVIDENCE_FILE}"
         echo "**GPU Utilization (DCGM_FI_DEV_GPU_UTIL)**" >> "${EVIDENCE_FILE}"
@@ -530,11 +554,12 @@ EOF
             python3 -c "import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data,indent=2))" >> "${EVIDENCE_FILE}" 2>&1
         echo '```' >> "${EVIDENCE_FILE}"
 
-        kill "${pf_pid}" 2>/dev/null || true
     else
         echo "" >> "${EVIDENCE_FILE}"
         echo "**WARNING:** Could not port-forward to Prometheus" >> "${EVIDENCE_FILE}"
     fi
+    # Always clean up port-forward process to avoid leaking on timeout/failure
+    kill "${pf_pid}" 2>/dev/null || true
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
@@ -845,29 +870,33 @@ EOF
     log_info "Deploying HPA GPU test..."
     capture "Apply test manifest" kubectl apply -f "${SCRIPT_DIR}/manifests/hpa-gpu-test.yaml"
 
-    # Wait for pod to start
+    # Wait for pod to become Ready (uses watch API for immediate detection)
     log_info "Waiting for GPU workload pod (up to ${POD_TIMEOUT}s)..."
-    local elapsed=0
-    while [ $elapsed -lt "${POD_TIMEOUT}" ]; do
-        ready=$(kubectl get pods -n hpa-test -l app=gpu-workload -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
-        if [ "$ready" = "True" ]; then break; fi
-        sleep 10
-        elapsed=$((elapsed + 10))
-    done
+    kubectl wait --for=condition=Ready pod -l app=gpu-workload -n hpa-test --timeout="${POD_TIMEOUT}s" 2>/dev/null || true
     capture "GPU workload pod" kubectl get pods -n hpa-test -o wide
 
     # Wait for GPU metrics to be available and HPA to scale up (up to 3 minutes)
+    # Check-then-sleep pattern: detect scale-up or failure as early as possible
     log_info "Waiting for GPU metrics and HPA scale-up (up to 3 minutes)..."
     local hpa_scaled=false
-    for i in $(seq 1 12); do
-        sleep 15
+    for i in $(seq 1 18); do
         targets=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.currentMetrics[0].pods.current.averageValue}' 2>/dev/null)
         replicas=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.currentReplicas}' 2>/dev/null)
-        log_info "  Check ${i}/12: gpu_utilization=${targets:-unknown}, replicas=${replicas:-1}"
+        log_info "  Check ${i}/18: gpu_utilization=${targets:-unknown}, replicas=${replicas:-1}"
         if [ "${replicas:-1}" -gt 1 ] && [ -n "$targets" ]; then
             hpa_scaled=true
             break
         fi
+        # Fail early on unrecoverable HPA conditions
+        local hpa_conditions
+        hpa_conditions=$(kubectl get hpa gpu-workload-hpa -n hpa-test -o jsonpath='{.status.conditions[?(@.status=="False")].reason}' 2>/dev/null)
+        case "$hpa_conditions" in
+            *FailedGetMetrics*|*InvalidMetricSourceType*)
+                log_error "HPA failed early: $hpa_conditions"
+                break
+                ;;
+        esac
+        sleep 10
     done
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'


### PR DESCRIPTION
## Summary

Replace fixed sleep delays in evidence collection with polling that exits early on success or failure, reducing collection time from ~15 minutes to ~4.5 minutes (3x faster). Refresh all evidence files against live cluster.

## Motivation / Context

The evidence collection script used fixed `sleep` durations that wasted time regardless of actual resource readiness. On success, the script waited unnecessarily; on failure, it couldn't detect errors early and would run to timeout.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/scripts/collect-evidence.sh`

## Implementation Notes

### Performance Improvement: ~15 min → ~4.5 min (3x faster)

| Location | Before | After |
|---|---|---|
| `wait_for_pod()` | 5s poll, no error detection | 5s poll + early exit on ErrImagePull, CrashLoopBackOff, etc. |
| Port-forward wait | Fixed `sleep 3` (race condition) | `wait_for_port` polling helper (1s interval, up to 30s) |
| HPA pod readiness | Manual 10s poll loop | `kubectl wait --for=condition=Ready` (watch API, instant) |
| HPA scale-up | `sleep 15` before first check | Check-then-sleep, 10s interval, early HPA error detection |

### Bug fixes
- Port-forward process leaked on timeout/failure (now always cleaned up)
- `log_error` in `wait_for_pod` polluted stdout return value (now redirected to stderr)

### Evidence refresh
- All 8 evidence files regenerated against live EKS cluster
- PRODUCT.yaml platformVersion updated to 0.8.0
- README timing estimates updated

## Testing

```bash
# Full evidence collection against live EKS cluster — all 8 sections PASS
EVIDENCE_DIR=docs/conformance/cncf/evidence ./pkg/evidence/scripts/collect-evidence.sh all

# Syntax check
bash -n pkg/evidence/scripts/collect-evidence.sh
```

Evidence collection completed in ~4.5 minutes (previously ~15 minutes).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)