### PR TITLE
fix(brew): escape backslashes in caveats for proper multiline display

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -187,11 +187,11 @@ brews:
     caveats: |
       To verify supply-chain provenance (requires cosign):
 
-        cosign verify-blob-attestation \
-          --bundle #{opt_bin}/aicr-attestation.sigstore.json \
-          --type https://slsa.dev/provenance/v1 \
-          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity-regexp "https://github.com/NVIDIA/aicr/.github/workflows/on-tag\\.yaml@refs/tags/.*" \
+        cosign verify-blob-attestation \\
+          --bundle #{opt_bin}/aicr-attestation.sigstore.json \\
+          --type https://slsa.dev/provenance/v1 \\
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
+          --certificate-identity-regexp "https://github.com/NVIDIA/aicr/.github/workflows/on-tag\\.yaml@refs/tags/.*" \\
           #{opt_bin}/aicr
 
       To update the trust root for bundle attestation:


### PR DESCRIPTION
## Summary
- Double-escape backslashes in `.goreleaser.yaml` Homebrew caveats so `\` line continuations render correctly in `brew install` output
- Ruby heredocs interpret `\` + newline as line continuation, collapsing the multi-line `cosign` command into a single line

## Test plan
- [x] Verify generated Homebrew formula contains `\\` in caveats
- [x] Confirm `brew info aicr` displays the cosign command with proper line breaks