### PR TITLE
chore: bump nvsentinel from v0.10.x to v1.1.0

### DIFF
--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -45,7 +45,7 @@ spec:
     - name: nvsentinel
       type: Helm
       source: oci://ghcr.io/nvidia
-      version: v0.10.0
+      version: v1.1.0
       valuesFile: components/nvsentinel/values.yaml
       dependencyRefs:
         - cert-manager

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -205,7 +205,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/nvsentinel
-      defaultVersion: v0.10.1
+      defaultVersion: v1.1.0
       defaultNamespace: nvsentinel
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary
- Update nvsentinel `defaultVersion` in `recipes/registry.yaml` from `v0.10.1` to `v1.1.0`
- Update nvsentinel version override in `recipes/overlays/base.yaml` from `v0.10.0` to `v1.1.0`

## Test plan
- [x] Verify `make qualify` passes
- [x] Verify recipe resolution picks up `v1.1.0` for nvsentinel