### PR TITLE
fix(gke): remove CAP_ prefix from capability names in TCPXO manifests

### DIFF
--- a/demos/workloads/training/gke-nccl-test-tcpxo.yaml
+++ b/demos/workloads/training/gke-nccl-test-tcpxo.yaml
@@ -137,7 +137,7 @@ spec:
           /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics 8
       securityContext:
         capabilities:
-          add: ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]
+          add: ["NET_ADMIN", "NET_BIND_SERVICE"]
       volumeMounts:
         - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia
@@ -252,7 +252,7 @@ spec:
           /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics 8
       securityContext:
         capabilities:
-          add: ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE"]
+          add: ["NET_ADMIN", "NET_BIND_SERVICE"]
       volumeMounts:
         - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -60,7 +60,7 @@ spec:
       image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
       securityContext:
         capabilities:
-          add: [CAP_NET_ADMIN, CAP_NET_BIND_SERVICE]
+          add: [NET_ADMIN, NET_BIND_SERVICE]
       volumeMounts:
         - name: nvtcpxo-libraries
           mountPath: /usr/local/nvidia
@@ -94,7 +94,7 @@ spec:
 
 Key properties:
 - `hostNetwork: false` — workloads get proper pod networking
-- `privileged: false` — tcpxo-daemon uses only `CAP_NET_ADMIN` and `CAP_NET_BIND_SERVICE`
+- `privileged: false` — tcpxo-daemon uses only `NET_ADMIN` and `NET_BIND_SERVICE`
 - `/sys` mounted as `/hostsysfs` — provides PCI sysfs visibility for GPU enumeration
 - `/proc/sys` mounted as `/hostprocsysfs` — allows kernel network tuning
 - NRI annotations inject GPU devices and multi-NIC interfaces


### PR DESCRIPTION
## Summary
Remove `CAP_` prefix from Kubernetes capability names in TCPXO demo manifest and documentation. The Kubernetes API spec expects capability names without the prefix (e.g., `NET_ADMIN` not `CAP_NET_ADMIN`).

Files changed:
- `demos/workloads/training/gke-nccl-test-tcpxo.yaml`
- `docs/integrator/gke-tcpxo-networking.md`

Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container

## Test plan
- [ ] Verify TCPXO test works with corrected capability names