### PR TITLE
docs: add Slack channel link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,7 @@ Choose the path that matches how you'll use the project.
 ## Contributing
 
 AI Cluster Runtime is Apache 2.0. Contributions are welcome: new recipes for environments we haven't covered (OpenShift, AKS, bare metal), additional bundler formats, validation checks, or bug reports. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the PR process.
+
+## Slack
+
+Join [Kubernetes](https://kubernetes.slack.com) and visit the [#aicr](https://kubernetes.slack.com/archives/C0AQMPP1BK7) channel on Slack.


### PR DESCRIPTION
## Summary

Add Kubernetes Slack workspace and #aicr channel link to README.

## Motivation / Context

Make it easy for users and contributors to find the project's Slack channel for community discussion.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Testing

```bash
# Documentation-only change, no code affected
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)