### PR TITLE
docs: prefer global GitHub links in review findings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,6 +80,12 @@ make validate-local RECIPE=recipe.yaml  # Full pipeline in Kind
 7. **Context timeouts** — All I/O operations need context with timeout
 8. **Check context in loops** — Always check `ctx.Done()` in long-running operations
 
+## Review Output Links
+
+When providing review findings, use global GitHub file links by default
+(`https://github.com/<org>/<repo>/blob/<sha>/<path>#L<line>`) instead of local
+workspace paths. Use local file paths only when explicitly requested.
+
 ## Git Configuration
 
 - Commit to `main` branch (not `master`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,12 @@ make validate-local RECIPE=recipe.yaml  # Full pipeline in Kind
 7. **Context timeouts** — All I/O operations need context with timeout
 8. **Check context in loops** — Always check `ctx.Done()` in long-running operations
 
+## Review Output Links
+
+When providing review findings, use global GitHub file links by default
+(`https://github.com/<org>/<repo>/blob/<sha>/<path>#L<line>`) instead of local
+workspace paths. Use local file paths only when explicitly requested.
+
 ## Git Configuration
 
 - Commit to `main` branch (not `master`)


### PR DESCRIPTION
## Summary
- add a review-output rule to use global GitHub file links by default
- apply the rule in both canonical and mirrored agent instructions

## Files
- .claude/CLAUDE.md
- AGENTS.md

## Test plan
- docs-only change; no runtime/code changes