### PR TITLE
docs: add Codex AGENTS.md with CI-enforced sync from CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Instructions for NVIDIA AI Cluster Runtime (AICR)
 
-This file contains extended technical documentation for GitHub Copilot. For core rules and patterns, see `.claude/CLAUDE.md`.
+This file contains extended technical documentation for GitHub Copilot. For core rules and patterns, see `AGENTS.md`.
 
 ## Critical Rules (Always Apply)
 
@@ -377,7 +377,8 @@ aicr bundle -r recipe.yaml \
 
 ### Key Links
 
-- **[CLAUDE.md](../.claude/CLAUDE.md)** – Core rules, patterns, and commands
+- **[AGENTS.md](../AGENTS.md)** – Core rules, patterns, and commands (synced from `.claude/CLAUDE.md`)
+- **[CLAUDE.md](../.claude/CLAUDE.md)** – Canonical source for coding-agent rules
 - **[Contributing Guide](../CONTRIBUTING.md)** – Design principles, development setup, PR process
 - **[Development Guide](../DEVELOPMENT.md)** – Local development, Make targets, Tilt/Kind setup
 - **[Release Process](../RELEASING.md)** – Maintainer guide for releases, verification, hotfixes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file is the canonical source for coding-agent rules. `AGENTS.md` is an auto-synced mirror (CI enforced).
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex and other coding agents when working with code in this repository.
+<!-- AUTO-SYNCED: canonical source is .claude/CLAUDE.md. Only the first 4 lines differ. CI enforces sync. -->
 
 ## Role & Expertise
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Before contributing:
 2. Check existing [issues](https://github.com/NVIDIA/aicr/issues) to avoid duplicates
 3. Review the [security policy](SECURITY.md) for security-related contributions
 4. Set up your development environment following [DEVELOPMENT.md](DEVELOPMENT.md)
+5. If using coding assistants, review [AGENTS.md](AGENTS.md) for project rules and workflows
 
 ## How to Contribute
 

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,12 @@ generate: ## Runs go generate for code generation
 	@echo "Code generation completed"
 
 .PHONY: lint
-lint: lint-go lint-yaml license ## Lints the entire project (Go, YAML, and license headers)
+lint: lint-go lint-yaml license check-agents-sync ## Lints the entire project (Go, YAML, and license headers)
 	@echo "Completed Go and YAML lints and ensured license headers"
+
+.PHONY: check-agents-sync
+check-agents-sync: ## Verifies AGENTS.md is in sync with .claude/CLAUDE.md
+	@./tools/check-agents-sync
 
 .PHONY: lint-go
 lint-go: ## Lints Go files with golangci-lint and go vet

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You deploy and operate GPU-accelerated Kubernetes clusters using validated confi
 
 You contribute code, extend functionality, or work on AICR internals.
 
+- **[Agent Instructions](AGENTS.md)** – Core coding-agent guidance for Codex/Copilot (mirrors `.claude/CLAUDE.md`)
 - **[Contributing Guide](CONTRIBUTING.md)** – Development setup, testing, and PR process
 - **[Development Guide](DEVELOPMENT.md)** – Local development, Make targets, and tooling
 - **[Architecture Overview](docs/contributor/README.md)** – System design and components

--- a/tools/check-agents-sync
+++ b/tools/check-agents-sync
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify AGENTS.md stays in sync with .claude/CLAUDE.md (canonical source).
+# The first 4 lines differ (tool-specific headers); everything after must match.
+
+set -euo pipefail
+
+CANONICAL=".claude/CLAUDE.md"
+MIRROR="AGENTS.md"
+
+if [[ ! -f "${CANONICAL}" ]]; then
+  echo "ERROR: canonical source ${CANONICAL} not found"
+  exit 1
+fi
+
+if [[ ! -f "${MIRROR}" ]]; then
+  echo "ERROR: mirror ${MIRROR} not found"
+  exit 1
+fi
+
+# Compare from line 5 onward (skip tool-specific headers)
+if ! diff <(tail -n +5 "${CANONICAL}") <(tail -n +5 "${MIRROR}") > /dev/null 2>&1; then
+  echo "ERROR: ${MIRROR} has drifted from ${CANONICAL} (canonical source)."
+  echo ""
+  echo "Diff (line 5+):"
+  diff <(tail -n +5 "${CANONICAL}") <(tail -n +5 "${MIRROR}") || true
+  echo ""
+  echo "Fix: copy .claude/CLAUDE.md content (from line 5) into AGENTS.md (from line 5)."
+  exit 1
+fi
+
+echo "OK: ${MIRROR} is in sync with ${CANONICAL}"


### PR DESCRIPTION
## Summary

Add `AGENTS.md` for OpenAI Codex compatibility, mirroring the coding-agent guidance from `.claude/CLAUDE.md`. Cross-reference all assistant guide files so each tool discovers the shared rules.

## Motivation / Context

The project uses `.claude/CLAUDE.md` for Claude Code and `.github/copilot-instructions.md` for GitHub Copilot. OpenAI Codex reads `AGENTS.md` at the repo root. This PR adds that file (mirroring the same rules and patterns) and links all three together so contributors using any AI coding assistant get consistent guidance.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- **`AGENTS.md`** (new, 532 lines): Mirrors `.claude/CLAUDE.md` with a Codex-specific header note. Includes all non-negotiable rules, required patterns, anti-patterns, key packages, CLI workflows, and design principles.
- **`.claude/CLAUDE.md`**: Added one-line pointer to `AGENTS.md`.
- **`.github/copilot-instructions.md`**: Updated primary reference from CLAUDE.md to AGENTS.md; added CLAUDE.md as secondary link.
- **`CONTRIBUTING.md`**: Added step 5 directing coding assistant users to `AGENTS.md`.
- **`README.md`**: Added "Agent Instructions" link in the Contributors section.
- Fixed `fmt.Errorf` → `errors.Wrap` in the errgroup concurrency example in both `AGENTS.md` and `.claude/CLAUDE.md` to match the "Never use `fmt.Errorf`" rule.

## Follow-up

- Refactor H100 and GB200 recipe overlay chains to extract shared configuration and reduce duplication. Planned after overlay configs stabilize.

## Testing

Documentation-only change — no code impact.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — no behavioral changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)