### PR TITLE
fix(ci): use correct field name 'subtype' in GPU snapshot validation

### DIFF
--- a/.github/actions/gpu-snapshot-validate/action.yml
+++ b/.github/actions/gpu-snapshot-validate/action.yml
@@ -45,9 +45,9 @@ runs:
     - name: Validate snapshot detected GPU
       shell: bash
       run: |
-        # Query by subtype name (not index) — #502 added a "hardware" subtype before "smi".
-        GPU_MODEL=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[] | select(.name == "smi") | .data["gpu.model"]' snapshot.yaml)
-        GPU_COUNT=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[] | select(.name == "smi") | .data["gpu-count"]' snapshot.yaml)
+        # Query by subtype field (not index) — #502 added a "hardware" subtype before "smi".
+        GPU_MODEL=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[] | select(.subtype == "smi") | .data["gpu.model"]' snapshot.yaml)
+        GPU_COUNT=$(yq eval '.measurements[] | select(.type == "GPU") | .subtypes[] | select(.subtype == "smi") | .data["gpu-count"]' snapshot.yaml)
         echo "GPU model: ${GPU_MODEL}"
         echo "GPU count: ${GPU_COUNT}"
         if [[ "${GPU_MODEL}" != *"${{ inputs.gpu_model }}"* ]]; then


### PR DESCRIPTION
## Summary

Follow-up fix to #509 — the yq query used `select(.name == "smi")` but the YAML field is `subtype`, not `name`.

```yaml
# Actual snapshot structure:
subtypes:
  - subtype: smi      # field is "subtype", not "name"
    data:
      gpu.model: NVIDIA H100 NVL
```

#509 fixed the index-based query (`subtypes[0]`) but used the wrong field name, so the query still returns empty.

## Fix

```diff
- select(.name == "smi")
+ select(.subtype == "smi")
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Commits are cryptographically signed (`git commit -S`)