### PR TITLE
feat(cli): add dynamic shell completion for flag values (#339)

### DIFF
--- a/pkg/bundler/verifier/trust.go
+++ b/pkg/bundler/verifier/trust.go
@@ -16,6 +16,7 @@ package verifier
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/constraints"
@@ -70,6 +71,17 @@ func ParseTrustLevel(s string) (TrustLevel, error) {
 			fmt.Sprintf("invalid trust level %q: must be one of unknown, unverified, attested, verified", s))
 	}
 	return level, nil
+}
+
+// GetTrustLevels returns all valid trust level names sorted alphabetically.
+// This excludes "max" which is a meta-value for auto-detection, not a real level.
+func GetTrustLevels() []string {
+	levels := make([]string, 0, len(trustOrder))
+	for level := range trustOrder {
+		levels = append(levels, string(level))
+	}
+	sort.Strings(levels)
+	return levels
 }
 
 // VerifyResult contains the outcome of bundle verification.

--- a/pkg/bundler/verifier/trust_test.go
+++ b/pkg/bundler/verifier/trust_test.go
@@ -229,3 +229,17 @@ func TestMaxAchievableTrustLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTrustLevels(t *testing.T) {
+	levels := GetTrustLevels()
+
+	expected := []string{"attested", "unknown", "unverified", "verified"}
+	if len(levels) != len(expected) {
+		t.Fatalf("got %d levels, want %d", len(levels), len(expected))
+	}
+	for i, v := range levels {
+		if v != expected[i] {
+			t.Errorf("levels[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -298,13 +298,13 @@ Package with explicit tag (overrides CLI version):
 				Usage:    "Estimated number of GPU nodes (written to nodeScheduling.nodeCountPaths in registry). 0 = unset.",
 				Category: "Scheduling",
 			},
-			&cli.StringFlag{
+			withCompletions(&cli.StringFlag{
 				Name:     "deployer",
 				Aliases:  []string{"d"},
 				Value:    string(config.DeployerHelm),
 				Usage:    fmt.Sprintf("Deployment method (e.g. %s)", strings.Join(config.GetDeployerTypes(), ", ")),
 				Category: "Deployment",
-			},
+			}, config.GetDeployerTypes),
 			&cli.StringFlag{
 				Name:     "repo",
 				Value:    "",

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -61,13 +61,13 @@ Output as JSON:
   aicr verify ./my-bundle --format json
 `,
 		Flags: []cli.Flag{
-			&cli.StringFlag{
+			withCompletions(&cli.StringFlag{
 				Name:  "min-trust-level",
 				Value: "max",
 				Usage: `Minimum required trust level. "max" (default) auto-detects the highest
 	achievable level for this bundle and verifies against it.
 	Explicit levels: verified, attested, unverified, unknown`,
-			},
+			}, verifier.GetTrustLevels),
 			&cli.StringFlag{
 				Name:  "require-creator",
 				Usage: "Require a specific creator identity (matched against bundle attestation certificate)",
@@ -83,11 +83,11 @@ Output as JSON:
 				Usage: `Override the certificate identity pattern for binary attestation verification.
 	Must contain "NVIDIA/aicr". Default pins to the release workflow on tag refs.`,
 			},
-			&cli.StringFlag{
+			withCompletions(&cli.StringFlag{
 				Name:  "format",
 				Value: "text",
 				Usage: "Output format: text, json",
-			},
+			}, func() []string { return []string{"json", "text"} }),
 		},
 		Action: runBundleVerifyCmd,
 	}

--- a/pkg/cli/bundle_verify_test.go
+++ b/pkg/cli/bundle_verify_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
-	"github.com/urfave/cli/v3"
 )
 
 func TestBundleVerifyCmd_HasExpectedFlags(t *testing.T) {
@@ -50,11 +49,12 @@ func TestBundleVerifyCmd_MinTrustLevelDefault(t *testing.T) {
 
 	for _, f := range cmd.Flags {
 		if f.Names()[0] == "min-trust-level" {
-			// Check it's a StringFlag with default "max"
-			sf, ok := f.(*cli.StringFlag)
+			// Check it's a completable StringFlag with default "max"
+			cf, ok := f.(*completableStringFlag)
 			if !ok {
-				t.Fatal("min-trust-level should be a StringFlag")
+				t.Fatal("min-trust-level should be a completableStringFlag")
 			}
+			sf := cf.StringFlag
 			if sf.Value != "max" {
 				t.Errorf("min-trust-level default = %q, want %q", sf.Value, "max")
 			}

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -22,6 +22,11 @@ import (
 	"testing"
 
 	urfave "github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // runCompletion runs the root command with --generate-shell-completion appended
@@ -158,6 +163,136 @@ func TestCompletion_NestedSubcommands(t *testing.T) {
 
 	if !strings.Contains(output, "update") {
 		t.Errorf("expected nested subcommand %q in trust completion output, got:\n%s", "update", output)
+	}
+}
+
+func TestCompletion_RecipeFlagValues(t *testing.T) {
+	tests := []struct {
+		flag   string
+		expect []string
+	}{
+		{"--intent", recipe.GetCriteriaIntentTypes()},
+		{"--service", recipe.GetCriteriaServiceTypes()},
+		{"--accelerator", recipe.GetCriteriaAcceleratorTypes()},
+		{"--gpu", recipe.GetCriteriaAcceleratorTypes()},
+		{"--os", recipe.GetCriteriaOSTypes()},
+		{"--platform", recipe.GetCriteriaPlatformTypes()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			output, err := runCompletion(t, "recipe", tt.flag, "")
+			if err != nil {
+				t.Fatalf("recipe %s completion failed: %v", tt.flag, err)
+			}
+			for _, v := range tt.expect {
+				if !strings.Contains(output, v) {
+					t.Errorf("expected %q in output for %s, got:\n%s", v, tt.flag, output)
+				}
+			}
+		})
+	}
+}
+
+func TestCompletion_SharedFormatFlag(t *testing.T) {
+	for _, cmd := range []string{"recipe", "snapshot"} {
+		t.Run(cmd, func(t *testing.T) {
+			output, err := runCompletion(t, cmd, "--format", "")
+			if err != nil {
+				t.Fatalf("%s --format completion failed: %v", cmd, err)
+			}
+			for _, v := range serializer.SupportedFormats() {
+				if !strings.Contains(output, v) {
+					t.Errorf("expected %q in %s --format output, got:\n%s", v, cmd, output)
+				}
+			}
+		})
+	}
+}
+
+func TestCompletion_BundleDeployerFlag(t *testing.T) {
+	output, err := runCompletion(t, "bundle", "--deployer", "")
+	if err != nil {
+		t.Fatalf("bundle --deployer completion failed: %v", err)
+	}
+	for _, v := range config.GetDeployerTypes() {
+		if !strings.Contains(output, v) {
+			t.Errorf("expected %q in --deployer output, got:\n%s", v, output)
+		}
+	}
+}
+
+func TestCompletion_VerifyFlagValues(t *testing.T) {
+	tests := []struct {
+		flag   string
+		expect []string
+	}{
+		{"--min-trust-level", verifier.GetTrustLevels()},
+		{"--format", []string{"text", "json"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			output, err := runCompletion(t, "verify", tt.flag, "")
+			if err != nil {
+				t.Fatalf("verify %s completion failed: %v", tt.flag, err)
+			}
+			for _, v := range tt.expect {
+				if !strings.Contains(output, v) {
+					t.Errorf("expected %q in output for %s, got:\n%s", v, tt.flag, output)
+				}
+			}
+		})
+	}
+}
+
+func TestCompletion_QueryInheritsRecipeCompletions(t *testing.T) {
+	output, err := runCompletion(t, "query", "--intent", "")
+	if err != nil {
+		t.Fatalf("query --intent completion failed: %v", err)
+	}
+	for _, v := range recipe.GetCriteriaIntentTypes() {
+		if !strings.Contains(output, v) {
+			t.Errorf("expected %q in query --intent output, got:\n%s", v, output)
+		}
+	}
+}
+
+func TestFindCompletableFlag(t *testing.T) {
+	cmd := &urfave.Command{
+		Flags: []urfave.Flag{
+			withCompletions(&urfave.StringFlag{
+				Name:    "intent",
+				Aliases: []string{"i"},
+			}, func() []string { return []string{"inference", "training"} }),
+			&urfave.StringFlag{
+				Name: "output",
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		flagArg string
+		wantOK  bool
+		wantLen int
+	}{
+		{"primary name", "--intent", true, 2},
+		{"alias", "-i", true, 2},
+		{"non-completable flag", "--output", false, 0},
+		{"unknown flag", "--bogus", false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf, ok := findCompletableFlag(cmd, tt.flagArg)
+			if ok != tt.wantOK {
+				t.Fatalf("findCompletableFlag(%q) ok = %v, want %v", tt.flagArg, ok, tt.wantOK)
+			}
+			if ok && len(cf.Completions()) != tt.wantLen {
+				t.Errorf("completions len = %d, want %d", len(cf.Completions()), tt.wantLen)
+			}
+		})
 	}
 }
 

--- a/pkg/cli/completion_values.go
+++ b/pkg/cli/completion_values.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"strings"
+
+	"github.com/urfave/cli/v3"
+)
+
+// CompletableFlag is implemented by flags that offer value completions.
+// When the user presses TAB after typing a flag name (e.g. "--intent "),
+// the shell completion handler calls Completions() to get valid values.
+type CompletableFlag interface {
+	cli.Flag
+	Completions() []string
+}
+
+// completableStringFlag wraps a cli.StringFlag with a completion function.
+type completableStringFlag struct {
+	*cli.StringFlag
+	completions func() []string
+}
+
+// Completions returns the valid values for this flag.
+func (f *completableStringFlag) Completions() []string {
+	return f.completions()
+}
+
+// withCompletions wraps a StringFlag with a function that returns valid values.
+// The completion function is called at completion time, so it always returns
+// current values from the source of truth.
+func withCompletions(flag *cli.StringFlag, completions func() []string) cli.Flag {
+	return &completableStringFlag{StringFlag: flag, completions: completions}
+}
+
+// findCompletableFlag looks up a CompletableFlag by flag name (with or without
+// leading dashes) on the given command. Returns the flag and true if found.
+func findCompletableFlag(cmd *cli.Command, name string) (CompletableFlag, bool) {
+	name = strings.TrimLeft(name, "-")
+	if name == "" {
+		return nil, false
+	}
+	for _, f := range cmd.Flags {
+		cf, ok := f.(CompletableFlag)
+		if !ok {
+			continue
+		}
+		for _, n := range f.Names() {
+			if n == name {
+				return cf, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -29,32 +29,32 @@ import (
 
 func recipeCmdFlags() []cli.Flag {
 	return []cli.Flag{
-		&cli.StringFlag{
+		withCompletions(&cli.StringFlag{
 			Name:     "service",
 			Usage:    fmt.Sprintf("Kubernetes service type (e.g. %s)", strings.Join(recipe.GetCriteriaServiceTypes(), ", ")),
 			Category: "Query Parameters",
-		},
-		&cli.StringFlag{
+		}, recipe.GetCriteriaServiceTypes),
+		withCompletions(&cli.StringFlag{
 			Name:     "accelerator",
 			Aliases:  []string{"gpu"},
 			Usage:    fmt.Sprintf("Accelerator/GPU type (e.g. %s)", strings.Join(recipe.GetCriteriaAcceleratorTypes(), ", ")),
 			Category: "Query Parameters",
-		},
-		&cli.StringFlag{
+		}, recipe.GetCriteriaAcceleratorTypes),
+		withCompletions(&cli.StringFlag{
 			Name:     "intent",
 			Usage:    fmt.Sprintf("Workload intent (e.g. %s)", strings.Join(recipe.GetCriteriaIntentTypes(), ", ")),
 			Category: "Query Parameters",
-		},
-		&cli.StringFlag{
+		}, recipe.GetCriteriaIntentTypes),
+		withCompletions(&cli.StringFlag{
 			Name:     "os",
 			Usage:    fmt.Sprintf("Operating system type of the GPU node (e.g. %s)", strings.Join(recipe.GetCriteriaOSTypes(), ", ")),
 			Category: "Query Parameters",
-		},
-		&cli.StringFlag{
+		}, recipe.GetCriteriaOSTypes),
+		withCompletions(&cli.StringFlag{
 			Name:     "platform",
 			Usage:    fmt.Sprintf("Platform/framework type to include in the runtime (e.g. %s)", strings.Join(recipe.GetCriteriaPlatformTypes(), ", ")),
 			Category: "Query Parameters",
-		},
+		}, recipe.GetCriteriaPlatformTypes),
 		&cli.IntFlag{
 			Name:     "nodes",
 			Usage:    "Number of worker/GPU nodes in the cluster",
@@ -77,7 +77,7 @@ func recipeCmdFlags() []cli.Flag {
 		},
 		dataFlag,
 		outputFlag,
-		formatFlag,
+		formatFlag(),
 		kubeconfigFlag,
 	}
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -36,6 +36,7 @@ const (
 	versionDefault         = "dev"
 	functionalCategoryName = "Functional"
 	agentImageBase         = "ghcr.io/nvidia/aicr"
+	shellCompletionFlag    = "--generate-shell-completion"
 )
 
 // defaultAgentImage returns the agent container image reference matching the
@@ -64,12 +65,16 @@ var (
 		Category: "Output",
 	}
 
-	formatFlag = &cli.StringFlag{
-		Name:     "format",
-		Aliases:  []string{"t"},
-		Value:    string(serializer.FormatYAML),
-		Usage:    fmt.Sprintf("output format (%s)", strings.Join(serializer.SupportedFormats(), ", ")),
-		Category: "Output",
+	// formatFlag is a function to avoid sharing a single flag instance across
+	// commands, which causes urfave/cli internal state conflicts in parallel tests.
+	formatFlag = func() cli.Flag {
+		return withCompletions(&cli.StringFlag{
+			Name:     "format",
+			Aliases:  []string{"t"},
+			Value:    string(serializer.FormatYAML),
+			Usage:    fmt.Sprintf("output format (%s)", strings.Join(serializer.SupportedFormats(), ", ")),
+			Category: "Output",
+		}, serializer.SupportedFormats)
 	}
 
 	kubeconfigFlag = &cli.StringFlag{
@@ -184,6 +189,18 @@ func completeWithAllFlags(_ context.Context, cmd *cli.Command) {
 	writer := cmd.Root().Writer
 
 	if strings.HasPrefix(lastArg, "-") {
+		// Flag value completion: when lastArg exactly matches a completable
+		// flag name (e.g. "--intent"), emit valid values. This handles the
+		// zsh/fish case where "aicr recipe --intent <TAB>" sends
+		// ["aicr", "recipe", "--intent", shellCompletionFlag]
+		// without an empty string for the value being completed.
+		if cf, ok := findCompletableFlag(cmd, lastArg); ok {
+			for _, v := range cf.Completions() {
+				fmt.Fprintln(writer, v)
+			}
+			return
+		}
+
 		cur := strings.TrimLeft(lastArg, "-")
 		for _, f := range cmd.Flags {
 			for _, flagName := range f.Names() {
@@ -210,6 +227,20 @@ func completeWithAllFlags(_ context.Context, cmd *cli.Command) {
 		return
 	}
 
+	// Flag value completion: if the previous arg is a completable flag,
+	// suggest its valid values instead of subcommands. This handles the
+	// bash case where "aicr recipe --intent <TAB>" sends
+	// ["aicr", "recipe", "--intent", "", shellCompletionFlag]
+	// with an empty string for the value being completed.
+	if prevArg := completionPrevArg(); prevArg != "" {
+		if cf, ok := findCompletableFlag(cmd, prevArg); ok {
+			for _, v := range cf.Completions() {
+				fmt.Fprintln(writer, v)
+			}
+			return
+		}
+	}
+
 	for _, sub := range cmd.Commands {
 		if !sub.Hidden {
 			fmt.Fprintln(writer, sub.Name)
@@ -224,11 +255,24 @@ func completeWithAllFlags(_ context.Context, cmd *cli.Command) {
 // cmd.Args().
 func completionLastArg() string {
 	n := len(os.Args)
-	if n >= 2 && os.Args[n-1] == "--generate-shell-completion" {
+	if n >= 2 && os.Args[n-1] == shellCompletionFlag {
 		return os.Args[n-2]
 	}
 	if n >= 1 {
 		return os.Args[n-1]
+	}
+	return ""
+}
+
+// completionPrevArg returns the second-to-last user-typed argument from
+// os.Args, which is the flag name when the user is completing a flag value.
+// For "aicr recipe --intent <TAB>", os.Args is
+// ["aicr", "recipe", "--intent", "", shellCompletionFlag]
+// and this returns "--intent".
+func completionPrevArg() string {
+	n := len(os.Args)
+	if n >= 3 && os.Args[n-1] == shellCompletionFlag {
+		return os.Args[n-3]
 	}
 	return ""
 }
@@ -261,7 +305,7 @@ func Execute() {
 }
 
 // sanitizeCompletionArgs works around a urfave/cli v3 limitation where "--"
-// immediately before "--generate-shell-completion" disables completion mode
+// immediately before shellCompletionFlag disables completion mode
 // entirely (checkShellCompleteFlag treats "--" as a flag terminator). This
 // causes the actual command to execute during TAB completion instead of
 // returning suggestions.
@@ -272,7 +316,7 @@ func Execute() {
 // arg that triggers flag suggestions.
 func sanitizeCompletionArgs(args []string) []string {
 	n := len(args)
-	if n < 3 || args[n-1] != "--generate-shell-completion" {
+	if n < 3 || args[n-1] != shellCompletionFlag {
 		return args
 	}
 	if args[n-2] != "--" {

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -155,7 +155,7 @@ func snapshotCmdFlags() []cli.Flag {
 			Category: "Output",
 		},
 		outputFlag,
-		formatFlag,
+		formatFlag(),
 		kubeconfigFlag,
 	}
 }


### PR DESCRIPTION
## Summary                                                                                                                  
                                                                                                                              
  Closes #339
                                                                                                                              
  - Add `CompletableFlag` wrapper that co-locates completion values with flag definitions, ensuring completions stay in sync  with accepted values
  - Extend `completeWithAllFlags` to emit flag values when the user TABs after an enum flag                                   
  - Wire completions for `--intent`, `--service`, `--accelerator`/`--gpu`, `--os`, `--platform`, `--format`, `--deployer`,    
  `--min-trust-level`                                                                                                         
  - Add `GetTrustLevels()` getter to verifier package (was the only enum type missing one)                                    
                                                                                                                              
  ## Test plan    
                                                                                                                              
  - [x] `go test -race ./pkg/cli/...` — 30 test cases pass including 6 new flag value completion tests                        
  - [x] `go test -race ./pkg/bundler/verifier/...` — `TestGetTrustLevels` passes
  - [x] Manual verification: `aicr recipe --intent "" --generate-shell-completion` outputs `inference`, `training`            
  - [ ] `make qualify` passes       
## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
