### PR TITLE
chore(recipes): bump kube-prometheus-stack, prometheus-adapter, kai-scheduler, nvsentinel

### DIFF
--- a/examples/recipes/kind.yaml
+++ b/examples/recipes/kind.yaml
@@ -44,7 +44,7 @@ componentRefs:
     chart: kube-prometheus-stack
     type: Helm
     source: https://prometheus-community.github.io/helm-charts
-    version: 81.2.2
+    version: 82.8.0
     valuesFile: components/kube-prometheus-stack/values.yaml
   - name: k8s-ephemeral-storage-metrics
     namespace: nvidia-system

--- a/pkg/validator/checks/conformance/ai_service_metrics_check.go
+++ b/pkg/validator/checks/conformance/ai_service_metrics_check.go
@@ -76,24 +76,32 @@ func discoverPrometheusURL(ctx *checks.ValidationContext) (string, error) {
 			fmt.Sprintf("component %q not found in recipe or has no namespace", prometheusComponentName))
 	}
 
-	services, err := ctx.Clientset.CoreV1().Services(namespace).List(ctx.Context, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=prometheus",
-	})
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to list Prometheus services", err)
+	// Try multiple label selectors to handle different kube-prometheus-stack versions.
+	// Older versions (<=81.x) use app.kubernetes.io/name=prometheus;
+	// newer versions (>=82.x) dropped that label but retain self-monitor=true.
+	selectors := []string{
+		"app.kubernetes.io/name=prometheus",
+		"self-monitor=true",
 	}
-
-	for i := range services.Items {
-		svc := &services.Items[i]
-		for _, port := range svc.Spec.Ports {
-			if port.Port == int32(prometheusDefaultPort) {
-				return fmt.Sprintf("http://%s.%s.svc:%d", svc.Name, namespace, prometheusDefaultPort), nil
+	for _, selector := range selectors {
+		services, err := ctx.Clientset.CoreV1().Services(namespace).List(ctx.Context, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return "", errors.Wrap(errors.ErrCodeInternal, "failed to list Prometheus services", err)
+		}
+		for i := range services.Items {
+			svc := &services.Items[i]
+			for _, port := range svc.Spec.Ports {
+				if port.Port == int32(prometheusDefaultPort) {
+					return fmt.Sprintf("http://%s.%s.svc:%d", svc.Name, namespace, prometheusDefaultPort), nil
+				}
 			}
 		}
 	}
 
 	return "", errors.New(errors.ErrCodeNotFound,
-		fmt.Sprintf("no Prometheus service with port %d found in namespace %q (label: app.kubernetes.io/name=prometheus)", prometheusDefaultPort, namespace))
+		fmt.Sprintf("no Prometheus service with port %d found in namespace %q", prometheusDefaultPort, namespace))
 }
 
 // checkAIServiceMetricsWithURL is the testable implementation that accepts a configurable URL.

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -45,7 +45,7 @@ spec:
     - name: nvsentinel
       type: Helm
       source: oci://ghcr.io/nvidia
-      version: v0.8.0
+      version: v0.10.0
       valuesFile: components/nvsentinel/values.yaml
       manifestFiles:
         - components/nvsentinel/manifests/allow-intra-namespace.yaml
@@ -62,7 +62,7 @@ spec:
     - name: kube-prometheus-stack
       type: Helm
       source: https://prometheus-community.github.io/helm-charts
-      version: 81.2.2
+      version: 82.8.0
       valuesFile: components/kube-prometheus-stack/values.yaml
 
     - name: k8s-ephemeral-storage-metrics
@@ -84,7 +84,7 @@ spec:
     - name: kai-scheduler
       type: Helm
       source: oci://ghcr.io/nvidia/kai-scheduler
-      version: v0.12.15
+      version: v0.12.17
       valuesFile: components/kai-scheduler/values.yaml
       # Workaround: KAI scheduler v0.12.x injects runtimeClassName: nvidia
       # into GPU pods, which fails with GPU Operator v25.10.0+ CDI defaults.

--- a/recipes/overlays/monitoring-hpa.yaml
+++ b/recipes/overlays/monitoring-hpa.yaml
@@ -30,7 +30,7 @@ spec:
     - name: prometheus-adapter
       type: Helm
       source: https://prometheus-community.github.io/helm-charts
-      version: 4.14.0
+      version: 5.3.0
       valuesFile: components/prometheus-adapter/values.yaml
       dependencyRefs:
         - kube-prometheus-stack

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -198,7 +198,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/nvsentinel
-      defaultVersion: v0.8.0
+      defaultVersion: v0.10.0
       defaultNamespace: nvsentinel
     nodeScheduling:
       system:
@@ -247,7 +247,7 @@ components:
     helm:
       defaultRepository: https://prometheus-community.github.io/helm-charts
       defaultChart: prometheus-community/kube-prometheus-stack
-      defaultVersion: 81.2.2
+      defaultVersion: 82.8.0
       defaultNamespace: monitoring
     nodeScheduling:
       system:
@@ -279,7 +279,7 @@ components:
     helm:
       defaultRepository: https://prometheus-community.github.io/helm-charts
       defaultChart: prometheus-community/prometheus-adapter
-      defaultVersion: 4.14.0
+      defaultVersion: 5.3.0
       defaultNamespace: monitoring
     nodeScheduling:
       system:
@@ -339,7 +339,7 @@ components:
     helm:
       defaultRepository: oci://ghcr.io/nvidia/kai-scheduler
       defaultChart: kai-scheduler
-      defaultVersion: v0.12.10
+      defaultVersion: v0.12.17
       defaultNamespace: kai-scheduler
     nodeScheduling:
       system:

--- a/tests/chainsaw/cli/cuj1-training/mock-snapshot.yaml
+++ b/tests/chainsaw/cli/cuj1-training/mock-snapshot.yaml
@@ -40,10 +40,10 @@ measurements:
           k8s-ephemeral-storage-metrics.version: 1.19.2
           k8s-ephemeral-storage-metrics.namespace: monitoring
           kai-scheduler.chart: kai-scheduler
-          kai-scheduler.version: v0.12.15
+          kai-scheduler.version: v0.12.17
           kai-scheduler.namespace: kai-scheduler
           kube-prometheus-stack.chart: kube-prometheus-stack
-          kube-prometheus-stack.version: 81.2.2
+          kube-prometheus-stack.version: 82.8.0
           kube-prometheus-stack.namespace: monitoring
           kubeflow-trainer.chart: kubeflow-trainer
           kubeflow-trainer.version: 2.1.0
@@ -52,10 +52,10 @@ measurements:
           nvidia-dra-driver-gpu.version: 25.12.0
           nvidia-dra-driver-gpu.namespace: nvidia-dra-driver
           nvsentinel.chart: nvsentinel
-          nvsentinel.version: v0.8.0
+          nvsentinel.version: v0.10.0
           nvsentinel.namespace: nvsentinel
           prometheus-adapter.chart: prometheus-adapter
-          prometheus-adapter.version: 4.14.0
+          prometheus-adapter.version: 5.3.0
           prometheus-adapter.namespace: monitoring
           skyhook-customizations.chart: skyhook-customizations
           skyhook-customizations.namespace: skyhook


### PR DESCRIPTION
## Summary

Bump four components to their latest available versions and fix Prometheus service discovery for kube-prometheus-stack 82.x.

## Motivation / Context

Keeping recipe components up to date with latest upstream releases for bug fixes, security patches, and feature improvements.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

| Component | Previous | New | Change |
|-----------|----------|-----|--------|
| kube-prometheus-stack | 81.2.2 | 82.8.0 | Minor |
| prometheus-adapter | 4.14.0 | 5.3.0 | Major |
| kai-scheduler | v0.12.15 | v0.12.17 | Patch |
| nvsentinel | v0.8.0 | v0.10.0 | 2 minor |

Updated in:
- `recipes/registry.yaml` (default versions)
- `recipes/overlays/base.yaml` (overlay versions)
- `recipes/overlays/monitoring-hpa.yaml` (prometheus-adapter)
- `examples/recipes/kind.yaml` (example recipe)
- `tests/chainsaw/cli/cuj1-training/mock-snapshot.yaml` (test fixtures)

**Breaking label change in kube-prometheus-stack 82.x:** The Prometheus service dropped the `app.kubernetes.io/name=prometheus` label that the AI service metrics conformance check used for discovery. The check now tries multiple label selectors (`app.kubernetes.io/name=prometheus` for <=81.x, `self-monitor=true` for >=82.x) to support both old and new chart versions.

Note: `prometheus-adapter` 5.x is a major version bump. The chart renamed some values but our `values.yaml` uses standard fields that are compatible.

## Testing

```bash
make test
```

All unit tests pass. Validated on EKS cluster `eidos-validation-2-11` with all 16 components deployed, dynamo inference workload running, and CNCF conformance evidence collected successfully.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** prometheus-adapter 5.x is a major version bump. If CI reveals breaking changes, that component can be reverted independently. The other three are minor/patch updates with low risk. The Prometheus label fix is backwards-compatible with older chart versions.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`) — golangci-lint version mismatch (pre-existing)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)