### PR TITLE
fix(recipes): replace hardcoded h100/eks in skyhook tuning configMaps with template variables

### DIFF
--- a/recipes/components/skyhook-customizations/manifests/no-op.yaml
+++ b/recipes/components/skyhook-customizations/manifests/no-op.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Skyhook H100 EKS Ubuntu Customization
+# Skyhook EKS Ubuntu GPU Customization (no-op)
 # Minimal templating - only tolerations/nodeSelectors are dynamic for CLI flag support
 #
-# This customization configures H100 GPU nodes on Ubuntu with:
+# No-op placeholder for accelerators without tuning packages.
 # - GRUB parameters for hugepages and nokaslr
 # - Containerd service limits
 # - Sysctl kernel tuning parameters
@@ -55,7 +55,7 @@ spec:
     matchLabels:
       {{- toYaml $cust.acceleratedNodeSelector | nindent 6 }}
   {{- end }}
-  # Static: Baked-in tuning for H100 Ubuntu training
+  # Static: No-op placeholder for accelerators without tuning packages
   packages:
     no-op:
       image: ghcr.io/nvidia/skyhook-packages/shellscript

--- a/recipes/components/skyhook-customizations/manifests/tuning.yaml
+++ b/recipes/components/skyhook-customizations/manifests/tuning.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Skyhook H100 EKS Ubuntu Customization
+# Skyhook EKS Ubuntu GPU Customization
 # Minimal templating - only tolerations/nodeSelectors are dynamic for CLI flag support
 #
-# This customization configures H100 GPU nodes on Ubuntu with:
+# This customization configures GPU nodes on Ubuntu with:
 # - GRUB parameters for hugepages and nokaslr
 # - Containerd service limits
 # - Sysctl kernel tuning parameters
@@ -68,8 +68,10 @@ spec:
       image: ghcr.io/nvidia/skyhook-packages/nvidia-setup
       version: "0.2.0"
       configMap:
-        service: eks
-        accelerator: h100
+        {{- if $cust.service }}
+        service: {{ $cust.service }}
+        {{- end }}
+        accelerator: {{ $cust.accelerator }}
       env:
         - name: NVIDIA_SETUP_INSTALL_KERNEL
           value: "true"
@@ -107,8 +109,10 @@ spec:
         memoryLimit: 8192Mi
         memoryRequest: 4096Mi
       configMap:
-        service: eks
-        accelerator: h100
+        {{- if $cust.service }}
+        service: {{ $cust.service }}
+        {{- end }}
+        accelerator: {{ $cust.accelerator }}
       env:
         - name: NVIDIA_SETUP_INSTALL_KERNEL
           value: "false"


### PR DESCRIPTION
## Summary

Replace hardcoded `accelerator: h100` and `service: eks` in skyhook tuning manifest template with template variables, so overlay accelerator/service overrides propagate correctly to all packages.

## Motivation / Context

During GB200 validation, we discovered that `nvidia-setup-kernel` and `nvidia-setup-full` packages rendered with `accelerator: h100` even when the GB200 overlay passed `accelerator: gb200`. The `nvidia-tuned` package correctly used `{{ $cust.accelerator }}`, but the other two had hardcoded values. We had to manually sed the rendered manifest to fix the tags.

Fixes: N/A
Related: #292

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

**tuning.yaml** — `nvidia-setup-kernel` and `nvidia-setup-full` configMaps:

| Field | Before | After |
|-------|--------|-------|
| `accelerator` | `h100` (hardcoded) | `{{ $cust.accelerator }}` |
| `service` | `eks` (hardcoded) | `{{ $cust.service }}` (conditional) |

This matches the pattern already used by `nvidia-tuned` (line 91). All overlays (H100 and GB200) already pass explicit `accelerator` and `service` overrides, so no overlay changes needed.

Also updated H100-specific comments in `tuning.yaml` and `no-op.yaml` to be accelerator-agnostic.

## Testing

```bash
go test -race ./pkg/recipe/...
```

All recipe tests pass. H100 overlays continue to render `accelerator: h100` (from overlay override), GB200 overlays now correctly render `accelerator: gb200`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** All existing overlays pass explicit accelerator/service overrides, so this change has no effect on rendered output for any current recipe. It only fixes the case where the override was being ignored.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)