### PR TITLE
fix(ci): expand GPU test triggers to cover collector, snapshotter, validator, and add run-gpu-tests label

### DIFF
--- a/.github/workflows/gpu-h100-conformance-test.yaml
+++ b/.github/workflows/gpu-h100-conformance-test.yaml
@@ -43,6 +43,17 @@ on:
       - 'recipes/overlays/h100-kind-conformance.yaml'
       - 'kwok/manifests/karpenter/**'
       - 'kwok/scripts/install-karpenter-kwok.sh'
+      # Collector/snapshotter — affects GPU detection and snapshot content
+      - 'pkg/collector/**'
+      - 'pkg/snapshotter/**'
+      # Validator infrastructure — affects how validator Jobs are deployed and run
+      - 'pkg/validator/job/**'
+      - 'pkg/validator/catalog/**'
+      - 'pkg/defaults/timeouts.go'
+      # Conformance validator source
+      - 'validators/conformance/**'
+  pull_request:
+    types: [labeled]
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -55,6 +66,9 @@ concurrency:
 jobs:
 
   gpu-conformance-test:
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'run-gpu-tests'
     name: GPU Conformance Test (nvkind + H100 x2)
     runs-on: linux-amd64-gpu-h100-latest-2
     timeout-minutes: 60

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -41,6 +41,18 @@ on:
       - 'recipes/overlays/h100-kind-inference-dynamo.yaml'
       - 'kwok/manifests/karpenter/**'
       - 'kwok/scripts/install-karpenter-kwok.sh'
+      # Collector/snapshotter — affects GPU detection and snapshot content
+      - 'pkg/collector/**'
+      - 'pkg/snapshotter/**'
+      - '.github/actions/gpu-snapshot-validate/**'
+      # Validator infrastructure — affects how validator Jobs are deployed and run
+      - 'pkg/validator/job/**'
+      - 'pkg/validator/catalog/**'
+      - 'pkg/defaults/timeouts.go'
+      # Conformance validator source
+      - 'validators/conformance/**'
+  pull_request:
+    types: [labeled]
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -53,6 +65,9 @@ concurrency:
 jobs:
 
   gpu-inference-test:
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'run-gpu-tests'
     name: GPU Inference Test (nvkind + H100)
     runs-on: linux-amd64-gpu-h100-latest-1
     timeout-minutes: 45

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -37,6 +37,18 @@ on:
       - 'kwok/manifests/karpenter/**'
       - 'kwok/scripts/install-karpenter-kwok.sh'
       - 'recipes/components/prometheus-adapter/**'
+      # Collector/snapshotter — affects GPU detection and snapshot content
+      - 'pkg/collector/**'
+      - 'pkg/snapshotter/**'
+      - '.github/actions/gpu-snapshot-validate/**'
+      # Validator infrastructure — affects how validator Jobs are deployed and run
+      - 'pkg/validator/job/**'
+      - 'pkg/validator/catalog/**'
+      - 'pkg/defaults/timeouts.go'
+      # Conformance validator source
+      - 'validators/conformance/**'
+  pull_request:
+    types: [labeled]
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -49,6 +61,9 @@ concurrency:
 jobs:
 
   gpu-training-test:
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'run-gpu-tests'
     name: GPU Training Test (nvkind + H100 x2)
     runs-on: linux-amd64-gpu-h100-latest-2
     timeout-minutes: 45

--- a/.github/workflows/gpu-smoke-test.yaml
+++ b/.github/workflows/gpu-smoke-test.yaml
@@ -27,6 +27,18 @@ on:
       - '.github/actions/aicr-build/**'
       - '.github/actions/gpu-test-cleanup/**'
       - '.github/actions/load-versions/**'
+      # Collector/snapshotter — affects GPU detection and snapshot content
+      - 'pkg/collector/**'
+      - 'pkg/snapshotter/**'
+      - '.github/actions/gpu-snapshot-validate/**'
+      # Validator infrastructure — affects how validator Jobs are deployed and run
+      - 'pkg/validator/job/**'
+      - 'pkg/validator/catalog/**'
+      - 'pkg/defaults/timeouts.go'
+      # Conformance validator source
+      - 'validators/conformance/**'
+  pull_request:
+    types: [labeled]
   workflow_dispatch: {}  # Allow manual runs
 
 permissions:
@@ -39,6 +51,9 @@ concurrency:
 jobs:
 
   gpu-smoke-test:
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'run-gpu-tests'
     name: GPU Smoke Test (nvkind + T4)
     runs-on: linux-amd64-gpu-t4-latest-1
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- Expand path triggers on all four GPU CI workflows to cover `pkg/collector/`, `pkg/snapshotter/`, `pkg/validator/job/`, `pkg/validator/catalog/`, `pkg/defaults/timeouts.go`, `validators/conformance/`, and `.github/actions/gpu-snapshot-validate/`
- Add `run-gpu-tests` label trigger as a safety net for cases not covered by path filtering

## Motivation

GPU CI tests only trigger on a narrow set of file paths. Recent PRs that affected GPU test behavior were not caught:
- #502 changed `pkg/collector/gpu/` and `pkg/snapshotter/` — broke GPU model detection, but GPU tests didn't run
- #444 changed `pkg/validator/job/deployer.go` — broke `imagePullPolicy` for local images, causing 100% GPU test failure for a week

Closes #510

## Test plan

- [ ] `make lint` passes (no yamllint errors in workflow files)
- [ ] Verify each workflow includes all 7 new paths in `push.paths`
- [ ] Verify `pull_request: types: [labeled]` trigger is present on all 4 workflows
- [ ] Verify job-level `if:` condition doesn't block schedule/push/dispatch triggers
- [ ] Label a test PR with `run-gpu-tests` to confirm manual trigger works

