### PR TITLE
fix(site): remove dompurify dependency by stubbing it for mermaid

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -16,9 +16,29 @@
 
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default withMermaid(
   defineConfig({
+    vite: {
+      resolve: {
+        alias: {
+          // Stub out dompurify — mermaid imports it statically but
+          // vitepress-plugin-mermaid uses securityLevel:'loose' which
+          // bypasses sanitization. Safe for author-controlled docs content.
+          dompurify: path.resolve(__dirname, 'dompurify-stub.mjs'),
+        },
+      },
+      ssr: {
+        // Force mermaid through Vite's pipeline during SSR so the
+        // dompurify alias above is applied (Node native resolution
+        // would bypass it).
+        noExternal: ['mermaid'],
+      },
+    },
     title: 'NVIDIA AI Cluster Runtime',
     description: 'Optimized, validated, and reproducible Kubernetes configurations for GPU infrastructure',
     base: '/',

--- a/site/.vitepress/dompurify-stub.mjs
+++ b/site/.vitepress/dompurify-stub.mjs
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// No-op stub for dompurify. Mermaid imports this statically but
+// vitepress-plugin-mermaid uses securityLevel:'loose' by default,
+// so sanitization is effectively a passthrough. This avoids bundling
+// the real dompurify (which also needs a DOM environment problematic
+// for SSR). Safe because all diagram content is author-controlled.
+const DOMPurify = {
+  sanitize: (html) => html,
+  addHook: () => {},
+  removeHook: () => {},
+  removeHooks: () => {},
+  removeAllHooks: () => {},
+  isSupported: true,
+}
+
+export default DOMPurify

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -2571,15 +2571,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
@@ -2884,7 +2875,6 @@
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
         "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
         "katex": "^0.16.25",
         "khroma": "^2.1.0",
         "lodash-es": "^4.17.23",


### PR DESCRIPTION
## Summary

Remove the `dompurify` npm dependency and replace it with a no-op stub so that mermaid diagrams build without requiring a real DOM sanitizer.

## Motivation / Context

Mermaid statically imports `dompurify` even when `securityLevel` is set to `'loose'` (which bypasses sanitization). This pulls in an unnecessary dependency that also causes issues during SSR since dompurify expects a DOM environment. Since all diagram content is author-controlled, sanitization is not needed.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Added a Vite resolve alias in `site/.vitepress/config.ts` to redirect `dompurify` imports to a local no-op stub (`dompurify-stub.mjs`)
- Forced `mermaid` through Vite's SSR pipeline (`ssr.noExternal`) so the alias applies during server-side rendering (Node's native resolution would bypass it)
- Removed `dompurify` from `site/package-lock.json`

## Testing

```bash
# Verified site builds successfully without dompurify
cd site && npm run build
```

Site builds cleanly with mermaid diagrams rendering correctly.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — docs site only, no impact on CLI or runtime components.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)