### PR TITLE
fix(recipes): add global tolerate-all for nvsentinel GPU-node daemonsets

### DIFF
--- a/recipes/components/nvsentinel/values.yaml
+++ b/recipes/components/nvsentinel/values.yaml
@@ -18,7 +18,15 @@
 # Override release name prefix to avoid aicr-stack- prefix in resource names
 fullnameOverride: nvsentinel
 
-global: {}
+global:
+  # Tolerate all taints so GPU-node daemonsets (platform-connectors,
+  # gpu-health-monitor, syslog-health-monitor, metadata-collector) can
+  # schedule on nodes with NoSchedule/NoExecute taints set by ASG.
+  # Matches internal platform template behavior.
+  # TODO: remove once upstream NVSentinel chart defaults to this
+  # (see https://github.com/NVIDIA/NVSentinel/pull/1004)
+  tolerations:
+    - operator: Exists
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
## Summary
- Add `global.tolerations: [{operator: Exists}]` to nvsentinel component values so GPU-node daemonsets can schedule on tainted nodes.

## Problem
PR #309 upgraded NVSentinel and inadvertently removed the `accelerated` nodeScheduling section from the registry. This caused nvsentinel GPU-node daemonsets (platform-connectors, gpu-health-monitor, syslog-health-monitor, metadata-collector) to have no tolerations, preventing scheduling on GPU nodes with `NoSchedule`/`NoExecute` taints.

## Fix
Rather than restoring the registry `accelerated` section, match the internal platform template behavior by setting `global.tolerations: [{operator: Exists}]` in the component values. This propagates to all GPU-node daemonsets via the chart's `(.Values.global.tolerations | default .Values.tolerations)` pattern.

## Upstream
Filed https://github.com/NVIDIA/NVSentinel/pull/1004 to make this the chart default. This workaround can be removed once that's released.

## Test plan
- [x] Recipe validation tests pass
- [ ] Deploy on cluster with tainted GPU nodes and verify all nvsentinel daemonsets schedule