### PR TITLE
feat(skyhook): make autoTaintNewNodes configurable, add template tests, bump to v0.13.0

### DIFF
--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -142,7 +142,7 @@ componentRefs:
     chart: skyhook-operator
     type: Helm
     source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: 0.11.1
+    version: 0.13.0
     valuesFile: components/skyhook-operator/values.yaml
     overrides:
       customization: ubuntu

--- a/examples/recipes/eks-training.yaml
+++ b/examples/recipes/eks-training.yaml
@@ -59,7 +59,7 @@ componentRefs:
     chart: skyhook-operator
     type: Helm
     source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: 0.11.1
+    version: 0.13.0
     valuesFile: components/skyhook-operator/values.yaml
 deploymentOrder:
   - cert-manager

--- a/examples/recipes/kind.yaml
+++ b/examples/recipes/kind.yaml
@@ -37,7 +37,7 @@ componentRefs:
     chart: skyhook-operator
     type: Helm
     source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: 0.11.1
+    version: 0.13.0
     valuesFile: components/skyhook-operator/values.yaml
   - name: kube-prometheus-stack
     namespace: nvidia-system

--- a/pkg/validator/checks/performance/trainer_lifecycle.go
+++ b/pkg/validator/checks/performance/trainer_lifecycle.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -186,8 +187,7 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 // defer time; cleanup must still complete.
 func deleteTrainer(dynamicClient dynamic.Interface, resources []trainerResourceRef) {
 	slog.Info("Deleting installed Kubeflow Trainer resources", "count", len(resources))
-	for i := len(resources) - 1; i >= 0; i-- {
-		ref := resources[i]
+	for _, ref := range slices.Backward(resources) {
 		deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 
 		var err error

--- a/recipes/components/skyhook-customizations/manifests/no-op.yaml
+++ b/recipes/components/skyhook-customizations/manifests/no-op.yaml
@@ -39,6 +39,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   runtimeRequired: true
+  # Default: true. Disable with --set skyhookcustomizations:autoTaintNewNodes=false
+  autoTaintNewNodes: {{ ne (toString ($cust.autoTaintNewNodes | default true)) "false" }}
   # Dynamic: Supports --accelerated-node-toleration CLI flag
   additionalTolerations:
     {{- if $cust.acceleratedTolerations }}

--- a/recipes/components/skyhook-customizations/manifests/tuning.yaml
+++ b/recipes/components/skyhook-customizations/manifests/tuning.yaml
@@ -39,6 +39,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   runtimeRequired: true
+  # Default: true. Disable with --set skyhookcustomizations:autoTaintNewNodes=false
+  autoTaintNewNodes: {{ ne (toString ($cust.autoTaintNewNodes | default true)) "false" }}
   # Dynamic: Supports --accelerated-node-toleration CLI flag
   additionalTolerations:
     {{- if $cust.acceleratedTolerations }}

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -56,7 +56,7 @@ spec:
     - name: skyhook-operator
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/skyhook
-      version: v0.12.0
+      version: v0.13.0
       valuesFile: components/skyhook-operator/values.yaml
 
     - name: kube-prometheus-stack

--- a/tests/chainsaw/bundle-templates/README.md
+++ b/tests/chainsaw/bundle-templates/README.md
@@ -1,0 +1,48 @@
+# Bundle Template Tests
+
+Template rendering tests for AICR component manifests. These tests verify that
+Go template conditionals in manifest files produce correct output across
+different value combinations.
+
+## Why These Tests Matter
+
+Component manifests use Go templates with conditionals (`if`/`else`, `default`,
+`toYaml`) to support dynamic configuration. Without rendering tests, template
+bugs (wrong defaults, broken conditionals, typos in value keys) would only
+surface during live deployments.
+
+## Pattern
+
+Each component gets its own subdirectory with:
+
+1. **`chainsaw-test.yaml`** — Generates a recipe, runs `aicr bundle` with
+   different `--set` flags and scheduling options, then asserts on the rendered
+   manifest output.
+2. **`assert-*.yaml`** — Structural YAML assertions validated by
+   `chainsaw assert`. Since rendered manifests are valid K8s resources
+   (`apiVersion`/`kind`), chainsaw can parse them directly.
+
+This follows the same pattern used in the
+[skyhook project](https://github.com/NVIDIA/skyhook/blob/main/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml),
+adapted for AICR's `aicr bundle` rendering pipeline instead of `helm template`.
+
+## Running
+
+```bash
+# Build the binary first
+unset GITLAB_TOKEN && make build
+
+# Run all bundle template tests
+AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/
+
+# Run a specific component's tests
+AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/skyhook-customizations
+```
+
+## Adding Tests for a New Component
+
+1. Create `tests/chainsaw/bundle-templates/<component-name>/`
+2. Add a `chainsaw-test.yaml` that generates a recipe, bundles with different
+   flag combinations, and asserts on the rendered output at
+   `${WORK}/bundle/<component-name>/manifests/<manifest>.yaml`
+3. Add `assert-*.yaml` files with the expected structural YAML

--- a/tests/chainsaw/bundle-templates/skyhook-customizations/assert-tuning-defaults.yaml
+++ b/tests/chainsaw/bundle-templates/skyhook-customizations/assert-tuning-defaults.yaml
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Assert Skyhook operator controller-manager is available.
-# fullnameOverride: skyhook-operator (from values.yaml)
-# Chart: skyhook-operator v0.13.0
-# Manages NodeConfiguration CRs for node-level customizations (sysctl, kmod, etc.)
-apiVersion: apps/v1
-kind: Deployment
+# Assert default tuning manifest rendering.
+# autoTaintNewNodes defaults to true.
+# When no --accelerated-node-toleration is passed, ParseTolerations() returns
+# a "tolerate all" default (operator: Exists with no key).
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
 metadata:
-  name: skyhook-operator-controller-manager
-  namespace: skyhook
-status:
-  (conditions[?type == 'Available']):
-    - status: "True"
+  name: tuning
+spec:
+  runtimeRequired: true
+  autoTaintNewNodes: true
+  additionalTolerations:
+    - operator: Exists

--- a/tests/chainsaw/bundle-templates/skyhook-customizations/assert-tuning-no-autotaint.yaml
+++ b/tests/chainsaw/bundle-templates/skyhook-customizations/assert-tuning-no-autotaint.yaml
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Assert Skyhook operator controller-manager is available.
-# fullnameOverride: skyhook-operator (from values.yaml)
-# Chart: skyhook-operator v0.13.0
-# Manages NodeConfiguration CRs for node-level customizations (sysctl, kmod, etc.)
-apiVersion: apps/v1
-kind: Deployment
+# Assert tuning manifest with autoTaintNewNodes disabled.
+# --set skyhookcustomizations:autoTaintNewNodes=false
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
 metadata:
-  name: skyhook-operator-controller-manager
-  namespace: skyhook
-status:
-  (conditions[?type == 'Available']):
-    - status: "True"
+  name: tuning
+spec:
+  runtimeRequired: true
+  autoTaintNewNodes: false

--- a/tests/chainsaw/bundle-templates/skyhook-customizations/assert-tuning-scheduling.yaml
+++ b/tests/chainsaw/bundle-templates/skyhook-customizations/assert-tuning-scheduling.yaml
@@ -12,15 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Assert Skyhook operator controller-manager is available.
-# fullnameOverride: skyhook-operator (from values.yaml)
-# Chart: skyhook-operator v0.13.0
-# Manages NodeConfiguration CRs for node-level customizations (sysctl, kmod, etc.)
-apiVersion: apps/v1
-kind: Deployment
+# Assert tuning manifest with custom scheduling options.
+# --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule
+# --accelerated-node-selector nodeGroup=gpu-worker
+# --workload-selector app=training
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
 metadata:
-  name: skyhook-operator-controller-manager
-  namespace: skyhook
-status:
-  (conditions[?type == 'Available']):
-    - status: "True"
+  name: tuning
+spec:
+  runtimeRequired: true
+  autoTaintNewNodes: true
+  additionalTolerations:
+    - key: nvidia.com/gpu
+      operator: Equal
+      value: present
+      effect: NoSchedule
+  nodeSelectors:
+    matchLabels:
+      nodeGroup: gpu-worker
+  podNonInterruptLabels:
+    matchLabels:
+      app: training

--- a/tests/chainsaw/bundle-templates/skyhook-customizations/chainsaw-test.yaml
+++ b/tests/chainsaw/bundle-templates/skyhook-customizations/chainsaw-test.yaml
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-bundle-skyhook-template
+spec:
+  description: |
+    Validates that skyhook-customizations manifest templates render correctly
+    with different inputs. Tests autoTaintNewNodes default/override, tolerations,
+    node selectors, and workload selectors.
+    No cluster needed -- purely CLI output validation.
+    Run with: AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/skyhook-customizations
+  timeouts:
+    exec: 30s
+  steps:
+
+    ## ── Setup: generate recipe ─────────────────────────────────────────
+
+    - name: generate-recipe
+      description: Generate an EKS H100 training recipe.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              ${AICR_BIN} recipe \
+                --service eks \
+                --accelerator h100 \
+                --os ubuntu \
+                --intent training \
+                --output "${WORK}/recipe.yaml"
+
+    ## ── Default values ─────────────────────────────────────────────────
+
+    - name: bundle-defaults
+      description: Generate bundle with default values (no overrides).
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              rm -rf "${WORK}/bundle-defaults"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-defaults"
+
+    - name: assert-tuning-defaults
+      description: Verify tuning manifest renders with autoTaintNewNodes true and default tolerations.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              chainsaw assert \
+                --resource "${WORK}/bundle-defaults/skyhook-customizations/manifests/tuning.yaml" \
+                --file ./assert-tuning-defaults.yaml \
+                --no-color --timeout 5s
+
+    ## ── autoTaintNewNodes=false ────────────────────────────────────────
+
+    - name: bundle-no-autotaint
+      description: Generate bundle with autoTaintNewNodes disabled.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              rm -rf "${WORK}/bundle-no-autotaint"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-no-autotaint" \
+                --set skyhookcustomizations:autoTaintNewNodes=false
+
+    - name: assert-tuning-no-autotaint
+      description: Verify tuning manifest renders with autoTaintNewNodes false.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              chainsaw assert \
+                --resource "${WORK}/bundle-no-autotaint/skyhook-customizations/manifests/tuning.yaml" \
+                --file ./assert-tuning-no-autotaint.yaml \
+                --no-color --timeout 5s
+
+    ## ── Edge case: non-boolean input coerces to true ─────────────────
+
+    - name: bundle-autotaint-garbage
+      description: Verify garbage string defaults to true (ne toString coercion).
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              rm -rf "${WORK}/bundle-garbage"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-garbage" \
+                --set skyhookcustomizations:autoTaintNewNodes=banana
+
+    - name: assert-autotaint-garbage
+      description: Verify autoTaintNewNodes=banana coerces to true (not "false", so ne returns true).
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              chainsaw assert \
+                --resource "${WORK}/bundle-garbage/skyhook-customizations/manifests/tuning.yaml" \
+                --file ./assert-tuning-defaults.yaml \
+                --no-color --timeout 5s
+
+    ## ── Custom scheduling ──────────────────────────────────────────────
+
+    - name: bundle-scheduling
+      description: Generate bundle with custom tolerations, node selectors, and workload selector.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              rm -rf "${WORK}/bundle-scheduling"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-scheduling" \
+                --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule \
+                --accelerated-node-selector nodeGroup=gpu-worker \
+                --workload-selector app=training
+
+    - name: assert-tuning-scheduling
+      description: Verify tuning manifest renders with custom tolerations, selectors, and workload selector.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-skyhook-template"
+              chainsaw assert \
+                --resource "${WORK}/bundle-scheduling/skyhook-customizations/manifests/tuning.yaml" \
+                --file ./assert-tuning-scheduling.yaml \
+                --no-color --timeout 5s
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/chainsaw-bundle-skyhook-template

--- a/tests/chainsaw/cli/cuj1-training/mock-snapshot.yaml
+++ b/tests/chainsaw/cli/cuj1-training/mock-snapshot.yaml
@@ -60,7 +60,7 @@ measurements:
           skyhook-customizations.chart: skyhook-customizations
           skyhook-customizations.namespace: skyhook
           skyhook-operator.chart: skyhook-operator
-          skyhook-operator.version: v0.12.0
+          skyhook-operator.version: v0.13.0
           skyhook-operator.namespace: skyhook
   - type: OS
     subtypes:


### PR DESCRIPTION


## Summary

- Bump skyhook-operator from v0.12.0 to v0.13.0 across overlays, examples, and test fixtures
- Make autoTaintNewNodes configurable in skyhook-customizations manifests (tuning.yaml and no-op.yaml), defaulting to true. Users who pre-taint nodes at the cluster/provisioner level can disable it via --set skyhookcustomizations:autoTaintNewNodes=false
- Add chainsaw-based template rendering tests under tests/chainsaw/bundle-templates/skyhook-customizations/ — a new pattern for verifying manifest template branches produce correct output
- fix broken linting in main

## Motivation / Context

This enables runtime required tainting to auto taint new nodes by default in skyhook operator. This is so skyhook can block other work tell its done with runtime required skyhooks.

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
