### PR TITLE
fix(evidence): track check results at runtime instead of scanning directory

### DIFF
--- a/pkg/evidence/scripts/collect-evidence.sh
+++ b/pkg/evidence/scripts/collect-evidence.sh
@@ -110,6 +110,29 @@ wait_for_port() {
     return 1
 }
 
+# Runtime results tracker — records check name and status as they execute.
+# Format: "name:status" entries separated by newlines.
+CHECK_RESULTS=""
+
+# Run a collector and record its result based on the evidence file it produces.
+# Usage: run_check "DRA Support" "dra-support" collect_dra
+run_check() {
+    local display_name="$1" file_key="$2" collector_fn="$3"
+    local evidence_path="${EVIDENCE_DIR}/${file_key}.md"
+
+    "${collector_fn}"
+
+    if [ ! -f "${evidence_path}" ]; then
+        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:SKIP\n"
+    elif grep -q "Result: PASS" "${evidence_path}" 2>/dev/null; then
+        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:PASS\n"
+    elif grep -q "Result: FAIL" "${evidence_path}" 2>/dev/null; then
+        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:FAIL\n"
+    else
+        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:UNKNOWN\n"
+    fi
+}
+
 # Clean up a test namespace properly: pods → resourceclaims → namespace
 # This order prevents stale DRA kubelet checkpoint issues caused by
 # orphaned ResourceClaims with delete-protection finalizers.
@@ -1438,38 +1461,38 @@ main() {
 
     case "${SECTION}" in
         dra)
-            collect_dra
+            run_check "DRA Support" "dra-support" collect_dra
             ;;
         gang)
-            collect_gang
+            run_check "Gang Scheduling" "gang-scheduling" collect_gang
             ;;
         secure)
-            collect_secure
+            run_check "Secure Accelerator Access" "secure-accelerator-access" collect_secure
             ;;
         metrics)
-            collect_metrics
+            run_check "Accelerator Metrics" "accelerator-metrics" collect_metrics
             ;;
         gateway)
-            collect_gateway
+            run_check "Inference Gateway" "inference-gateway" collect_gateway
             ;;
         operator)
-            collect_operator
+            run_check "Robust AI Operator" "robust-operator" collect_operator
             ;;
         hpa)
-            collect_hpa
+            run_check "Pod Autoscaling (HPA)" "pod-autoscaling" collect_hpa
             ;;
         cluster-autoscaling)
-            collect_cluster_autoscaling
+            run_check "Cluster Autoscaling" "cluster-autoscaling" collect_cluster_autoscaling
             ;;
         all)
-            collect_dra
-            collect_gang
-            collect_secure
-            collect_metrics
-            collect_gateway
-            collect_operator
-            collect_hpa
-            collect_cluster_autoscaling
+            run_check "DRA Support" "dra-support" collect_dra
+            run_check "Gang Scheduling" "gang-scheduling" collect_gang
+            run_check "Secure Accelerator Access" "secure-accelerator-access" collect_secure
+            run_check "Accelerator Metrics" "accelerator-metrics" collect_metrics
+            run_check "Inference Gateway" "inference-gateway" collect_gateway
+            run_check "Robust AI Operator" "robust-operator" collect_operator
+            run_check "Pod Autoscaling (HPA)" "pod-autoscaling" collect_hpa
+            run_check "Cluster Autoscaling" "cluster-autoscaling" collect_cluster_autoscaling
             ;;
         *)
             log_error "Unknown section: ${SECTION}"
@@ -1496,36 +1519,20 @@ main() {
     echo "  OS:         ${CLUSTER_OS_IMAGE}"
     echo "  Evidence:   ${EVIDENCE_DIR}/"
     echo ""
-    local checks=(
-        "dra-support:DRA Support"
-        "gang-scheduling:Gang Scheduling"
-        "secure-accelerator-access:Secure Accelerator Access"
-        "accelerator-metrics:Accelerator Metrics"
-        "inference-gateway:Inference Gateway"
-        "robust-operator:Robust AI Operator"
-        "pod-autoscaling:Pod Autoscaling (HPA)"
-        "cluster-autoscaling:Cluster Autoscaling"
-    )
     local passed=0 failed=0 skipped=0
     printf "  %-30s %s\n" "Check" "Status"
     printf "  %-30s %s\n" "-----" "------"
-    for entry in "${checks[@]}"; do
-        local file="${entry%%:*}"
-        local name="${entry#*:}"
-        local evidence_path="${EVIDENCE_DIR}/${file}.md"
-        if [ ! -f "${evidence_path}" ]; then
-            printf "  %-30s %s\n" "${name}" "SKIP"
-            skipped=$((skipped + 1))
-        elif grep -q "Result: PASS" "${evidence_path}" 2>/dev/null; then
-            printf "  %-30s %s\n" "${name}" "PASS"
-            passed=$((passed + 1))
-        elif grep -q "Result: FAIL" "${evidence_path}" 2>/dev/null; then
-            printf "  %-30s %s\n" "${name}" "FAIL"
-            failed=$((failed + 1))
-        else
-            printf "  %-30s %s\n" "${name}" "UNKNOWN"
-        fi
-    done
+    while IFS= read -r line; do
+        [ -z "${line}" ] && continue
+        local name="${line%%:*}"
+        local status="${line#*:}"
+        printf "  %-30s %s\n" "${name}" "${status}"
+        case "${status}" in
+            PASS*) passed=$((passed + 1)) ;;
+            FAIL*) failed=$((failed + 1)) ;;
+            SKIP)  skipped=$((skipped + 1)) ;;
+        esac
+    done < <(printf '%b' "${CHECK_RESULTS}")
     echo ""
     echo "  Total: $((passed + failed + skipped)) | Passed: ${passed} | Failed: ${failed} | Skipped: ${skipped}"
     echo ""


### PR DESCRIPTION
## Summary

Replace directory-scanning summary in `collect-evidence.sh` with runtime result tracking. A new `run_check()` wrapper records each check's outcome as it executes, so the final summary only reflects checks from the current run — not stale files from previous runs.

## Motivation / Context

The evidence summary scanned `EVIDENCE_DIR` for `.md` files, which meant leftover files from earlier runs could inflate pass counts or hide regressions.

Fixes: #392
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/scripts/collect-evidence.sh`

## Implementation Notes

- Added `CHECK_RESULTS` global variable and `run_check()` helper after `wait_for_port()`.
- Every collector call in the `case` statement (individual and `all`) now goes through `run_check`.
- Summary reads `CHECK_RESULTS` instead of globbing the evidence directory.

## Testing

```bash
# Script is a bash helper — verified via shellcheck and manual review
shellcheck pkg/evidence/scripts/collect-evidence.sh
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)