### PR TITLE
feat(ci): auto-assign issues based on area labels

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -36,11 +36,54 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .settings.yaml
+          sparse-checkout-cone-mode: false
+
       - name: Label by Path
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
+
+      - name: Parse area assignees
+        id: assignees
+        run: |
+          # Extract area_assignees map from .settings.yaml as JSON
+          yq -o=json '.area_assignees' .settings.yaml > /tmp/area_assignees.json
+
+      - name: Assign by Area
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            const assignees = JSON.parse(fs.readFileSync('/tmp/area_assignees.json', 'utf8'));
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const toAssign = new Set();
+            for (const label of labels) {
+              const user = assignees[label.name];
+              if (user) {
+                toAssign.add(user);
+              }
+            }
+
+            if (toAssign.size > 0) {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                assignees: [...toAssign],
+              });
+            }
 
       - name: Label by Size
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -36,54 +36,11 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          sparse-checkout: .settings.yaml
-          sparse-checkout-cone-mode: false
-
       - name: Label by Path
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
-
-      - name: Parse area assignees
-        id: assignees
-        run: |
-          # Extract area_assignees map from .settings.yaml as JSON
-          yq -o=json '.area_assignees' .settings.yaml > /tmp/area_assignees.json
-
-      - name: Assign by Area
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
-        with:
-          script: |
-            const fs = require('fs');
-
-            const assignees = JSON.parse(fs.readFileSync('/tmp/area_assignees.json', 'utf8'));
-
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const toAssign = new Set();
-            for (const label of labels) {
-              const user = assignees[label.name];
-              if (user) {
-                toAssign.add(user);
-              }
-            }
-
-            if (toAssign.size > 0) {
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                assignees: [...toAssign],
-              });
-            }
 
       - name: Label by Size
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -28,6 +28,7 @@ jobs:
     name: Auto-Triage Issues
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     timeout-minutes: 5
     steps:

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -63,3 +63,49 @@ jobs:
                 name: 'needs-triage',
               });
             }
+
+      - name: Assign by area label
+        if: >-
+          github.event.action == 'labeled' &&
+          startsWith(github.event.label.name, 'area/')
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.settings.yaml',
+            });
+            const content = Buffer.from(file.content, 'base64').toString('utf8');
+
+            // Parse area_assignees from .settings.yaml
+            const assignees = {};
+            let inBlock = false;
+            for (const line of content.split('\n')) {
+              if (line.startsWith('area_assignees:')) {
+                inBlock = true;
+                continue;
+              }
+              if (inBlock) {
+                const m = line.match(/^\s+(area\/\S+):\s*(\S+)/);
+                if (m) {
+                  assignees[m[1]] = m[2];
+                } else if (/^\S/.test(line)) {
+                  break;
+                }
+              }
+            }
+
+            const label = context.payload.label.name;
+            const user = assignees[label];
+            if (!user) {
+              core.info(`No assignee configured for ${label}`);
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [user],
+            });

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -53,7 +53,7 @@ testing_tools:
   yq: 'v4.52.4'
   karpenter: 'v1.8.0'
 
-# Area Assignees (GitHub usernames assigned to PRs by area label)
+# Area Assignees (GitHub usernames assigned to issues by area label)
 area_assignees:
   area/api: cullenmcdermott
   area/bundler: ArangoGutierrez

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -53,6 +53,19 @@ testing_tools:
   yq: 'v4.52.4'
   karpenter: 'v1.8.0'
 
+# Area Assignees (GitHub usernames assigned to PRs by area label)
+area_assignees:
+  area/api: cullenmcdermott
+  area/bundler: ArangoGutierrez
+  area/ci: mchmarny
+  area/cli: lockwobr
+  area/collector: ayuskauskas
+  area/docs: dims
+  area/infra: mchmarny
+  area/recipes: yuanchen8911
+  area/tests: atif1996
+  area/validator: xdu31
+
 # Quality Thresholds
 quality:
   coverage_threshold: '70'


### PR DESCRIPTION
## Summary
- Add `area_assignees` map to `.settings.yaml` mapping each `area/*` label to a team member
- Update `triage.yaml` workflow to auto-assign issues when an area label is applied
- Fetches `.settings.yaml` via GitHub API — no checkout or `yq` dependency needed

## Test plan
- [ ] Verify workflow syntax passes `actionlint`
- [ ] Add an `area/cli` label to a test issue and confirm `lockwobr` is assigned
- [ ] Add multiple area labels to an issue and confirm each mapped user is assigned