### PR TITLE
feat(release): add supply chain verification to Homebrew formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -179,3 +179,19 @@ brews:
     homepage: "https://github.com/NVIDIA/aicr"
     description: "Tooling for deploying optimized, validated, and reproducible GPU-accelerated AI runtime in Kubernetes."
     license: "Apache-2.0"
+    install: |
+      bin.install "aicr"
+      # Install attestation bundle next to binary (aicr looks for <binary>-attestation.sigstore.json)
+      bin.install "aicr-attestation.sigstore.json" if File.exist? "aicr-attestation.sigstore.json"
+      # Verify provenance attestation if cosign is available
+      if File.exist?(bin/"aicr-attestation.sigstore.json") && which("cosign")
+        system "cosign", "verify-blob-attestation",
+               "--bundle", bin/"aicr-attestation.sigstore.json",
+               "--type", "https://slsa.dev/provenance/v1",
+               "--certificate-oidc-issuer", "https://token.actions.githubusercontent.com",
+               "--certificate-identity-regexp", "https://github.com/NVIDIA/aicr/.github/workflows/on-tag\\.yaml@refs/tags/.*",
+               bin/"aicr"
+        ohai "Provenance verified — binary built by github.com/NVIDIA/aicr CI pipeline"
+      end
+    post_install: |
+      system(bin/"aicr", "trust", "update") rescue opoo("could not fetch latest Sigstore trusted root; run 'aicr trust update' later")

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -34,13 +34,14 @@ linting:
 security_tools:
   grype: 'v0.107.0'
   cosign: 'v3.0.4'
+  syft: 'v1.42.2'
 
 # E2E Testing Tools
 testing_tools:
   kubectl: 'v1.35.0'
   kind: '0.31.0'
   ctlptl: '0.9.0'
-  tilt: '0.36.3'
+  tilt: '0.37.0'
   helm: 'v4.1.1'
   kwok: 'v0.7.0'
   chainsaw: 'v0.2.14'

--- a/tools/check-tools
+++ b/tools/check-tools
@@ -97,6 +97,9 @@ get_tool_metadata() {
         grype)
             echo "grype:::grype version 2>/dev/null | grep -E '^Version:' | awk '{print \$2}' | grep -v '^\[' || echo installed:::presence"
             ;;
+        syft)
+            echo "syft:::syft version 2>/dev/null | grep -E '^Version:' | awk '{print \$2}':::major_minor"
+            ;;
         # Testing tools
         kubectl)
             echo "kubectl:::kubectl version --client -o json 2>/dev/null | grep gitVersion | grep -oE 'v[0-9]+\.[0-9]+' || echo installed:::major"

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -278,6 +278,7 @@ ADDLICENSE_VERSION=$(yq '.linting.addlicense' .settings.yaml)
 GO_LICENSES_VERSION=$(yq '.linting.go_licenses' .settings.yaml)
 GRYPE_VERSION=$(yq '.security_tools.grype' .settings.yaml)
 COSIGN_VERSION=$(yq '.security_tools.cosign' .settings.yaml)
+SYFT_VERSION=$(yq '.security_tools.syft' .settings.yaml)
 KIND_VERSION=$(yq '.testing_tools.kind' .settings.yaml)
 KUBECTL_VERSION=$(yq '.testing_tools.kubectl' .settings.yaml)
 CTLPTL_VERSION=$(yq '.testing_tools.ctlptl' .settings.yaml)
@@ -294,6 +295,7 @@ echo "  Go:              ${GO_VERSION}"
 echo "  golangci-lint:   ${GOLANGCI_LINT_VERSION}"
 echo "  grype:           ${GRYPE_VERSION}"
 echo "  cosign:          ${COSIGN_VERSION}"
+echo "  syft:            ${SYFT_VERSION}"
 echo "  kind:            ${KIND_VERSION}"
 echo "  kubectl:         ${KUBECTL_VERSION}"
 echo "  tilt:            ${TILT_VERSION}"
@@ -515,6 +517,32 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
                 fi
             fi
             log_success "cosign installed"
+        fi
+    fi
+
+    # syft (SBOM generator)
+    if command_exists syft && [[ "${UPGRADE}" != "true" ]]; then
+        log_success "syft already installed: $(syft version 2>/dev/null | grep -E '^Version:' | awk '{print $2}')"
+    else
+        log_info "Installing syft ${SYFT_VERSION}..."
+        if prompt_continue; then
+            if [[ "${OS}" == "darwin" ]]; then
+                brew install syft
+            elif [[ "${OS}" == "linux" ]]; then
+                SYFT_VER="${SYFT_VERSION#v}"
+                SYFT_TMP=$(mktemp -d)
+                SYFT_URL="https://github.com/anchore/syft/releases/download/v${SYFT_VER}/syft_${SYFT_VER}_linux_${GO_ARCH}.tar.gz"
+                if verify_download_url "$SYFT_URL" "syft ${SYFT_VERSION} for Linux ${GO_ARCH}"; then
+                    curl -fsSL "$SYFT_URL" | tar -xzC "$SYFT_TMP"
+                    sudo mv "$SYFT_TMP/syft" /usr/local/bin/syft
+                    sudo chmod +x /usr/local/bin/syft
+                    rm -rf "$SYFT_TMP"
+                else
+                    log_error "Failed to install syft. Please install manually."
+                    rm -rf "$SYFT_TMP"
+                fi
+            fi
+            log_success "syft installed"
         fi
     fi
 
@@ -770,6 +798,7 @@ TOOLS=(
     "yamllint:yamllint --version 2>/dev/null | awk '{print \$2}'"
     "grype:grype version 2>/dev/null | grep -E '^Version:' | awk '{print \$2}' | grep -v '^\\[' || echo installed"
     "cosign:cosign version 2>/dev/null | grep -oE 'v[0-9]+\\.[0-9]+\\.[0-9]+' | head -1"
+    "syft:syft version 2>/dev/null | grep -E '^Version:' | awk '{print \$2}'"
     "tilt:tilt version 2>/dev/null | grep -oE 'v[0-9]+\\.[0-9]+\\.[0-9]+'"
     "kind:kind version 2>/dev/null | grep -oE 'v[0-9]+\\.[0-9]+\\.[0-9]+'"
     "ctlptl:ctlptl version 2>/dev/null | grep -oE 'v[0-9]+\\.[0-9]+\\.[0-9]+'"


### PR DESCRIPTION
## Summary

- **Homebrew formula now installs from tar archives** (not bare binaries), placing the Sigstore attestation bundle next to the binary in `bin/` so `aicr` can find it at `<binary>-attestation.sigstore.json`
- **Optional cosign verification on install** — if cosign is present, the formula verifies binary provenance against the SLSA attestation bundle before completing
- **Runs `aicr trust update` post-install** to fetch the latest Sigstore trusted root (fails gracefully with a warning if sandboxed or offline)
- **Added syft to dev tooling** — `.settings.yaml`, `setup-tools`, and `check-tools` now include syft (SBOM generator required by goreleaser)
- **Bumped tilt** from 0.36.3 to 0.37.0

## Changed Files

| File | Change |
|------|--------|
| `.goreleaser.yaml` | Added `install` and `post_install` blocks to brews section |
| `.settings.yaml` | Added `syft: v1.42.2`, bumped `tilt: 0.37.0` |
| `tools/setup-tools` | Added syft install (brew on macOS, binary on Linux) |
| `tools/check-tools` | Added syft version detection metadata |

## How It Works

```ruby
# 1. Install binary and attestation bundle next to it
bin.install "aicr"
bin.install "aicr-attestation.sigstore.json"

# 2. Verify provenance if cosign is available
if File.exist?(bin/"aicr-attestation.sigstore.json") && which("cosign")
  system "cosign", "verify-blob-attestation", ...
end

# 3. Update Sigstore trusted root (graceful fallback)
system(bin/"aicr", "trust", "update") rescue opoo("...")
```

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Testing

Local testing, but might require a some round of testing in CI yet.


-  `goreleaser release --snapshot --clean --skip=publish` generates correct formula
-  `ruby -c dist/homebrew/Formula/aicr.rb` passes syntax check
-  Local tap install succeeds (`brew install local/aicr/aicr`)
-  Post-install `trust update` fails gracefully in Homebrew sandbox
-  Attestation bundle skipped correctly when not present (snapshot builds)
-  `make tools-check` shows syft with correct version
-  Verified syft Linux download URLs return 302 (amd64 + arm64)
-  Tested setup-tools on Linux — syft installs correctly with updated `.settings.yaml`
-  TODO: Full release build verifies cosign attestation path (requires CI tag build)

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
