### PR TITLE
fix(bundler): resolve ArgoCD RepoURL placeholder in child applications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,27 @@ slog.Error("operation failed", "error", err, "component", "gpu-collector")
 
 **Note:** A component must have either `helm` OR `kustomize` configuration, not both.
 
+**Using mixins for shared OS/platform content:**
+```yaml
+# Leaf overlay referencing mixins instead of duplicating content
+spec:
+  base: h100-eks-ubuntu-training
+  mixins:
+    - os-ubuntu          # Ubuntu constraints (defined once in recipes/mixins/)
+    - platform-kubeflow  # kubeflow-trainer component (defined once in recipes/mixins/)
+  criteria:
+    service: eks
+    accelerator: h100
+    os: ubuntu
+    intent: training
+    platform: kubeflow
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+```
+
+Mixins carry only `constraints` and `componentRefs` — no `criteria`, `base`, `mixins`, or `validation`. They live in `recipes/mixins/` with `kind: RecipeMixin`.
+
 ## Error Wrapping Rules
 
 **Never return bare errors.** Every `return err` must wrap with context:
@@ -467,6 +488,7 @@ ${AICR_BIN} validate -r recipe.yaml -s snapshot.yaml --no-cluster
 | `.settings.yaml` | Project settings: tool versions, quality thresholds, build/test config (single source of truth) |
 | `recipes/registry.yaml` | Declarative component configuration |
 | `recipes/overlays/*.yaml` | Recipe overlay definitions |
+| `recipes/mixins/*.yaml` | Composable mixin fragments (OS constraints, platform components) |
 | `recipes/components/*/values.yaml` | Component Helm values |
 | `api/aicr/v1/server.yaml` | OpenAPI spec |
 | `.goreleaser.yaml` | Release configuration |

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -365,6 +365,7 @@ func (b *DefaultBundler) makeArgoCD(ctx context.Context, recipeResult *recipe.Re
 		ComponentValues:  componentValues,
 		Version:          b.Config.Version(),
 		RepoURL:          b.Config.RepoURL(),
+		TargetRevision:   b.Config.TargetRevision(),
 		IncludeChecksums: b.Config.IncludeChecksums(),
 	}
 

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -101,6 +101,9 @@ type Config struct {
 	// repoURL specifies the Git repository URL for ArgoCD applications.
 	repoURL string
 
+	// targetRevision specifies the target revision for the ArgoCD repo (default: "main").
+	targetRevision string
+
 	// workloadGateTaint specifies the taint for skyhook-operator runtime required feature.
 	workloadGateTaint *corev1.Taint
 
@@ -207,6 +210,11 @@ func (c *Config) Deployer() DeployerType {
 // RepoURL returns the Git repository URL for ArgoCD applications.
 func (c *Config) RepoURL() string {
 	return c.repoURL
+}
+
+// TargetRevision returns the target revision for the ArgoCD repo.
+func (c *Config) TargetRevision() string {
+	return c.targetRevision
 }
 
 // WorkloadGateTaint returns a copy of the workload gate taint.
@@ -359,6 +367,13 @@ func WithDeployer(deployer DeployerType) Option {
 func WithRepoURL(repoURL string) Option {
 	return func(c *Config) {
 		c.repoURL = repoURL
+	}
+}
+
+// WithTargetRevision sets the target revision for the ArgoCD repo.
+func WithTargetRevision(targetRevision string) Option {
+	return func(c *Config) {
+		c.targetRevision = targetRevision
 	}
 }
 

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -415,6 +415,20 @@ func TestDeployerOptions(t *testing.T) {
 			t.Errorf("RepoURL() = %s, want empty string", cfg.RepoURL())
 		}
 	})
+
+	t.Run("WithTargetRevision sets target revision", func(t *testing.T) {
+		cfg := NewConfig(WithTargetRevision("v1.0.0"))
+		if cfg.TargetRevision() != "v1.0.0" {
+			t.Errorf("TargetRevision() = %s, want v1.0.0", cfg.TargetRevision())
+		}
+	})
+
+	t.Run("default TargetRevision is empty", func(t *testing.T) {
+		cfg := NewConfig()
+		if cfg.TargetRevision() != "" {
+			t.Errorf("TargetRevision() = %s, want empty string", cfg.TargetRevision())
+		}
+	})
 }
 
 func TestParseValueOverrides(t *testing.T) {

--- a/pkg/bundler/deployer/argocd/argocd.go
+++ b/pkg/bundler/deployer/argocd/argocd.go
@@ -40,15 +40,17 @@ var readmeTemplate string
 
 // ApplicationData contains data for rendering an ArgoCD Application.
 type ApplicationData struct {
-	Name        string
-	Namespace   string
-	Repository  string
-	Chart       string
-	Version     string
-	SyncWave    int
-	IsKustomize bool   // True when the component uses Kustomize instead of Helm
-	Tag         string // Git ref for Kustomize components (tag, branch, or commit)
-	Path        string // Path within the repository to the kustomization
+	Name           string
+	Namespace      string
+	Repository     string
+	Chart          string
+	Version        string
+	SyncWave       int
+	IsKustomize    bool   // True when the component uses Kustomize instead of Helm
+	Tag            string // Git ref for Kustomize components (tag, branch, or commit)
+	Path           string // Path within the repository to the kustomization
+	RepoURL        string // Values repo URL for multi-source Helm apps
+	TargetRevision string // Target revision for values repo
 }
 
 // AppOfAppsData contains data for rendering the App of Apps manifest.
@@ -80,6 +82,9 @@ type GeneratorInput struct {
 	// If empty, a placeholder URL will be used.
 	RepoURL string
 
+	// TargetRevision is the target revision for the repo (default: "main").
+	TargetRevision string
+
 	// IncludeChecksums indicates whether to generate a checksums.txt file.
 	IncludeChecksums bool
 }
@@ -110,6 +115,20 @@ func NewGenerator() *Generator {
 	return &Generator{}
 }
 
+// resolveRepoSettings returns the effective repoURL and targetRevision,
+// applying defaults when the input values are empty.
+func resolveRepoSettings(input *GeneratorInput) (repoURL, targetRevision string) {
+	repoURL = input.RepoURL
+	if repoURL == "" {
+		repoURL = "https://github.com/YOUR-ORG/YOUR-REPO.git"
+	}
+	targetRevision = input.TargetRevision
+	if targetRevision == "" {
+		targetRevision = "main"
+	}
+	return repoURL, targetRevision
+}
+
 // Generate creates ArgoCD Applications from the given input.
 func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputDir string) (*GeneratorOutput, error) {
 	start := time.Now()
@@ -127,6 +146,8 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to create output directory", err)
 	}
+
+	repoURL, targetRevision := resolveRepoSettings(input)
 
 	// Sort components by deployment order
 	components := shared.SortComponentRefsByDeploymentOrder(
@@ -150,15 +171,17 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		}
 
 		appData := ApplicationData{
-			Name:        comp.Name,
-			Namespace:   comp.Namespace,
-			Repository:  comp.Source,
-			Chart:       chartName,
-			Version:     shared.NormalizeVersion(comp.Version),
-			SyncWave:    i, // Use index as sync wave
-			IsKustomize: isKustomize,
-			Tag:         comp.Tag,
-			Path:        comp.Path,
+			Name:           comp.Name,
+			Namespace:      comp.Namespace,
+			Repository:     comp.Source,
+			Chart:          chartName,
+			Version:        shared.NormalizeVersion(comp.Version),
+			SyncWave:       i, // Use index as sync wave
+			IsKustomize:    isKustomize,
+			Tag:            comp.Tag,
+			Path:           comp.Path,
+			RepoURL:        repoURL,
+			TargetRevision: targetRevision,
 		}
 		appDataList = append(appDataList, appData)
 	}
@@ -206,13 +229,9 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	}
 
 	// Generate app-of-apps.yaml
-	repoURL := input.RepoURL
-	if repoURL == "" {
-		repoURL = "https://github.com/YOUR-ORG/YOUR-REPO.git"
-	}
 	appOfAppsData := AppOfAppsData{
 		RepoURL:        repoURL,
-		TargetRevision: "main",
+		TargetRevision: targetRevision,
 		Path:           ".",
 	}
 	appOfAppsPath, appOfAppsSize, err := shared.GenerateFromTemplate(appOfAppsTemplate, appOfAppsData, outputDir, "app-of-apps.yaml")

--- a/pkg/bundler/deployer/argocd/argocd_test.go
+++ b/pkg/bundler/deployer/argocd/argocd_test.go
@@ -260,6 +260,121 @@ func TestGenerate_WithRepoURL(t *testing.T) {
 	if !strings.Contains(string(content), customRepoURL) {
 		t.Error("app-of-apps.yaml should contain custom repo URL")
 	}
+
+	// Verify child application.yaml contains custom repo URL in values source
+	gpuOperatorApp := filepath.Join(outputDir, "gpu-operator", "application.yaml")
+	appContent, err := os.ReadFile(gpuOperatorApp)
+	if err != nil {
+		t.Fatalf("Failed to read gpu-operator application.yaml: %v", err)
+	}
+	if !strings.Contains(string(appContent), customRepoURL) {
+		t.Errorf("application.yaml should contain custom repo URL %s, got:\n%s", customRepoURL, string(appContent))
+	}
+}
+
+func TestGenerate_WithOCIRepoURL(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	ociRepoURL := "nvcr.io/foo/aicr-bundles"
+	ociTag := "v0.0.1"
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{
+		{
+			Name:      "gpu-operator",
+			Namespace: "gpu-operator",
+			Chart:     "gpu-operator",
+			Version:   "v25.3.3",
+			Type:      "helm",
+			Source:    "https://helm.ngc.nvidia.com/nvidia",
+		},
+	}
+
+	input := &GeneratorInput{
+		RecipeResult:    recipeResult,
+		ComponentValues: map[string]map[string]any{"gpu-operator": {}},
+		Version:         "v0.9.0",
+		RepoURL:         ociRepoURL,
+		TargetRevision:  ociTag,
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Verify app-of-apps uses OCI repo URL and tag
+	appOfApps, err := os.ReadFile(filepath.Join(outputDir, "app-of-apps.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read app-of-apps.yaml: %v", err)
+	}
+	if !strings.Contains(string(appOfApps), ociRepoURL) {
+		t.Error("app-of-apps.yaml should contain OCI repo URL")
+	}
+	if !strings.Contains(string(appOfApps), ociTag) {
+		t.Error("app-of-apps.yaml should contain OCI tag as targetRevision")
+	}
+
+	// Verify child application uses OCI repo URL and tag
+	gpuApp, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "application.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read gpu-operator application.yaml: %v", err)
+	}
+	gpuAppStr := string(gpuApp)
+	if !strings.Contains(gpuAppStr, ociRepoURL) {
+		t.Errorf("application.yaml should contain OCI repo URL, got:\n%s", gpuAppStr)
+	}
+	if !strings.Contains(gpuAppStr, ociTag) {
+		t.Errorf("application.yaml should contain OCI tag as targetRevision, got:\n%s", gpuAppStr)
+	}
+	if strings.Contains(gpuAppStr, "{{ .RepoURL }}") {
+		t.Error("application.yaml should not contain literal {{ .RepoURL }} placeholder")
+	}
+}
+
+func TestGenerate_DefaultRepoURL_InChildApplications(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{
+		{
+			Name:      "gpu-operator",
+			Namespace: "gpu-operator",
+			Chart:     "gpu-operator",
+			Version:   "v25.3.3",
+			Type:      "helm",
+			Source:    "https://helm.ngc.nvidia.com/nvidia",
+		},
+	}
+
+	input := &GeneratorInput{
+		RecipeResult:    recipeResult,
+		ComponentValues: map[string]map[string]any{"gpu-operator": {}},
+		Version:         "v0.9.0",
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	gpuApp, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "application.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read application.yaml: %v", err)
+	}
+	gpuAppStr := string(gpuApp)
+	if !strings.Contains(gpuAppStr, "YOUR-ORG/YOUR-REPO") {
+		t.Errorf("application.yaml should contain placeholder URL, got:\n%s", gpuAppStr)
+	}
+	if strings.Contains(gpuAppStr, "{{ .RepoURL }}") {
+		t.Error("application.yaml should not contain literal {{ .RepoURL }} placeholder")
+	}
 }
 
 func TestGenerate_WithChecksums(t *testing.T) {

--- a/pkg/bundler/deployer/argocd/templates/application.yaml.tmpl
+++ b/pkg/bundler/deployer/argocd/templates/application.yaml.tmpl
@@ -20,8 +20,8 @@ spec:
       helm:
         valueFiles:
           - $values/{{ .Name }}/values.yaml
-    - repoURL: '{{ `{{ .RepoURL }}` }}'
-      targetRevision: main
+    - repoURL: '{{ .RepoURL }}'
+      targetRevision: {{ .TargetRevision }}
       ref: values
 {{- end }}
   destination:

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -52,6 +52,7 @@ type bundleCmdOptions struct {
 	workloadGateTaint          *corev1.Taint
 	workloadSelector           map[string]string
 	estimatedNodeCount         int
+	targetRevision             string
 
 	// attest enables bundle attestation and binary verification.
 	attest bool
@@ -136,6 +137,17 @@ func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
 			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to resolve output path: "+ref.LocalPath, absErr)
 		}
 		opts.outputDir = absOut
+	}
+
+	// When using ArgoCD deployer with OCI output and no explicit --repo,
+	// auto-populate repoURL from the OCI reference (issue #519).
+	if opts.deployer == config.DeployerArgoCD && opts.ociRef != nil && opts.repoURL == "" {
+		opts.repoURL = opts.ociRef.Registry + "/" + opts.ociRef.Repository
+	}
+
+	// Derive target revision: use OCI tag when available
+	if opts.ociRef != nil && opts.ociRef.Tag != "" {
+		opts.targetRevision = opts.ociRef.Tag
 	}
 
 	// Parse value overrides from --set flags
@@ -394,6 +406,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		config.WithVersion(version),
 		config.WithDeployer(opts.deployer),
 		config.WithRepoURL(opts.repoURL),
+		config.WithTargetRevision(opts.targetRevision),
 		config.WithAttest(opts.attest),
 		config.WithCertificateIdentityRegexp(opts.certificateIdentityRegexp),
 		config.WithValueOverrides(opts.valueOverrides),


### PR DESCRIPTION
## Summary

Closes #519

- Fix `{{ .RepoURL }}` literal placeholder in ArgoCD child `application.yaml` files. ArgoCD's directory-based app-of-apps does not template-render discovered files, so the escaped Go template string was used as a Git URL, causing `ComparisonError`.
- Pass actual `RepoURL` and `TargetRevision` through `ApplicationData` to each child application template.
- Auto-derive `RepoURL` and `TargetRevision` from OCI reference when using `--deployer argocd` with OCI output (`-o oci://...`), making `--repo` flag optional in that case.

## Test plan

- [x] Existing ArgoCD deployer tests pass with updated assertions
- [x] New test: OCI-style RepoURL with custom TargetRevision propagates to both app-of-apps and child applications
- [x] New test: default placeholder URL propagates to child applications (no literal `{{ .RepoURL }}`)
- [x] New test: config `WithTargetRevision` getter/option
- [x] `make lint` passes
- [x] Manual test: `aicr bundle --recipe recipe.yaml --deployer argocd --output oci://...` generates correct child application.yaml with OCI repo URL and tag