### PR TITLE
feat(recipes): add GB200 EKS recipe overlays, fix HPA multi-arch, add DRA evidence and deploy mitigations

### DIFF
--- a/docs/integrator/README.md
+++ b/docs/integrator/README.md
@@ -17,6 +17,7 @@ This section is for integrators who:
 | [Automation](automation.md) | CI/CD integration patterns for GitHub Actions, GitLab CI, Jenkins, and Terraform |
 | [Data Flow](data-flow.md) | Understanding snapshots, recipes, validation, and bundles data transformations |
 | [Kubernetes Deployment](kubernetes-deployment.md) | Self-hosted API server deployment with Kubernetes manifests |
+| [EKS Dynamo Networking](eks-dynamo-networking.md) | Security group prerequisites for Dynamo overlays on EKS |
 | [Recipe Development](recipe-development.md) | Creating and modifying recipe metadata for custom environments |
 
 ## Quick Start

--- a/docs/integrator/eks-dynamo-networking.md
+++ b/docs/integrator/eks-dynamo-networking.md
@@ -1,0 +1,46 @@
+# EKS Dynamo Networking Prerequisites
+
+For `*-eks-ubuntu-inference-dynamo` recipes, `dynamo-platform` commonly runs:
+- `etcd` on TCP `2379`
+- `nats` (JetStream) on TCP `4222`
+
+If system components and GPU workloads are on different node groups/security groups, these ports may be blocked from GPU nodes to system nodes. Typical symptoms:
+- `Unable to create lease` (etcd unreachable)
+- `JetStream not available` (NATS unreachable)
+
+## Required Security Group Rules
+
+Allow ingress from the GPU node security group to the system node security group on:
+- TCP `2379`
+- TCP `4222`
+
+Example:
+
+```shell
+# 1) Find SG IDs for system and GPU nodegroups
+aws ec2 describe-instances \
+  --filters "Name=tag:eks:nodegroup-name,Values=<system-nodegroup>" \
+  --query "Reservations[0].Instances[0].SecurityGroups[*].GroupId" \
+  --output text
+
+aws ec2 describe-instances \
+  --filters "Name=tag:eks:nodegroup-name,Values=<gpu-nodegroup>" \
+  --query "Reservations[0].Instances[0].SecurityGroups[*].GroupId" \
+  --output text
+
+# 2) Allow etcd + NATS from GPU SG -> system SG
+aws ec2 authorize-security-group-ingress --group-id <system-sg-id> \
+  --protocol tcp --port 2379 --source-group <gpu-sg-id>
+
+aws ec2 authorize-security-group-ingress --group-id <system-sg-id> \
+  --protocol tcp --port 4222 --source-group <gpu-sg-id>
+```
+
+## GB200 Skyhook Note
+
+GB200 EKS overlays use the Skyhook `no-op` customization manifest instead of the H100 `tuning.yaml`. The H100 tuning packages (`nvidia-setup`, `nvidia-tuned`) are not compatible with GB200 for two reasons:
+
+1. **ARM64 host CPU**: GB200 nodes use Graviton (ARM64) host processors. The H100 tuning packages include x86-specific operations (e.g., EFA driver installation, apt package upgrades) that fail on ARM64.
+2. **Blackwell GPU architecture**: GPU-specific tuning parameters (kernel module settings, sysctl values) differ between Hopper (H100) and Blackwell (GB200).
+
+When GB200-specific tuning packages are available, switch `skyhook-customizations` in the GB200 overlays from `no-op.yaml` to `tuning.yaml`.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1012,6 +1012,22 @@ After `helm install`, the same manifests are re-applied as post-install to ensur
 
 Components that use operator patterns with custom resources that reconcile asynchronously (e.g., `kai-scheduler`) are installed without `--wait` to avoid Helm timing out on CR readiness.
 
+**DRA kubelet plugin registration:**
+
+After installing `nvidia-dra-driver-gpu`, the script automatically restarts the DRA kubelet plugin daemonset. This is a best-effort mitigation for a known issue: after uninstall/reinstall, the kubelet's plugin watcher (`fsnotify`) may not detect new registration sockets, causing `DRA driver gpu.nvidia.com is not registered` errors.
+
+If DRA pods fail with this error after redeployment, the daemonset restart alone may not be sufficient — a **node reboot** is required to reset the kubelet's plugin registration state. To reboot GPU nodes:
+
+```bash
+# Cordon, drain, and reboot the affected node
+kubectl cordon <node-name>
+kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
+# Reboot via cloud provider (e.g., AWS EC2 console or CLI)
+aws ec2 reboot-instances --instance-ids <instance-id>
+# Uncordon after node returns
+kubectl uncordon <node-name>
+```
+
 #### Undeploy Script Behavior (`undeploy.sh`)
 
 The undeploy script removes components in reverse deployment order.

--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -104,6 +104,24 @@ helm upgrade --install {{ .Name }} {{ .ChartName }} \
 echo "Applying post-install manifests for {{ .Name }}..."
 kubectl apply -f "${SCRIPT_DIR}/{{ .Name }}/manifests/" || helm_failed "{{ .Name }}"
 {{ end -}}
+{{ if eq .Name "nvidia-dra-driver-gpu" -}}
+# Best-effort mitigation for kubelet DRA plugin registration drift.
+# After uninstall/reinstall, kubelet's fsnotify watcher may not detect new
+# registration sockets. Restarting the plugin DS forces fresh socket creation.
+# This does NOT fix cases where kubelet itself has lost registration state —
+# a node reboot is required for that. See docs/user/cli-reference.md.
+DRA_DS=$(kubectl get daemonset -n {{ .Namespace }} -o name 2>/dev/null | awk '/kubelet-plugin/{print; exit}' || true)
+if [[ -n "${DRA_DS}" ]]; then
+  echo "  Restarting DRA kubelet plugin (${DRA_DS##*/}) to ensure registration..."
+  if ! kubectl rollout restart "${DRA_DS}" -n {{ .Namespace }}; then
+    echo "  WARNING: failed to restart DRA kubelet plugin daemonset"
+  elif ! kubectl rollout status "${DRA_DS}" -n {{ .Namespace }} --timeout=120s; then
+    echo "  WARNING: DRA kubelet plugin rollout did not complete within 120s"
+  fi
+else
+  echo "  WARNING: no DRA kubelet plugin daemonset found in {{ .Namespace }}"
+fi
+{{ end -}}
 {{ else if .HasManifests -}}
 echo "Applying manifests for {{ .Name }}..."
 kubectl apply -f "${SCRIPT_DIR}/{{ .Name }}/manifests/" || helm_failed "{{ .Name }}"

--- a/pkg/evidence/scripts/collect-evidence.sh
+++ b/pkg/evidence/scripts/collect-evidence.sh
@@ -163,6 +163,12 @@ EOF
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
+## DeviceClasses
+EOF
+    capture "DeviceClasses" kubectl get deviceclass
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
 ## DRA Driver Health
 EOF
     capture "DRA driver pods" kubectl get pods -n nvidia-dra-driver -o wide

--- a/pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
+++ b/pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
@@ -47,11 +47,25 @@ spec:
         - operator: Exists
       containers:
         - name: gpu-worker
-          image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.7.1-ubuntu18.04
+          image: nvidia/cuda:12.9.0-devel-ubuntu24.04
           command: ["bash", "-c"]
-          args: ["/cuda-samples/nbody -benchmark -numbodies=4194304 -iterations=9999 || true"]
+          args:
+            - |
+              cat > /tmp/s.cu << 'EOF'
+              __global__ void k(float *d, int n) {
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                float v = (float)i;
+                for (int j = 0; j < n; j++) v = v * v + 0.1f;
+                if (i < 1) d[0] = v;
+              }
+              int main() {
+                float *d; cudaMalloc(&d, sizeof(float));
+                for (;;) { k<<<4096,256>>>(d, 1000000); cudaDeviceSynchronize(); }
+              }
+              EOF
+              nvcc -o /tmp/s /tmp/s.cu && exec /tmp/s
           securityContext:
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false  # nvcc writes to /tmp during compile
             allowPrivilegeEscalation: false
           resources:
             limits:

--- a/recipes/overlays/gb200-eks-inference.yaml
+++ b/recipes/overlays/gb200-eks-inference.yaml
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-inference
+
+spec:
+  # Inherits from eks-inference recipe (EKS + inference settings)
+  base: eks-inference
+
+  criteria:
+    service: eks
+    accelerator: gb200
+    intent: inference
+
+  # Specific constraints for GB200 on EKS inference workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+
+  componentRefs:
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - skyhook-customizations
+
+    # GB200 uses skyhook no-op: the H100 tuning packages (nvidia-setup,
+    # nvidia-tuned) are not compatible with GB200's ARM64 host CPU and
+    # Blackwell GPU architecture. Replace with tuning.yaml once GB200-specific
+    # packages are available. See docs/integrator/eks-dynamo-networking.md#gb200-skyhook-note.
+    - name: skyhook-customizations
+      type: Helm
+      manifestFiles:
+        - components/skyhook-customizations/manifests/no-op.yaml
+      overrides:
+        service: aws
+        accelerator: gb200
+        intent: inference
+      dependencyRefs:
+        - skyhook-operator

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-training
+
+spec:
+  # Inherits from eks-training recipe (EKS + training settings)
+  base: eks-training
+
+  criteria:
+    service: eks
+    accelerator: gb200
+    intent: training
+
+  # Specific constraints for GB200 on EKS training workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+
+  componentRefs:
+    # GB200-specific GPU Operator overrides (inherits valuesFile from eks-training)
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - skyhook-customizations
+      overrides:
+        cdi:
+          enabled: true
+        gdrcopy:
+          enabled: true
+
+    # GB200 uses skyhook no-op: the H100 tuning packages (nvidia-setup,
+    # nvidia-tuned) are not compatible with GB200's ARM64 host CPU and
+    # Blackwell GPU architecture. Replace with tuning.yaml once GB200-specific
+    # packages are available. See docs/integrator/eks-dynamo-networking.md#gb200-skyhook-note.
+    - name: skyhook-customizations
+      type: Helm
+      manifestFiles:
+        - components/skyhook-customizations/manifests/no-op.yaml
+      overrides:
+        service: aws
+        accelerator: gb200
+        intent: multiNodeTraining
+      dependencyRefs:
+        - skyhook-operator

--- a/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
@@ -15,16 +15,16 @@
 kind: RecipeMetadata
 apiVersion: aicr.nvidia.com/v1alpha1
 metadata:
-  name: h100-eks-ubuntu-inference-dynamo
+  name: gb200-eks-ubuntu-inference-dynamo
 
 spec:
-  # Inherits from h100-eks-ubuntu-inference (H100 + Ubuntu inference settings)
+  # Inherits from gb200-eks-ubuntu-inference (GB200 + Ubuntu inference settings)
   # Adds Dynamo inference platform components.
-  base: h100-eks-ubuntu-inference
+  base: gb200-eks-ubuntu-inference
 
   criteria:
     service: eks
-    accelerator: h100
+    accelerator: gb200
     os: ubuntu
     intent: inference
     platform: dynamo

--- a/recipes/overlays/gb200-eks-ubuntu-inference.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-inference.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-ubuntu-inference
+
+spec:
+  # Inherits from gb200-eks-inference recipe (GB200 + EKS + inference settings)
+  # This overlay adds Ubuntu-specific configurations
+  base: gb200-eks-inference
+
+  criteria:
+    service: eks
+    accelerator: gb200
+    os: ubuntu
+    intent: inference
+
+  # GB200 + Ubuntu specific constraints for inference workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+    - name: OS.release.ID
+      value: ubuntu
+    - name: OS.release.VERSION_ID
+      value: "24.04"
+    - name: OS.sysctl./proc/sys/kernel/osrelease
+      value: ">= 6.8"
+
+  componentRefs: []

--- a/recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-ubuntu-training-kubeflow
+
+spec:
+  # Inherits from gb200-eks-ubuntu-training recipe (GB200 + EKS + Ubuntu + training settings)
+  # This overlay adds Kubeflow Training Operator for distributed training with TrainJob
+  base: gb200-eks-ubuntu-training
+
+  criteria:
+    service: eks
+    accelerator: gb200
+    os: ubuntu
+    intent: training
+    platform: kubeflow
+
+  # Constraints for GB200 on EKS with Ubuntu for Kubeflow training workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+    - name: OS.release.ID
+      value: ubuntu
+    - name: OS.release.VERSION_ID
+      value: "24.04"
+    - name: OS.sysctl./proc/sys/kernel/osrelease
+      value: ">= 6.8"
+
+  # Kubeflow Training Operator for TrainJob support
+  componentRefs:
+    - name: kubeflow-trainer
+      type: Helm
+      valuesFile: components/kubeflow-trainer/values.yaml
+      manifestFiles:
+        - components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml

--- a/recipes/overlays/gb200-eks-ubuntu-training.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-training.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-ubuntu-training
+
+spec:
+  # Inherits from gb200-eks-training recipe (GB200 + EKS + training settings)
+  # This overlay adds Ubuntu-specific configurations
+  base: gb200-eks-training
+
+  criteria:
+    service: eks
+    accelerator: gb200
+    os: ubuntu
+    intent: training
+
+  # Constraints for GB200 on EKS with Ubuntu for training workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+    - name: OS.release.ID
+      value: ubuntu
+    - name: OS.release.VERSION_ID
+      value: "24.04"
+    - name: OS.sysctl./proc/sys/kernel/osrelease
+      value: ">= 6.8"
+
+  componentRefs: []
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/site/content/docs/integrator/_index.md
+++ b/site/content/docs/integrator/_index.md
@@ -22,6 +22,7 @@ This section is for integrators who:
 | [Automation](/docs/integrator/automation/) | CI/CD integration patterns for GitHub Actions, GitLab CI, Jenkins, and Terraform |
 | [Data Flow](/docs/integrator/data-flow/) | Understanding snapshots, recipes, validation, and bundles data transformations |
 | [Kubernetes Deployment](/docs/integrator/kubernetes-deployment/) | Self-hosted API server deployment with Kubernetes manifests |
+| [EKS Dynamo Networking](/docs/integrator/eks-dynamo-networking/) | Security group prerequisites for Dynamo overlays on EKS |
 | [Recipe Development](/docs/integrator/recipe-development/) | Creating and modifying recipe metadata for custom environments |
 
 ## Quick Start

--- a/site/content/docs/integrator/eks-dynamo-networking.md
+++ b/site/content/docs/integrator/eks-dynamo-networking.md
@@ -1,0 +1,51 @@
+---
+title: "EKS Dynamo Networking"
+linkTitle: "EKS Dynamo Networking"
+weight: 34
+description: "Security group prerequisites for Dynamo overlays on EKS"
+---
+
+For `*-eks-ubuntu-inference-dynamo` recipes, `dynamo-platform` commonly runs:
+- `etcd` on TCP `2379`
+- `nats` (JetStream) on TCP `4222`
+
+If system components and GPU workloads are on different node groups/security groups, these ports may be blocked from GPU nodes to system nodes. Typical symptoms:
+- `Unable to create lease` (etcd unreachable)
+- `JetStream not available` (NATS unreachable)
+
+## Required Security Group Rules
+
+Allow ingress from the GPU node security group to the system node security group on:
+- TCP `2379`
+- TCP `4222`
+
+Example:
+
+```shell
+# 1) Find SG IDs for system and GPU nodegroups
+aws ec2 describe-instances \
+  --filters "Name=tag:eks:nodegroup-name,Values=<system-nodegroup>" \
+  --query "Reservations[0].Instances[0].SecurityGroups[*].GroupId" \
+  --output text
+
+aws ec2 describe-instances \
+  --filters "Name=tag:eks:nodegroup-name,Values=<gpu-nodegroup>" \
+  --query "Reservations[0].Instances[0].SecurityGroups[*].GroupId" \
+  --output text
+
+# 2) Allow etcd + NATS from GPU SG -> system SG
+aws ec2 authorize-security-group-ingress --group-id <system-sg-id> \
+  --protocol tcp --port 2379 --source-group <gpu-sg-id>
+
+aws ec2 authorize-security-group-ingress --group-id <system-sg-id> \
+  --protocol tcp --port 4222 --source-group <gpu-sg-id>
+```
+
+## GB200 Skyhook Note
+
+GB200 EKS overlays use the Skyhook `no-op` customization manifest instead of the H100 `tuning.yaml`. The H100 tuning packages (`nvidia-setup`, `nvidia-tuned`) are not compatible with GB200 for two reasons:
+
+1. **ARM64 host CPU**: GB200 nodes use Graviton (ARM64) host processors. The H100 tuning packages include x86-specific operations (e.g., EFA driver installation, apt package upgrades) that fail on ARM64.
+2. **Blackwell GPU architecture**: GPU-specific tuning parameters (kernel module settings, sysctl values) differ between Hopper (H100) and Blackwell (GB200).
+
+When GB200-specific tuning packages are available, switch `skyhook-customizations` in the GB200 overlays from `no-op.yaml` to `tuning.yaml`.

--- a/site/content/docs/user/cli-reference.md
+++ b/site/content/docs/user/cli-reference.md
@@ -954,6 +954,22 @@ After `helm install`, the same manifests are re-applied as post-install to ensur
 
 Components that use operator patterns with custom resources that reconcile asynchronously (e.g., `kai-scheduler`) are installed without `--wait` to avoid Helm timing out on CR readiness.
 
+**DRA kubelet plugin registration:**
+
+After installing `nvidia-dra-driver-gpu`, the script automatically restarts the DRA kubelet plugin daemonset. This is a best-effort mitigation for a known issue: after uninstall/reinstall, the kubelet's plugin watcher (`fsnotify`) may not detect new registration sockets, causing `DRA driver gpu.nvidia.com is not registered` errors.
+
+If DRA pods fail with this error after redeployment, the daemonset restart alone may not be sufficient — a **node reboot** is required to reset the kubelet's plugin registration state. To reboot GPU nodes:
+
+```bash
+# Cordon, drain, and reboot the affected node
+kubectl cordon <node-name>
+kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
+# Reboot via cloud provider (e.g., AWS EC2 console or CLI)
+aws ec2 reboot-instances --instance-ids <instance-id>
+# Uncordon after node returns
+kubectl uncordon <node-name>
+```
+
 #### Undeploy Script Behavior (`undeploy.sh`)
 
 The undeploy script removes components in reverse deployment order.


### PR DESCRIPTION
## Summary

Add GB200 accelerator recipe overlays for EKS (inference + training), fix HPA evidence test for ARM64 clusters, add DeviceClass to DRA evidence, and add DRA kubelet plugin restart workaround to deploy script.

## Motivation / Context

GB200 nodes use ARM64 (Graviton) host CPUs with Blackwell GPUs. The existing H100 overlays and test images are not compatible with this architecture. This PR adds GB200-specific recipe overlays, fixes multi-arch issues in evidence tests, and documents DRA deployment nuances discovered during validation.

Validated on EKS cluster with GB200 nodes — all 16 components deployed, dynamo inference workload tested, and all 9 CNCF AI Conformance evidence artifacts collected successfully.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

### GB200 Recipe Overlays

6 new overlay files mirroring the H100 chain:
- `gb200-eks-inference` / `gb200-eks-training`
- `gb200-eks-ubuntu-inference` / `gb200-eks-ubuntu-training`
- `gb200-eks-ubuntu-inference-dynamo` / `gb200-eks-ubuntu-training-kubeflow`

Key difference from H100: skyhook-customizations uses `no-op.yaml` instead of `tuning.yaml` because the H100 tuning packages (`nvidia-setup`, `nvidia-tuned`) are not compatible with GB200's ARM64 host CPU and Blackwell GPU architecture.

### HPA Evidence Multi-Arch Fix

Replaced amd64-only `nvcr.io/nvidia/k8s/cuda-sample:nbody` image with multi-arch `nvidia/cuda:12.9.0-devel-ubuntu24.04` and an inline CUDA stress kernel. This fixes `exec format error` on ARM64 GPU nodes. Removed hard `nodeSelector` — `nvidia.com/gpu: 1` resource request is sufficient for GPU node scheduling.

### DRA Evidence Enhancement

Added `kubectl get deviceclass` to DRA evidence collection script for complete DRA readiness verification.

### DRA Deploy Mitigation

Added best-effort DRA kubelet plugin daemonset restart after `nvidia-dra-driver-gpu` install. After uninstall/reinstall, kubelet's `fsnotify` watcher may not detect new plugin registration sockets. The restart forces fresh socket creation. If this doesn't resolve registration, a node reboot is required — documented in CLI reference.

### Documentation

- Added `docs/integrator/eks-dynamo-networking.md` — extracted AWS SG prerequisites from overlay comments
- Added DRA kubelet plugin registration note to `docs/user/cli-reference.md`
- Both mirrored to `site/content/docs/`

## Follow-up Notes

- Current Skyhook customization does not work on GB200, so I set it to no-op for now. @lockwobr, can you take a look when you have time?
- We should verify all test pod images are multi-arch and run correctly on ARM. cc @mchmarny @dims @jduartedlr
- There's significant duplication between H100 and GB200 recipe chains. A larger refactor is needed, but it would be disruptive right now. I'll keep them separate for now and refactor after configs are stable.

## Testing

```bash
go test -race ./pkg/recipe/...
go test -race ./pkg/bundler/deployer/helm/...
```

All tests pass. Validated on GB200 EKS cluster:
- 16 components deployed with `deploy.sh`
- Dynamo vLLM inference workload running on GB200
- All 9 CNCF conformance evidence artifacts collected (DRA, gang scheduling, secure access, metrics, inference gateway, robust operator, HPA, cluster autoscaling)

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** New overlay files only — no changes to existing H100 overlays or component values. The HPA image change and DRA restart workaround apply to all clusters but are backwards-compatible.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`) — golangci-lint version mismatch (pre-existing)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)