### PR TITLE
docs(validator): remove stale Helm values reference from phase table

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -8,7 +8,7 @@ AICR uses a container-per-validator model. Each validation check runs as an isol
 
 | Phase | Purpose | Example |
 |-------|---------|---------|
-| `deployment` | Verify components are installed and healthy | GPU operator pods running, Helm values match recipe |
+| `deployment` | Verify components are installed and healthy | GPU operator pods running, expected resources present |
 | `performance` | Verify system meets performance thresholds | NCCL bandwidth, GPU utilization |
 | `conformance` | Verify workload-specific requirements | DRA support, gang scheduling, autoscaling |
 


### PR DESCRIPTION
## Summary

- Remove stale "Helm values match recipe" reference from validator phase table in `docs/contributor/validator.md`

## Motivation

The helm-values check was removed in PR #388, but the deployment phase example in the contributor docs still referenced it. Fixes #391.

## Test plan

- [x] Verify no remaining "Helm values match recipe" references in docs
