### PR TITLE
feat(validator): add per-check isolation and external validator support

### DIFF
--- a/demos/isolation/README.md
+++ b/demos/isolation/README.md
@@ -1,0 +1,224 @@
+# Validator Isolation Demo
+
+Demonstrates the three-tier validation execution model on a local Kind cluster:
+
+| Tier | Job | Image | What it proves |
+|------|-----|-------|----------------|
+| Shared | `aicr-{runID}-deployment` | validator image | Multiple checks combined in one Job |
+| Isolated | `aicr-{runID}-deployment-expected-resources` | validator image | Same check runs alone in its own Job |
+| External | `aicr-{runID}-deployment-cluster-dns-check` | `cluster-dns-check:v1` | Bring-your-own OCI container |
+
+## Prerequisites
+
+- Kind cluster with local registry at `localhost:5001`
+- `aicr` binary built (`make build`)
+- Validator image built and pushed (`make image-validator`)
+- A snapshot file (any valid AICR snapshot)
+
+## Recipe
+
+```yaml
+# demos/isolation/recipe.yaml
+validation:
+  deployment:
+    checks:
+      - expected-resources                     # Tier 1: shared (default)
+      - name: expected-resources               # Tier 2: isolated override
+        isolated: true
+        timeout: 3m
+    constraints:
+      - name: Deployment.gpu-operator.version  # Tier 1: shared (default)
+        value: ">= v24.6.0"
+    validators:
+      - name: cluster-dns-check               # Tier 3: external BYO image
+        image: localhost:5001/cluster-dns-check:v1
+        timeout: 2m
+```
+
+## Steps
+
+### 1. Build the external validator image
+
+```bash
+docker build -t localhost:5001/cluster-dns-check:v1 demos/isolation/external-validator/
+docker push localhost:5001/cluster-dns-check:v1
+```
+
+### 2. Build the validator image
+
+```bash
+make build
+make image-validator IMAGE_REGISTRY=localhost:5001 IMAGE_TAG=local
+```
+
+### 3. Deploy a fake GPU operator
+
+```bash
+kubectl create namespace gpu-operator --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-operator
+  namespace: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    app.kubernetes.io/version: v24.6.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: gpu-operator }
+  template:
+    metadata:
+      labels: { app: gpu-operator }
+    spec:
+      containers:
+      - name: gpu-operator
+        image: nvcr.io/nvidia/gpu-operator:v24.6.0
+        imagePullPolicy: IfNotPresent
+EOF
+```
+
+### 4. Run validation
+
+```bash
+aicr validate \
+  --recipe demos/isolation/recipe.yaml \
+  --snapshot snapshot.yaml \
+  --image localhost:5001/aicr-validator:local \
+  --phase deployment \
+  --output demos/isolation/result.yaml \
+  --cleanup=false \
+  --validation-namespace aicr-validation
+```
+
+### 5. Inspect Jobs and labels
+
+```bash
+kubectl get jobs -n aicr-validation -o wide
+kubectl get pods -n aicr-validation -o custom-columns=\
+'NAME:.metadata.name,TIER:.metadata.labels.aicr\.nvidia\.com/tier,PHASE:.metadata.labels.aicr\.nvidia\.com/phase,CHECK:.metadata.labels.aicr\.nvidia\.com/check,VALIDATOR:.metadata.labels.aicr\.nvidia\.com/validator'
+```
+
+## Expected Output
+
+### Console
+
+```
+[cli] running deployment validation phase
+
+# --- Tier 1: Shared Job ---
+[cli] built test pattern from items: pattern=^(TestGPUOperatorVersion|TestCheckExpectedResources)$ tests=2
+[cli] --- BEGIN TEST OUTPUT ---
+[cli]     expected_resources_check_test.go:51: ✓ Check passed: expected-resources
+[cli] --- PASS: TestCheckExpectedResources (0.02s)
+[cli] --- PASS: TestGPUOperatorVersion (0.00s)
+[cli] PASS
+[cli] --- END TEST OUTPUT ---
+
+# --- Tier 2: Isolated Job ---
+[cli] built test pattern from items: pattern=^(TestCheckExpectedResources)$ tests=1
+[cli] --- BEGIN TEST OUTPUT ---
+[cli]     expected_resources_check_test.go:51: ✓ Check passed: expected-resources
+[cli] --- PASS: TestCheckExpectedResources (0.01s)
+[cli] PASS
+[cli] --- END TEST OUTPUT ---
+
+# --- Tier 3: External Job ---
+[cli] deploying external validator: name=cluster-dns-check image=localhost:5001/cluster-dns-check:v1 phase=deployment
+[cli] === External Validator: Cluster DNS Check ===
+[cli] Checking if kubernetes.default.svc.cluster.local resolves...
+[cli] PASS: DNS resolution works
+[cli] Resolved: Address: 10.96.0.1
+[cli] external validator passed: name=cluster-dns-check image=localhost:5001/cluster-dns-check:v1
+
+[cli] deployment validation completed: status=pass checks=4 duration=8.926139959s
+[cli] validation completed: status=pass passed=4 failed=0 skipped=0 duration=8.926139959s
+```
+
+### Jobs
+
+```
+NAME                                                      STATUS     COMPLETIONS   DURATION   IMAGES
+aicr-20260305-223332-f734-deployment                      Complete   1/1           3s         localhost:5001/aicr-validator:local
+aicr-20260305-223332-f734-deployment-expected-resources   Complete   1/1           3s         localhost:5001/aicr-validator:local
+aicr-20260305-223332-f734-deployment-cluster-dns-check    Complete   1/1           3s         localhost:5001/cluster-dns-check:v1
+```
+
+### Structured Pod Labels
+
+Each pod gets structured labels for querying by tier, phase, check name, or run ID:
+
+```
+NAME                                                            TIER       PHASE        CHECK                VALIDATOR
+aicr-...-deployment-xd25j                                       shared     deployment   <none>               <none>
+aicr-...-deployment-expected-resources-ln7v2                     isolated   deployment   expected-resources   <none>
+aicr-...-deployment-cluster-dns-check-2qkcb                     external   deployment   <none>               cluster-dns-check
+```
+
+Label queries:
+
+```bash
+# All pods for a specific run
+kubectl get pods -n aicr-validation -l aicr.nvidia.com/run-id=20260305-223332-f734
+
+# All isolated checks
+kubectl get pods -n aicr-validation -l aicr.nvidia.com/tier=isolated
+
+# All external validators
+kubectl get pods -n aicr-validation -l aicr.nvidia.com/tier=external
+
+# Specific check by name
+kubectl get pods -n aicr-validation -l aicr.nvidia.com/check=expected-resources
+```
+
+### Result YAML
+
+```yaml
+summary:
+  passed: 4
+  failed: 0
+  skipped: 0
+  total: 4
+  status: pass
+phases:
+  deployment:
+    status: pass
+    checks:
+      - name: TestCheckExpectedResources
+        status: pass
+        source: shared                          # <-- Tier 1
+      - name: TestGPUOperatorVersion
+        status: pass
+        source: shared                          # <-- Tier 1
+      - name: TestCheckExpectedResources
+        status: pass
+        source: isolated                        # <-- Tier 2
+      - name: cluster-dns-check
+        status: pass
+        source: external                        # <-- Tier 3
+```
+
+## Cleanup
+
+```bash
+kubectl delete jobs -l app.kubernetes.io/name=aicr -n aicr-validation
+kubectl delete deployment gpu-operator -n gpu-operator
+```
+
+## Writing External Validators
+
+External validators are OCI containers that follow a simple exit-code protocol:
+
+| Exit Code | Meaning |
+|-----------|---------|
+| 0 | Pass |
+| non-zero | Fail |
+
+The framework:
+- Mounts snapshot and recipe as ConfigMap volumes at `/data/snapshot/` and `/data/recipe/`
+- Sets `AICR_SNAPSHOT_PATH`, `AICR_RECIPE_PATH`, `AICR_NAMESPACE` environment variables
+- Captures stdout as evidence
+- Reads `/dev/termination-log` (or last 10 lines of stdout) for failure reason
+
+See `demos/isolation/external-validator/` for a minimal example.

--- a/demos/isolation/external-validator/Dockerfile
+++ b/demos/isolation/external-validator/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.21
+RUN apk add --no-cache bind-tools
+COPY check.sh /check.sh
+RUN chmod +x /check.sh
+ENTRYPOINT ["/check.sh"]

--- a/demos/isolation/external-validator/Dockerfile
+++ b/demos/isolation/external-validator/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM alpine:3.21
 RUN apk add --no-cache bind-tools
+RUN adduser -D -u 1000 validator
 COPY check.sh /check.sh
 RUN chmod +x /check.sh
+USER validator
 ENTRYPOINT ["/check.sh"]

--- a/demos/isolation/external-validator/check.sh
+++ b/demos/isolation/external-validator/check.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# External validator example: Cluster DNS check
+#
+# Protocol: exit 0 = pass, exit 1 = fail
+# The validator framework captures stdout as evidence and reads
+# /dev/termination-log (or last 10 lines of stdout) for failure reason.
+
+echo "=== External Validator: Cluster DNS Check ==="
+echo "Checking if kubernetes.default.svc.cluster.local resolves..."
+
+if nslookup kubernetes.default.svc.cluster.local > /dev/null 2>&1; then
+    resolved=$(nslookup kubernetes.default.svc.cluster.local 2>/dev/null | grep -A1 "Name:" | tail -1)
+    echo "PASS: DNS resolution works"
+    echo "Resolved: ${resolved}"
+    exit 0
+else
+    echo "FAIL: DNS resolution failed for kubernetes.default.svc.cluster.local"
+    exit 1
+fi

--- a/demos/isolation/recipe.yaml
+++ b/demos/isolation/recipe.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeResult
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  version: demo
+
+componentRefs:
+  - name: gpu-operator
+    enabled: true
+    expectedResources:
+      - kind: Deployment
+        name: gpu-operator
+        namespace: gpu-operator
+
+validation:
+  deployment:
+    checks:
+      - expected-resources                     # Tier 1: shared (default)
+      - name: expected-resources               # Tier 2: isolated override
+        isolated: true
+        timeout: 3m
+    constraints:
+      - name: Deployment.gpu-operator.version  # Tier 1: shared (default)
+        value: ">= v24.6.0"
+    validators:
+      - name: cluster-dns-check               # Tier 3: external BYO image
+        image: localhost:5001/cluster-dns-check:v1
+        timeout: 2m

--- a/demos/isolation/result.yaml
+++ b/demos/isolation/result.yaml
@@ -1,0 +1,42 @@
+recipeSource: demos/isolation/recipe.yaml
+snapshotSource: snapshot.yaml
+summary:
+  passed: 4
+  failed: 0
+  skipped: 0
+  total: 4
+  status: pass
+  duration: 8.926139959s
+phases:
+  deployment:
+    status: pass
+    checks:
+      - name: TestCheckExpectedResources
+        status: pass
+        reason: |-
+          === RUN   TestCheckExpectedResources
+              expected_resources_check_test.go:42: Running check: expected-resources
+              expected_resources_check_test.go:51: ✓ Check passed: expected-resources
+          --- PASS: TestCheckExpectedResources (0.02s)
+        source: shared
+      - name: TestGPUOperatorVersion
+        status: pass
+        reason: |-
+          === RUN   TestGPUOperatorVersion
+              gpu_operator_version_constraint_test.go:43: Validating constraint: Deployment.gpu-operator.version = >= v24.6.0
+              gpu_operator_version_constraint_test.go:52: CONSTRAINT_RESULT: name=Deployment.gpu-operator.version expected=>= v24.6.0 actual=v24.6.0 passed=true
+              gpu_operator_version_constraint_test.go:58: ✓ Constraint satisfied: Deployment.gpu-operator.version = v24.6.0
+          --- PASS: TestGPUOperatorVersion (0.00s)
+        source: shared
+      - name: TestCheckExpectedResources
+        status: pass
+        reason: |-
+          === RUN   TestCheckExpectedResources
+              expected_resources_check_test.go:42: Running check: expected-resources
+              expected_resources_check_test.go:51: ✓ Check passed: expected-resources
+          --- PASS: TestCheckExpectedResources (0.01s)
+        source: isolated
+      - name: cluster-dns-check
+        status: pass
+        source: external
+    duration: 8.926139959s

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -136,6 +136,14 @@ const (
 	InteractiveOIDCTimeout = 5 * time.Minute
 )
 
+// External validator timeouts.
+const (
+	// ExternalValidatorTimeout is the default timeout for external validator Jobs.
+	// External validators are user-provided OCI containers, which may need to pull
+	// images and perform arbitrary validation logic.
+	ExternalValidatorTimeout = 10 * time.Minute
+)
+
 // Validation phase timeouts for validation phase operations.
 // These are used when the recipe does not specify a timeout.
 const (

--- a/pkg/recipe/conformance_test.go
+++ b/pkg/recipe/conformance_test.go
@@ -204,7 +204,7 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 			// 3. All required conformance checks present
 			checkSet := make(map[string]bool)
 			for _, c := range result.Validation.Conformance.Checks {
-				checkSet[c] = true
+				checkSet[c.Name] = true
 			}
 			for _, check := range tt.requiredChecks {
 				if !checkSet[check] {

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"gopkg.in/yaml.v3"
 )
 
 // RecipeMetadataKind is the kind value for RecipeMetadata resources.
@@ -58,6 +59,63 @@ type Constraint struct {
 
 	// Unit specifies the unit for numeric constraints (e.g., "GB/s").
 	Unit string `json:"unit,omitempty" yaml:"unit,omitempty"`
+
+	// Isolated overrides the phase/top-level isolated setting for this constraint.
+	// nil means "inherit from parent"; explicit value overrides.
+	Isolated *bool `json:"isolated,omitempty" yaml:"isolated,omitempty"`
+
+	// Timeout overrides the phase timeout for this individual constraint.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+// CheckRef represents a reference to a validation check.
+// Supports both string shorthand ("expected-resources") and full object form
+// with optional isolation and timeout overrides.
+type CheckRef struct {
+	// Name is the check identifier (e.g., "expected-resources").
+	Name string `json:"name" yaml:"name"`
+
+	// Isolated overrides the phase/top-level isolated setting for this check.
+	// nil means "inherit from parent"; explicit value overrides.
+	Isolated *bool `json:"isolated,omitempty" yaml:"isolated,omitempty"`
+
+	// Timeout overrides the phase timeout for this individual check.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for CheckRef.
+// Accepts either a plain string ("expected-resources") or a mapping
+// ({name: heavy-test, isolated: true, timeout: 10m}).
+func (c *CheckRef) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		c.Name = node.Value
+		return nil
+	}
+	if node.Kind == yaml.MappingNode {
+		// Use alias type to avoid infinite recursion.
+		type checkRefAlias CheckRef
+		var raw checkRefAlias
+		if err := node.Decode(&raw); err != nil {
+			return fmt.Errorf("line %d: invalid check object: %w", node.Line, err)
+		}
+		*c = CheckRef(raw)
+		return nil
+	}
+	return fmt.Errorf("line %d: check must be a string or object, got %v", node.Line, node.Tag)
+}
+
+// ExternalValidator represents a user-provided OCI container for validation.
+// External validators communicate results via exit codes (0=pass, 1=fail, 2=skip),
+// /dev/termination-log (error context), and stdout (evidence).
+type ExternalValidator struct {
+	// Name is a human-readable identifier for this validator.
+	Name string `json:"name" yaml:"name"`
+
+	// Image is the OCI container image reference (e.g., "myregistry.io/check:v1.0").
+	Image string `json:"image" yaml:"image"`
+
+	// Timeout overrides the phase timeout for this external validator.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // ComponentRef represents a reference to a deployable component.
@@ -133,6 +191,11 @@ type ExpectedResource struct {
 
 // ValidationConfig defines validation phases and settings.
 type ValidationConfig struct {
+	// Isolated is the top-level default for check/constraint isolation.
+	// When true, each check and constraint runs in its own Kubernetes Job.
+	// Can be overridden at phase level and individual check/constraint level.
+	Isolated *bool `json:"isolated,omitempty" yaml:"isolated,omitempty"`
+
 	// Readiness defines readiness validation phase settings.
 	Readiness *ValidationPhase `json:"readiness,omitempty" yaml:"readiness,omitempty"`
 
@@ -151,11 +214,20 @@ type ValidationPhase struct {
 	// Timeout is the maximum duration for this phase (e.g., "10m").
 	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 
+	// Isolated overrides the top-level isolated setting for all items in this phase.
+	// nil means "inherit from top-level"; explicit value overrides.
+	Isolated *bool `json:"isolated,omitempty" yaml:"isolated,omitempty"`
+
 	// Constraints are phase-level constraints to evaluate.
 	Constraints []Constraint `json:"constraints,omitempty" yaml:"constraints,omitempty"`
 
 	// Checks are named validation checks to run in this phase.
-	Checks []string `json:"checks,omitempty" yaml:"checks,omitempty"`
+	// Supports both string shorthand and object form with isolation/timeout overrides.
+	Checks []CheckRef `json:"checks,omitempty" yaml:"checks,omitempty"`
+
+	// Validators lists external OCI containers to run as validation Jobs.
+	// Each validator runs in its own isolated Job with the user-provided image.
+	Validators []ExternalValidator `json:"validators,omitempty" yaml:"validators,omitempty"`
 
 	// NodeSelection defines which nodes to include in validation.
 	NodeSelection *NodeSelection `json:"nodeSelection,omitempty" yaml:"nodeSelection,omitempty"`
@@ -383,6 +455,9 @@ func (s *RecipeMetadataSpec) Merge(other *RecipeMetadataSpec) {
 		if s.Validation == nil {
 			s.Validation = other.Validation
 		} else {
+			if other.Validation.Isolated != nil {
+				s.Validation.Isolated = other.Validation.Isolated
+			}
 			if other.Validation.Readiness != nil {
 				s.Validation.Readiness = other.Validation.Readiness
 			}

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -37,6 +37,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestRecipeMetadataSpecValidateDependencies(t *testing.T) {
@@ -493,7 +495,7 @@ func TestMergeValidationConfig(t *testing.T) {
 				},
 				Deployment: &ValidationPhase{
 					Timeout: "5m",
-					Checks:  []string{"expected-resources"},
+					Checks:  []CheckRef{{Name: "expected-resources"}},
 				},
 			},
 		}
@@ -501,7 +503,7 @@ func TestMergeValidationConfig(t *testing.T) {
 			Validation: &ValidationConfig{
 				Deployment: &ValidationPhase{
 					Timeout: "10m",
-					Checks:  []string{"expected-resources", "check-nvidia-smi"},
+					Checks:  []CheckRef{{Name: "expected-resources"}, {Name: "check-nvidia-smi"}},
 				},
 				Performance: &ValidationPhase{
 					Timeout:        "15m",
@@ -539,7 +541,7 @@ func TestMergeValidationConfig(t *testing.T) {
 		overlay := RecipeMetadataSpec{
 			Validation: &ValidationConfig{
 				Deployment: &ValidationPhase{
-					Checks: []string{"expected-resources"},
+					Checks: []CheckRef{{Name: "expected-resources"}},
 				},
 			},
 		}
@@ -548,7 +550,7 @@ func TestMergeValidationConfig(t *testing.T) {
 		if base.Validation == nil {
 			t.Fatal("validation should be set from overlay")
 		}
-		if base.Validation.Deployment == nil || base.Validation.Deployment.Checks[0] != "expected-resources" {
+		if base.Validation.Deployment == nil || base.Validation.Deployment.Checks[0].Name != "expected-resources" {
 			t.Error("deployment check should be set from overlay")
 		}
 	})
@@ -557,7 +559,7 @@ func TestMergeValidationConfig(t *testing.T) {
 		base := RecipeMetadataSpec{
 			Validation: &ValidationConfig{
 				Deployment: &ValidationPhase{
-					Checks: []string{"expected-resources"},
+					Checks: []CheckRef{{Name: "expected-resources"}},
 				},
 			},
 		}
@@ -577,7 +579,7 @@ func TestFinalizeRecipeResultIncludesValidation(t *testing.T) {
 		},
 		Validation: &ValidationConfig{
 			Deployment: &ValidationPhase{
-				Checks: []string{"expected-resources"},
+				Checks: []CheckRef{{Name: "expected-resources"}},
 			},
 		},
 	}
@@ -592,8 +594,8 @@ func TestFinalizeRecipeResultIncludesValidation(t *testing.T) {
 	if result.Validation.Deployment == nil {
 		t.Fatal("result.Validation.Deployment should not be nil")
 	}
-	if result.Validation.Deployment.Checks[0] != "expected-resources" {
-		t.Errorf("check = %q, want expected-resources", result.Validation.Deployment.Checks[0])
+	if result.Validation.Deployment.Checks[0].Name != "expected-resources" {
+		t.Errorf("check = %q, want expected-resources", result.Validation.Deployment.Checks[0].Name)
 	}
 }
 
@@ -1272,3 +1274,107 @@ func TestComponentRefMergeWithPath(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckRefUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantIso  *bool
+		wantErr  bool
+	}{
+		{
+			name:     "string form",
+			input:    `platform-health`,
+			wantName: "platform-health",
+		},
+		{
+			name:     "object form with name only",
+			input:    "name: gpu-test\n",
+			wantName: "gpu-test",
+		},
+		{
+			name:     "object form with isolated true",
+			input:    "name: heavy-check\nisolated: true\ntimeout: 10m\n",
+			wantName: "heavy-check",
+			wantIso:  boolP(true),
+		},
+		{
+			name:     "object form with isolated false",
+			input:    "name: light-check\nisolated: false\n",
+			wantName: "light-check",
+			wantIso:  boolP(false),
+		},
+		{
+			name:    "invalid type (sequence)",
+			input:   "- a\n- b\n",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ref CheckRef
+			err := yaml.Unmarshal([]byte(tt.input), &ref)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if ref.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", ref.Name, tt.wantName)
+			}
+			if tt.wantIso == nil && ref.Isolated != nil {
+				t.Errorf("Isolated = %v, want nil", *ref.Isolated)
+			}
+			if tt.wantIso != nil {
+				if ref.Isolated == nil {
+					t.Errorf("Isolated = nil, want %v", *tt.wantIso)
+				} else if *ref.Isolated != *tt.wantIso {
+					t.Errorf("Isolated = %v, want %v", *ref.Isolated, *tt.wantIso)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckRefUnmarshalYAMLInList(t *testing.T) {
+	input := `
+- dra-support
+- name: heavy-gpu-test
+  isolated: true
+  timeout: 10m
+- platform-health
+`
+	var refs []CheckRef
+	if err := yaml.Unmarshal([]byte(input), &refs); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if len(refs) != 3 {
+		t.Fatalf("got %d refs, want 3", len(refs))
+	}
+
+	if refs[0].Name != "dra-support" {
+		t.Errorf("refs[0].Name = %q, want %q", refs[0].Name, "dra-support")
+	}
+	if refs[0].Isolated != nil {
+		t.Errorf("refs[0].Isolated = %v, want nil", *refs[0].Isolated)
+	}
+
+	if refs[1].Name != "heavy-gpu-test" {
+		t.Errorf("refs[1].Name = %q, want %q", refs[1].Name, "heavy-gpu-test")
+	}
+	if refs[1].Isolated == nil || !*refs[1].Isolated {
+		t.Errorf("refs[1].Isolated = %v, want true", refs[1].Isolated)
+	}
+	if refs[1].Timeout != "10m" {
+		t.Errorf("refs[1].Timeout = %q, want %q", refs[1].Timeout, "10m")
+	}
+
+	if refs[2].Name != "platform-health" {
+		t.Errorf("refs[2].Name = %q, want %q", refs[2].Name, "platform-health")
+	}
+}
+
+func boolP(b bool) *bool { return &b }

--- a/pkg/validator/README.md
+++ b/pkg/validator/README.md
@@ -180,9 +180,9 @@ The test wrapper pattern enables:
 
 Each validation run is assigned a unique **RunID** for resource isolation and resumability:
 
-**RunID Format:** `YYYYMMDD-HHMMSS-XXXXXXXXXXXXXXXX` (e.g., `20260206-140523-a3f9b2c1e7d04a68b2c1e7d04a68`)
+**RunID Format:** `YYYYMMDD-HHMMSS-XXXX` (e.g., `20260206-140523-a3f9`)
 - Timestamp: Date and time when validation started
-- Random suffix: 16 hex characters for uniqueness
+- Random suffix: 4 hex characters for uniqueness
 
 **Resource Naming:**
 All resources created during a validation run include the RunID:

--- a/pkg/validator/agent/job.go
+++ b/pkg/validator/agent/job.go
@@ -62,16 +62,11 @@ func (d *Deployer) deleteJob(ctx context.Context) error {
 
 // buildJobSpec constructs the Kubernetes Job specification.
 func (d *Deployer) buildJobSpec() *batchv1.Job {
-	// Build command to run tests
-	testCommand := d.buildTestCommand()
-
-	// Build container
+	// Build container with env vars and volume mounts common to all modes
 	container := corev1.Container{
 		Name:            "validator",
 		Image:           d.config.Image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"/bin/sh", "-c"},
-		Args:            []string{testCommand},
 		Env: []corev1.EnvVar{
 			{
 				Name:  "AICR_SNAPSHOT_PATH",
@@ -102,6 +97,19 @@ func (d *Deployer) buildJobSpec() *batchv1.Job {
 				ReadOnly:  true,
 			},
 		},
+	}
+
+	// Mode-specific container configuration
+	if d.config.ExternalCommand {
+		// External validator: use container's own ENTRYPOINT/CMD.
+		// Termination message falls back to last few bytes of stdout on error,
+		// giving us a failure reason even without structured output.
+		container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
+	} else {
+		// Internal validator: run pre-compiled go test binary
+		testCommand := d.buildTestCommand()
+		container.Command = []string{"/bin/sh", "-c"}
+		container.Args = []string{testCommand}
 	}
 
 	// Add debug flag if enabled
@@ -168,6 +176,14 @@ func (d *Deployer) buildJobSpec() *batchv1.Job {
 	backoffLimit := int32(0)                                                 // No retries - validation should be deterministic
 	ttlSecondsAfterFinished := int32(defaults.JobTTLAfterFinished.Seconds()) // Keep for 1 hour for debugging
 
+	podLabels := map[string]string{
+		"app.kubernetes.io/name":      "aicr",
+		"app.kubernetes.io/component": "validation",
+	}
+	for k, v := range d.config.Labels {
+		podLabels[k] = v
+	}
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      d.config.JobName,
@@ -183,11 +199,7 @@ func (d *Deployer) buildJobSpec() *batchv1.Job {
 			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app.kubernetes.io/name":      "aicr",
-						"app.kubernetes.io/component": "validation",
-						"aicr.nvidia.com/job":         d.config.JobName,
-					},
+					Labels: podLabels,
 				},
 				Spec: podSpec,
 			},

--- a/pkg/validator/agent/job_test.go
+++ b/pkg/validator/agent/job_test.go
@@ -48,11 +48,10 @@ func TestBuildJobSpec(t *testing.T) {
 		}
 	}
 
-	// Verify pod labels
+	// Verify pod labels (base labels always present)
 	expectedPodLabels := map[string]string{
 		"app.kubernetes.io/name":      "aicr",
 		"app.kubernetes.io/component": "validation",
-		"aicr.nvidia.com/job":         deployer.config.JobName,
 	}
 	for key, expectedValue := range expectedPodLabels {
 		if value, ok := job.Spec.Template.Labels[key]; !ok || value != expectedValue {
@@ -500,6 +499,96 @@ func TestDeleteJob(t *testing.T) {
 			t.Errorf("deleteJob() should ignore not found: %v", err)
 		}
 	})
+}
+
+func TestBuildJobSpec_ExternalCommand(t *testing.T) {
+	deployer, _ := createDeployer()
+	deployer.config.ExternalCommand = true
+	deployer.config.Image = "myregistry.io/custom-check:v1.0"
+
+	job := deployer.buildJobSpec()
+	container := job.Spec.Template.Spec.Containers[0]
+
+	// External command: no Command or Args (use container ENTRYPOINT)
+	if len(container.Command) != 0 {
+		t.Errorf("expected no Command for external validator, got %v", container.Command)
+	}
+	if len(container.Args) != 0 {
+		t.Errorf("expected no Args for external validator, got %v", container.Args)
+	}
+
+	// TerminationMessagePolicy should be FallbackToLogsOnError
+	if container.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
+		t.Errorf("expected TerminationMessagePolicy FallbackToLogsOnError, got %v", container.TerminationMessagePolicy)
+	}
+
+	// Should still have the same env vars and volume mounts
+	foundSnapshot := false
+	foundRecipe := false
+	for _, env := range container.Env {
+		if env.Name == "AICR_SNAPSHOT_PATH" {
+			foundSnapshot = true
+		}
+		if env.Name == "AICR_RECIPE_PATH" {
+			foundRecipe = true
+		}
+	}
+	if !foundSnapshot {
+		t.Error("external validator should have AICR_SNAPSHOT_PATH env var")
+	}
+	if !foundRecipe {
+		t.Error("external validator should have AICR_RECIPE_PATH env var")
+	}
+
+	if len(container.VolumeMounts) != 2 {
+		t.Errorf("expected 2 volume mounts, got %d", len(container.VolumeMounts))
+	}
+}
+
+func TestBuildJobSpec_InternalCommand(t *testing.T) {
+	deployer, _ := createDeployer()
+	deployer.config.ExternalCommand = false
+
+	job := deployer.buildJobSpec()
+	container := job.Spec.Template.Spec.Containers[0]
+
+	// Internal command: should have Command and Args
+	if len(container.Command) == 0 {
+		t.Error("expected Command for internal validator")
+	}
+	if len(container.Args) == 0 {
+		t.Error("expected Args for internal validator")
+	}
+
+	// TerminationMessagePolicy should be empty (default)
+	if container.TerminationMessagePolicy != "" {
+		t.Errorf("expected default TerminationMessagePolicy, got %v", container.TerminationMessagePolicy)
+	}
+}
+
+func TestBuildJobSpec_WithLabels(t *testing.T) {
+	deployer, _ := createDeployer()
+	deployer.config.Labels = map[string]string{
+		"aicr.nvidia.com/run-id": "20260305-185555-5d19",
+		"aicr.nvidia.com/phase":  "deployment",
+		"aicr.nvidia.com/tier":   "isolated",
+		"aicr.nvidia.com/check":  "expected-resources",
+	}
+
+	job := deployer.buildJobSpec()
+
+	// Config labels should be merged into pod template labels
+	podLabels := job.Spec.Template.Labels
+	for k, v := range deployer.config.Labels {
+		if podLabels[k] != v {
+			t.Errorf("pod label %s = %q, want %q", k, podLabels[k], v)
+		}
+	}
+
+	// Base labels should still be present
+	if podLabels["app.kubernetes.io/name"] != "aicr" {
+		t.Errorf("base label app.kubernetes.io/name missing")
+	}
 }
 
 // Helper function to create test ConfigMaps

--- a/pkg/validator/agent/types.go
+++ b/pkg/validator/agent/types.go
@@ -66,6 +66,15 @@ type Config struct {
 	// Timeout for the Job to complete
 	Timeout time.Duration
 
+	// Labels are additional labels applied to the pod template.
+	// Used for structured identification (run-id, phase, check) and pod lookup.
+	Labels map[string]string
+
+	// ExternalCommand indicates this Job runs a user-provided container ENTRYPOINT
+	// instead of go test. When true, Command and Args are omitted from the container
+	// spec, and TerminationMessagePolicy is set to FallbackToLogsOnError.
+	ExternalCommand bool
+
 	// Cleanup determines whether to remove Job and RBAC on completion
 	Cleanup bool
 

--- a/pkg/validator/agent/wait.go
+++ b/pkg/validator/agent/wait.go
@@ -326,10 +326,11 @@ func (d *Deployer) getPodLogsAsString(ctx context.Context) (string, error) {
 	return pod.GetPodLogs(ctx, d.clientset, d.config.Namespace, jobPod.Name, "")
 }
 
-// getPodForJob finds the pod created by the Job.
+// getPodForJob finds the pod created by the Job using the Kubernetes-managed
+// batch.kubernetes.io/job-name label (auto-added by the Job controller).
 func (d *Deployer) getPodForJob(ctx context.Context) (*corev1.Pod, error) {
 	pods, err := d.clientset.CoreV1().Pods(d.config.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("aicr.nvidia.com/job=%s", d.config.JobName),
+		LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", d.config.JobName),
 	})
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to list pods for job", err)

--- a/pkg/validator/agent/wait_test.go
+++ b/pkg/validator/agent/wait_test.go
@@ -279,7 +279,7 @@ func TestGetPodForJob(t *testing.T) {
 				Name:      "test-pod",
 				Namespace: deployer.config.Namespace,
 				Labels: map[string]string{
-					"aicr.nvidia.com/job": deployer.config.JobName,
+					"batch.kubernetes.io/job-name": deployer.config.JobName,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -688,7 +688,7 @@ func TestWaitForJobPodTermination_AlreadyTerminal(t *testing.T) {
 			Name:      "test-pod",
 			Namespace: deployer.config.Namespace,
 			Labels: map[string]string{
-				"aicr.nvidia.com/job": deployer.config.JobName,
+				"batch.kubernetes.io/job-name": deployer.config.JobName,
 			},
 		},
 		Status: corev1.PodStatus{
@@ -720,7 +720,7 @@ func TestWaitForJobPodTermination_Succeeded(t *testing.T) {
 			Name:      "test-pod",
 			Namespace: deployer.config.Namespace,
 			Labels: map[string]string{
-				"aicr.nvidia.com/job": deployer.config.JobName,
+				"batch.kubernetes.io/job-name": deployer.config.JobName,
 			},
 		},
 		Status: corev1.PodStatus{

--- a/pkg/validator/checks/runner.go
+++ b/pkg/validator/checks/runner.go
@@ -171,7 +171,7 @@ func (r *TestRunner) HasCheck(phase, checkName string) bool {
 		return false
 	}
 
-	var checkList []string
+	var checkList []recipe.CheckRef
 	switch phase {
 	case "deployment":
 		if r.ctx.Recipe.Validation.Deployment != nil {
@@ -187,8 +187,8 @@ func (r *TestRunner) HasCheck(phase, checkName string) bool {
 		}
 	}
 
-	for _, name := range checkList {
-		if name == checkName {
+	for _, check := range checkList {
+		if check.Name == checkName {
 			return true
 		}
 	}

--- a/pkg/validator/checks/runner_test.go
+++ b/pkg/validator/checks/runner_test.go
@@ -380,13 +380,13 @@ func TestTestRunner_HasCheck(t *testing.T) {
 	recipeResult := &recipe.RecipeResult{
 		Validation: &recipe.ValidationConfig{
 			Deployment: &recipe.ValidationPhase{
-				Checks: []string{"expected-resources", "check-nvidia-smi"},
+				Checks: []recipe.CheckRef{{Name: "expected-resources"}, {Name: "check-nvidia-smi"}},
 			},
 			Performance: &recipe.ValidationPhase{
-				Checks: []string{"nccl-bandwidth"},
+				Checks: []recipe.CheckRef{{Name: "nccl-bandwidth"}},
 			},
 			Conformance: &recipe.ValidationPhase{
-				Checks: []string{"k8s-conformance"},
+				Checks: []recipe.CheckRef{{Name: "k8s-conformance"}},
 			},
 		},
 	}

--- a/pkg/validator/isolation.go
+++ b/pkg/validator/isolation.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// resolveIsolated returns the effective isolated flag for a check or constraint.
+// Precedence: individual > phase > top-level > default (false).
+func resolveIsolated(individual, phase, topLevel *bool) bool {
+	if individual != nil {
+		return *individual
+	}
+	if phase != nil {
+		return *phase
+	}
+	if topLevel != nil {
+		return *topLevel
+	}
+	return false
+}
+
+// checkPartition holds checks and constraints partitioned by isolation mode.
+type checkPartition struct {
+	// SharedChecks are non-isolated checks to combine into one Job.
+	SharedChecks []recipe.CheckRef
+	// IsolatedChecks each get their own Job.
+	IsolatedChecks []recipe.CheckRef
+	// SharedConstraints are non-isolated constraints to combine into one Job.
+	SharedConstraints []recipe.Constraint
+	// IsolatedConstraints each get their own Job.
+	IsolatedConstraints []recipe.Constraint
+}
+
+// partitionByIsolation splits a phase's checks and constraints into shared vs isolated groups.
+func partitionByIsolation(phase *recipe.ValidationPhase, topLevel *bool) checkPartition {
+	var result checkPartition
+	if phase == nil {
+		return result
+	}
+
+	for _, check := range phase.Checks {
+		if resolveIsolated(check.Isolated, phase.Isolated, topLevel) {
+			result.IsolatedChecks = append(result.IsolatedChecks, check)
+		} else {
+			result.SharedChecks = append(result.SharedChecks, check)
+		}
+	}
+
+	for _, constraint := range phase.Constraints {
+		if resolveIsolated(constraint.Isolated, phase.Isolated, topLevel) {
+			result.IsolatedConstraints = append(result.IsolatedConstraints, constraint)
+		} else {
+			result.SharedConstraints = append(result.SharedConstraints, constraint)
+		}
+	}
+
+	return result
+}
+
+// hasShared returns true if there are any shared checks or constraints.
+func (p checkPartition) hasShared() bool {
+	return len(p.SharedChecks) > 0 || len(p.SharedConstraints) > 0
+}
+
+// hasIsolated returns true if there are any isolated checks or constraints.
+func (p checkPartition) hasIsolated() bool {
+	return len(p.IsolatedChecks) > 0 || len(p.IsolatedConstraints) > 0
+}

--- a/pkg/validator/isolation_test.go
+++ b/pkg/validator/isolation_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestResolveIsolated(t *testing.T) {
+	tests := []struct {
+		name       string
+		individual *bool
+		phase      *bool
+		topLevel   *bool
+		want       bool
+	}{
+		{
+			name: "all nil defaults to false",
+			want: false,
+		},
+		{
+			name:     "top-level true",
+			topLevel: boolPtr(true),
+			want:     true,
+		},
+		{
+			name:     "top-level false",
+			topLevel: boolPtr(false),
+			want:     false,
+		},
+		{
+			name:     "phase overrides top-level",
+			phase:    boolPtr(false),
+			topLevel: boolPtr(true),
+			want:     false,
+		},
+		{
+			name:  "phase true with nil top-level",
+			phase: boolPtr(true),
+			want:  true,
+		},
+		{
+			name:       "individual overrides phase",
+			individual: boolPtr(true),
+			phase:      boolPtr(false),
+			topLevel:   boolPtr(false),
+			want:       true,
+		},
+		{
+			name:       "individual false overrides phase true",
+			individual: boolPtr(false),
+			phase:      boolPtr(true),
+			topLevel:   boolPtr(true),
+			want:       false,
+		},
+		{
+			name:       "individual overrides all",
+			individual: boolPtr(true),
+			phase:      boolPtr(false),
+			topLevel:   boolPtr(false),
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveIsolated(tt.individual, tt.phase, tt.topLevel)
+			if got != tt.want {
+				t.Errorf("resolveIsolated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartitionByIsolation(t *testing.T) {
+	tests := []struct {
+		name                    string
+		phase                   *recipe.ValidationPhase
+		topLevel                *bool
+		wantSharedChecks        int
+		wantIsolatedChecks      int
+		wantSharedConstraints   int
+		wantIsolatedConstraints int
+	}{
+		{
+			name:  "nil phase returns empty partition",
+			phase: nil,
+		},
+		{
+			name: "all shared by default",
+			phase: &recipe.ValidationPhase{
+				Checks: []recipe.CheckRef{
+					{Name: "check-a"},
+					{Name: "check-b"},
+				},
+				Constraints: []recipe.Constraint{
+					{Name: "Deployment.x.version", Value: ">= v1.0"},
+				},
+			},
+			wantSharedChecks:      2,
+			wantSharedConstraints: 1,
+		},
+		{
+			name:     "top-level isolated makes all isolated",
+			topLevel: boolPtr(true),
+			phase: &recipe.ValidationPhase{
+				Checks: []recipe.CheckRef{
+					{Name: "check-a"},
+					{Name: "check-b"},
+				},
+				Constraints: []recipe.Constraint{
+					{Name: "Deployment.x.version", Value: ">= v1.0"},
+				},
+			},
+			wantIsolatedChecks:      2,
+			wantIsolatedConstraints: 1,
+		},
+		{
+			name:     "phase-level isolated overrides top-level",
+			topLevel: boolPtr(false),
+			phase: &recipe.ValidationPhase{
+				Isolated: boolPtr(true),
+				Checks: []recipe.CheckRef{
+					{Name: "check-a"},
+				},
+				Constraints: []recipe.Constraint{
+					{Name: "c1", Value: "v1"},
+				},
+			},
+			wantIsolatedChecks:      1,
+			wantIsolatedConstraints: 1,
+		},
+		{
+			name: "individual check overrides phase",
+			phase: &recipe.ValidationPhase{
+				Isolated: boolPtr(true),
+				Checks: []recipe.CheckRef{
+					{Name: "shared-check", Isolated: boolPtr(false)},
+					{Name: "isolated-check"},
+				},
+				Constraints: []recipe.Constraint{
+					{Name: "shared-constraint", Value: "v1", Isolated: boolPtr(false)},
+					{Name: "isolated-constraint", Value: "v2"},
+				},
+			},
+			wantSharedChecks:        1,
+			wantIsolatedChecks:      1,
+			wantSharedConstraints:   1,
+			wantIsolatedConstraints: 1,
+		},
+		{
+			name: "mixed isolation within phase",
+			phase: &recipe.ValidationPhase{
+				Checks: []recipe.CheckRef{
+					{Name: "default-check"},
+					{Name: "isolated-check", Isolated: boolPtr(true)},
+					{Name: "explicit-shared", Isolated: boolPtr(false)},
+				},
+				Constraints: []recipe.Constraint{
+					{Name: "default-constraint", Value: "v1"},
+					{Name: "isolated-constraint", Value: "v2", Isolated: boolPtr(true)},
+				},
+			},
+			wantSharedChecks:        2,
+			wantIsolatedChecks:      1,
+			wantSharedConstraints:   1,
+			wantIsolatedConstraints: 1,
+		},
+		{
+			name: "empty checks and constraints",
+			phase: &recipe.ValidationPhase{
+				Checks:      []recipe.CheckRef{},
+				Constraints: []recipe.Constraint{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := partitionByIsolation(tt.phase, tt.topLevel)
+			if len(got.SharedChecks) != tt.wantSharedChecks {
+				t.Errorf("SharedChecks = %d, want %d", len(got.SharedChecks), tt.wantSharedChecks)
+			}
+			if len(got.IsolatedChecks) != tt.wantIsolatedChecks {
+				t.Errorf("IsolatedChecks = %d, want %d", len(got.IsolatedChecks), tt.wantIsolatedChecks)
+			}
+			if len(got.SharedConstraints) != tt.wantSharedConstraints {
+				t.Errorf("SharedConstraints = %d, want %d", len(got.SharedConstraints), tt.wantSharedConstraints)
+			}
+			if len(got.IsolatedConstraints) != tt.wantIsolatedConstraints {
+				t.Errorf("IsolatedConstraints = %d, want %d", len(got.IsolatedConstraints), tt.wantIsolatedConstraints)
+			}
+		})
+	}
+}
+
+func TestCheckPartitionHelpers(t *testing.T) {
+	tests := []struct {
+		name         string
+		partition    checkPartition
+		wantShared   bool
+		wantIsolated bool
+	}{
+		{
+			name:      "empty partition",
+			partition: checkPartition{},
+		},
+		{
+			name: "shared checks only",
+			partition: checkPartition{
+				SharedChecks: []recipe.CheckRef{{Name: "a"}},
+			},
+			wantShared: true,
+		},
+		{
+			name: "shared constraints only",
+			partition: checkPartition{
+				SharedConstraints: []recipe.Constraint{{Name: "c1", Value: "v1"}},
+			},
+			wantShared: true,
+		},
+		{
+			name: "isolated checks only",
+			partition: checkPartition{
+				IsolatedChecks: []recipe.CheckRef{{Name: "a"}},
+			},
+			wantIsolated: true,
+		},
+		{
+			name: "isolated constraints only",
+			partition: checkPartition{
+				IsolatedConstraints: []recipe.Constraint{{Name: "c1", Value: "v1"}},
+			},
+			wantIsolated: true,
+		},
+		{
+			name: "both shared and isolated",
+			partition: checkPartition{
+				SharedChecks:        []recipe.CheckRef{{Name: "a"}},
+				IsolatedConstraints: []recipe.Constraint{{Name: "c1", Value: "v1"}},
+			},
+			wantShared:   true,
+			wantIsolated: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.partition.hasShared(); got != tt.wantShared {
+				t.Errorf("hasShared() = %v, want %v", got, tt.wantShared)
+			}
+			if got := tt.partition.hasIsolated(); got != tt.wantIsolated {
+				t.Errorf("hasIsolated() = %v, want %v", got, tt.wantIsolated)
+			}
+		})
+	}
+}

--- a/pkg/validator/phases_runners.go
+++ b/pkg/validator/phases_runners.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	k8sclient "github.com/NVIDIA/aicr/pkg/k8s/client"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
@@ -117,79 +118,14 @@ func (v *Validator) validateDeployment(
 	if recipeResult.Validation == nil || recipeResult.Validation.Deployment == nil {
 		phaseResult.Status = ValidationStatusSkipped
 		phaseResult.Reason = "deployment phase not configured in recipe"
-	} else { //nolint:gocritic // elseif not applicable, multiple statements in else block
-		// NOTE: Deployment phase constraints require live cluster access.
-		// They are NOT evaluated inline like readiness constraints.
-		// Instead, they should be registered as constraint validators in the checks registry
-		// and will be evaluated inside the validation Job with cluster access.
-		// See pkg/validator/checks/deployment/constraints.go for examples.
-
-		// Run checks and evaluate constraints as Kubernetes Jobs
-		// Note: RBAC resources must be created by the caller before invoking this function.
-		// For multi-phase validation, validateAll() manages RBAC lifecycle.
-		// For single-phase validation, the CLI/API should call agent.EnsureRBAC() first.
-		if len(recipeResult.Validation.Deployment.Checks) > 0 || len(recipeResult.Validation.Deployment.Constraints) > 0 {
-			if v.NoCluster {
-				slog.Info("no-cluster mode enabled, skipping cluster check execution for deployment phase")
-				// Create stub check results for each check in the recipe
-				for _, checkName := range recipeResult.Validation.Deployment.Checks {
-					phaseResult.Checks = append(phaseResult.Checks, CheckResult{
-						Name:   checkName,
-						Status: ValidationStatusSkipped,
-						Reason: "skipped - no-cluster mode (test mode)",
-					})
-				}
-			} else {
-				clientset, _, err := k8sclient.GetKubeClient()
-				if err != nil {
-					// If Kubernetes is not available (e.g., running in test mode), skip check execution
-					slog.Warn("Kubernetes client unavailable, skipping check execution",
-						"error", err,
-						"checks", len(recipeResult.Validation.Deployment.Checks))
-					// Add skeleton check result
-					phaseResult.Checks = append(phaseResult.Checks, CheckResult{
-						Name:   "deployment",
-						Status: ValidationStatusPass,
-						Reason: "skipped - Kubernetes unavailable (test mode)",
-					})
-				} else {
-					// ConfigMap names (created once per validation run by validateAll)
-					snapshotCMName := fmt.Sprintf("aicr-snapshot-%s", v.RunID)
-					recipeCMName := fmt.Sprintf("aicr-recipe-%s", v.RunID)
-
-					// Validate that all recipe constraints/checks are registered (logs warnings for missing)
-					v.validateRecipeRegistrations(recipeResult, "deployment")
-
-					// Build test pattern from recipe (constraint names -> test names)
-					patternResult := v.buildTestPattern(recipeResult, "deployment")
-
-					// Deploy ONE Job for ALL deployment checks and constraints in this phase
-					jobConfig := agent.Config{
-						Namespace:          v.Namespace,
-						JobName:            fmt.Sprintf("aicr-%s-deployment", v.RunID),
-						Image:              v.Image,
-						ImagePullSecrets:   v.ImagePullSecrets,
-						ServiceAccountName: "aicr-validator",
-						SnapshotConfigMap:  snapshotCMName,
-						RecipeConfigMap:    recipeCMName,
-						TestPackage:        "./pkg/validator/checks/deployment",
-						TestPattern:        patternResult.Pattern,
-						ExpectedTests:      patternResult.ExpectedTests,
-						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Deployment, DefaultDeploymentTimeout),
-						Tolerations:        v.Tolerations,
-						Affinity:           preferCPUNodeAffinity(),
-					}
-
-					deployer := agent.NewDeployer(clientset, jobConfig)
-
-					// Run the phase Job and aggregate results
-					phaseJobResult := v.runPhaseJob(ctx, deployer, jobConfig, "deployment")
-
-					// Merge Job results into phase result
-					phaseResult.Checks = phaseJobResult.Checks
-				}
-			}
-		}
+	} else {
+		v.executePhaseChecks(ctx, recipeResult, phaseExecConfig{
+			name:           string(PhaseDeployment),
+			testPackage:    "./pkg/validator/checks/deployment",
+			defaultTimeout: DefaultDeploymentTimeout,
+			phase:          recipeResult.Validation.Deployment,
+			topLevel:       recipeResult.Validation.Isolated,
+		}, phaseResult)
 	}
 
 	// Determine phase status based on checks
@@ -255,86 +191,19 @@ func (v *Validator) validatePerformance(
 		phaseResult.Status = ValidationStatusSkipped
 		phaseResult.Reason = "performance phase not configured in recipe"
 	} else {
-		// NOTE: Performance phase constraints require live cluster access and measurements.
-		// They are NOT evaluated inline like readiness constraints.
-		// Instead, they should be registered as constraint validators in the checks registry
-		// and will be evaluated inside the validation Job with cluster access.
-		// See pkg/validator/checks/performance/ for examples.
-
 		// Log infrastructure component if specified
 		if recipeResult.Validation.Performance.Infrastructure != "" {
 			slog.Debug("performance infrastructure specified",
 				"component", recipeResult.Validation.Performance.Infrastructure)
 		}
 
-		// Run checks and evaluate constraints as Kubernetes Jobs
-		// Note: RBAC resources must be created by the caller before invoking this function.
-		// For multi-phase validation, validateAll() manages RBAC lifecycle.
-		// For single-phase validation, the CLI/API should call agent.EnsureRBAC() first.
-		if len(recipeResult.Validation.Performance.Checks) > 0 || len(recipeResult.Validation.Performance.Constraints) > 0 {
-			if v.NoCluster {
-				slog.Info("no-cluster mode enabled, skipping cluster check execution for performance phase")
-				// Create stub check results for each check in the recipe
-				for _, checkName := range recipeResult.Validation.Performance.Checks {
-					phaseResult.Checks = append(phaseResult.Checks, CheckResult{
-						Name:   checkName,
-						Status: ValidationStatusSkipped,
-						Reason: "skipped - no-cluster mode (test mode)",
-					})
-				}
-			} else {
-				clientset, _, err := k8sclient.GetKubeClient()
-				if err != nil {
-					// If Kubernetes is not available (e.g., running in test mode), skip check execution
-					slog.Warn("Kubernetes client unavailable, skipping check execution",
-						"error", err,
-						"checks", len(recipeResult.Validation.Performance.Checks))
-					// Add skeleton check result
-					phaseResult.Checks = append(phaseResult.Checks, CheckResult{
-						Name:   "performance",
-						Status: ValidationStatusPass,
-						Reason: "skipped - Kubernetes unavailable (test mode)",
-					})
-				} else {
-					// ConfigMap names (created once per validation run by validateAll)
-					snapshotCMName := fmt.Sprintf("aicr-snapshot-%s", v.RunID)
-					recipeCMName := fmt.Sprintf("aicr-recipe-%s", v.RunID)
-
-					// Validate that all recipe constraints/checks are registered (logs warnings for missing)
-					v.validateRecipeRegistrations(recipeResult, "performance")
-
-					// Build a test pattern so only the tests required by the recipe run,
-					// not every test in the package (including unit tests).
-					patternResult := v.buildTestPattern(recipeResult, "performance")
-
-					// Deploy ONE Job for ALL performance checks and constraints in this phase
-					// The Job pod is an orchestration layer (creates GPU workload Pods);
-					// it only needs K8s API access, so prefer CPU nodes.
-					jobConfig := agent.Config{
-						Namespace:          v.Namespace,
-						JobName:            fmt.Sprintf("aicr-%s-performance", v.RunID),
-						Image:              v.Image,
-						ImagePullSecrets:   v.ImagePullSecrets,
-						ServiceAccountName: "aicr-validator",
-						SnapshotConfigMap:  snapshotCMName,
-						RecipeConfigMap:    recipeCMName,
-						TestPackage:        "./pkg/validator/checks/performance",
-						TestPattern:        patternResult.Pattern,
-						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Performance, DefaultPerformanceTimeout),
-						Tolerations:        v.Tolerations,
-						Affinity:           preferCPUNodeAffinity(),
-					}
-
-					deployer := agent.NewDeployer(clientset, jobConfig)
-
-					// Run the phase Job and aggregate results
-					phaseJobResult := v.runPhaseJob(ctx, deployer, jobConfig, "performance")
-
-					// Merge Job results into phase result
-					phaseResult.Checks = phaseJobResult.Checks
-				}
-			}
-		}
+		v.executePhaseChecks(ctx, recipeResult, phaseExecConfig{
+			name:           string(PhasePerformance),
+			testPackage:    "./pkg/validator/checks/performance",
+			defaultTimeout: DefaultPerformanceTimeout,
+			phase:          recipeResult.Validation.Performance,
+			topLevel:       recipeResult.Validation.Isolated,
+		}, phaseResult)
 	}
 
 	// Determine phase status based on checks
@@ -400,79 +269,14 @@ func (v *Validator) validateConformance(
 	if recipeResult.Validation == nil || recipeResult.Validation.Conformance == nil {
 		phaseResult.Status = ValidationStatusSkipped
 		phaseResult.Reason = "conformance phase not configured in recipe"
-	} else { //nolint:gocritic // elseif not applicable, multiple statements in else block
-		// NOTE: Conformance phase constraints require live cluster access.
-		// They are NOT evaluated inline like readiness constraints.
-		// Instead, they should be registered as constraint validators in the checks registry
-		// and will be evaluated inside the validation Job with cluster access.
-		// See pkg/validator/checks/conformance/ for examples.
-
-		// Run checks and evaluate constraints as Kubernetes Jobs
-		// Note: RBAC resources must be created by the caller before invoking this function.
-		// For multi-phase validation, validateAll() manages RBAC lifecycle.
-		// For single-phase validation, the CLI/API should call agent.EnsureRBAC() first.
-		if len(recipeResult.Validation.Conformance.Checks) > 0 || len(recipeResult.Validation.Conformance.Constraints) > 0 {
-			if v.NoCluster {
-				slog.Info("no-cluster mode enabled, skipping cluster check execution for conformance phase")
-				// Create stub check results for each check in the recipe
-				for _, checkName := range recipeResult.Validation.Conformance.Checks {
-					phaseResult.Checks = append(phaseResult.Checks, CheckResult{
-						Name:   checkName,
-						Status: ValidationStatusSkipped,
-						Reason: "skipped - no-cluster mode (test mode)",
-					})
-				}
-			} else {
-				clientset, _, err := k8sclient.GetKubeClient()
-				if err != nil {
-					// If Kubernetes is not available (e.g., running in test mode), skip check execution
-					slog.Warn("Kubernetes client unavailable, skipping check execution",
-						"error", err,
-						"checks", len(recipeResult.Validation.Conformance.Checks))
-					// Add skeleton check result
-					phaseResult.Checks = append(phaseResult.Checks, CheckResult{
-						Name:   "conformance",
-						Status: ValidationStatusSkipped,
-						Reason: "skipped - Kubernetes unavailable (test mode)",
-					})
-				} else {
-					// ConfigMap names (created once per validation run by validateAll)
-					snapshotCMName := fmt.Sprintf("aicr-snapshot-%s", v.RunID)
-					recipeCMName := fmt.Sprintf("aicr-recipe-%s", v.RunID)
-
-					// Validate that all recipe constraints/checks are registered (logs warnings for missing)
-					v.validateRecipeRegistrations(recipeResult, "conformance")
-
-					// Build test pattern from recipe (check/constraint names -> test names)
-					patternResult := v.buildTestPattern(recipeResult, "conformance")
-
-					// Deploy ONE Job for ALL conformance checks and constraints in this phase
-					jobConfig := agent.Config{
-						Namespace:          v.Namespace,
-						JobName:            fmt.Sprintf("aicr-%s-conformance", v.RunID),
-						Image:              v.Image,
-						ImagePullSecrets:   v.ImagePullSecrets,
-						ServiceAccountName: "aicr-validator",
-						SnapshotConfigMap:  snapshotCMName,
-						RecipeConfigMap:    recipeCMName,
-						TestPackage:        "./pkg/validator/checks/conformance",
-						TestPattern:        patternResult.Pattern,
-						ExpectedTests:      patternResult.ExpectedTests,
-						Timeout:            resolvePhaseTimeout(recipeResult.Validation.Conformance, DefaultConformanceTimeout),
-						Tolerations:        v.Tolerations,
-						Affinity:           preferCPUNodeAffinity(),
-					}
-
-					deployer := agent.NewDeployer(clientset, jobConfig)
-
-					// Run the phase Job and aggregate results
-					phaseJobResult := v.runPhaseJob(ctx, deployer, jobConfig, "conformance")
-
-					// Merge Job results into phase result
-					phaseResult.Checks = phaseJobResult.Checks
-				}
-			}
-		}
+	} else {
+		v.executePhaseChecks(ctx, recipeResult, phaseExecConfig{
+			name:           string(PhaseConformance),
+			testPackage:    "./pkg/validator/checks/conformance",
+			defaultTimeout: DefaultConformanceTimeout,
+			phase:          recipeResult.Validation.Conformance,
+			topLevel:       recipeResult.Validation.Isolated,
+		}, phaseResult)
 	}
 
 	// Determine phase status based on checks
@@ -532,10 +336,10 @@ func (v *Validator) validateRecipeRegistrations(recipeResult *recipe.RecipeResul
 			}
 
 			// Check explicit checks
-			for _, checkName := range recipeResult.Validation.Deployment.Checks {
-				_, ok := checks.GetCheck(checkName)
+			for _, check := range recipeResult.Validation.Deployment.Checks {
+				_, ok := checks.GetCheck(check.Name)
 				if !ok {
-					unregisteredChecks = append(unregisteredChecks, checkName)
+					unregisteredChecks = append(unregisteredChecks, check.Name)
 				}
 			}
 		}
@@ -548,10 +352,10 @@ func (v *Validator) validateRecipeRegistrations(recipeResult *recipe.RecipeResul
 				}
 			}
 
-			for _, checkName := range recipeResult.Validation.Performance.Checks {
-				_, ok := checks.GetCheck(checkName)
+			for _, check := range recipeResult.Validation.Performance.Checks {
+				_, ok := checks.GetCheck(check.Name)
 				if !ok {
-					unregisteredChecks = append(unregisteredChecks, checkName)
+					unregisteredChecks = append(unregisteredChecks, check.Name)
 				}
 			}
 		}
@@ -564,10 +368,10 @@ func (v *Validator) validateRecipeRegistrations(recipeResult *recipe.RecipeResul
 				}
 			}
 
-			for _, checkName := range recipeResult.Validation.Conformance.Checks {
-				_, ok := checks.GetCheck(checkName)
+			for _, check := range recipeResult.Validation.Conformance.Checks {
+				_, ok := checks.GetCheck(check.Name)
 				if !ok {
-					unregisteredChecks = append(unregisteredChecks, checkName)
+					unregisteredChecks = append(unregisteredChecks, check.Name)
 				}
 			}
 		}
@@ -624,97 +428,378 @@ type buildTestPatternResult struct {
 }
 
 func (v *Validator) buildTestPattern(recipeResult *recipe.RecipeResult, phase string) buildTestPatternResult {
-	var testNames []string
-	uniqueTests := make(map[string]bool)
+	if recipeResult.Validation == nil {
+		return buildTestPatternResult{}
+	}
 
 	switch phase {
 	case string(PhaseDeployment):
-		if recipeResult.Validation != nil && recipeResult.Validation.Deployment != nil {
-			// Add tests for constraints
-			for _, constraint := range recipeResult.Validation.Deployment.Constraints {
-				testName, ok := checks.GetTestNameForConstraint(constraint.Name)
-				if ok && !uniqueTests[testName] {
-					testNames = append(testNames, testName)
-					uniqueTests[testName] = true
-					slog.Debug("constraint mapped to test", "constraint", constraint.Name, "test", testName)
-				}
-				// Note: Missing registrations are caught by validateRecipeRegistrations
-			}
-
-			// Add tests for explicit checks
-			for _, checkName := range recipeResult.Validation.Deployment.Checks {
-				testName, ok := checks.GetTestNameForCheck(checkName)
-				if !ok {
-					// Fallback to generated name if not registered
-					testName = checkNameToTestName(checkName)
-				}
-				if !uniqueTests[testName] {
-					testNames = append(testNames, testName)
-					uniqueTests[testName] = true
-					slog.Debug("check mapped to test", "check", checkName, "test", testName)
-				}
-			}
+		if recipeResult.Validation.Deployment != nil {
+			return buildTestPatternFromItems(recipeResult.Validation.Deployment.Checks, recipeResult.Validation.Deployment.Constraints)
 		}
 	case string(PhasePerformance):
-		if recipeResult.Validation != nil && recipeResult.Validation.Performance != nil {
-			// Add tests for constraints
-			for _, constraint := range recipeResult.Validation.Performance.Constraints {
-				testName, ok := checks.GetTestNameForConstraint(constraint.Name)
-				if ok && !uniqueTests[testName] {
-					testNames = append(testNames, testName)
-					uniqueTests[testName] = true
-					slog.Debug("constraint mapped to test", "constraint", constraint.Name, "test", testName)
-				}
-			}
-
-			// Add tests for explicit checks
-			for _, checkName := range recipeResult.Validation.Performance.Checks {
-				testName, ok := checks.GetTestNameForCheck(checkName)
-				if !ok {
-					testName = checkNameToTestName(checkName)
-				}
-				if !uniqueTests[testName] {
-					testNames = append(testNames, testName)
-					uniqueTests[testName] = true
-					slog.Debug("check mapped to test", "check", checkName, "test", testName)
-				}
-			}
+		if recipeResult.Validation.Performance != nil {
+			return buildTestPatternFromItems(recipeResult.Validation.Performance.Checks, recipeResult.Validation.Performance.Constraints)
 		}
 	case string(PhaseConformance):
-		if recipeResult.Validation != nil && recipeResult.Validation.Conformance != nil {
-			// Add tests for constraints
-			for _, constraint := range recipeResult.Validation.Conformance.Constraints {
-				testName, ok := checks.GetTestNameForConstraint(constraint.Name)
-				if ok && !uniqueTests[testName] {
-					testNames = append(testNames, testName)
-					uniqueTests[testName] = true
-					slog.Debug("constraint mapped to test", "constraint", constraint.Name, "test", testName)
-				}
-			}
+		if recipeResult.Validation.Conformance != nil {
+			return buildTestPatternFromItems(recipeResult.Validation.Conformance.Checks, recipeResult.Validation.Conformance.Constraints)
+		}
+	}
 
-			// Add tests for explicit checks
-			for _, checkName := range recipeResult.Validation.Conformance.Checks {
-				testName, ok := checks.GetTestNameForCheck(checkName)
-				if !ok {
-					testName = checkNameToTestName(checkName)
-				}
-				if !uniqueTests[testName] {
-					testNames = append(testNames, testName)
-					uniqueTests[testName] = true
-					slog.Debug("check mapped to test", "check", checkName, "test", testName)
-				}
-			}
+	return buildTestPatternResult{}
+}
+
+// buildTestPatternFromItems builds a test pattern from explicit check and constraint lists.
+// This is the core pattern builder used by both buildTestPattern and executePhaseChecks.
+func buildTestPatternFromItems(checkRefs []recipe.CheckRef, constraints []recipe.Constraint) buildTestPatternResult {
+	var testNames []string
+	uniqueTests := make(map[string]bool)
+
+	for _, constraint := range constraints {
+		testName, ok := checks.GetTestNameForConstraint(constraint.Name)
+		if ok && !uniqueTests[testName] {
+			testNames = append(testNames, testName)
+			uniqueTests[testName] = true
+			slog.Debug("constraint mapped to test", "constraint", constraint.Name, "test", testName)
+		}
+	}
+
+	for _, check := range checkRefs {
+		testName, ok := checks.GetTestNameForCheck(check.Name)
+		if !ok {
+			testName = checkNameToTestName(check.Name)
+		}
+		if !uniqueTests[testName] {
+			testNames = append(testNames, testName)
+			uniqueTests[testName] = true
+			slog.Debug("check mapped to test", "check", check.Name, "test", testName)
 		}
 	}
 
 	if len(testNames) == 0 {
-		// No pattern - run all tests
-		slog.Debug("no pattern specified, will run all tests in package")
-		return buildTestPatternResult{Pattern: "", ExpectedTests: 0}
+		return buildTestPatternResult{}
 	}
 
-	// Build regex: ^(TestGPUOperatorVersion|TestCheckExpectedResources)$
 	pattern := "^(" + strings.Join(testNames, "|") + ")$"
-	slog.Info("built test pattern from recipe", "pattern", pattern, "tests", len(testNames))
+	slog.Info("built test pattern from items", "pattern", pattern, "tests", len(testNames))
 	return buildTestPatternResult{Pattern: pattern, ExpectedTests: len(testNames)}
+}
+
+// sanitizeLabelValue converts a check/constraint name to a valid Kubernetes Job name suffix.
+// Lowercases, replaces dots and underscores with hyphens, truncates to 40 chars.
+// sanitizeLabelValue converts a check or constraint name to a valid Kubernetes label value.
+// Lowercase, dots/underscores become hyphens, capped at 63 chars, no trailing hyphen.
+func sanitizeLabelValue(name string) string {
+	s := strings.ToLower(name)
+	s = strings.NewReplacer(".", "-", "_", "-").Replace(s)
+	if len(s) > 63 {
+		s = s[:63]
+	}
+	return strings.TrimRight(s, "-")
+}
+
+// resolveItemTimeout returns the timeout for an individual check or constraint.
+// Falls back to phaseTimeout if the item has no timeout specified.
+func resolveItemTimeout(itemTimeout string, phaseTimeout time.Duration) time.Duration {
+	if itemTimeout != "" {
+		if parsed, err := time.ParseDuration(itemTimeout); err == nil {
+			return parsed
+		}
+		slog.Warn("invalid item timeout, using phase timeout",
+			"timeout", itemTimeout, "phaseTimeout", phaseTimeout)
+	}
+	return phaseTimeout
+}
+
+// baseJobConfig returns a Job config with fields common to all Jobs in a validation run.
+// Callers set JobName, TestPattern, ExpectedTests, and Timeout on the returned config.
+func (v *Validator) baseJobConfig(testPackage string) agent.Config {
+	return agent.Config{
+		Namespace:          v.Namespace,
+		Image:              v.Image,
+		ImagePullSecrets:   v.ImagePullSecrets,
+		ServiceAccountName: "aicr-validator",
+		SnapshotConfigMap:  fmt.Sprintf("aicr-snapshot-%s", v.RunID),
+		RecipeConfigMap:    fmt.Sprintf("aicr-recipe-%s", v.RunID),
+		TestPackage:        testPackage,
+		Tolerations:        v.Tolerations,
+		Affinity:           preferCPUNodeAffinity(),
+	}
+}
+
+// phaseExecConfig holds phase-specific parameters for executePhaseChecks.
+type phaseExecConfig struct {
+	name           string
+	testPackage    string
+	defaultTimeout time.Duration
+	phase          *recipe.ValidationPhase
+	topLevel       *bool
+}
+
+// executePhaseChecks runs all checks and constraints for a phase using the
+// three-tier execution model: shared Job, isolated Jobs, external validators.
+// Results are appended to phaseResult.Checks.
+//
+//nolint:funlen // Orchestration function with sequential tier execution
+func (v *Validator) executePhaseChecks(
+	ctx context.Context,
+	recipeResult *recipe.RecipeResult,
+	cfg phaseExecConfig,
+	phaseResult *PhaseResult,
+) {
+
+	if cfg.phase == nil {
+		return
+	}
+
+	partition := partitionByIsolation(cfg.phase, cfg.topLevel)
+	if !partition.hasShared() && !partition.hasIsolated() {
+		return
+	}
+
+	if v.NoCluster {
+		slog.Info("no-cluster mode enabled, skipping cluster check execution",
+			"phase", cfg.name)
+		for _, check := range partition.SharedChecks {
+			phaseResult.Checks = append(phaseResult.Checks, CheckResult{
+				Name:   check.Name,
+				Status: ValidationStatusSkipped,
+				Reason: "skipped - no-cluster mode (test mode)",
+				Source: CheckSourceShared,
+			})
+		}
+		for _, check := range partition.IsolatedChecks {
+			phaseResult.Checks = append(phaseResult.Checks, CheckResult{
+				Name:   check.Name,
+				Status: ValidationStatusSkipped,
+				Reason: "skipped - no-cluster mode (test mode)",
+				Source: CheckSourceIsolated,
+			})
+		}
+		for _, ev := range cfg.phase.Validators {
+			phaseResult.Checks = append(phaseResult.Checks, CheckResult{
+				Name:   ev.Name,
+				Status: ValidationStatusSkipped,
+				Reason: "skipped - no-cluster mode (test mode)",
+				Source: CheckSourceExternal,
+			})
+		}
+		return
+	}
+
+	clientset, _, err := k8sclient.GetKubeClient()
+	if err != nil {
+		slog.Warn("Kubernetes client unavailable, skipping check execution",
+			"error", err, "phase", cfg.name)
+		phaseResult.Checks = append(phaseResult.Checks, CheckResult{
+			Name:   cfg.name,
+			Status: ValidationStatusPass,
+			Reason: "skipped - Kubernetes unavailable (test mode)",
+		})
+		return
+	}
+
+	v.validateRecipeRegistrations(recipeResult, cfg.name)
+	phaseTimeout := resolvePhaseTimeout(cfg.phase, cfg.defaultTimeout)
+	baseCfg := v.baseJobConfig(cfg.testPackage)
+
+	// Tier 1: Shared Job — all non-isolated checks + constraints in one Job
+	if partition.hasShared() {
+		patternResult := buildTestPatternFromItems(partition.SharedChecks, partition.SharedConstraints)
+		jobCfg := baseCfg
+		jobCfg.JobName = fmt.Sprintf("aicr-%s-%s", v.RunID, cfg.name)
+		jobCfg.TestPattern = patternResult.Pattern
+		jobCfg.ExpectedTests = patternResult.ExpectedTests
+		jobCfg.Timeout = phaseTimeout
+		jobCfg.Labels = map[string]string{
+			"aicr.nvidia.com/run-id": v.RunID,
+			"aicr.nvidia.com/phase":  cfg.name,
+			"aicr.nvidia.com/tier":   "shared",
+		}
+
+		deployer := agent.NewDeployer(clientset, jobCfg)
+		jobResult := v.runPhaseJob(ctx, deployer, jobCfg, cfg.name)
+		for i := range jobResult.Checks {
+			jobResult.Checks[i].Source = CheckSourceShared
+		}
+		phaseResult.Checks = append(phaseResult.Checks, jobResult.Checks...)
+	}
+
+	// Tier 2: Isolated checks — each gets its own Job with the same validator image
+	for _, check := range partition.IsolatedChecks {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		checkLabel := sanitizeLabelValue(check.Name)
+		patternResult := buildTestPatternFromItems([]recipe.CheckRef{check}, nil)
+		jobCfg := baseCfg
+		jobCfg.JobName = fmt.Sprintf("aicr-%s-%s-%s", v.RunID, cfg.name, checkLabel)
+		jobCfg.TestPattern = patternResult.Pattern
+		jobCfg.ExpectedTests = patternResult.ExpectedTests
+		jobCfg.Timeout = resolveItemTimeout(check.Timeout, phaseTimeout)
+		jobCfg.Labels = map[string]string{
+			"aicr.nvidia.com/run-id": v.RunID,
+			"aicr.nvidia.com/phase":  cfg.name,
+			"aicr.nvidia.com/tier":   "isolated",
+			"aicr.nvidia.com/check":  checkLabel,
+		}
+
+		deployer := agent.NewDeployer(clientset, jobCfg)
+		jobResult := v.runPhaseJob(ctx, deployer, jobCfg, cfg.name)
+		for i := range jobResult.Checks {
+			jobResult.Checks[i].Source = CheckSourceIsolated
+		}
+		phaseResult.Checks = append(phaseResult.Checks, jobResult.Checks...)
+	}
+
+	// Tier 2: Isolated constraints — each gets its own Job
+	for _, constraint := range partition.IsolatedConstraints {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		constraintLabel := sanitizeLabelValue(constraint.Name)
+		patternResult := buildTestPatternFromItems(nil, []recipe.Constraint{constraint})
+		jobCfg := baseCfg
+		jobCfg.JobName = fmt.Sprintf("aicr-%s-%s-%s", v.RunID, cfg.name, constraintLabel)
+		jobCfg.TestPattern = patternResult.Pattern
+		jobCfg.ExpectedTests = patternResult.ExpectedTests
+		jobCfg.Timeout = resolveItemTimeout(constraint.Timeout, phaseTimeout)
+		jobCfg.Labels = map[string]string{
+			"aicr.nvidia.com/run-id":     v.RunID,
+			"aicr.nvidia.com/phase":      cfg.name,
+			"aicr.nvidia.com/tier":       "isolated",
+			"aicr.nvidia.com/constraint": constraintLabel,
+		}
+
+		deployer := agent.NewDeployer(clientset, jobCfg)
+		jobResult := v.runPhaseJob(ctx, deployer, jobCfg, cfg.name)
+		for i := range jobResult.Checks {
+			jobResult.Checks[i].Source = CheckSourceIsolated
+		}
+		phaseResult.Checks = append(phaseResult.Checks, jobResult.Checks...)
+	}
+
+	// Tier 3: External validators — user-provided OCI containers
+	for _, ev := range cfg.phase.Validators {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		result := v.runExternalJob(ctx, clientset, ev, cfg.name)
+		phaseResult.Checks = append(phaseResult.Checks, result)
+	}
+}
+
+// runExternalJob deploys an external validator container as a Kubernetes Job.
+// Exit 0 = pass, non-zero = fail. Failure reason is extracted from pod termination
+// message or last lines of stdout.
+//
+//nolint:funlen // Sequential Job lifecycle steps
+func (v *Validator) runExternalJob(
+	ctx context.Context,
+	clientset k8sclient.Interface,
+	ev recipe.ExternalValidator,
+	phaseName string,
+) CheckResult {
+
+	evTimeout := resolveItemTimeout(ev.Timeout, defaults.ExternalValidatorTimeout)
+
+	validatorLabel := sanitizeLabelValue(ev.Name)
+	jobCfg := agent.Config{
+		Namespace:          v.Namespace,
+		JobName:            fmt.Sprintf("aicr-%s-%s-%s", v.RunID, phaseName, validatorLabel),
+		Image:              ev.Image,
+		ImagePullSecrets:   v.ImagePullSecrets,
+		ServiceAccountName: "aicr-validator",
+		SnapshotConfigMap:  fmt.Sprintf("aicr-snapshot-%s", v.RunID),
+		RecipeConfigMap:    fmt.Sprintf("aicr-recipe-%s", v.RunID),
+		ExternalCommand:    true,
+		Timeout:            evTimeout,
+		Tolerations:        v.Tolerations,
+		Affinity:           preferCPUNodeAffinity(),
+		Labels: map[string]string{
+			"aicr.nvidia.com/run-id":    v.RunID,
+			"aicr.nvidia.com/phase":     phaseName,
+			"aicr.nvidia.com/tier":      "external",
+			"aicr.nvidia.com/validator": validatorLabel,
+		},
+	}
+
+	deployer := agent.NewDeployer(clientset, jobCfg)
+
+	slog.Info("deploying external validator", "name", ev.Name, "image", ev.Image, "phase", phaseName)
+
+	// Deploy Job
+	if err := deployer.DeployJob(ctx); err != nil {
+		return CheckResult{
+			Name:   ev.Name,
+			Status: ValidationStatusFail,
+			Reason: fmt.Sprintf("failed to deploy external validator Job: %v", err),
+			Source: CheckSourceExternal,
+		}
+	}
+
+	// Stream logs in background
+	logCtx, cancelLogs := context.WithCancel(ctx)
+	defer cancelLogs()
+	streamingActive := startLogStreaming(logCtx, deployer, ev.Name)
+
+	// Wait for Job completion
+	if err := deployer.WaitForCompletion(ctx, evTimeout); err != nil {
+		cancelLogs()
+
+		// Capture logs for error context
+		var logs string
+		if !streamingActive {
+			if captured, logErr := deployer.GetPodLogs(ctx); logErr == nil && captured != "" {
+				logs = captured
+			}
+		}
+
+		if v.Cleanup {
+			if cleanupErr := deployer.CleanupJob(ctx); cleanupErr != nil {
+				slog.Warn("failed to cleanup external validator Job", "name", ev.Name, "error", cleanupErr)
+			}
+		}
+
+		reason := fmt.Sprintf("external validator %q failed: %v", ev.Name, err)
+		if logs != "" {
+			logLines := strings.Split(strings.TrimSpace(logs), "\n")
+			lastLines := logLines
+			if len(logLines) > 10 {
+				lastLines = logLines[len(logLines)-10:]
+			}
+			reason += fmt.Sprintf("\n\nLast %d lines of output:\n%s", len(lastLines), strings.Join(lastLines, "\n"))
+		}
+
+		return CheckResult{
+			Name:   ev.Name,
+			Status: ValidationStatusFail,
+			Reason: reason,
+			Source: CheckSourceExternal,
+		}
+	}
+
+	// Success — cleanup and return pass
+	if v.Cleanup {
+		if cleanupErr := deployer.CleanupJob(ctx); cleanupErr != nil {
+			slog.Warn("failed to cleanup external validator Job", "name", ev.Name, "error", cleanupErr)
+		}
+	}
+
+	slog.Info("external validator passed", "name", ev.Name, "image", ev.Image)
+	return CheckResult{
+		Name:   ev.Name,
+		Status: ValidationStatusPass,
+		Source: CheckSourceExternal,
+	}
 }

--- a/pkg/validator/phases_test.go
+++ b/pkg/validator/phases_test.go
@@ -218,7 +218,7 @@ func TestValidateDeployment(t *testing.T) {
 			name: "with checks",
 			validationConfig: &recipe.ValidationConfig{
 				Deployment: &recipe.ValidationPhase{
-					Checks: []string{"expected-resources"},
+					Checks: []recipe.CheckRef{{Name: "expected-resources"}},
 				},
 			},
 			wantStatus: ValidationStatusPass,
@@ -237,7 +237,7 @@ func TestValidateDeployment(t *testing.T) {
 					Constraints: []recipe.Constraint{
 						{Name: "gpu-operator.version", Value: "== v25.10.1"},
 					},
-					Checks: []string{"expected-resources"},
+					Checks: []recipe.CheckRef{{Name: "expected-resources"}},
 				},
 			},
 			wantStatus: ValidationStatusPass,
@@ -297,7 +297,7 @@ func TestValidatePerformance(t *testing.T) {
 			validationConfig: &recipe.ValidationConfig{
 				Performance: &recipe.ValidationPhase{
 					Infrastructure: "nccl-doctor",
-					Checks:         []string{"nccl-bandwidth-test", "fabric-health"},
+					Checks:         []recipe.CheckRef{{Name: "nccl-bandwidth-test"}, {Name: "fabric-health"}},
 				},
 			},
 			wantStatus: ValidationStatusPass,
@@ -362,7 +362,7 @@ func TestValidateConformance(t *testing.T) {
 			name: "with checks",
 			validationConfig: &recipe.ValidationConfig{
 				Conformance: &recipe.ValidationPhase{
-					Checks: []string{"ai-workload-validation"},
+					Checks: []recipe.CheckRef{{Name: "ai-workload-validation"}},
 				},
 			},
 			wantStatus: ValidationStatusPass,
@@ -529,11 +529,11 @@ func createTestRecipeWithValidation() *recipe.RecipeResult {
 		},
 		Validation: &recipe.ValidationConfig{
 			Deployment: &recipe.ValidationPhase{
-				Checks: []string{"expected-resources"},
+				Checks: []recipe.CheckRef{{Name: "expected-resources"}},
 			},
 			Performance: &recipe.ValidationPhase{
 				Infrastructure: "nccl-doctor",
-				Checks:         []string{"nccl-bandwidth-test", "fabric-health"},
+				Checks:         []recipe.CheckRef{{Name: "nccl-bandwidth-test"}, {Name: "fabric-health"}},
 			},
 			// Conformance not configured (will be skipped)
 		},
@@ -908,7 +908,7 @@ func TestValidateRecipeRegistrations(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Deployment: &recipe.ValidationPhase{
-						Checks: []string{"nonexistent-check"},
+						Checks: []recipe.CheckRef{{Name: "nonexistent-check"}},
 					},
 				},
 			},
@@ -953,7 +953,7 @@ func TestValidateRecipeRegistrations(t *testing.T) {
 						Constraints: []recipe.Constraint{
 							{Name: "Performance.nonexistent-metric.value", Value: ">= 100"},
 						},
-						Checks: []string{"nonexistent-perf-check"},
+						Checks: []recipe.CheckRef{{Name: "nonexistent-perf-check"}},
 					},
 				},
 			},
@@ -969,7 +969,7 @@ func TestValidateRecipeRegistrations(t *testing.T) {
 						Constraints: []recipe.Constraint{
 							{Name: "Conformance.fake.value", Value: ">= 1.0"},
 						},
-						Checks: []string{"fake-conformance-check"},
+						Checks: []recipe.CheckRef{{Name: "fake-conformance-check"}},
 					},
 				},
 			},
@@ -1116,7 +1116,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Deployment: &recipe.ValidationPhase{
-						Checks:      []string{},
+						Checks:      []recipe.CheckRef{},
 						Constraints: []recipe.Constraint{},
 					},
 				},
@@ -1130,7 +1130,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Performance: &recipe.ValidationPhase{
-						Checks: []string{"perf-check"},
+						Checks: []recipe.CheckRef{{Name: "perf-check"}},
 					},
 				},
 			},
@@ -1158,7 +1158,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Performance: &recipe.ValidationPhase{
-						Checks:      []string{},
+						Checks:      []recipe.CheckRef{},
 						Constraints: []recipe.Constraint{},
 					},
 				},
@@ -1172,7 +1172,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Conformance: &recipe.ValidationPhase{
-						Checks: []string{"conformance-check"},
+						Checks: []recipe.CheckRef{{Name: "conformance-check"}},
 					},
 				},
 			},
@@ -1185,7 +1185,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Deployment: &recipe.ValidationPhase{
-						Checks: []string{"test-registered-check"},
+						Checks: []recipe.CheckRef{{Name: "test-registered-check"}},
 					},
 				},
 			},
@@ -1198,7 +1198,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Deployment: &recipe.ValidationPhase{
-						Checks: []string{"some-unknown-check"},
+						Checks: []recipe.CheckRef{{Name: "some-unknown-check"}},
 					},
 				},
 			},
@@ -1211,7 +1211,7 @@ func TestBuildTestPattern(t *testing.T) {
 			recipe: &recipe.RecipeResult{
 				Validation: &recipe.ValidationConfig{
 					Deployment: &recipe.ValidationPhase{
-						Checks: []string{"test-registered-check", "some-unknown-check"},
+						Checks: []recipe.CheckRef{{Name: "test-registered-check"}, {Name: "some-unknown-check"}},
 					},
 				},
 			},
@@ -1315,6 +1315,229 @@ func TestResolvePhaseTimeout(t *testing.T) {
 			got := resolvePhaseTimeout(tt.phase, tt.defaultTimeout)
 			if got != tt.want {
 				t.Errorf("resolvePhaseTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutePhaseChecks_NoCluster_WithIsolation(t *testing.T) {
+	isoTrue := true
+	isoFalse := false
+
+	v := &Validator{
+		NoCluster: true,
+		RunID:     "test-run",
+		Namespace: "default",
+	}
+
+	phaseResult := &PhaseResult{
+		Checks: []CheckResult{},
+	}
+
+	v.executePhaseChecks(context.Background(), &recipe.RecipeResult{
+		Validation: &recipe.ValidationConfig{
+			Deployment: &recipe.ValidationPhase{
+				Checks: []recipe.CheckRef{
+					{Name: "shared-check"},
+					{Name: "isolated-check", Isolated: &isoTrue},
+					{Name: "explicit-shared", Isolated: &isoFalse},
+				},
+				Validators: []recipe.ExternalValidator{
+					{Name: "custom-check", Image: "myregistry.io/check:v1.0"},
+				},
+			},
+		},
+	}, phaseExecConfig{
+		name:           "deployment",
+		testPackage:    "./pkg/validator/checks/deployment",
+		defaultTimeout: 5 * time.Minute,
+		phase: &recipe.ValidationPhase{
+			Checks: []recipe.CheckRef{
+				{Name: "shared-check"},
+				{Name: "isolated-check", Isolated: &isoTrue},
+				{Name: "explicit-shared", Isolated: &isoFalse},
+			},
+			Validators: []recipe.ExternalValidator{
+				{Name: "custom-check", Image: "myregistry.io/check:v1.0"},
+			},
+		},
+	}, phaseResult)
+
+	// Should have 4 stubs: 2 shared + 1 isolated + 1 external
+	if len(phaseResult.Checks) != 4 {
+		t.Fatalf("expected 4 checks, got %d: %+v", len(phaseResult.Checks), phaseResult.Checks)
+	}
+
+	// Check sources
+	sourceCount := map[string]int{}
+	for _, c := range phaseResult.Checks {
+		sourceCount[c.Source]++
+		if c.Status != ValidationStatusSkipped {
+			t.Errorf("check %q status = %q, want %q", c.Name, c.Status, ValidationStatusSkipped)
+		}
+	}
+
+	if sourceCount[CheckSourceShared] != 2 {
+		t.Errorf("shared checks = %d, want 2", sourceCount[CheckSourceShared])
+	}
+	if sourceCount[CheckSourceIsolated] != 1 {
+		t.Errorf("isolated checks = %d, want 1", sourceCount[CheckSourceIsolated])
+	}
+	if sourceCount[CheckSourceExternal] != 1 {
+		t.Errorf("external checks = %d, want 1", sourceCount[CheckSourceExternal])
+	}
+}
+
+func TestExecutePhaseChecks_NilPhase(t *testing.T) {
+	v := &Validator{NoCluster: true}
+	phaseResult := &PhaseResult{Checks: []CheckResult{}}
+
+	v.executePhaseChecks(context.Background(), &recipe.RecipeResult{}, phaseExecConfig{
+		name:  "deployment",
+		phase: nil,
+	}, phaseResult)
+
+	if len(phaseResult.Checks) != 0 {
+		t.Errorf("expected 0 checks for nil phase, got %d", len(phaseResult.Checks))
+	}
+}
+
+func TestSanitizeLabelValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple check name",
+			input: "expected-resources",
+			want:  "expected-resources",
+		},
+		{
+			name:  "constraint with dots",
+			input: "Deployment.gpu-operator.version",
+			want:  "deployment-gpu-operator-version",
+		},
+		{
+			name:  "underscores",
+			input: "my_custom_check",
+			want:  "my-custom-check",
+		},
+		{
+			name:  "mixed case",
+			input: "MyCheck",
+			want:  "mycheck",
+		},
+		{
+			name:  "truncation at 63 chars",
+			input: "this-is-a-very-long-check-name-that-exceeds-sixty-three-characters-by-a-lot",
+			want:  "this-is-a-very-long-check-name-that-exceeds-sixty-three-charact",
+		},
+		{
+			name:  "trailing hyphen removed",
+			input: "check-name-",
+			want:  "check-name",
+		},
+		{
+			name:  "trailing hyphen from truncation",
+			input: "a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-a-b-c-d-e-",
+			want:  "a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-a-b-c-d-e",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLabelValue(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeLabelValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveItemTimeout(t *testing.T) {
+	phaseTimeout := 10 * time.Minute
+
+	tests := []struct {
+		name         string
+		itemTimeout  string
+		phaseTimeout time.Duration
+		want         time.Duration
+	}{
+		{
+			name:         "empty falls back to phase timeout",
+			itemTimeout:  "",
+			phaseTimeout: phaseTimeout,
+			want:         phaseTimeout,
+		},
+		{
+			name:         "valid item timeout",
+			itemTimeout:  "5m",
+			phaseTimeout: phaseTimeout,
+			want:         5 * time.Minute,
+		},
+		{
+			name:         "invalid timeout falls back to phase",
+			itemTimeout:  "not-a-duration",
+			phaseTimeout: phaseTimeout,
+			want:         phaseTimeout,
+		},
+		{
+			name:         "seconds",
+			itemTimeout:  "30s",
+			phaseTimeout: phaseTimeout,
+			want:         30 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveItemTimeout(tt.itemTimeout, tt.phaseTimeout)
+			if got != tt.want {
+				t.Errorf("resolveItemTimeout(%q, %v) = %v, want %v", tt.itemTimeout, tt.phaseTimeout, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTestPatternFromItems(t *testing.T) {
+	tests := []struct {
+		name         string
+		checks       []recipe.CheckRef
+		constraints  []recipe.Constraint
+		wantPattern  string
+		wantExpected int
+		wantNonEmpty bool
+	}{
+		{
+			name:        "empty inputs",
+			checks:      nil,
+			wantPattern: "",
+		},
+		{
+			name:   "checks only",
+			checks: []recipe.CheckRef{{Name: "platform-health"}},
+			// The pattern depends on check registration; since we're testing the function
+			// itself and the check isn't registered, it falls back to checkNameToTestName
+			wantNonEmpty: true,
+			wantExpected: 1,
+		},
+		{
+			name:         "no registered items produces empty for unregistered constraints",
+			constraints:  []recipe.Constraint{{Name: "Unregistered.constraint", Value: ">= v1.0"}},
+			wantPattern:  "",
+			wantExpected: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTestPatternFromItems(tt.checks, tt.constraints)
+			if tt.wantNonEmpty && got.Pattern == "" {
+				t.Error("expected non-empty pattern")
+			}
+			if !tt.wantNonEmpty && got.Pattern != tt.wantPattern {
+				t.Errorf("Pattern = %q, want %q", got.Pattern, tt.wantPattern)
+			}
+			if tt.wantExpected > 0 && got.ExpectedTests != tt.wantExpected {
+				t.Errorf("ExpectedTests = %d, want %d", got.ExpectedTests, tt.wantExpected)
 			}
 		})
 	}

--- a/pkg/validator/result.go
+++ b/pkg/validator/result.go
@@ -41,6 +41,18 @@ const (
 	ValidationStatusWarning ValidationStatus = "warning"
 )
 
+// CheckSource constants indicate how a check was executed.
+const (
+	// CheckSourceShared means the check ran in the shared (combined) Job.
+	CheckSourceShared = "shared"
+
+	// CheckSourceIsolated means the check ran in its own isolated Job.
+	CheckSourceIsolated = "isolated"
+
+	// CheckSourceExternal means the check ran in a user-provided container.
+	CheckSourceExternal = "external"
+)
+
 // ConstraintStatus represents the outcome of evaluating a single constraint.
 type ConstraintStatus string
 
@@ -159,6 +171,9 @@ type CheckResult struct {
 
 	// Reason explains why the check failed or was skipped.
 	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
+
+	// Source indicates how this check was executed (shared, isolated, external).
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
 
 	// Remediation provides actionable guidance for fixing failures.
 	Remediation string `json:"remediation,omitempty" yaml:"remediation,omitempty"`

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -186,15 +186,16 @@ func WithTolerations(tolerations []corev1.Toleration) Option {
 }
 
 // generateRunID creates a unique identifier for a validation run.
-// Format: YYYYMMDD-HHMMSS-RANDOM (e.g., "20260206-140523-a3f9b2c1e7d04a68")
+// Format: YYYYMMDD-HHMMSS-XXXX (e.g., "20260206-140523-a3f9").
+// The 4-hex suffix (2 bytes) provides sufficient uniqueness when combined with
+// the second-precision timestamp. The total RunID length (20 chars) keeps
+// derived Job names like "aicr-{runID}-{phase}-{check}" within the Kubernetes
+// 63-character label value limit.
 func generateRunID() string {
-	// Generate timestamp
 	timestamp := time.Now().Format("20060102-150405")
 
-	// Generate 16 random hex characters (8 bytes)
-	randomBytes := make([]byte, 8)
+	randomBytes := make([]byte, 2)
 	if _, err := rand.Read(randomBytes); err != nil {
-		// Fallback to timestamp only if random generation fails
 		return timestamp
 	}
 	randomHex := hex.EncodeToString(randomBytes)

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -575,7 +575,7 @@ func TestGenerateRunID(t *testing.T) {
 	// Test that RunID generation produces a valid format
 	runID := generateRunID()
 
-	// Expected format: YYYYMMDD-HHMMSS-XXXXXXXXXXXXXXXX (16 hex chars)
+	// Expected format: YYYYMMDD-HHMMSS-XXXX (4 hex chars)
 	parts := strings.Split(runID, "-")
 	if len(parts) != 3 {
 		t.Errorf("RunID format incorrect, expected 3 parts, got %d: %s", len(parts), runID)
@@ -591,9 +591,9 @@ func TestGenerateRunID(t *testing.T) {
 		t.Errorf("Time part should be 6 characters (HHMMSS), got %d: %s", len(parts[1]), parts[1])
 	}
 
-	// Check random part (16 hex characters)
-	if len(parts[2]) != 16 {
-		t.Errorf("Random part should be 16 characters, got %d: %s", len(parts[2]), parts[2])
+	// Check random part (4 hex characters)
+	if len(parts[2]) != 4 {
+		t.Errorf("Random part should be 4 characters, got %d: %s", len(parts[2]), parts[2])
 	}
 }
 


### PR DESCRIPTION
## Summary

Add per-check isolation and external validator support to the validation framework. Recipe authors can now run individual checks/constraints in their own Kubernetes Jobs for fault isolation, and bring their own OCI containers as external validators.

## Motivation

Today all checks in a phase run in a single Job. A crash or resource leak in one check kills the entire phase. This PR adds a cascading `isolated` flag (individual > phase > top-level > default false) that lets recipe authors control execution granularity, plus a `validators` field for external OCI containers.

## Recipe schema

```yaml
validation:
  isolated: false                         # top-level default
  deployment:
    isolated: true                        # phase override
    checks:
      - expected-resources                # string shorthand (backward compatible)
      - name: heavy-gpu-test              # object form with overrides
        isolated: true
        timeout: 10m
    constraints:
      - name: Deployment.gpu-operator.version
        value: ">= v24.6.0"
        isolated: true
    validators:                           # external OCI containers
      - name: custom-check
        image: myregistry.io/check:v1.0
        timeout: 5m
```

## Execution model

```
Phase: deployment
├── Tier 1: Shared Job (combined -run pattern for non-isolated items)
├── Tier 2: Isolated Jobs (individual -run pattern, same validator image)
└── Tier 3: External Jobs (user-provided image, exit-code protocol)
```

## Changes

**Recipe types** (`pkg/recipe/metadata.go`)
- Add `CheckRef` union type (string or object) with custom `UnmarshalYAML`
- Add `ExternalValidator` type (`name`, `image`, `timeout`)
- Add `Isolated *bool` and `Timeout` to `Constraint`, `ValidationPhase`, `ValidationConfig`
- Change `ValidationPhase.Checks` from `[]string` to `[]CheckRef` (backward compatible)

**Isolation logic** (`pkg/validator/isolation.go` — new)
- `resolveIsolated()`: cascading precedence (individual > phase > top-level > false)
- `partitionByIsolation()`: splits checks/constraints into shared vs isolated groups

**Phase runners** (`pkg/validator/phases_runners.go`)
- Extract `executePhaseChecks()` — central 3-tier orchestrator replacing duplicated logic in deployment/performance/conformance runners
- Add `runExternalJob()` for external validator Jobs
- Add helpers: `sanitizeLabelValue`, `resolveItemTimeout`, `baseJobConfig`

**Job agent** (`pkg/validator/agent/`)
- Add `Labels map[string]string` to `Config` — structured pod labels (`run-id`, `phase`, `tier`, `check`/`constraint`/`validator`)
- Add `ExternalCommand` flag — omits `go test` command, uses container ENTRYPOINT
- Add `TerminationMessageFallbackToLogsOnError` policy for external Jobs
- Merge config labels into pod template alongside base `app.kubernetes.io/*` labels
- Use `batch.kubernetes.io/job-name` for pod lookup (Kubernetes-native, no custom label needed)

**RunID** (`pkg/validator/validator.go`)
- Shorten from 16 hex chars to 4 hex chars (`YYYYMMDD-HHMMSS-XXXX`, 20 chars total)
- Keeps derived Job names within the Kubernetes 63-character label value limit

**Results** (`pkg/validator/result.go`)
- Add `Source` field (`shared`, `isolated`, `external`) to `CheckResult`

**Defaults** (`pkg/defaults/timeouts.go`)
- Add `ExternalValidatorTimeout` (10m) and `ExternalValidatorLogTailLines` (10)

**Demo** (`demos/isolation/`)
- End-to-end walkthrough on Kind cluster exercising all 3 tiers
- External validator example: DNS check (`Dockerfile` + `check.sh`)
- Captured output showing structured pod labels and result YAML

## Structured pod labels

Each validation pod gets structured labels for querying:

| Label | Tier 1 (shared) | Tier 2 (isolated) | Tier 3 (external) |
|-------|-----------------|--------------------|--------------------|
| `aicr.nvidia.com/run-id` | run ID | run ID | run ID |
| `aicr.nvidia.com/phase` | phase name | phase name | phase name |
| `aicr.nvidia.com/tier` | `shared` | `isolated` | `external` |
| `aicr.nvidia.com/check` | — | check name | — |
| `aicr.nvidia.com/constraint` | — | constraint name | — |
| `aicr.nvidia.com/validator` | — | — | validator name |

```bash
kubectl get pods -l aicr.nvidia.com/tier=isolated -n aicr-validation
kubectl get pods -l aicr.nvidia.com/check=expected-resources -n aicr-validation
```

## Files changed (24 files, +1702/−367)

| File | Change |
|------|--------|
| `pkg/recipe/metadata.go` | `CheckRef`, `ExternalValidator` types, `Isolated` fields |
| `pkg/recipe/metadata_test.go` | `CheckRef` YAML deserialization tests |
| `pkg/recipe/conformance_test.go` | Updated for `CheckRef` |
| `pkg/validator/isolation.go` | **New** — isolation resolution + partitioning |
| `pkg/validator/isolation_test.go` | **New** — 20 test cases |
| `pkg/validator/phases_runners.go` | 3-tier orchestrator, external validator support |
| `pkg/validator/phases_test.go` | Isolation, sanitization, timeout, pattern tests |
| `pkg/validator/result.go` | `Source` field, `CheckSource*` constants |
| `pkg/validator/validator.go` | RunID shortened to 4 hex chars |
| `pkg/validator/validator_test.go` | Updated RunID format assertion |
| `pkg/validator/agent/types.go` | `Labels`, `ExternalCommand`, `Cleanup` fields |
| `pkg/validator/agent/job.go` | Label merging, external command mode |
| `pkg/validator/agent/job_test.go` | External/internal/label tests |
| `pkg/validator/agent/wait.go` | `batch.kubernetes.io/job-name` pod lookup |
| `pkg/validator/agent/wait_test.go` | Updated pod label assertions |
| `pkg/validator/checks/runner.go` | `CheckRef` compatibility |
| `pkg/validator/checks/runner_test.go` | Updated for `CheckRef` |
| `pkg/validator/README.md` | Updated RunID format |
| `pkg/defaults/timeouts.go` | External validator constants |
| `demos/isolation/README.md` | **New** — end-to-end walkthrough |
| `demos/isolation/recipe.yaml` | **New** — mixed isolation demo recipe |
| `demos/isolation/result.yaml` | **New** — captured result output |
| `demos/isolation/external-validator/Dockerfile` | **New** — minimal BYO validator |
| `demos/isolation/external-validator/check.sh` | **New** — DNS check script |

## Test plan

- [x] `make test` (unit tests with race detector)
- [x] `make lint` (0 issues)
- [x] Kind cluster demo — all 3 tiers pass, structured labels verified on pods
- [x] Backward compatibility — string-form `checks: ["expected-resources"]` still works
