### PR TITLE
fix(install): replace post_install with caveats to avoid Homebrew sandbox error

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -193,5 +193,7 @@ brews:
                bin/"aicr"
         ohai "Provenance verified — binary built by github.com/NVIDIA/aicr CI pipeline"
       end
-    post_install: |
-      system(bin/"aicr", "trust", "update") rescue opoo("could not fetch latest Sigstore trusted root; run 'aicr trust update' later")
+    caveats: |
+      To enable supply chain verification, update the bundle attestation root:
+
+        aicr trust update


### PR DESCRIPTION

## Summary
- Homebrew sandbox blocks writes to `~/.sigstore/` during `post_install`, causing `aicr trust update` to fail on install
- Replaced `post_install` with `caveats` so users are prompted to run the command after installation instead

## Test plan
- [ ] `brew install aicr` completes without sandbox permission errors
- [ ] Caveat message displays after install with `aicr trust update` command
- [ ] `aicr trust update` works when run manually post-install

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
