### PR TITLE
fix(recipe): scope mixin fallback to affected candidates

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -194,6 +194,15 @@ paths:
                         - eks
                         - eks-training
                         - gb200-eks-training
+                      excludedOverlays:
+                        - name: h100-eks-ubuntu-training
+                          reason: mixin-constraint-failed
+                      constraintWarnings:
+                        - overlay: h100-eks-ubuntu-training
+                          constraint: OS.sysctl./proc/sys/kernel/osrelease
+                          expected: ">= 6.8"
+                          actual: "5.15.0"
+                          reason: "mixin-constraint-failed: expected >= 6.8, got 5.15.0"
                     criteria:
                       service: eks
                       accelerator: gb200
@@ -890,6 +899,15 @@ paths:
                       - eks
                       - eks-training
                       - gb200-eks-training
+                    excludedOverlays:
+                      - name: h100-eks-ubuntu-training
+                        reason: mixin-constraint-failed
+                    constraintWarnings:
+                      - overlay: h100-eks-ubuntu-training
+                        constraint: OS.sysctl./proc/sys/kernel/osrelease
+                        expected: ">= 6.8"
+                        actual: "5.15.0"
+                        reason: "mixin-constraint-failed: expected >= 6.8, got 5.15.0"
                   criteria:
                     service: eks
                     accelerator: gb200
@@ -1289,6 +1307,45 @@ components:
               items:
                 type: string
               description: List of overlay criteria that were applied
+            excludedOverlays:
+              type: array
+              description: Optional list of matching overlays excluded from the final recipe
+              items:
+                type: object
+                required: [name]
+                properties:
+                  name:
+                    type: string
+                    description: Name of the excluded overlay
+                  reason:
+                    type: string
+                    description: >
+                      Machine-readable reason for exclusion. API-generated responses
+                      populate this field; legacy stored recipes accepted for backward
+                      compatibility may omit it when deserialized.
+                    enum: [constraint-failed, mixin-constraint-failed]
+            constraintWarnings:
+              type: array
+              description: Optional details about failed constraint evaluations for excluded overlays
+              items:
+                type: object
+                required: [overlay, constraint, expected, reason]
+                properties:
+                  overlay:
+                    type: string
+                    description: Overlay that was excluded
+                  constraint:
+                    type: string
+                    description: Constraint name that failed evaluation
+                  expected:
+                    type: string
+                    description: Expected constraint value
+                  actual:
+                    type: string
+                    description: Actual evaluated value when available
+                  reason:
+                    type: string
+                    description: Human-readable explanation of the failure
         criteria:
           $ref: "#/components/schemas/Criteria"
           description: Original criteria parameters

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -368,6 +368,21 @@ spec:
       "eks",
       "eks-training",
       "gb200-eks-training"
+    ],
+    "excludedOverlays": [
+      {
+        "name": "h100-eks-ubuntu-training",
+        "reason": "mixin-constraint-failed"
+      }
+    ],
+    "constraintWarnings": [
+      {
+        "overlay": "h100-eks-ubuntu-training",
+        "constraint": "OS.sysctl./proc/sys/kernel/osrelease",
+        "expected": ">= 6.8",
+        "actual": "5.15.0",
+        "reason": "mixin-constraint-failed: expected >= 6.8, got 5.15.0"
+      }
     ]
   },
   "criteria": {
@@ -390,6 +405,8 @@ spec:
   }
 }
 ```
+
+`metadata.excludedOverlays` is optional. When present, it contains structured `{name, reason}` entries so API consumers can distinguish direct constraint failures from post-compose mixin fallback.
 
 **Error Response**: 400 Bad Request
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -233,6 +233,21 @@ Same as GET /v1/recipe - returns a recipe JSON response.
       "eks",
       "eks-training",
       "gb200-eks-training"
+    ],
+    "excludedOverlays": [
+      {
+        "name": "h100-eks-ubuntu-training",
+        "reason": "mixin-constraint-failed"
+      }
+    ],
+    "constraintWarnings": [
+      {
+        "overlay": "h100-eks-ubuntu-training",
+        "constraint": "OS.sysctl./proc/sys/kernel/osrelease",
+        "expected": ">= 6.8",
+        "actual": "5.15.0",
+        "reason": "mixin-constraint-failed: expected >= 6.8, got 5.15.0"
+      }
     ]
   },
   "criteria": {
@@ -264,6 +279,8 @@ Same as GET /v1/recipe - returns a recipe JSON response.
   }
 }
 ```
+
+`metadata.excludedOverlays` is optional. When present, each entry includes the overlay `name` and a machine-readable `reason` such as `constraint-failed` or `mixin-constraint-failed`.
 
 ---
 

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -1047,7 +1047,7 @@ func createKustomizeRecipeResult() *recipe.RecipeResult {
 		Metadata: struct {
 			Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
 			AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
-			ExcludedOverlays   []string                   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+			ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
 			ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
 		}{
 			Version: "v0.1.0",
@@ -1073,7 +1073,7 @@ func createMixedRecipeResult() *recipe.RecipeResult {
 		Metadata: struct {
 			Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
 			AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
-			ExcludedOverlays   []string                   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+			ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
 			ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
 		}{
 			Version: "v0.1.0",
@@ -1112,7 +1112,7 @@ func createTestRecipeResult() *recipe.RecipeResult {
 		Metadata: struct {
 			Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
 			AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
-			ExcludedOverlays   []string                   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+			ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
 			ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
 		}{
 			Version: "v0.1.0",
@@ -1149,7 +1149,7 @@ func createEmptyRecipeResult() *recipe.RecipeResult {
 		Metadata: struct {
 			Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
 			AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
-			ExcludedOverlays   []string                   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+			ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
 			ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
 		}{
 			Version: "v0.1.0",

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -16,6 +16,7 @@
 package recipe
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -23,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"gopkg.in/yaml.v3"
 )
 
 // RecipeMetadataKind is the kind value for RecipeMetadata resources.
@@ -335,6 +337,67 @@ type ConstraintWarning struct {
 	Reason string `json:"reason" yaml:"reason"`
 }
 
+// ExcludedOverlayReason indicates why a matching overlay was dropped.
+type ExcludedOverlayReason string
+
+const (
+	// ExcludedOverlayReasonConstraintFailed is used when an overlay's own
+	// constraints fail pre-merge evaluation.
+	ExcludedOverlayReasonConstraintFailed ExcludedOverlayReason = "constraint-failed"
+	// ExcludedOverlayReasonMixinConstraintFailed is used when a candidate chain
+	// is excluded during post-compose mixin constraint evaluation.
+	ExcludedOverlayReasonMixinConstraintFailed ExcludedOverlayReason = "mixin-constraint-failed"
+)
+
+// ExcludedOverlay records a matching overlay that was excluded from the final
+// recipe result, along with a machine-readable reason.
+type ExcludedOverlay struct {
+	// Name is the excluded overlay name.
+	Name string `json:"name" yaml:"name"`
+
+	// Reason identifies why the overlay was excluded.
+	Reason ExcludedOverlayReason `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+// UnmarshalYAML accepts both the legacy scalar string form:
+//   - excludedOverlays: ["overlay-name"]
+//
+// and the current object form:
+//   - excludedOverlays: [{name: overlay-name, reason: constraint-failed}]
+func (e *ExcludedOverlay) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		e.Name = node.Value
+		e.Reason = ""
+		return nil
+	}
+
+	type rawExcludedOverlay ExcludedOverlay
+	var raw rawExcludedOverlay
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	*e = ExcludedOverlay(raw)
+	return nil
+}
+
+// UnmarshalJSON accepts both the legacy string form and the current object form.
+func (e *ExcludedOverlay) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err == nil {
+		e.Name = name
+		e.Reason = ""
+		return nil
+	}
+
+	type rawExcludedOverlay ExcludedOverlay
+	var raw rawExcludedOverlay
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*e = ExcludedOverlay(raw)
+	return nil
+}
+
 // RecipeResult represents the final merged recipe output.
 type RecipeResult struct {
 	// Kind is always "RecipeResult".
@@ -352,9 +415,9 @@ type RecipeResult struct {
 		AppliedOverlays []string `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
 
 		// ExcludedOverlays lists overlays that matched criteria but were excluded
-		// due to failing constraint validation against the snapshot.
+		// from the final recipe, along with the machine-readable exclusion reason.
 		// Only populated when a snapshot is provided during recipe generation.
-		ExcludedOverlays []string `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+		ExcludedOverlays []ExcludedOverlay `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
 
 		// ConstraintWarnings contains details about why specific overlays were excluded.
 		// Helps users understand why certain environment-specific configurations

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -399,10 +399,10 @@ type mixinEvalResult struct {
 	// Failed is true if any mixin constraint failed evaluation.
 	Failed bool
 	// ExcludedOverlays are the overlays excluded due to the failure.
-	ExcludedOverlays []string
+	ExcludedOverlays []ExcludedOverlay
 	// Warnings are the constraint warnings for the failing constraints.
 	Warnings []ConstraintWarning
-	// Spec is the rebuilt spec (without mixin-bearing chains) if failed, or nil if all passed.
+	// Spec is the rebuilt spec (without the failed candidate chains) if failed, or nil if all passed.
 	Spec *RecipeMetadataSpec
 	// AppliedOverlays is the surviving applied overlays if failed.
 	AppliedOverlays []string
@@ -413,149 +413,148 @@ type mixinEvalResult struct {
 // This runs after mergeMixins so that constraints moved from inline overlay
 // definitions to mixins are still validated against the snapshot.
 //
-// If any mixin constraint fails, only the overlay chains that contributed
-// mixins are excluded. Independent overlays (e.g., monitoring-hpa) that do
-// not declare mixins are preserved. This maintains the existing maximal-leaf
-// filtering behavior for non-mixin overlays.
+// If any mixin constraint fails, only the candidate chains that contributed the
+// failing mixin constraints are excluded. Independent overlays
+// (e.g., monitoring-hpa) are preserved. This maintains the existing
+// maximal-leaf filtering behavior for non-mixin overlays.
 func (s *MetadataStore) evaluateMixinConstraints(
 	mergedSpec *RecipeMetadataSpec,
 	evaluator ConstraintEvaluatorFunc,
 	mixinConstraintNames map[string]bool,
-	appliedOverlays []string,
-) mixinEvalResult {
+	candidateOverlays []string,
+) (mixinEvalResult, error) {
 
 	if evaluator == nil || len(mixinConstraintNames) == 0 {
-		return mixinEvalResult{}
+		return mixinEvalResult{}, nil
+	}
+
+	constraintCandidates, err := s.buildMixinConstraintCandidateIndex(candidateOverlays)
+	if err != nil {
+		return mixinEvalResult{}, err
 	}
 
 	var failedConstraints []ConstraintWarning
+	failedCandidates := make(map[string]bool)
 	for _, constraint := range mergedSpec.Constraints {
 		if !mixinConstraintNames[constraint.Name] {
 			continue // already evaluated per-overlay
 		}
 		result := evaluator(constraint)
 		if !result.Passed {
-			// Identify the overlay that declared the mixin contributing this constraint.
-			declaringOverlay := s.findMixinDeclaringOverlay(constraint.Name, appliedOverlays)
-			warning := ConstraintWarning{
-				Overlay:    declaringOverlay,
-				Constraint: constraint.Name,
-				Expected:   constraint.Value,
-				Actual:     result.Actual,
-				Reason:     "mixin constraint failed post-compose evaluation",
+			affectedCandidates := constraintCandidates[constraint.Name]
+			if len(affectedCandidates) == 0 {
+				return mixinEvalResult{}, aicrerrors.NewWithContext(
+					aicrerrors.ErrCodeInternal,
+					"failed to map mixin constraint to candidate chain",
+					map[string]any{
+						"constraint":      constraint.Name,
+						"candidate_count": len(candidateOverlays),
+					},
+				)
 			}
-			if result.Error != nil {
-				warning.Reason = result.Error.Error()
+			for _, candidate := range affectedCandidates {
+				failedCandidates[candidate] = true
+				failedConstraints = append(failedConstraints, ConstraintWarning{
+					Overlay:    candidate,
+					Constraint: constraint.Name,
+					Expected:   constraint.Value,
+					Actual:     result.Actual,
+					Reason:     buildMixinConstraintWarningReason(constraint, result),
+				})
 			}
-			failedConstraints = append(failedConstraints, warning)
 		}
 	}
 
 	if len(failedConstraints) == 0 {
-		return mixinEvalResult{}
+		return mixinEvalResult{}, nil
 	}
 
-	// Identify which applied overlays declared mixins and which are in their
-	// inheritance chains. The mixin-declaring leaves and their ancestors are
-	// removed from the rebuilt spec. Only the leaf candidates themselves are
-	// reported in ExcludedOverlays (ancestors are shared infrastructure, not
-	// rejected candidates).
-	mixinDeclarers := make(map[string]bool)    // leaf overlays that declared mixins
-	mixinChainMembers := make(map[string]bool) // declarers + their ancestors (for spec rebuild)
-	for _, name := range appliedOverlays {
-		if name == baseRecipeName {
+	var excluded []ExcludedOverlay
+	survivingCandidates := make([]*RecipeMetadata, 0, len(candidateOverlays))
+	for _, name := range candidateOverlays {
+		if failedCandidates[name] {
+			excluded = append(excluded, ExcludedOverlay{
+				Name:   name,
+				Reason: ExcludedOverlayReasonMixinConstraintFailed,
+			})
 			continue
 		}
 		overlay, exists := s.Overlays[name]
 		if !exists {
-			continue
+			return mixinEvalResult{}, aicrerrors.New(
+				aicrerrors.ErrCodeNotFound,
+				fmt.Sprintf("overlay %q not found during mixin fallback rebuild", name),
+			)
 		}
-		if len(overlay.Spec.Mixins) > 0 {
-			mixinDeclarers[name] = true
-			mixinChainMembers[name] = true
-			s.markAncestors(name, mixinChainMembers)
-		}
+		survivingCandidates = append(survivingCandidates, overlay)
 	}
 
-	var excluded []string
-	var surviving []string
-	surviving = append(surviving, baseRecipeName)
-	for _, name := range appliedOverlays {
-		if name == baseRecipeName {
-			continue
-		}
-		if mixinChainMembers[name] {
-			// Only report leaf candidates in ExcludedOverlays, not ancestors
-			if mixinDeclarers[name] {
-				excluded = append(excluded, name)
-			}
-		} else {
-			surviving = append(surviving, name)
-		}
+	// Rebuild from the surviving candidate leaves so any shared ancestors remain
+	// present when still needed by another surviving chain.
+	rebuiltSpec, survivingApplied := s.initBaseMergedSpec()
+	survivingApplied, err = s.mergeOverlayChains(survivingCandidates, &rebuiltSpec, survivingApplied)
+	if err != nil {
+		return mixinEvalResult{}, err
+	}
+	if _, err := s.mergeMixins(&rebuiltSpec); err != nil {
+		return mixinEvalResult{}, err
 	}
 
-	// Rebuild the spec from surviving overlays only
-	rebuiltSpec, _ := s.initBaseMergedSpec()
-	for _, name := range surviving {
-		if name == baseRecipeName {
-			continue
-		}
-		if overlay, exists := s.Overlays[name]; exists {
-			rebuiltSpec.Merge(&overlay.Spec)
-		}
-	}
-
-	slog.Warn("post-compose constraint evaluation failed, excluding mixin-bearing chains",
+	slog.Warn("post-compose constraint evaluation failed, excluding affected mixin chains",
 		"failed_constraints", len(failedConstraints),
 		"excluded", excluded,
-		"surviving", surviving)
+		"surviving", survivingApplied)
 
 	return mixinEvalResult{
 		Failed:           true,
 		ExcludedOverlays: excluded,
 		Warnings:         failedConstraints,
 		Spec:             &rebuiltSpec,
-		AppliedOverlays:  surviving,
-	}
+		AppliedOverlays:  survivingApplied,
+	}, nil
 }
 
-// findMixinDeclaringOverlay finds the overlay that declared the mixin
-// contributing a given constraint name.
-func (s *MetadataStore) findMixinDeclaringOverlay(constraintName string, appliedOverlays []string) string {
-	// Walk applied overlays in reverse (most specific first) to find
-	// which overlay declared a mixin that contains this constraint.
-	for i := len(appliedOverlays) - 1; i >= 0; i-- {
-		name := appliedOverlays[i]
-		overlay, exists := s.Overlays[name]
-		if !exists {
-			continue
+func buildMixinConstraintWarningReason(constraint Constraint, result ConstraintEvalResult) string {
+	if result.Error != nil {
+		return fmt.Sprintf("mixin-constraint-failed: %s", result.Error.Error())
+	}
+	return fmt.Sprintf("mixin-constraint-failed: expected %s, got %s", constraint.Value, result.Actual)
+}
+
+// buildMixinConstraintCandidateIndex maps mixin-contributed constraint names to
+// the candidate leaf overlays whose inheritance chains contribute them.
+func (s *MetadataStore) buildMixinConstraintCandidateIndex(candidateOverlays []string) (map[string][]string, error) {
+	index := make(map[string][]string)
+	for _, candidate := range candidateOverlays {
+		chain, err := s.resolveInheritanceChain(candidate)
+		if err != nil {
+			return nil, aicrerrors.WrapWithContext(
+				aicrerrors.ErrCodeInvalidRequest,
+				"failed to resolve candidate chain for mixin constraint evaluation",
+				err,
+				map[string]any{"overlay": candidate},
+			)
 		}
-		for _, mixinName := range overlay.Spec.Mixins {
-			mixin, mExists := s.Mixins[mixinName]
-			if !mExists {
-				continue
-			}
-			for _, c := range mixin.Spec.Constraints {
-				if c.Name == constraintName {
-					return name
+
+		seen := make(map[string]bool)
+		for _, recipe := range chain {
+			for _, mixinName := range recipe.Spec.Mixins {
+				mixin, exists := s.Mixins[mixinName]
+				if !exists {
+					continue
+				}
+				for _, constraint := range mixin.Spec.Constraints {
+					if seen[constraint.Name] {
+						continue
+					}
+					index[constraint.Name] = append(index[constraint.Name], candidate)
+					seen[constraint.Name] = true
 				}
 			}
 		}
 	}
-	return "post-compose" // fallback if mapping not found
-}
 
-// markAncestors walks the inheritance chain of an overlay and marks all ancestors.
-func (s *MetadataStore) markAncestors(name string, marked map[string]bool) {
-	overlay, exists := s.Overlays[name]
-	if !exists || overlay.Spec.Base == "" {
-		return
-	}
-	ancestor := overlay.Spec.Base
-	if !marked[ancestor] {
-		marked[ancestor] = true
-		s.markAncestors(ancestor, marked)
-	}
+	return index, nil
 }
 
 // initBaseMergedSpec creates a copy of the base spec for overlay merging.
@@ -696,7 +695,7 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 	overlays := s.FindMatchingOverlays(criteria)
 
 	var filteredOverlays []*RecipeMetadata
-	var excludedOverlays []string
+	var excludedOverlays []ExcludedOverlay
 	var constraintWarnings []ConstraintWarning
 
 	for _, overlay := range overlays {
@@ -710,7 +709,10 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 			slog.Debug("overlay passed all constraints",
 				"overlay", overlay.Metadata.Name)
 		} else {
-			excludedOverlays = append(excludedOverlays, overlay.Metadata.Name)
+			excludedOverlays = append(excludedOverlays, ExcludedOverlay{
+				Name:   overlay.Metadata.Name,
+				Reason: ExcludedOverlayReasonConstraintFailed,
+			})
 			constraintWarnings = append(constraintWarnings, warnings...)
 			slog.Info("excluding overlay due to constraint failures",
 				"overlay", overlay.Metadata.Name,
@@ -736,7 +738,14 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 	// constraints are only present after mergeMixins. Without this post-compose
 	// evaluation, a mixin constraint (e.g., kernel >= 6.8 from os-ubuntu) could
 	// fail against the snapshot but the candidate would still be selected.
-	mixinResult := s.evaluateMixinConstraints(&mergedSpec, evaluator, mixinConstraintNames, appliedOverlays)
+	candidateOverlays := make([]string, 0, len(filteredOverlays))
+	for _, overlay := range filteredOverlays {
+		candidateOverlays = append(candidateOverlays, overlay.Metadata.Name)
+	}
+	mixinResult, err := s.evaluateMixinConstraints(&mergedSpec, evaluator, mixinConstraintNames, candidateOverlays)
+	if err != nil {
+		return nil, err
+	}
 	if mixinResult.Failed {
 		excludedOverlays = append(excludedOverlays, mixinResult.ExcludedOverlays...)
 		constraintWarnings = append(constraintWarnings, mixinResult.Warnings...)

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -17,10 +17,13 @@ package recipe
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,6 +32,7 @@ const (
 	testOverlayEKS         = "eks"
 	testK8sVersionConstant = "K8s.server.version"
 	testOverlayEKSTraning  = "eks-training"
+	testOverlaySharedTrain = "shared-training"
 )
 
 func TestMetadataStore_GetValuesFile(t *testing.T) {
@@ -642,19 +646,22 @@ func TestEvaluatorFailingLeafExcludesCandidate(t *testing.T) {
 		t.Fatal("expected at least one excluded overlay")
 	}
 
-	excluded := make(map[string]bool)
-	for _, name := range result.Metadata.ExcludedOverlays {
-		excluded[name] = true
+	excluded := make(map[string]ExcludedOverlayReason)
+	for _, overlay := range result.Metadata.ExcludedOverlays {
+		excluded[overlay.Name] = overlay.Reason
 	}
 
 	// The leaf should be excluded
-	if !excluded["h100-eks-ubuntu-training"] {
+	if _, ok := excluded["h100-eks-ubuntu-training"]; !ok {
 		t.Errorf("expected h100-eks-ubuntu-training in ExcludedOverlays, got %v", result.Metadata.ExcludedOverlays)
+	}
+	if excluded["h100-eks-ubuntu-training"] != ExcludedOverlayReasonConstraintFailed {
+		t.Errorf("expected constraint-failed reason, got %q", excluded["h100-eks-ubuntu-training"])
 	}
 
 	// Ancestors should NOT appear in ExcludedOverlays (they were never candidates)
 	for _, ancestor := range []string{"eks", testOverlayEKSTraning, "h100-eks-training"} {
-		if excluded[ancestor] {
+		if _, ok := excluded[ancestor]; ok {
 			t.Errorf("ancestor %q should not appear in ExcludedOverlays (not a candidate)", ancestor)
 		}
 	}
@@ -725,6 +732,13 @@ func TestMixinConstraintFailureExcludesCandidate(t *testing.T) {
 	if len(result.Metadata.ExcludedOverlays) == 0 {
 		t.Fatal("expected excluded overlays from mixin constraint failure")
 	}
+	excluded := make(map[string]ExcludedOverlayReason)
+	for _, overlay := range result.Metadata.ExcludedOverlays {
+		excluded[overlay.Name] = overlay.Reason
+	}
+	if excluded["h100-eks-ubuntu-training"] != ExcludedOverlayReasonMixinConstraintFailed {
+		t.Fatalf("expected mixin-constraint-failed reason, got %q", excluded["h100-eks-ubuntu-training"])
+	}
 
 	// Applied overlays should be base-only (plus monitoring-hpa which has no
 	// mixin constraints and passes evaluation independently)
@@ -758,6 +772,350 @@ func TestMixinConstraintFailureExcludesCandidate(t *testing.T) {
 	t.Logf("excluded: %v", result.Metadata.ExcludedOverlays)
 	t.Logf("applied: %v", result.Metadata.AppliedOverlays)
 	t.Logf("warnings: %d", len(result.Metadata.ConstraintWarnings))
+}
+
+func TestMixinConstraintFailureExcludesOnlyAffectedCandidateChain(t *testing.T) {
+	ctx := context.Background()
+
+	baseMeta := &RecipeMetadata{}
+	baseMeta.Metadata.Name = testRecipeBase
+
+	sharedTraining := &RecipeMetadata{}
+	sharedTraining.Metadata.Name = testOverlaySharedTrain
+	sharedTraining.Spec.Criteria = &Criteria{
+		Service: CriteriaServiceEKS,
+		Intent:  CriteriaIntentTraining,
+	}
+	sharedTraining.Spec.Mixins = []string{"kernel-gate"}
+
+	failingLeaf := &RecipeMetadata{}
+	failingLeaf.Metadata.Name = "h100-shared-training"
+	failingLeaf.Spec.Base = testOverlaySharedTrain
+	failingLeaf.Spec.Criteria = &Criteria{
+		Service:     CriteriaServiceEKS,
+		Accelerator: CriteriaAcceleratorH100,
+		Intent:      CriteriaIntentTraining,
+	}
+
+	independentLeaf := &RecipeMetadata{}
+	independentLeaf.Metadata.Name = "monitoring"
+	independentLeaf.Spec.Criteria = &Criteria{
+		Service: CriteriaServiceEKS,
+		Intent:  CriteriaIntentTraining,
+	}
+	independentLeaf.Spec.Mixins = []string{"monitoring-gate"}
+	independentLeaf.Spec.ComponentRefs = []ComponentRef{
+		{
+			Name:   "dcgm-exporter",
+			Type:   ComponentTypeHelm,
+			Source: "https://example.com/charts",
+			Chart:  "dcgm-exporter",
+		},
+	}
+
+	store := &MetadataStore{
+		Base: baseMeta,
+		Overlays: map[string]*RecipeMetadata{
+			testOverlaySharedTrain: sharedTraining,
+			"h100-shared-training": failingLeaf,
+			"monitoring":           independentLeaf,
+		},
+		Mixins: map[string]*RecipeMixin{
+			"kernel-gate": {
+				Kind:       RecipeMixinKind,
+				APIVersion: RecipeAPIVersion,
+				Metadata: struct {
+					Name string `json:"name" yaml:"name"`
+				}{
+					Name: "kernel-gate",
+				},
+				Spec: struct {
+					Constraints   []Constraint   `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+					ComponentRefs []ComponentRef `json:"componentRefs,omitempty" yaml:"componentRefs,omitempty"`
+				}{
+					Constraints: []Constraint{
+						{Name: "OS.kernel", Value: ">= 6.8"},
+					},
+				},
+			},
+			"monitoring-gate": {
+				Kind:       RecipeMixinKind,
+				APIVersion: RecipeAPIVersion,
+				Metadata: struct {
+					Name string `json:"name" yaml:"name"`
+				}{
+					Name: "monitoring-gate",
+				},
+				Spec: struct {
+					Constraints   []Constraint   `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+					ComponentRefs []ComponentRef `json:"componentRefs,omitempty" yaml:"componentRefs,omitempty"`
+				}{
+					Constraints: []Constraint{
+						{Name: "Monitoring.enabled", Value: "true"},
+					},
+					ComponentRefs: []ComponentRef{
+						{
+							Name:   "nvidia-dcgm-exporter",
+							Type:   ComponentTypeHelm,
+							Source: "https://example.com/charts",
+							Chart:  "nvidia-dcgm-exporter",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	criteria := &Criteria{
+		Service:     CriteriaServiceEKS,
+		Accelerator: CriteriaAcceleratorH100,
+		Intent:      CriteriaIntentTraining,
+	}
+
+	evaluator := func(c Constraint) ConstraintEvalResult {
+		switch c.Name {
+		case "OS.kernel":
+			return ConstraintEvalResult{Passed: false, Actual: "5.15"}
+		case "Monitoring.enabled":
+			return ConstraintEvalResult{Passed: true, Actual: "true"}
+		default:
+			return ConstraintEvalResult{Passed: true, Actual: "ok"}
+		}
+	}
+
+	result, err := store.BuildRecipeResultWithEvaluator(ctx, criteria, evaluator)
+	if err != nil {
+		t.Fatalf("BuildRecipeResultWithEvaluator failed: %v", err)
+	}
+
+	excluded := make(map[string]ExcludedOverlayReason)
+	for _, overlay := range result.Metadata.ExcludedOverlays {
+		excluded[overlay.Name] = overlay.Reason
+	}
+	if _, ok := excluded["h100-shared-training"]; !ok {
+		t.Fatalf("expected failed leaf in ExcludedOverlays, got %v", result.Metadata.ExcludedOverlays)
+	}
+	if excluded["h100-shared-training"] != ExcludedOverlayReasonMixinConstraintFailed {
+		t.Fatalf("failed leaf reason = %q, want %q",
+			excluded["h100-shared-training"], ExcludedOverlayReasonMixinConstraintFailed)
+	}
+	if _, ok := excluded[testOverlaySharedTrain]; ok {
+		t.Fatalf("ancestor should not appear in ExcludedOverlays, got %v", result.Metadata.ExcludedOverlays)
+	}
+	if _, ok := excluded["monitoring"]; ok {
+		t.Fatalf("independent passing leaf should not be excluded, got %v", result.Metadata.ExcludedOverlays)
+	}
+
+	applied := make(map[string]bool)
+	for _, name := range result.Metadata.AppliedOverlays {
+		applied[name] = true
+	}
+	if !applied[baseRecipeName] {
+		t.Fatal("base should always remain applied")
+	}
+	if applied[testOverlaySharedTrain] || applied["h100-shared-training"] {
+		t.Fatalf("failed candidate chain should be removed from applied overlays, got %v", result.Metadata.AppliedOverlays)
+	}
+	if !applied["monitoring"] {
+		t.Fatalf("independent passing leaf should remain applied, got %v", result.Metadata.AppliedOverlays)
+	}
+
+	foundWarning := false
+	for _, warning := range result.Metadata.ConstraintWarnings {
+		if warning.Constraint != "OS.kernel" {
+			continue
+		}
+		foundWarning = true
+		if warning.Overlay != "h100-shared-training" {
+			t.Fatalf("warning overlay = %q, want failed leaf candidate", warning.Overlay)
+		}
+		if warning.Reason != "mixin-constraint-failed: expected >= 6.8, got 5.15" {
+			t.Fatalf("warning reason = %q", warning.Reason)
+		}
+	}
+	if !foundWarning {
+		t.Fatal("expected warning for failed mixin constraint")
+	}
+
+	componentNames := make(map[string]bool)
+	for _, ref := range result.ComponentRefs {
+		componentNames[ref.Name] = true
+	}
+	if !componentNames["nvidia-dcgm-exporter"] {
+		t.Fatalf("surviving mixin component was dropped: %v", result.ComponentRefs)
+	}
+}
+
+func TestMixinConstraintFailurePreservesSharedAncestorsForSurvivingLeaf(t *testing.T) {
+	ctx := context.Background()
+
+	baseMeta := &RecipeMetadata{}
+	baseMeta.Metadata.Name = testRecipeBase
+
+	sharedTraining := &RecipeMetadata{}
+	sharedTraining.Metadata.Name = testOverlaySharedTrain
+	sharedTraining.Spec.Criteria = &Criteria{
+		Service: CriteriaServiceEKS,
+		Intent:  CriteriaIntentTraining,
+	}
+	sharedTraining.Spec.ComponentRefs = []ComponentRef{
+		{
+			Name:   "shared-component",
+			Type:   ComponentTypeHelm,
+			Source: "https://example.com/charts",
+			Chart:  "shared-component",
+		},
+	}
+
+	failingLeaf := &RecipeMetadata{}
+	failingLeaf.Metadata.Name = "leaf-a"
+	failingLeaf.Spec.Base = testOverlaySharedTrain
+	failingLeaf.Spec.Criteria = &Criteria{
+		Service:     CriteriaServiceEKS,
+		Accelerator: CriteriaAcceleratorH100,
+		Intent:      CriteriaIntentTraining,
+	}
+	failingLeaf.Spec.Mixins = []string{"failing-mixin"}
+
+	survivingLeaf := &RecipeMetadata{}
+	survivingLeaf.Metadata.Name = "leaf-b"
+	survivingLeaf.Spec.Base = testOverlaySharedTrain
+	survivingLeaf.Spec.Criteria = &Criteria{
+		Service:     CriteriaServiceEKS,
+		Accelerator: CriteriaAcceleratorAny,
+		Intent:      CriteriaIntentTraining,
+	}
+	survivingLeaf.Spec.Mixins = []string{"passing-mixin"}
+
+	store := &MetadataStore{
+		Base: baseMeta,
+		Overlays: map[string]*RecipeMetadata{
+			testOverlaySharedTrain: sharedTraining,
+			"leaf-a":               failingLeaf,
+			"leaf-b":               survivingLeaf,
+		},
+		Mixins: map[string]*RecipeMixin{
+			"failing-mixin": {
+				Kind:       RecipeMixinKind,
+				APIVersion: RecipeAPIVersion,
+				Metadata: struct {
+					Name string `json:"name" yaml:"name"`
+				}{Name: "failing-mixin"},
+				Spec: struct {
+					Constraints   []Constraint   `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+					ComponentRefs []ComponentRef `json:"componentRefs,omitempty" yaml:"componentRefs,omitempty"`
+				}{
+					Constraints: []Constraint{{Name: "GPU.ready", Value: "true"}},
+				},
+			},
+			"passing-mixin": {
+				Kind:       RecipeMixinKind,
+				APIVersion: RecipeAPIVersion,
+				Metadata: struct {
+					Name string `json:"name" yaml:"name"`
+				}{Name: "passing-mixin"},
+				Spec: struct {
+					Constraints   []Constraint   `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+					ComponentRefs []ComponentRef `json:"componentRefs,omitempty" yaml:"componentRefs,omitempty"`
+				}{
+					Constraints: []Constraint{{Name: "Monitoring.enabled", Value: "true"}},
+					ComponentRefs: []ComponentRef{{
+						Name:   "surviving-component",
+						Type:   ComponentTypeHelm,
+						Source: "https://example.com/charts",
+						Chart:  "surviving-component",
+					}},
+				},
+			},
+		},
+	}
+
+	criteria := &Criteria{
+		Service:     CriteriaServiceEKS,
+		Accelerator: CriteriaAcceleratorH100,
+		Intent:      CriteriaIntentTraining,
+	}
+
+	evaluator := func(c Constraint) ConstraintEvalResult {
+		switch c.Name {
+		case "GPU.ready":
+			return ConstraintEvalResult{Passed: false, Actual: "false"}
+		case "Monitoring.enabled":
+			return ConstraintEvalResult{Passed: true, Actual: "true"}
+		default:
+			return ConstraintEvalResult{Passed: true, Actual: "ok"}
+		}
+	}
+
+	result, err := store.BuildRecipeResultWithEvaluator(ctx, criteria, evaluator)
+	if err != nil {
+		t.Fatalf("BuildRecipeResultWithEvaluator failed: %v", err)
+	}
+
+	applied := make(map[string]bool)
+	for _, name := range result.Metadata.AppliedOverlays {
+		applied[name] = true
+	}
+	if !applied[testOverlaySharedTrain] {
+		t.Fatalf("shared ancestor should remain applied for surviving leaf, got %v", result.Metadata.AppliedOverlays)
+	}
+	if !applied["leaf-b"] {
+		t.Fatalf("surviving leaf should remain applied, got %v", result.Metadata.AppliedOverlays)
+	}
+	if applied["leaf-a"] {
+		t.Fatalf("failed leaf should be excluded, got %v", result.Metadata.AppliedOverlays)
+	}
+
+	componentNames := make(map[string]bool)
+	for _, ref := range result.ComponentRefs {
+		componentNames[ref.Name] = true
+	}
+	if !componentNames["shared-component"] {
+		t.Fatalf("shared ancestor component was lost after fallback rebuild: %v", result.ComponentRefs)
+	}
+	if !componentNames["surviving-component"] {
+		t.Fatalf("surviving leaf mixin component was lost after fallback rebuild: %v", result.ComponentRefs)
+	}
+}
+
+func TestEvaluateMixinConstraintsReturnsErrorWhenConstraintCannotBeMappedToCandidate(t *testing.T) {
+	store := &MetadataStore{
+		Overlays: map[string]*RecipeMetadata{
+			"candidate": {
+				RecipeMetadataHeader: RecipeMetadataHeader{
+					Metadata: struct {
+						Name string `json:"name" yaml:"name"`
+					}{Name: "candidate"},
+				},
+			},
+		},
+	}
+
+	result, err := store.evaluateMixinConstraints(
+		&RecipeMetadataSpec{
+			Constraints: []Constraint{
+				{Name: "OS.kernel", Value: ">= 6.8"},
+			},
+		},
+		func(_ Constraint) ConstraintEvalResult {
+			return ConstraintEvalResult{Passed: false, Actual: "5.15"}
+		},
+		map[string]bool{"OS.kernel": true},
+		[]string{"candidate"},
+	)
+	if err == nil {
+		t.Fatal("expected error when mixin constraint cannot be mapped to any candidate")
+	}
+	if result.Failed {
+		t.Fatal("expected zero-value result when mapping error occurs")
+	}
+	var structuredErr *aicrerrors.StructuredError
+	if !errors.As(err, &structuredErr) {
+		t.Fatalf("expected structured error, got %T", err)
+	}
+	if structuredErr.Code != aicrerrors.ErrCodeInternal {
+		t.Fatalf("expected INTERNAL error code, got %s", structuredErr.Code)
+	}
 }
 
 // TestMalformedMixinRejected verifies that mixin files with forbidden fields
@@ -821,6 +1179,126 @@ spec:
 			err := decoder.Decode(&mixin)
 			if err == nil {
 				t.Error("expected error for mixin with forbidden fields, got nil")
+			}
+		})
+	}
+}
+
+func TestExcludedOverlayUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ExcludedOverlay
+		wantErr  bool
+	}{
+		{
+			name:  "legacy string form",
+			input: "- overlay-a\n- overlay-b\n",
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a"},
+				{Name: "overlay-b"},
+			},
+		},
+		{
+			name:  "object form",
+			input: "- name: overlay-a\n  reason: constraint-failed\n- name: overlay-b\n  reason: mixin-constraint-failed\n",
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a", Reason: ExcludedOverlayReasonConstraintFailed},
+				{Name: "overlay-b", Reason: ExcludedOverlayReasonMixinConstraintFailed},
+			},
+		},
+		{
+			name:  "object form without reason",
+			input: "- name: overlay-a\n",
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []ExcludedOverlay
+			err := yaml.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("got %+v, want %+v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExcludedOverlayUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ExcludedOverlay
+		wantErr  bool
+	}{
+		{
+			name:  "legacy string form",
+			input: `["overlay-a","overlay-b"]`,
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a"},
+				{Name: "overlay-b"},
+			},
+		},
+		{
+			name:  "object form",
+			input: `[{"name":"overlay-a","reason":"constraint-failed"},{"name":"overlay-b","reason":"mixin-constraint-failed"}]`,
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a", Reason: ExcludedOverlayReasonConstraintFailed},
+				{Name: "overlay-b", Reason: ExcludedOverlayReasonMixinConstraintFailed},
+			},
+		},
+		{
+			name:  "object form without reason",
+			input: `[{"name":"overlay-a"}]`,
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []ExcludedOverlay
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("got %+v, want %+v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildMixinConstraintWarningReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint Constraint
+		result     ConstraintEvalResult
+		expected   string
+	}{
+		{
+			name:       "with error",
+			constraint: Constraint{Name: "kernel.version", Value: ">= 6.8"},
+			result:     ConstraintEvalResult{Passed: false, Error: errors.New("parse error")},
+			expected:   "mixin-constraint-failed: parse error",
+		},
+		{
+			name:       "without error",
+			constraint: Constraint{Name: "kernel.version", Value: ">= 6.8"},
+			result:     ConstraintEvalResult{Passed: false, Actual: "5.15"},
+			expected:   "mixin-constraint-failed: expected >= 6.8, got 5.15",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMixinConstraintWarningReason(tt.constraint, tt.result)
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
 			}
 		})
 	}

--- a/pkg/recipe/query_test.go
+++ b/pkg/recipe/query_test.go
@@ -250,6 +250,41 @@ func TestHydrateResult(t *testing.T) {
 		}
 	})
 
+	t.Run("excluded overlays include reasons", func(t *testing.T) {
+		result := &RecipeResult{
+			Kind:            "RecipeResult",
+			APIVersion:      "aicr.nvidia.com/v1alpha1",
+			DeploymentOrder: []string{},
+		}
+		result.Metadata.ExcludedOverlays = []ExcludedOverlay{
+			{Name: "eks-training", Reason: ExcludedOverlayReasonConstraintFailed},
+			{Name: "h100-eks-ubuntu-training", Reason: ExcludedOverlayReasonMixinConstraintFailed},
+		}
+
+		hydrated, err := HydrateResult(result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		metadata, ok := hydrated["metadata"].(map[string]any)
+		if !ok {
+			t.Fatal("metadata is not a map")
+		}
+		excluded, ok := metadata["excludedOverlays"].([]ExcludedOverlay)
+		if !ok {
+			t.Fatalf("excludedOverlays has type %T, want []ExcludedOverlay", metadata["excludedOverlays"])
+		}
+		if len(excluded) != 2 {
+			t.Fatalf("got %d excluded overlays, want 2", len(excluded))
+		}
+		if excluded[0].Reason != ExcludedOverlayReasonConstraintFailed {
+			t.Fatalf("first reason = %q", excluded[0].Reason)
+		}
+		if excluded[1].Reason != ExcludedOverlayReasonMixinConstraintFailed {
+			t.Fatalf("second reason = %q", excluded[1].Reason)
+		}
+	})
+
 	t.Run("nil criteria", func(t *testing.T) {
 		result := &RecipeResult{
 			Kind:       "RecipeResult",

--- a/pkg/serializer/reader_recipe_compat_test.go
+++ b/pkg/serializer/reader_recipe_compat_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serializer_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+func writeLegacyRecipeFile(t *testing.T, pattern, content string) string {
+	t.Helper()
+
+	tmpfile, err := os.CreateTemp("", pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmpfile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpfile.Name()
+}
+
+func assertLegacyRecipeLoads(t *testing.T, path string) {
+	t.Helper()
+	defer os.Remove(path)
+
+	result, err := serializer.FromFile[recipe.RecipeResult](path)
+	if err != nil {
+		t.Fatalf("FromFile failed for legacy recipe: %v", err)
+	}
+
+	if len(result.Metadata.ExcludedOverlays) != 1 {
+		t.Fatalf("expected 1 excluded overlay, got %d", len(result.Metadata.ExcludedOverlays))
+	}
+	if result.Metadata.ExcludedOverlays[0].Name != "h100-eks-ubuntu-training" {
+		t.Fatalf("unexpected excluded overlay name: %+v", result.Metadata.ExcludedOverlays[0])
+	}
+	if result.Metadata.ExcludedOverlays[0].Reason != "" {
+		t.Fatalf("legacy excluded overlay reason should be empty, got %q", result.Metadata.ExcludedOverlays[0].Reason)
+	}
+}
+
+func TestFromFile_LegacyRecipeExcludedOverlaysYAML(t *testing.T) {
+	path := writeLegacyRecipeFile(t, "recipe-legacy*.yaml", `kind: RecipeResult
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  excludedOverlays:
+    - h100-eks-ubuntu-training
+componentRefs: []
+deploymentOrder: []
+`)
+
+	assertLegacyRecipeLoads(t, path)
+}
+
+func TestFromFile_LegacyRecipeExcludedOverlaysJSON(t *testing.T) {
+	path := writeLegacyRecipeFile(t, "recipe-legacy*.json", `{
+  "kind": "RecipeResult",
+  "apiVersion": "aicr.nvidia.com/v1alpha1",
+  "metadata": {
+    "excludedOverlays": [
+      "h100-eks-ubuntu-training"
+    ]
+  },
+  "componentRefs": [],
+  "deploymentOrder": []
+}`)
+
+	assertLegacyRecipeLoads(t, path)
+}


### PR DESCRIPTION
## Summary

Scope mixin fallback to only the affected candidate chains instead of resetting the entire recipe to base-only output. Add structured `ExcludedOverlay` type with machine-readable reason field.

## Motivation / Context

When a mixin constraint fails in `evaluateMixinConstraints`, the previous behavior excluded *all* non-base overlays — including unrelated overlays (e.g., `monitoring-hpa`) that had nothing to do with the failing mixin. `ExcludedOverlays` also over-reported by including ancestors in the exclusion list.

Fixes: #507
Related: #501

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- `buildMixinConstraintCandidateIndex` maps each mixin constraint → the specific leaf candidates whose inheritance chains contribute it, so failures target specific chains rather than all applied overlays
- Rebuild surviving spec via `mergeOverlayChains` so shared ancestors remain present when still needed by another surviving leaf (the old code used flat `Merge` which lost ancestor ordering)
- `ExcludedOverlays` changed from `[]string` to `[]ExcludedOverlay{Name, Reason}` with two reason constants: `constraint-failed` (pre-merge) and `mixin-constraint-failed` (post-compose)
- Backward-compatible `UnmarshalYAML`/`UnmarshalJSON` accept both legacy `"string"` and new `{name, reason}` object forms
- `evaluateMixinConstraints` now returns `error` instead of silently proceeding when constraint mapping fails
- `ConstraintWarning.Reason` format changed from free-text to `"mixin-constraint-failed: expected X, got Y"`
- Verified 800 recipe+bundle combos (5 services × 5 accelerators × 2 intents × 4 OSes × 4 platforms): 0 content diffs in Helm values/deploy scripts; 35 recipes have harmless `appliedOverlays` ordering changes in b200/gb200-training combos due to `mergeOverlayChains`-based rebuild

## Testing

```bash
make qualify
```

- 5 new/updated test functions in `metadata_store_test.go`:
  - `TestMixinConstraintFailureExcludesOnlyAffectedCandidateChain`
  - `TestMixinConstraintFailurePreservesSharedAncestorsForSurvivingLeaf`
  - `TestEvaluateMixinConstraintsReturnsErrorWhenConstraintCannotBeMappedToCandidate`
  - Updated `TestEvaluatorFailingLeafExcludesCandidate` and `TestMixinConstraintFailureExcludesCandidate` with reason assertions
- `TestHydrateResult/"excluded overlays include reasons"` in `query_test.go`
- Legacy compat tests in `reader_recipe_compat_test.go` (YAML + JSON)

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** `ExcludedOverlays` is now `[]ExcludedOverlay` (object) instead of `[]string`. Custom unmarshalers ensure backward compatibility for consumers reading stored recipes in the old format. API consumers will see the new `{name, reason}` format going forward.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)