### PR TITLE
fix(recipe bug): treat empty string as "any" in Criteria.Specificity()

### DIFF
--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -377,19 +377,22 @@ func (c *Criteria) Validate() error {
 // Used for ordering overlay application - more specific overlays are applied later.
 func (c *Criteria) Specificity() int {
 	score := 0
-	if c.Service != CriteriaServiceAny {
+	// Empty string is treated as equivalent to "any" because when YAML is parsed,
+	// omitted fields get the zero value ("") rather than the "any" constant.
+	// This is consistent with Matches() and MatchesCriteriaField().
+	if c.Service != CriteriaServiceAny && c.Service != "" {
 		score++
 	}
-	if c.Accelerator != CriteriaAcceleratorAny {
+	if c.Accelerator != CriteriaAcceleratorAny && c.Accelerator != "" {
 		score++
 	}
-	if c.Intent != CriteriaIntentAny {
+	if c.Intent != CriteriaIntentAny && c.Intent != "" {
 		score++
 	}
-	if c.OS != CriteriaOSAny {
+	if c.OS != CriteriaOSAny && c.OS != "" {
 		score++
 	}
-	if c.Platform != CriteriaPlatformAny {
+	if c.Platform != CriteriaPlatformAny && c.Platform != "" {
 		score++
 	}
 	if c.Nodes != 0 {

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -336,6 +336,38 @@ func TestCriteriaSpecificity(t *testing.T) {
 			},
 			want: 6,
 		},
+		// Regression tests: YAML-parsed criteria have empty strings for omitted
+		// fields, not "any". Specificity must treat "" as equivalent to "any".
+		{
+			name: "yaml-parsed one field - empty strings are zero specificity",
+			criteria: &Criteria{
+				Service: CriteriaServiceEKS,
+				// Remaining fields omitted — Go zero value is ""
+			},
+			want: 1,
+		},
+		{
+			name: "yaml-parsed two fields - empty strings are zero specificity",
+			criteria: &Criteria{
+				Service: CriteriaServiceEKS,
+				Intent:  CriteriaIntentTraining,
+			},
+			want: 2,
+		},
+		{
+			name: "yaml-parsed three fields - empty strings are zero specificity",
+			criteria: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorH100,
+				Intent:      CriteriaIntentTraining,
+			},
+			want: 3,
+		},
+		{
+			name:     "all empty strings - zero specificity",
+			criteria: &Criteria{},
+			want:     0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fix `Specificity()` to treat empty string `""` as equivalent to `"any"` for YAML-parsed criteria fields, consistent with `Matches()` and `MatchesCriteriaField()`.

## Motivation / Context

When overlay YAML is parsed, omitted criteria fields get the Go zero value `""`, not the `"any"` constant. `Specificity()` checked only `field \!= "any"`, so empty fields contributed to the score — all overlays reported specificity 4-5 regardless of how many criteria fields they actually specify. This made the sort in `FindMatchingOverlays` non-deterministic for overlays at different specificity levels.

The bug was masked by the current linear overlay tree structure (every matching overlay is an ancestor of the most-specific leaf). It becomes observable with any overlay structure that has competing matches at different specificity levels.

Discovered during prototype implementation of ADR-005 (PR #439).

Fixes: N/A
Related: #439, #305

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

The fix adds `&& field \!= ""` to each specificity check, aligning with the existing logic in `MatchesCriteriaField()` which already treats both `""` and `"any"` as wildcards.

Regression tests cover YAML-parsed zero-value criteria (struct literals with omitted fields) alongside the existing tests that use explicit `Criteria*Any` values.

**Observable behavior change:** `appliedOverlays` metadata may list overlays in a different order for queries that match `b200-any-training` or `gb200-any-training` (these overlays now sort at their correct specificity). Hydrated recipe content (constraints, components, validation, deployment order) is unchanged for all current leaf overlays.

## Testing

```bash
go test -race -v ./pkg/recipe/... -run TestCriteriaSpecificity
```

Golden-file comparison of all current leaf overlays confirms zero semantic change to hydrated recipe output.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No migration needed. The fix only affects sort ordering of overlays with different specificity levels. Current overlay tree is linear, so recipe output is unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)