### PR TITLE
feat(recipes): add GKE COS inference and Dynamo overlay recipes

### DIFF
--- a/demos/cuj2-gke.md
+++ b/demos/cuj2-gke.md
@@ -1,0 +1,109 @@
+# AICR - Critical User Journey (CUJ) 2 — GKE Inference
+
+## Assumptions
+
+* Assuming user is already authenticated to a GKE cluster with 1+ H100 (a3-megagpu-8g) nodes.
+* GKE cluster runs Container-Optimized OS (COS) with GPU drivers pre-installed.
+* Values used in `--accelerated-node-selector`, `--accelerated-node-toleration` flags are only for example purposes. Assuming user will update these to match their cluster.
+* System nodes have no custom taints (GKE managed pods don't tolerate them).
+
+## Snapshot
+
+```shell
+aicr snapshot \
+    --namespace aicr-validation \
+    --node-selector nodeGroup=gpu-worker \
+    --toleration dedicated=gpu-workload:NoSchedule \
+    --output snapshot.yaml
+```
+
+## Gen Recipe
+
+```shell
+aicr recipe \
+  --service gke \
+  --accelerator h100 \
+  --intent inference \
+  --os cos \
+  --platform dynamo \
+  --output recipe.yaml
+```
+
+## Validate Recipe Constraints
+
+```shell
+aicr validate \
+    --recipe recipe.yaml \
+    --snapshot snapshot.yaml \
+    --no-cluster \
+    --phase deployment \
+    --output dry-run.json
+```
+
+## Generate Bundle
+
+```shell
+aicr bundle \
+  --recipe recipe.yaml \
+  --accelerated-node-selector nodeGroup=gpu-worker \
+  --accelerated-node-toleration dedicated=gpu-workload:NoSchedule \
+  --system-node-selector nodeGroup=system-worker \
+  --output bundle
+```
+
+> Note: GKE system nodes should not have custom taints (breaks konnectivity-agent and other GKE managed pods). Only `--system-node-selector` is needed, no `--system-node-toleration`.
+
+## Install Bundle into the Cluster
+
+```shell
+cd ./bundle && chmod +x deploy.sh && ./deploy.sh
+```
+
+## Validate Cluster
+
+```shell
+aicr validate \
+    --recipe recipe.yaml \
+    --toleration dedicated=gpu-workload:NoSchedule \
+    --phase conformance \
+    --output report.json
+```
+
+## Deploy Inference Workload
+
+Deploy an inference serving graph using the Dynamo platform:
+
+```shell
+# Deploy the vLLM aggregation workload (includes KAI queue + DynamoGraphDeployment)
+# Note: update tolerations in vllm-agg.yaml to match your cluster taints
+kubectl apply -f demos/workloads/inference/vllm-agg.yaml
+
+# Monitor the deployment
+kubectl get dynamographdeployments -n dynamo-workload
+kubectl get pods -n dynamo-workload -o wide -w
+
+# Verify the inference gateway routes to the workload
+kubectl get gateway inference-gateway -n kgateway-system
+kubectl get inferencepool -n dynamo-workload
+```
+
+## Chat with the Model
+
+Once the workload is running, start a local chat server:
+
+```shell
+# Start the chat server (port-forwards to the inference gateway)
+bash demos/workloads/inference/chat-server.sh
+
+# Open the chat UI in your browser
+open demos/workloads/inference/chat.html
+```
+
+## Success
+
+* Bundle deployed with 14 components (inference recipe)
+* CNCF conformance requirements pass
+  * DRA Support, Gang Scheduling, Secure GPU Access, Accelerator Metrics,
+    AI Service Metrics, Inference Gateway, Robust Controller (Dynamo),
+    Pod Autoscaling (HPA), Cluster Autoscaling
+* Dynamo inference workload serving requests via inference gateway

--- a/pkg/recipe/conformance_test.go
+++ b/pkg/recipe/conformance_test.go
@@ -170,6 +170,44 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 			},
 			wantDRAConstraint: false,
 		},
+		{
+			name: "h100-gke-cos-inference-dynamo",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceGKE
+				c.Accelerator = CriteriaAcceleratorH100
+				c.OS = CriteriaOSCOS
+				c.Intent = CriteriaIntentInference
+				c.Platform = CriteriaPlatformDynamo
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+				"kgateway-crds",
+				"kgateway",
+				"dynamo-crds",
+				"dynamo-platform",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"inference-gateway",
+				"gang-scheduling",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+				"robust-controller",
+				"secure-accelerator-access",
+			},
+			wantDRAConstraint: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/recipes/overlays/gke-cos-inference.yaml
+++ b/recipes/overlays/gke-cos-inference.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gke-cos-inference
+
+spec:
+  # Inherits from gke-cos recipe (GKE COS-specific settings)
+  base: gke-cos
+
+  criteria:
+    service: gke
+    os: cos
+    intent: inference
+
+  # Inference specific constraints for GKE workloads
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs:
+    - name: kgateway-crds
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway-crds/values.yaml
+      manifestFiles:
+        - components/kgateway-crds/manifests/gateway-api-crds.yaml
+        - components/kgateway-crds/manifests/inference-extension-crds.yaml
+
+    - name: kgateway
+      type: Helm
+      source: oci://cr.kgateway.dev/kgateway-dev/charts
+      version: v2.0.0
+      valuesFile: components/kgateway/values.yaml
+      manifestFiles:
+        - components/kgateway/manifests/inference-gateway.yaml
+      dependencyRefs:
+        - kgateway-crds
+        - cert-manager

--- a/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
+++ b/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-gke-cos-inference-dynamo
+
+spec:
+  # Inherits from h100-gke-cos-inference (H100 + GKE COS inference settings)
+  # Adds Dynamo inference platform components.
+  base: h100-gke-cos-inference
+
+  criteria:
+    service: gke
+    accelerator: h100
+    os: cos
+    intent: inference
+    platform: dynamo
+
+  # DRA requires Kubernetes 1.34+ (GA)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.34"
+
+  componentRefs:
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      overrides:
+        gpuResourcesEnabledOverride: true
+
+    - name: dynamo-crds
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.9.0"
+      valuesFile: components/dynamo-crds/values.yaml
+
+    - name: dynamo-platform
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "0.9.0"
+      valuesFile: components/dynamo-platform/values.yaml
+      dependencyRefs:
+        - dynamo-crds
+        - cert-manager
+        - kube-prometheus-stack
+        - gpu-operator
+        - kai-scheduler
+      overrides:
+        etcd:
+          persistence:
+            storageClass: standard-rwo
+        nats:
+          config:
+            jetstream:
+              fileStore:
+                pvc:
+                  storageClassName: standard-rwo
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access

--- a/recipes/overlays/h100-gke-cos-inference.yaml
+++ b/recipes/overlays/h100-gke-cos-inference.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-gke-cos-inference
+
+spec:
+  # Inherits from gke-cos-inference recipe (GKE COS + inference settings)
+  base: gke-cos-inference
+
+  criteria:
+    service: gke
+    accelerator: h100
+    os: cos
+    intent: inference
+
+  # Specific constraints for H100 on GKE COS inference workloads
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32"
+
+  componentRefs:
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - cert-manager
+        - kube-prometheus-stack
+        - skyhook-customizations
+      overrides:
+        cdi:
+          enabled: true
+
+    - name: skyhook-customizations
+      type: Helm
+      manifestFiles:
+        - components/skyhook-customizations/manifests/tuning-gke.yaml
+      overrides:
+        accelerator: h100
+        intent: inference
+      dependencyRefs:
+        - skyhook-operator


### PR DESCRIPTION
## Summary

Add GKE inference overlay recipes and CUJ2 walkthrough for Dynamo inference on GKE.

## Motivation / Context

GKE lacked inference overlay recipes — only training overlays existed. This adds the full inference chain including Dynamo platform support, mirroring the existing EKS inference pattern.

Fixes: N/A
Related: CUJ2 for GKE

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Overlay inheritance chain:**
```
gke-cos → gke-cos-inference → h100-gke-cos-inference → h100-gke-cos-inference-dynamo
```

- `gke-cos-inference`: kgateway components (same as EKS inference)
- `h100-gke-cos-inference`: H100 skyhook tuning, CDI enabled
- `h100-gke-cos-inference-dynamo`: Dynamo platform with `standard-rwo` storage (GKE PD CSI), DRA, full deployment + conformance validation
- `demos/cuj2-gke.md`: End-to-end inference walkthrough for GKE
- Conformance test added for overlay selection regression prevention

## Testing

```bash
make test  # Recipe conformance test passes
```

Validated on live GKE cluster (aicr-demo2, 2x a3-megagpu-8g, COS, K8s 1.35):
- 14 components deployed, all pods healthy
- Conformance: 10/11 passed (cluster-autoscaling skipped — no Karpenter on GKE)
- CNCF submission evidence: 8/8 passed
- Dynamo vLLM workload (Qwen3-0.6B) serving via inference gateway

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — additive recipe overlays, no impact on existing recipes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)