### PR TITLE
fix(validator): truncate long stdout lines to prevent oversized reports

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -327,6 +327,12 @@ const (
 	// to prevent ConfigMap overflow.
 	ValidatorMaxStdoutLines = 1000
 
+	// ValidatorMaxStdoutLineLength is the maximum length of a single stdout
+	// line. Lines exceeding this are truncated with a suffix indicating the
+	// number of dropped characters. Prevents oversized report output from
+	// inline JSON payloads (e.g., Prometheus metric scrapes).
+	ValidatorMaxStdoutLineLength = 512
+
 	// ValidatorDefaultCPU is the default CPU request/limit for validator containers
 	// when not specified in the catalog entry.
 	ValidatorDefaultCPU = "1"

--- a/pkg/validator/job/result.go
+++ b/pkg/validator/job/result.go
@@ -86,7 +86,10 @@ func (d *Deployer) ExtractResult(ctx context.Context) *ctrf.ValidatorResult {
 		slog.Warn("failed to capture pod logs", "pod", jobPod.Name, "error", logErr)
 		// Not fatal — we still have exit code and termination message
 	} else if logs != "" {
-		result.Stdout = truncateLogLines(logs, defaults.ValidatorMaxStdoutLines)
+		result.Stdout = filterStdoutLines(
+			truncateLogLines(logs, defaults.ValidatorMaxStdoutLines),
+			defaults.ValidatorMaxStdoutLineLength,
+		)
 	}
 
 	return result
@@ -110,7 +113,10 @@ func (d *Deployer) HandleTimeout(ctx context.Context) *ctrf.ValidatorResult {
 
 	// Try to get logs
 	if logs, logErr := pod.GetPodLogs(ctx, d.clientset, d.namespace, jobPod.Name, ""); logErr == nil && logs != "" {
-		result.Stdout = truncateLogLines(logs, defaults.ValidatorMaxStdoutLines)
+		result.Stdout = filterStdoutLines(
+			truncateLogLines(logs, defaults.ValidatorMaxStdoutLines),
+			defaults.ValidatorMaxStdoutLineLength,
+		)
 	}
 
 	// Try to get container status
@@ -141,6 +147,24 @@ func truncateLogLines(logs string, maxLines int) []string {
 	if len(lines) > maxLines {
 		lines = lines[len(lines)-maxLines:]
 	}
+	return lines
+}
+
+// filterStdoutLines truncates lines that exceed maxLineLen characters.
+// Lines longer than maxLineLen are cut to maxLineLen with a
+// "... [truncated N chars]" suffix appended.
+func filterStdoutLines(lines []string, maxLineLen int) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+
+	for i, line := range lines {
+		if len(line) > maxLineLen {
+			dropped := len(line) - maxLineLen
+			lines[i] = line[:maxLineLen] + fmt.Sprintf("... [truncated %d chars]", dropped)
+		}
+	}
+
 	return lines
 }
 

--- a/pkg/validator/job/result_test.go
+++ b/pkg/validator/job/result_test.go
@@ -16,6 +16,7 @@ package job
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -352,5 +353,101 @@ func TestHandleTimeoutContainerTerminated(t *testing.T) {
 	}
 	if result.TerminationMsg != "killed by deadline" {
 		t.Errorf("TerminationMsg = %q", result.TerminationMsg)
+	}
+}
+
+func TestFilterStdoutLines(t *testing.T) {
+	tests := []struct {
+		name       string
+		lines      []string
+		maxLineLen int
+		want       []string
+	}{
+		{
+			name:       "empty input",
+			lines:      []string{},
+			maxLineLen: 100,
+			want:       []string{},
+		},
+		{
+			name:       "nil input",
+			lines:      nil,
+			maxLineLen: 100,
+			want:       nil,
+		},
+		{
+			name: "lines below max length pass through",
+			lines: []string{
+				`time=2026-03-10T10:00:00Z level=INFO msg="check started"`,
+				`time=2026-03-10T10:00:01Z level=INFO msg="check completed"`,
+			},
+			maxLineLen: 512,
+			want: []string{
+				`time=2026-03-10T10:00:00Z level=INFO msg="check started"`,
+				`time=2026-03-10T10:00:01Z level=INFO msg="check completed"`,
+			},
+		},
+		{
+			name: "long line gets truncated with suffix",
+			lines: []string{
+				"short line",
+				strings.Repeat("x", 600),
+			},
+			maxLineLen: 100,
+			want: []string{
+				"short line",
+				strings.Repeat("x", 100) + "... [truncated 500 chars]",
+			},
+		},
+		{
+			name: "line exactly at max length not truncated",
+			lines: []string{
+				strings.Repeat("a", 100),
+			},
+			maxLineLen: 100,
+			want: []string{
+				strings.Repeat("a", 100),
+			},
+		},
+		{
+			name: "line one over max length truncated",
+			lines: []string{
+				strings.Repeat("b", 101),
+			},
+			maxLineLen: 100,
+			want: []string{
+				strings.Repeat("b", 100) + "... [truncated 1 chars]",
+			},
+		},
+		{
+			name: "multiple long lines all truncated",
+			lines: []string{
+				strings.Repeat("a", 200),
+				"ok",
+				strings.Repeat("b", 300),
+			},
+			maxLineLen: 50,
+			want: []string{
+				strings.Repeat("a", 50) + "... [truncated 150 chars]",
+				"ok",
+				strings.Repeat("b", 50) + "... [truncated 250 chars]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterStdoutLines(tt.lines, tt.maxLineLen)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("filterStdoutLines() returned %d lines, want %d\ngot:  %v\nwant: %v",
+					len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("line[%d]:\n  got:  %q\n  want: %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Truncate individual stdout lines exceeding 512 characters in validation reports. Prevents oversized CTRF output from inline JSON payloads (e.g., 8.4KB single-line Prometheus metric responses from `ai-service-metrics`).

## Changes

| File | Change |
|------|--------|
| `pkg/defaults/timeouts.go` | Add `ValidatorMaxStdoutLineLength = 512` constant |
| `pkg/validator/job/result.go` | Add `filterStdoutLines()` to truncate long lines; wire into `ExtractResult` and `HandleTimeout` |
| `pkg/validator/job/result_test.go` | Table-driven tests for `filterStdoutLines` |

## Test plan

- [x] `go test -race ./pkg/validator/job/...` passes
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)