### PR TITLE
chore: update go version

### DIFF
--- a/.settings.yaml
+++ b/.settings.yaml
@@ -14,7 +14,7 @@
 
 # Language Versions
 languages:
-  go: '1.26.0'
+  go: '1.26.1'
 
 # Build Tools
 build_tools:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/aicr
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module github.com/NVIDIA/aicr/site
 
-go 1.26.0
+go 1.26.1
 
 require github.com/google/docsy v0.14.0

--- a/validators/conformance/Dockerfile
+++ b/validators/conformance/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.26.1-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/validators/deployment/Dockerfile
+++ b/validators/deployment/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.26.1-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/validators/performance/Dockerfile
+++ b/validators/performance/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.26.1-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

updating go version to 1.26.1

## Motivation / Context

fixes a different PR, plus out of date.

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

-  [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
