### PR TITLE
docs(conformance): refresh evidence from EKS v1.35 cluster

### DIFF
--- a/docs/conformance/cncf/README.md
+++ b/docs/conformance/cncf/README.md
@@ -4,15 +4,15 @@
 
 This directory contains evidence for [CNCF Kubernetes AI Conformance](https://github.com/cncf/k8s-ai-conformance)
 certification. The evidence demonstrates that a cluster configured with a specific
-recipe meets the Must-have requirements for Kubernetes v1.34.
+recipe meets the Must-have requirements for Kubernetes v1.35.
 
 > **Note:** It is the **cluster configured by a recipe** that is conformant, not the
 > tool itself. The recipe determines which components are deployed and how they are
 > configured. Different recipes may produce clusters with different conformance profiles.
 
 **Recipe used:** `h100-eks-ubuntu-inference-dynamo`
-**Cluster:** EKS with p5.48xlarge (8x NVIDIA H100 80GB HBM3)
-**Kubernetes:** v1.34
+**Cluster:** EKS with 2x p5.48xlarge (8x NVIDIA H100 80GB HBM3 each)
+**Kubernetes:** v1.35
 
 ## Directory Structure
 
@@ -92,7 +92,7 @@ Alternatively, run the evidence collection script directly:
 | **Output** | Pass/fail + diagnostic artifacts | Detailed behavioral evidence (command outputs, logs, metrics) |
 | **DRA GPU allocation test** | Deploys pod, verifies GPU access + isolation | Same + nvidia-smi output capture |
 | **Gang scheduling test** | Deploys PodGroup, verifies co-scheduling | Same + worker logs |
-| **HPA autoscaling** | Metrics API + scale-up/down validation | CUDA N-Body stress test + scale-up |
+| **HPA autoscaling** | Metrics API + scale-up validation | CUDA GPU stress test + scale-up |
 | **Metrics** | Custom metrics API data-path verification | DCGM exporter + Prometheus queries |
 | **Gateway** | Condition verification (Accepted, Programmed) | Same |
 | **Webhook test** | Rejection test with invalid CR | Same |

--- a/docs/conformance/cncf/evidence/accelerator-metrics.md
+++ b/docs/conformance/cncf/evidence/accelerator-metrics.md
@@ -1,8 +1,8 @@
 # Accelerator & AI Service Metrics
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:38:56 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:41:11 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -22,14 +22,14 @@ Demonstrates two CNCF AI Conformance observability requirements:
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus
 NAME                                      READY   STATUS    RESTARTS   AGE
-prometheus-kube-prometheus-prometheus-0   2/2     Running   0          47h
+prometheus-kube-prometheus-prometheus-0   2/2     Running   0          18m
 ```
 
 **Prometheus service**
 ```
 $ kubectl get svc kube-prometheus-prometheus -n monitoring
-NAME                         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-kube-prometheus-prometheus   ClusterIP   172.20.243.81   <none>        9090/TCP,8080/TCP   47h
+NAME                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+kube-prometheus-prometheus   ClusterIP   172.20.135.224   <none>        9090/TCP,8080/TCP   18m
 ```
 
 ### Prometheus Adapter (Custom Metrics API)
@@ -38,14 +38,14 @@ kube-prometheus-prometheus   ClusterIP   172.20.243.81   <none>        9090/TCP,
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus-adapter
 NAME                                  READY   STATUS    RESTARTS   AGE
-prometheus-adapter-585f5dfc99-cwwdj   1/1     Running   0          47h
+prometheus-adapter-78b8b8d75c-fh4cf   1/1     Running   0          17m
 ```
 
 **Prometheus adapter service**
 ```
 $ kubectl get svc prometheus-adapter -n monitoring
-NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
-prometheus-adapter   ClusterIP   172.20.140.0   <none>        443/TCP   47h
+NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
+prometheus-adapter   ClusterIP   172.20.178.141   <none>        443/TCP   17m
 ```
 
 ### Grafana
@@ -54,7 +54,7 @@ prometheus-adapter   ClusterIP   172.20.140.0   <none>        443/TCP   47h
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana
 NAME                       READY   STATUS    RESTARTS   AGE
-grafana-6494c6659c-rh2ck   3/3     Running   0          47h
+grafana-56fbffd7d7-r2htr   3/3     Running   0          18m
 ```
 
 ## Accelerator Metrics (DCGM Exporter)
@@ -67,15 +67,16 @@ temperature, power draw, and more in Prometheus exposition format.
 **DCGM exporter pod**
 ```
 $ kubectl get pods -n gpu-operator -l app=nvidia-dcgm-exporter -o wide
-NAME                         READY   STATUS    RESTARTS   AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-nvidia-dcgm-exporter-zfgtq   1/1     Running   0          44h   10.0.0.10   node-a.example.internal   <none>           <none>
+NAME                         READY   STATUS    RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
+nvidia-dcgm-exporter-g2fjs   1/1     Running   0          15m   10.0.247.52    ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-dcgm-exporter-wqqqn   1/1     Running   0          15m   10.0.172.246   ip-10-0-171-111.ec2.internal   <none>           <none>
 ```
 
 **DCGM exporter service**
 ```
 $ kubectl get svc -n gpu-operator -l app=nvidia-dcgm-exporter
-NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
-nvidia-dcgm-exporter   ClusterIP   172.20.81.36   <none>        9400/TCP   44h
+NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+nvidia-dcgm-exporter   ClusterIP   172.20.181.11   <none>        9400/TCP   15m
 ```
 
 ### DCGM Metrics Endpoint
@@ -84,6 +85,36 @@ Query DCGM exporter directly to show raw GPU metrics in Prometheus format.
 
 **Key GPU metrics from DCGM exporter (sampled)**
 ```
+DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 30
+DCGM_FI_DEV_GPU_TEMP{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
+DCGM_FI_DEV_GPU_TEMP{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_GPU_TEMP{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
+DCGM_FI_DEV_GPU_TEMP{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_GPU_TEMP{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 113.611000
+DCGM_FI_DEV_POWER_USAGE{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.347000
+DCGM_FI_DEV_POWER_USAGE{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 65.709000
+DCGM_FI_DEV_POWER_USAGE{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.316000
+DCGM_FI_DEV_POWER_USAGE{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.717000
+DCGM_FI_DEV_POWER_USAGE{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 65.742000
+DCGM_FI_DEV_POWER_USAGE{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.328000
+DCGM_FI_DEV_POWER_USAGE{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 66.997000
+DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
 ```
 
 ### Prometheus Querying GPU Metrics
@@ -100,184 +131,368 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
-          "__name__": "DCGM_FI_DEV_GPU_UTIL",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia0",
-          "endpoint": "gpu-metrics",
-          "gpu": "0",
-          "instance": "10.0.0.10:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1772826012.651,
-          "0"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia1",
           "endpoint": "gpu-metrics",
           "gpu": "1",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
-          "container": "main",
+          "container": "nvidia-dcgm-exporter",
           "device": "nvidia2",
           "endpoint": "gpu-metrics",
           "gpu": "2",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "dynamo-workload",
+          "namespace": "gpu-operator",
           "pci_bus_id": "00000000:75:00.0",
-          "pod": "vllm-agg-0-vllmdecodeworker-wmvrk",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia6",
           "endpoint": "gpu-metrics",
           "gpu": "6",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.651,
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia1",
+          "endpoint": "gpu-metrics",
+          "gpu": "1",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia3",
+          "endpoint": "gpu-metrics",
+          "gpu": "3",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:86:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia4",
+          "endpoint": "gpu-metrics",
+          "gpu": "4",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:97:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia5",
+          "endpoint": "gpu-metrics",
+          "gpu": "5",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:A8:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia6",
+          "endpoint": "gpu-metrics",
+          "gpu": "6",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:B9:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia7",
+          "endpoint": "gpu-metrics",
+          "gpu": "7",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:CA:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
+          "__name__": "DCGM_FI_DEV_GPU_UTIL",
+          "container": "main",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-s65j5",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.184,
           "0"
         ]
       }
@@ -296,185 +511,369 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
-          "__name__": "DCGM_FI_DEV_FB_USED",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia0",
-          "endpoint": "gpu-metrics",
-          "gpu": "0",
-          "instance": "10.0.0.10:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1772826012.9,
-          "0"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia1",
           "endpoint": "gpu-metrics",
           "gpu": "1",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
+          1773114089.444,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_FB_USED",
-          "container": "main",
+          "container": "nvidia-dcgm-exporter",
           "device": "nvidia2",
           "endpoint": "gpu-metrics",
           "gpu": "2",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "dynamo-workload",
+          "namespace": "gpu-operator",
           "pci_bus_id": "00000000:75:00.0",
-          "pod": "vllm-agg-0-vllmdecodeworker-wmvrk",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
-          "74166"
+          1773114089.444,
+          "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
+          1773114089.444,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
+          1773114089.444,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
+          1773114089.444,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia6",
           "endpoint": "gpu-metrics",
           "gpu": "6",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
+          1773114089.444,
           "0"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826012.9,
+          1773114089.444,
           "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia1",
+          "endpoint": "gpu-metrics",
+          "gpu": "1",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia3",
+          "endpoint": "gpu-metrics",
+          "gpu": "3",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:86:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia4",
+          "endpoint": "gpu-metrics",
+          "gpu": "4",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:97:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia5",
+          "endpoint": "gpu-metrics",
+          "gpu": "5",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:A8:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia6",
+          "endpoint": "gpu-metrics",
+          "gpu": "6",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:B9:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia7",
+          "endpoint": "gpu-metrics",
+          "gpu": "7",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:CA:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "0"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
+          "__name__": "DCGM_FI_DEV_FB_USED",
+          "container": "main",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-s65j5",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.444,
+          "74166"
         ]
       }
     ]
@@ -492,185 +891,369 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
-          "__name__": "DCGM_FI_DEV_GPU_TEMP",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia0",
-          "endpoint": "gpu-metrics",
-          "gpu": "0",
-          "instance": "10.0.0.10:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1772826013.126,
-          "27"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia1",
           "endpoint": "gpu-metrics",
           "gpu": "1",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.126,
+          1773114089.702,
           "29"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
-          "container": "main",
+          "container": "nvidia-dcgm-exporter",
           "device": "nvidia2",
           "endpoint": "gpu-metrics",
           "gpu": "2",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "dynamo-workload",
+          "namespace": "gpu-operator",
           "pci_bus_id": "00000000:75:00.0",
-          "pod": "vllm-agg-0-vllmdecodeworker-wmvrk",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.126,
-          "30"
+          1773114089.702,
+          "26"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.126,
-          "30"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
-          "__name__": "DCGM_FI_DEV_GPU_TEMP",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia4",
-          "endpoint": "gpu-metrics",
-          "gpu": "4",
-          "instance": "10.0.0.10:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1772826013.126,
+          1773114089.702,
           "29"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia4",
+          "endpoint": "gpu-metrics",
+          "gpu": "4",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:97:00.0",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "28"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.126,
+          1773114089.702,
+          "26"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia6",
+          "endpoint": "gpu-metrics",
+          "gpu": "6",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:B9:00.0",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "28"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia7",
+          "endpoint": "gpu-metrics",
+          "gpu": "7",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:CA:00.0",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "26"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
           "27"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
-          "device": "nvidia6",
+          "device": "nvidia1",
           "endpoint": "gpu-metrics",
-          "gpu": "6",
-          "instance": "10.0.0.10:9400",
+          "gpu": "1",
+          "instance": "10.0.247.52:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.126,
+          1773114089.702,
+          "29"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
           "28"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia3",
+          "endpoint": "gpu-metrics",
+          "gpu": "3",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:86:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "29"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia4",
+          "endpoint": "gpu-metrics",
+          "gpu": "4",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:97:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "29"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia5",
+          "endpoint": "gpu-metrics",
+          "gpu": "5",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:A8:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "27"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia6",
+          "endpoint": "gpu-metrics",
+          "gpu": "6",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:B9:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "30"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.247.52:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.126,
-          "28"
+          1773114089.702,
+          "27"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
+          "__name__": "DCGM_FI_DEV_GPU_TEMP",
+          "container": "main",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-s65j5",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.702,
+          "30"
         ]
       }
     ]
@@ -688,185 +1271,369 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138",
-          "__name__": "DCGM_FI_DEV_POWER_USAGE",
-          "container": "nvidia-dcgm-exporter",
-          "device": "nvidia0",
-          "endpoint": "gpu-metrics",
-          "gpu": "0",
-          "instance": "10.0.0.10:9400",
-          "job": "nvidia-dcgm-exporter",
-          "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "gpu-operator",
-          "pci_bus_id": "00000000:53:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
-          "service": "nvidia-dcgm-exporter"
-        },
-        "value": [
-          1772826013.35,
-          "67.56"
-        ]
-      },
-      {
-        "metric": {
-          "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia1",
           "endpoint": "gpu-metrics",
           "gpu": "1",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:64:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "71.226"
+          1773114089.943,
+          "68.347"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
-          "container": "main",
+          "container": "nvidia-dcgm-exporter",
           "device": "nvidia2",
           "endpoint": "gpu-metrics",
           "gpu": "2",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
-          "namespace": "dynamo-workload",
+          "namespace": "gpu-operator",
           "pci_bus_id": "00000000:75:00.0",
-          "pod": "vllm-agg-0-vllmdecodeworker-wmvrk",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "116.381"
+          1773114089.943,
+          "65.709"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia3",
           "endpoint": "gpu-metrics",
           "gpu": "3",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:86:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "67.94"
+          1773114089.943,
+          "67.316"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia4",
           "endpoint": "gpu-metrics",
           "gpu": "4",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:97:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "69.245"
+          1773114089.943,
+          "68.717"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia5",
           "endpoint": "gpu-metrics",
           "gpu": "5",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:A8:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "66.621"
+          1773114089.943,
+          "65.742"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia6",
           "endpoint": "gpu-metrics",
           "gpu": "6",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:B9:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "67.478"
+          1773114089.943,
+          "67.328"
         ]
       },
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "node-a.example.internal",
-          "UUID": "GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
           "device": "nvidia7",
           "endpoint": "gpu-metrics",
           "gpu": "7",
-          "instance": "10.0.0.10:9400",
+          "instance": "10.0.172.246:9400",
           "job": "nvidia-dcgm-exporter",
           "modelName": "NVIDIA H100 80GB HBM3",
           "namespace": "gpu-operator",
           "pci_bus_id": "00000000:CA:00.0",
-          "pod": "nvidia-dcgm-exporter-zfgtq",
+          "pod": "nvidia-dcgm-exporter-wqqqn",
           "service": "nvidia-dcgm-exporter"
         },
         "value": [
-          1772826013.35,
-          "68.215"
+          1773114089.943,
+          "66.997"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "69.339"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia1",
+          "endpoint": "gpu-metrics",
+          "gpu": "1",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:64:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "68.754"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia2",
+          "endpoint": "gpu-metrics",
+          "gpu": "2",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:75:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "68.61"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia3",
+          "endpoint": "gpu-metrics",
+          "gpu": "3",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:86:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "66.499"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia4",
+          "endpoint": "gpu-metrics",
+          "gpu": "4",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:97:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "67.645"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia5",
+          "endpoint": "gpu-metrics",
+          "gpu": "5",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:A8:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "66.68"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia6",
+          "endpoint": "gpu-metrics",
+          "gpu": "6",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:B9:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "68.395"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "nvidia-dcgm-exporter",
+          "device": "nvidia7",
+          "endpoint": "gpu-metrics",
+          "gpu": "7",
+          "instance": "10.0.247.52:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "gpu-operator",
+          "pci_bus_id": "00000000:CA:00.0",
+          "pod": "nvidia-dcgm-exporter-g2fjs",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "69.523"
+        ]
+      },
+      {
+        "metric": {
+          "DCGM_FI_DRIVER_VERSION": "580.105.08",
+          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
+          "__name__": "DCGM_FI_DEV_POWER_USAGE",
+          "container": "main",
+          "device": "nvidia0",
+          "endpoint": "gpu-metrics",
+          "gpu": "0",
+          "instance": "10.0.172.246:9400",
+          "job": "nvidia-dcgm-exporter",
+          "modelName": "NVIDIA H100 80GB HBM3",
+          "namespace": "dynamo-workload",
+          "pci_bus_id": "00000000:53:00.0",
+          "pod": "vllm-agg-0-vllmdecodeworker-s65j5",
+          "service": "nvidia-dcgm-exporter"
+        },
+        "value": [
+          1773114089.943,
+          "113.611"
         ]
       }
     ]
@@ -881,13 +1648,13 @@ enabling HPA and other consumers to act on workload-specific metrics.
 
 **Custom metrics API available resources**
 ```
-$ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | jq .resources[].name
-pods/gpu_power_usage
+$ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | python3 -c "..." # extract resource names
 namespaces/gpu_utilization
 pods/gpu_utilization
 namespaces/gpu_memory_used
 pods/gpu_memory_used
 namespaces/gpu_power_usage
+pods/gpu_power_usage
 ```
 
 **Result: PASS** — DCGM exporter provides per-GPU metrics (utilization, memory, temperature, power). Prometheus actively scrapes and stores metrics. Custom metrics API available via prometheus-adapter.

--- a/docs/conformance/cncf/evidence/cluster-autoscaling.md
+++ b/docs/conformance/cncf/evidence/cluster-autoscaling.md
@@ -1,15 +1,15 @@
 # Cluster Autoscaling
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:43:17 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:44:07 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
 
-Demonstrates CNCF AI Conformance requirement that the platform can scale up/down
-node groups containing specific accelerator types based on pending pods requesting
-those accelerators.
+Demonstrates CNCF AI Conformance requirement that the platform has GPU-aware
+cluster autoscaling infrastructure configured, with Auto Scaling Groups capable
+of scaling GPU node groups based on workload demand.
 
 ## Summary
 
@@ -31,7 +31,7 @@ up/down based on workload demand. The ASG is configured with p5.48xlarge instanc
 ## EKS Cluster Details
 
 - **Region:** us-east-1
-- **Cluster:** aws-us-east-1-example-cluster
+- **Cluster:** aws-us-east-1-aicr-cuj2
 - **GPU Node Group:** gpu-worker
 
 ## GPU Nodes
@@ -39,24 +39,57 @@ up/down based on workload demand. The ASG is configured with p5.48xlarge instanc
 **GPU nodes**
 ```
 $ kubectl get nodes -l nvidia.com/gpu.present=true -o custom-columns=NAME:.metadata.name,INSTANCE-TYPE:.metadata.labels.node\.kubernetes\.io/instance-type,GPUS:.metadata.labels.nvidia\.com/gpu\.count,PRODUCT:.metadata.labels.nvidia\.com/gpu\.product,NODE-GROUP:.metadata.labels.nodeGroup,ZONE:.metadata.labels.topology\.kubernetes\.io/zone
-NAME                             INSTANCE-TYPE   GPUS   PRODUCT                 NODE-GROUP   ZONE
-node-a.example.internal   p5.48xlarge     8      NVIDIA-H100-80GB-HBM3   gpu-worker   us-east-1e
+NAME                           INSTANCE-TYPE   GPUS   PRODUCT                 NODE-GROUP   ZONE
+ip-10-0-171-111.ec2.internal   p5.48xlarge     8      NVIDIA-H100-80GB-HBM3   gpu-worker   us-east-1e
+ip-10-0-206-2.ec2.internal     p5.48xlarge     8      NVIDIA-H100-80GB-HBM3   gpu-worker   us-east-1e
 ```
 
 ## Auto Scaling Group (AWS)
 
 **GPU ASG details**
 ```
-$ aws autoscaling describe-auto-scaling-groups --region us-east-1 --auto-scaling-group-names None
-None --query AutoScalingGroups[0].{Name:AutoScalingGroupName,MinSize:MinSize,MaxSize:MaxSize,DesiredCapacity:DesiredCapacity,AvailabilityZones:AvailabilityZones,HealthCheckType:HealthCheckType} --output table
+$ aws autoscaling describe-auto-scaling-groups --region us-east-1 --auto-scaling-group-names aicr-cuj2-gpu-worker --query AutoScalingGroups[0].{Name:AutoScalingGroupName,MinSize:MinSize,MaxSize:MaxSize,DesiredCapacity:DesiredCapacity,AvailabilityZones:AvailabilityZones,HealthCheckType:HealthCheckType} --output table
+---------------------------------------------
+|         DescribeAutoScalingGroups         |
++------------------+------------------------+
+|  DesiredCapacity |  2                     |
+|  HealthCheckType |  EC2                   |
+|  MaxSize         |  2                     |
+|  MinSize         |  2                     |
+|  Name            |  aicr-cuj2-gpu-worker  |
++------------------+------------------------+
+||            AvailabilityZones            ||
+|+-----------------------------------------+|
+||  us-east-1e                             ||
+|+-----------------------------------------+|
+```
 
+**GPU launch template**
+```
+$ aws ec2 describe-launch-template-versions --region us-east-1 --launch-template-id lt-038186420dd139467 --versions $Latest --query LaunchTemplateVersions[0].LaunchTemplateData.{InstanceType:InstanceType,ImageId:ImageId} --output table
+-------------------------------------------
+|     DescribeLaunchTemplateVersions      |
++------------------------+----------------+
+|         ImageId        | InstanceType   |
++------------------------+----------------+
+|  ami-0d60865d127c3d404 |  p5.48xlarge   |
++------------------------+----------------+
 ```
 
 **ASG autoscaler tags**
 ```
-$ aws autoscaling describe-tags --region us-east-1 --filters Name=auto-scaling-group,Values=None
-None --query Tags[*].{Key:Key,Value:Value} --output table
-
+$ aws autoscaling describe-tags --region us-east-1 --filters Name=auto-scaling-group,Values=aicr-cuj2-gpu-worker --query Tags[*].{Key:Key,Value:Value} --output table
+-----------------------------------------------------------------
+|                         DescribeTags                          |
++--------------------------------------+------------------------+
+|                  Key                 |         Value          |
++--------------------------------------+------------------------+
+|  Name                                |  aicr-cuj2-gpu-worker  |
+|  k8s.io/cluster-autoscaler/aicr-cuj2 |  owned                 |
+|  k8s.io/cluster-autoscaler/enabled   |  true                  |
+|  k8s.io/cluster/aicr-cuj2            |  owned                 |
+|  kubernetes.io/cluster/aicr-cuj2     |  owned                 |
++--------------------------------------+------------------------+
 ```
 
 ## Capacity Reservation
@@ -68,7 +101,7 @@ $ aws ec2 describe-capacity-reservations --region us-east-1 --query CapacityRese
 |    DescribeCapacityReservations     |
 +------------+------------------------+
 |  AZ        |  us-east-1e            |
-|  Available |  3                     |
+|  Available |  2                     |
 |  ID        |  cr-0cbe491320188dfa6  |
 |  State     |  active                |
 |  Total     |  10                    |
@@ -76,4 +109,4 @@ $ aws ec2 describe-capacity-reservations --region us-east-1 --query CapacityRese
 +------------+------------------------+
 ```
 
-**Result: PASS** — EKS cluster with GPU nodes managed by Auto Scaling Group, ASG configuration verified via AWS API.
+**Result: PASS** — EKS cluster with GPU nodes managed by Auto Scaling Group, ASG configuration verified via AWS API. Evidence is configuration-level; a live scale event is not triggered to avoid disrupting the cluster.

--- a/docs/conformance/cncf/evidence/dra-support.md
+++ b/docs/conformance/cncf/evidence/dra-support.md
@@ -1,8 +1,8 @@
 # DRA Support (Dynamic Resource Allocation)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:36:55 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:39:16 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -29,11 +29,11 @@ resourceslices                        resource.k8s.io/v1   false        Resource
 ```
 $ kubectl get deviceclass
 NAME                                        AGE
-compute-domain-daemon.nvidia.com            44h
-compute-domain-default-channel.nvidia.com   44h
-gpu.nvidia.com                              44h
-mig.nvidia.com                              44h
-vfio.gpu.nvidia.com                         44h
+compute-domain-daemon.nvidia.com            10m
+compute-domain-default-channel.nvidia.com   10m
+gpu.nvidia.com                              10m
+mig.nvidia.com                              10m
+vfio.gpu.nvidia.com                         10m
 ```
 
 ## DRA Driver Health
@@ -41,9 +41,10 @@ vfio.gpu.nvidia.com                         44h
 **DRA driver pods**
 ```
 $ kubectl get pods -n nvidia-dra-driver -o wide
-NAME                                               READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
-nvidia-dra-driver-gpu-controller-9d69fbdcb-z27mn   1/1     Running   0          44h   10.0.0.10      node-a.example.internal     <none>           <none>
-nvidia-dra-driver-gpu-kubelet-plugin-bdmdm         2/2     Running   0          44h   10.0.0.10   node-a.example.internal   <none>           <none>
+NAME                                                READY   STATUS    RESTARTS   AGE     IP             NODE                           NOMINATED NODE   READINESS GATES
+nvidia-dra-driver-gpu-controller-68966c79bb-zj7lf   1/1     Running   0          10m     10.0.4.122     ip-10-0-6-173.ec2.internal     <none>           <none>
+nvidia-dra-driver-gpu-kubelet-plugin-4kfhk          2/2     Running   0          9m54s   10.0.143.178   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-dra-driver-gpu-kubelet-plugin-grg2l          2/2     Running   0          9m54s   10.0.216.98    ip-10-0-206-2.ec2.internal     <none>           <none>
 ```
 
 ## Device Advertisement (ResourceSlices)
@@ -51,9 +52,11 @@ nvidia-dra-driver-gpu-kubelet-plugin-bdmdm         2/2     Running   0          
 **ResourceSlices**
 ```
 $ kubectl get resourceslices
-NAME                                                             NODE                             DRIVER                      POOL                             AGE
-node-a.example.internal-compute-domain.nvidia.com-bbg8t   node-a.example.internal   compute-domain.nvidia.com   node-a.example.internal   44h
-node-a.example.internal-gpu.nvidia.com-sgw47              node-a.example.internal   gpu.nvidia.com              node-a.example.internal   44h
+NAME                                                           NODE                           DRIVER                      POOL                           AGE
+ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-q9xqc   ip-10-0-171-111.ec2.internal   compute-domain.nvidia.com   ip-10-0-171-111.ec2.internal   10m
+ip-10-0-171-111.ec2.internal-gpu.nvidia.com-7cbz2              ip-10-0-171-111.ec2.internal   gpu.nvidia.com              ip-10-0-171-111.ec2.internal   10m
+ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-2n2cq     ip-10-0-206-2.ec2.internal     compute-domain.nvidia.com   ip-10-0-206-2.ec2.internal     10m
+ip-10-0-206-2.ec2.internal-gpu.nvidia.com-79gvw                ip-10-0-206-2.ec2.internal     gpu.nvidia.com              ip-10-0-206-2.ec2.internal     10m
 ```
 
 ## GPU Allocation Test
@@ -140,11 +143,13 @@ NAME        STATE     AGE
 gpu-claim   pending   11s
 ```
 
+> **Note:** ResourceClaim shows `pending` because the DRA controller deallocates the claim after pod completion. The pod logs below confirm the GPU was successfully allocated and visible during execution.
+
 **Pod status**
 ```
 $ kubectl get pod dra-gpu-test -n dra-test -o wide
-NAME           READY   STATUS      RESTARTS   AGE   IP              NODE                             NOMINATED NODE   READINESS GATES
-dra-gpu-test   0/1     Completed   0          11s   10.0.0.10   node-a.example.internal   <none>           <none>
+NAME           READY   STATUS      RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
+dra-gpu-test   0/1     Completed   0          13s   10.0.177.19   ip-10-0-206-2.ec2.internal   <none>           <none>
 ```
 
 **Pod logs**
@@ -153,7 +158,7 @@ $ kubectl logs dra-gpu-test -n dra-test
 /dev/nvidia-modeset
 /dev/nvidia-uvm
 /dev/nvidia-uvm-tools
-/dev/nvidia3
+/dev/nvidia2
 /dev/nvidiactl
 DRA GPU allocation successful
 ```

--- a/docs/conformance/cncf/evidence/gang-scheduling.md
+++ b/docs/conformance/cncf/evidence/gang-scheduling.md
@@ -1,8 +1,8 @@
 # Gang Scheduling (KAI Scheduler)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:37:40 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:39:53 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -16,26 +16,26 @@ scheduler with PodGroups. Both pods in the group must be scheduled together or n
 ```
 $ kubectl get deploy -n kai-scheduler
 NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
-admission               1/1     1            1           44h
-binder                  1/1     1            1           44h
-kai-operator            1/1     1            1           44h
-kai-scheduler-default   1/1     1            1           44h
-pod-grouper             1/1     1            1           44h
-podgroup-controller     1/1     1            1           44h
-queue-controller        1/1     1            1           44h
+admission               1/1     1            1           12m
+binder                  1/1     1            1           12m
+kai-operator            1/1     1            1           12m
+kai-scheduler-default   1/1     1            1           12m
+pod-grouper             1/1     1            1           12m
+podgroup-controller     1/1     1            1           12m
+queue-controller        1/1     1            1           12m
 ```
 
 **KAI scheduler pods**
 ```
 $ kubectl get pods -n kai-scheduler
 NAME                                     READY   STATUS    RESTARTS   AGE
-admission-54f4bcf874-lczkp               1/1     Running   0          44h
-binder-5f9dc97959-thrf8                  1/1     Running   0          44h
-kai-operator-86675bdc5d-ww9sf            1/1     Running   0          44h
-kai-scheduler-default-68bc7484b8-hczc2   1/1     Running   0          44h
-pod-grouper-56947ccdf-rslf9              1/1     Running   0          44h
-podgroup-controller-65c74cbc9c-nbwvr     1/1     Running   0          44h
-queue-controller-7847c76b97-zhzdv        1/1     Running   0          44h
+admission-6589f784c7-p268j               1/1     Running   0          12m
+binder-68767ff976-rf6n9                  1/1     Running   0          12m
+kai-operator-d48dd544d-g7pnx             1/1     Running   0          12m
+kai-scheduler-default-5b7c69664d-v5g8t   1/1     Running   0          12m
+pod-grouper-58d85f4696-jwlwg             1/1     Running   0          12m
+podgroup-controller-7df6598c76-dxjsc     1/1     Running   0          12m
+queue-controller-5f8fffc65b-2lz4q        1/1     Running   0          12m
 ```
 
 ## PodGroup CRD
@@ -44,7 +44,7 @@ queue-controller-7847c76b97-zhzdv        1/1     Running   0          44h
 ```
 $ kubectl get crd podgroups.scheduling.run.ai
 NAME                          CREATED AT
-podgroups.scheduling.run.ai   2026-02-28T18:05:52Z
+podgroups.scheduling.run.ai   2026-03-09T23:36:37Z
 ```
 
 ## Gang Scheduling Test
@@ -155,23 +155,23 @@ pod/gang-worker-1 created
 ```
 $ kubectl get podgroups -n gang-scheduling-test -o wide
 NAME                                                    AGE
-gang-test-group                                         11s
-pg-gang-worker-0-99f4d8ea-2574-4ed1-ba4f-8e83daededad   10s
-pg-gang-worker-1-0605b26c-1b90-4954-9e6f-8ec74c2713c2   10s
+gang-test-group                                         12s
+pg-gang-worker-0-e9426680-e2b1-4223-9a79-db8f979844f9   12s
+pg-gang-worker-1-f04dd44d-819f-4069-b367-df05c6685404   12s
 ```
 
 **Pod status**
 ```
 $ kubectl get pods -n gang-scheduling-test -o wide
-NAME            READY   STATUS      RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
-gang-worker-0   0/1     Completed   0          13s   10.0.0.10   node-a.example.internal   <none>           <none>
-gang-worker-1   0/1     Completed   0          12s   10.0.0.10   node-a.example.internal   <none>           <none>
+NAME            READY   STATUS      RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
+gang-worker-0   0/1     Completed   0          13s   10.0.162.59    ip-10-0-171-111.ec2.internal   <none>           <none>
+gang-worker-1   0/1     Completed   0          13s   10.0.144.109   ip-10-0-171-111.ec2.internal   <none>           <none>
 ```
 
 **gang-worker-0 logs**
 ```
 $ kubectl logs gang-worker-0 -n gang-scheduling-test
-Fri Mar  6 19:37:52 2026       
+Tue Mar 10 03:40:04 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
 +-----------------------------------------+------------------------+----------------------+
@@ -179,8 +179,8 @@ Fri Mar  6 19:37:52 2026
 | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
-|   0  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
-| N/A   29C    P0             71W /  700W |       0MiB /  81559MiB |      0%      Default |
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:97:00.0 Off |                    0 |
+| N/A   28C    P0             68W /  700W |       0MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 
@@ -197,7 +197,7 @@ Gang worker 0 completed successfully
 **gang-worker-1 logs**
 ```
 $ kubectl logs gang-worker-1 -n gang-scheduling-test
-Fri Mar  6 19:37:52 2026       
+Tue Mar 10 03:40:04 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
 +-----------------------------------------+------------------------+----------------------+
@@ -205,8 +205,8 @@ Fri Mar  6 19:37:52 2026
 | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
-|   0  NVIDIA H100 80GB HBM3          On  |   00000000:86:00.0 Off |                    0 |
-| N/A   30C    P0             67W /  700W |       0MiB /  81559MiB |      0%      Default |
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:B9:00.0 Off |                    0 |
+| N/A   28C    P0             67W /  700W |       0MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 

--- a/docs/conformance/cncf/evidence/index.md
+++ b/docs/conformance/cncf/evidence/index.md
@@ -1,8 +1,9 @@
 # CNCF AI Conformance Evidence
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Kubernetes Version:** v1.34
-**Platform:** EKS (p5.48xlarge, NVIDIA H100 80GB HBM3)
+**Kubernetes Version:** v1.35
+**Platform:** EKS (p5.48xlarge, 2x NVIDIA H100 80GB HBM3 nodes)
+**Generated:** 2026-03-10
 
 ## Results
 

--- a/docs/conformance/cncf/evidence/inference-gateway.md
+++ b/docs/conformance/cncf/evidence/inference-gateway.md
@@ -1,8 +1,8 @@
 # Inference API Gateway (kgateway)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:40:14 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:49:45 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -15,8 +15,8 @@ with an implementation for advanced traffic management for inference services.
 1. **kgateway controller** — Running in `kgateway-system`
 2. **inference-gateway deployment** — Running (the inference extension controller)
 3. **Gateway API CRDs** — All present (GatewayClass, Gateway, HTTPRoute, GRPCRoute, ReferenceGrant)
-4. **Inference extension CRDs** — InferencePool, InferenceModelRewrite, InferenceObjective, InferencePoolImport
-5. **Active Gateway** — `inference-gateway` with class `kgateway`, programmed with an AWS ELB address
+4. **Active Gateway** — `inference-gateway` with class `kgateway`, programmed with an AWS ELB address
+5. **Inference Extension CRDs** — InferencePool, InferenceModelRewrite, InferenceObjective installed
 6. **Result: PASS**
 
 ---
@@ -27,16 +27,16 @@ with an implementation for advanced traffic management for inference services.
 ```
 $ kubectl get deploy -n kgateway-system
 NAME                READY   UP-TO-DATE   AVAILABLE   AGE
-inference-gateway   1/1     1            1           47h
-kgateway            1/1     1            1           47h
+inference-gateway   1/1     1            1           28m
+kgateway            1/1     1            1           28m
 ```
 
 **kgateway pods**
 ```
 $ kubectl get pods -n kgateway-system
 NAME                                 READY   STATUS    RESTARTS   AGE
-inference-gateway-6f458cff9d-vtdl7   1/1     Running   0          47h
-kgateway-db4cf9d47-zh7sz             1/1     Running   0          47h
+inference-gateway-6f55d54bd8-gj9t8   1/1     Running   0          28m
+kgateway-7d6dfdc5dc-s6lwc            1/1     Running   0          28m
 ```
 
 ## GatewayClass
@@ -45,36 +45,20 @@ kgateway-db4cf9d47-zh7sz             1/1     Running   0          47h
 ```
 $ kubectl get gatewayclass
 NAME                CONTROLLER              ACCEPTED   AGE
-kgateway            kgateway.dev/kgateway   True       47h
-kgateway-waypoint   kgateway.dev/kgateway   True       47h
+kgateway            kgateway.dev/kgateway   True       28m
+kgateway-waypoint   kgateway.dev/kgateway   True       28m
 ```
 
 ## Gateway API CRDs
 
 **Gateway API CRDs**
 ```
-$ kubectl get crds -l gateway.networking.k8s.io/bundle-version
-No resources found
-```
-
-**All gateway-related CRDs**
-```
-gatewayclasses.gateway.networking.k8s.io               2026-03-04T19:59:49Z
-gateways.gateway.networking.k8s.io                     2026-03-04T19:59:49Z
-grpcroutes.gateway.networking.k8s.io                   2026-03-04T19:59:50Z
-httproutes.gateway.networking.k8s.io                   2026-03-04T19:59:50Z
-referencegrants.gateway.networking.k8s.io              2026-03-04T19:59:51Z
-```
-
-## Inference Extension CRDs
-
-**Inference CRDs**
-```
-inferencemodelrewrites.inference.networking.x-k8s.io   2026-03-04T19:59:52Z
-inferenceobjectives.inference.networking.x-k8s.io      2026-03-04T19:59:52Z
-inferencepoolimports.inference.networking.x-k8s.io     2026-03-04T19:59:53Z
-inferencepools.inference.networking.k8s.io             2026-03-04T19:59:53Z
-inferencepools.inference.networking.x-k8s.io           2026-03-04T19:59:53Z
+$ kubectl get crds | grep gateway.networking.k8s.io
+gatewayclasses.gateway.networking.k8s.io               2026-03-10T03:21:04Z
+gateways.gateway.networking.k8s.io                     2026-03-10T03:21:05Z
+grpcroutes.gateway.networking.k8s.io                   2026-03-10T03:21:05Z
+httproutes.gateway.networking.k8s.io                   2026-03-10T03:21:06Z
+referencegrants.gateway.networking.k8s.io              2026-03-10T03:21:06Z
 ```
 
 ## Active Gateway
@@ -82,8 +66,8 @@ inferencepools.inference.networking.x-k8s.io           2026-03-04T19:59:53Z
 **Gateways**
 ```
 $ kubectl get gateways -A
-NAMESPACE         NAME                CLASS      ADDRESS                                                                  PROGRAMMED   AGE
-kgateway-system   inference-gateway   kgateway   a190c6734e7d3416883754566d933798-665417928.us-east-1.elb.amazonaws.com   True         47h
+NAMESPACE         NAME                CLASS      ADDRESS                                                                   PROGRAMMED   AGE
+kgateway-system   inference-gateway   kgateway   <elb-redacted>.elb.amazonaws.com   True         28m
 ```
 
 **Gateway details**
@@ -98,12 +82,12 @@ metadata:
     helm.sh/hook-weight: "10"
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"gateway.networking.k8s.io/v1","kind":"Gateway","metadata":{"annotations":{"helm.sh/hook":"post-install,post-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"10"},"name":"inference-gateway","namespace":"kgateway-system"},"spec":{"gatewayClassName":"kgateway","infrastructure":{"parametersRef":{"group":"gateway.kgateway.dev","kind":"GatewayParameters","name":"system-proxy"}},"listeners":[{"allowedRoutes":{"namespaces":{"from":"All"}},"name":"http","port":80,"protocol":"HTTP"}]}}
-  creationTimestamp: "2026-03-04T20:00:08Z"
+  creationTimestamp: "2026-03-10T03:21:34Z"
   generation: 1
   name: inference-gateway
   namespace: kgateway-system
-  resourceVersion: "11036893"
-  uid: 039170bc-2d11-474c-917e-fbbc8ab35d48
+  resourceVersion: "1158803"
+  uid: 4dac636a-d90d-431c-9397-4baf2c81a150
 spec:
   gatewayClassName: kgateway
   infrastructure:
@@ -121,15 +105,15 @@ spec:
 status:
   addresses:
   - type: Hostname
-    value: a190c6734e7d3416883754566d933798-665417928.us-east-1.elb.amazonaws.com
+    value: <elb-redacted>.elb.amazonaws.com
   conditions:
-  - lastTransitionTime: "2026-03-04T20:00:15Z"
+  - lastTransitionTime: "2026-03-10T03:21:40Z"
     message: ""
     observedGeneration: 1
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: "2026-03-04T20:00:15Z"
+  - lastTransitionTime: "2026-03-10T03:21:40Z"
     message: ""
     observedGeneration: 1
     reason: Programmed
@@ -138,25 +122,25 @@ status:
   listeners:
   - attachedRoutes: 0
     conditions:
-    - lastTransitionTime: "2026-03-04T20:00:15Z"
+    - lastTransitionTime: "2026-03-10T03:21:40Z"
       message: ""
       observedGeneration: 1
       reason: Accepted
       status: "True"
       type: Accepted
-    - lastTransitionTime: "2026-03-04T20:00:15Z"
+    - lastTransitionTime: "2026-03-10T03:21:40Z"
       message: ""
       observedGeneration: 1
       reason: NoConflicts
       status: "False"
       type: Conflicted
-    - lastTransitionTime: "2026-03-04T20:00:15Z"
+    - lastTransitionTime: "2026-03-10T03:21:40Z"
       message: ""
       observedGeneration: 1
       reason: ResolvedRefs
       status: "True"
       type: ResolvedRefs
-    - lastTransitionTime: "2026-03-04T20:00:15Z"
+    - lastTransitionTime: "2026-03-10T03:21:40Z"
       message: ""
       observedGeneration: 1
       reason: Programmed
@@ -184,18 +168,16 @@ Accepted: True (Accepted)
 Programmed: True (Programmed)
 ```
 
-## Inference Resources
+## Inference Extension CRDs
 
-**InferencePools**
+**Inference extension CRDs installed**
 ```
-$ kubectl get inferencepools -A
-No resources found
-```
-
-**HTTPRoutes**
-```
-$ kubectl get httproutes -A
-No resources found
+$ kubectl get crds | grep inference
+inferencemodelrewrites.inference.networking.x-k8s.io   2026-03-10T03:21:06Z
+inferenceobjectives.inference.networking.x-k8s.io      2026-03-10T03:21:06Z
+inferencepoolimports.inference.networking.x-k8s.io     2026-03-10T03:21:07Z
+inferencepools.inference.networking.k8s.io             2026-03-10T03:21:07Z
+inferencepools.inference.networking.x-k8s.io           2026-03-10T03:21:07Z
 ```
 
 **Result: PASS** — kgateway controller running, GatewayClass Accepted, Gateway Programmed, inference CRDs installed.

--- a/docs/conformance/cncf/evidence/pod-autoscaling.md
+++ b/docs/conformance/cncf/evidence/pod-autoscaling.md
@@ -1,8 +1,8 @@
 # Pod Autoscaling (HPA with GPU Metrics)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:40:52 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:42:06 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -27,27 +27,27 @@ utilizing accelerators, including the ability to scale based on custom GPU metri
 ```
 $ kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus-adapter
 NAME                                  READY   STATUS    RESTARTS   AGE
-prometheus-adapter-585f5dfc99-cwwdj   1/1     Running   0          47h
+prometheus-adapter-78b8b8d75c-fh4cf   1/1     Running   0          18m
 ```
 
 **Prometheus adapter service**
 ```
 $ kubectl get svc prometheus-adapter -n monitoring
-NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
-prometheus-adapter   ClusterIP   172.20.140.0   <none>        443/TCP   47h
+NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
+prometheus-adapter   ClusterIP   172.20.178.141   <none>        443/TCP   18m
 ```
 
 ## Custom Metrics API
 
 **Available custom metrics**
 ```
-$ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | jq .resources[].name
-pods/gpu_memory_used
+$ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | python3 -c "..." # extract resource names
+namespaces/gpu_memory_used
 namespaces/gpu_power_usage
 pods/gpu_power_usage
 pods/gpu_utilization
 namespaces/gpu_utilization
-namespaces/gpu_memory_used
+pods/gpu_memory_used
 ```
 
 ## GPU Stress Test Deployment
@@ -166,8 +166,8 @@ horizontalpodautoscaler.autoscaling/gpu-workload-hpa created
 **GPU workload pod**
 ```
 $ kubectl get pods -n hpa-test -o wide
-NAME                            READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
-gpu-workload-6d87f8c876-dk552   1/1     Running   0          58s   10.0.0.10   node-a.example.internal   <none>           <none>
+NAME                            READY   STATUS    RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
+gpu-workload-86c75dcd97-2wk4f   1/1     Running   0          3s    10.0.254.75   ip-10-0-206-2.ec2.internal   <none>           <none>
 ```
 
 ## HPA Status
@@ -176,7 +176,7 @@ gpu-workload-6d87f8c876-dk552   1/1     Running   0          58s   10.0.0.10   n
 ```
 $ kubectl get hpa -n hpa-test
 NAME               REFERENCE                 TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
-gpu-workload-hpa   Deployment/gpu-workload   100/50    1         2         2          116s
+gpu-workload-hpa   Deployment/gpu-workload   100/50    1         2         2          90s
 ```
 
 **HPA details**
@@ -186,10 +186,10 @@ Name:                         gpu-workload-hpa
 Namespace:                    hpa-test
 Labels:                       <none>
 Annotations:                  <none>
-CreationTimestamp:            Fri, 06 Mar 2026 11:41:01 -0800
+CreationTimestamp:            Mon, 09 Mar 2026 20:42:14 -0700
 Reference:                    Deployment/gpu-workload
 Metrics:                      ( current / target )
-  "gpu_utilization" on pods:  100 / 50
+  "gpu_utilization" on pods:  50 / 50
 Min replicas:                 1
 Max replicas:                 2
 Behavior:
@@ -212,22 +212,20 @@ Conditions:
   ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from pods metric gpu_utilization
   ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
 Events:
-  Type     Reason                        Age                From                       Message
-  ----     ------                        ----               ----                       -------
-  Warning  FailedGetPodsMetric           102s               horizontal-pod-autoscaler  unable to get metric gpu_utilization: no metrics returned from custom metrics API
-  Warning  FailedComputeMetricsReplicas  102s               horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get pods metric value: unable to get metric gpu_utilization: no metrics returned from custom metrics API
-  Warning  FailedGetPodsMetric           71s (x2 over 86s)  horizontal-pod-autoscaler  did not receive metrics for targeted pods (pods might be unready)
-  Warning  FailedComputeMetricsReplicas  71s (x2 over 86s)  horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get pods metric value: did not receive metrics for targeted pods (pods might be unready)
-  Normal   SuccessfulRescale             26s                horizontal-pod-autoscaler  New size: 2; reason: pods metric gpu_utilization above target
+  Type     Reason                        Age   From                       Message
+  ----     ------                        ----  ----                       -------
+  Warning  FailedGetPodsMetric           76s   horizontal-pod-autoscaler  unable to get metric gpu_utilization: no metrics returned from custom metrics API
+  Warning  FailedComputeMetricsReplicas  76s   horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get pods metric value: unable to get metric gpu_utilization: no metrics returned from custom metrics API
+  Normal   SuccessfulRescale             31s   horizontal-pod-autoscaler  New size: 2; reason: pods metric gpu_utilization above target
 ```
 
 ## GPU Utilization Evidence
 
 **GPU utilization (nvidia-smi)**
 ```
-$ kubectl exec -n hpa-test gpu-workload-6d87f8c876-64jdz -- nvidia-smi --query-gpu=utilization.gpu,utilization.memory,power.draw --format=csv
+$ kubectl exec -n hpa-test gpu-workload-86c75dcd97-2wk4f -- nvidia-smi --query-gpu=utilization.gpu,utilization.memory,power.draw --format=csv
 utilization.gpu [%], utilization.memory [%], power.draw [W]
-100 %, 0 %, 304.79 W
+100 %, 0 %, 290.28 W
 ```
 
 ## Pods After Scale-Up
@@ -235,9 +233,9 @@ utilization.gpu [%], utilization.memory [%], power.draw [W]
 **Pods after scale-up**
 ```
 $ kubectl get pods -n hpa-test -o wide
-NAME                            READY   STATUS    RESTARTS   AGE    IP               NODE                             NOMINATED NODE   READINESS GATES
-gpu-workload-6d87f8c876-64jdz   1/1     Running   0          30s    10.0.0.10    node-a.example.internal   <none>           <none>
-gpu-workload-6d87f8c876-dk552   1/1     Running   0          2m1s   10.0.0.10   node-a.example.internal   <none>           <none>
+NAME                            READY   STATUS    RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
+gpu-workload-86c75dcd97-2wk4f   1/1     Running   0          96s   10.0.254.75   ip-10-0-206-2.ec2.internal   <none>           <none>
+gpu-workload-86c75dcd97-4gbn8   1/1     Running   0          36s   10.0.219.76   ip-10-0-206-2.ec2.internal   <none>           <none>
 ```
 
 **Result: PASS** — HPA successfully read gpu_utilization metric and scaled replicas when utilization exceeded target threshold.

--- a/docs/conformance/cncf/evidence/robust-operator.md
+++ b/docs/conformance/cncf/evidence/robust-operator.md
@@ -1,8 +1,8 @@
 # Robust AI Operator (Dynamo Platform)
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:40:34 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:41:48 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -16,7 +16,7 @@ webhooks operational, and custom resources reconciled.
 1. **Dynamo Operator** — Controller manager running in `dynamo-system`
 2. **Custom Resource Definitions** — 6 Dynamo CRDs registered (DynamoGraphDeployment, DynamoComponentDeployment, etc.)
 3. **Webhooks Operational** — Validating webhook configured and active
-4. **Custom Resource Reconciled** — `DynamoGraphDeployment/vllm-agg` reconciled with workload pods running
+4. **Custom Resource Reconciled** — `DynamoGraphDeployment/vllm-agg` reconciled into running workload pods via PodCliques
 5. **Supporting Services** — etcd and NATS running for Dynamo platform state management
 6. **Result: PASS**
 
@@ -28,30 +28,30 @@ webhooks operational, and custom resources reconciled.
 ```
 $ kubectl get deploy -n dynamo-system
 NAME                                                 READY   UP-TO-DATE   AVAILABLE   AGE
-dynamo-platform-dynamo-operator-controller-manager   1/1     1            1           45h
-grove-operator                                       1/1     1            1           45h
+dynamo-platform-dynamo-operator-controller-manager   1/1     1            1           13m
+grove-operator                                       1/1     1            1           13m
 ```
 
 **Dynamo operator pods**
 ```
 $ kubectl get pods -n dynamo-system
 NAME                                                              READY   STATUS      RESTARTS      AGE
-dynamo-platform-dynamo-operator-controller-manager-79b8c695zghj   2/2     Running     0             45h
-dynamo-platform-dynamo-operator-webhook-ca-inject-1-dtl2s         0/1     Completed   0             45h
-dynamo-platform-dynamo-operator-webhook-cert-gen-1-qzzdr          0/1     Completed   0             45h
-grove-operator-6848cc55b8-xdlcm                                   1/1     Running     1 (45h ago)   45h
+dynamo-platform-dynamo-operator-controller-manager-59f6dc6gs7tt   2/2     Running     0             13m
+dynamo-platform-dynamo-operator-webhook-ca-inject-1-6t95h         0/1     Completed   0             13m
+dynamo-platform-dynamo-operator-webhook-cert-gen-1-bnqwh          0/1     Completed   0             13m
+grove-operator-7c69b46ddf-mxgtz                                   1/1     Running     1 (13m ago)   13m
 ```
 
 ## Custom Resource Definitions
 
 **Dynamo CRDs**
 ```
-dynamocomponentdeployments.nvidia.com                  2026-03-04T19:59:36Z
-dynamographdeploymentrequests.nvidia.com               2026-03-04T19:59:35Z
-dynamographdeployments.nvidia.com                      2026-03-04T19:59:36Z
-dynamographdeploymentscalingadapters.nvidia.com        2026-03-04T19:59:35Z
-dynamomodels.nvidia.com                                2026-03-04T19:59:35Z
-dynamoworkermetadatas.nvidia.com                       2026-03-04T19:59:35Z
+dynamocomponentdeployments.nvidia.com                  2026-03-10T03:20:42Z
+dynamographdeploymentrequests.nvidia.com               2026-03-10T03:20:42Z
+dynamographdeployments.nvidia.com                      2026-03-10T03:20:42Z
+dynamographdeploymentscalingadapters.nvidia.com        2026-03-10T03:20:42Z
+dynamomodels.nvidia.com                                2026-03-10T03:20:42Z
+dynamoworkermetadatas.nvidia.com                       2026-03-10T03:20:42Z
 ```
 
 ## Webhooks
@@ -60,24 +60,24 @@ dynamoworkermetadatas.nvidia.com                       2026-03-04T19:59:35Z
 ```
 $ kubectl get validatingwebhookconfigurations -l app.kubernetes.io/instance=dynamo-platform
 NAME                                         WEBHOOKS   AGE
-dynamo-platform-dynamo-operator-validating   4          45h
+dynamo-platform-dynamo-operator-validating   4          13m
 ```
 
 **Dynamo validating webhooks**
 ```
-dynamo-platform-dynamo-operator-validating   4          45h
+dynamo-platform-dynamo-operator-validating   4          13m
 ```
 
 ## Custom Resource Reconciliation
 
 A `DynamoGraphDeployment` defines an inference serving graph. The operator reconciles
-it into component deployments with pods, services, and scaling configuration.
+it into workload pods managed via PodCliques.
 
 **DynamoGraphDeployments**
 ```
 $ kubectl get dynamographdeployments -A
 NAMESPACE         NAME       AGE
-dynamo-workload   vllm-agg   45h
+dynamo-workload   vllm-agg   5m33s
 ```
 
 **DynamoGraphDeployment details**
@@ -88,15 +88,15 @@ kind: DynamoGraphDeployment
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoGraphDeployment","metadata":{"annotations":{},"name":"vllm-agg","namespace":"dynamo-workload"},"spec":{"services":{"Frontend":{"componentType":"frontend","envs":[{"name":"SERVED_MODEL_NAME","value":"Qwen/Qwen3-0.6B"},{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"image":"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0"},"nodeSelector":{"dedicated":"cpu-workload"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"cpu-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"cpu-workload"}]},"replicas":1},"VllmDecodeWorker":{"componentType":"worker","envs":[{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"args":["--model","Qwen/Qwen3-0.6B"],"command":["python3","-m","dynamo.vllm"],"image":"nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0","workingDir":"/workspace/examples/backends/vllm"},"nodeSelector":{"dedicated":"gpu-workload"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"gpu-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"gpu-workload"}]},"replicas":1,"resources":{"limits":{"gpu":"1"}}}}}}
-  creationTimestamp: "2026-03-04T22:35:53Z"
+      {"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoGraphDeployment","metadata":{"annotations":{},"name":"vllm-agg","namespace":"dynamo-workload"},"spec":{"services":{"Frontend":{"componentType":"frontend","envs":[{"name":"SERVED_MODEL_NAME","value":"Qwen/Qwen3-0.6B"},{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"image":"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0"},"nodeSelector":{"nodeGroup":"cpu-worker"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"worker-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"worker-workload"}]},"replicas":1},"VllmDecodeWorker":{"componentType":"worker","envs":[{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"args":["--model","Qwen/Qwen3-0.6B"],"command":["python3","-m","dynamo.vllm"],"image":"nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0","workingDir":"/workspace/examples/backends/vllm"},"nodeSelector":{"nodeGroup":"gpu-worker"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"worker-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"worker-workload"}]},"replicas":1,"resources":{"limits":{"gpu":"1"}}}}}}
+  creationTimestamp: "2026-03-10T03:36:25Z"
   finalizers:
   - nvidia.com/finalizer
   generation: 2
   name: vllm-agg
   namespace: dynamo-workload
-  resourceVersion: "11964563"
-  uid: 5cee71eb-5d99-482a-b4f9-524d88c36633
+  resourceVersion: "1196446"
+  uid: c38afc11-ad45-41af-aca9-6cdabfeb456d
 spec:
   services:
     Frontend:
@@ -114,16 +114,16 @@ spec:
           name: ""
           resources: {}
         nodeSelector:
-          dedicated: cpu-workload
+          nodeGroup: cpu-worker
         tolerations:
         - effect: NoSchedule
           key: dedicated
           operator: Equal
-          value: cpu-workload
+          value: worker-workload
         - effect: NoExecute
           key: dedicated
           operator: Equal
-          value: cpu-workload
+          value: worker-workload
       replicas: 1
     VllmDecodeWorker:
       componentType: worker
@@ -146,23 +146,23 @@ spec:
           resources: {}
           workingDir: /workspace/examples/backends/vllm
         nodeSelector:
-          dedicated: gpu-workload
+          nodeGroup: gpu-worker
         tolerations:
         - effect: NoSchedule
           key: dedicated
           operator: Equal
-          value: gpu-workload
+          value: worker-workload
         - effect: NoExecute
           key: dedicated
           operator: Equal
-          value: gpu-workload
+          value: worker-workload
       replicas: 1
       resources:
         limits:
           gpu: "1"
 status:
   conditions:
-  - lastTransitionTime: "2026-03-06T13:33:50Z"
+  - lastTransitionTime: "2026-03-10T03:38:07Z"
     message: All resources are ready
     reason: all_resources_are_ready
     status: "True"
@@ -187,18 +187,20 @@ status:
 
 **Dynamo workload pods**
 ```
-$ kubectl get pods -n dynamo-workload -o wide
-NAME                                READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
-vllm-agg-0-frontend-kdhdj           1/1     Running   0          45h   10.0.0.10   node-a.example.internal    <none>           <none>
-vllm-agg-0-vllmdecodeworker-wmvrk   1/1     Running   0          45h   10.0.0.10   node-a.example.internal   <none>           <none>
+$ kubectl get pods -n dynamo-workload -l nvidia.com/dynamo-graph-deployment-name -o wide
+NAME                                READY   STATUS    RESTARTS   AGE     IP             NODE                           NOMINATED NODE   READINESS GATES
+vllm-agg-0-frontend-kkmpd           1/1     Running   0          5m35s   10.0.222.55    ip-10-0-196-144.ec2.internal   <none>           <none>
+vllm-agg-0-vllmdecodeworker-s65j5   1/1     Running   0          5m35s   10.0.235.180   ip-10-0-171-111.ec2.internal   <none>           <none>
 ```
 
-### Component Deployments
+### PodCliques
 
-**DynamoComponentDeployments**
+**PodCliques**
 ```
-$ kubectl get dynamocomponentdeployments -n dynamo-workload
-No resources found in dynamo-workload namespace.
+$ kubectl get podcliques -n dynamo-workload
+NAME                          AGE
+vllm-agg-0-frontend           5m36s
+vllm-agg-0-vllmdecodeworker   5m36s
 ```
 
 ## Webhook Rejection Test
@@ -213,4 +215,4 @@ Error from server (Forbidden): error when creating "STDIN": admission webhook "v
 
 Webhook correctly rejected the invalid resource.
 
-**Result: PASS** — Dynamo operator running, webhooks operational (rejection verified), CRDs registered, DynamoGraphDeployment reconciled with workload pods.
+**Result: PASS** — Dynamo operator running, webhooks operational (rejection verified), CRDs registered, DynamoGraphDeployment reconciled with 2 healthy workload pod(s).

--- a/docs/conformance/cncf/evidence/secure-accelerator-access.md
+++ b/docs/conformance/cncf/evidence/secure-accelerator-access.md
@@ -1,8 +1,8 @@
 # Secure Accelerator Access
 
 **Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-06 19:38:16 UTC
-**Kubernetes Version:** v1.34
+**Generated:** 2026-03-10 03:40:33 UTC
+**Kubernetes Version:** v1.35
 **Platform:** linux/amd64
 
 ---
@@ -19,7 +19,7 @@ access control, and auditability of accelerator usage.
 ```
 $ kubectl get clusterpolicy -o wide
 NAME             STATUS   AGE
-cluster-policy   ready    2026-03-04T22:42:37Z
+cluster-policy   ready    2026-03-10T03:25:45Z
 ```
 
 ### GPU Operator Pods
@@ -27,20 +27,31 @@ cluster-policy   ready    2026-03-04T22:42:37Z
 **GPU operator pods**
 ```
 $ kubectl get pods -n gpu-operator -o wide
-NAME                                            READY   STATUS      RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
-gpu-feature-discovery-8ll95                     1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-gpu-operator-786cd6c97d-ltrx4                   1/1     Running     0          44h   10.0.0.10     node-a.example.internal      <none>           <none>
-node-feature-discovery-gc-bc77948b7-c4s4w       1/1     Running     0          44h   10.0.0.10     node-a.example.internal      <none>           <none>
-node-feature-discovery-master-69bb75cbf-w5d79   1/1     Running     0          44h   10.0.0.10      node-a.example.internal      <none>           <none>
-node-feature-discovery-worker-n2s2p             1/1     Running     0          44h   10.0.0.10     node-a.example.internal   <none>           <none>
-nvidia-container-toolkit-daemonset-lvc26        1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-nvidia-cuda-validator-dcdzt                     0/1     Completed   0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-nvidia-dcgm-bn89w                               1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-nvidia-dcgm-exporter-zfgtq                      1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-nvidia-device-plugin-daemonset-4vrtv            1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-nvidia-driver-daemonset-ppwxt                   3/3     Running     0          44h   10.0.0.10   node-a.example.internal   <none>           <none>
-nvidia-mig-manager-95lbg                        1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
-nvidia-operator-validator-gwj97                 1/1     Running     0          44h   10.0.0.10    node-a.example.internal   <none>           <none>
+NAME                                             READY   STATUS      RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
+gpu-feature-discovery-6rcxf                      1/1     Running     0          14m   10.0.224.30    ip-10-0-206-2.ec2.internal     <none>           <none>
+gpu-feature-discovery-8jhh7                      1/1     Running     0          14m   10.0.224.179   ip-10-0-171-111.ec2.internal   <none>           <none>
+gpu-operator-6bf99d6478-r55t5                    1/1     Running     0          14m   10.0.6.44      ip-10-0-6-165.ec2.internal     <none>           <none>
+node-feature-discovery-gc-5495c9b5c9-5jhtb       1/1     Running     0          14m   10.0.4.105     ip-10-0-6-165.ec2.internal     <none>           <none>
+node-feature-discovery-master-6f876b9c85-97zcw   1/1     Running     0          14m   10.0.6.62      ip-10-0-6-165.ec2.internal     <none>           <none>
+node-feature-discovery-worker-7z8fm              1/1     Running     0          14m   10.0.230.31    ip-10-0-196-144.ec2.internal   <none>           <none>
+node-feature-discovery-worker-9s5tc              1/1     Running     0          14m   10.0.154.69    ip-10-0-171-111.ec2.internal   <none>           <none>
+node-feature-discovery-worker-vb62k              1/1     Running     0          14m   10.0.189.91    ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-container-toolkit-daemonset-c49gs         1/1     Running     0          14m   10.0.201.217   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-container-toolkit-daemonset-lr895         1/1     Running     0          14m   10.0.182.110   ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-cuda-validator-9866n                      0/1     Completed   0          12m   10.0.247.169   ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-cuda-validator-f42hd                      0/1     Completed   0          12m   10.0.143.223   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-dcgm-4bq8l                                1/1     Running     0          14m   10.0.145.214   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-dcgm-exporter-g2fjs                       1/1     Running     0          14m   10.0.247.52    ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-dcgm-exporter-wqqqn                       1/1     Running     0          14m   10.0.172.246   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-dcgm-xjsqq                                1/1     Running     0          14m   10.0.159.246   ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-device-plugin-daemonset-5884b             1/1     Running     0          14m   10.0.255.120   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-device-plugin-daemonset-kx2zg             1/1     Running     0          14m   10.0.185.249   ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-driver-daemonset-qc7cg                    3/3     Running     0          14m   10.0.198.38    ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-driver-daemonset-vvlsc                    3/3     Running     0          14m   10.0.166.43    ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-mig-manager-4gn76                         1/1     Running     0          14m   10.0.135.89    ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-mig-manager-8s9wj                         1/1     Running     0          14m   10.0.253.166   ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-operator-validator-twprm                  1/1     Running     0          14m   10.0.231.53    ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-operator-validator-vwnsb                  1/1     Running     0          14m   10.0.194.119   ip-10-0-206-2.ec2.internal     <none>           <none>
 ```
 
 ### GPU Operator DaemonSets
@@ -49,16 +60,16 @@ nvidia-operator-validator-gwj97                 1/1     Running     0          4
 ```
 $ kubectl get ds -n gpu-operator
 NAME                                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                                          AGE
-gpu-feature-discovery                     1         1         1       1            1           nvidia.com/gpu.deploy.gpu-feature-discovery=true                       44h
-node-feature-discovery-worker             1         1         1       1            1           <none>                                                                 44h
-nvidia-container-toolkit-daemonset        1         1         1       1            1           nvidia.com/gpu.deploy.container-toolkit=true                           44h
-nvidia-dcgm                               1         1         1       1            1           nvidia.com/gpu.deploy.dcgm=true                                        44h
-nvidia-dcgm-exporter                      1         1         1       1            1           nvidia.com/gpu.deploy.dcgm-exporter=true                               44h
-nvidia-device-plugin-daemonset            1         1         1       1            1           nvidia.com/gpu.deploy.device-plugin=true                               44h
-nvidia-device-plugin-mps-control-daemon   0         0         0       0            0           nvidia.com/gpu.deploy.device-plugin=true,nvidia.com/mps.capable=true   44h
-nvidia-driver-daemonset                   1         1         1       1            1           nvidia.com/gpu.deploy.driver=true                                      44h
-nvidia-mig-manager                        1         1         1       1            1           nvidia.com/gpu.deploy.mig-manager=true                                 44h
-nvidia-operator-validator                 1         1         1       1            1           nvidia.com/gpu.deploy.operator-validator=true                          44h
+gpu-feature-discovery                     2         2         2       2            2           nvidia.com/gpu.deploy.gpu-feature-discovery=true                       14m
+node-feature-discovery-worker             3         3         3       3            3           <none>                                                                 14m
+nvidia-container-toolkit-daemonset        2         2         2       2            2           nvidia.com/gpu.deploy.container-toolkit=true                           14m
+nvidia-dcgm                               2         2         2       2            2           nvidia.com/gpu.deploy.dcgm=true                                        14m
+nvidia-dcgm-exporter                      2         2         2       2            2           nvidia.com/gpu.deploy.dcgm-exporter=true                               14m
+nvidia-device-plugin-daemonset            2         2         2       2            2           nvidia.com/gpu.deploy.device-plugin=true                               14m
+nvidia-device-plugin-mps-control-daemon   0         0         0       0            0           nvidia.com/gpu.deploy.device-plugin=true,nvidia.com/mps.capable=true   14m
+nvidia-driver-daemonset                   2         2         2       2            2           nvidia.com/gpu.deploy.driver=true                                      14m
+nvidia-mig-manager                        2         2         2       2            2           nvidia.com/gpu.deploy.mig-manager=true                                 14m
+nvidia-operator-validator                 2         2         2       2            2           nvidia.com/gpu.deploy.operator-validator=true                          14m
 ```
 
 ## DRA-Mediated GPU Access
@@ -72,9 +83,11 @@ GPU devices via ResourceSlices, and pods request access through ResourceClaims.
 **ResourceSlices**
 ```
 $ kubectl get resourceslices -o wide
-NAME                                                             NODE                             DRIVER                      POOL                             AGE
-node-a.example.internal-compute-domain.nvidia.com-bbg8t   node-a.example.internal   compute-domain.nvidia.com   node-a.example.internal   44h
-node-a.example.internal-gpu.nvidia.com-sgw47              node-a.example.internal   gpu.nvidia.com              node-a.example.internal   44h
+NAME                                                           NODE                           DRIVER                      POOL                           AGE
+ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-q9xqc   ip-10-0-171-111.ec2.internal   compute-domain.nvidia.com   ip-10-0-171-111.ec2.internal   11m
+ip-10-0-171-111.ec2.internal-gpu.nvidia.com-7cbz2              ip-10-0-171-111.ec2.internal   gpu.nvidia.com              ip-10-0-171-111.ec2.internal   11m
+ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-2n2cq     ip-10-0-206-2.ec2.internal     compute-domain.nvidia.com   ip-10-0-206-2.ec2.internal     11m
+ip-10-0-206-2.ec2.internal-gpu.nvidia.com-79gvw                ip-10-0-206-2.ec2.internal     gpu.nvidia.com              ip-10-0-206-2.ec2.internal     11m
 ```
 
 ### GPU Device Details
@@ -87,18 +100,18 @@ items:
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
-    creationTimestamp: "2026-03-04T22:44:34Z"
-    generateName: node-a.example.internal-compute-domain.nvidia.com-
-    generation: 1
-    name: node-a.example.internal-compute-domain.nvidia.com-bbg8t
+    creationTimestamp: "2026-03-10T03:29:20Z"
+    generateName: ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-
+    generation: 2
+    name: ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-q9xqc
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: node-a.example.internal
-      uid: 2e8f0172-e1d7-4713-9160-a9f215925a19
-    resourceVersion: "11088653"
-    uid: 0308025e-5f16-44ed-9e0c-e9b9aa51a0ef
+      name: ip-10-0-171-111.ec2.internal
+      uid: fef55be3-f566-47c8-8bb8-52c117cb3855
+    resourceVersion: "1169500"
+    uid: 8087c1b4-71e0-42c3-9f74-12629e2ee5b5
   spec:
     devices:
     - attributes:
@@ -114,190 +127,28 @@ items:
           string: channel
       name: channel-0
     driver: compute-domain.nvidia.com
-    nodeName: node-a.example.internal
+    nodeName: ip-10-0-171-111.ec2.internal
     pool:
       generation: 1
-      name: node-a.example.internal
+      name: ip-10-0-171-111.ec2.internal
       resourceSliceCount: 1
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
-    creationTimestamp: "2026-03-04T22:44:35Z"
-    generateName: node-a.example.internal-gpu.nvidia.com-
-    generation: 1
-    name: node-a.example.internal-gpu.nvidia.com-sgw47
+    creationTimestamp: "2026-03-10T03:29:22Z"
+    generateName: ip-10-0-171-111.ec2.internal-gpu.nvidia.com-
+    generation: 2
+    name: ip-10-0-171-111.ec2.internal-gpu.nvidia.com-7cbz2
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: node-a.example.internal
-      uid: 2e8f0172-e1d7-4713-9160-a9f215925a19
-    resourceVersion: "11088663"
-    uid: bde9cab9-6c52-4d1b-aed5-3fcd2241708b
+      name: ip-10-0-171-111.ec2.internal
+      uid: fef55be3-f566-47c8-8bb8-52c117cb3855
+    resourceVersion: "1169562"
+    uid: 3441669c-08c4-43ff-9b83-42c5f3dddcff
   spec:
     devices:
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:86:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:77
-        type:
-          string: gpu
-        uuid:
-          string: GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-3
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:97:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:88
-        type:
-          string: gpu
-        uuid:
-          string: GPU-eaef2c36-d7aa-5f60-37bc-3e0a53de34ff
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-4
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:a8:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:99
-        type:
-          string: gpu
-        uuid:
-          string: GPU-1af5cfae-1878-a06c-5dc0-c16e5cf11a20
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-5
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:b9:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:aa
-        type:
-          string: gpu
-        uuid:
-          string: GPU-a0e6d978-c416-5df8-1ab9-eb27b31eab35
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-6
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: 0000:ca:00.0
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:bb
-        type:
-          string: gpu
-        uuid:
-          string: GPU-bd2999a7-7982-6643-fa9e-2d1a2cd7be27
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-7
-    - attributes:
-        addressingMode:
-          string: HMM
-        architecture:
-          string: Hopper
-        brand:
-          string: Nvidia
-        cudaComputeCapability:
-          version: 9.0.0
-        cudaDriverVersion:
-          version: 13.0.0
-        driverVersion:
-          version: 580.105.8
-        productName:
-          string: NVIDIA H100 80GB HBM3
-        resource.kubernetes.io/pciBusID:
-          string: "0000:53:00.0"
-        resource.kubernetes.io/pcieRoot:
-          string: pci0000:44
-        type:
-          string: gpu
-        uuid:
-          string: GPU-81d79b08-40a0-40ae-3fc5-82b8ff8b8138
-      capacity:
-        memory:
-          value: 81559Mi
-      name: gpu-0
     - attributes:
         addressingMode:
           string: HMM
@@ -320,7 +171,7 @@ items:
         type:
           string: gpu
         uuid:
-          string: GPU-4fc48812-c1c8-3bb7-1313-724533aa7df7
+          string: GPU-bc5610b9-79c8-fedd-8899-07539c7f868a
       capacity:
         memory:
           value: 81559Mi
@@ -347,16 +198,452 @@ items:
         type:
           string: gpu
         uuid:
-          string: GPU-8d76cfcf-a144-5e43-876b-a4b71f2aecd1
+          string: GPU-fbc2c554-4d37-8938-0032-f923bad0f716
       capacity:
         memory:
           value: 81559Mi
       name: gpu-2
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:86:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:77
+        type:
+          string: gpu
+        uuid:
+          string: GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-3
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:97:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:88
+        type:
+          string: gpu
+        uuid:
+          string: GPU-82e45d1b-1618-559f-144c-eab51545030b
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-4
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:a8:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:99
+        type:
+          string: gpu
+        uuid:
+          string: GPU-39e28159-8c62-ee71-64db-b748edd61e15
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-5
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:b9:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:aa
+        type:
+          string: gpu
+        uuid:
+          string: GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-6
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:ca:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:bb
+        type:
+          string: gpu
+        uuid:
+          string: GPU-04d228d3-3b5a-3534-f5cf-969706647d56
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-7
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: "0000:53:00.0"
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:44
+        type:
+          string: gpu
+        uuid:
+          string: GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-0
     driver: gpu.nvidia.com
-    nodeName: node-a.example.internal
+    nodeName: ip-10-0-171-111.ec2.internal
     pool:
       generation: 1
-      name: node-a.example.internal
+      name: ip-10-0-171-111.ec2.internal
+      resourceSliceCount: 1
+- apiVersion: resource.k8s.io/v1
+  kind: ResourceSlice
+  metadata:
+    creationTimestamp: "2026-03-10T03:29:19Z"
+    generateName: ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-
+    generation: 1
+    name: ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-2n2cq
+    ownerReferences:
+    - apiVersion: v1
+      controller: true
+      kind: Node
+      name: ip-10-0-206-2.ec2.internal
+      uid: b171b90a-eb8f-4662-bd0d-2055b634dc98
+    resourceVersion: "1168846"
+    uid: 3eca27ae-5231-4845-8407-1e24fd9b5683
+  spec:
+    devices:
+    - attributes:
+        id:
+          int: 0
+        type:
+          string: channel
+      name: channel-0
+    - attributes:
+        id:
+          int: 0
+        type:
+          string: daemon
+      name: daemon-0
+    driver: compute-domain.nvidia.com
+    nodeName: ip-10-0-206-2.ec2.internal
+    pool:
+      generation: 1
+      name: ip-10-0-206-2.ec2.internal
+      resourceSliceCount: 1
+- apiVersion: resource.k8s.io/v1
+  kind: ResourceSlice
+  metadata:
+    creationTimestamp: "2026-03-10T03:29:21Z"
+    generateName: ip-10-0-206-2.ec2.internal-gpu.nvidia.com-
+    generation: 2
+    name: ip-10-0-206-2.ec2.internal-gpu.nvidia.com-79gvw
+    ownerReferences:
+    - apiVersion: v1
+      controller: true
+      kind: Node
+      name: ip-10-0-206-2.ec2.internal
+      uid: b171b90a-eb8f-4662-bd0d-2055b634dc98
+    resourceVersion: "1169576"
+    uid: 0b3dc1d8-a1ba-4fae-894b-cb90e62ed783
+  spec:
+    devices:
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:75:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:66
+        type:
+          string: gpu
+        uuid:
+          string: GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-2
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:86:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:77
+        type:
+          string: gpu
+        uuid:
+          string: GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-3
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:97:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:88
+        type:
+          string: gpu
+        uuid:
+          string: GPU-95085215-739e-e7c6-4011-8dbe004af8c3
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-4
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:a8:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:99
+        type:
+          string: gpu
+        uuid:
+          string: GPU-a7b658ad-f23e-cea9-2523-569d521700bf
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-5
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:b9:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:aa
+        type:
+          string: gpu
+        uuid:
+          string: GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-6
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:ca:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:bb
+        type:
+          string: gpu
+        uuid:
+          string: GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-7
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: "0000:53:00.0"
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:44
+        type:
+          string: gpu
+        uuid:
+          string: GPU-92da0328-2f33-b563-d577-9d2b9f21f280
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-0
+    - attributes:
+        addressingMode:
+          string: HMM
+        architecture:
+          string: Hopper
+        brand:
+          string: Nvidia
+        cudaComputeCapability:
+          version: 9.0.0
+        cudaDriverVersion:
+          version: 13.0.0
+        driverVersion:
+          version: 580.105.8
+        productName:
+          string: NVIDIA H100 80GB HBM3
+        resource.kubernetes.io/pciBusID:
+          string: 0000:64:00.0
+        resource.kubernetes.io/pcieRoot:
+          string: pci0000:55
+        type:
+          string: gpu
+        uuid:
+          string: GPU-184dab49-47ce-eeec-2239-3e03fbd4c002
+      capacity:
+        memory:
+          value: 81559Mi
+      name: gpu-1
+    driver: gpu.nvidia.com
+    nodeName: ip-10-0-206-2.ec2.internal
+    pool:
+      generation: 1
+      name: ip-10-0-206-2.ec2.internal
       resourceSliceCount: 1
 kind: List
 metadata:
@@ -381,15 +668,17 @@ $ kubectl get pod isolation-test -n secure-access-test -o jsonpath={.spec.resour
 **Pod volumes (no hostPath)**
 ```
 $ kubectl get pod isolation-test -n secure-access-test -o jsonpath={.spec.volumes}
-[{"name":"kube-api-access-w42nb","projected":{"defaultMode":420,"sources":[{"serviceAccountToken":{"expirationSeconds":3607,"path":"token"}},{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kube-root-ca.crt"}},{"downwardAPI":{"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"},"path":"namespace"}]}}]}}]
+[{"name":"kube-api-access-dl259","projected":{"defaultMode":420,"sources":[{"serviceAccountToken":{"expirationSeconds":3607,"path":"token"}},{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kube-root-ca.crt"}},{"downwardAPI":{"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"},"path":"namespace"}]}}]}}]
 ```
 
 **ResourceClaim allocation**
 ```
 $ kubectl get resourceclaim isolated-gpu -n secure-access-test -o wide
 NAME           STATE     AGE
-isolated-gpu   pending   13s
+isolated-gpu   pending   12s
 ```
+
+> **Note:** ResourceClaim may show `pending` after pod completion because the DRA controller deallocates claims when the consuming pod terminates. The pod logs below confirm GPU isolation was enforced during execution.
 
 ### Container GPU Visibility (only allocated GPU visible)
 
@@ -397,17 +686,17 @@ isolated-gpu   pending   13s
 ```
 $ kubectl logs isolation-test -n secure-access-test
 === Visible NVIDIA devices ===
-crw-rw-rw- 1 root root 195, 254 Mar  6 19:38 /dev/nvidia-modeset
-crw-rw-rw- 1 root root 507,   0 Mar  6 19:38 /dev/nvidia-uvm
-crw-rw-rw- 1 root root 507,   1 Mar  6 19:38 /dev/nvidia-uvm-tools
-crw-rw-rw- 1 root root 195,   3 Mar  6 19:38 /dev/nvidia3
-crw-rw-rw- 1 root root 195, 255 Mar  6 19:38 /dev/nvidiactl
+crw-rw-rw- 1 root root 195, 254 Mar 10 03:40 /dev/nvidia-modeset
+crw-rw-rw- 1 root root 507,   0 Mar 10 03:40 /dev/nvidia-uvm
+crw-rw-rw- 1 root root 507,   1 Mar 10 03:40 /dev/nvidia-uvm-tools
+crw-rw-rw- 1 root root 195,   1 Mar 10 03:40 /dev/nvidia1
+crw-rw-rw- 1 root root 195, 255 Mar 10 03:40 /dev/nvidiactl
 
 === nvidia-smi output ===
-GPU 0: NVIDIA H100 80GB HBM3 (UUID: GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692)
+GPU 0: NVIDIA H100 80GB HBM3 (UUID: GPU-bc5610b9-79c8-fedd-8899-07539c7f868a)
 
 === GPU count ===
-0, NVIDIA H100 80GB HBM3, GPU-e69a4117-e5f9-04a7-d170-aafac6a7e692
+0, NVIDIA H100 80GB HBM3, GPU-bc5610b9-79c8-fedd-8899-07539c7f868a
 
 Secure accelerator access test completed
 ```


### PR DESCRIPTION
## Summary

Refresh all 8 CNCF AI Conformance evidence files from a fresh deployment on EKS v1.35 with 2x p5.48xlarge GPU nodes, generated using `--cncf-submission`.

## Motivation / Context

Evidence was last refreshed in PR #302 against K8s v1.34 with 1 GPU node. This updates to v1.35 with 2 GPU nodes and incorporates evidence script improvements from PR #322.

Fixes: N/A
Related: #322, #302

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Evidence improvements over previous version:
- DCGM metrics section populated (was empty due to flaky curl pod)
- ASG details resolved (was empty due to missing nodegroup tag)
- ELB hostnames auto-redacted
- Robust operator evidence shows PodCliques and filtered workload pods (no stale curl-test pods)
- DRA evidence includes note explaining post-completion pending state
- Cluster autoscaling clarifies configuration-level evidence scope
- Inference gateway shows CRDs via name-grep (no empty label query results)

## Testing

Documentation-only change. Evidence generated and verified on live EKS cluster.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)