### PR TITLE
fix(validator): correct NCCL bandwidth tolerance log from 90% to 10%

### DIFF
--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -196,9 +196,9 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	actualValue := fmt.Sprintf("%.2f GB/s", bandwidth)
 
 	if passed {
-		slog.Info("Bandwidth validation passed", "bandwidth", bandwidth, "threshold", threshold*0.9, "tolerance", "90%")
+		slog.Info("Bandwidth validation passed", "bandwidth", bandwidth, "threshold", threshold*0.9, "tolerance", "10%")
 	} else {
-		slog.Info("Bandwidth validation failed", "bandwidth", bandwidth, "threshold", threshold*0.9, "tolerance", "90%")
+		slog.Info("Bandwidth validation failed", "bandwidth", bandwidth, "threshold", threshold*0.9, "tolerance", "10%")
 	}
 
 	return actualValue, passed, nil


### PR DESCRIPTION
## Summary

- Fix misleading log message in NCCL all-reduce bandwidth validation: `tolerance=90%` → `tolerance=10%`

The math was correct (`threshold * 0.9`), but the log reported the multiplier (90%) instead of the tolerance (10%). This aligns with the comment on L194 and the earlier log on L126 which both already say 10%.

## Test plan

- [ ] `make test` passes
- [ ] Verify log output shows `tolerance=10%` in next validation run