### PR TITLE
docs: remove --phase readiness, replace ValidationResult with CTRF output

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ NVIDIA AI Cluster Runtime (AICR) is a suite of tooling designed to automate the 
 | **Component** | A deployable software package (e.g., GPU Operator, Network Operator, cert-manager). Components have versions, Helm sources, and configuration values. |
 | **ComponentRef** | A reference to a component in a recipe, including version, source repository, values file, and dependency references. |
 | **Constraint** | A validation rule in a recipe specifying required system conditions (e.g., `K8s.server.version >= 1.31`, `OS.release.ID == ubuntu`). Constraints can have severity (error/warning), remediation guidance, and units. |
-| **Validation Phase** | A stage of validation in the deployment lifecycle: readiness (infrastructure), deployment (components), performance (system), conformance (workloads). |
+| **Validation Phase** | A stage of validation in the deployment lifecycle: deployment (components), performance (system), conformance (workloads). Readiness constraints are evaluated implicitly before any phase. |
 | **ValidationConfig** | Configuration in a recipe defining phase-specific checks, constraints, expected resources, and node selection for validation. |
 | **Measurement** | A captured data point from the system organized by type (K8s, OS, GPU, SystemD), subtype, and key-value readings. |
 | **Specificity** | A score indicating how specific a recipe's criteria is (number of non-"any" fields). More specific recipes are applied later during merge. |
@@ -179,7 +179,7 @@ aicr recipe --snapshot snapshot.yaml --intent training --platform kubeflow
 ### Validate Configuration
 
 ```shell
-# Validate readiness phase (default)
+# Validate recipe against snapshot (readiness constraints run implicitly)
 aicr validate --recipe recipe.yaml --snapshot snapshot.yaml
 
 # Validate all phases

--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -401,30 +401,39 @@ aicr validate \
 
 ### Validation Output
 
-```yaml
-apiVersion: aicr.nvidia.com/v1alpha1
-kind: ValidationResult
-metadata:
-  created: "2025-01-15T10:30:00Z"
-summary:
-  total: 5
-  passed: 4
-  failed: 1
-  skipped: 0
-results:
-  - constraint: "K8s.server.version>=1.28"
-    status: passed
-    expected: ">=1.28"
-    actual: "1.33.5"
-  - constraint: "OS.release.ID==ubuntu"
-    status: passed
-    expected: "ubuntu"
-    actual: "ubuntu"
-  - constraint: "GPU.driver.version>=570.00"
-    status: failed
-    expected: ">=570.00"
-    actual: "560.28.03"
-    message: "version 560.28.03 does not satisfy >=570.00"
+Results are output in [CTRF](https://ctrf.io/) (Common Test Report Format) JSON:
+
+```json
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-03-10T20:10:44Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": { "name": "aicr", "version": "v0.10.3-next" },
+    "summary": {
+      "tests": 16, "passed": 13, "failed": 0, "skipped": 3,
+      "pending": 0, "other": 0,
+      "start": 1773173400872, "stop": 1773173799002
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": ["deployment"],
+        "stdout": ["Found 1 gpu-operator pod(s)", "Running: 1/1"]
+      },
+      {
+        "name": "nccl-all-reduce-bw",
+        "status": "passed",
+        "duration": 234000,
+        "suite": ["performance"],
+        "stdout": ["NCCL All Reduce bandwidth: 488.37 GB/s", "Constraint: >= 100 → true"]
+      }
+    ]
+  }
+}
 ```
 
 ### CI/CD Integration

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -275,7 +275,7 @@ validation:
     checks: [nccl-bandwidth-test]
 ```
 
-**Phases:** `readiness`, `deployment`, `performance`, `conformance`
+**Phases:** `deployment`, `performance`, `conformance` (readiness constraints are evaluated implicitly)
 
 ### Testing
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -431,11 +431,10 @@ aicr validate [flags]
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--recipe` | `-r` | string | Path/URI to recipe file containing constraints (required) |
-| `--snapshot` | `-s` | string | Path/URI to snapshot file containing measurements (required) |
+| `--snapshot` | `-s` | string | Path/URI to snapshot file containing measurements (omit to capture live) |
 | `--phase` | | string | Validation phase to run: deployment, performance, conformance, all (default: all) |
 | `--fail-on-error` | | bool | Exit with non-zero status if any constraint fails (default: true) |
 | `--output` | `-o` | string | Output destination (file or stdout, default: stdout) |
-| `--format` | `-t` | string | Output format: json, yaml, table (default: yaml) |
 | `--kubeconfig` | `-k` | string | Path to kubeconfig file (for ConfigMap URIs) |
 
 **Input Sources:**
@@ -525,12 +524,6 @@ aicr validate \
   --snapshot snapshot.yaml \
   --phase performance
 
-# JSON output format
-aicr validate \
-  --recipe recipe.yaml \
-  --snapshot snapshot.yaml \
-  --format json
-
 # With custom kubeconfig
 aicr validate \
   --recipe recipe.yaml \
@@ -618,8 +611,8 @@ Results are output in CTRF (Common Test Report Format) — an industry-standard 
 | Code | Description |
 |------|-------------|
 | `0` | All checks passed |
-| `1` | One or more checks failed (when `--fail-on-error` is set) |
-| `2` | Invalid input (bad flags, missing recipe/snapshot) |
+| `2` | Invalid input (bad flags, missing recipe) |
+| `8` | One or more checks failed (when `--fail-on-error` is set) |
 
 ---
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -432,7 +432,7 @@ aicr validate [flags]
 |------|-------|------|-------------|
 | `--recipe` | `-r` | string | Path/URI to recipe file containing constraints (required) |
 | `--snapshot` | `-s` | string | Path/URI to snapshot file containing measurements (required) |
-| `--phase` | | string | Validation phase to run: readiness (default), deployment, performance, conformance, all |
+| `--phase` | | string | Validation phase to run: deployment, performance, conformance, all (default: all) |
 | `--fail-on-error` | | bool | Exit with non-zero status if any constraint fails (default: true) |
 | `--output` | `-o` | string | Output destination (file or stdout, default: stdout) |
 | `--format` | `-t` | string | Output format: json, yaml, table (default: yaml) |
@@ -449,11 +449,12 @@ Validation can be run in different phases to validate different aspects of the d
 
 | Phase | Description | When to Run |
 |-------|-------------|-------------|
-| `readiness` | Evaluates constraints inline against snapshot (K8s version, OS, kernel) — no checks or Jobs | Before deploying any components |
 | `deployment` | Validates component deployment health and expected resources | After deploying components |
 | `performance` | Validates system performance and network fabric health | After components are running |
 | `conformance` | Validates workload-specific requirements and conformance | Before running production workloads |
 | `all` | Runs all phases sequentially with dependency logic | Complete end-to-end validation |
+
+> **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs.
 
 **Phase Dependencies:**
 - Phases run sequentially when using `--phase all`
@@ -486,7 +487,7 @@ Constraints use fully qualified measurement paths: `{Type}.{Subtype}.{Key}`
 **Examples:**
 
 ```shell
-# Validate snapshot against recipe (default: readiness phase)
+# Validate snapshot against recipe (readiness constraints run implicitly)
 aicr validate --recipe recipe.yaml --snapshot snapshot.yaml
 
 # Validate specific phase
@@ -510,14 +511,7 @@ aicr validate \
 aicr validate \
   --recipe recipe.yaml \
   --snapshot cm://gpu-operator/aicr-snapshot \
-  --output validation-results.yaml
-
-# Validate readiness phase before installing components
-aicr validate \
-  --recipe recipe.yaml \
-  --snapshot snapshot.yaml \
-  --phase readiness \
-  --fail-on-error
+  --output validation-results.json
 
 # Validate deployment phase after components are installed
 aicr validate \
@@ -544,101 +538,88 @@ aicr validate \
   --kubeconfig ~/.kube/prod-cluster
 ```
 
-**Output Structure (Readiness Phase):**
-```yaml
-apiVersion: aicr.nvidia.com/v1alpha1
-kind: ValidationResult
-metadata:
-  timestamp: "2025-12-31T10:30:00Z"
-  version: v0.14.0
-recipeSource: recipe.yaml
-snapshotSource: cm://gpu-operator/aicr-snapshot
-summary:
-  passed: 5
-  failed: 0
-  skipped: 0
-  total: 5
-  status: pass
-  duration: 20.5µs
-phases:
-  readiness:
-    status: pass
-    constraints:
-      - name: K8s.server.version
-        expected: '>= 1.30'
-        actual: v1.30.14-eks-3025e55
-        status: passed
-      - name: OS.release.ID
-        expected: ubuntu
-        actual: ubuntu
-        status: passed
-    duration: 20.5µs
+**Output Structure ([CTRF](https://ctrf.io/) JSON):**
+
+Results are output in CTRF (Common Test Report Format) — an industry-standard schema for test reporting.
+
+```json
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-03-10T20:10:44Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "v0.10.3-next"
+    },
+    "summary": {
+      "tests": 16,
+      "passed": 13,
+      "failed": 0,
+      "skipped": 3,
+      "pending": 0,
+      "other": 0,
+      "start": 1773173400872,
+      "stop": 1773173799002
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": ["deployment"],
+        "stdout": ["Found 1 gpu-operator pod(s)", "Running: 1/1"]
+      },
+      {
+        "name": "expected-resources",
+        "status": "passed",
+        "duration": 0,
+        "suite": ["deployment"],
+        "stdout": ["All expected resources are healthy"]
+      },
+      {
+        "name": "nccl-all-reduce-bw",
+        "status": "passed",
+        "duration": 234000,
+        "suite": ["performance"],
+        "stdout": ["NCCL All Reduce bandwidth: 488.37 GB/s", "Constraint: >= 100 → true"]
+      },
+      {
+        "name": "dra-support",
+        "status": "passed",
+        "duration": 8000,
+        "suite": ["conformance"],
+        "stdout": ["DRA GPU allocation successful"]
+      },
+      {
+        "name": "cluster-autoscaling",
+        "status": "skipped",
+        "duration": 0,
+        "suite": ["conformance"],
+        "stdout": ["SKIP reason=\"Karpenter not found\""]
+      }
+    ]
+  }
+}
 ```
 
-**Output Structure (All Phases):**
-```yaml
-apiVersion: aicr.nvidia.com/v1alpha1
-kind: ValidationResult
-metadata:
-  timestamp: "2025-12-31T10:30:00Z"
-  version: v0.14.0
-recipeSource: recipe.yaml
-snapshotSource: snapshot.yaml
-summary:
-  passed: 3
-  failed: 0
-  skipped: 1
-  total: 4
-  status: pass
-  duration: 58.4µs
-phases:
-  readiness:
-    status: pass
-    constraints:
-      - name: K8s.server.version
-        expected: '>= 1.32.4'
-        actual: v1.35.0
-        status: passed
-      - name: OS.release.ID
-        expected: ubuntu
-        actual: ubuntu
-        status: passed
-    duration: 20.7µs
-  deployment:
-    status: pass
-    checks:
-      - name: gpu-operator.version
-        status: pass
-      - name: expected-resources
-        status: pass
-    duration: 1.2µs
-  performance:
-    status: pass
-    checks:
-      - name: nccl-bandwidth-test
-        status: pass
-      - name: fabric-health-check
-        status: pass
-    duration: 1.2µs
-  conformance:
-    status: skipped
-    reason: conformance phase not configured in recipe
-    duration: 0.8µs
-```
+> **Note:** The `tests` array above is truncated for brevity. A full validation run produces one entry per check across all phases. Each entry includes `stdout` with detailed diagnostic output.
 
-**Validation Statuses:**
+**Test Statuses:**
 | Status | Description |
 |--------|-------------|
-| `passed` | Constraint satisfied |
-| `failed` | Constraint not satisfied |
-| `skipped` | Constraint could not be evaluated (missing data, invalid path) |
+| `passed` | Check or constraint passed |
+| `failed` | Check or constraint failed |
+| `skipped` | Check could not be evaluated (missing data, no-cluster mode) |
+| `other` | Unexpected outcome (crash, OOM, timeout) |
 
-**Summary Status:**
-| Status | Description |
-|--------|-------------|
-| `pass` | All constraints passed |
-| `fail` | One or more constraints failed |
-| `partial` | Some constraints skipped, none failed |
+**Exit Codes:**
+| Code | Description |
+|------|-------------|
+| `0` | All checks passed |
+| `1` | One or more checks failed (when `--fail-on-error` is set) |
+| `2` | Invalid input (bad flags, missing recipe/snapshot) |
 
 ---
 

--- a/site/docs/integrator/data-flow.md
+++ b/site/docs/integrator/data-flow.md
@@ -405,30 +405,39 @@ aicr validate \
 
 ### Validation Output
 
-```yaml
-apiVersion: aicr.nvidia.com/v1alpha1
-kind: ValidationResult
-metadata:
-  created: "2025-01-15T10:30:00Z"
-summary:
-  total: 5
-  passed: 4
-  failed: 1
-  skipped: 0
-results:
-  - constraint: "K8s.server.version>=1.28"
-    status: passed
-    expected: ">=1.28"
-    actual: "1.33.5"
-  - constraint: "OS.release.ID==ubuntu"
-    status: passed
-    expected: "ubuntu"
-    actual: "ubuntu"
-  - constraint: "GPU.driver.version>=570.00"
-    status: failed
-    expected: ">=570.00"
-    actual: "560.28.03"
-    message: "version 560.28.03 does not satisfy >=570.00"
+Results are output in [CTRF](https://ctrf.io/) (Common Test Report Format) JSON:
+
+```json
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-03-10T20:10:44Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": { "name": "aicr", "version": "v0.10.3-next" },
+    "summary": {
+      "tests": 16, "passed": 13, "failed": 0, "skipped": 3,
+      "pending": 0, "other": 0,
+      "start": 1773173400872, "stop": 1773173799002
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": ["deployment"],
+        "stdout": ["Found 1 gpu-operator pod(s)", "Running: 1/1"]
+      },
+      {
+        "name": "nccl-all-reduce-bw",
+        "status": "passed",
+        "duration": 234000,
+        "suite": ["performance"],
+        "stdout": ["NCCL All Reduce bandwidth: 488.37 GB/s", "Constraint: >= 100 → true"]
+      }
+    ]
+  }
+}
 ```
 
 ### CI/CD Integration

--- a/site/docs/user/cli-reference.md
+++ b/site/docs/user/cli-reference.md
@@ -433,11 +433,10 @@ aicr validate [flags]
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--recipe` | `-r` | string | Path/URI to recipe file containing constraints (required) |
-| `--snapshot` | `-s` | string | Path/URI to snapshot file containing measurements (required) |
+| `--snapshot` | `-s` | string | Path/URI to snapshot file containing measurements (omit to capture live) |
 | `--phase` | | string | Validation phase to run: deployment, performance, conformance, all (default: all) |
 | `--fail-on-error` | | bool | Exit with non-zero status if any constraint fails (default: true) |
 | `--output` | `-o` | string | Output destination (file or stdout, default: stdout) |
-| `--format` | `-t` | string | Output format: json, yaml, table (default: yaml) |
 | `--kubeconfig` | `-k` | string | Path to kubeconfig file (for ConfigMap URIs) |
 
 **Input Sources:**
@@ -527,12 +526,6 @@ aicr validate \
   --snapshot snapshot.yaml \
   --phase performance
 
-# JSON output format
-aicr validate \
-  --recipe recipe.yaml \
-  --snapshot snapshot.yaml \
-  --format json
-
 # With custom kubeconfig
 aicr validate \
   --recipe recipe.yaml \
@@ -620,8 +613,8 @@ Results are output in CTRF (Common Test Report Format) — an industry-standard 
 | Code | Description |
 |------|-------------|
 | `0` | All checks passed |
-| `1` | One or more checks failed (when `--fail-on-error` is set) |
-| `2` | Invalid input (bad flags, missing recipe/snapshot) |
+| `2` | Invalid input (bad flags, missing recipe) |
+| `8` | One or more checks failed (when `--fail-on-error` is set) |
 
 ---
 

--- a/site/docs/user/cli-reference.md
+++ b/site/docs/user/cli-reference.md
@@ -434,7 +434,7 @@ aicr validate [flags]
 |------|-------|------|-------------|
 | `--recipe` | `-r` | string | Path/URI to recipe file containing constraints (required) |
 | `--snapshot` | `-s` | string | Path/URI to snapshot file containing measurements (required) |
-| `--phase` | | string | Validation phase to run: readiness (default), deployment, performance, conformance, all |
+| `--phase` | | string | Validation phase to run: deployment, performance, conformance, all (default: all) |
 | `--fail-on-error` | | bool | Exit with non-zero status if any constraint fails (default: true) |
 | `--output` | `-o` | string | Output destination (file or stdout, default: stdout) |
 | `--format` | `-t` | string | Output format: json, yaml, table (default: yaml) |
@@ -451,11 +451,12 @@ Validation can be run in different phases to validate different aspects of the d
 
 | Phase | Description | When to Run |
 |-------|-------------|-------------|
-| `readiness` | Evaluates constraints inline against snapshot (K8s version, OS, kernel) -- no checks or Jobs | Before deploying any components |
 | `deployment` | Validates component deployment health and expected resources | After deploying components |
 | `performance` | Validates system performance and network fabric health | After components are running |
 | `conformance` | Validates workload-specific requirements and conformance | Before running production workloads |
 | `all` | Runs all phases sequentially with dependency logic | Complete end-to-end validation |
+
+> **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs.
 
 **Phase Dependencies:**
 - Phases run sequentially when using `--phase all`
@@ -488,7 +489,7 @@ Constraints use fully qualified measurement paths: `{Type}.{Subtype}.{Key}`
 **Examples:**
 
 ```shell
-# Validate snapshot against recipe (default: readiness phase)
+# Validate snapshot against recipe (readiness constraints run implicitly)
 aicr validate --recipe recipe.yaml --snapshot snapshot.yaml
 
 # Validate specific phase
@@ -512,14 +513,7 @@ aicr validate \
 aicr validate \
   --recipe recipe.yaml \
   --snapshot cm://gpu-operator/aicr-snapshot \
-  --output validation-results.yaml
-
-# Validate readiness phase before installing components
-aicr validate \
-  --recipe recipe.yaml \
-  --snapshot snapshot.yaml \
-  --phase readiness \
-  --fail-on-error
+  --output validation-results.json
 
 # Validate deployment phase after components are installed
 aicr validate \
@@ -546,101 +540,88 @@ aicr validate \
   --kubeconfig ~/.kube/prod-cluster
 ```
 
-**Output Structure (Readiness Phase):**
-```yaml
-apiVersion: aicr.nvidia.com/v1alpha1
-kind: ValidationResult
-metadata:
-  timestamp: "2025-12-31T10:30:00Z"
-  version: v0.14.0
-recipeSource: recipe.yaml
-snapshotSource: cm://gpu-operator/aicr-snapshot
-summary:
-  passed: 5
-  failed: 0
-  skipped: 0
-  total: 5
-  status: pass
-  duration: 20.5µs
-phases:
-  readiness:
-    status: pass
-    constraints:
-      - name: K8s.server.version
-        expected: '>= 1.30'
-        actual: v1.30.14-eks-3025e55
-        status: passed
-      - name: OS.release.ID
-        expected: ubuntu
-        actual: ubuntu
-        status: passed
-    duration: 20.5µs
+**Output Structure ([CTRF](https://ctrf.io/) JSON):**
+
+Results are output in CTRF (Common Test Report Format) — an industry-standard schema for test reporting.
+
+```json
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-03-10T20:10:44Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "v0.10.3-next"
+    },
+    "summary": {
+      "tests": 16,
+      "passed": 13,
+      "failed": 0,
+      "skipped": 3,
+      "pending": 0,
+      "other": 0,
+      "start": 1773173400872,
+      "stop": 1773173799002
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": ["deployment"],
+        "stdout": ["Found 1 gpu-operator pod(s)", "Running: 1/1"]
+      },
+      {
+        "name": "expected-resources",
+        "status": "passed",
+        "duration": 0,
+        "suite": ["deployment"],
+        "stdout": ["All expected resources are healthy"]
+      },
+      {
+        "name": "nccl-all-reduce-bw",
+        "status": "passed",
+        "duration": 234000,
+        "suite": ["performance"],
+        "stdout": ["NCCL All Reduce bandwidth: 488.37 GB/s", "Constraint: >= 100 → true"]
+      },
+      {
+        "name": "dra-support",
+        "status": "passed",
+        "duration": 8000,
+        "suite": ["conformance"],
+        "stdout": ["DRA GPU allocation successful"]
+      },
+      {
+        "name": "cluster-autoscaling",
+        "status": "skipped",
+        "duration": 0,
+        "suite": ["conformance"],
+        "stdout": ["SKIP reason=\"Karpenter not found\""]
+      }
+    ]
+  }
+}
 ```
 
-**Output Structure (All Phases):**
-```yaml
-apiVersion: aicr.nvidia.com/v1alpha1
-kind: ValidationResult
-metadata:
-  timestamp: "2025-12-31T10:30:00Z"
-  version: v0.14.0
-recipeSource: recipe.yaml
-snapshotSource: snapshot.yaml
-summary:
-  passed: 3
-  failed: 0
-  skipped: 1
-  total: 4
-  status: pass
-  duration: 58.4µs
-phases:
-  readiness:
-    status: pass
-    constraints:
-      - name: K8s.server.version
-        expected: '>= 1.32.4'
-        actual: v1.35.0
-        status: passed
-      - name: OS.release.ID
-        expected: ubuntu
-        actual: ubuntu
-        status: passed
-    duration: 20.7µs
-  deployment:
-    status: pass
-    checks:
-      - name: gpu-operator.version
-        status: pass
-      - name: expected-resources
-        status: pass
-    duration: 1.2µs
-  performance:
-    status: pass
-    checks:
-      - name: nccl-bandwidth-test
-        status: pass
-      - name: fabric-health-check
-        status: pass
-    duration: 1.2µs
-  conformance:
-    status: skipped
-    reason: conformance phase not configured in recipe
-    duration: 0.8µs
-```
+> **Note:** The `tests` array above is truncated for brevity. A full validation run produces one entry per check across all phases. Each entry includes `stdout` with detailed diagnostic output.
 
-**Validation Statuses:**
+**Test Statuses:**
 | Status | Description |
 |--------|-------------|
-| `passed` | Constraint satisfied |
-| `failed` | Constraint not satisfied |
-| `skipped` | Constraint could not be evaluated (missing data, invalid path) |
+| `passed` | Check or constraint passed |
+| `failed` | Check or constraint failed |
+| `skipped` | Check could not be evaluated (missing data, no-cluster mode) |
+| `other` | Unexpected outcome (crash, OOM, timeout) |
 
-**Summary Status:**
-| Status | Description |
-|--------|-------------|
-| `pass` | All constraints passed |
-| `fail` | One or more constraints failed |
-| `partial` | Some constraints skipped, none failed |
+**Exit Codes:**
+| Code | Description |
+|------|-------------|
+| `0` | All checks passed |
+| `1` | One or more checks failed (when `--fail-on-error` is set) |
+| `2` | Invalid input (bad flags, missing recipe/snapshot) |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #353

- Remove `--phase readiness` as a selectable CLI option — readiness constraints run implicitly before any phase
- Replace outdated `ValidationResult` YAML output examples with actual CTRF JSON from a real validation run
- Fix validation output file extension from `.yaml` to `.json`

## Changes

| File | Change |
|------|--------|
| `docs/user/cli-reference.md` | Remove readiness from `--phase` flag, phase table, and examples; replace `ValidationResult` YAML with CTRF JSON; fix output file extension |
| `docs/README.md` | Update glossary and validate example comment |
| `docs/integrator/data-flow.md` | Replace `ValidationResult` YAML with CTRF JSON |
| `docs/integrator/recipe-development.md` | Remove readiness from phases list |
| `site/content/docs/user/cli-reference.md` | Mirror changes from `docs/user/cli-reference.md` |
| `site/content/docs/integrator/data-flow.md` | Mirror changes from `docs/integrator/data-flow.md` |

## Context

- Readiness is implicit — always runs before any phase, errors if constraints fail
- The old `ValidationResult` YAML format (`apiVersion: aicr.nvidia.com/v1alpha1`) never existed in code; actual output is CTRF JSON
- ADR (`docs/design/002-validatorv2-adr.md`) references left as-is — historical context describing the old approach

## Test plan

- [x] No code changes — docs only
- [x] No remaining `ValidationResult` references outside the ADR
- [x] No remaining `--phase readiness` references