### PR TITLE
fix(install): detect outdated cosign before attestation verification (#337)

### DIFF
--- a/install
+++ b/install
@@ -65,6 +65,13 @@ msg() {
   printf "  %s\n" "$1" >&2
 }
 
+# Compare semver: returns 0 if $1 >= $2
+version_gte() {
+  local highest
+  highest=$(printf '%s\n%s' "$1" "$2" | sort -V | tail -1)
+  [[ "$highest" == "$1" ]]
+}
+
 has_tools() {
   local missing=()
   for tool in "$@"; do
@@ -252,19 +259,38 @@ main() {
   tar -xzf "${temp_dir}/${archive_name}" -C "$temp_dir"
 
   # Optional: verify attestation if cosign is available
+  COSIGN_MIN_VERSION="v3.0.4"
   if command -v cosign &>/dev/null && [[ -f "${temp_dir}/${BIN_NAME}-attestation.sigstore.json" ]]; then
-    step "Verifying provenance attestation (Sigstore cosign)..."
-    info "Confirms this binary was built by NVIDIA/aicr CI — not a third-party rebuild"
-    if cosign verify-blob-attestation \
-      --bundle "${temp_dir}/${BIN_NAME}-attestation.sigstore.json" \
-      --type https://slsa.dev/provenance/v1 \
-      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-      --certificate-identity-regexp 'https://github.com/NVIDIA/aicr/.github/workflows/on-tag\.yaml@refs/tags/.*' \
-      "${temp_dir}/${BIN_NAME}" 2>/dev/null; then
-      ok "Provenance verified — binary built by github.com/NVIDIA/aicr CI pipeline"
+    cosign_version=$(cosign version --json 2>/dev/null | grep -o '"gitVersion":"[^"]*"' | cut -d'"' -f4)
+    if [[ -z "$cosign_version" ]]; then
+      # Fallback: try text output
+      cosign_version=$(cosign version 2>/dev/null | grep -i 'gitversion' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+    fi
+
+    if [[ -n "$cosign_version" ]] && ! version_gte "$cosign_version" "$COSIGN_MIN_VERSION"; then
+      warn "Installed cosign version ($cosign_version) is older than the minimum required ($COSIGN_MIN_VERSION)"
+      info "Update cosign to verify provenance: https://docs.sigstore.dev/cosign/system_config/installation/"
     else
-      warn "Attestation verification failed — cannot confirm binary provenance"
-      info "The binary may still be valid, but its build origin could not be cryptographically verified"
+      step "Verifying provenance attestation (Sigstore cosign)..."
+      info "Confirms this binary was built by NVIDIA/aicr CI — not a third-party rebuild"
+      cosign_stderr=$(mktemp)
+      if cosign verify-blob-attestation \
+        --bundle "${temp_dir}/${BIN_NAME}-attestation.sigstore.json" \
+        --type https://slsa.dev/provenance/v1 \
+        --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+        --certificate-identity-regexp 'https://github.com/NVIDIA/aicr/.github/workflows/on-tag\.yaml@refs/tags/.*' \
+        "${temp_dir}/${BIN_NAME}" 2>"${cosign_stderr}"; then
+        ok "Provenance verified — binary built by github.com/NVIDIA/aicr CI pipeline"
+      else
+        warn "Attestation verification failed — cannot confirm binary provenance"
+        info "The binary may still be valid, but its build origin could not be cryptographically verified"
+        if [[ -s "${cosign_stderr}" ]]; then
+          while IFS= read -r line; do
+            info "cosign: $line"
+          done < "${cosign_stderr}"
+        fi
+      fi
+      rm -f "${cosign_stderr}"
     fi
   elif [[ -f "${temp_dir}/${BIN_NAME}-attestation.sigstore.json" ]]; then
     warn "cosign not found — skipping provenance verification"


### PR DESCRIPTION
## Summary
- Check installed cosign version against minimum required (v3.0.4) before attempting attestation verification
- Show a clear upgrade message when cosign is too old, instead of a generic "verification failed" error
- Capture and display cosign stderr on verification failure for easier debugging

## Test plan
- [x] Old cosign (v2.4.0) — warns about outdated version with upgrade link
- [x] Current cosign (v3.1.0) — passes version check; on failure shows actual cosign error
- [x] Exact minimum (v3.0.4) — treated as acceptable
- [x] Unparseable version — falls through to attempt verification (safe default)
- [x] No cosign installed — existing "cosign not found" message unchanged
- [x] shellcheck clean (no new warnings)

Closes #337

### Testing 
Did some mocking to the logic out:
```bash
=== Test 1: Old cosign (v2.4.0) ===
  Detected version: v2.4.0
  ! Installed cosign version (v2.4.0) is older than the minimum required (v3.0.4)
    Update cosign to verify provenance: https://docs.sigstore.dev/cosign/system_config/installation/
  Correctly caught old version

=== Test 2: Current cosign (v3.1.0) ===
  Detected version: v3.1.0
  Correctly passed version check (would proceed to verify)
  ! Attestation verification failed — cannot confirm binary provenance
    cosign: some verify error detail
  Stderr captured and displayed

=== Test 3: Exact minimum version (v3.0.4) ===
  Detected version: v3.0.4
  Correctly passed (equal to minimum)

=== Test 4: Version not parseable ===
  Detected version: ''
  Correctly fell through to verification (version unknown)
```

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
