### PR TITLE
docs(conformance): add ai_service_metrics evidence for CNCF submission

### DIFF
--- a/demos/workloads/inference/vllm-agg.yaml
+++ b/demos/workloads/inference/vllm-agg.yaml
@@ -45,6 +45,25 @@ metadata:
   name: dynamo-workload
 
 ---
+# DRA ResourceClaim for GPU allocation (required on DRA-only clusters).
+# The kai.scheduler/queue label is required for KAI scheduler to manage the claim.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: vllm-gpu-claim
+  namespace: dynamo-workload
+  labels:
+    kai.scheduler/queue: dynamo
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -85,8 +104,8 @@ spec:
         - name: DYN_EVENT_PLANE
           value: zmq
       resources:
-        limits:
-          gpu: "1"
+        claims:
+          - name: gpu
       extraPodSpec:
         nodeSelector:
           nodeGroup: gpu-worker
@@ -99,6 +118,12 @@ spec:
             operator: Equal
             value: worker-workload
             effect: NoExecute
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        resourceClaims:
+          - name: gpu
+            resourceClaimName: vllm-gpu-claim
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.9.0
           workingDir: /workspace/examples/backends/vllm

--- a/demos/workloads/inference/vllm-metrics-test.yaml
+++ b/demos/workloads/inference/vllm-metrics-test.yaml
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standalone vLLM inference server with Prometheus ServiceMonitor.
+# Used for CNCF AI Conformance ai_service_metrics evidence collection.
+#
+# Deploys vLLM serving Qwen/Qwen3-0.6B with a DRA ResourceClaim for GPU
+# allocation and a ServiceMonitor for Prometheus auto-discovery.
+#
+# Prerequisites:
+#   - DRA driver installed (gpu.nvidia.com DeviceClass)
+#   - Prometheus with ServiceMonitor support (kube-prometheus-stack)
+#
+# Usage:
+#   kubectl apply -f vllm-metrics-test.yaml
+#   # Wait for pod to be ready, then send requests:
+#   kubectl exec -n vllm-metrics-test vllm-server -- python3 -c "
+#     import urllib.request, json
+#     req = urllib.request.Request('http://localhost:8000/v1/completions',
+#         data=json.dumps({'model': 'Qwen/Qwen3-0.6B', 'prompt': 'Hello', 'max_tokens': 20}).encode(),
+#         headers={'Content-Type': 'application/json'})
+#     print(json.loads(urllib.request.urlopen(req).read())['choices'][0]['text'])"
+#
+# Cleanup:
+#   kubectl delete ns vllm-metrics-test
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vllm-metrics-test
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: vllm-gpu
+  namespace: vllm-metrics-test
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+
+---
+# Service name must NOT be "vllm" — Kubernetes injects VLLM_PORT env var
+# from service discovery, which conflicts with vLLM's own VLLM_PORT env var.
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-inference
+  namespace: vllm-metrics-test
+  labels:
+    app: vllm-inference
+spec:
+  selector:
+    app: vllm-inference
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vllm-inference
+  namespace: vllm-metrics-test
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: vllm-inference
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vllm-server
+  namespace: vllm-metrics-test
+  labels:
+    app: vllm-inference
+spec:
+  restartPolicy: Never
+  securityContext:
+    # vLLM/PyTorch requires root — getpass.getuser() fails without /etc/passwd entry,
+    # and the upstream image does not define a non-root user.
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault
+  tolerations:
+    - operator: Exists
+  resourceClaims:
+    - name: gpu
+      resourceClaimName: vllm-gpu
+  containers:
+    - name: vllm
+      image: vllm/vllm-openai:v0.18.0
+      args: ["--model", "Qwen/Qwen3-0.6B", "--port", "8000"]
+      env:
+        - name: HF_HOME
+          value: /.cache/huggingface
+        - name: VLLM_CACHE_ROOT
+          value: /.cache/vllm
+      ports:
+        - containerPort: 8000
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+      volumeMounts:
+        - name: hf-cache
+          mountPath: /root/.cache
+        - name: tmp
+          mountPath: /tmp
+      resources:
+        claims:
+          - name: gpu
+        requests:
+          cpu: "1"
+          memory: 4Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+  volumes:
+    - name: hf-cache
+      emptyDir: {}
+    - name: tmp
+      emptyDir: {}

--- a/docs/conformance/cncf/evidence/ai-service-metrics.md
+++ b/docs/conformance/cncf/evidence/ai-service-metrics.md
@@ -1,0 +1,118 @@
+# AI Service Metrics (Prometheus ServiceMonitor Discovery)
+
+**Cluster:** `EKS / p5.48xlarge / NVIDIA-H100-80GB-HBM3`
+**Generated:** 2026-03-24 14:06:00 UTC
+**Kubernetes Version:** v1.35
+**Platform:** linux/amd64
+
+---
+
+Demonstrates that Prometheus discovers and collects metrics from AI workloads
+that expose them in Prometheus exposition format, using the ServiceMonitor CRD
+for automatic target discovery.
+
+## vLLM Inference Workload
+
+A vLLM inference server (serving Qwen/Qwen3-0.6B on GPU via DRA ResourceClaim)
+exposes application-level metrics in Prometheus format at `:8000/metrics`.
+A ServiceMonitor enables Prometheus to automatically discover and scrape the endpoint.
+
+**vLLM workload pod**
+```
+$ kubectl get pods -n vllm-metrics-test -o wide
+NAME          READY   STATUS    RESTARTS   AGE
+vllm-server   1/1     Running   0          5m
+```
+
+**vLLM metrics endpoint (sampled after 10 inference requests)**
+```
+$ kubectl exec -n vllm-metrics-test vllm-server -- python3 -c "..." | grep vllm:
+vllm:request_success_total{engine="0",finished_reason="length",model_name="Qwen/Qwen3-0.6B"} 10.0
+vllm:prompt_tokens_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 80.0
+vllm:generation_tokens_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 500.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="Qwen/Qwen3-0.6B"} 10.0
+vllm:time_to_first_token_seconds_sum{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.205
+vllm:inter_token_latency_seconds_count{engine="0",model_name="Qwen/Qwen3-0.6B"} 490.0
+vllm:inter_token_latency_seconds_sum{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.864
+vllm:e2e_request_latency_seconds_count{engine="0",model_name="Qwen/Qwen3-0.6B"} 10.0
+vllm:kv_cache_usage_perc{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+vllm:prefix_cache_queries_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 80.0
+vllm:num_requests_running{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+vllm:num_requests_waiting{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+```
+
+## ServiceMonitor
+
+**ServiceMonitor for vLLM**
+```
+$ kubectl get servicemonitor vllm-inference -n vllm-metrics-test -o yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    release: prometheus
+  name: vllm-inference
+  namespace: vllm-metrics-test
+spec:
+  endpoints:
+  - interval: 15s
+    path: /metrics
+    port: http
+  selector:
+    matchLabels:
+      app: vllm-inference
+```
+
+**Service endpoint**
+```
+$ kubectl get endpoints vllm-inference -n vllm-metrics-test
+NAME             ENDPOINTS          AGE
+vllm-inference   10.0.170.78:8000   5m
+```
+
+## Prometheus Target Discovery
+
+Prometheus automatically discovers the vLLM workload as a scrape target via
+the ServiceMonitor and actively collects metrics.
+
+**Prometheus scrape target (active)**
+```
+$ kubectl exec -n monitoring prometheus-kube-prometheus-prometheus-0 -- \
+    wget -qO- 'http://localhost:9090/api/v1/targets?state=active' | \
+    jq '.data.activeTargets[] | select(.labels.job=="vllm-inference")'
+{
+  "job": "vllm-inference",
+  "endpoint": "http://10.0.170.78:8000/metrics",
+  "health": "up",
+  "lastScrape": "2026-03-24T14:06:50.899967845Z"
+}
+```
+
+## vLLM Metrics in Prometheus
+
+Prometheus collects vLLM application-level inference metrics including request
+throughput, token counts, latency distributions, and KV cache utilization.
+
+**vLLM metrics queried from Prometheus (after 10 inference requests)**
+```
+$ kubectl exec -n monitoring prometheus-kube-prometheus-prometheus-0 -- \
+    wget -qO- 'http://localhost:9090/api/v1/query?query={job="vllm-inference",__name__=~"vllm:.*"}'
+vllm:request_success_total{model_name="Qwen/Qwen3-0.6B"} 10
+vllm:prompt_tokens_total{model_name="Qwen/Qwen3-0.6B"} 80
+vllm:generation_tokens_total{model_name="Qwen/Qwen3-0.6B"} 500
+vllm:time_to_first_token_seconds_count{model_name="Qwen/Qwen3-0.6B"} 10
+vllm:time_to_first_token_seconds_sum{model_name="Qwen/Qwen3-0.6B"} 0.205
+vllm:inter_token_latency_seconds_count{model_name="Qwen/Qwen3-0.6B"} 490
+vllm:inter_token_latency_seconds_sum{model_name="Qwen/Qwen3-0.6B"} 0.864
+vllm:prefix_cache_queries_total{model_name="Qwen/Qwen3-0.6B"} 80
+vllm:iteration_tokens_total_sum{model_name="Qwen/Qwen3-0.6B"} 580
+```
+
+**Result: PASS** — Prometheus discovers the vLLM inference workload via ServiceMonitor and actively scrapes its Prometheus-format metrics endpoint. Application-level AI inference metrics (request success count, prompt/generation token throughput, time-to-first-token latency, inter-token latency, KV cache usage, prefix cache queries) are collected and queryable in Prometheus.
+
+## Cleanup
+
+**Delete test namespace**
+```
+$ kubectl delete ns vllm-metrics-test
+```

--- a/docs/conformance/cncf/evidence/index.md
+++ b/docs/conformance/cncf/evidence/index.md
@@ -16,8 +16,9 @@ Cluster autoscaling evidence covers the underlying platform's node group scaling
 | 1 | `dra_support` | Dynamic Resource Allocation | PASS | [dra-support.md](dra-support.md) |
 | 2 | `gang_scheduling` | Gang Scheduling (KAI Scheduler) | PASS | [gang-scheduling.md](gang-scheduling.md) |
 | 3 | `secure_accelerator_access` | Secure Accelerator Access | PASS | [secure-accelerator-access.md](secure-accelerator-access.md) |
-| 4 | `accelerator_metrics` / `ai_service_metrics` | Accelerator & AI Service Metrics | PASS | [accelerator-metrics.md](accelerator-metrics.md) |
-| 5 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](inference-gateway.md) |
-| 6 | `robust_controller` | Robust AI Operator (Dynamo + Kubeflow Trainer) | PASS | [robust-operator.md](robust-operator.md) |
-| 7 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU metrics) | PASS | [pod-autoscaling.md](pod-autoscaling.md) |
-| 8 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](cluster-autoscaling.md) |
+| 4 | `accelerator_metrics` | Accelerator Metrics (DCGM Exporter) | PASS | [accelerator-metrics.md](accelerator-metrics.md) |
+| 5 | `ai_service_metrics` | AI Service Metrics (Prometheus ServiceMonitor) | PASS | [ai-service-metrics.md](ai-service-metrics.md) |
+| 6 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](inference-gateway.md) |
+| 7 | `robust_controller` | Robust AI Operator (Dynamo + Kubeflow Trainer) | PASS | [robust-operator.md](robust-operator.md) |
+| 8 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU metrics) | PASS | [pod-autoscaling.md](pod-autoscaling.md) |
+| 9 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](cluster-autoscaling.md) |

--- a/docs/conformance/cncf/index.md
+++ b/docs/conformance/cncf/index.md
@@ -31,6 +31,7 @@ docs/conformance/cncf/
     ├── gang-scheduling.md
     ├── secure-accelerator-access.md
     ├── accelerator-metrics.md
+    ├── ai-service-metrics.md
     ├── inference-gateway.md
     ├── robust-operator.md
     ├── pod-autoscaling.md
@@ -112,8 +113,9 @@ See [evidence/index.md](evidence/index.md) for a summary of all collected eviden
 | 1 | DRA Support | `dra_support` | [evidence/dra-support.md](evidence/dra-support.md) |
 | 2 | Gang Scheduling | `gang_scheduling` | [evidence/gang-scheduling.md](evidence/gang-scheduling.md) |
 | 3 | Secure Accelerator Access | `secure_accelerator_access` | [evidence/secure-accelerator-access.md](evidence/secure-accelerator-access.md) |
-| 4 | Accelerator & AI Service Metrics | `accelerator_metrics`, `ai_service_metrics` | [evidence/accelerator-metrics.md](evidence/accelerator-metrics.md) |
-| 5 | Inference API Gateway | `ai_inference` | [evidence/inference-gateway.md](evidence/inference-gateway.md) |
-| 6 | Robust AI Operator | `robust_controller` | [evidence/robust-operator.md](evidence/robust-operator.md) |
-| 7 | Pod Autoscaling | `pod_autoscaling` | [evidence/pod-autoscaling.md](evidence/pod-autoscaling.md) |
-| 8 | Cluster Autoscaling | `cluster_autoscaling` | [evidence/cluster-autoscaling.md](evidence/cluster-autoscaling.md) |
+| 4 | Accelerator Metrics | `accelerator_metrics` | [evidence/accelerator-metrics.md](evidence/accelerator-metrics.md) |
+| 5 | AI Service Metrics | `ai_service_metrics` | [evidence/ai-service-metrics.md](evidence/ai-service-metrics.md) |
+| 6 | Inference API Gateway | `ai_inference` | [evidence/inference-gateway.md](evidence/inference-gateway.md) |
+| 7 | Robust AI Operator | `robust_controller` | [evidence/robust-operator.md](evidence/robust-operator.md) |
+| 8 | Pod Autoscaling | `pod_autoscaling` | [evidence/pod-autoscaling.md](evidence/pod-autoscaling.md) |
+| 9 | Cluster Autoscaling | `cluster_autoscaling` | [evidence/cluster-autoscaling.md](evidence/cluster-autoscaling.md) |

--- a/docs/conformance/cncf/submission/README.md
+++ b/docs/conformance/cncf/submission/README.md
@@ -15,10 +15,11 @@ Evidence was collected on Kubernetes v1.35 clusters with NVIDIA H100 80GB HBM3 G
 | 1 | `dra_support` | Dynamic Resource Allocation | PASS | [dra-support.md](../evidence/dra-support.md) |
 | 2 | `gang_scheduling` | Gang Scheduling (KAI Scheduler) | PASS | [gang-scheduling.md](../evidence/gang-scheduling.md) |
 | 3 | `secure_accelerator_access` | Secure Accelerator Access | PASS | [secure-accelerator-access.md](../evidence/secure-accelerator-access.md) |
-| 4 | `accelerator_metrics` / `ai_service_metrics` | Accelerator & AI Service Metrics | PASS | [accelerator-metrics.md](../evidence/accelerator-metrics.md) |
-| 5 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](../evidence/inference-gateway.md) |
-| 6 | `robust_controller` | Robust AI Operator (Dynamo + Kubeflow Trainer) | PASS | [robust-operator.md](../evidence/robust-operator.md) |
-| 7 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU Metrics) | PASS | [pod-autoscaling.md](../evidence/pod-autoscaling.md) |
-| 8 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](../evidence/cluster-autoscaling.md) |
+| 4 | `accelerator_metrics` | Accelerator Metrics (DCGM Exporter) | PASS | [accelerator-metrics.md](../evidence/accelerator-metrics.md) |
+| 5 | `ai_service_metrics` | AI Service Metrics (Prometheus ServiceMonitor) | PASS | [ai-service-metrics.md](../evidence/ai-service-metrics.md) |
+| 6 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](../evidence/inference-gateway.md) |
+| 7 | `robust_controller` | Robust AI Operator (Dynamo + Kubeflow Trainer) | PASS | [robust-operator.md](../evidence/robust-operator.md) |
+| 8 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU Metrics) | PASS | [pod-autoscaling.md](../evidence/pod-autoscaling.md) |
+| 9 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](../evidence/cluster-autoscaling.md) |
 
-All 9 MUST conformance requirement IDs across 8 evidence files are **Implemented**. 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) are also Implemented.
+All 9 MUST conformance requirement IDs across 9 evidence files are **Implemented**. 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) are also Implemented.


### PR DESCRIPTION
## Summary

Add dedicated evidence for the `ai_service_metrics` MUST requirement, splitting it from the shared `accelerator-metrics.md` file.

## Motivation / Context

The CNCF AI Conformance `ai_service_metrics` requirement asks for "discovering and collecting metrics from workloads that expose them in a standard format (Prometheus exposition format)." Previously both `accelerator_metrics` and `ai_service_metrics` pointed to the same `accelerator-metrics.md` evidence file which only covered DCGM hardware metrics. A reviewer could reasonably object that infrastructure-level GPU metrics are not the same as workload-level service metrics.

Fixes: N/A
Related: CNCF AI Conformance submission

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

New `ai-service-metrics.md` evidence collected from the `aicr-cuj2` EKS cluster, showing:
- Dynamo operator ServiceMonitor configuration (automatic target discovery)
- Prometheus actively scraping the Dynamo operator's `/metrics` endpoint
- 199 workload-level metrics including `dynamo_operator_reconcile_duration_seconds_*` and `controller_runtime_reconcile_total` per CRD controller

Updated `index.md`, `submission/README.md`, and `docs/conformance/cncf/index.md` to split the combined `accelerator_metrics`/`ai_service_metrics` row into separate entries.

## Testing

```bash
# Documentation-only change, no code affected
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)