### PR TITLE
fix(validator): remove hostNetwork and privileged from GKE NCCL runtime, use NRI device injection

### DIFF
--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -327,6 +327,23 @@ func buildGKENetworkInterfacesAnnotation(gpuNICs []string) string {
 	return "[" + strings.Join(interfaces, ",") + "]"
 }
 
+// buildNRIDeviceAnnotation builds the devices.gke.io/container.tcpxo-daemon
+// annotation value for NRI device injection. Lists /dev/nvidia0..N-1 plus
+// the control and DMA devices the tcpxo-daemon needs without privileged mode.
+// Each line after the first is indented with 20 spaces to match the YAML
+// template indentation at the ${NRI_DEVICE_ANNOTATION} placeholder.
+func buildNRIDeviceAnnotation(gpuCount int) string {
+	const indent = "                    " // 20 spaces — matches template position
+	var lines []string
+	for i := range gpuCount {
+		lines = append(lines, fmt.Sprintf("- path: /dev/nvidia%d", i))
+	}
+	lines = append(lines, "- path: /dev/nvidiactl")
+	lines = append(lines, "- path: /dev/nvidia-uvm")
+	lines = append(lines, "- path: /dev/dmabuf_import_helper")
+	return strings.Join(lines, "\n"+indent)
+}
+
 // applyNCCLResources applies the per-platform TrainingRuntime and shared TrainJob
 // YAML files with template substitution using the dynamic client.
 // Runtime: testdata/{accelerator}/{service}/runtime.yaml (per-platform, contains all config)
@@ -355,6 +372,7 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 				fmt.Sprintf("expected 8 GPU NIC networks, found %d — cluster may not have multi-NIC networking configured", len(gpuNICs)))
 		}
 		templateData["GKE_NETWORK_INTERFACES"] = buildGKENetworkInterfacesAnnotation(gpuNICs)
+		templateData["NRI_DEVICE_ANNOTATION"] = buildNRIDeviceAnnotation(config.GPUCountPerNode)
 		slog.Info("Discovered GKE GPU NIC networks", "count", len(gpuNICs), "networks", gpuNICs)
 	}
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -334,7 +334,7 @@ func buildGKENetworkInterfacesAnnotation(gpuNICs []string) string {
 // template indentation at the ${NRI_DEVICE_ANNOTATION} placeholder.
 func buildNRIDeviceAnnotation(gpuCount int) string {
 	const indent = "                    " // 20 spaces — matches template position
-	var lines []string
+	lines := make([]string, 0, gpuCount+3)
 	for i := range gpuCount {
 		lines = append(lines, fmt.Sprintf("- path: /dev/nvidia%d", i))
 	}

--- a/validators/performance/nccl_test.go
+++ b/validators/performance/nccl_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,6 +261,55 @@ func TestIsCRDEstablished(t *testing.T) {
 			got := isCRDEstablished(tt.obj)
 			if got != tt.want {
 				t.Errorf("isCRDEstablished() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildNRIDeviceAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		gpuCount int
+		wantDevs []string
+	}{
+		{
+			name:     "8 GPUs (a3-megagpu-8g)",
+			gpuCount: 8,
+			wantDevs: []string{
+				"/dev/nvidia0", "/dev/nvidia1", "/dev/nvidia2", "/dev/nvidia3",
+				"/dev/nvidia4", "/dev/nvidia5", "/dev/nvidia6", "/dev/nvidia7",
+				"/dev/nvidiactl", "/dev/nvidia-uvm", "/dev/dmabuf_import_helper",
+			},
+		},
+		{
+			name:     "4 GPUs",
+			gpuCount: 4,
+			wantDevs: []string{
+				"/dev/nvidia0", "/dev/nvidia1", "/dev/nvidia2", "/dev/nvidia3",
+				"/dev/nvidiactl", "/dev/nvidia-uvm", "/dev/dmabuf_import_helper",
+			},
+		},
+		{
+			name:     "1 GPU",
+			gpuCount: 1,
+			wantDevs: []string{
+				"/dev/nvidia0",
+				"/dev/nvidiactl", "/dev/nvidia-uvm", "/dev/dmabuf_import_helper",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildNRIDeviceAnnotation(tt.gpuCount)
+			for _, dev := range tt.wantDevs {
+				if !strings.Contains(got, "- path: "+dev) {
+					t.Errorf("buildNRIDeviceAnnotation(%d) missing device %q\ngot:\n%s", tt.gpuCount, dev, got)
+				}
+			}
+			// Verify no extra nvidia devices beyond the count.
+			notWanted := fmt.Sprintf("/dev/nvidia%d", tt.gpuCount)
+			if strings.Contains(got, notWanted) {
+				t.Errorf("buildNRIDeviceAnnotation(%d) should not contain %q", tt.gpuCount, notWanted)
 			}
 		})
 	}

--- a/validators/performance/testdata/h100/gke/runtime.yaml
+++ b/validators/performance/testdata/h100/gke/runtime.yaml
@@ -17,7 +17,8 @@
 # Full runtime with TCPXO sidecar, FastRak mpirun args, GKE multi-NIC
 # and GPU device annotations, and a3-megagpu-8g node selector.
 #
-# TCPXO sidecar uses native sidecar pattern (initContainer + restartPolicy: Always).
+# TCPXO sidecar uses native sidecar pattern (initContainer + restartPolicy: Always)
+# with NRI device injection (devices.gke.io annotation) instead of privileged mode.
 #
 # Must stay in sync with ncclTrainingRuntimeName in nccl_all_reduce_bw_constraint.go.
 
@@ -82,9 +83,9 @@ spec:
                   - --allow-run-as-root
                   - --mca
                   - plm_rsh_args
-                  - -o StrictHostKeyChecking=no -o ConnectionAttempts=10 -p 2222
-                  # Restrict MPI OOB and UCX to control NIC — UCX discovers GPU
-                  # NIC link-local addresses which aren't routable cross-node.
+                  - -o StrictHostKeyChecking=no -o ConnectionAttempts=10
+                  # Restrict MPI OOB and UCX to control NIC — without hostNetwork,
+                  # eth0 is the default/control NIC, eth1-eth8 are GPU NICs.
                   - --mca
                   - oob_tcp_if_include
                   - eth0
@@ -136,14 +137,17 @@ spec:
             template:
               metadata:
                 annotations:
+                  # NRI device injection: expose GPU and DMA devices to the tcpxo-daemon
+                  # sidecar without requiring privileged mode. Device list is generated
+                  # by buildNRIDeviceAnnotation() based on GPU count per node.
+                  devices.gke.io/container.tcpxo-daemon: |
+                    ${NRI_DEVICE_ANNOTATION}
                   # Multi-NIC for 8 GPU NICs (GPUDirect TCPXO).
                   # Network names are cluster-specific (e.g., "aicr-demo2-gpu-nic-0");
                   # discovered at runtime by discoverGKEGPUNICNetworks().
                   networking.gke.io/default-interface: eth0
                   networking.gke.io/interfaces: '${GKE_NETWORK_INTERFACES}'
               spec:
-                hostNetwork: true
-                dnsPolicy: ClusterFirstWithHostNet
                 nodeSelector:
                   cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
                 tolerations:
@@ -154,8 +158,8 @@ spec:
                   effect: NoSchedule
                 initContainers:
                 # TCPXO FastRak native sidecar — runs fastrak_gpumem_manager
-                # alongside the worker. Requires hostNetwork: true for full
-                # PCI sysfs visibility (GKE upstream issue #580).
+                # alongside the worker. Uses NRI device injection (devices.gke.io
+                # annotation) for GPU device access instead of privileged mode.
                 - name: tcpxo-daemon
                   image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
                   imagePullPolicy: Always
@@ -165,9 +169,10 @@ spec:
                   - |
                     set -ex
                     chmod 755 /fts/entrypoint_rxdm_container.sh
-                    /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics 8
+                    /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=${GPU_COUNT_PER_NODE} --uid= --alsologtostderr
                   securityContext:
-                    privileged: true
+                    capabilities:
+                      add: ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]
                   volumeMounts:
                   - name: nvtcpxo-libraries
                     mountPath: /usr/local/nvidia
@@ -198,14 +203,15 @@ spec:
                     NCCL_LIB_DIR=/usr/local/nvidia/lib64 . /usr/local/nvidia/lib64/nccl-env-profile.sh &&
                     env | grep -E '^NCCL_|^CUDA_' > /root/.ssh/environment &&
                     echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config &&
-                    /usr/sbin/sshd -De -p 2222
+                    /usr/sbin/sshd -De
                   resources:
                     limits:
                       nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
                     requests:
                       nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
                   securityContext:
-                    privileged: true
+                    capabilities:
+                      add: ["IPC_LOCK"]
                   volumeMounts:
                   - name: dshm
                     mountPath: /dev/shm

--- a/validators/performance/testdata/h100/gke/runtime.yaml
+++ b/validators/performance/testdata/h100/gke/runtime.yaml
@@ -20,6 +20,10 @@
 # TCPXO sidecar uses native sidecar pattern (initContainer + restartPolicy: Always)
 # with NRI device injection (devices.gke.io annotation) instead of privileged mode.
 #
+# Prerequisite: GPU node pool must NOT have a gVNIC additional network.
+# A gVNIC network takes a PCI slot, displacing one GPU NIC (7/8 detection).
+# See https://github.com/NVIDIA/aicr/issues/381 for details.
+#
 # Must stay in sync with ncclTrainingRuntimeName in nccl_all_reduce_bw_constraint.go.
 
 apiVersion: trainer.kubeflow.org/v1alpha1
@@ -161,7 +165,7 @@ spec:
                 # alongside the worker. Uses NRI device injection (devices.gke.io
                 # annotation) for GPU device access instead of privileged mode.
                 - name: tcpxo-daemon
-                  image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+                  image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
                   imagePullPolicy: Always
                   restartPolicy: Always
                   command: ["/bin/sh", "-c"]
@@ -169,10 +173,10 @@ spec:
                   - |
                     set -ex
                     chmod 755 /fts/entrypoint_rxdm_container.sh
-                    /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=${GPU_COUNT_PER_NODE} --uid= --alsologtostderr
+                    /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics ${GPU_COUNT_PER_NODE}
                   securityContext:
                     capabilities:
-                      add: ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]
+                      add: ["NET_ADMIN", "NET_BIND_SERVICE"]
                   volumeMounts:
                   - name: nvtcpxo-libraries
                     mountPath: /usr/local/nvidia


### PR DESCRIPTION
## Summary

- Remove `hostNetwork: true` and `privileged: true` from GKE NCCL
  TrainingRuntime, matching Excalibur non-privileged configuration
- Use NRI device injection (`devices.gke.io` annotation) for tcpxo-daemon
  GPU/DMA device access instead of privileged mode
- Replace privileged security contexts with minimal capabilities:
  `CAP_NET_ADMIN`+`CAP_NET_BIND_SERVICE` for tcpxo-daemon, `IPC_LOCK` for worker
- Shift NIC names for pod networking: control NIC `eth0`, GPU NICs `eth1-eth8`
  (previously `eth1`/`eth2-eth9` with hostNetwork)
- Generate NRI device annotation dynamically from GPU count per node
  via `buildNRIDeviceAnnotation()` instead of hardcoding 8 devices
- Remove custom SSH port (`-p 2222`), use default port 22
- Update rxdm entrypoint args: `--num_nics=8 --uid= --alsologtostderr`

## Motivation

The previous runtime used `hostNetwork: true` and `privileged: true` which
caused issues on GKE clusters with extra gVNIC Network CRs. The gVNIC
network interfered with multi-NIC pod injection, causing gpu-nic-7 to be
missing (only 7 of 8 GPU NICs injected). Moving to pod networking with NRI
device injection matches the Excalibur reference configuration and avoids
the gVNIC interference while also improving security posture.

## How it works

1. Worker pods use pod networking (no hostNetwork) with multi-NIC annotation
2. NRI device injector exposes `/dev/nvidia*`, `/dev/nvidiactl`,
   `/dev/nvidia-uvm`, and `/dev/dmabuf_import_helper` to tcpxo-daemon
3. Device list is generated dynamically from `GPU_COUNT_PER_NODE`
4. SSH uses default port 22 (no `-p 2222` remapping needed without hostNetwork)
5. NCCL env vars sourced from host `nccl-env-profile.sh` (unchanged)

## Test plan

- [ ] Run NCCL All-Reduce validation on GKE H100 cluster (a3-megagpu-8g)
- [ ] Verify all 8 GPU NICs are injected into worker pods
- [ ] Verify bandwidth ~335 GB/s at 8 GB message size (2 nodes)
- [ ] Verify tcpxo-daemon runs without privileged mode
- [ ] Verify no guest config checker mismatches in launcher logs
