### PR TITLE
fix(recipes): add missing gpu-operator dependency refs

### DIFF
--- a/pkg/recipe/deployment_order_guard_test.go
+++ b/pkg/recipe/deployment_order_guard_test.go
@@ -73,10 +73,69 @@ func TestDeploymentOrderGuards(t *testing.T) {
 				return c
 			},
 			requiredDeps: map[string][]string{
-				"dynamo-platform": {"dynamo-crds", "cert-manager", "kube-prometheus-stack", "kai-scheduler"},
+				"dynamo-platform": {"dynamo-crds", "cert-manager", "kube-prometheus-stack", "gpu-operator", "kai-scheduler"},
 			},
 			requiredOrdering: [][2]string{
+				{"gpu-operator", "dynamo-platform"},
 				{"kai-scheduler", "dynamo-platform"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+		{
+			name: "gb200-eks-ubuntu-inference-dynamo",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorGB200
+				c.Intent = CriteriaIntentInference
+				c.OS = CriteriaOSUbuntu
+				c.Platform = CriteriaPlatformDynamo
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"dynamo-platform": {"dynamo-crds", "cert-manager", "kube-prometheus-stack", "gpu-operator", "kai-scheduler"},
+			},
+			requiredOrdering: [][2]string{
+				{"gpu-operator", "dynamo-platform"},
+				{"kai-scheduler", "dynamo-platform"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+		{
+			name: "h100-eks-ubuntu-training-kubeflow",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorH100
+				c.Intent = CriteriaIntentTraining
+				c.OS = CriteriaOSUbuntu
+				c.Platform = CriteriaPlatformKubeflow
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"kubeflow-trainer": {"cert-manager", "kube-prometheus-stack", "gpu-operator"},
+			},
+			requiredOrdering: [][2]string{
+				{"gpu-operator", "kubeflow-trainer"},
+				{"gpu-operator", "nvsentinel"},
+			},
+		},
+		{
+			name: "gb200-eks-ubuntu-training-kubeflow",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorGB200
+				c.Intent = CriteriaIntentTraining
+				c.OS = CriteriaOSUbuntu
+				c.Platform = CriteriaPlatformKubeflow
+				return c
+			},
+			requiredDeps: map[string][]string{
+				"kubeflow-trainer": {"cert-manager", "kube-prometheus-stack", "gpu-operator"},
+			},
+			requiredOrdering: [][2]string{
+				{"gpu-operator", "kubeflow-trainer"},
 				{"gpu-operator", "nvsentinel"},
 			},
 		},

--- a/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
@@ -59,6 +59,7 @@ spec:
         - dynamo-crds
         - cert-manager
         - kube-prometheus-stack
+        - gpu-operator
         - kai-scheduler
       overrides:
         etcd:

--- a/recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml
@@ -48,3 +48,7 @@ spec:
       valuesFile: components/kubeflow-trainer/values.yaml
       manifestFiles:
         - components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - gpu-operator

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -59,6 +59,7 @@ spec:
         - dynamo-crds
         - cert-manager
         - kube-prometheus-stack
+        - gpu-operator
         - kai-scheduler
       overrides:
         etcd:

--- a/recipes/overlays/h100-eks-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-training-kubeflow.yaml
@@ -48,3 +48,7 @@ spec:
       valuesFile: components/kubeflow-trainer/values.yaml
       manifestFiles:
         - components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - gpu-operator


### PR DESCRIPTION
## Summary

Add `gpu-operator` to `dependencyRefs` for components that require it to be running before deployment, ensuring correct topological order in `deploy.sh`.

## Changes

| Component | Overlay | Added Dependencies |
|-----------|---------|-------------------|
| `kubeflow-trainer` | h100-eks-ubuntu-training-kubeflow | `cert-manager`, `kube-prometheus-stack`, `gpu-operator` |
| `kubeflow-trainer` | gb200-eks-ubuntu-training-kubeflow | `cert-manager`, `kube-prometheus-stack`, `gpu-operator` |
| `dynamo-platform` | h100-eks-ubuntu-inference-dynamo | `gpu-operator` |
| `dynamo-platform` | gb200-eks-ubuntu-inference-dynamo | `gpu-operator` |

## Test plan

- [x] Generated H100 EKS Kubeflow recipe — `kubeflow-trainer` deploys after `gpu-operator`
- [x] Generated H100 EKS Dynamo recipe — `dynamo-platform` deploys after `gpu-operator`
- [x] Topological sort produces correct deployment order