### PR TITLE
fix(validator): prefer CPU nodes for validation Jobs and decouple node-selector from phase Jobs

### DIFF
--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -106,7 +106,7 @@ func snapshotCmdFlags() []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:     "node-selector",
-			Usage:    "Node selector for Job scheduling (format: key=value, can be repeated)",
+			Usage:    "Node selector for Job scheduling (format: key=value, can be repeated). Recommended in heterogeneous clusters to target GPU nodes",
 			Category: "Agent Deployment",
 		},
 		&cli.StringSliceFlag{
@@ -186,13 +186,23 @@ The snapshot process:
   5. Save it to the target output location
   6. Clean up the Job (optionally keep RBAC for reuse)
 
+The snapshot Job must run on a GPU node to collect GPU hardware information
+(nvidia-smi, device properties, driver version). In heterogeneous clusters
+with both CPU and GPU nodes, use --node-selector to ensure the Job lands
+on a GPU node. Before GPU Operator is installed, use the node name or a
+user-defined label; after installation, nvidia.com/gpu.present=true is
+available.
+
 Examples:
 
-Basic snapshot:
+Basic snapshot (homogeneous GPU cluster):
   aicr snapshot --output cm://default/aicr-snapshot
 
-Target specific GPU nodes with node selector:
-  aicr snapshot --node-selector nodeGroup=customer-gpu
+Target a GPU node before GPU Operator installation:
+  aicr snapshot --node-selector kubernetes.io/hostname=gpu-node-1
+
+Target GPU nodes after GPU Operator installation:
+  aicr snapshot --node-selector nvidia.com/gpu.present=true
 
 Override default tolerations (by default, all taints are tolerated):
   aicr snapshot --toleration dedicated=user-workload:NoSchedule

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -168,7 +168,6 @@ func runValidation(
 	evidenceDir string,
 	evidenceResultPath string,
 	tolerations []corev1.Toleration,
-	nodeSelector map[string]string,
 ) error {
 
 	slog.Info("running validation",
@@ -190,7 +189,6 @@ func runValidation(
 		validator.WithImagePullSecrets(imagePullSecrets),
 		validator.WithNoCluster(noCluster),
 		validator.WithTolerations(tolerations),
-		validator.WithNodeSelector(nodeSelector),
 	}
 	if resumeRunID != "" {
 		opts = append(opts, validator.WithRunID(resumeRunID))
@@ -412,7 +410,7 @@ func validateCmdFlags() []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:     "toleration",
-			Usage:    "Toleration for Job scheduling (format: key=value:effect). By default, all taints are tolerated.",
+			Usage:    "Toleration for snapshot agent and validation phase Job scheduling (format: key=value:effect). By default, all taints are tolerated.",
 			Category: "Agent Deployment",
 		},
 		&cli.DurationFlag{
@@ -682,18 +680,14 @@ Use a saved result file for evidence instead of the live run:
 				}
 			}
 
-			// Parse tolerations and node selectors for validation phase Jobs.
-			// These are always needed regardless of snapshot source.
+			// Parse tolerations for validation phase Jobs.
+			// Tolerations are always needed regardless of snapshot source.
 			tolerations, tolErr := snapshotter.ParseTolerations(cmd.StringSlice("toleration"))
 			if tolErr != nil {
 				return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid toleration", tolErr)
 			}
-			nodeSelector, nsErr := snapshotter.ParseNodeSelectors(cmd.StringSlice("node-selector"))
-			if nsErr != nil {
-				return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid node-selector", nsErr)
-			}
 
-			return runValidation(ctx, rec, snap, phases, recipeFilePath, snapshotSource, cmd.String("output"), outFormat, failOnError, validationNamespace, cmd.String("resume"), cmd.String("image"), cmd.Bool("cleanup"), cmd.StringSlice("image-pull-secret"), cmd.Bool("no-cluster"), evidenceDir, resultPath, tolerations, nodeSelector)
+			return runValidation(ctx, rec, snap, phases, recipeFilePath, snapshotSource, cmd.String("output"), outFormat, failOnError, validationNamespace, cmd.String("resume"), cmd.String("image"), cmd.Bool("cleanup"), cmd.StringSlice("image-pull-secret"), cmd.Bool("no-cluster"), evidenceDir, resultPath, tolerations)
 		},
 	}
 }

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -407,7 +407,7 @@ func validateCmdFlags() []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:     "node-selector",
-			Usage:    "Node selector for Job scheduling (format: key=value, can be repeated)",
+			Usage:    "Node selector for snapshot agent Job scheduling (format: key=value, can be repeated). Recommended in heterogeneous clusters to target GPU nodes. Validation phase Jobs automatically prefer CPU nodes.",
 			Category: "Agent Deployment",
 		},
 		&cli.StringSliceFlag{
@@ -500,6 +500,11 @@ pass, fail, or cannot be evaluated.
 You can either provide an existing snapshot file or deploy an agent to capture
 a fresh snapshot from the cluster.
 
+Validation runs post-deploy (after GPU Operator installation), so
+nvidia.com/gpu.present labels are available on GPU nodes. In heterogeneous
+clusters, --node-selector targets the snapshot agent to a GPU node, while
+validation phase Jobs automatically prefer CPU nodes via soft affinity.
+
 # Examples
 
 Validate using an existing snapshot file:
@@ -511,10 +516,10 @@ Load snapshot from ConfigMap:
 Deploy agent to capture and validate in one step:
   aicr validate --recipe recipe.yaml --namespace default
 
-Target specific GPU nodes with node selector:
+Target GPU nodes for snapshot agent in a heterogeneous cluster:
   aicr validate --recipe recipe.yaml \
     --namespace default \
-    --node-selector nodeGroup=customer-gpu
+    --node-selector nvidia.com/gpu.present=true
 
 Run multiple validation phases:
   aicr validate -r recipe.yaml -s snapshot.yaml \

--- a/pkg/validator/README.md
+++ b/pkg/validator/README.md
@@ -78,7 +78,7 @@ All checks run inside Kubernetes Jobs for:
 - **Isolation**: Proper RBAC and resource limits
 - **Observability**: Jobs visible in `kubectl get jobs`
 - **Reproducibility**: Consistent execution environment
-- **Flexibility**: Node affinity for GPU tests
+- **Smart scheduling**: Jobs prefer CPU nodes via soft affinity; checks that need GPUs create their own workload Pods with GPU resource requests
 
 ```
 Validator (CLI/API)
@@ -544,7 +544,7 @@ go test -v ./pkg/validator/checks/deployment/...
 
 1. **Cluster Context**: Checks run with proper RBAC inside the cluster
 2. **Resource Control**: Jobs can have CPU/memory limits
-3. **Node Scheduling**: Performance tests can target GPU nodes
+3. **Node Scheduling**: Jobs prefer CPU nodes; checks create GPU workload Pods as needed
 4. **Observability**: Jobs appear in `kubectl get jobs`
 5. **Isolation**: Each check is independent
 

--- a/pkg/validator/agent/README.md
+++ b/pkg/validator/agent/README.md
@@ -99,7 +99,7 @@ fmt.Printf("Check: %s, Status: %s\n", result.CheckName, result.Status)
 
 1. **Isolation** - Tests run in cluster context with proper RBAC
 2. **Resource limits** - Jobs can have CPU/memory constraints
-3. **Node affinity** - Performance tests can target GPU nodes
+3. **Smart scheduling** - Jobs prefer CPU nodes via soft affinity (`nvidia.com/gpu.present DoesNotExist`); checks that need GPUs create their own workload Pods with GPU resource requests
 4. **Observability** - Jobs show up in `kubectl get jobs`
 5. **Reproducibility** - Same execution environment every time
 
@@ -113,9 +113,8 @@ fmt.Printf("Check: %s, Status: %s\n", result.CheckName, result.Status)
 ### Why one Job per phase?
 
 1. **Early exit** - Can skip subsequent phases on failure
-2. **Resource scheduling** - Different phases need different nodes
-3. **Granular control** - Easier to retry specific phases
-4. **Clear boundaries** - Each phase is independent unit of work
+2. **Granular control** - Easier to retry specific phases
+3. **Clear boundaries** - Each phase is independent unit of work
 
 ## Integration with Validator
 

--- a/pkg/validator/agent/deployer_test.go
+++ b/pkg/validator/agent/deployer_test.go
@@ -48,9 +48,6 @@ func createConfig() Config {
 		TestPattern:        "TestOperatorHealth",
 		Timeout:            5 * time.Minute,
 		ImagePullSecrets:   []string{"regcred"},
-		NodeSelector: map[string]string{
-			"nodeGroup": "gpu-nodes",
-		},
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "nvidia.com/gpu",
@@ -197,11 +194,6 @@ func TestDeployer_DeployJob(t *testing.T) {
 		if job.Spec.Template.Spec.ServiceAccountName != deployer.config.ServiceAccountName {
 			t.Errorf("expected ServiceAccountName %q, got %q",
 				deployer.config.ServiceAccountName, job.Spec.Template.Spec.ServiceAccountName)
-		}
-
-		// Verify node selector
-		if job.Spec.Template.Spec.NodeSelector["nodeGroup"] != "gpu-nodes" {
-			t.Errorf("expected nodeGroup=gpu-nodes, got %v", job.Spec.Template.Spec.NodeSelector)
 		}
 
 		// Verify tolerations

--- a/pkg/validator/agent/job.go
+++ b/pkg/validator/agent/job.go
@@ -154,11 +154,6 @@ func (d *Deployer) buildJobSpec() *batchv1.Job {
 		ImagePullSecrets:   imagePullSecrets,
 	}
 
-	// Add node selector if specified
-	if len(d.config.NodeSelector) > 0 {
-		podSpec.NodeSelector = d.config.NodeSelector
-	}
-
 	// Add tolerations if specified
 	if len(d.config.Tolerations) > 0 {
 		podSpec.Tolerations = d.config.Tolerations

--- a/pkg/validator/agent/job.go
+++ b/pkg/validator/agent/job.go
@@ -164,6 +164,11 @@ func (d *Deployer) buildJobSpec() *batchv1.Job {
 		podSpec.Tolerations = d.config.Tolerations
 	}
 
+	// Add affinity if specified
+	if d.config.Affinity != nil {
+		podSpec.Affinity = d.config.Affinity
+	}
+
 	// Build Job
 	backoffLimit := int32(0)                                                 // No retries - validation should be deterministic
 	ttlSecondsAfterFinished := int32(defaults.JobTTLAfterFinished.Seconds()) // Keep for 1 hour for debugging

--- a/pkg/validator/agent/job_test.go
+++ b/pkg/validator/agent/job_test.go
@@ -196,6 +196,68 @@ func TestBuildJobSpec_WithTolerations(t *testing.T) {
 	}
 }
 
+func TestBuildJobSpec_WithAffinity(t *testing.T) {
+	deployer, _ := createDeployer()
+	deployer.config.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 100,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "nvidia.com/gpu.present",
+								Operator: corev1.NodeSelectorOpDoesNotExist,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	job := deployer.buildJobSpec()
+
+	// Verify affinity is set
+	affinity := job.Spec.Template.Spec.Affinity
+	if affinity == nil {
+		t.Fatal("expected affinity to be set")
+	}
+	if affinity.NodeAffinity == nil {
+		t.Fatal("expected NodeAffinity to be set")
+	}
+
+	preferred := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(preferred) != 1 {
+		t.Fatalf("expected 1 preferred scheduling term, got %d", len(preferred))
+	}
+	if preferred[0].Weight != 100 {
+		t.Errorf("expected weight 100, got %d", preferred[0].Weight)
+	}
+
+	expressions := preferred[0].Preference.MatchExpressions
+	if len(expressions) != 1 {
+		t.Fatalf("expected 1 match expression, got %d", len(expressions))
+	}
+	if expressions[0].Key != "nvidia.com/gpu.present" {
+		t.Errorf("expected key nvidia.com/gpu.present, got %q", expressions[0].Key)
+	}
+	if expressions[0].Operator != corev1.NodeSelectorOpDoesNotExist {
+		t.Errorf("expected operator DoesNotExist, got %v", expressions[0].Operator)
+	}
+}
+
+func TestBuildJobSpec_WithoutAffinity(t *testing.T) {
+	deployer, _ := createDeployer()
+
+	job := deployer.buildJobSpec()
+
+	// Verify affinity is nil when not configured
+	if job.Spec.Template.Spec.Affinity != nil {
+		t.Error("expected affinity to be nil when not configured")
+	}
+}
+
 func TestBuildJobSpec_WithImagePullSecrets(t *testing.T) {
 	deployer, _ := createDeployer()
 	deployer.config.ImagePullSecrets = []string{"regcred", "dockerhub-secret", "gcr-secret"}

--- a/pkg/validator/agent/job_test.go
+++ b/pkg/validator/agent/job_test.go
@@ -122,32 +122,6 @@ func TestBuildJobSpec(t *testing.T) {
 	}
 }
 
-func TestBuildJobSpec_WithNodeSelector(t *testing.T) {
-	deployer, _ := createDeployer()
-	deployer.config.NodeSelector = map[string]string{
-		"nodeGroup":            "gpu-nodes",
-		"kubernetes.io/arch":   "amd64",
-		"nvidia.com/gpu.count": "8",
-	}
-
-	job := deployer.buildJobSpec()
-
-	// Verify node selector
-	nodeSelector := job.Spec.Template.Spec.NodeSelector
-	if len(nodeSelector) != 3 {
-		t.Errorf("expected 3 node selector entries, got %d", len(nodeSelector))
-	}
-	if nodeSelector["nodeGroup"] != "gpu-nodes" {
-		t.Errorf("expected nodeGroup=gpu-nodes, got %q", nodeSelector["nodeGroup"])
-	}
-	if nodeSelector["kubernetes.io/arch"] != "amd64" {
-		t.Errorf("expected kubernetes.io/arch=amd64, got %q", nodeSelector["kubernetes.io/arch"])
-	}
-	if nodeSelector["nvidia.com/gpu.count"] != "8" {
-		t.Errorf("expected nvidia.com/gpu.count=8, got %q", nodeSelector["nvidia.com/gpu.count"])
-	}
-}
-
 func TestBuildJobSpec_WithTolerations(t *testing.T) {
 	deployer, _ := createDeployer()
 	deployer.config.Tolerations = []corev1.Toleration{

--- a/pkg/validator/agent/types.go
+++ b/pkg/validator/agent/types.go
@@ -38,9 +38,6 @@ type Config struct {
 	// ServiceAccountName for the Job pods
 	ServiceAccountName string
 
-	// NodeSelector for targeting specific nodes (e.g., GPU nodes for performance tests)
-	NodeSelector map[string]string
-
 	// Tolerations for scheduling on tainted nodes
 	Tolerations []corev1.Toleration
 

--- a/pkg/validator/agent/types.go
+++ b/pkg/validator/agent/types.go
@@ -44,6 +44,10 @@ type Config struct {
 	// Tolerations for scheduling on tainted nodes
 	Tolerations []corev1.Toleration
 
+	// Affinity specifies pod scheduling affinity rules.
+	// Used to prefer CPU nodes for non-GPU validation Jobs.
+	Affinity *corev1.Affinity
+
 	// SnapshotConfigMap is the ConfigMap containing the snapshot data
 	SnapshotConfigMap string
 

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"strings"
 	"time"
 
@@ -68,12 +67,6 @@ const (
 	DefaultConformanceTimeout = defaults.ValidateConformanceTimeout
 )
 
-// gpuPresentLabelKey and gpuPresentLabelValue are used to select GPU nodes for validation Jobs.
-const (
-	gpuPresentLabelKey   = "nvidia.com/gpu.present"
-	gpuPresentLabelValue = "true"
-)
-
 // PhaseOrder defines the canonical execution order for validation phases.
 // Readiness and deployment must run before performance or conformance.
 var PhaseOrder = []ValidationPhaseName{
@@ -95,6 +88,30 @@ func resolvePhaseTimeout(phase *recipe.ValidationPhase, defaultTimeout time.Dura
 			"timeout", phase.Timeout, "default", defaultTimeout, "error", err)
 	}
 	return defaultTimeout
+}
+
+// preferCPUNodeAffinity returns a soft node affinity that prefers nodes
+// without nvidia.com/gpu.present labels. Validator Jobs only need K8s API
+// access and should avoid consuming GPU resources in heterogeneous clusters.
+// The preference is soft: if no CPU-only nodes exist, Jobs still schedule.
+func preferCPUNodeAffinity() *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 100,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "nvidia.com/gpu.present",
+								Operator: corev1.NodeSelectorOpDoesNotExist,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // ValidatePhase runs validation for a specific phase.
@@ -416,6 +433,7 @@ func (v *Validator) validateDeployment(
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Deployment, DefaultDeploymentTimeout),
 						Tolerations:        v.Tolerations,
 						NodeSelector:       v.NodeSelector,
+						Affinity:           preferCPUNodeAffinity(),
 					}
 
 					deployer := agent.NewDeployer(clientset, jobConfig)
@@ -557,7 +575,8 @@ func (v *Validator) validatePerformance(
 					patternResult := v.buildTestPattern(recipeResult, "performance")
 
 					// Deploy ONE Job for ALL performance checks and constraints in this phase
-					// Performance tests may need GPU nodes
+					// The Job pod is an orchestration layer (creates GPU workload Pods);
+					// it only needs K8s API access, so prefer CPU nodes.
 					jobConfig := agent.Config{
 						Namespace:          v.Namespace,
 						JobName:            fmt.Sprintf("aicr-%s-performance", v.RunID),
@@ -571,22 +590,7 @@ func (v *Validator) validatePerformance(
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Performance, DefaultPerformanceTimeout),
 						Tolerations:        v.Tolerations,
 						NodeSelector:       v.NodeSelector,
-					}
-
-					// Add GPU node selector if recipe specifies a GPU accelerator.
-					// This intentionally overrides any user-provided value for the GPU label
-					// since the recipe's accelerator requirement takes precedence.
-					// Clone the map to avoid mutating v.NodeSelector, which is shared across phases.
-					if recipeResult.Criteria != nil &&
-						recipeResult.Criteria.Accelerator != "" &&
-						recipeResult.Criteria.Accelerator != recipe.CriteriaAcceleratorAny {
-
-						if jobConfig.NodeSelector == nil {
-							jobConfig.NodeSelector = make(map[string]string)
-						} else {
-							jobConfig.NodeSelector = maps.Clone(jobConfig.NodeSelector)
-						}
-						jobConfig.NodeSelector[gpuPresentLabelKey] = gpuPresentLabelValue
+						Affinity:           preferCPUNodeAffinity(),
 					}
 
 					deployer := agent.NewDeployer(clientset, jobConfig)
@@ -725,6 +729,7 @@ func (v *Validator) validateConformance(
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Conformance, DefaultConformanceTimeout),
 						Tolerations:        v.Tolerations,
 						NodeSelector:       v.NodeSelector,
+						Affinity:           preferCPUNodeAffinity(),
 					}
 
 					deployer := agent.NewDeployer(clientset, jobConfig)

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -67,6 +67,10 @@ const (
 	DefaultConformanceTimeout = defaults.ValidateConformanceTimeout
 )
 
+// gpuPresentLabelKey is the node label set by GPU Feature Discovery when a GPU is present.
+// Used in soft anti-affinity to prefer scheduling validator Jobs on CPU-only nodes.
+const gpuPresentLabelKey = "nvidia.com/gpu.present"
+
 // PhaseOrder defines the canonical execution order for validation phases.
 // Readiness and deployment must run before performance or conformance.
 var PhaseOrder = []ValidationPhaseName{
@@ -103,7 +107,7 @@ func preferCPUNodeAffinity() *corev1.Affinity {
 					Preference: corev1.NodeSelectorTerm{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      "nvidia.com/gpu.present",
+								Key:      gpuPresentLabelKey,
 								Operator: corev1.NodeSelectorOpDoesNotExist,
 							},
 						},

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -432,7 +432,6 @@ func (v *Validator) validateDeployment(
 						ExpectedTests:      patternResult.ExpectedTests,
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Deployment, DefaultDeploymentTimeout),
 						Tolerations:        v.Tolerations,
-						NodeSelector:       v.NodeSelector,
 						Affinity:           preferCPUNodeAffinity(),
 					}
 
@@ -589,7 +588,6 @@ func (v *Validator) validatePerformance(
 						TestPattern:        patternResult.Pattern,
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Performance, DefaultPerformanceTimeout),
 						Tolerations:        v.Tolerations,
-						NodeSelector:       v.NodeSelector,
 						Affinity:           preferCPUNodeAffinity(),
 					}
 
@@ -728,7 +726,6 @@ func (v *Validator) validateConformance(
 						ExpectedTests:      patternResult.ExpectedTests,
 						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Conformance, DefaultConformanceTimeout),
 						Tolerations:        v.Tolerations,
-						NodeSelector:       v.NodeSelector,
 						Affinity:           preferCPUNodeAffinity(),
 					}
 

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 	"github.com/NVIDIA/aicr/pkg/validator/checks"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func init() {
@@ -1230,6 +1231,43 @@ func TestBuildTestPattern(t *testing.T) {
 				t.Errorf("buildTestPattern() expectedTests = %d, want %d", result.ExpectedTests, tt.wantExpectedTests)
 			}
 		})
+	}
+}
+
+func TestPreferCPUNodeAffinity(t *testing.T) {
+	affinity := preferCPUNodeAffinity()
+
+	if affinity == nil {
+		t.Fatal("expected non-nil affinity")
+	}
+	if affinity.NodeAffinity == nil {
+		t.Fatal("expected non-nil NodeAffinity")
+	}
+
+	// Should use preferred (soft), not required (hard)
+	if affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Error("expected no required scheduling terms (soft preference only)")
+	}
+
+	preferred := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(preferred) != 1 {
+		t.Fatalf("expected 1 preferred scheduling term, got %d", len(preferred))
+	}
+
+	term := preferred[0]
+	if term.Weight != 100 {
+		t.Errorf("expected weight 100, got %d", term.Weight)
+	}
+
+	expressions := term.Preference.MatchExpressions
+	if len(expressions) != 1 {
+		t.Fatalf("expected 1 match expression, got %d", len(expressions))
+	}
+	if expressions[0].Key != "nvidia.com/gpu.present" {
+		t.Errorf("expected key nvidia.com/gpu.present, got %q", expressions[0].Key)
+	}
+	if expressions[0].Operator != corev1.NodeSelectorOpDoesNotExist {
+		t.Errorf("expected operator DoesNotExist, got %v", expressions[0].Operator)
 	}
 }
 

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -1263,8 +1263,8 @@ func TestPreferCPUNodeAffinity(t *testing.T) {
 	if len(expressions) != 1 {
 		t.Fatalf("expected 1 match expression, got %d", len(expressions))
 	}
-	if expressions[0].Key != "nvidia.com/gpu.present" {
-		t.Errorf("expected key nvidia.com/gpu.present, got %q", expressions[0].Key)
+	if expressions[0].Key != gpuPresentLabelKey {
+		t.Errorf("expected key %s, got %q", gpuPresentLabelKey, expressions[0].Key)
 	}
 	if expressions[0].Operator != corev1.NodeSelectorOpDoesNotExist {
 		t.Errorf("expected operator DoesNotExist, got %v", expressions[0].Operator)

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -121,9 +121,6 @@ type Validator struct {
 	// Tolerations are applied to validation phase Jobs for scheduling on tainted nodes.
 	// Defaults to tolerate-all so Jobs can schedule on any node regardless of taints.
 	Tolerations []corev1.Toleration
-
-	// NodeSelector constrains validation phase Jobs to specific nodes.
-	NodeSelector map[string]string
 }
 
 // Option is a functional option for configuring Validator instances.
@@ -185,13 +182,6 @@ func WithNoCluster(noCluster bool) Option {
 func WithTolerations(tolerations []corev1.Toleration) Option {
 	return func(v *Validator) {
 		v.Tolerations = tolerations
-	}
-}
-
-// WithNodeSelector returns an Option that sets node selectors for validation phase Jobs.
-func WithNodeSelector(nodeSelector map[string]string) Option {
-	return func(v *Validator) {
-		v.NodeSelector = nodeSelector
 	}
 }
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -729,12 +729,10 @@ func TestNew_WithImage_MultipleOptions(t *testing.T) {
 
 func TestNew_SchedulingOptions(t *testing.T) {
 	tests := []struct {
-		name              string
-		opts              []Option
-		wantTolerations   int
-		wantNodeSelectors int
-		checkToleration   func(t *testing.T, tolerations []corev1.Toleration)
-		checkNodeSelector func(t *testing.T, nodeSelector map[string]string)
+		name            string
+		opts            []Option
+		wantTolerations int
+		checkToleration func(t *testing.T, tolerations []corev1.Toleration)
 	}{
 		{
 			name:            "default tolerate-all",
@@ -755,8 +753,7 @@ func TestNew_SchedulingOptions(t *testing.T) {
 				{Key: "dedicated", Value: "worker-workload", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual},
 				{Key: "dedicated", Value: "worker-workload", Effect: corev1.TaintEffectNoExecute, Operator: corev1.TolerationOpEqual},
 			})},
-			wantTolerations:   2,
-			wantNodeSelectors: 0,
+			wantTolerations: 2,
 			checkToleration: func(t *testing.T, tolerations []corev1.Toleration) {
 				if tolerations[0].Key != "dedicated" {
 					t.Errorf("expected toleration key 'dedicated', got %q", tolerations[0].Key)
@@ -771,8 +768,7 @@ func TestNew_SchedulingOptions(t *testing.T) {
 			opts: []Option{WithTolerations([]corev1.Toleration{
 				{Operator: corev1.TolerationOpExists},
 			})},
-			wantTolerations:   1,
-			wantNodeSelectors: 0,
+			wantTolerations: 1,
 			checkToleration: func(t *testing.T, tolerations []corev1.Toleration) {
 				if tolerations[0].Operator != corev1.TolerationOpExists {
 					t.Errorf("expected Exists operator, got %q", tolerations[0].Operator)
@@ -782,26 +778,6 @@ func TestNew_SchedulingOptions(t *testing.T) {
 				}
 			},
 		},
-		{
-			name:              "with node selector",
-			opts:              []Option{WithNodeSelector(map[string]string{"gpu": "true"})},
-			wantTolerations:   1,
-			wantNodeSelectors: 1,
-			checkNodeSelector: func(t *testing.T, nodeSelector map[string]string) {
-				if nodeSelector["gpu"] != "true" {
-					t.Errorf("expected node selector gpu=true, got %q", nodeSelector["gpu"])
-				}
-			},
-		},
-		{
-			name: "with tolerations and node selector",
-			opts: []Option{
-				WithTolerations([]corev1.Toleration{{Operator: corev1.TolerationOpExists}}),
-				WithNodeSelector(map[string]string{"gpu": "true"}),
-			},
-			wantTolerations:   1,
-			wantNodeSelectors: 1,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -810,14 +786,8 @@ func TestNew_SchedulingOptions(t *testing.T) {
 			if len(v.Tolerations) != tt.wantTolerations {
 				t.Fatalf("expected %d tolerations, got %d", tt.wantTolerations, len(v.Tolerations))
 			}
-			if len(v.NodeSelector) != tt.wantNodeSelectors {
-				t.Fatalf("expected %d node selectors, got %d", tt.wantNodeSelectors, len(v.NodeSelector))
-			}
 			if tt.checkToleration != nil {
 				tt.checkToleration(t, v.Tolerations)
-			}
-			if tt.checkNodeSelector != nil {
-				tt.checkNodeSelector(t, v.NodeSelector)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Builds on #250 (propagate tolerations and node selectors to validation phase Jobs). Replaces hard `NodeSelector` on validation Jobs with a soft node affinity that prefers CPU nodes, and removes `--node-selector` propagation to validation Jobs entirely.

Validation phase Jobs (deployment, performance, conformance) are orchestration layers — they interact with the K8s API to create workload Pods but don't need GPU hardware themselves. In heterogeneous clusters, these Jobs should avoid consuming GPU resources.

### Changes on top of #250

- **Remove `NodeSelector` from Validator** — validation Jobs no longer accept `--node-selector`; that flag now only targets the snapshot agent
- **Add soft CPU-node affinity** — all three phase Jobs get `preferredDuringSchedulingIgnoredDuringExecution` with `nvidia.com/gpu.present DoesNotExist` (weight 100)
- **Remove GPU nodeSelector from performance phase** — the previous hardcoded `nvidia.com/gpu.present=true` selector was wrong; the Job itself doesn't need a GPU, it creates workload Pods that do
- **Update `--toleration` help text** — clarify it applies to both snapshot agent and validation phase Jobs
- **Update `--node-selector` help text** — clarify it only targets the snapshot agent; validation Jobs auto-prefer CPU nodes

## Node scheduling model

| Component | Needs GPU? | Scheduling |
|-----------|-----------|------------|
| Snapshot agent | Yes (nvidia-smi, device properties) | User-provided `--node-selector` |
| Deployment Job | No (orchestrates via K8s API) | Soft prefer CPU nodes |
| Performance Job | No (creates NCCL TrainJob Pods with GPU requests) | Soft prefer CPU nodes |
| Conformance Job | No (creates workload Pods with GPU requests) | Soft prefer CPU nodes |

## Changes

| File | Change |
|------|--------|
| `pkg/validator/agent/types.go` | Add `Affinity *corev1.Affinity` to Config |
| `pkg/validator/agent/job.go` | Apply `config.Affinity` to PodSpec in `buildJobSpec()` |
| `pkg/validator/agent/job_test.go` | Add `TestBuildJobSpec_WithAffinity` and `TestBuildJobSpec_WithoutAffinity` |
| `pkg/validator/phases.go` | Add `preferCPUNodeAffinity()` helper, set on all three phase Jobs, remove GPU nodeSelector from performance |
| `pkg/validator/phases_test.go` | Add `TestPreferCPUNodeAffinity` |
| `pkg/validator/validator.go` | Remove `NodeSelector` field and `WithNodeSelector` option |
| `pkg/validator/validator_test.go` | Remove nodeSelector test cases |
| `pkg/cli/validate.go` | Remove `--node-selector` propagation to validator, update help text |
| `pkg/cli/snapshot.go` | Update `--node-selector` docs for heterogeneous clusters |
| `pkg/validator/README.md` | Update node scheduling documentation |
| `pkg/validator/agent/README.md` | Update node scheduling documentation |

## Test plan

- [ ] `go test -race ./pkg/validator/agent/...` — affinity unit tests
- [ ] `go test -race ./pkg/validator/...` — preferCPUNodeAffinity unit test, scheduling options tests
- [ ] `make test` — all packages pass
- [ ] `make lint` — no new lint issues
- [ ] E2E: in heterogeneous cluster, verify validator Jobs schedule on CPU nodes
- [ ] E2E: in GPU-only cluster, verify validator Jobs still schedule (soft preference ignored)
