### PR TITLE
fix(recipes): disable gdrcopy by default on EKS

### DIFF
--- a/recipes/overlays/eks.yaml
+++ b/recipes/overlays/eks.yaml
@@ -59,6 +59,16 @@ spec:
                   resources:
                     requests:
                       storage: 50Gi
+
+    # Disable GDRCopy by default on EKS to avoid driver build/runtime
+    # incompatibilities across AMI kernel versions.
+    # Cluster-specific overlays may re-enable once kernel/driver combo is validated.
+    - name: gpu-operator
+      type: Helm
+      overrides:
+        gdrcopy:
+          enabled: false
+
     # EKS has no control-plane nodes — remove the default nodeAffinity
     # that requires node-role.kubernetes.io/control-plane
     - name: nvidia-dra-driver-gpu

--- a/recipes/overlays/h100-eks-training.yaml
+++ b/recipes/overlays/h100-eks-training.yaml
@@ -43,8 +43,6 @@ spec:
       overrides:
         cdi:
           enabled: true
-        gdrcopy:
-          enabled: true
 
     - name: skyhook-customizations
       type: Helm


### PR DESCRIPTION
Summary:
- disable gdrcopy by default in the EKS overlay
- remove the H100 EKS training override that forced gdrcopy enabled

Why:
Some EKS AMI/kernel combinations (for example kernel 6.17) can fail in gdrcopy build/runtime paths and destabilize GPU operator bring-up. DRA does not require gdrcopy, so defaulting it off improves portability across AMI versions.

Scope:
- EKS defaults only
- non-EKS recipes unchanged
- cluster-specific overlays can re-enable gdrcopy after validation