### PR TITLE
refactor(validator): rename ConstraintValidator.Pattern to Name and remove legacy ConstraintTest type

### DIFF
--- a/pkg/validator/checks/README.md
+++ b/pkg/validator/checks/README.md
@@ -286,7 +286,7 @@ import (
 
 func init() {
     checks.RegisterConstraintValidator(&checks.ConstraintValidator{
-        Pattern:     "Deployment.my-app.version",
+        Name:        "Deployment.my-app.version",
         Description: "Validates my-app deployment version",
         TestName:    "TestMyAppVersion",  // Test function name for Job execution
         Phase:       "deployment",
@@ -623,7 +623,7 @@ import (
 
 func init() {
     checks.RegisterConstraintValidator(&checks.ConstraintValidator{
-        Pattern:     "Deployment.device-plugin.replicas",  // ← Constraint name pattern
+        Name:        "Deployment.device-plugin.replicas",  // ← Constraint name
         Description: "Validates device plugin replica count",
         Func:        ValidateDevicePluginReplicas,
     })
@@ -1190,10 +1190,10 @@ The generator creates `my_app_version_integration_test.go` with proper registrat
 
 ```go
 func init() {
-    checks.RegisterConstraintTest(&checks.ConstraintTest{
-        TestName:    "TestMyAppVersion",
-        Pattern:     "Deployment.my-app.version",
+    checks.RegisterConstraintValidator(&checks.ConstraintValidator{
+        Name:        "Deployment.my-app.version",
         Description: "Validates my-app version",
+        TestName:    "TestMyAppVersion",
         Phase:       "deployment",
     })
 }

--- a/pkg/validator/checks/deployment/README.md
+++ b/pkg/validator/checks/deployment/README.md
@@ -151,7 +151,7 @@ Return (actualVersion, passed, error)
    ```go
    func init() {
        checks.RegisterConstraintValidator(&checks.ConstraintValidator{
-           Pattern:     "Deployment.my-resource.property",
+           Name:        "Deployment.my-resource.property",
            Description: "Validates my resource property",
            Func:        ValidateMyConstraint,
        })

--- a/pkg/validator/checks/deployment/gpu_operator_version_constraint.go
+++ b/pkg/validator/checks/deployment/gpu_operator_version_constraint.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 	checks.RegisterConstraintValidator(&checks.ConstraintValidator{
-		Pattern:     "Deployment.gpu-operator.version",
+		Name:        "Deployment.gpu-operator.version",
 		Description: "Validates GPU Operator version by querying deployed resources",
 		Func:        ValidateGPUOperatorVersion,
 		TestName:    "TestGPUOperatorVersion",

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint.go
@@ -82,7 +82,7 @@ func templatePath(accelerator recipe.CriteriaAcceleratorType, service recipe.Cri
 func init() {
 	// Register this constraint validator
 	checks.RegisterConstraintValidator(&checks.ConstraintValidator{
-		Pattern:     "nccl-all-reduce-bw",
+		Name:        "nccl-all-reduce-bw",
 		Description: "Verify NCCL All Reduce Bus Bandwidth within 10% of threshold",
 		Func:        validateNcclAllReduceBw,
 		TestName:    "TestNcclAllReduceBw",

--- a/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
+++ b/pkg/validator/checks/performance/nccl_all_reduce_bw_constraint_unit_test.go
@@ -317,8 +317,8 @@ func TestValidateNcclAllReduceBwRegistration(t *testing.T) {
 		t.Fatal("nccl-all-reduce-bw constraint validator not registered")
 	}
 
-	if validator.Pattern != "nccl-all-reduce-bw" {
-		t.Errorf("Pattern = %v, want nccl-all-reduce-bw", validator.Pattern)
+	if validator.Name != "nccl-all-reduce-bw" {
+		t.Errorf("Name = %v, want nccl-all-reduce-bw", validator.Name)
 	}
 
 	if validator.Description == "" {

--- a/pkg/validator/checks/registration_test.go
+++ b/pkg/validator/checks/registration_test.go
@@ -44,7 +44,7 @@ func TestConstraintRegistrationCompleteness(t *testing.T) {
 	var missing []string
 	for _, ct := range constraintTests {
 		if !existingTests[ct.TestName] {
-			missing = append(missing, ct.TestName+" (pattern: "+ct.Pattern+")")
+			missing = append(missing, ct.TestName+" (constraint: "+ct.Name+")")
 		}
 	}
 
@@ -118,7 +118,7 @@ func TestIntegrationTestsAreRegistered(t *testing.T) {
 	}
 
 	if len(unregistered) > 0 {
-		t.Errorf("Integration tests without registration (add RegisterConstraintTest or RegisterCheck):\n%s",
+		t.Errorf("Integration tests without registration (add RegisterConstraintValidator or RegisterCheck):\n%s",
 			strings.Join(unregistered, "\n"))
 	}
 }

--- a/pkg/validator/checks/registry.go
+++ b/pkg/validator/checks/registry.go
@@ -110,9 +110,8 @@ type Check struct {
 
 // ConstraintValidator represents a registered constraint validator.
 type ConstraintValidator struct {
-	// Pattern is the constraint name pattern this validator handles
-	// Examples: "GPU.*", "Deployment.gpu-operator.*", "k8s.version"
-	Pattern string
+	// Name is the unique identifier for this constraint (e.g., "Deployment.gpu-operator.version")
+	Name string
 
 	// Description explains what constraints this validator handles
 	Description string
@@ -121,34 +120,27 @@ type ConstraintValidator struct {
 	Func ConstraintValidatorFunc
 
 	// TestName is the Go test function name (e.g., "TestGPUOperatorVersion")
-	// If empty, derived from Pattern automatically
+	// If empty, derived from Name automatically
 	TestName string
 
 	// Phase indicates which validation phase (deployment, performance, conformance)
 	Phase string
 }
 
-// ConstraintTest represents a registered integration test for constraint validation.
-// These tests run in Jobs and contain the actual validation logic.
-type ConstraintTest struct {
-	// TestName is the Go test function name (e.g., "TestGPUOperatorVersion")
-	TestName string
-
-	// Pattern is the constraint name this test validates (e.g., "Deployment.gpu-operator.version")
-	Pattern string
-
-	// Description explains what this test validates
-	Description string
-
-	// Phase indicates which validation phase (deployment, performance, conformance)
-	Phase string
-}
-
+// The check and constraint registries serve two purposes:
+//
+//  1. Name → test function mapping: The validator orchestrator (pkg/validator) looks up
+//     registered test names to build -test.run patterns for Jobs it deploys.
+//
+//  2. Function dispatch: Inside those Jobs, TestRunner.RunCheck() and runtime tests
+//     look up Func by name and call it directly (runner.go, deployment/runtime_test.go).
+//
+// Both purposes require init()-time registration, which is why Func must be populated
+// even though the orchestrator never calls it.
 var (
-	checkRegistry          = make(map[string]*Check)
-	constraintRegistry     = make(map[string]*ConstraintValidator)
-	constraintTestRegistry = make(map[string]*ConstraintTest)
-	registryMu             sync.RWMutex
+	checkRegistry      = make(map[string]*Check)
+	constraintRegistry = make(map[string]*ConstraintValidator)
+	registryMu         sync.RWMutex
 )
 
 // RegisterCheck adds a check to the registry.
@@ -164,7 +156,7 @@ func RegisterCheck(check *Check) {
 
 	// Auto-derive TestName if not provided
 	if check.TestName == "" {
-		check.TestName = "TestCheck" + patternToFuncName(check.Name)
+		check.TestName = "TestCheck" + nameToFuncName(check.Name)
 	}
 
 	checkRegistry[check.Name] = check
@@ -185,21 +177,21 @@ func GetTestNameForCheck(checkName string) (string, bool) {
 
 // RegisterConstraintValidator adds a constraint validator to the registry.
 // This should be called from init() functions in constraint validator packages.
-// If TestName is empty, it's derived from the Pattern automatically.
+// If TestName is empty, it's derived from the Name automatically.
 func RegisterConstraintValidator(validator *ConstraintValidator) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
-	if _, exists := constraintRegistry[validator.Pattern]; exists {
-		panic(fmt.Sprintf("constraint validator for pattern %q is already registered", validator.Pattern))
+	if _, exists := constraintRegistry[validator.Name]; exists {
+		panic(fmt.Sprintf("constraint validator %q is already registered", validator.Name))
 	}
 
 	// Auto-derive TestName if not provided
 	if validator.TestName == "" {
-		validator.TestName = "Test" + patternToFuncName(validator.Pattern)
+		validator.TestName = "Test" + nameToFuncName(validator.Name)
 	}
 
-	constraintRegistry[validator.Pattern] = validator
+	constraintRegistry[validator.Name] = validator
 }
 
 // GetCheck retrieves a registered check by name.
@@ -234,14 +226,11 @@ func ResolveCheck(name string) (*Check, bool) {
 	return GetCheckByTestName(name)
 }
 
-// GetConstraintValidator retrieves a constraint validator by pattern.
-// For now, uses exact match. Can be enhanced to support pattern matching.
+// GetConstraintValidator retrieves a constraint validator by name.
 func GetConstraintValidator(constraintName string) (*ConstraintValidator, bool) {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	// TODO(#142): Implement pattern matching (e.g., "GPU.*" matches "GPU.smi.count")
-	// For now, use exact match or prefix match
 	validator, ok := constraintRegistry[constraintName]
 	return validator, ok
 }
@@ -272,45 +261,26 @@ func ListConstraintValidators() []*ConstraintValidator {
 	return validators
 }
 
-// RegisterConstraintTest adds a constraint test to the registry.
-// This maps constraint names to test function names for pattern building.
-func RegisterConstraintTest(test *ConstraintTest) {
-	registryMu.Lock()
-	defer registryMu.Unlock()
-
-	if _, exists := constraintTestRegistry[test.Pattern]; exists {
-		panic(fmt.Sprintf("constraint test for pattern %q is already registered", test.Pattern))
-	}
-
-	constraintTestRegistry[test.Pattern] = test
-}
-
 // GetTestNameForConstraint looks up which test function validates a constraint.
 // Returns the test name and true if found, empty string and false otherwise.
 func GetTestNameForConstraint(constraintName string) (string, bool) {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	// First check constraint registry (preferred, single registration)
 	if validator, ok := constraintRegistry[constraintName]; ok && validator.TestName != "" {
 		return validator.TestName, true
 	}
 
-	// Fallback to legacy test registry for backwards compatibility
-	test, ok := constraintTestRegistry[constraintName]
-	if !ok {
-		return "", false
-	}
-	return test.TestName, true
+	return "", false
 }
 
-// patternToFuncName converts a constraint pattern to a function name.
+// nameToFuncName converts a dotted/dashed name to a Go function name.
 // "Deployment.gpu-operator.version" -> "DeploymentGpuOperatorVersion"
-func patternToFuncName(pattern string) string {
+func nameToFuncName(name string) string {
 	var result []rune
 	capitalizeNext := true
 
-	for _, r := range pattern {
+	for _, r := range name {
 		if r == '.' || r == '-' || r == '_' {
 			capitalizeNext = true
 			continue
@@ -325,37 +295,16 @@ func patternToFuncName(pattern string) string {
 	return string(result)
 }
 
-// ListConstraintTests returns all registered constraint tests.
-// Includes both legacy ConstraintTest registrations and new ConstraintValidator registrations with Phase.
-// Deduplicates by pattern — new ConstraintValidator registrations take precedence.
-func ListConstraintTests(phase string) []*ConstraintTest {
+// ListConstraintTests returns all registered constraint validators, optionally filtered by phase.
+func ListConstraintTests(phase string) []*ConstraintValidator {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	var tests []*ConstraintTest
-	seen := make(map[string]bool)
-
-	// Include tests from constraint validators (new single-registration pattern)
+	var validators []*ConstraintValidator
 	for _, validator := range constraintRegistry {
 		if validator.Phase != "" && (phase == "" || validator.Phase == phase) {
-			seen[validator.Pattern] = true
-			tests = append(tests, &ConstraintTest{
-				TestName:    validator.TestName,
-				Pattern:     validator.Pattern,
-				Description: validator.Description,
-				Phase:       validator.Phase,
-			})
+			validators = append(validators, validator)
 		}
 	}
-
-	// Include legacy test registry for backwards compatibility (skip duplicates)
-	for _, test := range constraintTestRegistry {
-		if seen[test.Pattern] {
-			continue
-		}
-		if phase == "" || test.Phase == phase {
-			tests = append(tests, test)
-		}
-	}
-	return tests
+	return validators
 }

--- a/pkg/validator/checks/registry_test.go
+++ b/pkg/validator/checks/registry_test.go
@@ -347,7 +347,7 @@ func TestRegisterConstraintValidator(t *testing.T) {
 	}()
 
 	validator := &ConstraintValidator{
-		Pattern:     "test.pattern",
+		Name:        "test.pattern",
 		Description: "Test validator",
 		Func: func(ctx *ValidationContext, constraint recipe.Constraint) (string, bool, error) {
 			return "test", true, nil
@@ -363,8 +363,8 @@ func TestRegisterConstraintValidator(t *testing.T) {
 		t.Fatal("ConstraintValidator not found after registration")
 	}
 
-	if retrieved.Pattern != validator.Pattern {
-		t.Errorf("Pattern = %v, want %v", retrieved.Pattern, validator.Pattern)
+	if retrieved.Name != validator.Name {
+		t.Errorf("Name = %v, want %v", retrieved.Name, validator.Name)
 	}
 }
 
@@ -385,7 +385,7 @@ func TestRegisterConstraintValidatorDuplicate(t *testing.T) {
 	}()
 
 	validator := &ConstraintValidator{
-		Pattern: "duplicate.pattern",
+		Name: "duplicate.pattern",
 		Func: func(ctx *ValidationContext, constraint recipe.Constraint) (string, bool, error) {
 			return "", false, nil
 		},
@@ -412,7 +412,7 @@ func TestGetConstraintValidator(t *testing.T) {
 		originalRegistry[k] = v
 	}
 	constraintRegistry = map[string]*ConstraintValidator{
-		"existing.pattern": {Pattern: "existing.pattern"},
+		"existing.pattern": {Name: "existing.pattern"},
 	}
 	registryMu.Unlock()
 
@@ -445,8 +445,8 @@ func TestGetConstraintValidator(t *testing.T) {
 			if ok != tt.wantOk {
 				t.Errorf("GetConstraintValidator() ok = %v, want %v", ok, tt.wantOk)
 			}
-			if tt.wantOk && validator.Pattern != tt.pattern {
-				t.Errorf("GetConstraintValidator() Pattern = %v, want %v", validator.Pattern, tt.pattern)
+			if tt.wantOk && validator.Name != tt.pattern {
+				t.Errorf("GetConstraintValidator() Name = %v, want %v", validator.Name, tt.pattern)
 			}
 		})
 	}
@@ -460,9 +460,9 @@ func TestListConstraintValidators(t *testing.T) {
 		originalRegistry[k] = v
 	}
 	constraintRegistry = map[string]*ConstraintValidator{
-		"pattern1": {Pattern: "pattern1"},
-		"pattern2": {Pattern: "pattern2"},
-		"pattern3": {Pattern: "pattern3"},
+		"pattern1": {Name: "pattern1"},
+		"pattern2": {Name: "pattern2"},
+		"pattern3": {Name: "pattern3"},
 	}
 	registryMu.Unlock()
 
@@ -481,7 +481,7 @@ func TestListConstraintValidators(t *testing.T) {
 	// Verify all validators are included
 	patterns := make(map[string]bool)
 	for _, v := range validators {
-		patterns[v.Pattern] = true
+		patterns[v.Name] = true
 	}
 
 	expectedPatterns := []string{"pattern1", "pattern2", "pattern3"}
@@ -550,96 +550,25 @@ func TestRegistryConcurrency(t *testing.T) {
 	}
 }
 
-func TestRegisterConstraintTest(t *testing.T) {
-	// Save and restore registry
-	originalRegistry := make(map[string]*ConstraintTest)
-	registryMu.Lock()
-	for k, v := range constraintTestRegistry {
-		originalRegistry[k] = v
-	}
-	constraintTestRegistry = make(map[string]*ConstraintTest)
-	registryMu.Unlock()
-
-	defer func() {
-		registryMu.Lock()
-		constraintTestRegistry = originalRegistry
-		registryMu.Unlock()
-	}()
-
-	tests := []struct {
-		name      string
-		test      *ConstraintTest
-		wantPanic bool
-	}{
-		{
-			name: "register valid constraint test",
-			test: &ConstraintTest{
-				TestName:    "TestMyConstraint",
-				Pattern:     "Deployment.my-app.version",
-				Description: "Validates my-app version",
-				Phase:       "deployment",
-			},
-			wantPanic: false,
-		},
-		{
-			name: "register constraint test with nil",
-			test: nil,
-			// Panics because it accesses test.Pattern without nil check
-			// This is consistent with RegisterCheck behavior
-			wantPanic: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if (r != nil) != tt.wantPanic {
-					t.Errorf("RegisterConstraintTest() panic = %v, wantPanic = %v", r, tt.wantPanic)
-				}
-			}()
-
-			RegisterConstraintTest(tt.test)
-
-			if tt.test != nil && !tt.wantPanic {
-				// Verify registration
-				testName, found := GetTestNameForConstraint(tt.test.Pattern)
-				if !found {
-					t.Errorf("constraint test not found after registration")
-				}
-				if testName != tt.test.TestName {
-					t.Errorf("GetTestNameForConstraint() = %v, want %v", testName, tt.test.TestName)
-				}
-			}
-		})
-	}
-}
-
 func TestGetTestNameForConstraint(t *testing.T) {
-	// Save and restore both registries
-	originalTestRegistry := make(map[string]*ConstraintTest)
+	// Save and restore registry
 	originalValidatorRegistry := make(map[string]*ConstraintValidator)
 	registryMu.Lock()
-	for k, v := range constraintTestRegistry {
-		originalTestRegistry[k] = v
-	}
 	for k, v := range constraintRegistry {
 		originalValidatorRegistry[k] = v
 	}
-	constraintTestRegistry = make(map[string]*ConstraintTest)
 	constraintRegistry = make(map[string]*ConstraintValidator)
 	registryMu.Unlock()
 
 	defer func() {
 		registryMu.Lock()
-		constraintTestRegistry = originalTestRegistry
 		constraintRegistry = originalValidatorRegistry
 		registryMu.Unlock()
 	}()
 
 	// Register a test constraint via ConstraintValidator (preferred single-registration)
 	RegisterConstraintValidator(&ConstraintValidator{
-		Pattern:     "Deployment.gpu-operator.version",
+		Name:        "Deployment.gpu-operator.version",
 		Description: "Validates GPU operator version",
 		TestName:    "TestGPUOperatorVersion",
 		Phase:       "deployment",
@@ -685,40 +614,34 @@ func TestGetTestNameForConstraint(t *testing.T) {
 }
 
 func TestListConstraintTests(t *testing.T) {
-	// Save and restore both registries
-	originalTestRegistry := make(map[string]*ConstraintTest)
+	// Save and restore registry
 	originalValidatorRegistry := make(map[string]*ConstraintValidator)
 	registryMu.Lock()
-	for k, v := range constraintTestRegistry {
-		originalTestRegistry[k] = v
-	}
 	for k, v := range constraintRegistry {
 		originalValidatorRegistry[k] = v
 	}
-	constraintTestRegistry = make(map[string]*ConstraintTest)
 	constraintRegistry = make(map[string]*ConstraintValidator)
 	registryMu.Unlock()
 
 	defer func() {
 		registryMu.Lock()
-		constraintTestRegistry = originalTestRegistry
 		constraintRegistry = originalValidatorRegistry
 		registryMu.Unlock()
 	}()
 
 	// Register test constraints using preferred single-registration pattern
 	RegisterConstraintValidator(&ConstraintValidator{
-		Pattern:  "Deployment.test1.version",
+		Name:     "Deployment.test1.version",
 		TestName: "TestDeploymentConstraint1",
 		Phase:    "deployment",
 	})
 	RegisterConstraintValidator(&ConstraintValidator{
-		Pattern:  "Deployment.test2.version",
+		Name:     "Deployment.test2.version",
 		TestName: "TestDeploymentConstraint2",
 		Phase:    "deployment",
 	})
 	RegisterConstraintValidator(&ConstraintValidator{
-		Pattern:  "Readiness.test.version",
+		Name:     "Readiness.test.version",
 		TestName: "TestReadinessConstraint",
 		Phase:    "readiness",
 	})

--- a/pkg/validator/phases_runners.go
+++ b/pkg/validator/phases_runners.go
@@ -589,7 +589,7 @@ func (v *Validator) validateRecipeRegistrations(recipeResult *recipe.RecipeResul
 			if len(available) > 0 {
 				fmt.Fprintf(&msg, "\nAvailable constraints for phase '%s' (%d):\n", phase, len(available))
 				for _, ct := range available {
-					fmt.Fprintf(&msg, "  - %s: %s\n", ct.Pattern, ct.Description)
+					fmt.Fprintf(&msg, "  - %s: %s\n", ct.Name, ct.Description)
 				}
 			}
 		}

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -37,7 +37,7 @@ func init() {
 		TestName:    "TestRegisteredCheck",
 	})
 	checks.RegisterConstraintValidator(&checks.ConstraintValidator{
-		Pattern:     "test-perf-constraint",
+		Name:        "test-perf-constraint",
 		Description: "Test-only performance constraint for buildTestPattern coverage",
 		Phase:       "performance",
 		TestName:    "TestPerfConstraint",

--- a/tools/generate-validator
+++ b/tools/generate-validator
@@ -448,7 +448,7 @@ import (
 func init() {
 \t// Register this constraint validator
 \tchecks.RegisterConstraintValidator(&checks.ConstraintValidator{
-\t\tPattern:     "{{.ConstraintName}}",
+\t\tName:        "{{.ConstraintName}}",
 \t\tDescription: "{{.Description}}",
 \t\tFunc:        validate{{.FuncName}},
 \t\tTestName:    "{{.TestName}}",
@@ -608,8 +608,8 @@ func TestValidate{{.FuncName}}Registration(t *testing.T) {
 \t\tt.Fatal("{{.ConstraintName}} constraint validator not registered")
 \t}
 
-\tif validator.Pattern != "{{.ConstraintName}}" {
-\t\tt.Errorf("Pattern = %v, want {{.ConstraintName}}", validator.Pattern)
+\tif validator.Name != "{{.ConstraintName}}" {
+\t\tt.Errorf("Name = %v, want {{.ConstraintName}}", validator.Name)
 \t}
 
 \tif validator.Description == "" {


### PR DESCRIPTION
## Summary

Clean up the check/constraint validator registry: rename `ConstraintValidator.Pattern` to `Name` for consistency with `Check.Name`, remove the unused legacy `ConstraintTest` type and `constraintTestRegistry`, and document the dual-purpose registry pattern.

## Changes

- Rename `ConstraintValidator.Pattern` to `Name` across registry, init() registrations, and tests
- Rename internal helper `patternToFuncName` to `nameToFuncName`
- Remove `ConstraintTest` struct, `constraintTestRegistry` map, and `RegisterConstraintTest()` (no production callers)
- Simplify `GetTestNameForConstraint()` by removing legacy fallback
- Change `ListConstraintTests()` return type from `[]*ConstraintTest` to `[]*ConstraintValidator`
- Add doc comment explaining the registry's dual purpose (orchestrator name mapping + in-Job function dispatch)
- Update `tools/generate-validator` templates to emit `Name:` instead of `Pattern:`
- Update READMEs to match new field names

## Test plan

- [x] `go test -race ./pkg/validator/checks/... -count=1`
- [x] `go test -race ./pkg/validator/... -count=1`
- [x] `make test`
- [x] `make lint`
- [x] Generator produces correct `Name:` field (verified with `--constraint` on Kind cluster)
