### PR TITLE
fix(evidence): use nvcr image in HPA GPU test manifest

### DIFF
--- a/pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
+++ b/pkg/evidence/scripts/manifests/hpa-gpu-test.yaml
@@ -47,7 +47,7 @@ spec:
         - operator: Exists
       containers:
         - name: gpu-worker
-          image: nvidia/cuda:12.9.0-devel-ubuntu24.04
+          image: nvcr.io/nvidia/cuda:12.9.0-devel-ubuntu24.04
           command: ["bash", "-c"]
           args:
             - |


### PR DESCRIPTION
## Summary

Switch the HPA GPU evidence workload image in `hpa-gpu-test.yaml` from Docker Hub shorthand to explicit NVIDIA registry (`nvcr.io`). This addresses trusted-registry policy findings without changing workload behavior.

## Motivation / Context

Security policy flagged `nvidia/cuda:12.9.0-devel-ubuntu24.04` as untrusted/implicit registry usage. Using `nvcr.io/nvidia/cuda:12.9.0-devel-ubuntu24.04` keeps the same image lineage while satisfying registry restrictions.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/scripts/manifests`

## Implementation Notes

- Updated one line in `pkg/evidence/scripts/manifests/hpa-gpu-test.yaml`:
  - `nvidia/cuda:12.9.0-devel-ubuntu24.04`
  - -> `nvcr.io/nvidia/cuda:12.9.0-devel-ubuntu24.04`
- No changes to resource requests, securityContext, command, or HPA behavior.

## Testing

```bash
# Commands run
make lint
kubectl --context aws-us-east-1-pdybhicbdc-dgxc-k8s-aws-use1-non-prod apply -f pkg/evidence/scripts/manifests/hpa-gpu-test.yaml --validate=false
```

- `make lint` failed locally due toolchain mismatch:
  - `golangci-lint` built with Go 1.25, repo targets Go 1.26.
- Cluster apply could not be completed from this environment due intermittent EKS endpoint DNS resolution failures (`...gr7.us-east-1.eks.amazonaws.com: no such host`).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
