### PR TITLE
fix(recipes): override deprecated gcr.io kube-rbac-proxy image for dynamo

### DIFF
--- a/recipes/components/dynamo-platform/values.yaml
+++ b/recipes/components/dynamo-platform/values.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dynamo Platform Helm values (v0.9.0)
+# Dynamo Platform Helm values (v0.9.1)
 # NVIDIA Dynamo inference serving platform: operator and grove.
 # Provides OpenAI-compatible endpoints, KV-cache-aware routing,
 # disaggregated prefill/decode, and SLA-driven autoscaling.
@@ -30,6 +30,12 @@ dynamo-operator:
       image:
         # Pin to 0.9.0 — chart default renders 0.7.1 which lacks --enable-webhooks
         tag: "0.9.0"
+    kubeRbacProxy:
+      image:
+        # gcr.io/kubebuilder/kube-rbac-proxy is no longer available after gcr.io deprecation.
+        # TODO: remove once upstream dynamo chart updates the default image reference.
+        repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
+        tag: v0.15.0
 
   # Use Kubernetes-native service discovery (operator-level only;
   # runtime pods still require DYN_STORE_KV=mem to skip etcd leases)

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -347,7 +347,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
       defaultChart: dynamo-crds
-      defaultVersion: "0.9.0"
+      defaultVersion: "0.9.1"
       defaultNamespace: dynamo-system
 
   - name: dynamo-platform
@@ -360,7 +360,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
       defaultChart: dynamo-platform
-      defaultVersion: "0.9.0"
+      defaultVersion: "0.9.1"
       defaultNamespace: dynamo-system
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary
- Override `kube-rbac-proxy` image in dynamo-platform component values from deprecated `gcr.io` to `registry.k8s.io`.

## Problem
The dynamo-platform chart (v0.9.0) hardcodes `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0` as a sidecar image. Google deprecated `gcr.io` and this image is no longer available, causing `ImagePullBackOff` on the dynamo-operator controller-manager pod on new clusters (older clusters may have the image cached).

## Fix
Override via Helm values:
```yaml
dynamo-operator:
  controllerManager:
    kubeRbacProxy:
      image:
        repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
        tag: v0.15.0
```

## Test plan
- [ ] Deploy dynamo-platform on a fresh cluster and verify controller-manager pod starts successfully