### PR TITLE
docs: launch prep — README refresh, component catalog, and fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,10 +88,10 @@ NVIDIA AICR provides validated GPU-accelerated Kubernetes configurations through
 - **CLI (`aicr`)**: All four stages (snapshot/recipe/validate/bundle)
 - **API Server (`aicrd`)**: Recipe generation and bundle creation via REST API
 - **Agent**: Kubernetes Job for automated cluster snapshots → ConfigMaps
-- **Bundlers**: Plugin-based artifact generators (GPU Operator, Network Operator, Cert-Manager, NVSentinel, Skyhook, DRA Driver)
+- **Bundlers**: Plugin-based artifact generators — one per component in `recipes/registry.yaml`
 - **Deployers**: GitOps integration providers (helm, argocd) with deployment ordering
 
-**Tech Stack:** Go 1.25, Kubernetes 1.33+, golangci-lint v2.9, Container images via Ko
+**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.10.1, Container images via Ko
 
 **Package Architecture (Critical Principle):**
 - **User Interaction Packages** (`pkg/cli`, `pkg/api`): Focus solely on capturing user intent, validating input, and formatting output. No business logic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ This creates three files with TODOs guiding implementation:
 3. Run `make test` - registration validation ensures completeness
 4. Submit PR - CI enforces all requirements
 
-**See [pkg/validator/checks/README.md](pkg/validator/checks/README.md) for complete guide with examples, architecture overview, and troubleshooting.**
+**See [docs/contributor/validator.md](docs/contributor/validator.md) for complete guide with examples, architecture overview, and troubleshooting.**
 
 ## Design Principles
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -806,7 +806,7 @@ make validate-local RECIPE=recipe.yaml IMAGE_TAG=dev
 
 For detailed information on adding validation checks and constraint validators, see:
 
-**[pkg/validator/checks/README.md](pkg/validator/checks/README.md)**
+**[docs/contributor/validator.md](docs/contributor/validator.md)**
 
 This comprehensive guide covers:
 - Architecture overview (Job-based validation, test registration framework)

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ The `bundles/` directory contains per-component Helm charts with values files, c
 
 See the [Installation Guide](docs/user/installation.md) for manual installation, building from source, and container images.
 
-## Components
+## Features
 
-| Component | Description |
-|-----------|-------------|
+| Feature | Description |
+|---------|-------------|
 | **`aicr` CLI** | Single binary. Generate recipes, create bundles, capture snapshots, validate configs. |
 | **API Server (`aicrd`)** | REST API with the same capabilities as the CLI. Run in-cluster for CI/CD integration or air-gapped environments. |
 | **Snapshot Agent** | Kubernetes Job that captures live cluster state (GPU hardware, drivers, OS, operators) into a ConfigMap for validation against recipes. |
 | **Supply Chain Security** | SLSA Level 3 provenance, signed SBOMs, image attestations (cosign), and checksum verification on every release. |
 
-## Supported Environments
+## Supported Components
 
 | Dimension | This Release |
 |-----------|-------------|
@@ -61,7 +61,7 @@ See the [Installation Guide](docs/user/installation.md) for manual installation,
 | **GPUs** | NVIDIA H100, GB200 |
 | **OS** | Ubuntu |
 | **Workloads** | Training (Kubeflow), Inference (Dynamo) |
-| **Components** | GPU Operator, Network Operator, cert-manager, Prometheus stack, and others |
+| **Components** | GPU Operator, Network Operator, cert-manager, Prometheus stack, and [others](docs/user/component-catalog.md) |
 
 Need a different combination? [Open an issue](https://github.com/NVIDIA/aicr/issues) — that feedback directly shapes what gets validated next.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI Cluster Runtime (AICR) makes it easy to stand up GPU-accelerated Kubernetes c
 
 Running GPU-accelerated Kubernetes clusters reliably is hard. Small differences in kernel versions, drivers, container runtimes, operators, and Kubernetes releases can cause failures that are difficult to diagnose and expensive to reproduce.
 
-Historically, this knowledge has lived in internal validation pipelines and runbooks. AI Cluster Runtime makes it available to everyone. 
+Historically, this knowledge has lived in internal validation pipelines and runbooks. AI Cluster Runtime makes it available to everyone.
 
 Every AICR recipe is:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Choose the path that matches how you'll use the project.
 - **[CLI Reference](docs/user/cli-reference.md)** — Complete command reference with examples
 - **[API Reference](docs/user/api-reference.md)** — REST API quick start
 - **[Agent Deployment](docs/user/agent-deployment.md)** — Deploy the Kubernetes agent for automated snapshots
+- **[Component Catalog](docs/user/component-catalog.md)** — Every component that can appear in a recipe
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See the [Installation Guide](docs/user/installation.md) for manual installation,
 |-----------|-------------|
 | **`aicr` CLI** | Single binary. Generate recipes, create bundles, capture snapshots, validate configs. |
 | **API Server (`aicrd`)** | REST API with the same capabilities as the CLI. Run in-cluster for CI/CD integration or air-gapped environments. |
-| **Cluster Agent** | Optional Kubernetes agent for continuous state monitoring. Flags configuration drift as it happens. |
+| **Snapshot Agent** | Kubernetes Job that captures live cluster state (GPU hardware, drivers, OS, operators) into a ConfigMap for validation against recipes. |
 | **Supply Chain Security** | SLSA Level 3 provenance, signed SBOMs, image attestations (cosign), and checksum verification on every release. |
 
 ## Supported Environments

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ See the [Installation Guide](docs/user/installation.md) for manual installation,
 | **GPUs** | NVIDIA H100, GB200 |
 | **OS** | Ubuntu |
 | **Workloads** | Training (Kubeflow), Inference (Dynamo) |
-| **Components** | GPU Operator, Network Operator, cert-manager, Prometheus stack, and [others](docs/user/component-catalog.md) |
+| **Components** | GPU Operator, Network Operator, cert-manager, Prometheus stack, etc. |
 
-Need a different combination? [Open an issue](https://github.com/NVIDIA/aicr/issues) — that feedback directly shapes what gets validated next.
+See the full [Component Catalog](docs/user/component-catalog.md) for every component that can appear in a recipe. Don't see what you need? [Open an issue](https://github.com/NVIDIA/aicr/issues) — that feedback directly shapes what gets validated next.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -67,15 +67,9 @@ Need a different combination? [Open an issue](https://github.com/NVIDIA/aicr/iss
 
 ## How It Works
 
-A **recipe** is a version-locked configuration for a specific environment. You describe your target (cloud, GPU, OS, workload intent), and the recipe engine matches it against a library of validated **overlays** — layered configurations that compose bottom-up from base defaults through cloud, accelerator, OS, and workload-specific tuning.
+![AICR end-to-end workflow](docs/images/aicr-end-to-end.png)
 
-```
-Overlays (many)  →  Recipe (one)  →  Bundle (deployable)
-                     version-locked     Helm charts,
-base + cloud +       YAML with all      manifests,
-accelerator + OS +   resolved values    scripts
-intent + platform
-```
+A **recipe** is a version-locked configuration for a specific environment. You describe your target (cloud, GPU, OS, workload intent), and the recipe engine matches it against a library of validated **overlays** — layered configurations that compose bottom-up from base defaults through cloud, accelerator, OS, and workload-specific tuning.
 
 The **bundler** materializes a recipe into deployment-ready artifacts: one folder per component, each with Helm values, checksums, and a README. The **validator** compares a recipe against a live cluster snapshot and flags anything out of spec.
 

--- a/README.md
+++ b/README.md
@@ -1,132 +1,136 @@
-# AI Cluster Runtime (AICR)
+# NVIDIA AI Cluster Runtime
 
 [![On Push CI](https://github.com/NVIDIA/aicr/actions/workflows/on-push.yaml/badge.svg)](https://github.com/NVIDIA/aicr/actions/workflows/on-push.yaml)
 [![On Tag Release](https://github.com/NVIDIA/aicr/actions/workflows/on-tag.yaml/badge.svg)](https://github.com/NVIDIA/aicr/actions/workflows/on-tag.yaml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-AICR provides tooling for deploying optimized and validated GPU-accelerated AI runtime in Kubernetes. It captures known-good combinations of drivers, operators, kernels, and system configurations to create a reproducible artifacts for common Kubernetes deployment frameworks like Helm and ArgoCD.
+AI Cluster Runtime (AICR) makes it easy to stand up GPU-accelerated Kubernetes clusters. It captures known-good combinations of drivers, operators, kernels, and system configurations and publishes them as version-locked **recipes** — reproducible artifacts for Helm, ArgoCD, and other deployment frameworks.
 
 ## Why We Built This
 
 Running GPU-accelerated Kubernetes clusters reliably is hard. Small differences in kernel versions, drivers, container runtimes, operators, and Kubernetes releases can cause failures that are difficult to diagnose and expensive to reproduce.
 
-Historically, this knowledge has lived in internal validation pipelines, playbooks, and tribal knowledge. AICR exists to externalize that experience. Its goal is to make validated configurations visible, repeatable, and reusable across environments.
+Historically, this knowledge has lived in internal validation pipelines and runbooks. AI Cluster Runtime makes it available to everyone. 
 
-## What AICR Is (and Is Not)
+Every AICR recipe is:
 
-AICR is a **source of validated configuration knowledge** for NVIDIA-accelerated Kubernetes environments.
+- **Optimized** — Tuned for a specific combination of hardware, cloud, OS, and workload intent.
+- **Validated** — Passes automated constraint and compatibility checks before publishing.
+- **Reproducible** — Same inputs produce identical deployments every time.
 
-It **is**:
-- A curated set of tested and validated component combinations
-- A reference for how NVIDIA-accelerated Kubernetes clusters are expected to be configured
-- A foundation for generating reproducible deployment artifacts
-- Designed to integrate with existing provisioning, CI/CD, and GitOps workflows
+## Quick Start
 
-It **is not**:
-- A Kubernetes distribution
-- A cluster provisioning or lifecycle management system
-- A managed control plane or hosted service
-- A replacement for cloud provider or OEM platforms
-
-## How It Works
-
-AICR separates **validated configuration knowledge** from **how that knowledge is consumed**.
-
-- Human-readable documentation lives under `docs/`.
-- Version-locked configuration definitions (“recipes”) capture known-good system states.
-- Those definitions can be rendered into concrete artifacts such as Helm values, Kubernetes manifests, or install scripts.- Recipes can be validated against actual system configurations to verify compatibility.
-
-This separation allows the same validated configuration to be applied consistently across different environments and automation systems.
-
-*For example, a configuration validated for GB200 on Ubuntu 22.04 with Kubernetes 1.34 can be rendered into Helm values and manifests suitable for use in an existing GitOps pipeline.*
-
-## Get Started
-
-> Some tooling and APIs are under active development; documentation reflects current and near-term capabilities.
-
-### Installation
-
-Install the latest version using the installation script:
-
-```shell
-curl -sfL https://raw.githubusercontent.com/NVIDIA/aicr/main/install | bash -s --
-```
-
-See [Installation Guide](docs/user/installation.md) for manual installation, building from source, and container images.
-
-### Quick Start
-
-Get started quickly with AICR:
-1. Review the documentation under `docs/` to understand supported platforms and required components.
-2. Identify your target environment:
-   - GPU architecture
-   - Operating system and kernel
-   - Kubernetes distribution and version
-   - Workload intent (for example, training or inference)
-3. Apply the validated configuration guidance using your existing tools (Helm, kubectl, CI/CD, or GitOps).
-4. Validate and iterate as platforms and workloads evolve.
-
-**Example:** Generate a validated configuration for GB200 on EKS with Ubuntu, optimized for Kubeflow training:
+Install and generate your first recipe in under two minutes:
 
 ```bash
-# Generate a recipe for your environment
-aicr recipe --service eks --accelerator gb200 --os ubuntu --intent training --platform kubeflow -o recipe.yaml
+# Install the CLI
+curl -sfL https://raw.githubusercontent.com/NVIDIA/aicr/main/install | bash -s --
 
-# Render the recipe into Helm values for your GitOps pipeline
+# Capture your cluster's current state
+aicr snapshot --output snapshot.yaml
+
+# Generate a validated recipe for your environment
+aicr recipe --service eks --accelerator h100 --os ubuntu \
+  --intent training --platform kubeflow -o recipe.yaml
+
+# Validate the recipe against your cluster
+aicr validate --recipe recipe.yaml --snapshot snapshot.yaml
+
+# Render into deployment-ready Helm charts
 aicr bundle --recipe recipe.yaml -o ./bundles
 ```
 
-The generated `bundles/` directory contains a Helm per-component bundle ready to deploy or commit to your GitOps repository. See [CLI Reference](docs/user/cli-reference.md) for more options.
+The `bundles/` directory contains per-component Helm charts with values files, checksums, and deployer configs. Deploy with `helm install`, commit to a GitOps repo, or use the built-in ArgoCD deployer.
 
-### Get Started by Use Case
+See the [Installation Guide](docs/user/installation.md) for manual installation, building from source, and container images.
 
-Choose the documentation path that matches how you'll use AICR.
+## Components
+
+| Component | Description |
+|-----------|-------------|
+| **`aicr` CLI** | Single binary. Generate recipes, create bundles, capture snapshots, validate configs. |
+| **API Server (`aicrd`)** | REST API with the same capabilities as the CLI. Run in-cluster for CI/CD integration or air-gapped environments. |
+| **Cluster Agent** | Optional Kubernetes agent for continuous state monitoring. Flags configuration drift as it happens. |
+| **Supply Chain Security** | SLSA Level 3 provenance, signed SBOMs, image attestations (cosign), and checksum verification on every release. |
+
+## Supported Environments
+
+| Dimension | This Release |
+|-----------|-------------|
+| **Kubernetes** | Amazon EKS, GKE, self-managed (Kind) |
+| **GPUs** | NVIDIA H100, GB200 |
+| **OS** | Ubuntu |
+| **Workloads** | Training (Kubeflow), Inference (Dynamo) |
+| **Components** | GPU Operator, Network Operator, cert-manager, Prometheus stack, and others |
+
+Need a different combination? [Open an issue](https://github.com/NVIDIA/aicr/issues) — that feedback directly shapes what gets validated next.
+
+## How It Works
+
+A **recipe** is a version-locked configuration for a specific environment. You describe your target (cloud, GPU, OS, workload intent), and the recipe engine matches it against a library of validated **overlays** — layered configurations that compose bottom-up from base defaults through cloud, accelerator, OS, and workload-specific tuning.
+
+```
+Overlays (many)  →  Recipe (one)  →  Bundle (deployable)
+                     version-locked     Helm charts,
+base + cloud +       YAML with all      manifests,
+accelerator + OS +   resolved values    scripts
+intent + platform
+```
+
+The **bundler** materializes a recipe into deployment-ready artifacts: one folder per component, each with Helm values, checksums, and a README. The **validator** compares a recipe against a live cluster snapshot and flags anything out of spec.
+
+This separation means the same validated configuration works whether you deploy with Helm, ArgoCD, Flux, or a custom pipeline.
+
+## What AI Cluster Runtime Is Not
+
+- Not a Kubernetes distribution
+- Not a cluster provisioner or lifecycle management system
+- Not a managed control plane or hosted service
+- Not a replacement for your cloud provider or OEM platform
+
+You bring your cluster and your tools. AI Cluster Runtime tells you what should be installed and how it should be configured.
+
+## Documentation
+
+Choose the path that matches how you'll use the project.
 
 <details>
-<summary><strong>User</strong> – Platform and Infrastructure Operators</summary>
+<summary><strong>User</strong> — Platform and Infrastructure Operators</summary>
 
-You deploy and operate GPU-accelerated Kubernetes clusters using validated configurations.
-
-- **[Installation Guide](docs/user/installation.md)** – Install the aicr CLI (automated script, manual, or build from source)
-- **[CLI Reference](docs/user/cli-reference.md)** – Complete command reference with examples
-- **[API Reference](docs/user/api-reference.md)** – REST API quick start
-- **[Agent Deployment](docs/user/agent-deployment.md)** – Deploy the Kubernetes agent for automated snapshots
+- **[Installation Guide](docs/user/installation.md)** — Install the `aicr` CLI (automated script, manual, or build from source)
+- **[CLI Reference](docs/user/cli-reference.md)** — Complete command reference with examples
+- **[API Reference](docs/user/api-reference.md)** — REST API quick start
+- **[Agent Deployment](docs/user/agent-deployment.md)** — Deploy the Kubernetes agent for automated snapshots
 </details>
 
 <details>
-<summary><strong>Contributor</strong> – Developers and Maintainers</summary>
+<summary><strong>Contributor</strong> — Developers and Maintainers</summary>
 
-You contribute code, extend functionality, or work on AICR internals.
-
-- **[Agent Instructions](AGENTS.md)** – Core coding-agent guidance for Codex/Copilot (mirrors `.claude/CLAUDE.md`)
-- **[Contributing Guide](CONTRIBUTING.md)** – Development setup, testing, and PR process
-- **[Development Guide](DEVELOPMENT.md)** – Local development, Make targets, and tooling
-- **[Architecture Overview](docs/contributor/README.md)** – System design and components
-- **[Bundler Development](docs/contributor/component.md)** – How to create new bundlers
-- **[Data Architecture](docs/contributor/data.md)** – Recipe data model and query matching
+- **[Contributing Guide](CONTRIBUTING.md)** — Development setup, testing, and PR process
+- **[Development Guide](DEVELOPMENT.md)** — Local development, Make targets, and tooling
+- **[Architecture Overview](docs/contributor/README.md)** — System design and components
+- **[Bundler Development](docs/contributor/component.md)** — How to create new bundlers
+- **[Data Architecture](docs/contributor/data.md)** — Recipe data model and query matching
+- **[Agent Instructions](AGENTS.md)** — Coding-agent guidance for Codex/Copilot
 </details>
 
 <details>
-<summary><strong>Integrator</strong> – Automation and Platform Engineers</summary>
+<summary><strong>Integrator</strong> — Automation and Platform Engineers</summary>
 
-You integrate AICR into CI/CD pipelines, GitOps workflows, or larger platforms.
-
-- **[API Reference](docs/user/api-reference.md)** – REST API endpoints and usage examples
-- **[Data Flow](docs/integrator/data-flow.md)** – Understanding snapshots, recipes, and bundles
-- **[Automation Guide](docs/integrator/automation.md)** – CI/CD integration patterns
-- **[Kubernetes Deployment](docs/integrator/kubernetes-deployment.md)** – Self-hosted API server setup
-- **[Recipe Development](docs/integrator/recipe-development.md)** – Adding and modifying recipe metadata
+- **[API Reference](docs/user/api-reference.md)** — REST API endpoints and usage examples
+- **[Data Flow](docs/integrator/data-flow.md)** — Understanding snapshots, recipes, and bundles
+- **[Automation Guide](docs/integrator/automation.md)** — CI/CD integration patterns
+- **[Kubernetes Deployment](docs/integrator/kubernetes-deployment.md)** — Self-hosted API server setup
+- **[Recipe Development](docs/integrator/recipe-development.md)** — Adding and modifying recipe metadata
 </details>
 
-## Documentation & Resources
+## Resources
 
-- **[Documentation](docs/README.md)** – Documentation, guides, and examples.
-- **[Roadmap](ROADMAP.md)** – Feature priorities and development timeline
-- **[Overview](docs/README.md)** - Detailed system overview and glossary
-- **[Security](SECURITY.md)** - Security-related resources 
-- **[Releases](https://github.com/NVIDIA/aicr/releases)** - Binaries, SBOMs, and other artifacts
-- **[Issues](https://github.com/NVIDIA/aicr/issues)** - Bugs, feature requests, and questions
+- **[Roadmap](ROADMAP.md)** — Feature priorities and development timeline
+- **[Security](SECURITY.md)** — Supply chain security, vulnerability reporting, and verification
+- **[Releases](https://github.com/NVIDIA/aicr/releases)** — Binaries, SBOMs, and attestations
+- **[Issues](https://github.com/NVIDIA/aicr/issues)** — Bugs, feature requests, and questions
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, contribution guidelines, and the pull request process.
+AI Cluster Runtime is Apache 2.0. Contributions are welcome: new recipes for environments we haven't covered (OpenShift, AKS, bare metal), additional bundler formats, validation checks, or bug reports. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the PR process.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # AICR Roadmap
 
-This roadmap tracks remaining work for AICR v2 launch and future enhancements.
+This roadmap tracks remaining work for the AICR launch and future enhancements.
 
 ## Structure
 
 | Section | Description |
 |---------|-------------|
-| **Remaining MVP Work** | Tasks blocking v2 launch |
+| **Remaining MVP Work** | Tasks blocking launch |
 | **Backlog** | Post-launch enhancements by priority |
 | **Completed** | Delivered capabilities (reference only) |
 
@@ -98,7 +98,7 @@ Extend beyond MVP platforms and accelerators.
 
 #### New Bundlers
 
-Migrate capabilities from AICR v1 playbooks.
+Additional component bundlers.
 
 | Bundler | Description |
 |---------|-------------|

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1033,8 +1033,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/go-ci
         with:
-          go_version: '1.25'
-          golangci_lint_version: 'v2.6'
+          go_version: '1.26'
+          golangci_lint_version: 'v2.10.1'
 ```
 
 ### Adding New Tests

--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -40,7 +40,7 @@ Deploy the AICR API Server in your Kubernetes cluster for self-hosted recipe gen
 # Create namespace
 kubectl create namespace aicr
 
-# Deploy API server (see full manifest below)
+# Deploy API server (save the manifest from the Deployment section below as aicrd-deployment.yaml)
 kubectl apply -f aicrd-deployment.yaml
 
 # Check deployment

--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -321,13 +321,20 @@ spec:
         - cm://gpu-operator/aicr-snapshot
         
         securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 65532
-          capabilities:
-            drop: ["ALL"]
+          privileged: true
+          runAsUser: 0
+          runAsGroup: 0
+      hostPID: true
+      hostNetwork: true
+      hostIPC: true
+      volumes:
+      - name: systemd
+        hostPath:
+          path: /run/systemd
+          type: Directory
 ```
+
+> **Note:** The agent defaults to privileged mode, which is required for GPU, SystemD, and OS collectors. For PSS-restricted namespaces where only the Kubernetes collector is needed, use `--privileged=false` when deploying via the CLI. See [Agent Deployment](../user/agent-deployment.md) for details.
 
 ```shell
 kubectl apply -f agent-job.yaml

--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -40,8 +40,8 @@ Deploy the AICR API Server in your Kubernetes cluster for self-hosted recipe gen
 # Create namespace
 kubectl create namespace aicr
 
-# Deploy API server
-kubectl apply -k https://github.com/NVIDIA/aicr/deploy/aicrd
+# Deploy API server (see full manifest below)
+kubectl apply -f aicrd-deployment.yaml
 
 # Check deployment
 kubectl get pods -n aicr
@@ -542,8 +542,6 @@ kubectl apply -f servicemonitor.yaml
 ```
 
 ### Grafana Dashboard
-
-Import dashboard JSON from `docs/monitoring/grafana-dashboard.json`:
 
 **Key panels:**
 - Request rate (by status code)

--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -15,7 +15,7 @@ Deploy the AICR API Server in your Kubernetes cluster for self-hosted recipe gen
 
 - Recipe generation from query parameters (query mode)
 - Does not capture snapshots (use agent Job or CLI)
-- Does not generate bundles (use CLI)
+- Generates bundles via `POST /v1/bundle`
 - Does not analyze snapshots (query mode only)
 
 **Agent deployment** (separate component):

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -18,6 +18,7 @@ This section is for users who:
 | [CLI Reference](cli-reference.md) | Complete command reference with examples for all CLI operations |
 | [API Reference](api-reference.md) | REST API quick start and endpoint documentation |
 | [Agent Deployment](agent-deployment.md) | Deploy the Kubernetes agent for automated cluster snapshots |
+| [Component Catalog](component-catalog.md) | Every component that can appear in a recipe |
 
 ## Quick Start
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -289,14 +289,28 @@ The request body is the recipe (RecipeResult) directly. No wrapper object needed
 
 **Supported Bundlers:**
 
+Bundler names correspond to component names in [`recipes/registry.yaml`](../../recipes/registry.yaml). Any component registered there can be passed as a bundler. Current components:
+
 | Bundler | Description |
 |---------|-------------|
-| `gpu-operator` | NVIDIA GPU Operator |
-| `network-operator` | NVIDIA Network Operator |
-| `cert-manager` | Certificate Manager |
-| `nvsentinel` | NVSentinel monitoring |
-| `skyhook-operator` | Skyhook node optimization |
-| `nvidia-dra-driver-gpu` | NVIDIA DRA (Dynamic Resource Allocation) Driver |
+| `gpu-operator` | NVIDIA GPU Operator — driver and runtime lifecycle |
+| `network-operator` | NVIDIA Network Operator — RDMA, SR-IOV, host networking |
+| `aws-efa` | AWS Elastic Fabric Adapter device plugin (EKS) |
+| `cert-manager` | TLS certificate management |
+| `skyhook-operator` | OS-level node tuning and kernel configuration |
+| `skyhook-customizations` | Environment-specific node tuning profiles |
+| `nvsentinel` | GPU health monitoring and automated remediation |
+| `nvidia-dra-driver-gpu` | Dynamic Resource Allocation driver for GPUs |
+| `kube-prometheus-stack` | Prometheus, Grafana, Alertmanager monitoring stack |
+| `prometheus-adapter` | Custom metrics for HPA scaling |
+| `aws-ebs-csi-driver` | Amazon EBS CSI driver (EKS) |
+| `k8s-ephemeral-storage-metrics` | Ephemeral storage usage metrics |
+| `kai-scheduler` | DRA-aware gang scheduler with topology-aware placement |
+| `dynamo-crds` | NVIDIA Dynamo inference serving CRDs |
+| `dynamo-platform` | NVIDIA Dynamo inference serving platform |
+| `kgateway-crds` | Kubernetes Gateway API CRDs |
+| `kgateway` | Kubernetes Gateway API implementation |
+| `kubeflow-trainer` | Kubeflow Training Operator for distributed training |
 
 **Examples:**
 
@@ -614,13 +628,12 @@ recipe = resp.json()
 
 print(f"Recipe has {len(recipe['componentRefs'])} components")
 
-# Generate bundles
-bundle_req = {
-    "recipe": recipe,
-    "bundlers": ["gpu-operator"]
-}
-
-resp = requests.post(f"{BASE_URL}/v1/bundle", json=bundle_req)
+# Generate bundles — recipe is the request body, bundlers are query params
+resp = requests.post(
+    f"{BASE_URL}/v1/bundle",
+    params={"bundlers": "gpu-operator"},
+    json=recipe,
+)
 resp.raise_for_status()
 
 # Extract zip
@@ -683,14 +696,11 @@ async function main() {
     
     console.log(`Recipe has ${recipe.componentRefs.length} components`);
     
-    // Generate bundles
-    const bundleResp = await fetch(`${BASE_URL}/v1/bundle`, {
+    // Generate bundles — recipe is the request body, bundlers are query params
+    const bundleResp = await fetch(`${BASE_URL}/v1/bundle?bundlers=gpu-operator`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-            recipe: recipe,
-            bundlers: ["gpu-operator"]
-        })
+        body: JSON.stringify(recipe),
     });
     
     // Save zip

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -1,0 +1,51 @@
+# Component Catalog
+
+AICR recipes are composed of components — the individual software packages that make up a GPU-accelerated Kubernetes runtime. This page lists every component that can appear in a recipe. 
+
+> ***Note:*** Components are include as appropriate in recipes. Not every component listed here will appear in a recipe.
+
+The source of truth is [`recipes/registry.yaml`](../../recipes/registry.yaml). Each entry in the registry defines the component's Helm chart (or Kustomize source), default version, namespace, and node scheduling configuration. If a component is not listed there, it cannot appear in a recipe.
+
+## Components
+
+| Component | Description | Source |
+|-----------|-------------|--------|
+| **gpu-operator** | Manages the GPU driver and runtime lifecycle on Kubernetes nodes. Handles driver installation, container runtime configuration, device plugin, and GPU feature discovery. | [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) |
+| **network-operator** | Manages high-performance networking for GPU workloads. Configures RDMA, SR-IOV, and host networking for multi-node communication. | [NVIDIA Network Operator](https://github.com/Mellanox/network-operator) |
+| **aws-efa** | Device plugin for AWS Elastic Fabric Adapter. Enables low-latency networking on EKS clusters with EFA-capable instances. EKS-specific. | [AWS EFA K8s Device Plugin](https://github.com/aws/eks-charts) |
+| **cert-manager** | Automates TLS certificate management. Required by several operators for webhook and API server certificates. | [cert-manager](https://github.com/cert-manager/cert-manager) |
+| **skyhook-operator** | OS-level node tuning and configuration management. Applies kernel parameters, sysctl settings, and system-level optimizations to nodes. | [Skyhook](https://github.com/nvidia/skyhook) |
+| **skyhook-customizations** | Custom tuning profiles applied via Skyhook. Extends the operator with environment-specific node configurations (kernel params, hugepages, etc.). | — |
+| **nvsentinel** | GPU health monitoring and automated remediation. Detects GPU errors and can cordon or drain affected nodes. | [NVSentinel](https://github.com/NVIDIA/nvsentinel) |
+| **nvidia-dra-driver-gpu** | Dynamic Resource Allocation driver for GPUs. Enables structured GPU device advertisement and claim-based allocation in Kubernetes 1.33+. | [NVIDIA DRA Driver](https://github.com/NVIDIA/k8s-dra-driver-gpu) |
+| **kube-prometheus-stack** | Cluster monitoring: Prometheus, Grafana, Alertmanager, and node exporters. Provides GPU and cluster metrics collection and dashboards. | [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts) |
+| **prometheus-adapter** | Exposes custom metrics from Prometheus to the Kubernetes metrics API. Enables HPA scaling based on GPU utilization and other custom metrics. | [prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter) |
+| **aws-ebs-csi-driver** | CSI driver for Amazon EBS volumes. Provides persistent storage for workloads on EKS. EKS-specific. | [AWS EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) |
+| **k8s-ephemeral-storage-metrics** | Exports ephemeral storage usage metrics per pod. Useful for monitoring scratch space consumption on GPU nodes. | [k8s-ephemeral-storage-metrics](https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics) |
+| **kai-scheduler** | DRA-aware gang scheduler with hierarchical queues and topology-aware placement. Ensures distributed training jobs land on nodes with optimal interconnect topology. | [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) |
+| **dynamo-crds** | Custom Resource Definitions for NVIDIA Dynamo inference serving. Installed separately from the platform to support CRD lifecycle management. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
+| **dynamo-platform** | NVIDIA Dynamo inference serving platform. Distributed inference with prefix-cache-aware routing and disaggregated prefill/decode. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
+| **kgateway-crds** | Custom Resource Definitions for kgateway (Kubernetes Gateway API implementation). | [kgateway](https://github.com/kgateway-dev/kgateway) |
+| **kgateway** | Kubernetes Gateway API implementation. Provides model-aware ingress routing for inference workloads. | [kgateway](https://github.com/kgateway-dev/kgateway) |
+| **kubeflow-trainer** | Kubeflow Training Operator for distributed training jobs (PyTorch, etc.). Manages multi-node training job lifecycle with JobSet integration. | [Kubeflow Trainer](https://github.com/kubeflow/trainer) |
+
+## How Components Are Selected
+
+Not every component appears in every recipe. The recipe engine selects components based on the overlay chain for your environment:
+
+- **Base components** (cert-manager, kube-prometheus-stack) appear in most recipes.
+- **Cloud-specific components** (aws-efa, aws-ebs-csi-driver) are added when the service matches.
+- **Intent-specific components** (kubeflow-trainer, dynamo-platform, kai-scheduler) are added based on workload intent.
+- **Accelerator/OS-specific tuning** (skyhook-customizations, nvidia-dra-driver-gpu) varies by hardware and OS combination.
+
+To see exactly which components appear in a given recipe, generate one:
+
+```bash
+aicr recipe --service eks --accelerator h100 --os ubuntu --intent training -o recipe.yaml
+```
+
+The output lists every component with its pinned version and configuration values.
+
+## Adding Components
+
+New components are added declaratively in `recipes/registry.yaml` — no Go code required. See the [Contributing Guide](../../CONTRIBUTING.md) and [Bundler Development](../contributor/component.md) docs for details.

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -15,7 +15,6 @@ The source of truth is [`recipes/registry.yaml`](../../recipes/registry.yaml). E
 | **aws-efa** | Device plugin for AWS Elastic Fabric Adapter. Enables low-latency networking on EKS clusters with EFA-capable instances. EKS-specific. | [AWS EFA K8s Device Plugin](https://github.com/aws/eks-charts) |
 | **cert-manager** | Automates TLS certificate management. Required by several operators for webhook and API server certificates. | [cert-manager](https://github.com/cert-manager/cert-manager) |
 | **skyhook-operator** | OS-level node tuning and configuration management. Applies kernel parameters, sysctl settings, and system-level optimizations to nodes. | [Skyhook](https://github.com/nvidia/skyhook) |
-| **skyhook-customizations** | Custom tuning profiles applied via Skyhook. Extends the operator with environment-specific node configurations (kernel params, hugepages, etc.). | — |
 | **nvsentinel** | GPU health monitoring and automated remediation. Detects GPU errors and can cordon or drain affected nodes. | [NVSentinel](https://github.com/NVIDIA/nvsentinel) |
 | **nvidia-dra-driver-gpu** | Dynamic Resource Allocation driver for GPUs. Enables structured GPU device advertisement and claim-based allocation in Kubernetes 1.33+. | [NVIDIA DRA Driver](https://github.com/NVIDIA/k8s-dra-driver-gpu) |
 | **kube-prometheus-stack** | Cluster monitoring: Prometheus, Grafana, Alertmanager, and node exporters. Provides GPU and cluster metrics collection and dashboards. | [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts) |
@@ -23,9 +22,7 @@ The source of truth is [`recipes/registry.yaml`](../../recipes/registry.yaml). E
 | **aws-ebs-csi-driver** | CSI driver for Amazon EBS volumes. Provides persistent storage for workloads on EKS. EKS-specific. | [AWS EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) |
 | **k8s-ephemeral-storage-metrics** | Exports ephemeral storage usage metrics per pod. Useful for monitoring scratch space consumption on GPU nodes. | [k8s-ephemeral-storage-metrics](https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics) |
 | **kai-scheduler** | DRA-aware gang scheduler with hierarchical queues and topology-aware placement. Ensures distributed training jobs land on nodes with optimal interconnect topology. | [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) |
-| **dynamo-crds** | Custom Resource Definitions for NVIDIA Dynamo inference serving. Installed separately from the platform to support CRD lifecycle management. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
-| **dynamo-platform** | NVIDIA Dynamo inference serving platform. Distributed inference with prefix-cache-aware routing and disaggregated prefill/decode. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
-| **kgateway-crds** | Custom Resource Definitions for kgateway (Kubernetes Gateway API implementation). | [kgateway](https://github.com/kgateway-dev/kgateway) |
+| **dynamo** | NVIDIA Dynamo inference serving platform. Distributed inference with prefix-cache-aware routing and disaggregated prefill/decode. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
 | **kgateway** | Kubernetes Gateway API implementation. Provides model-aware ingress routing for inference workloads. | [kgateway](https://github.com/kgateway-dev/kgateway) |
 | **kubeflow-trainer** | Kubeflow Training Operator for distributed training jobs (PyTorch, etc.). Manages multi-node training job lifecycle with JobSet integration. | [Kubeflow Trainer](https://github.com/kubeflow/trainer) |
 

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -2,7 +2,7 @@
 
 AICR recipes are composed of components — the individual software packages that make up a GPU-accelerated Kubernetes runtime. This page lists every component that can appear in a recipe. 
 
-> ***Note:*** Components are include as appropriate in recipes. Not every component listed here will appear in a recipe.
+> ***Note:*** Components are included as appropriate in recipes. Not every component listed here will appear in a recipe.
 
 The source of truth is [`recipes/registry.yaml`](../../recipes/registry.yaml). Each entry in the registry defines the component's Helm chart (or Kustomize source), default version, namespace, and node scheduling configuration. If a component is not listed there, it cannot appear in a recipe.
 
@@ -15,6 +15,7 @@ The source of truth is [`recipes/registry.yaml`](../../recipes/registry.yaml). E
 | **aws-efa** | Device plugin for AWS Elastic Fabric Adapter. Enables low-latency networking on EKS clusters with EFA-capable instances. EKS-specific. | [AWS EFA K8s Device Plugin](https://github.com/aws/eks-charts) |
 | **cert-manager** | Automates TLS certificate management. Required by several operators for webhook and API server certificates. | [cert-manager](https://github.com/cert-manager/cert-manager) |
 | **skyhook-operator** | OS-level node tuning and configuration management. Applies kernel parameters, sysctl settings, and system-level optimizations to nodes. | [Skyhook](https://github.com/nvidia/skyhook) |
+| **skyhook-customizations** | Environment-specific node tuning profiles applied via Skyhook. Extends the operator with kernel params, hugepages, and other host-level configurations. | — |
 | **nvsentinel** | GPU health monitoring and automated remediation. Detects GPU errors and can cordon or drain affected nodes. | [NVSentinel](https://github.com/NVIDIA/nvsentinel) |
 | **nvidia-dra-driver-gpu** | Dynamic Resource Allocation driver for GPUs. Enables structured GPU device advertisement and claim-based allocation in Kubernetes 1.33+. | [NVIDIA DRA Driver](https://github.com/NVIDIA/k8s-dra-driver-gpu) |
 | **kube-prometheus-stack** | Cluster monitoring: Prometheus, Grafana, Alertmanager, and node exporters. Provides GPU and cluster metrics collection and dashboards. | [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts) |
@@ -22,7 +23,9 @@ The source of truth is [`recipes/registry.yaml`](../../recipes/registry.yaml). E
 | **aws-ebs-csi-driver** | CSI driver for Amazon EBS volumes. Provides persistent storage for workloads on EKS. EKS-specific. | [AWS EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) |
 | **k8s-ephemeral-storage-metrics** | Exports ephemeral storage usage metrics per pod. Useful for monitoring scratch space consumption on GPU nodes. | [k8s-ephemeral-storage-metrics](https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics) |
 | **kai-scheduler** | DRA-aware gang scheduler with hierarchical queues and topology-aware placement. Ensures distributed training jobs land on nodes with optimal interconnect topology. | [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) |
-| **dynamo** | NVIDIA Dynamo inference serving platform. Distributed inference with prefix-cache-aware routing and disaggregated prefill/decode. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
+| **dynamo-crds** | Custom Resource Definitions for NVIDIA Dynamo inference serving. Installed separately to support CRD lifecycle management. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
+| **dynamo-platform** | NVIDIA Dynamo inference serving platform. Distributed inference with prefix-cache-aware routing and disaggregated prefill/decode. | [Dynamo](https://github.com/ai-dynamo/dynamo) |
+| **kgateway-crds** | Custom Resource Definitions for kgateway (Kubernetes Gateway API implementation). | [kgateway](https://github.com/kgateway-dev/kgateway) |
 | **kgateway** | Kubernetes Gateway API implementation. Provides model-aware ingress routing for inference workloads. | [kgateway](https://github.com/kgateway-dev/kgateway) |
 | **kubeflow-trainer** | Kubeflow Training Operator for distributed training jobs (PyTorch, etc.). Manages multi-node training job lifecycle with JobSet integration. | [Kubeflow Trainer](https://github.com/kubeflow/trainer) |
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -67,7 +67,7 @@ aicr --version
 ### Option 3: Build from Source
 
 **Requirements:**
-- Go 1.25 or higher
+- Go 1.26 or higher
 
 ```shell
 go install github.com/NVIDIA/aicr/cmd/aicr@latest


### PR DESCRIPTION
## Summary

Prepare documentation for the March 12 KubeCon EU launch.

- **README refresh** — New intro, full quick start workflow (snapshot/recipe/validate/bundle), features table, supported components, end-to-end workflow diagram
- **Component catalog** — New `docs/user/component-catalog.md` listing all components from `recipes/registry.yaml` with descriptions and upstream links
- **Stale version fixes** — Go 1.25→1.26, golangci-lint v2.6/v2.9→v2.10.1 across installation guide, contributor docs, and copilot instructions
- **API reference fixes** — Expanded bundler list from 6 to all 18 components; fixed Python/JS examples to match endpoint spec (recipe as body, bundlers as query param)
- **Agent security context** — Fixed kubernetes-deployment.md to show privileged mode (the default) instead of contradicting agent-deployment.md
- **Broken references** — Fixed dead links to `pkg/validator/checks/README.md`, removed reference to nonexistent `docs/monitoring/grafana-dashboard.json`, replaced broken `deploy/aicrd` Kustomize path
- **Roadmap** — Removed internal "v2" framing that has no meaning to external users

## Test plan

- [ ] Verify all internal doc links resolve
- [ ] Verify README renders correctly on GitHub (image, tables, collapsibles)
- [ ] Verify component catalog matches `recipes/registry.yaml`