### PR TITLE
test: add chainsaw template tests for gpu-operator, nvsentinel, kgateway

### DIFF
--- a/tests/chainsaw/bundle-templates/gpu-operator/assert-dcgm-defaults.yaml
+++ b/tests/chainsaw/bundle-templates/gpu-operator/assert-dcgm-defaults.yaml
@@ -12,26 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Skyhook Helm values
-# Base configuration for all deployments
-
-# Override release name prefix to avoid aicr-stack- prefix in resource names
-fullnameOverride: skyhook-operator
-
-limitRange:
-  default:
-    cpu: "1"
-    memory: "1Gi"
-  defaultRequest:
-    cpu: "500m"
-    memory: "512Mi"
-
-controllerManager:
-  manager:
-    resources:
-      limits:
-        cpu: 1000m
-        memory: 4000Mi
-      requests:
-        cpu: 1000m
-        memory: 2000Mi
+# Assert dcgm-exporter ConfigMap is created with default name.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcgm-exporter

--- a/tests/chainsaw/bundle-templates/gpu-operator/chainsaw-test.yaml
+++ b/tests/chainsaw/bundle-templates/gpu-operator/chainsaw-test.yaml
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-bundle-gpu-operator-templates
+spec:
+  description: |
+    Validates that gpu-operator manifest templates render correctly.
+    Tests the dcgm-exporter ConfigMap creation and disable gate.
+    Run with: AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/gpu-operator
+  timeouts:
+    exec: 30s
+  steps:
+
+    - name: generate-recipe
+      description: Generate an EKS H100 training recipe.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-gpu-operator-templates"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              ${AICR_BIN} recipe \
+                --service eks \
+                --accelerator h100 \
+                --os ubuntu \
+                --intent training \
+                --output "${WORK}/recipe.yaml"
+
+    ## ── DCGM Exporter: default (enabled) ───────────────────────────────
+
+    - name: bundle-dcgm-defaults
+      description: Generate bundle with default dcgm-exporter config.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-gpu-operator-templates"
+              rm -rf "${WORK}/bundle-defaults"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-defaults"
+
+    - name: assert-dcgm-defaults
+      description: Verify dcgm-exporter ConfigMap is created with default name.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-gpu-operator-templates"
+              chainsaw assert \
+                --resource "${WORK}/bundle-defaults/gpu-operator/manifests/dcgm-exporter.yaml" \
+                --file ./assert-dcgm-defaults.yaml \
+                --no-color --timeout 5s
+
+    ## ── DCGM Exporter: disabled ────────────────────────────────────────
+
+    - name: bundle-dcgm-disabled
+      description: Generate bundle with dcgm-exporter config creation disabled.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-gpu-operator-templates"
+              rm -rf "${WORK}/bundle-dcgm-disabled"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-dcgm-disabled" \
+                --set gpuoperator:dcgmExporter.config.create=false
+
+    - name: assert-dcgm-disabled
+      description: Verify dcgm-exporter manifest is empty when create=false.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-gpu-operator-templates"
+              MANIFEST="${WORK}/bundle-dcgm-disabled/gpu-operator/manifests/dcgm-exporter.yaml"
+              ## When create=false, the template gate prevents any YAML objects
+              ## from being rendered. The bundler removes empty manifests.
+              if [ -f "${MANIFEST}" ]; then
+                echo "FAIL: dcgm-exporter.yaml should not exist when create=false"
+                exit 1
+              fi
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/chainsaw-bundle-gpu-operator-templates

--- a/tests/chainsaw/bundle-templates/kgateway/chainsaw-test.yaml
+++ b/tests/chainsaw/bundle-templates/kgateway/chainsaw-test.yaml
@@ -1,0 +1,99 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-bundle-kgateway-templates
+spec:
+  description: |
+    Validates that kgateway manifest templates render correctly.
+    Tests inference-gateway GatewayParameters scheduling (nodeSelector/tolerations).
+    Run with: AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/kgateway
+  timeouts:
+    exec: 30s
+  steps:
+
+    - name: generate-recipe
+      description: Generate an EKS H100 inference recipe (kgateway is inference-only).
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-kgateway-templates"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              ${AICR_BIN} recipe \
+                --service eks \
+                --accelerator h100 \
+                --os ubuntu \
+                --intent inference \
+                --output "${WORK}/recipe.yaml"
+
+    ## ── Default: no scheduling overrides ───────────────────────────────
+
+    - name: bundle-defaults
+      description: Generate bundle with no system node scheduling flags.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-kgateway-templates"
+              rm -rf "${WORK}/bundle-defaults"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-defaults"
+
+    - name: assert-gateway-defaults
+      description: Verify GatewayParameters and Gateway resources exist.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-kgateway-templates"
+              ## The manifest contains two resources (GatewayParameters + Gateway).
+              ## Verify both are present.
+              grep -q 'kind: GatewayParameters' \
+                "${WORK}/bundle-defaults/kgateway/manifests/inference-gateway.yaml"
+              grep -q 'kind: Gateway' \
+                "${WORK}/bundle-defaults/kgateway/manifests/inference-gateway.yaml"
+
+    ## ── With system node scheduling ────────────────────────────────────
+
+    - name: bundle-scheduling
+      description: Generate bundle with system node selector.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-kgateway-templates"
+              rm -rf "${WORK}/bundle-scheduling"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-scheduling" \
+                --system-node-selector nodeGroup=system-pool
+
+    - name: assert-gateway-scheduling
+      description: Verify GatewayParameters has nodeSelector for proxy pods.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-kgateway-templates"
+              MANIFEST="${WORK}/bundle-scheduling/kgateway/manifests/inference-gateway.yaml"
+              ## Verify nodeSelector was injected into GatewayParameters
+              grep -q 'nodeSelector:' "${MANIFEST}"
+              grep -q 'nodeGroup: system-pool' "${MANIFEST}"
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/chainsaw-bundle-kgateway-templates

--- a/tests/chainsaw/bundle-templates/nvsentinel/assert-netpol-defaults.yaml
+++ b/tests/chainsaw/bundle-templates/nvsentinel/assert-netpol-defaults.yaml
@@ -12,26 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Skyhook Helm values
-# Base configuration for all deployments
-
-# Override release name prefix to avoid aicr-stack- prefix in resource names
-fullnameOverride: skyhook-operator
-
-limitRange:
-  default:
-    cpu: "1"
-    memory: "1Gi"
-  defaultRequest:
-    cpu: "500m"
-    memory: "512Mi"
-
-controllerManager:
-  manager:
-    resources:
-      limits:
-        cpu: 1000m
-        memory: 4000Mi
-      requests:
-        cpu: 1000m
-        memory: 2000Mi
+# Assert allow-intra-namespace NetworkPolicy is created with correct rules.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 9443
+          protocol: TCP
+        - port: 10250
+          protocol: TCP

--- a/tests/chainsaw/bundle-templates/nvsentinel/chainsaw-test.yaml
+++ b/tests/chainsaw/bundle-templates/nvsentinel/chainsaw-test.yaml
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-bundle-nvsentinel-templates
+spec:
+  description: |
+    Validates that nvsentinel manifest templates render correctly.
+    Tests the allow-intra-namespace NetworkPolicy creation and disable gate.
+    Run with: AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/nvsentinel
+  timeouts:
+    exec: 30s
+  steps:
+
+    - name: generate-recipe
+      description: Generate an EKS H100 training recipe.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-nvsentinel-templates"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              ${AICR_BIN} recipe \
+                --service eks \
+                --accelerator h100 \
+                --os ubuntu \
+                --intent training \
+                --output "${WORK}/recipe.yaml"
+
+    ## ── NetworkPolicy: default (enabled) ───────────────────────────────
+
+    - name: bundle-netpol-defaults
+      description: Generate bundle with default nvsentinel config.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-nvsentinel-templates"
+              rm -rf "${WORK}/bundle-defaults"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-defaults"
+
+    - name: assert-netpol-defaults
+      description: Verify NetworkPolicy is created with intra-namespace and webhook port rules.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-nvsentinel-templates"
+              chainsaw assert \
+                --resource "${WORK}/bundle-defaults/nvsentinel/manifests/allow-intra-namespace.yaml" \
+                --file ./assert-netpol-defaults.yaml \
+                --no-color --timeout 5s
+
+    ## ── NetworkPolicy: disabled ─────────────────────────────────────────
+
+    - name: bundle-netpol-disabled
+      description: Generate bundle with networkPolicyWorkaround disabled.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-nvsentinel-templates"
+              rm -rf "${WORK}/bundle-disabled"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-disabled" \
+                --set nvsentinel:networkPolicyWorkaround.enabled=false
+
+    - name: assert-netpol-disabled
+      description: Verify NetworkPolicy manifest is removed when disabled.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-nvsentinel-templates"
+              MANIFEST="${WORK}/bundle-disabled/nvsentinel/manifests/allow-intra-namespace.yaml"
+              if [ -f "${MANIFEST}" ]; then
+                echo "FAIL: allow-intra-namespace.yaml should not exist when disabled"
+                exit 1
+              fi
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/chainsaw-bundle-nvsentinel-templates

--- a/tools/e2e
+++ b/tools/e2e
@@ -96,17 +96,12 @@ build_binary
 
 export REPO_ROOT="${ROOT}"
 
-msg "Running chainsaw tests (no-cluster CLI tests)"
+msg "Running chainsaw tests (CLI + bundle template tests)"
 chainsaw test \
   --no-cluster \
   --config "${ROOT}/tests/chainsaw/chainsaw-config.yaml" \
   --test-dir "${ROOT}/tests/chainsaw/cli/" \
+  --test-dir "${ROOT}/tests/chainsaw/bundle-templates/" \
   --selector 'ci!=true'
-
-msg "Running chainsaw tests (bundle template tests)"
-chainsaw test \
-  --no-cluster \
-  --config "${ROOT}/tests/chainsaw/chainsaw-config.yaml" \
-  --test-dir "${ROOT}/tests/chainsaw/bundle-templates/"
 
 msg "All tests passed!"


### PR DESCRIPTION
## Summary

## Summary
- Add chainsaw bundle-template tests for all components with Go template manifests:
  - **gpu-operator**: dcgm-exporter ConfigMap creation + `create=false` disable gate
  - **nvsentinel**: allow-intra-namespace NetworkPolicy creation + `enabled=false` disable gate
  - **kgateway**: inference-gateway GatewayParameters + nodeSelector injection
- Update skyhook-operator values: replace `limitRange: null` with explicit resource defaults
- Fix `tools/e2e` to run bundle-template tests in a single chainsaw invocation via multiple `--test-dir` flags

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
