### PR TITLE
fix(recipes): remove gdrcopy version pin from GPU Operator defaults

### DIFF
--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -51,7 +51,6 @@ dcgmExporter:
 
 gdrcopy:
   enabled: true
-  version: v2.5
 
 gfd:
   enabled: true

--- a/tests/chainsaw/cli/helm-values-discovery/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/helm-values-discovery/chainsaw-test.yaml
@@ -88,7 +88,6 @@ spec:
                         gpu-operator.values.toolkit.enabled: "true"
                         gpu-operator.values.gfd.enabled: "true"
                         gpu-operator.values.gdrcopy.enabled: "true"
-                        gpu-operator.values.gdrcopy.version: v2.5
                         gpu-operator.values.fullnameOverride: gpu-operator
                         gpu-operator.values.operator.upgradeCRD: "true"
                         gpu-operator.values.migManager.enabled: "true"


### PR DESCRIPTION
## Summary

Remove the hardcoded `gdrcopy.version: v2.5` from the base GPU Operator values, allowing the chart to use its default GDRCopy version.

## Motivation / Context

Pinning `gdrcopy.version: v2.5` in the base values causes version conflicts when the GPU Operator chart bumps the bundled GDRCopy version. Removing the pin lets each chart version use its own validated default.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: recipes/components

## Implementation Notes

- Removes `gdrcopy.version: v2.5` from `recipes/components/gpu-operator/values.yaml`
- Updates helm-values-discovery test to remove the version assertion
- GDRCopy remains enabled; only the version pin is removed

## Testing

```bash
make test
make lint
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — the GPU Operator chart will use its own default GDRCopy version.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)