### PR TITLE
fix(cli): replace --cleanup flag with --no-cleanup and warn on use

### DIFF
--- a/docs/design/002-validatorv2-adr.md
+++ b/docs/design/002-validatorv2-adr.md
@@ -177,7 +177,7 @@ ValidateAll(ctx, recipe, snapshot)
 │   │   ├── WaitForCompletion(timeout + 30s buffer)
 │   │   ├── ExtractResult() — exit code, termination msg, stdout
 │   │   ├── Add to CTRF report
-│   │   └── CleanupJob() if --cleanup
+│   │   └── CleanupJob() unless --no-cleanup
 │   └── Write CTRF ConfigMap
 │
 ├── defer: CleanupRBAC()

--- a/docs/user/agent-deployment.md
+++ b/docs/user/agent-deployment.md
@@ -75,7 +75,7 @@ This single command:
 3. Waits for Job completion (5m timeout by default)
 4. Retrieves snapshot from ConfigMap
 5. Writes snapshot to stdout (or specified output)
-6. Cleans up Job and RBAC resources (use `--cleanup=false` to keep for debugging)
+6. Cleans up Job and RBAC resources (use `--no-cleanup` to keep for debugging)
 
 ### 2. View Snapshot Output
 
@@ -128,7 +128,7 @@ aicr snapshot \
 - `--node-selector`: Node selector (format: `key=value`, repeatable)
 - `--toleration`: Toleration (format: `key=value:effect`, repeatable). **Default: all taints are tolerated** (uses `operator: Exists` without key). Only specify this flag if you want to restrict which taints the Job can tolerate.
 - `--timeout`: Wait timeout (default: `5m`)
-- `--cleanup`: Delete Job and RBAC resources on completion. **Default: `true`**. Use `--cleanup=false` to keep resources for debugging.
+- `--no-cleanup`: Skip removal of Job and RBAC resources on completion. **Warning:** leaves a cluster-admin ClusterRoleBinding active.
 
 ### 4. Check Agent Logs (Debugging)
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -84,7 +84,7 @@ aicr snapshot [flags]
 | `--node-selector` | | string[] | | Node selector for agent scheduling (key=value, repeatable) |
 | `--toleration` | | string[] | all taints | Tolerations for agent scheduling (key=value:effect, repeatable). **Default: all taints tolerated** (uses `operator: Exists`). Only specify to restrict which taints are tolerated. |
 | `--timeout` | | duration | 5m | Timeout for agent Job completion |
-| `--cleanup` | | bool | true | Delete Job and RBAC resources on completion. Use `--cleanup=false` to keep resources for debugging. |
+| `--no-cleanup` | | bool | false | Skip removal of Job and RBAC resources on completion. **Warning:** leaves a cluster-admin ClusterRoleBinding active. |
 | `--privileged` | | bool | true | Run agent in privileged mode (required for GPU/SystemD collectors). Set to false for PSS-restricted namespaces. |
 | `--template` | | string | | Path to Go template file for custom output formatting (requires YAML format) |
 | `--max-nodes-per-entry` | | int | 0 | Maximum node names per taint/label entry in topology collection (0 = unlimited) |
@@ -144,7 +144,7 @@ aicr snapshot \
   --toleration nvidia.com/gpu:NoSchedule \
   --timeout 10m \
   --output cm://gpu-operator/aicr-snapshot \
-  --cleanup
+  --no-cleanup
 
 # Custom template formatting
 aicr snapshot --template examples/templates/snapshot-template.md.tmpl
@@ -200,7 +200,7 @@ When running against a cluster, AICR deploys a Kubernetes Job to capture the sna
 3. **Waits for completion**: Monitors Job status with configurable timeout
 4. **Retrieves snapshot**: Reads snapshot from ConfigMap after Job completes
 5. **Writes output**: Saves snapshot to specified output destination
-6. **Cleanup**: Deletes Job and RBAC resources (use `--cleanup=false` to keep for debugging)
+6. **Cleanup**: Deletes Job and RBAC resources (use `--no-cleanup` to keep for debugging)
 
 **Benefits of agent deployment:**
 - Capture configuration from actual cluster nodes (not local machine)

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -121,9 +121,8 @@ func snapshotCmdFlags() []cli.Flag {
 			Category: "Agent Deployment",
 		},
 		&cli.BoolFlag{
-			Name:     "cleanup",
-			Value:    true,
-			Usage:    "Remove Job and RBAC resources on completion",
+			Name:     "no-cleanup",
+			Usage:    "Skip removal of Job and RBAC resources on completion (leaves cluster-admin binding active)",
 			Category: "Agent Deployment",
 		},
 		&cli.BoolFlag{
@@ -289,7 +288,7 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				NodeSelector:       nodeSelector,
 				Tolerations:        tolerations,
 				Timeout:            cmd.Duration("timeout"),
-				Cleanup:            cmd.Bool("cleanup"),
+				Cleanup:            !cmd.Bool("no-cleanup"),
 				Output:             tmplOpts.outputPath,
 				Debug:              cmd.Bool("debug"),
 				Privileged:         cmd.Bool("privileged"),

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -76,7 +76,7 @@ func parseValidateAgentConfig(cmd *cli.Command) (*validateAgentConfig, error) {
 		nodeSelector:       nodeSelector,
 		tolerations:        tolerations,
 		timeout:            cmd.Duration("timeout"),
-		cleanup:            cmd.Bool("cleanup"),
+		cleanup:            !cmd.Bool("no-cleanup"),
 		debug:              cmd.Bool("debug"),
 		requireGPU:         cmd.Bool("require-gpu"),
 	}, nil
@@ -394,9 +394,8 @@ func validateCmdFlags() []cli.Flag {
 			Category: "Agent Deployment",
 		},
 		&cli.BoolFlag{
-			Name:     "cleanup",
-			Value:    true,
-			Usage:    "Remove Job and RBAC resources on completion",
+			Name:     "no-cleanup",
+			Usage:    "Skip removal of Job and RBAC resources on completion (leaves cluster-admin binding active)",
 			Category: "Agent Deployment",
 		},
 		&cli.BoolFlag{
@@ -547,13 +546,20 @@ Run validation without failing on check errors (informational mode):
 				return err
 			}
 
+			noCleanup := cmd.Bool("no-cleanup")
+			if noCleanup {
+				slog.Warn("--no-cleanup: cluster-admin ClusterRoleBinding will remain active after validation",
+					"namespace", validationNamespace,
+					"binding", "aicr-validator")
+			}
+
 			return runValidation(ctx, rec, snap, validationConfig{
 				phases:              phases,
 				output:              cmd.String("output"),
 				outFormat:           serializer.FormatJSON,
 				failOnError:         failOnError,
 				validationNamespace: validationNamespace,
-				cleanup:             cmd.Bool("cleanup"),
+				cleanup:             !noCleanup,
 				imagePullSecrets:    cmd.StringSlice("image-pull-secret"),
 				noCluster:           cmd.Bool("no-cluster"),
 				tolerations:         tolerations,

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -156,7 +156,7 @@ func TestValidateCmd_AgentFlags(t *testing.T) {
 		"node-selector",
 		"toleration",
 		"timeout",
-		"cleanup",
+		"no-cleanup",
 	}
 
 	for _, flagName := range agentFlags {

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1165,14 +1165,14 @@ RECIPE
     --snapshot "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}" \
     --phase deployment \
     --output "$validation_result" \
-    --cleanup=false 2>&1 || validation_exit=$?
+    --no-cleanup 2>&1 || validation_exit=$?
 
   # Check if RBAC resources were created
   if kubectl get sa aicr-validator -n aicr-validation &>/dev/null; then
     detail "ServiceAccount created: aicr-validator"
     pass "validate/job-rbac-serviceaccount"
   else
-    fail "validate/job-rbac-serviceaccount" "ServiceAccount not found after --cleanup=false"
+    fail "validate/job-rbac-serviceaccount" "ServiceAccount not found after --no-cleanup"
   fi
 
   if kubectl get clusterrolebinding aicr-validator &>/dev/null; then
@@ -1181,7 +1181,7 @@ RECIPE
     detail "ClusterRoleBinding created: aicr-validator → ${role_ref}"
     pass "validate/job-rbac-role"
   else
-    fail "validate/job-rbac-role" "ClusterRoleBinding not found after --cleanup=false"
+    fail "validate/job-rbac-role" "ClusterRoleBinding not found after --no-cleanup"
   fi
 
   # Check if jobs were created (they may not exist if recipe has no checks)
@@ -1233,7 +1233,7 @@ RECIPE
 
   # Test 2: Validation with custom namespace
   msg "--- Test: Validation Job in custom namespace ---"
-  echo -e "${DIM}  \$ aicr validate --namespace custom-validation --cleanup=true${NC}"
+  echo -e "${DIM}  \$ aicr validate --namespace custom-validation${NC}"
 
   # Create custom validation namespace
   kubectl create namespace custom-validation 2>&1 || true
@@ -1246,7 +1246,7 @@ RECIPE
     --phase deployment \
     --namespace custom-validation \
     --output "$validation_custom" \
-    --cleanup=true 2>&1 || true  # Keep || true here as this is just testing namespace config
+    2>&1 || true  # Keep || true here as this is just testing namespace config
 
   # Check if RBAC was created in custom namespace
   if kubectl get sa aicr-validator -n custom-validation &>/dev/null; then
@@ -1257,9 +1257,9 @@ RECIPE
     pass "validate/job-custom-namespace"
   fi
 
-  # Test 3: Job cleanup (verify cleanup from default namespace run with --cleanup=false)
+  # Test 3: Job cleanup (verify cleanup from default namespace run with --no-cleanup)
   msg "--- Test: Validation Job cleanup ---"
-  echo -e "${DIM}  \$ aicr validate --cleanup=true${NC}"
+  echo -e "${DIM}  \$ aicr validate${NC}"
 
   # Count existing jobs before cleanup test
   local jobs_before
@@ -1270,7 +1270,7 @@ RECIPE
     --recipe "$recipe_file" \
     --snapshot "cm://${SNAPSHOT_NAMESPACE}/${SNAPSHOT_CM}" \
     --phase deployment \
-    --cleanup=true 2>&1 || true  # Keep || true here as this is just testing cleanup
+    2>&1 || true  # Keep || true here as this is just testing cleanup
 
   # Wait for cleanup to complete
   kubectl wait --for=delete jobs -l app.kubernetes.io/name=aicr -n aicr-validation --timeout=30s 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Replace `--cleanup` (default `true`) with `--no-cleanup` (default `false`) on both `validate` and `snapshot` commands
- When `--no-cleanup` is used, emit a warning that a cluster-admin ClusterRoleBinding remains active in the cluster
- Update CLI reference, agent deployment guide, and validator ADR docs

## Test plan

- [x] `TestValidateCmd_AgentFlags` — validates `no-cleanup` flag is registered
- [x] `TestValidateCmd_CommandStructure` — command structure intact
- [x] `TestSnapshotCmd_CommandStructure` — command structure intact
- [x] All CLI tests pass with race detector

Closes #306