### PR TITLE
refactor(recipes): lift validation blocks from ubuntu leaves to intent overlays

### DIFF
--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -60,3 +60,17 @@ spec:
         intent: multiNodeTraining
       dependencyRefs:
         - skyhook-operator
+
+  # Validation checks for GB200 on EKS training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/recipes/overlays/gb200-eks-ubuntu-training.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-training.yaml
@@ -42,14 +42,4 @@ spec:
 
   componentRefs: []
 
-  validation:
-    conformance:
-      checks:
-        - platform-health
-        - gpu-operator-health
-        - dra-support
-        - accelerator-metrics
-        - ai-service-metrics
-        - gang-scheduling
-        - pod-autoscaling
-        - cluster-autoscaling
+  # Validation is inherited from gb200-eks-training (not OS-specific)

--- a/recipes/overlays/h100-aks-training.yaml
+++ b/recipes/overlays/h100-aks-training.yaml
@@ -46,3 +46,34 @@ spec:
       overrides:
         gdrcopy:
           enabled: true
+
+  # Validation checks for H100 on AKS training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"
+    performance:
+      checks:
+        - nccl-all-reduce-bw
+      constraints:
+        - name: nccl-all-reduce-bw
+          value: ">= 100"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access

--- a/recipes/overlays/h100-aks-ubuntu-training.yaml
+++ b/recipes/overlays/h100-aks-ubuntu-training.yaml
@@ -42,31 +42,4 @@ spec:
 
   componentRefs: []
 
-  validation:
-    deployment:
-      checks:
-        - operator-health
-        - expected-resources
-        - gpu-operator-version
-        - check-nvidia-smi
-      constraints:
-        - name: Deployment.gpu-operator.version
-          value: ">= v24.6.0"
-    performance:
-      checks:
-        - nccl-all-reduce-bw
-      constraints:
-        - name: nccl-all-reduce-bw
-          value: ">= 100"
-    conformance:
-      checks:
-        - platform-health
-        - gpu-operator-health
-        - dra-support
-        - accelerator-metrics
-        - ai-service-metrics
-        - gang-scheduling
-        - pod-autoscaling
-        - cluster-autoscaling
-        - robust-controller
-        - secure-accelerator-access
+  # Validation is inherited from h100-aks-training (not OS-specific)

--- a/recipes/overlays/h100-eks-training.yaml
+++ b/recipes/overlays/h100-eks-training.yaml
@@ -56,3 +56,34 @@ spec:
         intent: multiNodeTraining
       dependencyRefs:
         - skyhook-operator
+
+  # Validation checks for H100 on EKS training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"
+    performance:
+      checks:
+        - nccl-all-reduce-bw
+      constraints:
+        - name: nccl-all-reduce-bw
+          value: ">= 300"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access

--- a/recipes/overlays/h100-eks-ubuntu-training.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-training.yaml
@@ -42,31 +42,4 @@ spec:
 
   componentRefs: []
 
-  validation:
-    deployment:
-      checks:
-        - operator-health
-        - expected-resources
-        - gpu-operator-version
-        - check-nvidia-smi
-      constraints:
-        - name: Deployment.gpu-operator.version
-          value: ">= v24.6.0"
-    performance:
-      checks:
-        - nccl-all-reduce-bw
-      constraints:
-        - name: nccl-all-reduce-bw
-          value: ">= 300"
-    conformance:
-      checks:
-        - platform-health
-        - gpu-operator-health
-        - dra-support
-        - accelerator-metrics
-        - ai-service-metrics
-        - gang-scheduling
-        - pod-autoscaling
-        - cluster-autoscaling
-        - robust-controller
-        - secure-accelerator-access
+  # Validation is inherited from h100-eks-training (not OS-specific)


### PR DESCRIPTION
## Summary

Move validation blocks from three `-ubuntu-training` leaf overlays to their `{accel}-{service}-training` intent-level parents. Validation checks are not OS-specific — this places them at the correct architectural level and eliminates ~67 redundant lines.

## Motivation / Context

Validation blocks (deployment checks, performance checks, conformance checks) were defined in the ubuntu training leaves because that's where the inheritance tree bottoms out before platform-specific overlays. But these checks apply regardless of OS — they should be inherited by all OS variants and platform children from the intent layer.

This is Phase 1 (structure cleanup) of the revised ADR-005 (#439).

Fixes: N/A
Related: #439, #305

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Validation moved from → to:

| From (ubuntu leaf) | To (intent parent) |
|---|---|
| `h100-eks-ubuntu-training` | `h100-eks-training` |
| `gb200-eks-ubuntu-training` | `gb200-eks-training` |
| `h100-aks-ubuntu-training` | `h100-aks-training` |

`h100-gke-cos-training` already defines validation at the intent level (no ubuntu intermediate), so no change needed.

No code changes — YAML-only restructuring. The validation merge uses phase-replacement semantics, so children that don't define their own validation inherit from the parent unchanged.

## Testing

Golden-file comparison of all 9 affected overlay combinations (3 intent + 3 ubuntu + 3 kubeflow) confirms zero semantic change to hydrated recipe output (constraints, components, validation, deployment order).

```bash
# For each affected combo:
aicr query --service eks --accelerator h100 --intent training --selector . --format yaml
# ... compared before and after
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No migration needed. Validation content moves up the inheritance chain; all children produce identical hydrated output.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)