### PR TITLE
docs(site): align Go version requirements to 1.26

### DIFF
--- a/site/content/docs/project/development.md
+++ b/site/content/docs/project/development.md
@@ -46,7 +46,7 @@ make qualify        # Full check: test + lint + e2e + scan
 
 | Tool | Purpose | Installation |
 |------|---------|--------------|
-| **Go 1.25+** | Language runtime | [golang.org/dl](https://golang.org/dl/) |
+| **Go 1.26+** | Language runtime | [golang.org/dl](https://golang.org/dl/) |
 | **make** | Build automation | Pre-installed on macOS; `apt install make` on Ubuntu/Debian |
 | **git** | Version control | Pre-installed on most systems |
 | **Docker** | Container builds | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |

--- a/site/content/docs/user/installation.md
+++ b/site/content/docs/user/installation.md
@@ -79,7 +79,7 @@ aicr --version
 ### Option 4: Build from Source
 
 **Requirements:**
-- Go 1.25 or higher
+- Go 1.26 or higher
 
 ```shell
 go install github.com/NVIDIA/aicr/cmd/aicr@latest


### PR DESCRIPTION
## Summary
- update site installation guide requirement from Go 1.25 to Go 1.26
- update site development prerequisites from Go 1.25+ to Go 1.26+
- keep site docs consistent with source docs and project baseline

## Validation
- searched docs and site content for Go version references
- confirmed no remaining Go 1.25 references in user/project docs

Closes #359