### PR TITLE
fix(recipe): bump NCCL all-reduce bandwidth threshold to 300 Gbps

### DIFF
--- a/recipes/overlays/h100-eks-ubuntu-training.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-training.yaml
@@ -58,7 +58,7 @@ spec:
         - nccl-all-reduce-bw
       constraints:
         - name: nccl-all-reduce-bw
-          value: ">= 100"
+          value: ">= 300"
     conformance:
       checks:
         - platform-health


### PR DESCRIPTION
## Summary

Bump NCCL all-reduce bandwidth threshold from 100 Gbps to 300 Gbps in the H100 EKS training recipe.

## Changes

- `recipes/overlays/h100-eks-ubuntu-training.yaml`: Update `nccl-all-reduce-bw` constraint from `>= 100` to `>= 300`

## Test plan

- [x] Existing unit tests pass (`make test`)
