### PR TITLE
fix(ci): skip unnecessary checks on docs-only PRs

### DIFF
--- a/.github/workflows/docs-only-checks.yaml
+++ b/.github/workflows/docs-only-checks.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable workflow called by docs-only.yaml.
+# Job names here must match qualification.yaml exactly so that the
+# check names ("tests / Test", "tests / Lint", etc.) satisfy the
+# required status checks on documentation-only PRs.
+
+name: Qualification
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — tests not required"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — lint not required"
+
+  cli-e2e:
+    name: CLI E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — CLI E2E not required"
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — E2E not required"
+
+  security-scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — security scan not required"

--- a/.github/workflows/docs-only.yaml
+++ b/.github/workflows/docs-only.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Skip gate for documentation-only PRs.
+#
+# Required status checks (tests/*, analyze, malware-scan) use paths-ignore
+# to skip docs-only changes. When skipped, GitHub never receives a status,
+# blocking the PR. This workflow runs ONLY on docs-only changes and reports
+# success for each required check name so the PR can merge.
+#
+# The paths here are the inverse of the paths-ignore in on-push.yaml,
+# codeql.yaml, and vuln-scan.yaml. If a PR touches both code and docs,
+# the real workflows run (matching code paths) AND this workflow runs
+# (matching doc paths). Both report success — no conflict.
+#
+# Check name matching: required checks use the "<caller-job> / <called-job-name>"
+# format for reusable workflows. The on-push.yaml job key is "tests" and calls
+# qualification.yaml which has job names: Test, Lint, CLI E2E, E2E, Security Scan.
+# We replicate this by calling a local reusable workflow with matching job names.
+
+name: Docs Only Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+jobs:
+
+  tests:
+    uses: ./.github/workflows/docs-only-checks.yaml
+
+  # Required check: "analyze" (from codeql.yaml)
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — CodeQL analysis not required"
+
+  # Required check: "malware-scan" (from vuln-scan.yaml)
+  malware-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Documentation-only change — malware scan not required"

--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -23,6 +23,7 @@ on:
       - 'kwok/**'
       - '.github/workflows/kwok-recipes.yaml'
       - '.github/actions/kwok-test/**'
+      - '!**.md'
   pull_request:
     branches:
       - main
@@ -31,6 +32,7 @@ on:
       - 'kwok/**'
       - '.github/workflows/kwok-recipes.yaml'
       - '.github/actions/kwok-test/**'
+      - '!**.md'
   workflow_dispatch:
     inputs:
       recipe:

--- a/demos/cuj1.md
+++ b/demos/cuj1.md
@@ -1,6 +1,20 @@
 # AICR - Critical User Journey (CUJ) 1
 
-> Assuming user is already authenticated to an EKS cluster with 2+ H100 node
+## Assumptions
+
+* Assuming user is already authenticated to an EKS cluster with 2+ H100 node.
+* Values used in `--accelerated-node-selector`, `--accelerated-node-toleration`, in `--system-node-toleration` flags are only for example purposes. Assuming user will update these to match their cluster. 
+
+## Snapshot
+
+```shell
+aicr snapshot \
+    --namespace aicr-validation \
+    --node-selector nodeGroup=gpu-worker \
+    --toleration dedicated=worker-workload:NoSchedule \
+    --toleration dedicated=worker-workload:NoExecute \
+    --output snapshot.yaml
+```
 
 ## Gen Recipe
 
@@ -16,27 +30,30 @@ aicr recipe \
 
 ## Validate Recipe Constraints
 
-> Setting additional `--namespace` or `--node-selector` flag to land the agent on on the right node is OK
-
 ```shell
 aicr validate \
-  --phase readiness \
-  --recipe recipe.yaml
+    --recipe recipe.yaml \
+    --snapshot snapshot.yaml \
+    --no-cluster \
+    --phase deployment \
+    --output dry-run.json
 ```
 
 ## Generate Bundle
 
-> Setting additional `--accelerated-node-selector`, `--accelerated-node-toleration`, or `--system-node-toleration` flags to land the agent on on the right node is OK
-
 ```shell
 aicr bundle \
   --recipe recipe.yaml \
-  --output bundle \
-  --accelerated-node-selector [key]=[value] \
-  --accelerated-node-toleration [key]=[value]:[operation] 
+  --accelerated-node-selector nodeGroup=gpu-worker \
+  --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
+  --accelerated-node-toleration dedicated=worker-workload:NoExecute \
+  --system-node-selector dedicated=system-workload \
+  --system-node-toleration dedicated=system-workload:NoSchedule \
+  --system-node-toleration dedicated=system-workload:NoExecute \
+  --output bundle
 ```
 
-Replace the values for `--accelerated-node-selector` and `--accelerated-node-toleration` with the appropriate ones to match your gpu pool(s). You do not want optimizations and training workloads to run across all nodes. Both options allow for comma delimination to supply multiple values. See the [aicr bundle](../docs/user/cli-reference.md#aicr-bundle) section for more information.
+> Both options allow for comma delamination to supply multiple values. See the [bundle](../docs/user/cli-reference.md#aicr-bundle) section for more information.
 
 ## Install Bundle into the Cluster
 
@@ -48,11 +65,10 @@ cd ./bundle && chmod +x deploy.sh && ./deploy.sh
 
 ```shell
 aicr validate \
-  --recipe recipe.yaml \
-  --output report.yaml \
-  --phase readiness \
-  --phase deployment \
-  --phase conformance
+    --recipe recipe.yaml \
+    --toleration dedicated=worker-workload:NoSchedule \
+    --toleration dedicated=worker-workload:NoExecute \
+    --output report.json
 ```
 
 ## Run Job


### PR DESCRIPTION
## Summary

Two CI fixes for documentation-only PRs:

1. **Docs-only gate workflow** — All 7 required status checks (`tests / Test`, `tests / Lint`, `tests / CLI E2E`, `tests / E2E`, `tests / Security Scan`, `analyze`, `malware-scan`) use `paths-ignore` to skip docs-only changes. When skipped, GitHub never receives a status, so the PR hangs waiting for checks that never run. The new `docs-only.yaml` workflow triggers only on doc paths and reports success for each required check name.

2. **KWOK markdown exclusion** — `kwok-recipes.yaml` uses `paths: ['recipes/**']` which matches `recipes/validators/README.md`. Adding `'!**.md'` exclusion prevents markdown file changes from triggering KWOK cluster validation.

### How it works

- `docs-only.yaml` calls `docs-only-checks.yaml` (reusable workflow) from a job named `tests`, producing check names `tests / Test`, `tests / Lint`, etc. — matching the `on-push.yaml` → `qualification.yaml` pattern exactly
- Direct jobs `analyze` and `malware-scan` match the CodeQL and vuln-scan check names
- If a PR touches both code and docs, both the real workflows AND this gate run; both report success with no conflict

## Test plan

- [ ] Create a docs-only PR and verify all 7 required checks pass via the gate
- [ ] Create a code PR and verify real qualification workflows still run
- [ ] Verify `recipes/validators/README.md` changes no longer trigger KWOK