### PR TITLE
fix(install): widen JSON scan window to find browser_download_url on linux

### DIFF
--- a/install
+++ b/install
@@ -187,7 +187,7 @@ extract_asset_url() {
 
   # Fallback to browser_download_url (appears after "name" in the JSON)
   if [[ -z "$url" ]]; then
-    url=$(echo "$json" | sed -n "${name_line},$((name_line+15))p" | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+    url=$(echo "$json" | sed -n "${name_line},$((name_line+30))p" | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
   fi
 
   [[ -z "$url" ]] && err "Failed to extract download URL for '$asset_name'"


### PR DESCRIPTION
## Summary

- Widen JSON scan window from 15 to 30 lines in `extract_asset_url` to account for GitHub API `uploader` object nested between `name` and `browser_download_url` fields
- Without this fix, `./install` fails on Linux with: `Failed to extract download URL for 'aicr_0.9.0_linux_amd64.tar.gz'`

## Test plan

- [x] Run `./install` on Linux x86_64
- [x] Run `./install` on macOS arm64


## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
