### PR TITLE
docs: update cli ref docs with attestation feature

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -230,6 +230,8 @@ aicr trust update
 Run this when Sigstore rotates their keys (a few times per year) or if
 verification reports a stale root.
 
+For full CLI flag documentation, see the [CLI Reference](docs/user/cli-reference.md#aicr-verify) (`aicr verify`, `aicr bundle --attest`, `aicr trust update`). For a hands-on walkthrough, see the [Bundle Attestation Demo](demos/attestation.md).
+
 ### Setup
 
 Export variables for the image you want to verify:

--- a/demos/s3c.md
+++ b/demos/s3c.md
@@ -248,6 +248,56 @@ Get entry details:
 rekor-cli get --uuid <entry-uuid>
 ```
 
+## Bundle Attestation
+
+In addition to image and binary attestations, AICR can attest the **deployment bundles** it generates. When `--attest` is passed to `aicr bundle`, the bundle is signed with SLSA Build Provenance v1 using Sigstore keyless OIDC signing, binding the creator's identity to the bundle content and the binary that produced it.
+
+**Create an attested bundle:**
+
+```shell
+aicr bundle \
+  --recipe recipe.yaml \
+  --output ./my-bundle \
+  --attest
+```
+
+In GitHub Actions the OIDC token is detected automatically. Locally, a browser window opens for authentication.
+
+**Verify a bundle:**
+
+```shell
+aicr verify ./my-bundle
+```
+
+This verifies:
+1. **Checksums** — all content files match `checksums.txt`
+2. **Bundle attestation** — cryptographic signature verified against Sigstore trusted root
+3. **Binary attestation** — provenance chain verified with identity pinned to NVIDIA CI
+
+**Trust levels:**
+
+| Level | Name | Criteria |
+|-------|------|----------|
+| 4 | `verified` | Full chain: checksums + bundle attestation + binary attestation pinned to NVIDIA CI |
+| 3 | `attested` | Chain verified but binary attestation missing or external data used |
+| 2 | `unverified` | Checksums valid, `--attest` was not used |
+| 1 | `unknown` | Missing or invalid checksums |
+
+**Enforce a minimum trust level:**
+
+```shell
+aicr verify ./my-bundle --min-trust-level verified
+```
+
+**JSON output for CI pipelines:**
+
+```shell
+aicr verify ./my-bundle --format json
+```
+
+For the full demo walkthrough, see [demos/attestation.md](attestation.md). For CLI flag details, see the [CLI Reference](../docs/user/cli-reference.md#aicr-verify).
+
 ## Links
 
 * [Security](https://github.com/NVIDIA/aicr/blob/main/SECURITY.md)
+* [Bundle Attestation Demo](attestation.md)

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -669,6 +669,8 @@ aicr bundle [flags]
 | `--workload-gate` | | string | Taint for skyhook-operator runtime required (format: key=value:effect or key:effect). This is a day 2 option for cluster scaling operations. |
 | `--workload-selector` | | string[] | Label selector for skyhook-customizations to prevent eviction of running training jobs (format: key=value, repeatable). Required when skyhook-customizations is enabled with training intent. |
 | `--nodes` | | int | Estimated number of GPU nodes (default: 0 = unset). At bundle time, written to Helm value paths declared in the registry under `nodeScheduling.nodeCountPaths`. |
+| `--attest` | | bool | Enable bundle attestation and binary provenance verification. Requires OIDC authentication. See [Bundle Attestation](#bundle-attestation). |
+| `--certificate-identity-regexp` | | string | Override the certificate identity pattern for binary attestation verification. Must contain `"NVIDIA/aicr"`. For testing only. |
 
 **Node Scheduling:**
 
@@ -803,6 +805,12 @@ aicr bundle -r recipe.yaml \
   --workload-selector workload-type=training \
   -o ./bundles
 
+# Generate an attested bundle (opens browser for OIDC auth)
+aicr bundle -r recipe.yaml --attest -o ./bundles
+
+# In GitHub Actions (OIDC token detected automatically)
+aicr bundle -r recipe.yaml --attest -o ./bundles
+
 # Generate ArgoCD Application manifests for GitOps
 aicr bundle -r recipe.yaml --deployer argocd -o ./bundles
 
@@ -823,7 +831,10 @@ bundles/
 ├── README.md                      # Deployment guide with ordered steps
 ├── deploy.sh                      # One-command deployment script
 ├── recipe.yaml                    # Recipe used to generate bundle
-├── checksums.txt                  # SHA256 checksums (optional)
+├── checksums.txt                  # SHA256 checksums
+├── attestation/                   # Present when --attest is used
+│   ├── bundle-attestation.sigstore.json   # SLSA Build Provenance v1
+│   └── aicr-attestation.sigstore.json     # Binary SLSA provenance chain
 ├── gpu-operator/
 │   ├── values.yaml                # Component-specific Helm values
 │   ├── README.md                  # Per-component install/upgrade/uninstall
@@ -949,6 +960,17 @@ ArgoCD Applications use multi-source to:
 2. Apply values.yaml from your GitOps repository
 3. Deploy additional manifests from component's manifests/ directory (if present)
 
+#### Bundle Attestation
+
+When `--attest` is passed, the bundle command performs four steps:
+
+1. **Acquires an OIDC token** — In GitHub Actions the ambient OIDC token is used automatically. Locally, a browser window opens for Sigstore OIDC authentication.
+2. **Verifies the binary's own attestation** — The running `aicr` binary must have a valid SLSA provenance file (`aicr-attestation.sigstore.json`) from an NVIDIA release. This ensures only NVIDIA-built binaries can produce attested bundles.
+3. **Signs the bundle** — Creates a SLSA Build Provenance v1 in-toto statement binding the creator's identity to the bundle content (via `checksums.txt` digest) and the binary that produced it.
+4. **Writes attestation files** — `attestation/bundle-attestation.sigstore.json` and `attestation/aicr-attestation.sigstore.json` are added to the bundle output.
+
+Attestation is opt-in; bundles are unsigned by default. Signing uses Sigstore keyless signing (Fulcio CA + Rekor transparency log). For verification, see [`aicr verify`](#aicr-verify).
+
 **Deploying a bundle:**
 ```shell
 # Navigate to bundle
@@ -963,6 +985,84 @@ sha256sum -c checksums.txt
 
 # Deploy to cluster
 chmod +x deploy.sh && ./deploy.sh
+```
+
+---
+
+### aicr verify
+
+Verify the integrity and attestation chain of a bundle. Verification is fully offline — no network calls are made.
+
+**Synopsis:**
+```shell
+aicr verify <bundle-dir> [flags]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--min-trust-level` | string | `max` | Minimum required trust level. `max` auto-detects the highest achievable level and verifies against it. Explicit levels: `verified`, `attested`, `unverified`, `unknown`. |
+| `--require-creator` | string | | Require a specific creator identity, matched against the bundle attestation signing certificate. |
+| `--cli-version-constraint` | string | | Version constraint for the aicr CLI version in the attestation predicate. Supports `>=`, `>`, `<=`, `<`, `==`, `!=`. A bare version (e.g. `"0.8.0"`) defaults to `>=`. |
+| `--certificate-identity-regexp` | string | | Override the certificate identity pattern for binary attestation verification. Must contain `"NVIDIA/aicr"`. For testing only. |
+| `--format` | string | `text` | Output format: `text` or `json`. |
+
+**Trust Levels:**
+
+| Level | Name | Criteria |
+|-------|------|----------|
+| 4 | `verified` | Full chain: checksums + bundle attestation + binary attestation pinned to NVIDIA CI |
+| 3 | `attested` | Chain verified but binary attestation missing or external data (`--data`) was used |
+| 2 | `unverified` | Checksums valid, `--attest` was not used when creating the bundle |
+| 1 | `unknown` | Missing or invalid checksums |
+
+**Verification steps:**
+
+1. **Checksums** — verifies all content files match `checksums.txt`
+2. **Bundle attestation** — cryptographic signature verified against Sigstore trusted root
+3. **Binary attestation** — provenance chain verified with identity pinned to NVIDIA CI (`on-tag.yaml` workflow)
+
+**Examples:**
+```shell
+# Auto-detect maximum trust level
+aicr verify ./my-bundle
+
+# Enforce a minimum trust level
+aicr verify ./my-bundle --min-trust-level verified
+
+# Require a specific bundle creator
+aicr verify ./my-bundle --require-creator jdoe@company.com
+
+# Require minimum CLI version used to create the bundle
+aicr verify ./my-bundle --cli-version-constraint ">= 0.8.0"
+
+# JSON output for CI pipelines
+aicr verify ./my-bundle --format json
+```
+
+> **Stale root:** If verification fails with certificate chain errors, run `aicr trust update` to refresh the Sigstore trusted root.
+
+---
+
+### aicr trust update
+
+Fetch the latest Sigstore trusted root from the TUF CDN and update the local cache at `~/.sigstore/root/`. This is needed when Sigstore rotates signing keys (a few times per year).
+
+**Synopsis:**
+```shell
+aicr trust update
+```
+
+**No flags.** This command contacts `tuf-repo-cdn.sigstore.dev`, verifies the update chain against the embedded TUF root, and writes the result to `~/.sigstore/root/`.
+
+**When to run:**
+- After initial installation (the install script runs this automatically)
+- When `aicr verify` reports a stale or expired trusted root
+- When Sigstore announces key rotation
+
+**Example:**
+```shell
+aicr trust update
 ```
 
 ---

--- a/tools/e2e
+++ b/tools/e2e
@@ -7,12 +7,12 @@ set -euo pipefail
 #
 # PURPOSE:
 # Builds the aicr binary and runs Chainsaw-based CLI integration tests.
-# Tests are defined declaratively in tests/chainsaw/cli/*/chainsaw-test.yaml.
+# Tests are defined declaratively in tests/chainsaw/cli/ and tests/chainsaw/bundle-templates/.
 #
 # WHAT THIS SCRIPT DOES:
 # 1. Builds the aicr binary via make build
 # 2. Locates the platform-specific binary
-# 3. Runs chainsaw test --no-cluster on tests/chainsaw/cli/
+# 3. Runs chainsaw test --no-cluster on tests/chainsaw/cli/ and tests/chainsaw/bundle-templates/
 #
 # PREREQUISITES:
 # - chainsaw (brew install kyverno/tap/chainsaw)
@@ -102,5 +102,11 @@ chainsaw test \
   --config "${ROOT}/tests/chainsaw/chainsaw-config.yaml" \
   --test-dir "${ROOT}/tests/chainsaw/cli/" \
   --selector 'ci!=true'
+
+msg "Running chainsaw tests (bundle template tests)"
+chainsaw test \
+  --no-cluster \
+  --config "${ROOT}/tests/chainsaw/chainsaw-config.yaml" \
+  --test-dir "${ROOT}/tests/chainsaw/bundle-templates/"
 
 msg "All tests passed!"


### PR DESCRIPTION
## Summary

Here's a summary of all changes:

- **cli-reference.md**:
   - Added --attest and --certificate-identity-regexp flags to the bundle flags table
   - Added attestation examples to the bundle examples block
   - Updated bundle structure diagram to show attestation/ directory
   - Added "Bundle Attestation" subsection explaining the 4-step signing process
   - Added new aicr verify command section with flags, trust levels, verification steps, and examples
   - Added new aicr trust update command section
- **demos/s3c.md**:
   - Added "Bundle Attestation" section with create/verify examples, trust levels table, and links to the full attestation demo

- **SECURITY.md**:
   - Added cross-reference paragraph linking to CLI reference and attestation demo


## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout
