### PR TITLE
feat(recipe): add NFD as standalone shared component

### DIFF
--- a/recipes/checks/nfd/health-check.yaml
+++ b/recipes/checks/nfd/health-check.yaml
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Node Feature Discovery Health Check
+#
+# Validates the standalone NFD deployment by checking:
+# 1. NFD Master Deployment has at least one ready replica
+# 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+#    and numberUnavailable == 0, so partial failures don't pass)
+# 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+# 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+#    Running with a known-unhealthy container waiting reason
+#    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+#    CreateContainerConfigError)
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: nfd-health-check
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    - name: validate-master-deployment
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: node-feature-discovery-master
+                namespace: node-feature-discovery
+              status:
+                (availableReplicas > `0`): true
+    - name: validate-worker-daemonset
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: node-feature-discovery-worker
+                namespace: node-feature-discovery
+              status:
+                # Guard against vacuous pass when 0 nodes match the
+                # DaemonSet: require at least one scheduled pod.
+                (desiredNumberScheduled > `0`): true
+                # Full rollout: 0 unavailable pods. Combined with the
+                # guard above, this is equivalent to "all scheduled pods
+                # are ready". Replaces the earlier `numberReady > 0`
+                # which passed on partial failures.
+                (numberUnavailable == `0`): true
+    - name: validate-gc-deployment
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: node-feature-discovery-gc
+                namespace: node-feature-discovery
+              status:
+                (availableReplicas > `0`): true
+    - name: validate-all-pods-healthy
+      try:
+        # Phase-based errors: Pending/Failed/Unknown.
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                phase: Pending
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                phase: Failed
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                phase: Unknown
+        # Container-state errors: pods stuck in Running phase with a
+        # container in a known-bad waiting reason. Phase filtering alone
+        # misses CrashLoopBackOff/ImagePullBackOff because those pods
+        # typically remain in Running phase with unhealthy containers.
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                containerStatuses:
+                  - state:
+                      waiting:
+                        reason: CrashLoopBackOff
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                containerStatuses:
+                  - state:
+                      waiting:
+                        reason: ImagePullBackOff
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                containerStatuses:
+                  - state:
+                      waiting:
+                        reason: ErrImagePull
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: node-feature-discovery
+              status:
+                containerStatuses:
+                  - state:
+                      waiting:
+                        reason: CreateContainerConfigError

--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -82,6 +82,6 @@ validator:
       - name: WITH_WORKLOAD
         value: "false"
 
-# Node Feature Discovery sub-chart
-node-feature-discovery:
-  fullnameOverride: node-feature-discovery
+# NFD deployed as standalone shared component — disable sub-chart
+nfd:
+  enabled: false

--- a/recipes/components/nfd/values.yaml
+++ b/recipes/components/nfd/values.yaml
@@ -12,29 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Network Operator Helm values
-# Base configuration for all deployments
+# Node Feature Discovery standalone deployment
+# NFD v0.18.3 — shared by gpu-operator and network-operator
 
-# Override release name prefix to avoid aicr-stack- prefix in resource names
-operator:
-  fullnameOverride: network-operator
-  tolerations:
-    - operator: Exists
+# Enable NodeFeature API (CRD-based feature publishing)
+enableNodeFeatureApi: true
 
-deployCR: true
+# Explicitly pin master/worker enable so behavior doesn't drift with
+# upstream chart defaults on future chart upgrades.
+master:
+  enable: true
 
-nfd:
-  enabled: false
-  deployNodeFeatureRules: true
+worker:
+  enable: true
 
-sriovNetworkOperator:
-  enabled: false
+# Topology Updater disabled by default (enable via overlay override)
+topologyUpdater:
+  enable: false
 
-nvIpam:
-  enabled: true
-
-secondaryNetwork:
-  deploy: true
-
-nicClusterPolicy:
-  enabled: true
+# GC enabled for cleanup of stale NodeFeature/NodeResourceTopology CRs
+gc:
+  enable: true

--- a/recipes/overlays/aks.yaml
+++ b/recipes/overlays/aks.yaml
@@ -54,6 +54,7 @@ spec:
       version: "25.1.0"
       valuesFile: components/network-operator/values.yaml
       dependencyRefs:
+        - nfd
         - cert-manager
 
     # Prometheus persistent storage — Azure Disk Standard SSD

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -25,6 +25,12 @@ spec:
       value: ">= 1.25"
 
   componentRefs:
+    - name: nfd
+      type: Helm
+      source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+      version: v0.18.3
+      valuesFile: components/nfd/values.yaml
+
     - name: cert-manager
       type: Helm
       source: https://charts.jetstack.io
@@ -39,6 +45,7 @@ spec:
       manifestFiles:
         - components/gpu-operator/manifests/dcgm-exporter.yaml
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
 

--- a/recipes/overlays/gb200-eks-inference.yaml
+++ b/recipes/overlays/gb200-eks-inference.yaml
@@ -36,6 +36,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
         - skyhook-customizations

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -37,6 +37,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
         - skyhook-customizations

--- a/recipes/overlays/gb200-oke-inference.yaml
+++ b/recipes/overlays/gb200-oke-inference.yaml
@@ -36,5 +36,6 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack

--- a/recipes/overlays/gb200-oke-training.yaml
+++ b/recipes/overlays/gb200-oke-training.yaml
@@ -37,6 +37,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
       overrides:

--- a/recipes/overlays/h100-aks-inference.yaml
+++ b/recipes/overlays/h100-aks-inference.yaml
@@ -40,5 +40,6 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack

--- a/recipes/overlays/h100-aks-training.yaml
+++ b/recipes/overlays/h100-aks-training.yaml
@@ -41,6 +41,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
       overrides:

--- a/recipes/overlays/h100-eks-inference.yaml
+++ b/recipes/overlays/h100-eks-inference.yaml
@@ -36,6 +36,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
         - skyhook-customizations

--- a/recipes/overlays/h100-eks-training.yaml
+++ b/recipes/overlays/h100-eks-training.yaml
@@ -37,6 +37,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
         - skyhook-customizations

--- a/recipes/overlays/h100-gke-cos-inference.yaml
+++ b/recipes/overlays/h100-gke-cos-inference.yaml
@@ -36,6 +36,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
         - skyhook-customizations

--- a/recipes/overlays/h100-gke-cos-training.yaml
+++ b/recipes/overlays/h100-gke-cos-training.yaml
@@ -37,6 +37,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
         - skyhook-customizations

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -72,8 +72,6 @@ spec:
                   - matchExpressions:
                       - key: node-role.kubernetes.io/control-plane
                         operator: DoesNotExist
-        nfd:
-          enabled: true
         # Use chart-default device plugin env in kind (no CDI overrides)
         devicePlugin:
           env: []
@@ -193,6 +191,7 @@ spec:
       version: "25.1.0"
       valuesFile: components/network-operator/values.yaml
       dependencyRefs:
+        - nfd
         - cert-manager
 
   validation:

--- a/recipes/overlays/rtx-pro-6000-lke-inference.yaml
+++ b/recipes/overlays/rtx-pro-6000-lke-inference.yaml
@@ -37,6 +37,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
 

--- a/recipes/overlays/rtx-pro-6000-lke-training.yaml
+++ b/recipes/overlays/rtx-pro-6000-lke-training.yaml
@@ -38,6 +38,7 @@ spec:
     - name: gpu-operator
       type: Helm
       dependencyRefs:
+        - nfd
         - cert-manager
         - kube-prometheus-stack
 

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -41,6 +41,34 @@ apiVersion: aicr.nvidia.com/v1alpha1
 kind: ComponentRegistry
 
 components:
+  - name: nfd
+    displayName: Node Feature Discovery
+    valueOverrideKeys:
+      - nfd
+    healthCheck:
+      assertFile: checks/nfd/health-check.yaml
+    helm:
+      defaultRepository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+      defaultChart: node-feature-discovery
+      defaultNamespace: node-feature-discovery
+    nodeScheduling:
+      system:
+        nodeSelectorPaths:
+          - master.nodeSelector
+          - gc.nodeSelector
+        tolerationPaths:
+          - master.tolerations
+          - gc.tolerations
+          # Worker also inherits system tolerations — the DaemonSet must
+          # run on tainted system nodes (not just GPU nodes) to publish
+          # hardware features cluster-wide.
+          - worker.tolerations
+      accelerated:
+        # Worker intentionally excluded from accelerated nodeSelector —
+        # NFD workers must run on ALL nodes to detect hardware features.
+        tolerationPaths:
+          - worker.tolerations
+
   - name: gpu-operator
     displayName: gpu-operator
     valueOverrideKeys:
@@ -55,24 +83,13 @@ components:
       system:
         nodeSelectorPaths:
           - operator.nodeSelector
-          - node-feature-discovery.gc.nodeSelector
-          - node-feature-discovery.master.nodeSelector
         tolerationPaths:
           - operator.tolerations
-          - node-feature-discovery.gc.tolerations
-          - node-feature-discovery.master.tolerations
       accelerated:
         nodeSelectorPaths:
           - daemonsets.nodeSelector
-          # Note: NFD worker nodeSelector is intentionally excluded from
-          # accelerated scheduling. NFD must run on all nodes (GPU, CPU,
-          # and system) to detect hardware features — this matches the
-          # gpu-operator default behavior where NFD workers also run on
-          # control-plane nodes. NFD worker tolerations remain here so
-          # it inherits the same tolerations as GPU daemonsets.
         tolerationPaths:
           - daemonsets.tolerations
-          - node-feature-discovery.worker.tolerations
 
   - name: network-operator
     displayName: network-operator

--- a/tests/chainsaw/ai-conformance/cluster/assert-gpu-operator.yaml
+++ b/tests/chainsaw/ai-conformance/cluster/assert-gpu-operator.yaml
@@ -31,17 +31,6 @@ status:
   (conditions[?type == 'Available']):
     - status: "True"
 ---
-# Node Feature Discovery master
-# fullnameOverride: node-feature-discovery (from gpu-operator values.yaml)
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: node-feature-discovery-master
-  namespace: gpu-operator
-status:
-  (conditions[?type == 'Available']):
-    - status: "True"
----
 # ClusterPolicy — umbrella health check for all GPU operator sub-components.
 # When status.state is "ready", the driver, device-plugin, toolkit, DCGM
 # exporter, GFD, MIG manager, and validator are all functional.
@@ -113,26 +102,6 @@ metadata:
 status:
   (numberReady > `0`): true
   (desiredNumberScheduled > `0`): true
----
-# Node Feature Discovery worker DaemonSet — detects hardware features on each node
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: node-feature-discovery-worker
-  namespace: gpu-operator
-status:
-  (numberReady > `0`): true
-  (desiredNumberScheduled > `0`): true
----
-# Node Feature Discovery garbage collector — cleans up stale node feature labels
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: node-feature-discovery-gc
-  namespace: gpu-operator
-status:
-  (conditions[?type == 'Available']):
-    - status: "True"
 ---
 # NVIDIA DCGM DaemonSet — Data Center GPU Manager for health and diagnostics
 apiVersion: apps/v1

--- a/tests/chainsaw/ai-conformance/offline/assert-recipe.yaml
+++ b/tests/chainsaw/ai-conformance/offline/assert-recipe.yaml
@@ -47,6 +47,7 @@ componentRefs: ## alphabetically sorted
   - name: kgateway
   - name: kgateway-crds
   - name: kube-prometheus-stack
+  - name: nfd
   - name: nvidia-dra-driver-gpu
   - name: nvsentinel
   - name: prometheus-adapter
@@ -61,6 +62,7 @@ deploymentOrder:
   - kgateway
   - kube-prometheus-stack
   - k8s-ephemeral-storage-metrics
+  - nfd
   - prometheus-adapter
   - skyhook-operator
   - skyhook-customizations

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling-nfd.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling-nfd.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert standalone nfd values.yaml for CUJ1 training workload.
+#
+# Validates scheduling injection for the standalone NFD component:
+#   - master + gc get the system node selector
+#   - worker gets the accelerated toleration (worker runs on all nodes,
+#     so it must tolerate GPU-node taints)
+#
+# NOTE: chainsaw assert --resource requires apiVersion/kind to parse the YAML.
+# Helm values files don't have these natively, so we prepend them in the test
+# script before asserting. These two lines are not part of the actual values.
+apiVersion: helm/v1
+kind: Values
+
+# ── NodeFeature API enabled ──────────────────────────────────────────
+enableNodeFeatureApi: true
+
+# ── Scheduling: master on system nodes ───────────────────────────────
+master:
+  nodeSelector:
+    nodeGroup: system-pool
+
+# ── Scheduling: GC enabled and on system nodes ───────────────────────
+gc:
+  enable: true
+  nodeSelector:
+    nodeGroup: system-pool
+
+# ── Scheduling: worker gets accelerated toleration ───────────────────
+# Worker DaemonSet must run on all nodes (system + accelerated) to
+# publish hardware features; the accelerated toleration is required so
+# it can land on tainted GPU nodes.
+worker:
+  tolerations:
+    - key: nvidia.com/gpu
+      value: present
+      effect: NoSchedule
+  # Explicit regression guard: nodeSelector MUST NOT be injected, even
+  # by accident. If a future overlay/registry change adds one, this
+  # assertion fails and catches it.
+  (nodeSelector == null): true

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
@@ -62,13 +62,7 @@ migManager:
 toolkit:
   enabled: true
 
-# ── Node Feature Discovery scheduling ───────────────────────────────
-# NFD master/gc run on system nodes, worker runs on all worker nodes
-# (no accelerated nodeSelector — NFD must discover features everywhere)
-node-feature-discovery:
-  master:
-    nodeSelector:
-      nodeGroup: system-pool
-  gc:
-    nodeSelector:
-      nodeGroup: system-pool
+# ── Node Feature Discovery ──────────────────────────────────────────
+# NFD deployed as standalone shared component — sub-chart disabled
+nfd:
+  enabled: false

--- a/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-recipe.yaml
@@ -43,6 +43,7 @@ componentRefs: ## alphabetically sorted
   - name: kai-scheduler
   - name: kube-prometheus-stack
   - name: kubeflow-trainer
+  - name: nfd
   - name: nvidia-dra-driver-gpu
   - name: nvsentinel
   - name: prometheus-adapter
@@ -54,6 +55,7 @@ deploymentOrder:
   - cert-manager
   - kube-prometheus-stack
   - k8s-ephemeral-storage-metrics
+  - nfd
   - prometheus-adapter
   - skyhook-operator
   - skyhook-customizations

--- a/tests/chainsaw/cli/cuj1-training/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/cuj1-training/chainsaw-test.yaml
@@ -126,6 +126,19 @@ spec:
                 --file ./assert-bundle-scheduling.yaml \
                 --no-color --timeout 5s
 
+    - name: assert-bundle-scheduling-nfd
+      description: Verify standalone nfd values.yaml has scheduling for master/gc/worker.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-cuj1-training"
+              printf 'apiVersion: helm/v1\nkind: Values\n' > "${WORK}/nfd-values.yaml"
+              sed '/^---$/d' "${WORK}/bundle/nfd/values.yaml" >> "${WORK}/nfd-values.yaml"
+              chainsaw assert \
+                --resource "${WORK}/nfd-values.yaml" \
+                --file ./assert-bundle-scheduling-nfd.yaml \
+                --no-color --timeout 5s
+
     # ── Step 4: Deploy script validation ─────────────────────────────
     - name: assert-deploy-script
       description: Verify deploy.sh exists, is executable, and has correct shebang.


### PR DESCRIPTION
## Summary

- Extract Node Feature Discovery from gpu-operator's sub-chart into a standalone shared component
- Both gpu-operator and network-operator now depend on this shared NFD instance via `dependencyRefs`
- Network-operator gains NIC labeling via `NodeFeatureRule` CR (`deployNodeFeatureRules: true`)
- NFD becomes a base-level component — every recipe inherits it automatically

## Changes

| Area | Change |
|------|--------|
| `recipes/registry.yaml` | Add `nfd` component with helm config, healthCheck, nodeScheduling; remove NFD paths from gpu-operator |
| `recipes/components/nfd/values.yaml` | New file — Master + Worker + GC enabled, TopologyUpdater off |
| `recipes/overlays/base.yaml` | Add `nfd` componentRef before cert-manager |
| `recipes/overlays/*.yaml` | Add `nfd` to gpu-operator/network-operator `dependencyRefs` on every overlay that re-declares them (including `rtx-pro-6000-lke-{inference,training}`) |
| `recipes/components/gpu-operator/values.yaml` | `nfd.enabled: false` (disable sub-chart) |
| `recipes/components/network-operator/values.yaml` | `nfd.deployNodeFeatureRules: true` |
| `recipes/overlays/kind.yaml` | Remove `nfd.enabled: true` override (no longer needed) |
| `recipes/checks/nfd/health-check.yaml` | Chainsaw health check: Master Deployment + Worker DaemonSet + GC Deployment + pod phases |

## Design

Follows the existing cert-manager pattern — purely declarative, no Go code changes. NFD deploys to `node-feature-discovery` namespace. Worker DaemonSet runs on **all nodes** (excluded from accelerated nodeSelector) so it discovers hardware features everywhere.

**Resolved deployment order** (from `aicr query --selector deploymentOrder`): cert-manager → kube-prometheus-stack → k8s-ephemeral-storage-metrics → **nfd** → gpu-operator → kai-scheduler → … nfd and cert-manager are independent components; the `dependencyRefs` on gpu-operator/network-operator only require nfd to be up before those consumers start.

## Verification

- [x] `make test` — all packages pass with race detector (72.5% coverage)
- [x] `make lint` (golangci-lint v2.10.1) — 0 Go issues
- [x] `make build` — builds successfully
- [x] Recipe resolution: NFD appears in all resolved recipes
- [x] `aicr query` confirms `gpu-operator.values.nfd.enabled: false`
- [x] `aicr query` confirms `network-operator.values.nfd.deployNodeFeatureRules: true`
- [x] `aicr query` confirms `nfd ∈ gpu-operator.dependencyRefs` for `rtx-pro-6000-lke-{inference,training}`
- [x] gpu-operator and network-operator both have `nfd` in dependencyRefs

## Related

Track B of NFD Adoption (Track A — NFD snapshot enrichment — completed 2026-04-08).
