### PR TITLE
feat(validator): accept --phase readiness as standalone CLI option

### DIFF
--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -95,6 +95,7 @@ func parseValidationPhases(phaseStrs []string) ([]validator.Phase, error) {
 	}
 
 	validPhases := map[string]validator.Phase{
+		"readiness":   validator.PhaseReadiness,
 		"deployment":  validator.PhaseDeployment,
 		"performance": validator.PhasePerformance,
 		"conformance": validator.PhaseConformance,
@@ -106,7 +107,7 @@ func parseValidationPhases(phaseStrs []string) ([]validator.Phase, error) {
 		p, ok := validPhases[s]
 		if !ok {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("invalid phase %q: must be one of: deployment, performance, conformance, all", s))
+				fmt.Sprintf("invalid phase %q: must be one of: readiness, deployment, performance, conformance, all", s))
 		}
 		if !seen[p] {
 			phases = append(phases, p)
@@ -328,8 +329,9 @@ func validateCmdFlags() []cli.Flag {
 		&cli.StringSliceFlag{
 			Name: "phase",
 			Usage: `Validation phase(s) to run (can be repeated).
-	Options: "deployment", "performance", "conformance", "all".
+	Options: "readiness", "deployment", "performance", "conformance", "all".
 	Default: all phases.
+	Example: --phase readiness
 	Example: --phase deployment --phase conformance`,
 			Category: "Validation Control",
 		},

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -85,10 +85,9 @@ func TestParseValidationPhases(t *testing.T) {
 			errContain: "invalid phase",
 		},
 		{
-			name:       "readiness is invalid (not supported in v2)",
+			name:       "single readiness phase",
 			phaseStrs:  []string{"readiness"},
-			wantErr:    true,
-			errContain: "invalid phase",
+			wantPhases: []validator.Phase{validator.PhaseReadiness},
 		},
 	}
 

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -18,6 +18,9 @@ package validator
 type Phase string
 
 const (
+	// PhaseReadiness evaluates recipe constraints against the snapshot (no containers).
+	PhaseReadiness Phase = "readiness"
+
 	// PhaseDeployment validates that components are deployed and healthy.
 	PhaseDeployment Phase = "deployment"
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -41,29 +41,67 @@ import (
 	"github.com/NVIDIA/aicr/pkg/validator/labels"
 )
 
-// checkReadiness evaluates top-level recipe constraints against the snapshot.
-// Returns an error if any constraint fails, nil if all pass or no constraints exist.
-func checkReadiness(rec *recipe.RecipeResult, snap *snapshotter.Snapshot) error {
-	if rec == nil || snap == nil || len(rec.Constraints) == 0 {
-		return nil
+// runReadinessPhase evaluates top-level recipe constraints and returns a PhaseResult
+// with a CTRF report. No cluster access is needed — this runs entirely from the
+// recipe and snapshot.
+func (v *Validator) runReadinessPhase(rec *recipe.RecipeResult, snap *snapshotter.Snapshot) *PhaseResult {
+	start := time.Now()
+	builder := ctrf.NewBuilder("aicr", v.Version, string(PhaseReadiness))
+
+	if rec != nil && snap != nil {
+		for _, c := range rec.Constraints {
+			result := constraints.Evaluate(c, snap)
+			switch {
+			case result.Error != nil:
+				slog.Warn("readiness constraint skipped", "name", c.Name, "error", result.Error)
+				builder.AddSkipped(c.Name, string(PhaseReadiness), fmt.Sprintf("evaluation error: %v", result.Error))
+			case !result.Passed:
+				slog.Info("readiness constraint failed", "name", c.Name, "expected", c.Value, "actual", result.Actual)
+				builder.AddResult(&ctrf.ValidatorResult{
+					Name:           c.Name,
+					Phase:          string(PhaseReadiness),
+					ExitCode:       1,
+					TerminationMsg: fmt.Sprintf("expected %s, got %s", c.Value, result.Actual),
+					Stdout:         []string{fmt.Sprintf("Constraint: %s %s → false (actual: %s)", c.Name, c.Value, result.Actual)},
+				})
+			default:
+				slog.Info("readiness constraint passed", "name", c.Name, "expected", c.Value, "actual", result.Actual)
+				builder.AddResult(&ctrf.ValidatorResult{
+					Name:   c.Name,
+					Phase:  string(PhaseReadiness),
+					Stdout: []string{fmt.Sprintf("Constraint: %s %s → true (actual: %s)", c.Name, c.Value, result.Actual)},
+				})
+			}
+		}
 	}
 
-	slog.Info("readiness pre-flight", "constraints", len(rec.Constraints))
+	report := builder.Build()
 
-	for _, c := range rec.Constraints {
-		result := constraints.Evaluate(c, snap)
-		if result.Error != nil {
-			slog.Warn("readiness constraint skipped", "name", c.Name, "error", result.Error)
-			continue
-		}
-		if !result.Passed {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("readiness check failed: %s expected %s, got %s", c.Name, c.Value, result.Actual))
-		}
-		slog.Info("readiness constraint passed", "name", c.Name, "expected", c.Value, "actual", result.Actual)
+	var status string
+	switch {
+	case report.Results.Summary.Failed > 0:
+		status = ctrf.StatusFailed
+	case report.Results.Summary.Tests == 0:
+		status = ctrf.StatusSkipped
+	default:
+		status = ctrf.StatusPassed
 	}
 
-	return nil
+	duration := time.Since(start)
+	slog.Info("readiness phase completed",
+		"status", status,
+		"constraints", report.Results.Summary.Tests,
+		"passed", report.Results.Summary.Passed,
+		"failed", report.Results.Summary.Failed,
+		"skipped", report.Results.Summary.Skipped,
+		"duration", duration)
+
+	return &PhaseResult{
+		Phase:    PhaseReadiness,
+		Status:   status,
+		Report:   report,
+		Duration: duration,
+	}
 }
 
 // New creates a new Validator with the provided options.
@@ -158,10 +196,41 @@ func (v *Validator) ValidatePhases(
 
 	slog.Info("running validation phases", "runID", v.RunID, "phases", phases)
 
-	// Pre-flight: evaluate top-level recipe constraints against snapshot.
-	// Fails fast before deploying any Jobs if prerequisites aren't met.
-	if err := checkReadiness(recipeResult, snap); err != nil {
-		return nil, err
+	// Separate readiness from container-based phases.
+	hasReadiness := false
+	var containerPhases []Phase
+	for _, p := range phases {
+		if p == PhaseReadiness {
+			hasReadiness = true
+		} else {
+			containerPhases = append(containerPhases, p)
+		}
+	}
+
+	results := make([]*PhaseResult, 0, len(phases))
+	overallFailed := false
+
+	// Always run readiness. When explicitly requested, include the result in
+	// the report. When implicit (--phase all), fail fast with an error.
+	pr := v.runReadinessPhase(recipeResult, snap)
+	if hasReadiness {
+		results = append(results, pr)
+		if pr.Status == ctrf.StatusFailed {
+			overallFailed = true
+		}
+	} else if pr.Status == ctrf.StatusFailed {
+		for _, t := range pr.Report.Results.Tests {
+			if t.Status == ctrf.StatusFailed {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("readiness check failed: %s", t.Message))
+			}
+		}
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "readiness check failed")
+	}
+
+	// If readiness-only or no container phases remain, return early.
+	if len(containerPhases) == 0 {
+		return results, nil
 	}
 
 	cat, err := catalog.Load(v.Version)
@@ -171,7 +240,17 @@ func (v *Validator) ValidatePhases(
 
 	// --no-cluster: report all as skipped, no K8s calls
 	if v.NoCluster {
-		return v.phasesSkipped(cat, phases, "skipped - no-cluster mode"), nil
+		skipped := v.phasesSkipped(cat, containerPhases, "skipped - no-cluster mode")
+		return append(results, skipped...), nil
+	}
+
+	// Skip container phases if readiness failed.
+	if overallFailed {
+		for _, phase := range containerPhases {
+			pr := v.phaseSkipped(cat, phase, "skipped due to readiness phase failure")
+			results = append(results, pr)
+		}
+		return results, nil
 	}
 
 	cs, err := v.prepareCluster(ctx, recipeResult, snap)
@@ -181,10 +260,7 @@ func (v *Validator) ValidatePhases(
 	defer close(cs.stopCh)
 	defer v.deferClusterCleanup(cs.clientset) //nolint:contextcheck // cleanup uses fresh context
 
-	results := make([]*PhaseResult, 0, len(phases))
-	overallFailed := false
-
-	for _, phase := range phases {
+	for _, phase := range containerPhases {
 		select {
 		case <-ctx.Done():
 			return results, ctx.Err()
@@ -192,7 +268,6 @@ func (v *Validator) ValidatePhases(
 		}
 
 		if overallFailed {
-			// Skip with a CTRF report showing all validators as skipped
 			pr := v.phaseSkipped(cat, phase, "skipped due to previous phase failure")
 			results = append(results, pr)
 			slog.Info("skipping phase due to previous failure", "phase", phase)

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -221,7 +221,8 @@ func TestValidatePhaseNoCluster(t *testing.T) {
 	}
 }
 
-func TestCheckReadinessNilInputs(t *testing.T) {
+func TestRunReadinessPhaseNilInputsVariants(t *testing.T) {
+	v := New(WithVersion("test"))
 	tests := []struct {
 		name string
 		rec  *recipe.RecipeResult
@@ -233,36 +234,68 @@ func TestCheckReadinessNilInputs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := checkReadiness(tt.rec, tt.snap); err != nil {
-				t.Errorf("checkReadiness() = %v, want nil", err)
+			pr := v.runReadinessPhase(tt.rec, tt.snap)
+			if pr.Status == ctrf.StatusFailed {
+				t.Errorf("runReadinessPhase() status = %q, want non-failed", pr.Status)
 			}
 		})
 	}
 }
 
-func TestCheckReadinessEmptyConstraints(t *testing.T) {
-	rec := &recipe.RecipeResult{
-		Constraints: []recipe.Constraint{},
-	}
+func TestRunReadinessPhaseEmptyConstraints(t *testing.T) {
+	v := New(WithVersion("test"))
+	rec := &recipe.RecipeResult{}
 	snap := &snapshotter.Snapshot{}
-	if err := checkReadiness(rec, snap); err != nil {
-		t.Errorf("checkReadiness() = %v, want nil for empty constraints", err)
+
+	pr := v.runReadinessPhase(rec, snap)
+
+	if pr.Phase != PhaseReadiness {
+		t.Errorf("Phase = %q, want %q", pr.Phase, PhaseReadiness)
+	}
+	if pr.Status != "skipped" {
+		t.Errorf("Status = %q, want %q for empty constraints", pr.Status, "skipped")
+	}
+	if pr.Report.Results.Summary.Tests != 0 {
+		t.Errorf("Tests = %d, want 0", pr.Report.Results.Summary.Tests)
 	}
 }
 
-func TestCheckReadinessPassingConstraint(t *testing.T) {
-	// Use a constraint path that Evaluate can resolve.
-	// When the path cannot be parsed or value not found, Evaluate returns Error (skipped).
-	// A constraint with an unparseable name results in Error != nil -> skipped (not failure).
+func TestRunReadinessPhaseSkippedConstraint(t *testing.T) {
+	v := New(WithVersion("test"))
 	rec := &recipe.RecipeResult{
 		Constraints: []recipe.Constraint{
-			{Name: "invalid-path-that-will-be-skipped", Value: "anything"},
+			{Name: "invalid-path", Value: "anything"},
 		},
 	}
 	snap := &snapshotter.Snapshot{}
-	// Unparseable constraint path => skipped (warn), not failure.
-	if err := checkReadiness(rec, snap); err != nil {
-		t.Errorf("checkReadiness() = %v, want nil for skipped constraint", err)
+
+	pr := v.runReadinessPhase(rec, snap)
+
+	if pr.Phase != PhaseReadiness {
+		t.Errorf("Phase = %q, want %q", pr.Phase, PhaseReadiness)
+	}
+	// Skipped constraints still count as tests, but phase passes (no failures).
+	if pr.Report.Results.Summary.Tests != 1 {
+		t.Errorf("Tests = %d, want 1", pr.Report.Results.Summary.Tests)
+	}
+	if pr.Report.Results.Summary.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", pr.Report.Results.Summary.Skipped)
+	}
+	if pr.Status != "passed" {
+		t.Errorf("Status = %q, want %q", pr.Status, "passed")
+	}
+}
+
+func TestRunReadinessPhaseNilInputs(t *testing.T) {
+	v := New(WithVersion("test"))
+
+	pr := v.runReadinessPhase(nil, nil)
+
+	if pr.Phase != PhaseReadiness {
+		t.Errorf("Phase = %q, want %q", pr.Phase, PhaseReadiness)
+	}
+	if pr.Status != "skipped" {
+		t.Errorf("Status = %q, want %q for nil inputs", pr.Status, "skipped")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Re-enable `--phase readiness` as a selectable CLI option so users can validate recipe constraints against the snapshot before deploying
- Single shared `runReadinessPhase()` replaces the old `checkReadiness()`, serving both explicit and implicit paths
- `--phase all` behavior unchanged: readiness runs as an implicit pre-flight gate

## Motivation

V2 removed `--phase readiness` as a selectable option, breaking the CUJ1 workflow where users validate readiness standalone before deploying. This PR adds it back without duplicating logic.

## Behavior

| CLI | Readiness behavior |
|-----|-------------------|
| `--phase readiness` | Runs readiness only, returns CTRF report, no cluster access |
| `--phase readiness,deployment` | Runs readiness first; if it fails, skips container phases |
| `--phase all` (default) | Readiness runs implicitly as a gate; failure returns error before any Jobs deploy |

## Changes

| File | Change |
|------|--------|
| `pkg/validator/phases.go` | Add `PhaseReadiness` constant |
| `pkg/validator/validator.go` | Replace `checkReadiness()` with `runReadinessPhase()`, update `ValidatePhases()` |
| `pkg/cli/validate.go` | Accept "readiness" in CLI parser, update usage strings |
| `pkg/cli/validate_test.go` | Change "readiness is invalid" test to expect success |
| `pkg/validator/validator_test.go` | Replace `checkReadiness` tests with `runReadinessPhase` equivalents |

## Test plan

- [x] `go test -race ./pkg/validator/...` passes
- [x] `go test -race ./pkg/cli/...` passes
- [x] `--phase readiness` accepted by CLI parser
- [x] `--phase all` behavior unchanged (implicit readiness gate)
- [x] Nil/empty constraint edge cases covered
