### PR TITLE
fix(gke): update TCPXO to NRI profile without hostNetwork

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -56,7 +56,8 @@ misconfigurations:
   - id: AVD-KSV-0121
     paths:
       - "recipes/components/gke-nccl-tcpxo/manifests/nri-device-injector.yaml"
-    statement: "/dev hostPath mount is required for NRI device injection."
+      - "demos/workloads/training/gke-nccl-test-tcpxo.yaml"
+    statement: "/dev and /sys hostPath mounts are required for NRI device injection and TCPXO PCI sysfs visibility."
 
   - id: AVD-KSV-0023
     paths:

--- a/demos/cuj1-gke.md
+++ b/demos/cuj1-gke.md
@@ -145,12 +145,14 @@ kubectl get pods -n $NAMESPACE -o wide -w
 kubectl exec nccl-test-host-1 -n $NAMESPACE -c nccl-test -- \
   /scripts/allreduce.sh nccl-host-1 nccl-host-2
 
-# Expected: ~335 GB/s busBW at 8 GB (AllReduce), ~87 GB/s avg
+# Expected: ~340 GB/s busBW at 16 GB (AllReduce), ~100 GB/s avg
 # Clean up
 kubectl delete ns $NAMESPACE
 ```
 
-### Option 2: Using standalone demo manifest
+### Option 2: Using standalone demo manifests
+
+**NRI profile (recommended, no hostNetwork):**
 
 ```shell
 kubectl create ns nccl-test
@@ -163,10 +165,11 @@ kubectl get pods -n nccl-test -o wide -w
 kubectl exec nccl-test-host-1 -n nccl-test -c nccl-test -- bash -c '
   /scripts/init_ssh.sh nccl-host-1 nccl-host-2 &&
   pushd /scripts && /scripts/gen_hostfiles.sh nccl-host-1 nccl-host-2 && popd &&
-  BENCHMARK=all_reduce_perf NHOSTS=2 NCCL_LIB_DIR="/usr/local/nvidia/lib64" \
-    LD_LIBRARY_PATH="/usr/local/nvidia/lib64" /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh'
+  DATA_MIN=1K DATA_MAX=16G BENCHMARK=all_reduce_perf NHOSTS=2 \
+    NCCL_LIB_DIR="/usr/local/nvidia/lib64" LD_LIBRARY_PATH="/usr/local/nvidia/lib64" \
+    /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh'
 
-# Expected: ~335 GB/s busBW at 8 GB (AllReduce), ~87 GB/s avg
+# Expected: ~340 GB/s busBW at 16 GB (AllReduce), ~100 GB/s avg
 # Clean up
 kubectl delete ns nccl-test
 ```
@@ -174,27 +177,24 @@ kubectl delete ns nccl-test
 ### Prerequisites
 
 - GKE cluster with multi-NIC networking (8 GPU NICs per a3-megagpu-8g node)
+- GPU node pool must **not** have a gVNIC additional network (it takes a GPU NIC PCI slot)
 - `Network` + `GKENetworkParamSet` CRs configured for GPU NICs (infrastructure, cluster-specific)
 - `nccl-tcpxo-installer` DaemonSet deployed on GPU nodes (included in AICR bundle)
 - `nri-device-injector` DaemonSet deployed on GPU nodes (included in AICR bundle)
-- Without multi-NIC, NCCL falls back to TCP (~4 GB/s vs ~335 GB/s with TCPXO)
+- Without multi-NIC, NCCL falls back to TCP (~4 GB/s vs ~340 GB/s with TCPXO)
 
 ### TCPXO Runtime Requirements
 
 Each workload pod that needs GPUDirect TCPXO must include a `tcpxo-daemon` sidecar container.
+The NRI profile is used (no `hostNetwork`, no `privileged` for tcpxo-daemon):
 
-**Recommended profile** (validated on GKE 1.35 / a3-megagpu-8g):
-- `hostNetwork: true` — required for PCI sysfs visibility
-- `privileged: false` — not needed with NRI device injection
-- NRI annotations on the pod: `devices.gke.io/container.tcpxo-daemon` (GPU devices) and `networking.gke.io/interfaces` (multi-NIC mapping with cluster-specific network names)
-- `securityContext.capabilities: [NET_ADMIN, NET_BIND_SERVICE]` on the tcpxo-daemon container
+- `hostNetwork: false` — preserves pod networking (DNS, network policies)
+- `privileged: false` — tcpxo-daemon uses only `CAP_NET_ADMIN` and `CAP_NET_BIND_SERVICE`
+- Host `/sys` mounted as `/hostsysfs` and `/proc/sys` as `/hostprocsysfs` for PCI sysfs visibility
+- NRI annotations: `devices.gke.io/container.tcpxo-daemon` (GPU devices) and `networking.gke.io/interfaces` (multi-NIC mapping with cluster-specific network names)
 - Requires NRI device injector DaemonSet deployed on GPU nodes
 
-**Fallback profile** (if NRI injector is not available):
-- `hostNetwork: true` + `privileged: true`
-- No annotations needed
-
-> **Known issue:** Without `hostNetwork: true`, the TCPXO daemon cannot enumerate all GPUs via PCI sysfs — the container runtime restricts sysfs visibility, causing the daemon to detect fewer GPUs in the PCI tree than CUDA reports, and exit. NRI annotations provide `/dev/nvidia*` device access but do not restore full PCI sysfs visibility. This is a GKE container runtime limitation.
+See [GKE TCPXO Networking](../docs/integrator/gke-tcpxo-networking.md) for details and troubleshooting.
 
 ### Understanding the results
 
@@ -202,8 +202,15 @@ Each pod runs two containers: a `tcpxo-daemon` sidecar (manages GPUDirect TCPX d
 
 | Metric | Without TCPXO | With TCPXO |
 |--------|--------------|------------|
-| AllReduce busBW (8 GB) | ~4 GB/s | ~335 GB/s |
-| AllReduce avg busBW | ~4 GB/s | ~87 GB/s |
+| AllReduce busBW (16 GB) | ~4 GB/s | ~340 GB/s |
+| AllReduce avg busBW | ~4 GB/s | ~100 GB/s |
+
+> **Note:** The NCCL test container image must match the cluster's installed TCPXO plugin version. Check with:
+> ```shell
+> kubectl get ds nccl-tcpxo-installer -n kube-system \
+>   -o jsonpath='{.spec.template.spec.containers[?(@.name=="nccl-tcpxo-installer")].image}'
+> ```
+> Update the `nccl-plugin-gpudirecttcpx-dev` image tag in the demo manifest to match.
 
 ## Success
 

--- a/demos/workloads/training/gke-nccl-test-tcpxo.yaml
+++ b/demos/workloads/training/gke-nccl-test-tcpxo.yaml
@@ -12,21 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Standalone NCCL benchmark with GPUDirect TCPXO on GKE
-#
-# Derived from: validators/performance/testdata/h100/gke/runtime.yaml
-# This is a standalone version with hardcoded values for manual use.
-# The canonical parameterized source is the testdata file above.
+# Standalone NCCL benchmark with GPUDirect TCPXO on GKE (NRI profile)
 #
 # 2-node, 16-GPU (8 per node) NCCL test using GPUDirect TCPXO
 # for high-speed inter-node GPU communication on GKE a3-megagpu-8g instances.
+# Uses the NRI profile: no hostNetwork, no privileged for tcpxo-daemon.
+#
+# Important: The GPU node pool must NOT have a gVNIC additional network.
+# A gVNIC network takes a GPU NIC PCI slot, leaving only 7/8 GPUs available.
+# The node pool should have only the 8 GPU NIC networks (gpu-nic-0 through gpu-nic-7).
+#
 # Default script runs AllGather; AllReduce instructions in comments below.
 #
 # Prerequisites:
 #   - GKE cluster with multi-NIC networking (8 GPU NICs per node)
 #   - Network + GKENetworkParamSet CRs configured for GPU NICs
 #   - nccl-tcpxo-installer DaemonSet deployed on GPU nodes
+#   - NRI device-injector DaemonSet deployed on GPU nodes
 #   - GPU Operator with driver.enabled=false (GKE COS manages drivers)
+#
+# Image version note:
+#   The nccl-test container image must match the cluster's installed TCPXO
+#   plugin version. Check with:
+#     kubectl get ds nccl-tcpxo-installer -n kube-system \
+#       -o jsonpath='{.spec.template.spec.containers[?(@.name=="nccl-tcpxo-installer")].image}'
+#   Then update the nccl-plugin-gpudirecttcpx-dev tag below to match.
 #
 # Usage:
 #   kubectl create ns nccl-test
@@ -44,30 +54,14 @@
 #       LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh'
 #
 # Expected results (a3-megagpu-8g, 2 nodes):
-#   AllReduce busBW: ~335 GB/s at 8 GB message size
+#   AllReduce busBW: ~340 GB/s at 16 GB message size
 #   AllGather busBW: ~188 GB/s at 8 GB message size
 #
 # Note: Each pod includes a tcpxo-daemon sidecar container that manages the
 # GPUDirect TCPX data path. This sidecar is required for any workload that
 # needs TCPXO bandwidth — without it, NCCL falls back to TCP (~4 GB/s).
 #
-# TCPXO Runtime Requirements (validated on GKE 1.35 / a3-megagpu-8g):
-#
-#   Recommended (default profile):
-#     - hostNetwork: true (required for PCI sysfs visibility)
-#     - privileged: false
-#     - NRI annotations: devices.gke.io/container.tcpxo-daemon (GPU devices)
-#       and networking.gke.io/interfaces (multi-NIC mapping)
-#     - securityContext.capabilities: [NET_ADMIN, NET_BIND_SERVICE]
-#     - NRI device injector DaemonSet deployed on GPU nodes
-#
-#   Fallback (if NRI injector is not available):
-#     - hostNetwork: true + privileged: true (original known-good)
-#     - No annotations needed
-#
-# This test uses the fallback profile for broad compatibility.
 # See: https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx
-#
 # Source: adapted from https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/gpudirect-tcpxo/nccl-test.yaml
 
 ---
@@ -98,6 +92,21 @@ metadata:
   labels:
     name: nccl-host-1
     tcpxo: daemon
+  annotations:
+    devices.gke.io/container.tcpxo-daemon: |
+      - path: /dev/nvidia0
+      - path: /dev/nvidia1
+      - path: /dev/nvidia2
+      - path: /dev/nvidia3
+      - path: /dev/nvidia4
+      - path: /dev/nvidia5
+      - path: /dev/nvidia6
+      - path: /dev/nvidia7
+      - path: /dev/nvidiactl
+      - path: /dev/nvidia-uvm
+      - path: /dev/dmabuf_import_helper
+    networking.gke.io/default-interface: eth0
+    networking.gke.io/interfaces: '[{"interfaceName":"eth0","network":"default"},{"interfaceName":"eth1","network":"gpu-nic0"},{"interfaceName":"eth2","network":"gpu-nic1"},{"interfaceName":"eth3","network":"gpu-nic2"},{"interfaceName":"eth4","network":"gpu-nic3"},{"interfaceName":"eth5","network":"gpu-nic4"},{"interfaceName":"eth6","network":"gpu-nic5"},{"interfaceName":"eth7","network":"gpu-nic6"},{"interfaceName":"eth8","network":"gpu-nic7"}]'
 spec:
   affinity:
     podAntiAffinity:
@@ -111,15 +120,14 @@ spec:
           topologyKey: "kubernetes.io/hostname"
   hostname: host1
   subdomain: nccl-host-1
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
+  hostNetwork: false
   tolerations:
     - operator: Exists
   nodeSelector:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -128,15 +136,21 @@ spec:
           chmod 755 /fts/entrypoint_rxdm_container.sh
           /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics 8
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]
       volumeMounts:
-        - name: nvidia-install-dir-host
+        - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia
+          readOnly: true
+        - name: nvtcpxo-sys
+          mountPath: /hostsysfs
+        - name: nvtcpxo-proc-sys
+          mountPath: /hostprocsysfs
       env:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -159,17 +173,28 @@ spec:
       securityContext:
         privileged: true
       volumeMounts:
-        - name: nvidia-install-dir-host
+        - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia
         - name: shared-memory
           mountPath: /dev/shm
+        - name: nvtcpxo-aperture-devices
+          mountPath: /dev/aperture_devices
       resources:
         limits:
           nvidia.com/gpu: 8
   volumes:
-    - name: nvidia-install-dir-host
+    - name: nvtcpxo-libraries
       hostPath:
         path: /home/kubernetes/bin/nvidia
+    - name: nvtcpxo-sys
+      hostPath:
+        path: /sys
+    - name: nvtcpxo-proc-sys
+      hostPath:
+        path: /proc/sys
+    - name: nvtcpxo-aperture-devices
+      hostPath:
+        path: /dev/aperture_devices
     - name: shared-memory
       emptyDir:
         medium: "Memory"
@@ -182,6 +207,21 @@ metadata:
   labels:
     name: nccl-host-2
     tcpxo: daemon
+  annotations:
+    devices.gke.io/container.tcpxo-daemon: |
+      - path: /dev/nvidia0
+      - path: /dev/nvidia1
+      - path: /dev/nvidia2
+      - path: /dev/nvidia3
+      - path: /dev/nvidia4
+      - path: /dev/nvidia5
+      - path: /dev/nvidia6
+      - path: /dev/nvidia7
+      - path: /dev/nvidiactl
+      - path: /dev/nvidia-uvm
+      - path: /dev/dmabuf_import_helper
+    networking.gke.io/default-interface: eth0
+    networking.gke.io/interfaces: '[{"interfaceName":"eth0","network":"default"},{"interfaceName":"eth1","network":"gpu-nic0"},{"interfaceName":"eth2","network":"gpu-nic1"},{"interfaceName":"eth3","network":"gpu-nic2"},{"interfaceName":"eth4","network":"gpu-nic3"},{"interfaceName":"eth5","network":"gpu-nic4"},{"interfaceName":"eth6","network":"gpu-nic5"},{"interfaceName":"eth7","network":"gpu-nic6"},{"interfaceName":"eth8","network":"gpu-nic7"}]'
 spec:
   affinity:
     podAntiAffinity:
@@ -195,15 +235,14 @@ spec:
           topologyKey: "kubernetes.io/hostname"
   hostname: host2
   subdomain: nccl-host-2
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
+  hostNetwork: false
   tolerations:
     - operator: Exists
   nodeSelector:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -212,15 +251,21 @@ spec:
           chmod 755 /fts/entrypoint_rxdm_container.sh
           /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics 8
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]
       volumeMounts:
-        - name: nvidia-install-dir-host
+        - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia
+          readOnly: true
+        - name: nvtcpxo-sys
+          mountPath: /hostsysfs
+        - name: nvtcpxo-proc-sys
+          mountPath: /hostprocsysfs
       env:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -243,17 +288,28 @@ spec:
       securityContext:
         privileged: true
       volumeMounts:
-        - name: nvidia-install-dir-host
+        - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia
         - name: shared-memory
           mountPath: /dev/shm
+        - name: nvtcpxo-aperture-devices
+          mountPath: /dev/aperture_devices
       resources:
         limits:
           nvidia.com/gpu: 8
   volumes:
-    - name: nvidia-install-dir-host
+    - name: nvtcpxo-libraries
       hostPath:
         path: /home/kubernetes/bin/nvidia
+    - name: nvtcpxo-sys
+      hostPath:
+        path: /sys
+    - name: nvtcpxo-proc-sys
+      hostPath:
+        path: /proc/sys
+    - name: nvtcpxo-aperture-devices
+      hostPath:
+        path: /dev/aperture_devices
     - name: shared-memory
       emptyDir:
         medium: "Memory"

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -1,0 +1,150 @@
+# GKE TCPXO Networking Prerequisites
+
+For `*-gke-cos-training*` recipes, GPUDirect TCPXO enables high-speed inter-node GPU communication on GKE. Without it, NCCL falls back to TCP (~4 GB/s vs ~340 GB/s with TCPXO).
+
+## Infrastructure Prerequisites
+
+GKE clusters must have multi-NIC networking configured before deploying AICR bundles:
+
+- Multi-NIC networking enabled (8 GPU NICs per a3-megagpu-8g node)
+- `Network` + `GKENetworkParamSet` CRs configured for GPU NICs (cluster-specific, not managed by AICR)
+- `nccl-tcpxo-installer` DaemonSet on GPU nodes (included in AICR bundle)
+- `nri-device-injector` DaemonSet on GPU nodes (included in AICR bundle)
+
+**Important:** The GPU node pool must be provisioned with only the 8 GPU NIC
+networks (`gpu-nic-0` through `gpu-nic-7`). Do **not** include a gVNIC additional
+network — it takes a GPU NIC PCI slot (`0000:06:00.0`), leaving only 7/8 GPUs
+available for TCPXO.
+
+## Workload Pod Configuration (NRI Profile)
+
+The NRI profile mounts the host's `/sys` and `/proc/sys` into the TCPXO daemon
+container, giving it PCI sysfs visibility without `hostNetwork`. This preserves
+pod networking (DNS, network policies, service mesh compatibility).
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-workload
+  annotations:
+    # NRI device injection for tcpxo-daemon GPU access
+    devices.gke.io/container.tcpxo-daemon: |
+      - path: /dev/nvidia0
+      - path: /dev/nvidia1
+      - path: /dev/nvidia2
+      - path: /dev/nvidia3
+      - path: /dev/nvidia4
+      - path: /dev/nvidia5
+      - path: /dev/nvidia6
+      - path: /dev/nvidia7
+      - path: /dev/nvidiactl
+      - path: /dev/nvidia-uvm
+      - path: /dev/dmabuf_import_helper
+    # Multi-NIC mapping (network names are cluster-specific)
+    networking.gke.io/default-interface: eth0
+    networking.gke.io/interfaces: |
+      [{"interfaceName":"eth0","network":"default"},
+       {"interfaceName":"eth1","network":"gpu-nic0"},
+       {"interfaceName":"eth2","network":"gpu-nic1"},
+       {"interfaceName":"eth3","network":"gpu-nic2"},
+       {"interfaceName":"eth4","network":"gpu-nic3"},
+       {"interfaceName":"eth5","network":"gpu-nic4"},
+       {"interfaceName":"eth6","network":"gpu-nic5"},
+       {"interfaceName":"eth7","network":"gpu-nic6"},
+       {"interfaceName":"eth8","network":"gpu-nic7"}]
+spec:
+  hostNetwork: false
+  containers:
+    - name: tcpxo-daemon
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
+      securityContext:
+        capabilities:
+          add: [CAP_NET_ADMIN, CAP_NET_BIND_SERVICE]
+      volumeMounts:
+        - name: nvtcpxo-libraries
+          mountPath: /usr/local/nvidia
+          readOnly: true
+        - name: nvtcpxo-sys
+          mountPath: /hostsysfs
+        - name: nvtcpxo-proc-sys
+          mountPath: /hostprocsysfs
+      env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64
+    - name: workload
+      # ... your training container
+      volumeMounts:
+        - name: nvtcpxo-aperture-devices
+          mountPath: /dev/aperture_devices
+  volumes:
+    - name: nvtcpxo-libraries
+      hostPath:
+        path: /home/kubernetes/bin/nvidia
+    - name: nvtcpxo-sys
+      hostPath:
+        path: /sys
+    - name: nvtcpxo-proc-sys
+      hostPath:
+        path: /proc/sys
+    - name: nvtcpxo-aperture-devices
+      hostPath:
+        path: /dev/aperture_devices
+```
+
+Key properties:
+- `hostNetwork: false` — workloads get proper pod networking
+- `privileged: false` — tcpxo-daemon uses only `CAP_NET_ADMIN` and `CAP_NET_BIND_SERVICE`
+- `/sys` mounted as `/hostsysfs` — provides PCI sysfs visibility for GPU enumeration
+- `/proc/sys` mounted as `/hostprocsysfs` — allows kernel network tuning
+- NRI annotations inject GPU devices and multi-NIC interfaces
+- Requires NRI device injector DaemonSet deployed on GPU nodes
+
+See [`demos/workloads/training/gke-nccl-test-tcpxo.yaml`](../../demos/workloads/training/gke-nccl-test-tcpxo.yaml) for a complete 2-node NCCL benchmark example.
+
+## NCCL Plugin Version Matching
+
+The NCCL test container image must match the cluster's installed TCPXO plugin version. Check with:
+
+```shell
+kubectl get ds nccl-tcpxo-installer -n kube-system \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="nccl-tcpxo-installer")].image}'
+```
+
+Update the `nccl-plugin-gpudirecttcpx-dev` image tag in your workload to match.
+
+## Troubleshooting
+
+### RxDM detects 7/8 GPUs
+
+If RxDM reports `Number of GPUs detected 7 is not equal to the actual number of GPUs 8`, check the GPU node pool's additional network configuration:
+
+```shell
+gcloud container node-pools describe <pool-name> \
+  --cluster <cluster> --region <region> --project <project> \
+  --format="yaml(networkConfig.additionalNodeNetworkConfigs)"
+```
+
+If a **gVNIC network** appears in the list, it is taking a GPU NIC PCI slot. Remove the gVNIC from the node pool and reprovision the GPU nodes.
+
+You can also verify the node NIC mapping:
+
+```shell
+kubectl get node <gpu-node> \
+  -o jsonpath='{.metadata.annotations.networking\.gke\.io/nic-info}'
+```
+
+All 8 GPU NIC PCI addresses should be mapped to `eth1`–`eth8`. If a gVNIC is present, it typically occupies PCI `0000:06:00.0`, displacing the first GPU NIC.
+
+### RxDM detects 0/8 GPUs
+
+If RxDM reports `Number of GPUs detected in the PCI tree 0`, the pod is missing the `/sys` hostPath mount. Ensure `/sys` is mounted as `/hostsysfs` in the tcpxo-daemon container. Without it, the container network namespace hides the host PCI sysfs tree entirely.
+
+## Performance Reference
+
+Validated on GKE 1.35 / a3-megagpu-8g (2 nodes, 16 GPUs):
+
+| Profile | hostNetwork | busBW @ 16 GB | Avg busBW |
+|---------|-------------|---------------|-----------|
+| NRI (recommended) | false | ~340 GB/s | ~100 GB/s |
+| Without TCPXO | N/A | ~4 GB/s | ~4 GB/s |


### PR DESCRIPTION
## Summary
- Update `demos/workloads/training/gke-nccl-test-tcpxo.yaml` to NRI profile with `hostNetwork: false`
- Add `docs/integrator/gke-tcpxo-networking.md` documenting NRI profile, node pool prerequisites, and troubleshooting
- Update `demos/cuj1-gke.md` with NRI profile as default

### Root cause of previous 7/8 GPU issue

The GPU node pool was provisioned with an extra gVNIC additional network that occupied PCI address `0000:06:00.0` — one of the 8 GPU NIC slots. Removing the gVNIC from the node pool config resolves the issue. This was not a GKE version regression.

### NRI profile (no hostNetwork)
- `hostNetwork: false` — preserves pod networking
- `privileged: false` — tcpxo-daemon uses capabilities only
- `/sys` mounted as `/hostsysfs` for PCI sysfs visibility
- Validated on GKE 1.35: **338 GB/s AllReduce busBW** (8/8 GPUs)

Resolves #381

## Test plan
- [x] NRI profile validated on GKE 1.35 (aicr-demo4) — 338 GB/s AllReduce, 8/8 GPUs
- [x] Confirmed root cause: gVNIC network on node pool displaces GPU NIC PCI slot
- [ ] Verify markdown renders correctly on GitHub