### PR TITLE
fix(api): add b200 accelerator to OpenAPI spec enum

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -120,7 +120,7 @@ paths:
           description: GPU/accelerator type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [h100, gb200, a100, l40, any]
+            enum: [h100, gb200, b200, a100, l40, any]
             default: any
         - name: gpu
           in: query
@@ -128,7 +128,7 @@ paths:
           description: Alias for accelerator parameter (backwards compatibility).
           schema:
             type: string
-            enum: [h100, gb200, a100, l40, any]
+            enum: [h100, gb200, b200, a100, l40, any]
             default: any
         - name: intent
           in: query
@@ -478,7 +478,7 @@ paths:
           description: GPU/accelerator type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [h100, gb200, a100, l40, any]
+            enum: [h100, gb200, b200, a100, l40, any]
             default: any
         - name: gpu
           in: query
@@ -486,7 +486,7 @@ paths:
           description: Alias for accelerator parameter (backwards compatibility).
           schema:
             type: string
-            enum: [h100, gb200, a100, l40, any]
+            enum: [h100, gb200, b200, a100, l40, any]
             default: any
         - name: intent
           in: query
@@ -1188,7 +1188,7 @@ components:
         accelerator:
           type: string
           description: GPU/accelerator type
-          enum: [h100, gb200, a100, l40, any]
+          enum: [h100, gb200, b200, a100, l40, any]
           example: h100
         intent:
           type: string


### PR DESCRIPTION
## Summary

- Add `b200` to the accelerator enum in all 6 occurrences in `api/aicr/v1/server.yaml`
- The B200 accelerator is fully supported in the CLI (`pkg/recipe/criteria.go` defines `CriteriaAcceleratorB200`) but was missing from the OpenAPI spec, meaning the API server would reject `?accelerator=b200` requests

## Test plan

- [x] `make lint` — passes
- [x] `go test -race ./pkg/api/...` — passes
- [x] Verified all 6 enum instances updated (GET /v1/recipe accelerator + gpu, GET /v1/query accelerator + gpu, RecipeCriteria schema)