### PR TITLE
fix(verify): return FAILED and non-zero exit when bundle has verifica…

### DIFF
--- a/demos/attestation.md
+++ b/demos/attestation.md
@@ -1,5 +1,12 @@
 # AICR Bundle Attestation Demo
 
+Bundle attestation provides cryptographic proof of who created a bundle and what
+tool built it. When you run `aicr bundle --attest`, the CLI signs the bundle
+contents using [Sigstore](https://www.sigstore.dev/) and generates SLSA Build
+Provenance metadata. Anyone can later verify the bundle with `aicr verify` to
+confirm it hasn't been tampered with, was created by a trusted identity, and was
+built by an authorized version of the AICR CLI.
+
 ## Prerequisites
 
 * Installed `aicr` from a release archive (includes binary attestation)

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
@@ -140,61 +142,68 @@ func runBundleVerifyCmd(ctx context.Context, cmd *cli.Command) error {
 
 	// Output results with final verdict
 	if format == "json" {
-		if jsonErr := outputJSON(result); jsonErr != nil {
+		if jsonErr := outputJSON(os.Stdout, result); jsonErr != nil {
 			return jsonErr
 		}
 	} else {
-		outputText(result, policyFailure)
+		outputText(os.Stdout, result, policyFailure)
 	}
 
 	if policyFailure != "" {
 		return errors.New(errors.ErrCodeInvalidRequest, policyFailure)
 	}
 
+	if len(result.Errors) > 0 {
+		return errors.New(errors.ErrCodeUnauthorized, "bundle verification failed: "+result.Errors[0])
+	}
+
 	return nil
 }
 
-func outputText(r *verifier.VerifyResult, policyFailure string) {
+func outputText(w io.Writer, r *verifier.VerifyResult, policyFailure string) {
 	if r.ChecksumsPassed {
-		fmt.Printf("  ✓ Checksums verified (%d files)\n", r.ChecksumFiles)
+		fmt.Fprintf(w, "  ✓ Checksums verified (%d files)\n", r.ChecksumFiles)
 	} else {
-		fmt.Printf("  ✗ Checksum verification failed\n")
+		fmt.Fprintf(w, "  ✗ Checksum verification failed\n")
 	}
 
 	if r.BundleAttested {
-		fmt.Printf("  ✓ Bundle attested by: %s\n", r.BundleCreator)
+		fmt.Fprintf(w, "  ✓ Bundle attested by: %s\n", r.BundleCreator)
 	}
 
 	if r.BinaryAttested {
-		fmt.Printf("  ✓ Binary built by: %s\n", r.BinaryBuilder)
+		fmt.Fprintf(w, "  ✓ Binary built by: %s\n", r.BinaryBuilder)
 	}
 
 	if r.IdentityPinned {
-		fmt.Printf("  ✓ Identity pinned to NVIDIA CI\n")
+		fmt.Fprintf(w, "  ✓ Identity pinned to NVIDIA CI\n")
 	}
 
-	fmt.Printf("  Trust level: %s\n", r.TrustLevel)
+	fmt.Fprintf(w, "  Trust level: %s\n", r.TrustLevel)
 
 	if len(r.Errors) > 0 {
-		fmt.Printf("\nDetails:\n")
+		fmt.Fprintf(w, "\nDetails:\n")
 		for _, e := range r.Errors {
-			fmt.Printf("  - %s\n", e)
+			fmt.Fprintf(w, "  - %s\n", e)
 		}
 	}
 
-	if policyFailure != "" {
-		fmt.Printf("\nBundle verification: FAILED\n")
-		fmt.Printf("  %s\n", policyFailure)
-	} else {
-		fmt.Printf("\nBundle verification: PASSED\n")
+	switch {
+	case policyFailure != "":
+		fmt.Fprintf(w, "\nBundle verification: FAILED\n")
+		fmt.Fprintf(w, "  %s\n", policyFailure)
+	case len(r.Errors) > 0:
+		fmt.Fprintf(w, "\nBundle verification: FAILED\n")
+	default:
+		fmt.Fprintf(w, "\nBundle verification: PASSED\n")
 	}
 }
 
-func outputJSON(r *verifier.VerifyResult) error {
+func outputJSON(w io.Writer, r *verifier.VerifyResult) error {
 	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to marshal verification result", err)
 	}
-	fmt.Println(string(data))
+	fmt.Fprintln(w, string(data))
 	return nil
 }

--- a/pkg/cli/bundle_verify_test.go
+++ b/pkg/cli/bundle_verify_test.go
@@ -15,8 +15,11 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
 	"github.com/urfave/cli/v3"
 )
 
@@ -59,4 +62,81 @@ func TestBundleVerifyCmd_MinTrustLevelDefault(t *testing.T) {
 		}
 	}
 	t.Error("min-trust-level flag not found")
+}
+
+func TestOutputText_Verdict(t *testing.T) {
+	tests := []struct {
+		name          string
+		result        *verifier.VerifyResult
+		policyFailure string
+		wantContains  string
+		wantAbsent    string
+	}{
+		{
+			name: "clean bundle shows PASSED",
+			result: &verifier.VerifyResult{
+				ChecksumsPassed: true,
+				ChecksumFiles:   12,
+				TrustLevel:      verifier.TrustUnverified,
+			},
+			wantContains: "PASSED",
+			wantAbsent:   "FAILED",
+		},
+		{
+			name: "checksum mismatch shows FAILED",
+			result: &verifier.VerifyResult{
+				TrustLevel: verifier.TrustUnknown,
+				Errors:     []string{"checksum mismatch: deploy.sh"},
+			},
+			wantContains: "FAILED",
+			wantAbsent:   "PASSED",
+		},
+		{
+			name: "policy failure shows FAILED",
+			result: &verifier.VerifyResult{
+				ChecksumsPassed: true,
+				TrustLevel:      verifier.TrustUnverified,
+			},
+			policyFailure: "trust level unverified does not meet minimum attested",
+			wantContains:  "FAILED",
+			wantAbsent:    "PASSED",
+		},
+		{
+			name: "verified bundle shows PASSED",
+			result: &verifier.VerifyResult{
+				ChecksumsPassed: true,
+				ChecksumFiles:   12,
+				BundleAttested:  true,
+				BinaryAttested:  true,
+				IdentityPinned:  true,
+				TrustLevel:      verifier.TrustVerified,
+			},
+			wantContains: "PASSED",
+			wantAbsent:   "FAILED",
+		},
+		{
+			name: "attestation verification error shows FAILED",
+			result: &verifier.VerifyResult{
+				ChecksumsPassed: true,
+				TrustLevel:      verifier.TrustUnknown,
+				Errors:          []string{"bundle attestation verification failed: certificate chain error"},
+			},
+			wantContains: "FAILED",
+			wantAbsent:   "PASSED",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			outputText(&buf, tt.result, tt.policyFailure)
+			output := buf.String()
+
+			if !strings.Contains(output, tt.wantContains) {
+				t.Errorf("output missing %q:\n%s", tt.wantContains, output)
+			}
+			if tt.wantAbsent != "" && strings.Contains(output, tt.wantAbsent) {
+				t.Errorf("output should not contain %q:\n%s", tt.wantAbsent, output)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- **fix(verify)**: `aicr verify` now returns `FAILED` and exit code 4 when a bundle has verification errors (e.g., checksum mismatch). Previously it printed `PASSED` and exited 0 even when tampering was detected.
- **refactor(verify)**: `outputText` and `outputJSON` now accept `io.Writer` instead of writing directly to stdout, making them testable

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
