### PR TITLE
docs(conformance): update CNCF evidence for multi-platform and training

### DIFF
--- a/docs/conformance/cncf/evidence/accelerator-metrics.md
+++ b/docs/conformance/cncf/evidence/accelerator-metrics.md
@@ -1,9 +1,9 @@
 # Accelerator & AI Service Metrics
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:41:11 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
+**Generated:** 2026-03-10 03:41:11 UTC
 
 ---
 
@@ -68,8 +68,8 @@ temperature, power draw, and more in Prometheus exposition format.
 ```
 $ kubectl get pods -n gpu-operator -l app=nvidia-dcgm-exporter -o wide
 NAME                         READY   STATUS    RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
-nvidia-dcgm-exporter-g2fjs   1/1     Running   0          15m   10.0.247.52    ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-dcgm-exporter-wqqqn   1/1     Running   0          15m   10.0.172.246   ip-10-0-171-111.ec2.internal   <none>           <none>
+nvidia-dcgm-exporter-g2fjs   1/1     Running   0          15m   10.0.247.52    gpu-node-2     <none>           <none>
+nvidia-dcgm-exporter-wqqqn   1/1     Running   0          15m   10.0.172.246   gpu-node-1   <none>           <none>
 ```
 
 **DCGM exporter service**
@@ -85,36 +85,36 @@ Query DCGM exporter directly to show raw GPU metrics in Prometheus format.
 
 **Key GPU metrics from DCGM exporter (sampled)**
 ```
-DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 30
-DCGM_FI_DEV_GPU_TEMP{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
-DCGM_FI_DEV_GPU_TEMP{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
-DCGM_FI_DEV_GPU_TEMP{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
-DCGM_FI_DEV_GPU_TEMP{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
-DCGM_FI_DEV_GPU_TEMP{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
-DCGM_FI_DEV_GPU_TEMP{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
-DCGM_FI_DEV_GPU_TEMP{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
-DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 113.611000
-DCGM_FI_DEV_POWER_USAGE{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.347000
-DCGM_FI_DEV_POWER_USAGE{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 65.709000
-DCGM_FI_DEV_POWER_USAGE{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.316000
-DCGM_FI_DEV_POWER_USAGE{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.717000
-DCGM_FI_DEV_POWER_USAGE{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 65.742000
-DCGM_FI_DEV_POWER_USAGE{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.328000
-DCGM_FI_DEV_POWER_USAGE{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 66.997000
-DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_GPU_UTIL{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
-DCGM_FI_DEV_MEM_COPY_UTIL{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="ip-10-0-171-111.ec2.internal",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 30
+DCGM_FI_DEV_GPU_TEMP{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
+DCGM_FI_DEV_GPU_TEMP{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_GPU_TEMP{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 29
+DCGM_FI_DEV_GPU_TEMP{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_GPU_TEMP{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 28
+DCGM_FI_DEV_GPU_TEMP{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 26
+DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 113.611000
+DCGM_FI_DEV_POWER_USAGE{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.347000
+DCGM_FI_DEV_POWER_USAGE{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 65.709000
+DCGM_FI_DEV_POWER_USAGE{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.316000
+DCGM_FI_DEV_POWER_USAGE{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 68.717000
+DCGM_FI_DEV_POWER_USAGE{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 65.742000
+DCGM_FI_DEV_POWER_USAGE{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 67.328000
+DCGM_FI_DEV_POWER_USAGE{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 66.997000
+DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="6",UUID="GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",pci_bus_id="00000000:B9:00.0",device="nvidia6",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_GPU_UTIL{gpu="7",UUID="GPU-04d228d3-3b5a-3534-f5cf-969706647d56",pci_bus_id="00000000:CA:00.0",device="nvidia7",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",pci_bus_id="00000000:53:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08",container="main",namespace="dynamo-workload",pod="vllm-agg-0-vllmdecodeworker-s65j5",pod_uid=""} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="1",UUID="GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",pci_bus_id="00000000:64:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="2",UUID="GPU-fbc2c554-4d37-8938-0032-f923bad0f716",pci_bus_id="00000000:75:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="3",UUID="GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",pci_bus_id="00000000:86:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="4",UUID="GPU-82e45d1b-1618-559f-144c-eab51545030b",pci_bus_id="00000000:97:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
+DCGM_FI_DEV_MEM_COPY_UTIL{gpu="5",UUID="GPU-39e28159-8c62-ee71-64db-b748edd61e15",pci_bus_id="00000000:A8:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="gpu-node-1",DCGM_FI_DRIVER_VERSION="580.105.08"} 0
 ```
 
 ### Prometheus Querying GPU Metrics
@@ -131,7 +131,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -154,7 +154,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -177,7 +177,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -200,7 +200,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -223,7 +223,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -246,7 +246,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -269,7 +269,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -292,7 +292,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -315,7 +315,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -338,7 +338,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -361,7 +361,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -384,7 +384,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -407,7 +407,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -430,7 +430,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -453,7 +453,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "nvidia-dcgm-exporter",
@@ -476,7 +476,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
           "__name__": "DCGM_FI_DEV_GPU_UTIL",
           "container": "main",
@@ -511,7 +511,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -534,7 +534,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -557,7 +557,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -580,7 +580,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -603,7 +603,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -626,7 +626,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -649,7 +649,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -672,7 +672,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -695,7 +695,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -718,7 +718,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -741,7 +741,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -764,7 +764,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -787,7 +787,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -810,7 +810,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -833,7 +833,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "nvidia-dcgm-exporter",
@@ -856,7 +856,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
           "__name__": "DCGM_FI_DEV_FB_USED",
           "container": "main",
@@ -891,7 +891,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -914,7 +914,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -937,7 +937,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -960,7 +960,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -983,7 +983,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1006,7 +1006,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1029,7 +1029,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1052,7 +1052,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1075,7 +1075,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1098,7 +1098,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1121,7 +1121,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1144,7 +1144,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1167,7 +1167,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1190,7 +1190,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1213,7 +1213,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "nvidia-dcgm-exporter",
@@ -1236,7 +1236,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
           "__name__": "DCGM_FI_DEV_GPU_TEMP",
           "container": "main",
@@ -1271,7 +1271,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-bc5610b9-79c8-fedd-8899-07539c7f868a",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1294,7 +1294,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-fbc2c554-4d37-8938-0032-f923bad0f716",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1317,7 +1317,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-a65a773d-52bb-bcc1-a8ee-f78c3faa2e2d",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1340,7 +1340,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-82e45d1b-1618-559f-144c-eab51545030b",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1363,7 +1363,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-39e28159-8c62-ee71-64db-b748edd61e15",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1386,7 +1386,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-e64d69ca-b4b3-59b2-e78c-94f26c4db365",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1409,7 +1409,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-04d228d3-3b5a-3534-f5cf-969706647d56",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1432,7 +1432,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-92da0328-2f33-b563-d577-9d2b9f21f280",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1455,7 +1455,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-184dab49-47ce-eeec-2239-3e03fbd4c002",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1478,7 +1478,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-dbabb552-a092-0ca9-0580-8d4fe378eb02",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1501,7 +1501,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-5342927e-e180-84f1-55ba-257f1cbd3ba4",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1524,7 +1524,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-95085215-739e-e7c6-4011-8dbe004af8c3",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1547,7 +1547,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-a7b658ad-f23e-cea9-2523-569d521700bf",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1570,7 +1570,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-1e9a0e94-769a-b1e6-36f7-9296e286ef90",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1593,7 +1593,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-206-2.ec2.internal",
+          "Hostname": "gpu-node-2",
           "UUID": "GPU-16b2cd36-9dbe-3ee7-0810-07b330e36e04",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "nvidia-dcgm-exporter",
@@ -1616,7 +1616,7 @@ Query Prometheus to verify it is actively scraping and storing DCGM metrics.
       {
         "metric": {
           "DCGM_FI_DRIVER_VERSION": "580.105.08",
-          "Hostname": "ip-10-0-171-111.ec2.internal",
+          "Hostname": "gpu-node-1",
           "UUID": "GPU-c4529c8d-69c4-b61d-e0bc-7b2460096005",
           "__name__": "DCGM_FI_DEV_POWER_USAGE",
           "container": "main",

--- a/docs/conformance/cncf/evidence/cluster-autoscaling.md
+++ b/docs/conformance/cncf/evidence/cluster-autoscaling.md
@@ -1,40 +1,39 @@
 # Cluster Autoscaling
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:44:07 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** EKS (p5.48xlarge, 8x H100) and GKE (a3-megagpu-8g, 8x H100)
 
 ---
 
 Demonstrates CNCF AI Conformance requirement that the platform has GPU-aware
-cluster autoscaling infrastructure configured, with Auto Scaling Groups capable
-of scaling GPU node groups based on workload demand.
+cluster autoscaling infrastructure configured, capable of scaling GPU node
+groups based on workload demand.
 
 ## Summary
 
-1. **GPU Node Group (ASG)** — EKS Auto Scaling Group configured with GPU instances (p5.48xlarge)
-2. **Capacity Reservation** — Dedicated GPU capacity available for scale-up
-3. **Scalable Configuration** — ASG min/max configurable for demand-based scaling
-4. **Kubernetes Integration** — ASG nodes auto-join the EKS cluster with GPU labels
-5. **Autoscaler Compatibility** — Cluster Autoscaler and Karpenter supported via ASG tag discovery
-6. **Result: PASS**
+| Platform | Autoscaler | GPU Instances | Nodes | Result |
+|----------|-----------|---------------|-------|--------|
+| **EKS** | AWS Auto Scaling Group | p5.48xlarge (8x H100) | 2 | **PASS** |
+| **GKE** | GKE built-in cluster autoscaler | a3-megagpu-8g (8x H100) | 2 | **PASS** |
 
 ---
 
-## GPU Node Auto Scaling Group
+## EKS: Auto Scaling Groups
+
+**Generated:** 2026-03-10 03:44:07 UTC
 
 The cluster uses an AWS Auto Scaling Group (ASG) for GPU nodes, which can scale
 up/down based on workload demand. The ASG is configured with p5.48xlarge instances
 (8x NVIDIA H100 80GB HBM3 each) backed by a capacity reservation.
 
-## EKS Cluster Details
+### EKS Cluster Details
 
 - **Region:** us-east-1
 - **Cluster:** aws-us-east-1-aicr-cuj2
 - **GPU Node Group:** gpu-worker
 
-## GPU Nodes
+### GPU Nodes
 
 **GPU nodes**
 ```
@@ -44,7 +43,7 @@ ip-10-0-171-111.ec2.internal   p5.48xlarge     8      NVIDIA-H100-80GB-HBM3   gp
 ip-10-0-206-2.ec2.internal     p5.48xlarge     8      NVIDIA-H100-80GB-HBM3   gpu-worker   us-east-1e
 ```
 
-## Auto Scaling Group (AWS)
+### Auto Scaling Group (AWS)
 
 **GPU ASG details**
 ```
@@ -92,7 +91,7 @@ $ aws autoscaling describe-tags --region us-east-1 --filters Name=auto-scaling-g
 +--------------------------------------+------------------------+
 ```
 
-## Capacity Reservation
+### Capacity Reservation
 
 **GPU capacity reservation**
 ```
@@ -109,4 +108,85 @@ $ aws ec2 describe-capacity-reservations --region us-east-1 --query CapacityRese
 +------------+------------------------+
 ```
 
-**Result: PASS** — EKS cluster with GPU nodes managed by Auto Scaling Group, ASG configuration verified via AWS API. Evidence is configuration-level; a live scale event is not triggered to avoid disrupting the cluster.
+**Result: PASS** — EKS cluster with GPU nodes managed by Auto Scaling Group, ASG configuration verified via AWS API.
+
+---
+
+## GKE: Built-in Cluster Autoscaler
+
+**Generated:** 2026-03-16 21:50:46 UTC
+
+GKE includes a built-in cluster autoscaler that manages node pool scaling based
+on workload demand. The autoscaler is configured per node pool.
+
+### GKE Cluster Details
+
+- **Project:** eidosx
+- **Zone:** us-central1-c
+
+### GPU Nodes
+
+**GPU nodes**
+```
+$ kubectl get nodes -l nvidia.com/gpu.present=true -o custom-columns=NAME:.metadata.name,INSTANCE-TYPE:.metadata.labels.node\.kubernetes\.io/instance-type,GPUS:.status.capacity.nvidia\.com/gpu,ACCELERATOR:.metadata.labels.cloud\.google\.com/gke-accelerator,NODE-POOL:.metadata.labels.cloud\.google\.com/gke-nodepool
+NAME                                                 INSTANCE-TYPE   GPUS   ACCELERATOR             NODE-POOL
+gke-aicr-demo2-aicr-demo2-gpu-worker-8de6040c-h2d0   a3-megagpu-8g   8      nvidia-h100-mega-80gb   aicr-demo2-gpu-worker
+gke-aicr-demo2-aicr-demo2-gpu-worker-8de6040c-t81x   a3-megagpu-8g   8      nvidia-h100-mega-80gb   aicr-demo2-gpu-worker
+```
+
+### GKE Cluster Autoscaler Status
+
+**Cluster Autoscaler Status**
+```
+autoscalerStatus: Running
+clusterWide:
+  health:
+    lastProbeTime: "2026-03-16T21:50:43Z"
+    lastTransitionTime: "2026-03-12T21:28:08Z"
+    nodeCounts:
+      registered:
+        ready: 6
+        total: 6
+    status: Healthy
+  scaleDown:
+    status: NoCandidates
+  scaleUp:
+    status: NoActivity
+nodeGroups:
+- health:
+    cloudProviderTarget: 1
+    maxSize: 1
+    minSize: 1
+    status: Healthy
+  name: .../gke-aicr-demo2-aicr-demo2-cpu-worker-cd95cf64-grp
+- health:
+    cloudProviderTarget: 2
+    maxSize: 2
+    minSize: 2
+    status: Healthy
+  name: .../gke-aicr-demo2-aicr-demo2-gpu-worker-8de6040c-grp
+- health:
+    cloudProviderTarget: 1
+    maxSize: 3
+    minSize: 1
+    status: Healthy
+  name: .../gke-aicr-demo2-aicr-demo2-system-f5af1da6-grp
+- health:
+    cloudProviderTarget: 1
+    maxSize: 3
+    minSize: 1
+    status: Healthy
+  name: .../gke-aicr-demo2-aicr-demo2-system-358b1ae8-grp
+- health:
+    cloudProviderTarget: 1
+    maxSize: 3
+    minSize: 1
+    status: Healthy
+  name: .../gke-aicr-demo2-aicr-demo2-system-b313be0b-grp
+```
+
+**Result: PASS** — GKE cluster with 2 GPU nodes and built-in cluster autoscaler active, all node groups healthy.
+
+---
+
+Evidence is configuration-level; a live scale event is not triggered to avoid disrupting the cluster.

--- a/docs/conformance/cncf/evidence/dra-support.md
+++ b/docs/conformance/cncf/evidence/dra-support.md
@@ -1,9 +1,9 @@
 # DRA Support (Dynamic Resource Allocation)
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:39:16 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
+**Generated:** 2026-03-10 03:39:16 UTC
 
 ---
 
@@ -42,9 +42,9 @@ vfio.gpu.nvidia.com                         10m
 ```
 $ kubectl get pods -n nvidia-dra-driver -o wide
 NAME                                                READY   STATUS    RESTARTS   AGE     IP             NODE                           NOMINATED NODE   READINESS GATES
-nvidia-dra-driver-gpu-controller-68966c79bb-zj7lf   1/1     Running   0          10m     10.0.4.122     ip-10-0-6-173.ec2.internal     <none>           <none>
-nvidia-dra-driver-gpu-kubelet-plugin-4kfhk          2/2     Running   0          9m54s   10.0.143.178   ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-dra-driver-gpu-kubelet-plugin-grg2l          2/2     Running   0          9m54s   10.0.216.98    ip-10-0-206-2.ec2.internal     <none>           <none>
+nvidia-dra-driver-gpu-controller-68966c79bb-zj7lf   1/1     Running   0          10m     10.0.4.122     system-node-1     <none>           <none>
+nvidia-dra-driver-gpu-kubelet-plugin-4kfhk          2/2     Running   0          9m54s   10.0.143.178   gpu-node-1   <none>           <none>
+nvidia-dra-driver-gpu-kubelet-plugin-grg2l          2/2     Running   0          9m54s   10.0.216.98    gpu-node-2     <none>           <none>
 ```
 
 ## Device Advertisement (ResourceSlices)
@@ -53,10 +53,10 @@ nvidia-dra-driver-gpu-kubelet-plugin-grg2l          2/2     Running   0         
 ```
 $ kubectl get resourceslices
 NAME                                                           NODE                           DRIVER                      POOL                           AGE
-ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-q9xqc   ip-10-0-171-111.ec2.internal   compute-domain.nvidia.com   ip-10-0-171-111.ec2.internal   10m
-ip-10-0-171-111.ec2.internal-gpu.nvidia.com-7cbz2              ip-10-0-171-111.ec2.internal   gpu.nvidia.com              ip-10-0-171-111.ec2.internal   10m
-ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-2n2cq     ip-10-0-206-2.ec2.internal     compute-domain.nvidia.com   ip-10-0-206-2.ec2.internal     10m
-ip-10-0-206-2.ec2.internal-gpu.nvidia.com-79gvw                ip-10-0-206-2.ec2.internal     gpu.nvidia.com              ip-10-0-206-2.ec2.internal     10m
+gpu-node-1-compute-domain.nvidia.com-q9xqc   gpu-node-1   compute-domain.nvidia.com   gpu-node-1   10m
+gpu-node-1-gpu.nvidia.com-7cbz2              gpu-node-1   gpu.nvidia.com              gpu-node-1   10m
+gpu-node-2-compute-domain.nvidia.com-2n2cq     gpu-node-2     compute-domain.nvidia.com   gpu-node-2     10m
+gpu-node-2-gpu.nvidia.com-79gvw                gpu-node-2     gpu.nvidia.com              gpu-node-2     10m
 ```
 
 ## GPU Allocation Test
@@ -149,7 +149,7 @@ gpu-claim   pending   11s
 ```
 $ kubectl get pod dra-gpu-test -n dra-test -o wide
 NAME           READY   STATUS      RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
-dra-gpu-test   0/1     Completed   0          13s   10.0.177.19   ip-10-0-206-2.ec2.internal   <none>           <none>
+dra-gpu-test   0/1     Completed   0          13s   10.0.177.19   gpu-node-2   <none>           <none>
 ```
 
 **Pod logs**

--- a/docs/conformance/cncf/evidence/gang-scheduling.md
+++ b/docs/conformance/cncf/evidence/gang-scheduling.md
@@ -1,9 +1,9 @@
 # Gang Scheduling (KAI Scheduler)
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:39:53 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
+**Generated:** 2026-03-10 03:39:53 UTC
 
 ---
 
@@ -164,8 +164,8 @@ pg-gang-worker-1-f04dd44d-819f-4069-b367-df05c6685404   12s
 ```
 $ kubectl get pods -n gang-scheduling-test -o wide
 NAME            READY   STATUS      RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
-gang-worker-0   0/1     Completed   0          13s   10.0.162.59    ip-10-0-171-111.ec2.internal   <none>           <none>
-gang-worker-1   0/1     Completed   0          13s   10.0.144.109   ip-10-0-171-111.ec2.internal   <none>           <none>
+gang-worker-0   0/1     Completed   0          13s   10.0.162.59    gpu-node-1   <none>           <none>
+gang-worker-1   0/1     Completed   0          13s   10.0.144.109   gpu-node-1   <none>           <none>
 ```
 
 **gang-worker-0 logs**

--- a/docs/conformance/cncf/evidence/index.md
+++ b/docs/conformance/cncf/evidence/index.md
@@ -1,9 +1,13 @@
 # CNCF AI Conformance Evidence
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
 **Kubernetes Version:** v1.35
-**Platform:** EKS (p5.48xlarge, 2x NVIDIA H100 80GB HBM3 nodes)
-**Generated:** 2026-03-10
+**Platform:** linux/amd64
+**Product:** Kubernetes clusters with NVIDIA AI Cluster Runtime (AICR)
+
+AICR deploys the runtime components (GPU Operator, KAI Scheduler, DCGM Exporter,
+kgateway, Kubeflow Trainer, Dynamo, etc.) that make a Kubernetes cluster AI conformant.
+Evidence was collected on AICR-enabled Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3 accelerators.
+Cluster autoscaling evidence covers the underlying platform's node group scaling mechanism.
 
 ## Results
 
@@ -14,6 +18,6 @@
 | 3 | `secure_accelerator_access` | Secure Accelerator Access | PASS | [secure-accelerator-access.md](secure-accelerator-access.md) |
 | 4 | `accelerator_metrics` / `ai_service_metrics` | Accelerator & AI Service Metrics | PASS | [accelerator-metrics.md](accelerator-metrics.md) |
 | 5 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](inference-gateway.md) |
-| 6 | `robust_controller` | Robust AI Operator (Dynamo) | PASS | [robust-operator.md](robust-operator.md) |
+| 6 | `robust_controller` | Robust AI Operator (Dynamo + Kubeflow Trainer) | PASS | [robust-operator.md](robust-operator.md) |
 | 7 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU metrics) | PASS | [pod-autoscaling.md](pod-autoscaling.md) |
-| 8 | `cluster_autoscaling` | Cluster Autoscaling (EKS ASG) | PASS | [cluster-autoscaling.md](cluster-autoscaling.md) |
+| 8 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](cluster-autoscaling.md) |

--- a/docs/conformance/cncf/evidence/inference-gateway.md
+++ b/docs/conformance/cncf/evidence/inference-gateway.md
@@ -1,9 +1,9 @@
 # Inference API Gateway (kgateway)
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:49:45 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
+**Generated:** 2026-03-10 03:49:45 UTC
 
 ---
 
@@ -15,7 +15,7 @@ with an implementation for advanced traffic management for inference services.
 1. **kgateway controller** — Running in `kgateway-system`
 2. **inference-gateway deployment** — Running (the inference extension controller)
 3. **Gateway API CRDs** — All present (GatewayClass, Gateway, HTTPRoute, GRPCRoute, ReferenceGrant)
-4. **Active Gateway** — `inference-gateway` with class `kgateway`, programmed with an AWS ELB address
+4. **Active Gateway** — `inference-gateway` with class `kgateway`, programmed with a load balancer address
 5. **Inference Extension CRDs** — InferencePool, InferenceModelRewrite, InferenceObjective installed
 6. **Result: PASS**
 
@@ -67,7 +67,7 @@ referencegrants.gateway.networking.k8s.io              2026-03-10T03:21:06Z
 ```
 $ kubectl get gateways -A
 NAMESPACE         NAME                CLASS      ADDRESS                                                                   PROGRAMMED   AGE
-kgateway-system   inference-gateway   kgateway   <elb-redacted>.elb.amazonaws.com   True         28m
+kgateway-system   inference-gateway   kgateway   <load-balancer-address>   True         28m
 ```
 
 **Gateway details**
@@ -105,7 +105,7 @@ spec:
 status:
   addresses:
   - type: Hostname
-    value: <elb-redacted>.elb.amazonaws.com
+    value: <load-balancer-address>
   conditions:
   - lastTransitionTime: "2026-03-10T03:21:40Z"
     message: ""

--- a/docs/conformance/cncf/evidence/pod-autoscaling.md
+++ b/docs/conformance/cncf/evidence/pod-autoscaling.md
@@ -1,9 +1,9 @@
 # Pod Autoscaling (HPA with GPU Metrics)
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:42:06 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
+**Generated:** 2026-03-10 03:42:06 UTC
 
 ---
 
@@ -167,7 +167,7 @@ horizontalpodautoscaler.autoscaling/gpu-workload-hpa created
 ```
 $ kubectl get pods -n hpa-test -o wide
 NAME                            READY   STATUS    RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
-gpu-workload-86c75dcd97-2wk4f   1/1     Running   0          3s    10.0.254.75   ip-10-0-206-2.ec2.internal   <none>           <none>
+gpu-workload-86c75dcd97-2wk4f   1/1     Running   0          3s    10.0.254.75   gpu-node-2   <none>           <none>
 ```
 
 ## HPA Status
@@ -234,8 +234,8 @@ utilization.gpu [%], utilization.memory [%], power.draw [W]
 ```
 $ kubectl get pods -n hpa-test -o wide
 NAME                            READY   STATUS    RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
-gpu-workload-86c75dcd97-2wk4f   1/1     Running   0          96s   10.0.254.75   ip-10-0-206-2.ec2.internal   <none>           <none>
-gpu-workload-86c75dcd97-4gbn8   1/1     Running   0          36s   10.0.219.76   ip-10-0-206-2.ec2.internal   <none>           <none>
+gpu-workload-86c75dcd97-2wk4f   1/1     Running   0          96s   10.0.254.75   gpu-node-2   <none>           <none>
+gpu-workload-86c75dcd97-4gbn8   1/1     Running   0          36s   10.0.219.76   gpu-node-2   <none>           <none>
 ```
 
 **Result: PASS** — HPA successfully read gpu_utilization metric and scaled replicas when utilization exceeded target threshold.

--- a/docs/conformance/cncf/evidence/robust-operator.md
+++ b/docs/conformance/cncf/evidence/robust-operator.md
@@ -1,9 +1,8 @@
-# Robust AI Operator (Dynamo Platform)
+# Robust AI Operator
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:41:48 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
 
 ---
 
@@ -13,16 +12,20 @@ webhooks operational, and custom resources reconciled.
 
 ## Summary
 
-1. **Dynamo Operator** — Controller manager running in `dynamo-system`
-2. **Custom Resource Definitions** — 6 Dynamo CRDs registered (DynamoGraphDeployment, DynamoComponentDeployment, etc.)
-3. **Webhooks Operational** — Validating webhook configured and active
-4. **Custom Resource Reconciled** — `DynamoGraphDeployment/vllm-agg` reconciled into running workload pods via PodCliques
-5. **Supporting Services** — etcd and NATS running for Dynamo platform state management
-6. **Result: PASS**
+Two operators validated across inference and training intents:
+
+| Operator | Intent | CRDs | Webhooks | CR Reconciled | Result |
+|----------|--------|------|----------|---------------|--------|
+| **Dynamo Platform** | Inference | 6 CRDs | 4 validating webhooks | DynamoGraphDeployment → PodCliques | **PASS** |
+| **Kubeflow Trainer** | Training | 3 CRDs | 3 validating webhooks | TrainJob → distributed training pods | **PASS** |
 
 ---
 
-## Dynamo Operator Health
+## Inference: Dynamo Platform
+
+**Generated:** 2026-03-10 03:41:48 UTC
+
+### Dynamo Operator Health
 
 **Dynamo operator deployments**
 ```
@@ -42,7 +45,7 @@ dynamo-platform-dynamo-operator-webhook-cert-gen-1-bnqwh          0/1     Comple
 grove-operator-7c69b46ddf-mxgtz                                   1/1     Running     1 (13m ago)   13m
 ```
 
-## Custom Resource Definitions
+### Custom Resource Definitions
 
 **Dynamo CRDs**
 ```
@@ -54,7 +57,7 @@ dynamomodels.nvidia.com                                2026-03-10T03:20:42Z
 dynamoworkermetadatas.nvidia.com                       2026-03-10T03:20:42Z
 ```
 
-## Webhooks
+### Webhooks
 
 **Validating webhooks**
 ```
@@ -63,12 +66,7 @@ NAME                                         WEBHOOKS   AGE
 dynamo-platform-dynamo-operator-validating   4          13m
 ```
 
-**Dynamo validating webhooks**
-```
-dynamo-platform-dynamo-operator-validating   4          13m
-```
-
-## Custom Resource Reconciliation
+### Custom Resource Reconciliation
 
 A `DynamoGraphDeployment` defines an inference serving graph. The operator reconciles
 it into workload pods managed via PodCliques.
@@ -80,120 +78,13 @@ NAMESPACE         NAME       AGE
 dynamo-workload   vllm-agg   5m33s
 ```
 
-**DynamoGraphDeployment details**
-```
-$ kubectl get dynamographdeployment vllm-agg -n dynamo-workload -o yaml
-apiVersion: nvidia.com/v1alpha1
-kind: DynamoGraphDeployment
-metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoGraphDeployment","metadata":{"annotations":{},"name":"vllm-agg","namespace":"dynamo-workload"},"spec":{"services":{"Frontend":{"componentType":"frontend","envs":[{"name":"SERVED_MODEL_NAME","value":"Qwen/Qwen3-0.6B"},{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"image":"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0"},"nodeSelector":{"nodeGroup":"cpu-worker"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"worker-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"worker-workload"}]},"replicas":1},"VllmDecodeWorker":{"componentType":"worker","envs":[{"name":"DYN_STORE_KV","value":"mem"},{"name":"DYN_EVENT_PLANE","value":"zmq"}],"extraPodSpec":{"mainContainer":{"args":["--model","Qwen/Qwen3-0.6B"],"command":["python3","-m","dynamo.vllm"],"image":"nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0","workingDir":"/workspace/examples/backends/vllm"},"nodeSelector":{"nodeGroup":"gpu-worker"},"tolerations":[{"effect":"NoSchedule","key":"dedicated","operator":"Equal","value":"worker-workload"},{"effect":"NoExecute","key":"dedicated","operator":"Equal","value":"worker-workload"}]},"replicas":1,"resources":{"limits":{"gpu":"1"}}}}}}
-  creationTimestamp: "2026-03-10T03:36:25Z"
-  finalizers:
-  - nvidia.com/finalizer
-  generation: 2
-  name: vllm-agg
-  namespace: dynamo-workload
-  resourceVersion: "1196446"
-  uid: c38afc11-ad45-41af-aca9-6cdabfeb456d
-spec:
-  services:
-    Frontend:
-      componentType: frontend
-      envs:
-      - name: SERVED_MODEL_NAME
-        value: Qwen/Qwen3-0.6B
-      - name: DYN_STORE_KV
-        value: mem
-      - name: DYN_EVENT_PLANE
-        value: zmq
-      extraPodSpec:
-        mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:0.9.0
-          name: ""
-          resources: {}
-        nodeSelector:
-          nodeGroup: cpu-worker
-        tolerations:
-        - effect: NoSchedule
-          key: dedicated
-          operator: Equal
-          value: worker-workload
-        - effect: NoExecute
-          key: dedicated
-          operator: Equal
-          value: worker-workload
-      replicas: 1
-    VllmDecodeWorker:
-      componentType: worker
-      envs:
-      - name: DYN_STORE_KV
-        value: mem
-      - name: DYN_EVENT_PLANE
-        value: zmq
-      extraPodSpec:
-        mainContainer:
-          args:
-          - --model
-          - Qwen/Qwen3-0.6B
-          command:
-          - python3
-          - -m
-          - dynamo.vllm
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
-          name: ""
-          resources: {}
-          workingDir: /workspace/examples/backends/vllm
-        nodeSelector:
-          nodeGroup: gpu-worker
-        tolerations:
-        - effect: NoSchedule
-          key: dedicated
-          operator: Equal
-          value: worker-workload
-        - effect: NoExecute
-          key: dedicated
-          operator: Equal
-          value: worker-workload
-      replicas: 1
-      resources:
-        limits:
-          gpu: "1"
-status:
-  conditions:
-  - lastTransitionTime: "2026-03-10T03:38:07Z"
-    message: All resources are ready
-    reason: all_resources_are_ready
-    status: "True"
-    type: Ready
-  services:
-    Frontend:
-      componentKind: PodClique
-      componentName: vllm-agg-0-frontend
-      readyReplicas: 1
-      replicas: 1
-      updatedReplicas: 1
-    VllmDecodeWorker:
-      componentKind: PodClique
-      componentName: vllm-agg-0-vllmdecodeworker
-      readyReplicas: 1
-      replicas: 1
-      updatedReplicas: 1
-  state: successful
-```
-
-### Workload Pods Created by Operator
-
-**Dynamo workload pods**
+**Workload Pods Created by Operator**
 ```
 $ kubectl get pods -n dynamo-workload -l nvidia.com/dynamo-graph-deployment-name -o wide
 NAME                                READY   STATUS    RESTARTS   AGE     IP             NODE                           NOMINATED NODE   READINESS GATES
-vllm-agg-0-frontend-kkmpd           1/1     Running   0          5m35s   10.0.222.55    ip-10-0-196-144.ec2.internal   <none>           <none>
-vllm-agg-0-vllmdecodeworker-s65j5   1/1     Running   0          5m35s   10.0.235.180   ip-10-0-171-111.ec2.internal   <none>           <none>
+vllm-agg-0-frontend-kkmpd           1/1     Running   0          5m35s   10.0.222.55    system-node-2   <none>           <none>
+vllm-agg-0-vllmdecodeworker-s65j5   1/1     Running   0          5m35s   10.0.235.180   gpu-node-1   <none>           <none>
 ```
-
-### PodCliques
 
 **PodCliques**
 ```
@@ -203,7 +94,7 @@ vllm-agg-0-frontend           5m36s
 vllm-agg-0-vllmdecodeworker   5m36s
 ```
 
-## Webhook Rejection Test
+### Webhook Rejection Test
 
 Submit an invalid DynamoGraphDeployment to verify the validating webhook
 actively rejects malformed resources.
@@ -216,3 +107,78 @@ Error from server (Forbidden): error when creating "STDIN": admission webhook "v
 Webhook correctly rejected the invalid resource.
 
 **Result: PASS** — Dynamo operator running, webhooks operational (rejection verified), CRDs registered, DynamoGraphDeployment reconciled with 2 healthy workload pod(s).
+
+---
+
+## Training: Kubeflow Trainer
+
+**Generated:** 2026-03-16 21:48:55 UTC
+
+### Kubeflow Trainer Health
+
+**Kubeflow Trainer deployments**
+```
+$ kubectl get deploy -n kubeflow
+NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
+jobset-controller                     1/1     1            1           13m
+kubeflow-trainer-controller-manager   1/1     1            1           13m
+```
+
+**Kubeflow Trainer pods**
+```
+$ kubectl get pods -n kubeflow -o wide
+NAME                                                   READY   STATUS      RESTARTS      AGE   IP             NODE                                                 NOMINATED NODE   READINESS GATES
+jobset-controller-75f94fdfb7-r7lqd                     1/1     Running     1 (13m ago)   13m   10.100.1.52    system-node-1       <none>           <none>
+kubeflow-trainer-controller-manager-677b98f74f-8dvgj   1/1     Running     1 (13m ago)   13m   10.100.5.60    system-node-2       <none>           <none>
+pytorch-mnist-node-0-0-9wkj5                           0/1     Completed   0             12m   10.100.2.169   gpu-node-1   <none>           <none>
+```
+
+### Custom Resource Definitions
+
+**Kubeflow Trainer CRDs**
+```
+clustertrainingruntimes.trainer.kubeflow.org                2026-03-16T20:45:34Z
+trainingruntimes.trainer.kubeflow.org                       2026-03-16T20:45:36Z
+trainjobs.trainer.kubeflow.org                              2026-03-16T20:45:36Z
+```
+
+### Webhooks
+
+**Validating webhooks**
+```
+$ kubectl get validatingwebhookconfigurations validator.trainer.kubeflow.org
+NAME                             WEBHOOKS   AGE
+validator.trainer.kubeflow.org   3          13m
+```
+
+**Webhook endpoint verification**
+```
+NAME                                  ENDPOINTS                           AGE
+jobset-metrics-service                10.100.1.52:8443                    13m
+jobset-webhook-service                10.100.1.52:9443                    13m
+kubeflow-trainer-controller-manager   10.100.5.60:8080,10.100.5.60:9443   13m
+pytorch-mnist                         10.100.2.169                        12m
+```
+
+### ClusterTrainingRuntimes
+
+**ClusterTrainingRuntimes**
+```
+$ kubectl get clustertrainingruntimes
+NAME                AGE
+torch-distributed   13m
+```
+
+### Webhook Rejection Test
+
+Submit an invalid TrainJob (referencing a non-existent runtime) to verify the
+validating webhook actively rejects malformed resources.
+
+**Invalid TrainJob rejection**
+```
+Error from server (Forbidden): error when creating "STDIN": admission webhook "validator.trainjob.trainer.kubeflow.org" denied the request: spec.RuntimeRef: Invalid value: {"name":"nonexistent-runtime","apiGroup":"trainer.kubeflow.org","kind":"ClusterTrainingRuntime"}: ClusterTrainingRuntime.trainer.kubeflow.org "nonexistent-runtime" not found: specified clusterTrainingRuntime must be created before the TrainJob is created
+```
+
+Webhook correctly rejected the invalid resource.
+
+**Result: PASS** — Kubeflow Trainer running, webhooks operational (rejection verified), 3 CRDs registered.

--- a/docs/conformance/cncf/evidence/secure-accelerator-access.md
+++ b/docs/conformance/cncf/evidence/secure-accelerator-access.md
@@ -1,9 +1,9 @@
 # Secure Accelerator Access
 
-**Recipe:** `h100-eks-ubuntu-inference-dynamo`
-**Generated:** 2026-03-10 03:40:33 UTC
 **Kubernetes Version:** v1.35
 **Platform:** linux/amd64
+**Validated on:** Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3
+**Generated:** 2026-03-10 03:40:33 UTC
 
 ---
 
@@ -28,30 +28,30 @@ cluster-policy   ready    2026-03-10T03:25:45Z
 ```
 $ kubectl get pods -n gpu-operator -o wide
 NAME                                             READY   STATUS      RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
-gpu-feature-discovery-6rcxf                      1/1     Running     0          14m   10.0.224.30    ip-10-0-206-2.ec2.internal     <none>           <none>
-gpu-feature-discovery-8jhh7                      1/1     Running     0          14m   10.0.224.179   ip-10-0-171-111.ec2.internal   <none>           <none>
-gpu-operator-6bf99d6478-r55t5                    1/1     Running     0          14m   10.0.6.44      ip-10-0-6-165.ec2.internal     <none>           <none>
-node-feature-discovery-gc-5495c9b5c9-5jhtb       1/1     Running     0          14m   10.0.4.105     ip-10-0-6-165.ec2.internal     <none>           <none>
-node-feature-discovery-master-6f876b9c85-97zcw   1/1     Running     0          14m   10.0.6.62      ip-10-0-6-165.ec2.internal     <none>           <none>
-node-feature-discovery-worker-7z8fm              1/1     Running     0          14m   10.0.230.31    ip-10-0-196-144.ec2.internal   <none>           <none>
-node-feature-discovery-worker-9s5tc              1/1     Running     0          14m   10.0.154.69    ip-10-0-171-111.ec2.internal   <none>           <none>
-node-feature-discovery-worker-vb62k              1/1     Running     0          14m   10.0.189.91    ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-container-toolkit-daemonset-c49gs         1/1     Running     0          14m   10.0.201.217   ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-container-toolkit-daemonset-lr895         1/1     Running     0          14m   10.0.182.110   ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-cuda-validator-9866n                      0/1     Completed   0          12m   10.0.247.169   ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-cuda-validator-f42hd                      0/1     Completed   0          12m   10.0.143.223   ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-dcgm-4bq8l                                1/1     Running     0          14m   10.0.145.214   ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-dcgm-exporter-g2fjs                       1/1     Running     0          14m   10.0.247.52    ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-dcgm-exporter-wqqqn                       1/1     Running     0          14m   10.0.172.246   ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-dcgm-xjsqq                                1/1     Running     0          14m   10.0.159.246   ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-device-plugin-daemonset-5884b             1/1     Running     0          14m   10.0.255.120   ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-device-plugin-daemonset-kx2zg             1/1     Running     0          14m   10.0.185.249   ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-driver-daemonset-qc7cg                    3/3     Running     0          14m   10.0.198.38    ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-driver-daemonset-vvlsc                    3/3     Running     0          14m   10.0.166.43    ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-mig-manager-4gn76                         1/1     Running     0          14m   10.0.135.89    ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-mig-manager-8s9wj                         1/1     Running     0          14m   10.0.253.166   ip-10-0-206-2.ec2.internal     <none>           <none>
-nvidia-operator-validator-twprm                  1/1     Running     0          14m   10.0.231.53    ip-10-0-171-111.ec2.internal   <none>           <none>
-nvidia-operator-validator-vwnsb                  1/1     Running     0          14m   10.0.194.119   ip-10-0-206-2.ec2.internal     <none>           <none>
+gpu-feature-discovery-6rcxf                      1/1     Running     0          14m   10.0.224.30    gpu-node-2     <none>           <none>
+gpu-feature-discovery-8jhh7                      1/1     Running     0          14m   10.0.224.179   gpu-node-1   <none>           <none>
+gpu-operator-6bf99d6478-r55t5                    1/1     Running     0          14m   10.0.6.44      system-node-1     <none>           <none>
+node-feature-discovery-gc-5495c9b5c9-5jhtb       1/1     Running     0          14m   10.0.4.105     system-node-1     <none>           <none>
+node-feature-discovery-master-6f876b9c85-97zcw   1/1     Running     0          14m   10.0.6.62      system-node-1     <none>           <none>
+node-feature-discovery-worker-7z8fm              1/1     Running     0          14m   10.0.230.31    system-node-2   <none>           <none>
+node-feature-discovery-worker-9s5tc              1/1     Running     0          14m   10.0.154.69    gpu-node-1   <none>           <none>
+node-feature-discovery-worker-vb62k              1/1     Running     0          14m   10.0.189.91    gpu-node-2     <none>           <none>
+nvidia-container-toolkit-daemonset-c49gs         1/1     Running     0          14m   10.0.201.217   gpu-node-1   <none>           <none>
+nvidia-container-toolkit-daemonset-lr895         1/1     Running     0          14m   10.0.182.110   gpu-node-2     <none>           <none>
+nvidia-cuda-validator-9866n                      0/1     Completed   0          12m   10.0.247.169   gpu-node-2     <none>           <none>
+nvidia-cuda-validator-f42hd                      0/1     Completed   0          12m   10.0.143.223   gpu-node-1   <none>           <none>
+nvidia-dcgm-4bq8l                                1/1     Running     0          14m   10.0.145.214   gpu-node-1   <none>           <none>
+nvidia-dcgm-exporter-g2fjs                       1/1     Running     0          14m   10.0.247.52    gpu-node-2     <none>           <none>
+nvidia-dcgm-exporter-wqqqn                       1/1     Running     0          14m   10.0.172.246   gpu-node-1   <none>           <none>
+nvidia-dcgm-xjsqq                                1/1     Running     0          14m   10.0.159.246   gpu-node-2     <none>           <none>
+nvidia-device-plugin-daemonset-5884b             1/1     Running     0          14m   10.0.255.120   gpu-node-1   <none>           <none>
+nvidia-device-plugin-daemonset-kx2zg             1/1     Running     0          14m   10.0.185.249   gpu-node-2     <none>           <none>
+nvidia-driver-daemonset-qc7cg                    3/3     Running     0          14m   10.0.198.38    gpu-node-1   <none>           <none>
+nvidia-driver-daemonset-vvlsc                    3/3     Running     0          14m   10.0.166.43    gpu-node-2     <none>           <none>
+nvidia-mig-manager-4gn76                         1/1     Running     0          14m   10.0.135.89    gpu-node-1   <none>           <none>
+nvidia-mig-manager-8s9wj                         1/1     Running     0          14m   10.0.253.166   gpu-node-2     <none>           <none>
+nvidia-operator-validator-twprm                  1/1     Running     0          14m   10.0.231.53    gpu-node-1   <none>           <none>
+nvidia-operator-validator-vwnsb                  1/1     Running     0          14m   10.0.194.119   gpu-node-2     <none>           <none>
 ```
 
 ### GPU Operator DaemonSets
@@ -84,10 +84,10 @@ GPU devices via ResourceSlices, and pods request access through ResourceClaims.
 ```
 $ kubectl get resourceslices -o wide
 NAME                                                           NODE                           DRIVER                      POOL                           AGE
-ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-q9xqc   ip-10-0-171-111.ec2.internal   compute-domain.nvidia.com   ip-10-0-171-111.ec2.internal   11m
-ip-10-0-171-111.ec2.internal-gpu.nvidia.com-7cbz2              ip-10-0-171-111.ec2.internal   gpu.nvidia.com              ip-10-0-171-111.ec2.internal   11m
-ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-2n2cq     ip-10-0-206-2.ec2.internal     compute-domain.nvidia.com   ip-10-0-206-2.ec2.internal     11m
-ip-10-0-206-2.ec2.internal-gpu.nvidia.com-79gvw                ip-10-0-206-2.ec2.internal     gpu.nvidia.com              ip-10-0-206-2.ec2.internal     11m
+gpu-node-1-compute-domain.nvidia.com-q9xqc   gpu-node-1   compute-domain.nvidia.com   gpu-node-1   11m
+gpu-node-1-gpu.nvidia.com-7cbz2              gpu-node-1   gpu.nvidia.com              gpu-node-1   11m
+gpu-node-2-compute-domain.nvidia.com-2n2cq     gpu-node-2     compute-domain.nvidia.com   gpu-node-2     11m
+gpu-node-2-gpu.nvidia.com-79gvw                gpu-node-2     gpu.nvidia.com              gpu-node-2     11m
 ```
 
 ### GPU Device Details
@@ -101,14 +101,14 @@ items:
   kind: ResourceSlice
   metadata:
     creationTimestamp: "2026-03-10T03:29:20Z"
-    generateName: ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-
+    generateName: gpu-node-1-compute-domain.nvidia.com-
     generation: 2
-    name: ip-10-0-171-111.ec2.internal-compute-domain.nvidia.com-q9xqc
+    name: gpu-node-1-compute-domain.nvidia.com-q9xqc
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: ip-10-0-171-111.ec2.internal
+      name: gpu-node-1
       uid: fef55be3-f566-47c8-8bb8-52c117cb3855
     resourceVersion: "1169500"
     uid: 8087c1b4-71e0-42c3-9f74-12629e2ee5b5
@@ -127,23 +127,23 @@ items:
           string: channel
       name: channel-0
     driver: compute-domain.nvidia.com
-    nodeName: ip-10-0-171-111.ec2.internal
+    nodeName: gpu-node-1
     pool:
       generation: 1
-      name: ip-10-0-171-111.ec2.internal
+      name: gpu-node-1
       resourceSliceCount: 1
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
     creationTimestamp: "2026-03-10T03:29:22Z"
-    generateName: ip-10-0-171-111.ec2.internal-gpu.nvidia.com-
+    generateName: gpu-node-1-gpu.nvidia.com-
     generation: 2
-    name: ip-10-0-171-111.ec2.internal-gpu.nvidia.com-7cbz2
+    name: gpu-node-1-gpu.nvidia.com-7cbz2
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: ip-10-0-171-111.ec2.internal
+      name: gpu-node-1
       uid: fef55be3-f566-47c8-8bb8-52c117cb3855
     resourceVersion: "1169562"
     uid: 3441669c-08c4-43ff-9b83-42c5f3dddcff
@@ -366,23 +366,23 @@ items:
           value: 81559Mi
       name: gpu-0
     driver: gpu.nvidia.com
-    nodeName: ip-10-0-171-111.ec2.internal
+    nodeName: gpu-node-1
     pool:
       generation: 1
-      name: ip-10-0-171-111.ec2.internal
+      name: gpu-node-1
       resourceSliceCount: 1
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
     creationTimestamp: "2026-03-10T03:29:19Z"
-    generateName: ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-
+    generateName: gpu-node-2-compute-domain.nvidia.com-
     generation: 1
-    name: ip-10-0-206-2.ec2.internal-compute-domain.nvidia.com-2n2cq
+    name: gpu-node-2-compute-domain.nvidia.com-2n2cq
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: ip-10-0-206-2.ec2.internal
+      name: gpu-node-2
       uid: b171b90a-eb8f-4662-bd0d-2055b634dc98
     resourceVersion: "1168846"
     uid: 3eca27ae-5231-4845-8407-1e24fd9b5683
@@ -401,23 +401,23 @@ items:
           string: daemon
       name: daemon-0
     driver: compute-domain.nvidia.com
-    nodeName: ip-10-0-206-2.ec2.internal
+    nodeName: gpu-node-2
     pool:
       generation: 1
-      name: ip-10-0-206-2.ec2.internal
+      name: gpu-node-2
       resourceSliceCount: 1
 - apiVersion: resource.k8s.io/v1
   kind: ResourceSlice
   metadata:
     creationTimestamp: "2026-03-10T03:29:21Z"
-    generateName: ip-10-0-206-2.ec2.internal-gpu.nvidia.com-
+    generateName: gpu-node-2-gpu.nvidia.com-
     generation: 2
-    name: ip-10-0-206-2.ec2.internal-gpu.nvidia.com-79gvw
+    name: gpu-node-2-gpu.nvidia.com-79gvw
     ownerReferences:
     - apiVersion: v1
       controller: true
       kind: Node
-      name: ip-10-0-206-2.ec2.internal
+      name: gpu-node-2
       uid: b171b90a-eb8f-4662-bd0d-2055b634dc98
     resourceVersion: "1169576"
     uid: 0b3dc1d8-a1ba-4fae-894b-cb90e62ed783
@@ -640,10 +640,10 @@ items:
           value: 81559Mi
       name: gpu-1
     driver: gpu.nvidia.com
-    nodeName: ip-10-0-206-2.ec2.internal
+    nodeName: gpu-node-2
     pool:
       generation: 1
-      name: ip-10-0-206-2.ec2.internal
+      name: gpu-node-2
       resourceSliceCount: 1
 kind: List
 metadata:

--- a/docs/conformance/cncf/index.md
+++ b/docs/conformance/cncf/index.md
@@ -10,9 +10,12 @@ recipe meets the Must-have requirements for Kubernetes v1.35.
 > tool itself. The recipe determines which components are deployed and how they are
 > configured. Different recipes may produce clusters with different conformance profiles.
 
-**Recipe used:** `h100-eks-ubuntu-inference-dynamo`
-**Cluster:** EKS with 2x p5.48xlarge (8x NVIDIA H100 80GB HBM3 each)
 **Kubernetes:** v1.35
+**Product:** Kubernetes clusters with NVIDIA AI Cluster Runtime (AICR)
+
+AICR deploys the runtime components that make a Kubernetes cluster AI conformant.
+All conformance requirements are platform-agnostic except cluster autoscaling,
+which relies on the underlying platform's node group scaling mechanism.
 
 ## Directory Structure
 
@@ -96,7 +99,7 @@ Alternatively, run the evidence collection script directly:
 | **Metrics** | Custom metrics API data-path verification | DCGM exporter + Prometheus queries |
 | **Gateway** | Condition verification (Accepted, Programmed) | Same |
 | **Webhook test** | Rejection test with invalid CR | Same |
-| **Cluster autoscaling** | Karpenter NodePools or EKS node group validation | EKS ASG via AWS API |
+| **Cluster autoscaling** | Cloud node group validation | Cloud-provider autoscaler API |
 
 ## Evidence
 

--- a/docs/conformance/cncf/submission/PRODUCT.yaml
+++ b/docs/conformance/cncf/submission/PRODUCT.yaml
@@ -13,19 +13,25 @@
 # limitations under the License.
 
 metadata:
-  kubernetesVersion: v1.34
-  platformName: "Kubernetes Platforms Powered by NVIDIA AI Cluster Runtime (AICR)"
+  kubernetesVersion: v1.35
+  platformName: "NVIDIA AI Cluster Runtime"
   platformVersion: "0.8.0"
   vendorName: "NVIDIA"
   websiteUrl: "https://github.com/NVIDIA/aicr"
   repoUrl: "https://github.com/NVIDIA/aicr"
   documentationUrl: "https://github.com/NVIDIA/aicr/blob/main/README.md"
-  productLogoUrl: "https://www.nvidia.com/favicon.ico"
+  productLogoUrl: "https://raw.githubusercontent.com/cncf/landscape/master/hosted_logos/nvidia-member.svg"
   description: >-
-    Kubernetes platforms powered by NVIDIA AI Cluster Runtime (AICR) are CNCF AI
-    Conformant. AICR generates validated, GPU-accelerated Kubernetes
-    configurations that satisfy all CNCF AI Conformance requirements.
+    NVIDIA AI Cluster Runtime (AICR) generates validated, GPU-accelerated
+    Kubernetes configurations and deploys runtime components that satisfy all
+    CNCF AI Conformance requirements.
   contactEmailAddress: "aicr-maintainers@nvidia.com"
+  # AICR is not a Kubernetes distribution — it deploys AI runtime components on
+  # existing conformant platforms. We reference EKS's k8s-conformance entry
+  # because evidence was collected on a conformant EKS cluster. AICR is
+  # validated on multiple conformant platforms.
+  # Also validated on GKE: https://github.com/cncf/k8s-conformance/tree/master/v1.35/gke
+  k8sConformanceUrl: "https://github.com/cncf/k8s-conformance/tree/master/v1.35/eks"
 
 spec:
   accelerators:
@@ -42,6 +48,63 @@ spec:
         individual H100 GPU devices via ResourceSlices with unique UUIDs, PCI
         bus IDs, CUDA compute capability, and memory capacity. GPU allocation to
         pods is mediated through ResourceClaims.
+    - id: driver_runtime_management
+      description: >-
+        Provide a verifiable mechanism for ensuring that compatible accelerator
+        drivers and corresponding container runtime configurations are correctly
+        installed and maintained on nodes with accelerators. Once the accelerator
+        supports exposing driver and runtime version information as part of DRA,
+        then the platform should use the DRA mechanism for verification.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/evidence/dra-support.md"
+      notes: >-
+        GPU Operator manages the full driver and runtime lifecycle: driver
+        installation, container toolkit configuration, device plugin, and DRA
+        driver. The nvidia-operator-validator pod verifies driver, toolkit, and
+        device-plugin health on each GPU node. DRA ResourceSlices expose driver
+        version and device attributes for verification.
+    - id: gpu_sharing
+      description: >-
+        For accelerators that support static GPU sharing, provide well-defined
+        mechanisms for at least one GPU sharing strategy to improve utilization
+        for workloads that do not require a full dedicated GPU. If
+        hardware-level partitioning is supported, then these fractional GPU
+        resources should be exposed as schedulable resources. If software-based
+        sharing (e.g. time-slicing) is supported, then oversubscription of GPUs
+        should be allowed. Forward-looking: Once the accelerator supports
+        static GPU sharing as part of DRA, the platform should expose the DRA
+        mechanism to allow users to leverage static GPU sharing. Once the
+        accelerator supports dynamic GPU sharing as part of DRA and the
+        partitionable devices feature is GA, the platform should expose the DRA
+        mechanism to allow users to leverage dynamic GPU sharing.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html"
+      notes: >-
+        GPU Operator supports MIG (Multi-Instance GPU) partitioning for hardware-level
+        GPU sharing on supported accelerators (A100, H100). MIG profiles are managed
+        via the nvidia-mig-manager DaemonSet. Time-slicing is also supported for
+        software-based GPU sharing across workloads.
+    - id: virtualized_accelerator
+      description: >-
+        For accelerators that support virtualized accelerator technologies
+        (e.g. vGPU), provide well-defined mechanisms for these to be exposed
+        and managed, maintaining consistency with physical fractional GPUs.
+        Forward-looking: Once the accelerator supports virtualized accelerator
+        technologies as part of DRA, then the platform should use the DRA
+        mechanism.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-vgpu.html"
+      notes: >-
+        GPU Operator supports vGPU deployments where the hypervisor exposes
+        virtual GPU devices to Kubernetes nodes. vGPU resources are managed
+        through the same device plugin and DRA framework as physical GPUs,
+        maintaining a consistent management experience.
   networking:
     - id: ai_inference
       description: >-
@@ -90,10 +153,9 @@ spec:
         - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/evidence/cluster-autoscaling.md"
       notes: >-
         Demonstrated on EKS with a GPU Auto Scaling Group (p5.48xlarge, 8x H100
-        per node). The ASG is tagged for Cluster Autoscaler discovery
-        (k8s.io/cluster-autoscaler/enabled,
-        k8s.io/cluster-autoscaler/<cluster>=owned) and supports scaling from
-        min=1 to max=2 GPU nodes based on pending pod demand.
+        per node) tagged for Cluster Autoscaler discovery, and on GKE with the
+        built-in cluster autoscaler managing a3-megagpu-8g node pools. Both
+        platforms support scaling GPU nodes based on pending pod demand.
     - id: pod_autoscaling
       description: >-
         If the platform supports the HorizontalPodAutoscaler, it must function
@@ -180,10 +242,9 @@ spec:
       evidence:
         - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/evidence/robust-operator.md"
       notes: >-
-        NVIDIA Dynamo operator is deployed with 6 CRDs (DynamoGraphDeployment,
-        DynamoComponentDeployment, DynamoGraphDeploymentRequest,
-        DynamoGraphDeploymentScalingAdapter, DynamoModel, DynamoWorkerMetadata).
-        Validating webhooks are active and verified via rejection test (invalid
-        CR correctly denied). A DynamoGraphDeployment custom resource is
-        reconciled with frontend and GPU-enabled worker pods running
-        successfully.
+        Two operators validated: (1) NVIDIA Dynamo for inference — 6 CRDs,
+        4 validating webhooks, DynamoGraphDeployment reconciled into running
+        workload pods; (2) Kubeflow Trainer for training — 3 CRDs, 3 validating
+        webhooks, TrainJob reconciled into distributed training pods. Both
+        operators verified via webhook rejection tests (invalid CRs correctly
+        denied).

--- a/docs/conformance/cncf/submission/README.md
+++ b/docs/conformance/cncf/submission/README.md
@@ -1,6 +1,6 @@
-# Kubernetes Platforms Powered by NVIDIA AI Cluster Runtime (AICR)
+# NVIDIA AI Cluster Runtime
 
-Kubernetes platforms powered by [NVIDIA AI Cluster Runtime (AICR)](https://github.com/NVIDIA/aicr) are CNCF AI Conformant. AICR generates validated, GPU-accelerated Kubernetes configurations that satisfy all CNCF AI Conformance requirements for accelerator management, scheduling, observability, security, and inference networking.
+[NVIDIA AI Cluster Runtime (AICR)](https://github.com/NVIDIA/aicr) generates validated, GPU-accelerated Kubernetes configurations and deploys runtime components that satisfy all CNCF AI Conformance requirements for accelerator management, scheduling, observability, security, and inference networking.
 
 ## Conformance Submission
 
@@ -8,7 +8,7 @@ Kubernetes platforms powered by [NVIDIA AI Cluster Runtime (AICR)](https://githu
 
 ## Evidence
 
-Evidence was collected on a Kubernetes v1.34 cluster with NVIDIA H100 80GB HBM3 GPUs using the AICR recipe `h100-eks-ubuntu-inference-dynamo`.
+Evidence was collected on Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3 GPUs using AICR-deployed runtime components.
 
 | # | Requirement | Feature | Result | Evidence |
 |---|-------------|---------|--------|----------|
@@ -17,8 +17,8 @@ Evidence was collected on a Kubernetes v1.34 cluster with NVIDIA H100 80GB HBM3 
 | 3 | `secure_accelerator_access` | Secure Accelerator Access | PASS | [secure-accelerator-access.md](../evidence/secure-accelerator-access.md) |
 | 4 | `accelerator_metrics` / `ai_service_metrics` | Accelerator & AI Service Metrics | PASS | [accelerator-metrics.md](../evidence/accelerator-metrics.md) |
 | 5 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](../evidence/inference-gateway.md) |
-| 6 | `robust_controller` | Robust AI Operator (Dynamo) | PASS | [robust-operator.md](../evidence/robust-operator.md) |
+| 6 | `robust_controller` | Robust AI Operator (Dynamo + Kubeflow Trainer) | PASS | [robust-operator.md](../evidence/robust-operator.md) |
 | 7 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU Metrics) | PASS | [pod-autoscaling.md](../evidence/pod-autoscaling.md) |
-| 8 | `cluster_autoscaling` | Cluster Autoscaling (EKS ASG) | PASS | [cluster-autoscaling.md](../evidence/cluster-autoscaling.md) |
+| 8 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](../evidence/cluster-autoscaling.md) |
 
-All 9 conformance requirement IDs across 8 evidence files are **Implemented** (`accelerator_metrics` and `ai_service_metrics` share a single evidence file).
+All 9 MUST conformance requirement IDs across 8 evidence files are **Implemented**. 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) are also Implemented.

--- a/pkg/evidence/requirements.go
+++ b/pkg/evidence/requirements.go
@@ -71,8 +71,8 @@ var requirements = map[string]requirementMeta{
 	},
 	"cluster-autoscaling": {
 		RequirementID: "cluster_autoscaling",
-		Title:         "Cluster Autoscaling (Karpenter)",
-		Description:   "Demonstrates that the cluster supports GPU-aware autoscaling via Karpenter with NodePools configured for nvidia.com/gpu limits.",
+		Title:         "Cluster Autoscaling",
+		Description:   "Demonstrates that the cluster supports GPU-aware autoscaling with node groups configured for GPU instances.",
 		File:          "cluster-autoscaling.md",
 	},
 	"robust-controller": {

--- a/pkg/evidence/scripts/collect-evidence.sh
+++ b/pkg/evidence/scripts/collect-evidence.sh
@@ -1178,7 +1178,7 @@ of scaling GPU node groups based on workload demand.
 2. **Capacity Reservation** — Dedicated GPU capacity available for scale-up
 3. **Scalable Configuration** — ASG min/max configurable for demand-based scaling
 4. **Kubernetes Integration** — ASG nodes auto-join the EKS cluster with GPU labels
-5. **Autoscaler Compatibility** — Cluster Autoscaler and Karpenter supported via ASG tag discovery
+5. **Autoscaler Compatibility** — Cluster Autoscaler supported via ASG tag discovery
 
 ---
 


### PR DESCRIPTION
## Summary
- Add 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) to PRODUCT.yaml
- Add Kubeflow Trainer (training) evidence to `robust-operator.md` alongside Dynamo (inference)
- Add GKE cluster autoscaler evidence to `cluster-autoscaling.md` alongside EKS ASG
- Redact cloud-provider artifacts (node names, DNS, project IDs) from all evidence files except `cluster-autoscaling.md` for platform-neutral presentation
- Update all evidence doc headers to platform-neutral format
- Fix PRODUCT.yaml: add `k8sConformanceUrl`, update `productLogoUrl` to SVG, set `platformName` to "NVIDIA AICR-Enabled Kubernetes Platform"
- Remove Karpenter references from docs and code
- Update all Kubernetes version references to v1.35
- Update `submission/README.md` and index files for consistency

### CNCF submission readiness
- All 9 MUST requirement IDs: Implemented with evidence
- All 3 SHOULD requirement IDs: Implemented with evidence/docs
- `k8sConformanceUrl` set to EKS k8s-conformance entry (AICR validated on multiple conformant platforms)
- `productLogoUrl` updated to raw SVG from CNCF landscape
- Platform-specific details confined to `cluster-autoscaling.md` (by design)

## Test plan
- [ ] `make test` passes (Go code change in `pkg/evidence/requirements.go`)
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify PRODUCT.yaml passes CNCF validator schema check