### PR TITLE
feat(bundler): add pre-flight checks to deploy.sh and post-flight to undeploy.sh

### DIFF
--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -47,6 +47,75 @@ helm_failed() {
 # all pods start successfully. These components are installed without --wait.
 ASYNC_COMPONENTS="kai-scheduler"
 
+# ==============================================================================
+# Pre-flight checks
+# ==============================================================================
+# Verify the cluster is clean before deploying. Stale webhooks, terminating
+# namespaces, and orphaned API services from a previous install can block pod
+# creation and namespace deletion, causing silent deployment failures.
+
+preflight_failed=false
+
+# Bundle namespace list (deduplicated)
+BUNDLE_NAMESPACES=$(echo "{{ range .Components }}{{ .Namespace }} {{ end }}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+# Check for terminating namespaces that overlap with our components
+for ns in ${BUNDLE_NAMESPACES}; do
+  phase=$(kubectl get ns "${ns}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  if [[ "${phase}" == "Terminating" ]]; then
+    echo "ERROR: namespace '${ns}' is still terminating from a previous install."
+    echo "  Wait for it to finish, or force-finalize with:"
+    echo "    kubectl get ns ${ns} -o json | jq '.spec.finalizers=[]' | kubectl replace --raw /api/v1/namespaces/${ns}/finalize -f -"
+    preflight_failed=true
+  fi
+done
+
+# Check for stale webhooks whose backing services no longer exist.
+# Scoped to bundle namespaces only to avoid false positives from unrelated
+# platform webhooks in shared clusters.
+if command -v jq &>/dev/null; then
+  for kind in mutatingwebhookconfigurations validatingwebhookconfigurations; do
+    while IFS=$'\t' read -r wh_name svc_ns svc_name; do
+      # Only check webhooks pointing to our bundle namespaces
+      is_bundle_ns=false
+      for ns in ${BUNDLE_NAMESPACES}; do
+        [[ "${svc_ns}" == "${ns}" ]] && is_bundle_ns=true && break
+      done
+      [[ "${is_bundle_ns}" == "false" ]] && continue
+
+      # Use explicit NotFound check to avoid false positives from transient errors
+      svc_check=$(kubectl get svc "${svc_name}" -n "${svc_ns}" 2>&1) || true
+      if echo "${svc_check}" | grep -q "NotFound\|not found"; then
+        echo "ERROR: ${kind} '${wh_name}' references non-existent service ${svc_ns}/${svc_name}."
+        echo "  This will block pod/resource creation. Delete with: kubectl delete ${kind} ${wh_name}"
+        preflight_failed=true
+      fi
+    done < <(kubectl get "${kind}" -o json 2>/dev/null | \
+      jq -r '.items[] | .metadata.name as $wh | .webhooks[]? | select(.clientConfig.service != null) | [$wh, .clientConfig.service.namespace, .clientConfig.service.name] | @tsv' 2>/dev/null || true)
+  done
+else
+  echo "NOTE: jq not found — skipping webhook pre-flight checks. Install jq for full pre-flight validation."
+fi
+
+# Check for stale API services (e.g., custom.metrics.k8s.io from prometheus-adapter)
+if command -v jq &>/dev/null; then
+  for api_svc in $(kubectl get apiservices -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | .type == "Available" and .status == "False") | .metadata.name' 2>/dev/null || true); do
+    echo "WARNING: API service '${api_svc}' is unavailable. This can block namespace deletion."
+    echo "  Delete with: kubectl delete apiservice ${api_svc}"
+    # API service issues are warnings, not hard failures — they don't block deployment directly
+  done
+else
+  echo "NOTE: jq not found — skipping API service pre-flight checks."
+fi
+
+if [[ "${preflight_failed}" == "true" ]]; then
+  echo ""
+  echo "Pre-flight checks failed. Fix the issues above before deploying."
+  echo "To skip pre-flight checks, run: ./undeploy.sh first, then retry."
+  exit 1
+fi
+
+echo "Pre-flight checks passed."
 echo "Deploying Cloud Native Stack components..."
 
 # Install components in order

--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -188,4 +188,50 @@ done
 {{ range .Namespaces -}}
 delete_orphaned_webhooks_for_ns "{{ . }}"
 {{ end }}
+# ==============================================================================
+# Post-flight verification
+# ==============================================================================
+# Verify the cluster is clean after undeployment. Warn about any stale
+# resources that could block a subsequent deploy.
+
+postflight_issues=false
+
+# Check for remaining terminating namespaces
+TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+if [[ -n "${TERMINATING}" ]]; then
+  echo "WARNING: namespaces still terminating: ${TERMINATING}"
+  echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."
+  postflight_issues=true
+fi
+
+# Check for stale webhooks
+if command -v jq &>/dev/null; then
+  stale_wh=$(kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations -o json 2>/dev/null | \
+    jq -r '.items[] | .metadata.name as $wh | .webhooks[]? | select(.clientConfig.service != null) | [$wh, .clientConfig.service.namespace, .clientConfig.service.name] | @tsv' 2>/dev/null | \
+    while IFS=$'\t' read -r wh_name svc_ns svc_name; do
+      kubectl get svc "${svc_name}" -n "${svc_ns}" &>/dev/null || echo "${wh_name}"
+    done || true)
+  if [[ -n "${stale_wh}" ]]; then
+    echo "WARNING: stale webhooks found (backing service missing): ${stale_wh}"
+    postflight_issues=true
+  fi
+fi
+
+# Check for stale API services
+if command -v jq &>/dev/null; then
+  stale_apis=$(kubectl get apiservices -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | .type == "Available" and .status == "False") | .metadata.name' 2>/dev/null || true)
+  if [[ -n "${stale_apis}" ]]; then
+    echo "WARNING: unavailable API services found: ${stale_apis}"
+    echo "  These can block namespace deletion. Delete with: kubectl delete apiservice <name>"
+    postflight_issues=true
+  fi
+fi
+
+if [[ "${postflight_issues}" == "true" ]]; then
+  echo ""
+  echo "Post-flight: some stale resources remain. Run deploy.sh pre-flight checks to verify before redeploying."
+else
+  echo "Post-flight: cluster is clean."
+fi
+
 echo "Undeployment complete."


### PR DESCRIPTION
## Summary

Add pre-flight safety checks to `deploy.sh` and post-flight verification to `undeploy.sh` to prevent silent deployment failures caused by stale cluster-scoped resources from a previous install/uninstall cycle.

## Problem

When `undeploy.sh` or manual `helm uninstall` leaves behind stale webhooks, terminating namespaces, or unavailable API services, a subsequent `deploy.sh` fails silently:
- Stale mutating webhooks (e.g., KAI scheduler admission) block all pod creation
- Terminating namespaces prevent Helm from creating releases
- Stale API services (e.g., `custom.metrics.k8s.io` from prometheus-adapter) block namespace deletion

## Changes

### deploy.sh pre-flight checks
- Detects terminating namespaces that overlap with bundle components
- Detects stale mutating/validating webhooks whose backing services no longer exist
- Detects unavailable API services
- Aborts with actionable fix instructions

### undeploy.sh post-flight verification
- Warns about remaining terminating namespaces
- Warns about stale webhooks missed by orphan cleanup
- Warns about unavailable API services
- Reports clean/dirty state

## Test plan

- [x] Build succeeds with updated templates
- [x] Generated `deploy.sh` contains pre-flight section
- [x] Generated `undeploy.sh` contains post-flight section
- [x] Pre-flight checks require `jq` for webhook inspection (gracefully skipped if missing)