### PR TITLE
fix(ci): query GPU snapshot by subtype name instead of index

### DIFF
--- a/.github/actions/gpu-snapshot-validate/action.yml
+++ b/.github/actions/gpu-snapshot-validate/action.yml
@@ -45,8 +45,9 @@ runs:
     - name: Validate snapshot detected GPU
       shell: bash
       run: |
-        GPU_MODEL=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[0].data["gpu.model"]' snapshot.yaml)
-        GPU_COUNT=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[0].data["gpu-count"]' snapshot.yaml)
+        # Query by subtype name (not index) — #502 added a "hardware" subtype before "smi".
+        GPU_MODEL=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[] | select(.name == "smi") | .data["gpu.model"]' snapshot.yaml)
+        GPU_COUNT=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[] | select(.name == "smi") | .data["gpu-count"]' snapshot.yaml)
         echo "GPU model: ${GPU_MODEL}"
         echo "GPU count: ${GPU_COUNT}"
         if [[ "${GPU_MODEL}" != *"${{ inputs.gpu_model }}"* ]]; then


### PR DESCRIPTION
## Summary

Fix GPU CI validation failure caused by #502 adding a `hardware` subtype before `smi` in GPU measurements.

## Root Cause

PR #502 (`feat: wire NFDHardwareDetector into production snapshot pipeline`) added a Phase 1 `hardware` subtype that appears before the existing `smi` subtype in the GPU measurement array:

```yaml
measurements:
  - type: GPU
    subtypes:
      - name: hardware   # NEW — Phase 1 NFD detection (no gpu.model field)
      - name: smi        # Existing — has gpu.model, gpu-count, etc.
```

The snapshot validation action (`.github/actions/gpu-snapshot-validate/action.yml`) used `subtypes[0]` to read `gpu.model`, which now hits `hardware` instead of `smi` → `GPU model: null` → all H100 GPU tests fail.

Confirmed on main: https://github.com/NVIDIA/aicr/actions/runs/24151637858

## Fix

Query by subtype name instead of index:

```diff
- GPU_MODEL=$(yq eval '... | .subtypes[0].data["gpu.model"]' snapshot.yaml)
+ GPU_MODEL=$(yq eval '... | .subtypes[] | select(.name == "smi") | .data["gpu.model"]' snapshot.yaml)
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: CI action (`.github/actions/gpu-snapshot-validate`)

## Checklist

- [x] Commits are cryptographically signed (`git commit -S`)