### PR TITLE
feat(bundler): add --dynamic flag for install-time values (#515)

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -806,7 +806,7 @@ aicr bundle [flags]
 | `--deployer` | `-d` | string | Deployment method: helm (default), argocd |
 | `--repo` | | string | Git repository URL for ArgoCD applications (only used with `--deployer argocd`) |
 | `--set` | | string[] | Override values in bundle files (repeatable). Use `enabled` key to include/exclude components (e.g., `--set awsebscsidriver:enabled=false`) |
-| `--dynamic` | | string[] | Declare value paths as install-time parameters (repeatable, format: `component:path`). See [Dynamic Install-Time Values](#dynamic-install-time-values). |
+| `--dynamic` | | string[] | Declare value paths as install-time parameters (repeatable, format: `component:path`). Supported with `helm` and `argocd-helm` deployers. See [Dynamic Install-Time Values](#dynamic-install-time-values). |
 | `--data` | | string | External data directory to overlay on embedded data (see [External Data](#external-data-directory)) |
 | `--system-node-selector` | | string[] | Node selector for system components (format: key=value, repeatable) |
 | `--system-node-toleration` | | string[] | Toleration for system components (format: key=value:effect, repeatable) |
@@ -868,8 +868,11 @@ The `--deployer` flag controls how deployment artifacts are generated:
 
 | Method | Description |
 |--------|-------------|
-| `helm` | (Default) Generates Helm charts with values for deployment |
-| `argocd` | Generates ArgoCD Application manifests for GitOps deployment |
+| `helm` | (Default) Generates Helm charts with values for deployment. Supports `--dynamic`. |
+| `argocd` | Generates ArgoCD Application manifests for GitOps deployment. Does **not** support `--dynamic`. |
+| `argocd-helm` | Generates a Helm chart app-of-apps for ArgoCD. All values overridable at install time via `helm --set`. Use `--dynamic` to pre-populate specific paths. |
+
+> **Note:** `--dynamic` is not supported with `--deployer argocd`. Use `--deployer argocd-helm` instead, which produces a Helm chart where all values are overridable at install time.
 
 **Deployment Order:**
 
@@ -1014,7 +1017,7 @@ Before deploying, fill in `cluster-values.yaml` with cluster-specific values.
 
 **ArgoCD deployer behavior:**
 
-When `--dynamic` is used with `--deployer argocd`, the deployer automatically generates a Helm chart app-of-apps instead of flat Application manifests. Each component's Application template injects values via `valuesObject`, and dynamic values are supplied at install time via `helm install --set`:
+The `--deployer argocd-helm` generates a Helm chart app-of-apps where all values are overridable at install time. Static values are baked into the chart as files; dynamic overrides are merged on top at render time. Use `--dynamic` to pre-populate specific paths in the root `values.yaml`:
 
 ```shell
 helm install aicr-bundle ./bundle \
@@ -1022,31 +1025,34 @@ helm install aicr-bundle ./bundle \
   --set alloy.subnetName=subnet-abc123
 ```
 
-Without `--dynamic`, the ArgoCD deployer produces flat manifests as usual.
-
 **Examples:**
 ```shell
-# Declare cluster name as install-time parameter
+# Helm: declare cluster name as install-time parameter
 aicr bundle -r recipe.yaml \
   --dynamic alloy:clusterName \
   -o ./bundles
 
-# Multiple dynamic paths across components
+# Helm: multiple dynamic paths across components
 aicr bundle -r recipe.yaml \
   --dynamic alloy:clusterName \
   --dynamic alloy:subnetName \
   -o ./bundles
 
-# Combine with --set (static overrides + dynamic cluster-specific values)
+# Helm: combine with --set (static overrides + dynamic cluster-specific values)
 aicr bundle -r recipe.yaml \
   --set gpuoperator:driver.version=580.105.08 \
   --dynamic alloy:clusterName \
   -o ./bundles
 
-# ArgoCD with dynamic values (produces Helm chart app-of-apps)
+# ArgoCD Helm chart: all values overridable, --dynamic pre-populates specific paths
 aicr bundle -r recipe.yaml \
-  --deployer argocd \
+  --deployer argocd-helm \
   --dynamic alloy:clusterName \
+  -o ./bundles
+
+# ArgoCD Helm chart: without --dynamic, still fully overridable via helm --set
+aicr bundle -r recipe.yaml \
+  --deployer argocd-helm \
   -o ./bundles
 ```
 
@@ -1068,7 +1074,7 @@ bundles/
 ├── Chart.yaml                     # Helm chart metadata
 ├── values.yaml                    # Dynamic values only (defaults from recipe, override per cluster)
 ├── templates/
-│   ├── alloy.yaml                 # ArgoCD Application template with valuesObject
+│   ├── alloy.yaml                 # ArgoCD Application template with helm.values
 │   └── gpu-operator.yaml
 └── README.md
 ```

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -806,6 +806,7 @@ aicr bundle [flags]
 | `--deployer` | `-d` | string | Deployment method: helm (default), argocd |
 | `--repo` | | string | Git repository URL for ArgoCD applications (only used with `--deployer argocd`) |
 | `--set` | | string[] | Override values in bundle files (repeatable). Use `enabled` key to include/exclude components (e.g., `--set awsebscsidriver:enabled=false`) |
+| `--dynamic` | | string[] | Declare value paths as install-time parameters (repeatable, format: `component:path`). See [Dynamic Install-Time Values](#dynamic-install-time-values). |
 | `--data` | | string | External data directory to overlay on embedded data (see [External Data](#external-data-directory)) |
 | `--system-node-selector` | | string[] | Node selector for system components (format: key=value, repeatable) |
 | `--system-node-toleration` | | string[] | Toleration for system components (format: key=value:effect, repeatable) |
@@ -978,6 +979,98 @@ aicr bundle -r recipe.yaml --deployer argocd \
 aicr bundle -r recipe.yaml \
   --deployer argocd \
   -o ./bundles
+```
+
+**Dynamic Install-Time Values (`--dynamic`):**
+
+The `--dynamic` flag declares value paths that are cluster-specific and should be provided at install time rather than baked into the bundle at build time. This enables building a single bundle that can be deployed to multiple clusters with different configurations.
+
+Use `--dynamic` for values that genuinely vary per cluster — cluster names, subnet IDs, endpoint URLs, region-specific settings. For values that are static per bundle but differ from the recipe default (e.g., a specific driver version), use `--set` instead.
+
+| Use case | Flag | Example |
+|----------|------|---------|
+| Cluster-specific value (varies per deployment) | `--dynamic` | `--dynamic alloy:clusterName` |
+| Static override (same for all deployments of this bundle) | `--set` | `--set gpuoperator:driver.version=580.105.08` |
+
+```shell
+--dynamic component:path.to.field
+```
+
+**Format:** `component:path` where:
+- `component` - Component name or override key (same keys as `--set`, e.g., `gpuoperator`, `alloy`)
+- `path` - Dot-separated path to the value that varies per cluster
+
+**Helm deployer behavior:**
+
+Dynamic paths are removed from `values.yaml` and written to a separate `cluster-values.yaml` per component. The generated `deploy.sh` passes both files to Helm:
+
+```shell
+helm upgrade --install gpu-operator ... \
+  -f values.yaml \
+  -f cluster-values.yaml
+```
+
+Before deploying, fill in `cluster-values.yaml` with cluster-specific values.
+
+**ArgoCD deployer behavior:**
+
+When `--dynamic` is used with `--deployer argocd`, the deployer automatically generates a Helm chart app-of-apps instead of flat Application manifests. Each component's Application template injects values via `valuesObject`, and dynamic values are supplied at install time via `helm install --set`:
+
+```shell
+helm install aicr-bundle ./bundle \
+  --set alloy.clusterName=prod-east \
+  --set alloy.subnetName=subnet-abc123
+```
+
+Without `--dynamic`, the ArgoCD deployer produces flat manifests as usual.
+
+**Examples:**
+```shell
+# Declare cluster name as install-time parameter
+aicr bundle -r recipe.yaml \
+  --dynamic alloy:clusterName \
+  -o ./bundles
+
+# Multiple dynamic paths across components
+aicr bundle -r recipe.yaml \
+  --dynamic alloy:clusterName \
+  --dynamic alloy:subnetName \
+  -o ./bundles
+
+# Combine with --set (static overrides + dynamic cluster-specific values)
+aicr bundle -r recipe.yaml \
+  --set gpuoperator:driver.version=580.105.08 \
+  --dynamic alloy:clusterName \
+  -o ./bundles
+
+# ArgoCD with dynamic values (produces Helm chart app-of-apps)
+aicr bundle -r recipe.yaml \
+  --deployer argocd \
+  --dynamic alloy:clusterName \
+  -o ./bundles
+```
+
+**Bundle structure with `--dynamic`** (Helm deployer):
+```
+bundles/
+├── alloy/
+│   ├── values.yaml                # Static values (clusterName removed)
+│   └── cluster-values.yaml        # Dynamic stubs (fill in before deploying)
+├── gpu-operator/
+│   └── values.yaml                # No dynamic values, no cluster-values.yaml
+├── deploy.sh                      # Passes -f cluster-values.yaml when present
+└── ...
+```
+
+**ArgoCD Helm chart structure with `--dynamic`:**
+```
+bundles/
+├── Chart.yaml                     # Helm chart metadata
+├── values.yaml                    # All component values (dynamic paths are empty stubs)
+├── templates/
+│   ├── alloy.yaml                 # ArgoCD Application template with valuesObject
+│   └── gpu-operator.yaml
+└── README.md
 ```
 
 **Bundle structure** (with default Helm deployer):

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1055,7 +1055,7 @@ aicr bundle -r recipe.yaml \
 bundles/
 ├── alloy/
 │   ├── values.yaml                # Static values (clusterName removed)
-│   └── cluster-values.yaml        # Dynamic stubs (fill in before deploying)
+│   └── cluster-values.yaml        # Dynamic values (override before deploying)
 ├── gpu-operator/
 │   └── values.yaml                # No dynamic values, no cluster-values.yaml
 ├── deploy.sh                      # Passes -f cluster-values.yaml when present
@@ -1066,7 +1066,7 @@ bundles/
 ```
 bundles/
 ├── Chart.yaml                     # Helm chart metadata
-├── values.yaml                    # All component values (dynamic paths are empty stubs)
+├── values.yaml                    # Dynamic values only (defaults from recipe, override per cluster)
 ├── templates/
 │   ├── alloy.yaml                 # ArgoCD Application template with valuesObject
 │   └── gpu-operator.yaml

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -253,14 +253,21 @@ func (b *DefaultBundler) Make(ctx context.Context, input recipe.RecipeInput, dir
 	}
 
 	// Route based on deployer
-	deployer := b.Config.Deployer()
-	if deployer == config.DeployerArgoCD {
+	switch b.Config.Deployer() {
+	case config.DeployerArgoCDHelm:
+		return b.makeArgoCDHelmChart(ctx, recipeResult, componentValues, dir, start)
+	case config.DeployerArgoCD:
 		if b.Config.HasDynamicValues() {
-			return b.makeArgoCDHelmChart(ctx, recipeResult, componentValues, dir, start)
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				"--dynamic is not supported with --deployer argocd; use --deployer argocd-helm instead")
 		}
 		return b.makeArgoCD(ctx, recipeResult, componentValues, dir, start)
+	case config.DeployerHelm:
+		return b.makeHelmBundle(ctx, recipeResult, componentValues, dir, start)
+	default:
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported deployer type: %s", b.Config.Deployer()))
 	}
-	return b.makeHelmBundle(ctx, recipeResult, componentValues, dir, start)
 }
 
 // makeHelmBundle generates a Helm per-component bundle.
@@ -364,6 +371,18 @@ func (b *DefaultBundler) makeHelmBundle(ctx context.Context, recipeResult *recip
 
 // makeArgoCDHelmChart generates a Helm chart app-of-apps for ArgoCD with dynamic install-time values.
 func (b *DefaultBundler) makeArgoCDHelmChart(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dir string, start time.Time) (*result.Output, error) {
+	// Reject flags not yet supported by the argocd-helm deployer.
+	if b.Config.Attest() {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"--attest is not yet supported with --deployer argocd-helm")
+	}
+	if provider := recipe.GetDataProvider(); provider != nil {
+		if layered, ok := provider.(*recipe.LayeredDataProvider); ok && len(layered.ExternalFiles()) > 0 {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				"--data is not yet supported with --deployer argocd-helm")
+		}
+	}
+
 	dynamicValues, dynErr := b.buildDynamicValuesMap()
 	if dynErr != nil {
 		return nil, dynErr

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocd"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocdhelm"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/helm"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
 	"github.com/NVIDIA/aicr/pkg/bundler/validations"
@@ -254,6 +255,9 @@ func (b *DefaultBundler) Make(ctx context.Context, input recipe.RecipeInput, dir
 	// Route based on deployer
 	deployer := b.Config.Deployer()
 	if deployer == config.DeployerArgoCD {
+		if b.Config.HasDynamicValues() {
+			return b.makeArgoCDHelmChart(ctx, recipeResult, componentValues, dir, start)
+		}
 		return b.makeArgoCD(ctx, recipeResult, componentValues, dir, start)
 	}
 	return b.makeHelmBundle(ctx, recipeResult, componentValues, dir, start)
@@ -280,6 +284,12 @@ func (b *DefaultBundler) makeHelmBundle(ctx context.Context, recipeResult *recip
 			"failed to copy external data files", err)
 	}
 
+	// Resolve dynamic values for Helm deployer
+	dynamicValues, dynErr := b.buildDynamicValuesMap()
+	if dynErr != nil {
+		return nil, dynErr
+	}
+
 	// Generate per-component bundle
 	generator := helm.NewGenerator()
 	generatorInput := &helm.GeneratorInput{
@@ -289,6 +299,7 @@ func (b *DefaultBundler) makeHelmBundle(ctx context.Context, recipeResult *recip
 		IncludeChecksums:   b.Config.IncludeChecksums(),
 		ComponentManifests: componentManifests,
 		DataFiles:          dataFiles,
+		DynamicValues:      dynamicValues,
 	}
 
 	output, err := generator.Generate(ctx, generatorInput, dir)
@@ -347,6 +358,62 @@ func (b *DefaultBundler) makeHelmBundle(ctx context.Context, recipeResult *recip
 		"size_bytes", output.TotalSize,
 		"duration", output.Duration,
 	)
+
+	return resultOutput, nil
+}
+
+// makeArgoCDHelmChart generates a Helm chart app-of-apps for ArgoCD with dynamic install-time values.
+func (b *DefaultBundler) makeArgoCDHelmChart(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dir string, start time.Time) (*result.Output, error) {
+	dynamicValues, dynErr := b.buildDynamicValuesMap()
+	if dynErr != nil {
+		return nil, dynErr
+	}
+
+	slog.Debug("generating argocd helm chart app-of-apps",
+		"component_count", len(recipeResult.ComponentRefs),
+		"dynamic_components", len(dynamicValues),
+		"output_dir", dir,
+	)
+
+	generator := &argocdhelm.Generator{
+		RecipeResult:     recipeResult,
+		ComponentValues:  componentValues,
+		Version:          b.Config.Version(),
+		RepoURL:          b.Config.RepoURL(),
+		TargetRevision:   b.Config.TargetRevision(),
+		IncludeChecksums: b.Config.IncludeChecksums(),
+		DynamicValues:    dynamicValues,
+	}
+
+	output, err := generator.Generate(ctx, dir)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal,
+			"failed to generate argocd helm chart", err)
+	}
+
+	resultOutput := &result.Output{
+		Results:       make([]*result.Result, 0),
+		Errors:        make([]result.BundleError, 0),
+		TotalDuration: time.Since(start),
+		TotalSize:     output.TotalSize,
+		TotalFiles:    len(output.Files),
+		OutputDir:     dir,
+	}
+
+	argocdResult := &result.Result{
+		Type:     "argocd-helm-chart",
+		Success:  true,
+		Files:    output.Files,
+		Size:     output.TotalSize,
+		Duration: output.Duration,
+	}
+	resultOutput.Results = append(resultOutput.Results, argocdResult)
+
+	resultOutput.Deployment = &result.DeploymentInfo{
+		Type:  "ArgoCD Helm chart app-of-apps",
+		Steps: output.DeploymentSteps,
+		Notes: b.warnings,
+	}
 
 	return resultOutput, nil
 }
@@ -907,6 +974,32 @@ func (b *DefaultBundler) writeRecipeFile(recipeResult *recipe.RecipeResult, dir 
 
 	slog.Debug("wrote recipe file", "path", recipePath)
 	return int64(len(recipeData)), nil
+}
+
+// buildDynamicValuesMap re-keys the config's dynamic values from user override keys
+// (e.g., "gpuoperator") to component names (e.g., "gpu-operator") using the registry.
+func (b *DefaultBundler) buildDynamicValuesMap() (map[string][]string, error) {
+	if !b.Config.HasDynamicValues() {
+		return make(map[string][]string), nil
+	}
+
+	registry, err := recipe.GetComponentRegistry()
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load component registry for --dynamic resolution", err)
+	}
+
+	raw := b.Config.DynamicValues()
+	result := make(map[string][]string, len(raw))
+	for key, paths := range raw {
+		comp := registry.GetByOverrideKey(key)
+		if comp == nil {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("unknown component %q in --dynamic flag: not found in component registry", key))
+		}
+		result[comp.Name] = append(result[comp.Name], paths...)
+	}
+
+	return result, nil
 }
 
 // removeHyphens removes hyphens from a string.

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -1213,6 +1213,119 @@ func TestMake_DisabledComponentWithDynamic(t *testing.T) {
 	}
 }
 
+// TestMake_ArgoCDRejectsDynamic verifies that --deployer argocd with --dynamic
+// returns a clear error directing users to --deployer argocd-helm.
+func TestMake_ArgoCDRejectsDynamic(t *testing.T) {
+	cfg := config.NewConfig(
+		config.WithDeployer(config.DeployerArgoCD),
+		config.WithDynamicValues(map[string][]string{
+			"gpu-operator": {"driver.version"},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "RecipeResult",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator", Namespace: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator"},
+		},
+	}
+
+	_, err = bundler.Make(context.Background(), recipeResult, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for --deployer argocd with --dynamic")
+	}
+	if !strings.Contains(err.Error(), "argocd-helm") {
+		t.Errorf("error should suggest argocd-helm, got: %v", err)
+	}
+}
+
+// TestMake_ArgoCDHelmRejectsAttest verifies that --attest is rejected with
+// --deployer argocd-helm since attestation is not yet supported.
+func TestMake_ArgoCDHelmRejectsAttest(t *testing.T) {
+	cfg := config.NewConfig(
+		config.WithDeployer(config.DeployerArgoCDHelm),
+		config.WithAttest(true),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		// New() may fail for attest pre-flight (no binary attestation file)
+		// which is fine — the important thing is it doesn't silently succeed
+		return
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "RecipeResult",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator", Namespace: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator"},
+		},
+	}
+
+	_, err = bundler.Make(context.Background(), recipeResult, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for --attest with --deployer argocd-helm")
+	}
+	if !strings.Contains(err.Error(), "not yet supported") {
+		t.Errorf("error should mention not yet supported, got: %v", err)
+	}
+}
+
+// TestMake_ArgoCDHelmRejectsData verifies that --data is rejected with
+// --deployer argocd-helm since external data is not yet supported.
+func TestMake_ArgoCDHelmRejectsData(t *testing.T) {
+	// Create a temp external data dir with a minimal registry.yaml (required by LayeredDataProvider)
+	dataDir := t.TempDir()
+	registryContent := "components:\n  - name: custom\n    displayName: Custom\n"
+	if err := os.WriteFile(filepath.Join(dataDir, "registry.yaml"), []byte(registryContent), 0600); err != nil {
+		t.Fatalf("failed to write registry.yaml: %v", err)
+	}
+
+	// Set up layered data provider (simulates --data flag)
+	originalProvider := recipe.GetDataProvider()
+	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), ".")
+	layered, providerErr := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
+		ExternalDir: dataDir,
+	})
+	if providerErr != nil {
+		t.Fatalf("NewLayeredDataProvider error: %v", providerErr)
+	}
+	recipe.SetDataProvider(layered)
+	recipe.ResetComponentRegistryForTesting()
+	defer func() {
+		recipe.SetDataProvider(originalProvider)
+		recipe.ResetComponentRegistryForTesting()
+	}()
+
+	cfg := config.NewConfig(
+		config.WithDeployer(config.DeployerArgoCDHelm),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "RecipeResult",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator", Namespace: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator"},
+		},
+	}
+
+	_, err = bundler.Make(context.Background(), recipeResult, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for --data with --deployer argocd-helm")
+	}
+	if !strings.Contains(err.Error(), "not yet supported") {
+		t.Errorf("error should mention not yet supported, got: %v", err)
+	}
+}
+
 // computeTestChecksum computes SHA256 hash for test comparison.
 func computeTestChecksum(content []byte) string {
 	hash := make([]byte, 32)

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -1072,6 +1072,147 @@ func TestMake_Reproducible(t *testing.T) {
 	t.Logf("Reproducibility verified: both iterations produced %d identical files", len(fileHashes[0]))
 }
 
+func TestMake_DynamicValuesUnknownComponent(t *testing.T) {
+	cfg := config.NewConfig(
+		config.WithDynamicValues(map[string][]string{
+			"nonexistent-component": {"some.path"},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "RecipeResult",
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "gpu-operator",
+				Version: "v25.3.3",
+				Type:    "helm",
+				Source:  "https://helm.ngc.nvidia.com/nvidia",
+			},
+		},
+	}
+
+	_, err = bundler.Make(context.Background(), recipeResult, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for unknown component in --dynamic, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent-component") {
+		t.Errorf("error should mention the unknown component, got: %v", err)
+	}
+}
+
+func TestMake_DynamicValuesValidComponent(t *testing.T) {
+	cfg := config.NewConfig(
+		config.WithDynamicValues(map[string][]string{
+			"gpu-operator": {"driver.version"},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "RecipeResult",
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:      "gpu-operator",
+				Namespace: "gpu-operator",
+				Version:   "v25.3.3",
+				Type:      "helm",
+				Source:    "https://helm.ngc.nvidia.com/nvidia",
+				Chart:     "gpu-operator",
+			},
+		},
+	}
+
+	out, err := bundler.Make(context.Background(), recipeResult, t.TempDir())
+	if err != nil {
+		t.Fatalf("expected success for valid --dynamic component, got: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil output")
+	}
+}
+
+func TestMake_DisabledComponentWithDynamic(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig(
+		config.WithValueOverrides(map[string]map[string]string{
+			"awsebscsidriver": {"enabled": "false"},
+		}),
+		config.WithDynamicValues(map[string][]string{
+			"awsebscsidriver": {"controller.replicaCount"},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "RecipeResult",
+		Criteria:   &recipe.Criteria{Service: "eks", Accelerator: "h100", Intent: "training"},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:      "gpu-operator",
+				Namespace: "gpu-operator",
+				Version:   "v25.3.3",
+				Type:      "helm",
+				Source:    "https://helm.ngc.nvidia.com/nvidia",
+				Chart:     "gpu-operator",
+			},
+			{
+				Name:      "aws-ebs-csi-driver",
+				Namespace: "kube-system",
+				Version:   "2.55.0",
+				Type:      "helm",
+				Source:    "https://kubernetes-sigs.github.io/aws-ebs-csi-driver",
+				Chart:     "aws-ebs-csi-driver",
+			},
+		},
+		DeploymentOrder: []string{"gpu-operator", "aws-ebs-csi-driver"},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	_, makeErr := bundler.Make(ctx, recipeResult, tmpDir)
+	if makeErr != nil {
+		t.Fatalf("Make() error = %v", makeErr)
+	}
+
+	// Disabled component should NOT have a directory at all
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "aws-ebs-csi-driver")); !os.IsNotExist(statErr) {
+		t.Error("expected aws-ebs-csi-driver directory to NOT be created (component is disabled)")
+	}
+
+	// Disabled component should NOT have cluster-values.yaml
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "aws-ebs-csi-driver", "cluster-values.yaml")); !os.IsNotExist(statErr) {
+		t.Error("expected aws-ebs-csi-driver/cluster-values.yaml to NOT exist (component is disabled)")
+	}
+
+	// Enabled component should still exist
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "gpu-operator", "values.yaml")); os.IsNotExist(statErr) {
+		t.Error("expected gpu-operator/values.yaml to be created")
+	}
+
+	// deploy.sh should not reference the disabled component
+	deployScript, readErr := os.ReadFile(filepath.Join(tmpDir, "deploy.sh"))
+	if readErr != nil {
+		t.Fatalf("failed to read deploy.sh: %v", readErr)
+	}
+	if strings.Contains(string(deployScript), "aws-ebs-csi-driver") {
+		t.Error("deploy.sh should not contain aws-ebs-csi-driver (disabled component)")
+	}
+}
+
 // computeTestChecksum computes SHA256 hash for test comparison.
 func computeTestChecksum(content []byte) string {
 	hash := make([]byte, 32)

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -37,6 +37,10 @@ const (
 	DeployerHelm DeployerType = "helm"
 	// DeployerArgoCD generates ArgoCD App of Apps manifests.
 	DeployerArgoCD DeployerType = "argocd"
+	// DeployerArgoCDHelm generates a Helm chart app-of-apps for ArgoCD.
+	// All values are overridable at install time via helm --set.
+	// Use --dynamic to pre-populate specific paths in root values.yaml.
+	DeployerArgoCDHelm DeployerType = "argocd-helm"
 )
 
 // ParseDeployerType parses a string into a DeployerType.
@@ -47,6 +51,8 @@ func ParseDeployerType(s string) (DeployerType, error) {
 		return DeployerHelm, nil
 	case string(DeployerArgoCD):
 		return DeployerArgoCD, nil
+	case string(DeployerArgoCDHelm):
+		return DeployerArgoCDHelm, nil
 	default:
 		return "", errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid deployer type %q: must be one of %v", s, GetDeployerTypes()))
 	}
@@ -58,6 +64,7 @@ func GetDeployerTypes() []string {
 	types := []string{
 		string(DeployerHelm),
 		string(DeployerArgoCD),
+		string(DeployerArgoCDHelm),
 	}
 	sort.Strings(types)
 	return types

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -16,12 +16,17 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// safePathPattern validates that dynamic value path segments contain only safe characters.
+// Prevents injection of template expressions ({{ }}) or path traversal (../).
+var safePathPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // DeployerType represents the type of deployment method used for generated bundles.
 type DeployerType string
@@ -539,6 +544,14 @@ func ParseDynamicValues(inputs []string) (map[string][]string, error) {
 
 		if component == "" || path == "" {
 			return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid format '%s': component and path cannot be empty", input))
+		}
+
+		// Validate path segments contain only safe characters
+		for _, segment := range strings.Split(path, ".") {
+			if !safePathPattern.MatchString(segment) {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("invalid path segment %q in '%s': must contain only alphanumeric, dot, hyphen, or underscore characters", segment, input))
+			}
 		}
 
 		result[component] = append(result[component], path)

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -119,6 +119,10 @@ type Config struct {
 
 	// estimatedNodeCount is the estimated number of GPU nodes (0 = unset). Used by skyhook-operator for estimatedNodeCount Helm value.
 	estimatedNodeCount int
+
+	// dynamicValues declares value paths that should be provided at install time.
+	// Map structure: component_key -> [path1, path2, ...]
+	dynamicValues map[string][]string
 }
 
 // Getter methods for read-only access
@@ -253,6 +257,25 @@ func (c *Config) CertificateIdentityRegexp() string {
 // EstimatedNodeCount returns the estimated number of GPU nodes (0 means unset).
 func (c *Config) EstimatedNodeCount() int {
 	return c.estimatedNodeCount
+}
+
+// DynamicValues returns a deep copy of the dynamic value declarations.
+func (c *Config) DynamicValues() map[string][]string {
+	if c.dynamicValues == nil {
+		return nil
+	}
+	result := make(map[string][]string, len(c.dynamicValues))
+	for component, paths := range c.dynamicValues {
+		pathsCopy := make([]string, len(paths))
+		copy(pathsCopy, paths)
+		result[component] = pathsCopy
+	}
+	return result
+}
+
+// HasDynamicValues returns true if any dynamic value declarations exist.
+func (c *Config) HasDynamicValues() bool {
+	return len(c.dynamicValues) > 0
 }
 
 // Validate checks if the Config has valid settings.
@@ -429,6 +452,19 @@ func WithEstimatedNodeCount(n int) Option {
 	}
 }
 
+// WithDynamicValues sets the dynamic value declarations for the bundler.
+// Dynamic values are paths that should be provided at install time rather than bundle time.
+func WithDynamicValues(dynamicValues map[string][]string) Option {
+	return func(c *Config) {
+		if dynamicValues == nil {
+			return
+		}
+		for component, paths := range dynamicValues {
+			c.dynamicValues[component] = append(c.dynamicValues[component], paths...)
+		}
+	}
+}
+
 // NewConfig returns a Config with default values.
 func NewConfig(options ...Option) *Config {
 	c := &Config{
@@ -436,6 +472,7 @@ func NewConfig(options ...Option) *Config {
 		includeChecksums: true,
 		includeReadme:    true,
 		valueOverrides:   make(map[string]map[string]string),
+		dynamicValues:    make(map[string][]string),
 		verbose:          false,
 		version:          "dev",
 	}
@@ -480,6 +517,31 @@ func ParseValueOverrides(overrides []string) (map[string]map[string]string, erro
 		}
 
 		result[bundlerName][path] = value
+	}
+
+	return result, nil
+}
+
+// ParseDynamicValues parses dynamic value declarations in format "component:path.to.field".
+// Returns a map of component -> list of paths.
+// This function is used by both CLI and API handlers to parse --dynamic flags.
+func ParseDynamicValues(inputs []string) (map[string][]string, error) {
+	result := make(map[string][]string)
+
+	for _, input := range inputs {
+		parts := strings.SplitN(input, ":", 2)
+		if len(parts) != 2 {
+			return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid format '%s': expected 'component:path'", input))
+		}
+
+		component := parts[0]
+		path := parts[1]
+
+		if component == "" || path == "" {
+			return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid format '%s': component and path cannot be empty", input))
+		}
+
+		result[component] = append(result[component], path)
 	}
 
 	return result, nil

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -523,6 +523,131 @@ func TestParseValueOverrides(t *testing.T) {
 	})
 }
 
+// TestWithDynamicValues verifies the functional option sets dynamic value paths
+// on the Config and that the getter returns a deep copy (mutations don't leak).
+func TestWithDynamicValues(t *testing.T) {
+	input := map[string][]string{
+		"alloy": {"clusterName", "subnetName"},
+	}
+	cfg := NewConfig(WithDynamicValues(input))
+
+	// HasDynamicValues should be true
+	if !cfg.HasDynamicValues() {
+		t.Error("HasDynamicValues() should be true after WithDynamicValues")
+	}
+
+	// DynamicValues should return a deep copy
+	got := cfg.DynamicValues()
+	if len(got["alloy"]) != 2 {
+		t.Fatalf("DynamicValues() returned %d paths, want 2", len(got["alloy"]))
+	}
+
+	// Mutating the returned copy should not affect the config
+	got["alloy"] = append(got["alloy"], "injected")
+	if len(cfg.DynamicValues()["alloy"]) != 2 {
+		t.Error("DynamicValues() should return independent copy; mutation leaked")
+	}
+}
+
+// TestWithDynamicValues_Nil verifies that nil input is a no-op.
+func TestWithDynamicValues_Nil(t *testing.T) {
+	cfg := NewConfig(WithDynamicValues(nil))
+	if cfg.HasDynamicValues() {
+		t.Error("HasDynamicValues() should be false for nil input")
+	}
+}
+
+// TestHasDynamicValues_Empty verifies default config has no dynamic values.
+func TestHasDynamicValues_Empty(t *testing.T) {
+	cfg := NewConfig()
+	if cfg.HasDynamicValues() {
+		t.Error("HasDynamicValues() should be false for default config")
+	}
+}
+
+func TestParseDynamicValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		inputs  []string
+		want    map[string][]string
+		wantErr bool
+	}{
+		{
+			name:   "single component single path",
+			inputs: []string{"alloy:clusterName"},
+			want:   map[string][]string{"alloy": {"clusterName"}},
+		},
+		{
+			name:   "single component multiple paths",
+			inputs: []string{"alloy:clusterName", "alloy:subnetName"},
+			want:   map[string][]string{"alloy": {"clusterName", "subnetName"}},
+		},
+		{
+			name:   "multiple components",
+			inputs: []string{"alloy:clusterName", "gpuoperator:driver.version"},
+			want:   map[string][]string{"alloy": {"clusterName"}, "gpuoperator": {"driver.version"}},
+		},
+		{
+			name:   "nested path",
+			inputs: []string{"gpuoperator:driver.version"},
+			want:   map[string][]string{"gpuoperator": {"driver.version"}},
+		},
+		{
+			name:    "missing colon",
+			inputs:  []string{"alloy-clusterName"},
+			wantErr: true,
+		},
+		{
+			name:    "empty component",
+			inputs:  []string{":clusterName"},
+			wantErr: true,
+		},
+		{
+			name:    "empty path",
+			inputs:  []string{"alloy:"},
+			wantErr: true,
+		},
+		{
+			name:   "empty input list",
+			inputs: []string{},
+			want:   map[string][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDynamicValues(tt.inputs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseDynamicValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseDynamicValues() returned %d components, want %d", len(got), len(tt.want))
+				return
+			}
+			for component, wantPaths := range tt.want {
+				gotPaths, ok := got[component]
+				if !ok {
+					t.Errorf("ParseDynamicValues() missing component %q", component)
+					continue
+				}
+				if len(gotPaths) != len(wantPaths) {
+					t.Errorf("ParseDynamicValues() component %q has %d paths, want %d", component, len(gotPaths), len(wantPaths))
+					continue
+				}
+				for i, wantPath := range wantPaths {
+					if gotPaths[i] != wantPath {
+						t.Errorf("ParseDynamicValues() component %q path[%d] = %q, want %q", component, i, gotPaths[i], wantPath)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestParseDeployerType(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -612,6 +612,27 @@ func TestParseDynamicValues(t *testing.T) {
 			inputs: []string{},
 			want:   map[string][]string{},
 		},
+		// Security: safePathPattern blocks dangerous path segments
+		{
+			name:    "template injection in path",
+			inputs:  []string{"gpuoperator:{{.Values.x}}"},
+			wantErr: true,
+		},
+		{
+			name:    "path traversal",
+			inputs:  []string{"gpuoperator:../../../etc/passwd"},
+			wantErr: true,
+		},
+		{
+			name:    "double dot segment",
+			inputs:  []string{"gpuoperator:foo..bar"},
+			wantErr: true,
+		},
+		{
+			name:    "space in path",
+			inputs:  []string{"gpuoperator:driver version"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -684,9 +705,9 @@ func TestParseDeployerType(t *testing.T) {
 func TestGetDeployerTypes(t *testing.T) {
 	types := GetDeployerTypes()
 
-	// Verify we get the expected types
-	if len(types) != 2 {
-		t.Errorf("GetDeployerTypes() returned %d types, want 2", len(types))
+	// Verify we get the expected types (helm, argocd, argocd-helm)
+	if len(types) != 3 {
+		t.Errorf("GetDeployerTypes() returned %d types, want 3", len(types))
 	}
 
 	// Verify types are sorted alphabetically

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -26,9 +26,9 @@
 //     per-component application.yaml + values.yaml)
 //  2. For each Helm component, transform the multi-source Application manifest
 //     into a single-source template with valuesObject: {{ .Values.<key> }}
-//  3. Build a root values.yaml with all component values keyed by override key,
-//     replacing dynamic paths with empty string stubs
-//  4. Write Chart.yaml + templates/ + values.yaml as a valid Helm chart
+//  3. Build a root values.yaml with ONLY dynamic paths (recipe defaults when
+//     available, empty strings otherwise). Static values stay in chart files.
+//  4. Write Chart.yaml + static/ + templates/ + values.yaml as a valid Helm chart
 //
 // This approach means changes to the ArgoCD deployer (new component types,
 // sync policies, etc.) automatically flow through without duplication.
@@ -44,7 +44,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -160,7 +159,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	for _, ref := range g.RecipeResult.ComponentRefs {
 		select {
 		case <-ctx.Done():
-			return nil, errors.Wrap(errors.ErrCodeInternal, "context cancelled", ctx.Err())
+			return nil, errors.Wrap(errors.ErrCodeTimeout, "context cancelled", ctx.Err())
 		default:
 		}
 
@@ -177,7 +176,10 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 			continue
 		}
 
-		overrideKey := resolveOverrideKey(ref.Name)
+		overrideKey, keyErr := resolveOverrideKey(ref.Name)
+		if keyErr != nil {
+			return nil, keyErr
+		}
 		hasDynamic := len(g.DynamicValues[ref.Name]) > 0
 		tmplPath, tmplSize, transformErr := transformApplication(tmpDir, templatesDir, ref.Name, overrideKey, hasDynamic)
 		if transformErr != nil {
@@ -254,17 +256,22 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		// Deep-copy values so we can remove dynamic paths without mutating the input
 		staticValues := deepCopyMap(values)
 
-		// Extract dynamic paths: remove from static, build stubs for root values.yaml
+		// Extract dynamic paths: remove from static, build stubs for root values.yaml.
+		// When the path exists in static values, the resolved default is preserved
+		// so users see what value to override. When the path doesn't exist, an
+		// empty string stub is created.
 		if dynPaths, ok := g.DynamicValues[ref.Name]; ok {
-			overrideKey := resolveOverrideKey(ref.Name)
+			overrideKey, keyErr := resolveOverrideKey(ref.Name)
+			if keyErr != nil {
+				return nil, 0, nil, keyErr
+			}
 			stubs := make(map[string]any)
 			for _, path := range dynPaths {
 				if val, found := component.GetValueByPath(staticValues, path); found {
 					component.RemoveValueByPath(staticValues, path)
-					setStubValue(stubs, path)
-					setNestedValue(stubs, path, val)
+					component.SetValueByPath(stubs, path, val)
 				} else {
-					setStubValue(stubs, path)
+					component.SetValueByPath(stubs, path, "")
 				}
 			}
 			dynamicOnlyValues[overrideKey] = stubs
@@ -287,7 +294,14 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 // its multi-source helm block to a single-source with valuesObject that loads
 // static values from chart files and merges dynamic overrides from .Values.
 func transformApplication(srcDir, templatesDir, componentName, overrideKey string, hasDynamic bool) (string, int64, error) {
-	srcPath := filepath.Join(srcDir, componentName, "application.yaml")
+	componentDir, joinErr := shared.SafeJoin(srcDir, componentName)
+	if joinErr != nil {
+		return "", 0, joinErr
+	}
+	srcPath, joinErr := shared.SafeJoin(componentDir, "application.yaml")
+	if joinErr != nil {
+		return "", 0, joinErr
+	}
 	content, err := os.ReadFile(srcPath)
 	if err != nil {
 		return "", 0, errors.Wrap(errors.ErrCodeInternal,
@@ -357,7 +371,14 @@ func transformMultiSourceToValuesObject(content, componentName, overrideKey stri
 
 // copyAsTemplate copies an application.yaml from the flat output to templates/ as-is.
 func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, error) {
-	srcPath := filepath.Join(srcDir, componentName, "application.yaml")
+	componentDir, joinErr := shared.SafeJoin(srcDir, componentName)
+	if joinErr != nil {
+		return "", 0, joinErr
+	}
+	srcPath, joinErr := shared.SafeJoin(componentDir, "application.yaml")
+	if joinErr != nil {
+		return "", 0, joinErr
+	}
 	content, err := os.ReadFile(srcPath)
 	if err != nil {
 		return "", 0, errors.Wrap(errors.ErrCodeInternal,
@@ -458,7 +479,10 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	buf.WriteString("Dynamic values are supplied at install time using `helm install --set`.\n\n")
 	buf.WriteString("## Install\n\n```bash\nhelm install aicr-bundle .")
 
-	dynamicSetFlags := buildDynamicSetFlags(g.DynamicValues)
+	dynamicSetFlags, flagsErr := buildDynamicSetFlags(g.DynamicValues)
+	if flagsErr != nil {
+		return "", 0, flagsErr
+	}
 	if len(dynamicSetFlags) > 0 {
 		buf.WriteString(" \\\n  " + strings.Join(dynamicSetFlags, " \\\n  "))
 	}
@@ -472,7 +496,10 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 		}
 		sort.Strings(compNames)
 		for _, name := range compNames {
-			overrideKey := resolveOverrideKey(name)
+			overrideKey, keyErr := resolveOverrideKey(name)
+			if keyErr != nil {
+				return "", 0, keyErr
+			}
 			for _, path := range g.DynamicValues[name] {
 				fmt.Fprintf(&buf, "- `%s.%s`\n", overrideKey, path)
 			}
@@ -486,9 +513,9 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	return readmePath, int64(len(content)), nil
 }
 
-func buildDynamicSetFlags(dynamicValues map[string][]string) []string {
+func buildDynamicSetFlags(dynamicValues map[string][]string) ([]string, error) {
 	if len(dynamicValues) == 0 {
-		return nil
+		return nil, nil
 	}
 	var flags []string
 	compNames := make([]string, 0, len(dynamicValues))
@@ -497,24 +524,36 @@ func buildDynamicSetFlags(dynamicValues map[string][]string) []string {
 	}
 	sort.Strings(compNames)
 	for _, name := range compNames {
-		overrideKey := resolveOverrideKey(name)
+		overrideKey, keyErr := resolveOverrideKey(name)
+		if keyErr != nil {
+			return nil, keyErr
+		}
 		for _, path := range dynamicValues[name] {
 			flags = append(flags, fmt.Sprintf("--set %s.%s=VALUE", overrideKey, path))
 		}
 	}
-	return flags
+	return flags, nil
 }
 
-func resolveOverrideKey(componentName string) string {
+// resolveOverrideKey returns the valueOverrideKey for a component (e.g., "gpuOperator"
+// for "gpu-operator"). Returns an error if the registry is unavailable or the component
+// has no override keys — using the wrong key would produce a broken chart.
+func resolveOverrideKey(componentName string) (string, error) {
 	registry, err := recipe.GetComponentRegistry()
 	if err != nil {
-		return componentName
+		return "", errors.Wrap(errors.ErrCodeInternal,
+			"failed to load component registry for override key resolution", err)
 	}
 	comp := registry.Get(componentName)
-	if comp != nil && len(comp.ValueOverrideKeys) > 0 {
-		return comp.ValueOverrideKeys[0]
+	if comp == nil {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("component %q not found in registry", componentName))
 	}
-	return componentName
+	if len(comp.ValueOverrideKeys) == 0 {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("component %q has no valueOverrideKeys in registry", componentName))
+	}
+	return comp.ValueOverrideKeys[0], nil
 }
 
 func deepCopyMap(m map[string]any) map[string]any {
@@ -523,6 +562,7 @@ func deepCopyMap(m map[string]any) map[string]any {
 	}
 	data, err := yaml.Marshal(m)
 	if err != nil {
+		slog.Warn("deepCopyMap: yaml.Marshal failed, falling back to shallow copy", "error", err)
 		result := make(map[string]any, len(m))
 		for k, v := range m {
 			result[k] = v
@@ -531,44 +571,11 @@ func deepCopyMap(m map[string]any) map[string]any {
 	}
 	var result map[string]any
 	if unmarshalErr := yaml.Unmarshal(data, &result); unmarshalErr != nil {
+		slog.Warn("deepCopyMap: yaml.Unmarshal failed, falling back to shallow copy", "error", unmarshalErr)
 		result = make(map[string]any, len(m))
 		for k, v := range m {
 			result[k] = v
 		}
 	}
 	return result
-}
-
-func setNestedValue(m map[string]any, path string, value any) {
-	parts := strings.Split(path, ".")
-	current := m
-	for _, part := range parts[:len(parts)-1] {
-		if next, ok := current[part]; ok {
-			if nextMap, ok := next.(map[string]any); ok {
-				current = nextMap
-				continue
-			}
-		}
-		newMap := make(map[string]any)
-		current[part] = newMap
-		current = newMap
-	}
-	current[parts[len(parts)-1]] = value
-}
-
-func setStubValue(m map[string]any, path string) {
-	parts := strings.Split(path, ".")
-	current := m
-	for _, part := range parts[:len(parts)-1] {
-		if next, ok := current[part]; ok {
-			if nextMap, ok := next.(map[string]any); ok {
-				current = nextMap
-				continue
-			}
-		}
-		newMap := make(map[string]any)
-		current[part] = newMap
-		current = newMap
-	}
-	current[parts[len(parts)-1]] = ""
 }

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -1,0 +1,574 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package argocdhelm generates a Helm chart app-of-apps for ArgoCD with
+// dynamic install-time values.
+//
+// # How it works
+//
+// Rather than reimplementing ArgoCD Application generation, this deployer
+// delegates to the existing flat ArgoCD deployer (pkg/bundler/deployer/argocd)
+// to produce proven Application manifests, then transforms the output into a
+// Helm chart:
+//
+//  1. Generate flat ArgoCD output to a temp directory (app-of-apps.yaml,
+//     per-component application.yaml + values.yaml)
+//  2. For each Helm component, transform the multi-source Application manifest
+//     into a single-source template with valuesObject: {{ .Values.<key> }}
+//  3. Build a root values.yaml with all component values keyed by override key,
+//     replacing dynamic paths with empty string stubs
+//  4. Write Chart.yaml + templates/ + values.yaml as a valid Helm chart
+//
+// This approach means changes to the ArgoCD deployer (new component types,
+// sync policies, etc.) automatically flow through without duplication.
+//
+// # When this deployer is used
+//
+// The bundler routes here when --deployer argocd AND --dynamic flags are both
+// present. Without --dynamic, the standard flat ArgoCD deployer is used.
+package argocdhelm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocd"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/component"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// compile-time interface check
+var _ deployer.Deployer = (*Generator)(nil)
+
+// HasDynamicValues reports whether this deployer has dynamic install-time values.
+func (g *Generator) HasDynamicValues() bool {
+	return len(g.DynamicValues) > 0
+}
+
+// Generator creates Helm chart app-of-apps bundles by transforming flat ArgoCD output.
+// Configure it with the required fields, then call Generate.
+type Generator struct {
+	RecipeResult     *recipe.RecipeResult
+	ComponentValues  map[string]map[string]any
+	Version          string
+	RepoURL          string
+	TargetRevision   string
+	IncludeChecksums bool
+
+	// DynamicValues maps component names to their dynamic value paths.
+	DynamicValues map[string][]string
+}
+
+// sourcesPattern matches the multi-source block in ArgoCD Application manifests.
+// Used to replace it with a single-source + valuesObject for the Helm chart.
+var sourcesPattern = regexp.MustCompile(`(?ms)  sources:\n.*?(?:  destination:)`)
+
+// Generate creates a Helm chart app-of-apps by:
+//  1. Delegating to the flat ArgoCD deployer for proven Application generation
+//  2. Transforming the output into a Helm chart with {{ .Values }} references
+func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.Output, error) {
+	start := time.Now()
+
+	if g.RecipeResult == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "RecipeResult is required")
+	}
+
+	// Step 1: Generate flat ArgoCD output to a temp directory
+	tmpDir, err := os.MkdirTemp("", "argocdhelm-*")
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create temp directory", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	argocdInput := &argocd.GeneratorInput{
+		RecipeResult:     g.RecipeResult,
+		ComponentValues:  g.ComponentValues,
+		Version:          g.Version,
+		RepoURL:          g.RepoURL,
+		TargetRevision:   g.TargetRevision,
+		IncludeChecksums: false, // we generate our own checksums
+	}
+
+	argocdGen := argocd.NewGenerator()
+	if _, genErr := argocdGen.Generate(ctx, argocdInput, tmpDir); genErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate base ArgoCD output", genErr)
+	}
+
+	// Step 2: Create Helm chart output structure
+	if mkdirErr := os.MkdirAll(outputDir, 0755); mkdirErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create output directory", mkdirErr)
+	}
+
+	output := &deployer.Output{Files: make([]string, 0)}
+
+	// Write Chart.yaml
+	chartPath, chartSize, err := writeChartYAML(outputDir, shared.NormalizeVersionWithDefault(g.RecipeResult.Metadata.Version))
+	if err != nil {
+		return nil, err
+	}
+	output.Files = append(output.Files, chartPath)
+	output.TotalSize += chartSize
+
+	// Step 3: Write static values as chart files and build dynamic-only root values.yaml
+	staticFiles, staticSize, dynamicOnlyValues, err := g.writeStaticValuesAndBuildStubs(outputDir)
+	if err != nil {
+		return nil, err
+	}
+	output.Files = append(output.Files, staticFiles...)
+	output.TotalSize += staticSize
+
+	valuesPath, valuesSize, err := shared.WriteValuesFile(dynamicOnlyValues, outputDir, "values.yaml")
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write root values.yaml", err)
+	}
+	output.Files = append(output.Files, valuesPath)
+	output.TotalSize += valuesSize
+
+	// Step 4: Transform Application manifests into Helm templates
+	templatesDir, err := shared.SafeJoin(outputDir, "templates")
+	if err != nil {
+		return nil, err
+	}
+	if mkdirErr := os.MkdirAll(templatesDir, 0755); mkdirErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create templates directory", mkdirErr)
+	}
+
+	for _, ref := range g.RecipeResult.ComponentRefs {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrap(errors.ErrCodeInternal, "context cancelled", ctx.Err())
+		default:
+		}
+
+		// Non-Helm components (Kustomize, manifest-only) have no multi-source
+		// block to transform — copy their Application template as-is.
+		isHelmChart := ref.Type != recipe.ComponentTypeKustomize && ref.Source != ""
+		if !isHelmChart {
+			tmplPath, tmplSize, cpErr := copyAsTemplate(tmpDir, templatesDir, ref.Name)
+			if cpErr != nil {
+				return nil, cpErr
+			}
+			output.Files = append(output.Files, tmplPath)
+			output.TotalSize += tmplSize
+			continue
+		}
+
+		overrideKey := resolveOverrideKey(ref.Name)
+		hasDynamic := len(g.DynamicValues[ref.Name]) > 0
+		tmplPath, tmplSize, transformErr := transformApplication(tmpDir, templatesDir, ref.Name, overrideKey, hasDynamic)
+		if transformErr != nil {
+			return nil, transformErr
+		}
+		output.Files = append(output.Files, tmplPath)
+		output.TotalSize += tmplSize
+	}
+
+	// Step 5: Generate README
+	readmePath, readmeSize, err := g.writeReadme(outputDir)
+	if err != nil {
+		return nil, err
+	}
+	output.Files = append(output.Files, readmePath)
+	output.TotalSize += readmeSize
+
+	// Generate checksums if requested
+	if g.IncludeChecksums {
+		if checksumErr := checksum.GenerateChecksums(ctx, outputDir, output.Files); checksumErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate checksums", checksumErr)
+		}
+		checksumPath := checksum.GetChecksumFilePath(outputDir)
+		info, statErr := os.Stat(checksumPath)
+		if statErr == nil {
+			output.Files = append(output.Files, checksumPath)
+			output.TotalSize += info.Size()
+		}
+	}
+
+	output.Duration = time.Since(start)
+	output.DeploymentSteps = []string{
+		fmt.Sprintf("cd %s", outputDir),
+		"helm install aicr-bundle .",
+	}
+
+	slog.Debug("argocd helm chart generated",
+		"components", len(g.RecipeResult.ComponentRefs),
+		"dynamic_components", len(g.DynamicValues),
+		"files", len(output.Files),
+		"size_bytes", output.TotalSize,
+	)
+
+	return output, nil
+}
+
+// writeStaticValuesAndBuildStubs writes each component's values to static/<name>.yaml
+// and builds the dynamic-only stubs map for the root values.yaml.
+func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, int64, map[string]any, error) {
+	staticDir, err := shared.SafeJoin(outputDir, "static")
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	if mkdirErr := os.MkdirAll(staticDir, 0755); mkdirErr != nil {
+		return nil, 0, nil, errors.Wrap(errors.ErrCodeInternal, "failed to create static directory", mkdirErr)
+	}
+
+	var files []string
+	var totalSize int64
+	dynamicOnlyValues := make(map[string]any)
+
+	for _, ref := range g.RecipeResult.ComponentRefs {
+		// Skip non-Helm components (Kustomize, manifest-only)
+		isHelmChart := ref.Type != recipe.ComponentTypeKustomize && ref.Source != ""
+		if !isHelmChart {
+			continue
+		}
+
+		values := g.ComponentValues[ref.Name]
+		if values == nil {
+			values = make(map[string]any)
+		}
+
+		// Deep-copy values so we can remove dynamic paths without mutating the input
+		staticValues := deepCopyMap(values)
+
+		// Extract dynamic paths: remove from static, build stubs for root values.yaml
+		if dynPaths, ok := g.DynamicValues[ref.Name]; ok {
+			overrideKey := resolveOverrideKey(ref.Name)
+			stubs := make(map[string]any)
+			for _, path := range dynPaths {
+				if val, found := component.GetValueByPath(staticValues, path); found {
+					component.RemoveValueByPath(staticValues, path)
+					setStubValue(stubs, path)
+					setNestedValue(stubs, path, val)
+				} else {
+					setStubValue(stubs, path)
+				}
+			}
+			dynamicOnlyValues[overrideKey] = stubs
+		}
+
+		// Write static values (dynamic paths removed)
+		staticPath, staticSize, staticErr := shared.WriteValuesFile(staticValues, staticDir, ref.Name+".yaml")
+		if staticErr != nil {
+			return nil, 0, nil, errors.Wrap(errors.ErrCodeInternal,
+				fmt.Sprintf("failed to write static values for %s", ref.Name), staticErr)
+		}
+		files = append(files, staticPath)
+		totalSize += staticSize
+	}
+
+	return files, totalSize, dynamicOnlyValues, nil
+}
+
+// transformApplication reads a flat ArgoCD Application manifest and converts
+// its multi-source helm block to a single-source with valuesObject that loads
+// static values from chart files and merges dynamic overrides from .Values.
+func transformApplication(srcDir, templatesDir, componentName, overrideKey string, hasDynamic bool) (string, int64, error) {
+	srcPath := filepath.Join(srcDir, componentName, "application.yaml")
+	content, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to read application.yaml for %s", componentName), err)
+	}
+
+	transformed, transformErr := transformMultiSourceToValuesObject(string(content), componentName, overrideKey, hasDynamic)
+	if transformErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to transform application.yaml for %s", componentName), transformErr)
+	}
+
+	destPath, pathErr := shared.SafeJoin(templatesDir, componentName+".yaml")
+	if pathErr != nil {
+		return "", 0, pathErr
+	}
+
+	if writeErr := os.WriteFile(destPath, []byte(transformed), 0600); writeErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to write template for %s", componentName), writeErr)
+	}
+	return destPath, int64(len(transformed)), nil
+}
+
+// transformMultiSourceToValuesObject replaces the ArgoCD multi-source block
+// with a single-source block that loads static values from chart files and
+// merges dynamic overrides from .Values.
+//
+// Static values are loaded via .Files.Get from the chart's static/ directory.
+// When the component has dynamic values, they are merged on top using
+// mustMergeOverwrite so user-provided values win.
+func transformMultiSourceToValuesObject(content, componentName, overrideKey string, hasDynamic bool) (string, error) {
+	repoURL, chart, targetRevision, err := extractFirstSourceValues(content)
+	if err != nil {
+		return "", err
+	}
+
+	if !sourcesPattern.MatchString(content) {
+		return "", errors.New(errors.ErrCodeInternal,
+			"ArgoCD Application manifest does not contain expected multi-source block; "+
+				"the upstream template format may have changed")
+	}
+
+	var replacement strings.Builder
+	fmt.Fprintf(&replacement, "  source:\n")
+	fmt.Fprintf(&replacement, "    repoURL: %s\n", repoURL)
+	fmt.Fprintf(&replacement, "    chart: %s\n", chart)
+	fmt.Fprintf(&replacement, "    targetRevision: %s\n", targetRevision)
+	fmt.Fprintf(&replacement, "    helm:\n")
+
+	if hasDynamic {
+		// Merge static (from chart file) + dynamic (from .Values) at render time
+		fmt.Fprintf(&replacement, "      valuesObject: |-\n")
+		fmt.Fprintf(&replacement, `        {{- $static := (.Files.Get "static/%s.yaml") | fromYaml -}}`+"\n", componentName)
+		fmt.Fprintf(&replacement, `        {{- $dynamic := index .Values %q | default dict -}}`+"\n", overrideKey)
+		fmt.Fprintf(&replacement, "        {{- mustMergeOverwrite $static $dynamic | toYaml | nindent 8 }}\n")
+	} else {
+		// Static only — load directly from chart file
+		fmt.Fprintf(&replacement, "      valuesObject: |-\n")
+		fmt.Fprintf(&replacement, `        {{- (.Files.Get "static/%s.yaml") | fromYaml | toYaml | nindent 8 }}`+"\n", componentName)
+	}
+
+	replacement.WriteString("  destination:")
+
+	return sourcesPattern.ReplaceAllLiteralString(content, replacement.String()), nil
+}
+
+// copyAsTemplate copies an application.yaml from the flat output to templates/ as-is.
+func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, error) {
+	srcPath := filepath.Join(srcDir, componentName, "application.yaml")
+	content, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to read application.yaml for %s", componentName), err)
+	}
+
+	destPath, pathErr := shared.SafeJoin(templatesDir, componentName+".yaml")
+	if pathErr != nil {
+		return "", 0, pathErr
+	}
+
+	if writeErr := os.WriteFile(destPath, content, 0600); writeErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to write template for %s", componentName), writeErr)
+	}
+	return destPath, int64(len(content)), nil
+}
+
+// extractFirstSourceValues parses the multi-source block and extracts
+// repoURL, chart, and targetRevision from the first source entry.
+// Returns an error if any required field is missing, which indicates the
+// upstream ArgoCD template format has changed.
+func extractFirstSourceValues(content string) (repoURL, chart, targetRevision string, err error) {
+	lines := strings.Split(content, "\n")
+	inFirstSource := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- repoURL:") {
+			if !inFirstSource {
+				inFirstSource = true
+				repoURL = strings.TrimSpace(strings.TrimPrefix(trimmed, "- repoURL:"))
+				repoURL = strings.Trim(repoURL, "'")
+			}
+			continue
+		}
+		if !inFirstSource {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "ref:") {
+			break // hit second source entry or ref field
+		}
+		if strings.HasPrefix(trimmed, "chart:") {
+			chart = strings.TrimSpace(strings.TrimPrefix(trimmed, "chart:"))
+		}
+		if strings.HasPrefix(trimmed, "targetRevision:") {
+			targetRevision = strings.TrimSpace(strings.TrimPrefix(trimmed, "targetRevision:"))
+		}
+	}
+
+	var missing []string
+	if repoURL == "" {
+		missing = append(missing, "repoURL")
+	}
+	if chart == "" {
+		missing = append(missing, "chart")
+	}
+	if targetRevision == "" {
+		missing = append(missing, "targetRevision")
+	}
+	if len(missing) > 0 {
+		return "", "", "", errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to extract source fields [%s] from ArgoCD Application manifest; "+
+				"the upstream template format may have changed", strings.Join(missing, ", ")))
+	}
+
+	return repoURL, chart, targetRevision, nil
+}
+
+func writeChartYAML(outputDir, version string) (string, int64, error) {
+	chartPath, err := shared.SafeJoin(outputDir, "Chart.yaml")
+	if err != nil {
+		return "", 0, err
+	}
+
+	var buf strings.Builder
+	buf.WriteString("apiVersion: v2\n")
+	buf.WriteString("name: aicr-bundle\n")
+	buf.WriteString("description: AICR deployment bundle with dynamic install-time values\n")
+	buf.WriteString("type: application\n")
+	fmt.Fprintf(&buf, "version: %s\n", version)
+
+	content := buf.String()
+	if writeErr := os.WriteFile(chartPath, []byte(content), 0600); writeErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal, "failed to write Chart.yaml", writeErr)
+	}
+	return chartPath, int64(len(content)), nil
+}
+
+func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
+	readmePath, err := shared.SafeJoin(outputDir, "README.md")
+	if err != nil {
+		return "", 0, err
+	}
+
+	var buf strings.Builder
+	buf.WriteString("# ArgoCD Helm Chart Deployment Bundle\n\n")
+	buf.WriteString("This bundle is a Helm chart that generates ArgoCD Application manifests.\n")
+	buf.WriteString("Dynamic values are supplied at install time using `helm install --set`.\n\n")
+	buf.WriteString("## Install\n\n```bash\nhelm install aicr-bundle .")
+
+	dynamicSetFlags := buildDynamicSetFlags(g.DynamicValues)
+	if len(dynamicSetFlags) > 0 {
+		buf.WriteString(" \\\n  " + strings.Join(dynamicSetFlags, " \\\n  "))
+	}
+	buf.WriteString("\n```\n")
+
+	if len(g.DynamicValues) > 0 {
+		buf.WriteString("\n## Dynamic Values\n\n")
+		compNames := make([]string, 0, len(g.DynamicValues))
+		for name := range g.DynamicValues {
+			compNames = append(compNames, name)
+		}
+		sort.Strings(compNames)
+		for _, name := range compNames {
+			overrideKey := resolveOverrideKey(name)
+			for _, path := range g.DynamicValues[name] {
+				fmt.Fprintf(&buf, "- `%s.%s`\n", overrideKey, path)
+			}
+		}
+	}
+
+	content := buf.String()
+	if writeErr := os.WriteFile(readmePath, []byte(content), 0600); writeErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal, "failed to write README.md", writeErr)
+	}
+	return readmePath, int64(len(content)), nil
+}
+
+func buildDynamicSetFlags(dynamicValues map[string][]string) []string {
+	if len(dynamicValues) == 0 {
+		return nil
+	}
+	var flags []string
+	compNames := make([]string, 0, len(dynamicValues))
+	for name := range dynamicValues {
+		compNames = append(compNames, name)
+	}
+	sort.Strings(compNames)
+	for _, name := range compNames {
+		overrideKey := resolveOverrideKey(name)
+		for _, path := range dynamicValues[name] {
+			flags = append(flags, fmt.Sprintf("--set %s.%s=VALUE", overrideKey, path))
+		}
+	}
+	return flags
+}
+
+func resolveOverrideKey(componentName string) string {
+	registry, err := recipe.GetComponentRegistry()
+	if err != nil {
+		return componentName
+	}
+	comp := registry.Get(componentName)
+	if comp != nil && len(comp.ValueOverrideKeys) > 0 {
+		return comp.ValueOverrideKeys[0]
+	}
+	return componentName
+}
+
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		result := make(map[string]any, len(m))
+		for k, v := range m {
+			result[k] = v
+		}
+		return result
+	}
+	var result map[string]any
+	if unmarshalErr := yaml.Unmarshal(data, &result); unmarshalErr != nil {
+		result = make(map[string]any, len(m))
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func setNestedValue(m map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	current := m
+	for _, part := range parts[:len(parts)-1] {
+		if next, ok := current[part]; ok {
+			if nextMap, ok := next.(map[string]any); ok {
+				current = nextMap
+				continue
+			}
+		}
+		newMap := make(map[string]any)
+		current[part] = newMap
+		current = newMap
+	}
+	current[parts[len(parts)-1]] = value
+}
+
+func setStubValue(m map[string]any, path string) {
+	parts := strings.Split(path, ".")
+	current := m
+	for _, part := range parts[:len(parts)-1] {
+		if next, ok := current[part]; ok {
+			if nextMap, ok := next.(map[string]any); ok {
+				current = nextMap
+				continue
+			}
+		}
+		newMap := make(map[string]any)
+		current[part] = newMap
+		current = newMap
+	}
+	current[parts[len(parts)-1]] = ""
+}

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -25,7 +25,7 @@
 //  1. Generate flat ArgoCD output to a temp directory (app-of-apps.yaml,
 //     per-component application.yaml + values.yaml)
 //  2. For each Helm component, transform the multi-source Application manifest
-//     into a single-source template with valuesObject: {{ .Values.<key> }}
+//     into a single-source template with helm.values containing {{ .Values.<key> }}
 //  3. Build a root values.yaml with ONLY dynamic paths (recipe defaults when
 //     available, empty strings otherwise). Static values stay in chart files.
 //  4. Write Chart.yaml + static/ + templates/ + values.yaml as a valid Helm chart
@@ -35,8 +35,9 @@
 //
 // # When this deployer is used
 //
-// The bundler routes here when --deployer argocd AND --dynamic flags are both
-// present. Without --dynamic, the standard flat ArgoCD deployer is used.
+// The bundler routes here when --deployer argocd-helm is specified.
+// The --dynamic flag is optional — it pre-populates specific paths in the
+// root values.yaml, but all values are overridable regardless.
 package argocdhelm
 
 import (
@@ -44,7 +45,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -81,10 +81,6 @@ type Generator struct {
 	// DynamicValues maps component names to their dynamic value paths.
 	DynamicValues map[string][]string
 }
-
-// sourcesPattern matches the multi-source block in ArgoCD Application manifests.
-// Used to replace it with a single-source + valuesObject for the Helm chart.
-var sourcesPattern = regexp.MustCompile(`(?ms)  sources:\n.*?(?:  destination:)`)
 
 // Generate creates a Helm chart app-of-apps by:
 //  1. Delegating to the flat ArgoCD deployer for proven Application generation
@@ -127,7 +123,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	// Write Chart.yaml
 	chartPath, chartSize, err := writeChartYAML(outputDir, shared.NormalizeVersionWithDefault(g.RecipeResult.Metadata.Version))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write Chart.yaml", err)
 	}
 	output.Files = append(output.Files, chartPath)
 	output.TotalSize += chartSize
@@ -135,7 +131,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	// Step 3: Write static values as chart files and build dynamic-only root values.yaml
 	staticFiles, staticSize, dynamicOnlyValues, err := g.writeStaticValuesAndBuildStubs(outputDir)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write static values", err)
 	}
 	output.Files = append(output.Files, staticFiles...)
 	output.TotalSize += staticSize
@@ -150,7 +146,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	// Step 4: Transform Application manifests into Helm templates
 	templatesDir, err := shared.SafeJoin(outputDir, "templates")
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to resolve templates directory", err)
 	}
 	if mkdirErr := os.MkdirAll(templatesDir, 0755); mkdirErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create templates directory", mkdirErr)
@@ -180,8 +176,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 		if keyErr != nil {
 			return nil, keyErr
 		}
-		hasDynamic := len(g.DynamicValues[ref.Name]) > 0
-		tmplPath, tmplSize, transformErr := transformApplication(tmpDir, templatesDir, ref.Name, overrideKey, hasDynamic)
+		tmplPath, tmplSize, transformErr := transformApplication(tmpDir, templatesDir, ref.Name, overrideKey)
 		if transformErr != nil {
 			return nil, transformErr
 		}
@@ -192,28 +187,14 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	// Step 5: Generate README
 	readmePath, readmeSize, err := g.writeReadme(outputDir)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write README", err)
 	}
 	output.Files = append(output.Files, readmePath)
 	output.TotalSize += readmeSize
 
-	// Generate checksums if requested
-	if g.IncludeChecksums {
-		if checksumErr := checksum.GenerateChecksums(ctx, outputDir, output.Files); checksumErr != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate checksums", checksumErr)
-		}
-		checksumPath := checksum.GetChecksumFilePath(outputDir)
-		info, statErr := os.Stat(checksumPath)
-		if statErr == nil {
-			output.Files = append(output.Files, checksumPath)
-			output.TotalSize += info.Size()
-		}
-	}
-
-	output.Duration = time.Since(start)
-	output.DeploymentSteps = []string{
-		fmt.Sprintf("cd %s", outputDir),
-		"helm install aicr-bundle .",
+	// Generate checksums and finalize output
+	if err := g.finalizeOutput(ctx, output, outputDir, start); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to finalize output", err)
 	}
 
 	slog.Debug("argocd helm chart generated",
@@ -224,6 +205,27 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	)
 
 	return output, nil
+}
+
+// finalizeOutput generates checksums (if requested) and sets deployment metadata.
+func (g *Generator) finalizeOutput(ctx context.Context, output *deployer.Output, outputDir string, start time.Time) error {
+	if g.IncludeChecksums {
+		if checksumErr := checksum.GenerateChecksums(ctx, outputDir, output.Files); checksumErr != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to generate checksums", checksumErr)
+		}
+		checksumPath := checksum.GetChecksumFilePath(outputDir)
+		info, statErr := os.Stat(checksumPath)
+		if statErr == nil {
+			output.Files = append(output.Files, checksumPath)
+			output.TotalSize += info.Size()
+		}
+	}
+	output.Duration = time.Since(start)
+	output.DeploymentSteps = []string{
+		fmt.Sprintf("cd %s", outputDir),
+		"helm install aicr-bundle .",
+	}
+	return nil
 }
 
 // writeStaticValuesAndBuildStubs writes each component's values to static/<name>.yaml
@@ -254,7 +256,7 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		}
 
 		// Deep-copy values so we can remove dynamic paths without mutating the input
-		staticValues := deepCopyMap(values)
+		staticValues := component.DeepCopyMap(values)
 
 		// Extract dynamic paths: remove from static, build stubs for root values.yaml.
 		// When the path exists in static values, the resolved default is preserved
@@ -290,10 +292,14 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 	return files, totalSize, dynamicOnlyValues, nil
 }
 
-// transformApplication reads a flat ArgoCD Application manifest and converts
-// its multi-source helm block to a single-source with valuesObject that loads
-// static values from chart files and merges dynamic overrides from .Values.
-func transformApplication(srcDir, templatesDir, componentName, overrideKey string, hasDynamic bool) (string, int64, error) {
+// transformApplication reads a flat ArgoCD Application manifest, parses it as
+// structured YAML, replaces the multi-source block with a single-source +
+// helm.values Helm template, and writes the result as a chart template file.
+func transformApplication(srcDir, templatesDir, componentName, overrideKey string) (string, int64, error) {
+	if !shared.IsSafePathComponent(componentName) {
+		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", componentName))
+	}
 	componentDir, joinErr := shared.SafeJoin(srcDir, componentName)
 	if joinErr != nil {
 		return "", 0, joinErr
@@ -308,69 +314,152 @@ func transformApplication(srcDir, templatesDir, componentName, overrideKey strin
 			fmt.Sprintf("failed to read application.yaml for %s", componentName), err)
 	}
 
-	transformed, transformErr := transformMultiSourceToValuesObject(string(content), componentName, overrideKey, hasDynamic)
-	if transformErr != nil {
+	// Parse as structured YAML to avoid fragile regex/string manipulation.
+	var app map[string]any
+	if unmarshalErr := yaml.Unmarshal(content, &app); unmarshalErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to parse application.yaml for %s", componentName), unmarshalErr)
+	}
+
+	if transformErr := convertToSingleSourceWithValues(app, componentName, overrideKey); transformErr != nil {
 		return "", 0, errors.Wrap(errors.ErrCodeInternal,
 			fmt.Sprintf("failed to transform application.yaml for %s", componentName), transformErr)
 	}
+
+	// Marshal to YAML, then replace the quoted values string with the
+	// raw Helm template expression. yaml.Marshal wraps the template in quotes
+	// (since it contains {{ }}), but ArgoCD needs the raw template text so
+	// Helm can evaluate it at render time.
+	out, marshalErr := yaml.Marshal(app)
+	if marshalErr != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to marshal transformed application for %s", componentName), marshalErr)
+	}
+	out = fixValuesTemplate(out, app)
 
 	destPath, pathErr := shared.SafeJoin(templatesDir, componentName+".yaml")
 	if pathErr != nil {
 		return "", 0, pathErr
 	}
 
-	if writeErr := os.WriteFile(destPath, []byte(transformed), 0600); writeErr != nil {
+	if writeErr := os.WriteFile(destPath, out, 0600); writeErr != nil {
 		return "", 0, errors.Wrap(errors.ErrCodeInternal,
 			fmt.Sprintf("failed to write template for %s", componentName), writeErr)
 	}
-	return destPath, int64(len(transformed)), nil
+	return destPath, int64(len(out)), nil
 }
 
-// transformMultiSourceToValuesObject replaces the ArgoCD multi-source block
-// with a single-source block that loads static values from chart files and
-// merges dynamic overrides from .Values.
+// convertToSingleSourceWithValues mutates an ArgoCD Application map,
+// replacing the multi-source "sources" block with a single "source" that
+// loads static values from a chart file and merges dynamic overrides.
 //
-// Static values are loaded via .Files.Get from the chart's static/ directory.
-// When the component has dynamic values, they are merged on top using
-// mustMergeOverwrite so user-provided values win.
-func transformMultiSourceToValuesObject(content, componentName, overrideKey string, hasDynamic bool) (string, error) {
-	repoURL, chart, targetRevision, err := extractFirstSourceValues(content)
-	if err != nil {
-		return "", err
+// All Helm components use the merge pattern — every value is overridable
+// at install time via --set, not just paths declared with --dynamic.
+func convertToSingleSourceWithValues(app map[string]any, componentName, overrideKey string) error {
+	spec, ok := app["spec"].(map[string]any)
+	if !ok {
+		return errors.New(errors.ErrCodeInternal, "application manifest missing 'spec'")
 	}
 
-	if !sourcesPattern.MatchString(content) {
-		return "", errors.New(errors.ErrCodeInternal,
-			"ArgoCD Application manifest does not contain expected multi-source block; "+
-				"the upstream template format may have changed")
+	sources, ok := spec["sources"].([]any)
+	if !ok || len(sources) == 0 {
+		return errors.New(errors.ErrCodeInternal, "application manifest missing 'spec.sources'")
 	}
 
-	var replacement strings.Builder
-	fmt.Fprintf(&replacement, "  source:\n")
-	fmt.Fprintf(&replacement, "    repoURL: %s\n", repoURL)
-	fmt.Fprintf(&replacement, "    chart: %s\n", chart)
-	fmt.Fprintf(&replacement, "    targetRevision: %s\n", targetRevision)
-	fmt.Fprintf(&replacement, "    helm:\n")
-
-	if hasDynamic {
-		// Merge static (from chart file) + dynamic (from .Values) at render time
-		fmt.Fprintf(&replacement, "      valuesObject: |-\n")
-		fmt.Fprintf(&replacement, `        {{- $static := (.Files.Get "static/%s.yaml") | fromYaml -}}`+"\n", componentName)
-		fmt.Fprintf(&replacement, `        {{- $dynamic := index .Values %q | default dict -}}`+"\n", overrideKey)
-		fmt.Fprintf(&replacement, "        {{- mustMergeOverwrite $static $dynamic | toYaml | nindent 8 }}\n")
-	} else {
-		// Static only — load directly from chart file
-		fmt.Fprintf(&replacement, "      valuesObject: |-\n")
-		fmt.Fprintf(&replacement, `        {{- (.Files.Get "static/%s.yaml") | fromYaml | toYaml | nindent 8 }}`+"\n", componentName)
+	// First source entry has the chart reference
+	firstSource, ok := sources[0].(map[string]any)
+	if !ok {
+		return errors.New(errors.ErrCodeInternal, "first source entry is not a map")
 	}
 
-	replacement.WriteString("  destination:")
+	repoURL, _ := firstSource["repoURL"].(string)
+	chart, _ := firstSource["chart"].(string)
+	targetRevision, _ := firstSource["targetRevision"].(string)
 
-	return sourcesPattern.ReplaceAllLiteralString(content, replacement.String()), nil
+	if repoURL == "" || chart == "" || targetRevision == "" {
+		var missing []string
+		if repoURL == "" {
+			missing = append(missing, "repoURL")
+		}
+		if chart == "" {
+			missing = append(missing, "chart")
+		}
+		if targetRevision == "" {
+			missing = append(missing, "targetRevision")
+		}
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("first source entry missing fields: %s", strings.Join(missing, ", ")))
+	}
+
+	// Build the Helm template expression for values.
+	// ArgoCD's spec.source.helm.values is a string field containing YAML text.
+	// This template merges static values (from chart files) with dynamic overrides
+	// (from .Values) at Helm render time.
+	valuesTmpl := fmt.Sprintf(
+		`{{- $static := (.Files.Get "static/%s.yaml") | fromYaml | default dict -}}`+"\n"+
+			`{{- $dynamic := index .Values %q | default dict -}}`+"\n"+
+			`{{- mustMergeOverwrite $static $dynamic | toYaml | nindent 8 }}`,
+		componentName, overrideKey)
+
+	// Replace multi-source with single source + values
+	spec["source"] = map[string]any{
+		"repoURL":        repoURL,
+		"chart":          chart,
+		"targetRevision": targetRevision,
+		"helm": map[string]any{
+			"values": valuesTmpl,
+		},
+	}
+	delete(spec, "sources")
+
+	return nil
 }
 
-// copyAsTemplate copies an application.yaml from the flat output to templates/ as-is.
+// fixValuesTemplate replaces the yaml.Marshal-quoted values string with a raw
+// block scalar. yaml.Marshal wraps strings containing {{ }} in quotes, but the
+// output needs to be a raw Helm template that Helm evaluates at render time.
+// ArgoCD's spec.source.helm.values is a string field, so |- block scalar is correct.
+func fixValuesTemplate(marshaled []byte, app map[string]any) []byte {
+	spec, _ := app["spec"].(map[string]any)
+	source, _ := spec["source"].(map[string]any)
+	helm, _ := source["helm"].(map[string]any)
+	tmpl, _ := helm["values"].(string)
+	if tmpl == "" {
+		return marshaled
+	}
+
+	// Build the raw block scalar version
+	var raw strings.Builder
+	raw.WriteString("      values: |-\n")
+	for _, line := range strings.Split(tmpl, "\n") {
+		raw.WriteString("        " + line + "\n")
+	}
+
+	// Replace whatever yaml.Marshal produced for values with the raw version.
+	result := string(marshaled)
+	start := strings.Index(result, "      values:")
+	if start == -1 {
+		return marshaled
+	}
+	// Find the end of the values value (next line at indent <= 6 spaces)
+	rest := result[start:]
+	lines := strings.Split(rest, "\n")
+	end := len(lines[0]) + 1
+	for _, line := range lines[1:] {
+		if line == "" || (len(line) > 0 && len(line)-len(strings.TrimLeft(line, " ")) <= 6 && strings.TrimSpace(line) != "") {
+			break
+		}
+		end += len(line) + 1
+	}
+
+	return []byte(result[:start] + raw.String() + result[start+end:])
+}
+
 func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, error) {
+	if !shared.IsSafePathComponent(componentName) {
+		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", componentName))
+	}
 	componentDir, joinErr := shared.SafeJoin(srcDir, componentName)
 	if joinErr != nil {
 		return "", 0, joinErr
@@ -395,56 +484,6 @@ func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, 
 			fmt.Sprintf("failed to write template for %s", componentName), writeErr)
 	}
 	return destPath, int64(len(content)), nil
-}
-
-// extractFirstSourceValues parses the multi-source block and extracts
-// repoURL, chart, and targetRevision from the first source entry.
-// Returns an error if any required field is missing, which indicates the
-// upstream ArgoCD template format has changed.
-func extractFirstSourceValues(content string) (repoURL, chart, targetRevision string, err error) {
-	lines := strings.Split(content, "\n")
-	inFirstSource := false
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "- repoURL:") {
-			if !inFirstSource {
-				inFirstSource = true
-				repoURL = strings.TrimSpace(strings.TrimPrefix(trimmed, "- repoURL:"))
-				repoURL = strings.Trim(repoURL, "'")
-			}
-			continue
-		}
-		if !inFirstSource {
-			continue
-		}
-		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "ref:") {
-			break // hit second source entry or ref field
-		}
-		if strings.HasPrefix(trimmed, "chart:") {
-			chart = strings.TrimSpace(strings.TrimPrefix(trimmed, "chart:"))
-		}
-		if strings.HasPrefix(trimmed, "targetRevision:") {
-			targetRevision = strings.TrimSpace(strings.TrimPrefix(trimmed, "targetRevision:"))
-		}
-	}
-
-	var missing []string
-	if repoURL == "" {
-		missing = append(missing, "repoURL")
-	}
-	if chart == "" {
-		missing = append(missing, "chart")
-	}
-	if targetRevision == "" {
-		missing = append(missing, "targetRevision")
-	}
-	if len(missing) > 0 {
-		return "", "", "", errors.New(errors.ErrCodeInternal,
-			fmt.Sprintf("failed to extract source fields [%s] from ArgoCD Application manifest; "+
-				"the upstream template format may have changed", strings.Join(missing, ", ")))
-	}
-
-	return repoURL, chart, targetRevision, nil
 }
 
 func writeChartYAML(outputDir, version string) (string, int64, error) {
@@ -554,28 +593,4 @@ func resolveOverrideKey(componentName string) (string, error) {
 			fmt.Sprintf("component %q has no valueOverrideKeys in registry", componentName))
 	}
 	return comp.ValueOverrideKeys[0], nil
-}
-
-func deepCopyMap(m map[string]any) map[string]any {
-	if m == nil {
-		return nil
-	}
-	data, err := yaml.Marshal(m)
-	if err != nil {
-		slog.Warn("deepCopyMap: yaml.Marshal failed, falling back to shallow copy", "error", err)
-		result := make(map[string]any, len(m))
-		for k, v := range m {
-			result[k] = v
-		}
-		return result
-	}
-	var result map[string]any
-	if unmarshalErr := yaml.Unmarshal(data, &result); unmarshalErr != nil {
-		slog.Warn("deepCopyMap: yaml.Unmarshal failed, falling back to shallow copy", "error", unmarshalErr)
-		result = make(map[string]any, len(m))
-		for k, v := range m {
-			result[k] = v
-		}
-	}
-	return result
 }

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -1,0 +1,401 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocdhelm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+func newRecipeResult(version string, refs []recipe.ComponentRef) *recipe.RecipeResult {
+	r := &recipe.RecipeResult{
+		ComponentRefs: refs,
+	}
+	r.Metadata.Version = version
+	return r
+}
+
+func TestGenerate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *Generator
+		assert  func(t *testing.T, outputDir string, output *deployer.Output)
+		wantErr bool
+	}{
+		{
+			name: "produces Chart.yaml and templates directory",
+			input: &Generator{
+				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
+					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
+				}),
+				ComponentValues: map[string]map[string]any{
+					"gpu-operator": {"driver": map[string]any{"version": "580"}},
+				},
+				Version: "test",
+				RepoURL: "https://github.com/example/repo.git",
+				DynamicValues: map[string][]string{
+					"gpu-operator": {"driver.version"},
+				},
+			},
+			assert: func(t *testing.T, outputDir string, _ *deployer.Output) {
+				t.Helper()
+				for _, f := range []string{"Chart.yaml", "values.yaml", "README.md"} {
+					if _, err := os.Stat(filepath.Join(outputDir, f)); os.IsNotExist(err) {
+						t.Errorf("%s should exist", f)
+					}
+				}
+				if _, err := os.Stat(filepath.Join(outputDir, "templates", "gpu-operator.yaml")); os.IsNotExist(err) {
+					t.Error("templates/gpu-operator.yaml should exist")
+				}
+				// Should NOT have flat ArgoCD artifacts
+				if _, err := os.Stat(filepath.Join(outputDir, "app-of-apps.yaml")); !os.IsNotExist(err) {
+					t.Error("app-of-apps.yaml should NOT exist in Helm chart output")
+				}
+			},
+		},
+		{
+			name: "dynamic paths stubbed in root values.yaml",
+			input: &Generator{
+				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
+					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
+				}),
+				ComponentValues: map[string]map[string]any{
+					"gpu-operator": {"driver": map[string]any{"version": "580", "registry": "nvcr.io"}},
+				},
+				Version: "test",
+				RepoURL: "https://github.com/example/repo.git",
+				DynamicValues: map[string][]string{
+					"gpu-operator": {"driver.version"},
+				},
+			},
+			assert: func(t *testing.T, outputDir string, _ *deployer.Output) {
+				t.Helper()
+				content, err := os.ReadFile(filepath.Join(outputDir, "values.yaml"))
+				if err != nil {
+					t.Fatalf("failed to read values.yaml: %v", err)
+				}
+				var values map[string]any
+				if unmarshalErr := yaml.Unmarshal(content, &values); unmarshalErr != nil {
+					t.Fatalf("failed to parse values.yaml: %v", unmarshalErr)
+				}
+
+				// Root values.yaml should ONLY have dynamic stubs
+				key := resolveOverrideKey("gpu-operator")
+				compValues, ok := values[key].(map[string]any)
+				if !ok {
+					t.Fatalf("expected dynamic stubs under key %q", key)
+				}
+				driver, ok := compValues["driver"].(map[string]any)
+				if !ok {
+					t.Fatal("expected driver map in dynamic stubs")
+				}
+				// Dynamic path should have the resolved default value (not empty —
+				// the ArgoCD Helm chart preserves defaults so users see what to override)
+				if driver["version"] == nil {
+					t.Error("dynamic path driver.version should be present in root values.yaml")
+				}
+				// Static values should NOT be in root values.yaml
+				if _, hasRegistry := driver["registry"]; hasRegistry {
+					t.Error("static path driver.registry should NOT be in root values.yaml (it's in static/)")
+				}
+
+				// Static values should be in static/ directory
+				staticContent, staticErr := os.ReadFile(filepath.Join(outputDir, "static", "gpu-operator.yaml"))
+				if staticErr != nil {
+					t.Fatalf("failed to read static/gpu-operator.yaml: %v", staticErr)
+				}
+				if !strings.Contains(string(staticContent), "nvcr.io") {
+					t.Error("static/gpu-operator.yaml should contain static values like registry")
+				}
+			},
+		},
+		{
+			name: "transformed template uses valuesObject",
+			input: &Generator{
+				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
+					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
+				}),
+				ComponentValues: map[string]map[string]any{
+					"gpu-operator": {"driver": map[string]any{"version": "580"}},
+				},
+				Version: "test",
+				RepoURL: "https://github.com/example/repo.git",
+				DynamicValues: map[string][]string{
+					"gpu-operator": {"driver.version"},
+				},
+			},
+			assert: func(t *testing.T, outputDir string, _ *deployer.Output) {
+				t.Helper()
+				tmplContent, err := os.ReadFile(filepath.Join(outputDir, "templates", "gpu-operator.yaml"))
+				if err != nil {
+					t.Fatalf("failed to read template: %v", err)
+				}
+				tmplStr := string(tmplContent)
+
+				if !strings.Contains(tmplStr, "valuesObject") {
+					t.Error("template should contain valuesObject")
+				}
+				if !strings.Contains(tmplStr, "static/gpu-operator.yaml") {
+					t.Error("template should load static values via .Files.Get")
+				}
+				if !strings.Contains(tmplStr, "mustMergeOverwrite") {
+					t.Error("template should merge static + dynamic values")
+				}
+				// Should be single-source, not multi-source
+				if strings.Contains(tmplStr, "sources:") {
+					t.Error("template should use single 'source:', not multi-source 'sources:'")
+				}
+				if strings.Contains(tmplStr, "$values") {
+					t.Error("template should not reference $values (flat ArgoCD pattern)")
+				}
+			},
+		},
+		{
+			name: "deployment steps reference helm install",
+			input: &Generator{
+				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
+					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1.0.0"},
+				}),
+				ComponentValues: map[string]map[string]any{"gpu-operator": {}},
+				Version:         "test",
+				RepoURL:         "https://github.com/example/repo.git",
+				DynamicValues:   map[string][]string{"gpu-operator": {"driver.version"}},
+			},
+			assert: func(t *testing.T, _ string, output *deployer.Output) {
+				t.Helper()
+				found := false
+				for _, step := range output.DeploymentSteps {
+					if strings.Contains(step, "helm install") {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Error("deployment steps should reference 'helm install'")
+				}
+			},
+		},
+		{
+			name: "Chart.yaml has correct version from recipe",
+			input: &Generator{
+				RecipeResult: newRecipeResult("2.5.0", []recipe.ComponentRef{
+					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1.0.0"},
+				}),
+				ComponentValues: map[string]map[string]any{"gpu-operator": {}},
+				Version:         "test",
+				RepoURL:         "https://github.com/example/repo.git",
+				DynamicValues:   map[string][]string{"gpu-operator": {"driver.version"}},
+			},
+			assert: func(t *testing.T, outputDir string, _ *deployer.Output) {
+				t.Helper()
+				content, err := os.ReadFile(filepath.Join(outputDir, "Chart.yaml"))
+				if err != nil {
+					t.Fatalf("failed to read Chart.yaml: %v", err)
+				}
+				if !strings.Contains(string(content), "version: 2.5.0") {
+					t.Error("Chart.yaml should contain version: 2.5.0")
+				}
+			},
+		},
+		{
+			name:    "nil input returns error",
+			input:   nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			var output *deployer.Output
+			var err error
+			if tt.input != nil {
+				output, err = tt.input.Generate(context.Background(), outputDir)
+			} else {
+				gen := &Generator{}
+				output, err = gen.Generate(context.Background(), outputDir)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Generate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.assert != nil {
+				tt.assert(t, outputDir, output)
+			}
+		})
+	}
+}
+
+func TestTransformMultiSourceToValuesObject(t *testing.T) {
+	input := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gpu-operator
+spec:
+  project: default
+  sources:
+    - repoURL: https://helm.ngc.nvidia.com/nvidia
+      chart: gpu-operator
+      targetRevision: v24.9.0
+      helm:
+        valueFiles:
+          - $values/gpu-operator/values.yaml
+    - repoURL: 'https://github.com/example/repo.git'
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gpu-operator
+`
+
+	result, err := transformMultiSourceToValuesObject(input, "gpu-operator", "gpuOperator", true)
+	if err != nil {
+		t.Fatalf("transformMultiSourceToValuesObject() error = %v", err)
+	}
+
+	if strings.Contains(result, "sources:") {
+		t.Error("should not contain multi-source 'sources:'")
+	}
+	if !strings.Contains(result, "source:") {
+		t.Error("should contain single 'source:'")
+	}
+	if !strings.Contains(result, "valuesObject") {
+		t.Error("should contain valuesObject")
+	}
+	if !strings.Contains(result, "static/gpu-operator.yaml") {
+		t.Error("should reference static values file")
+	}
+	if !strings.Contains(result, "mustMergeOverwrite") {
+		t.Error("should merge static + dynamic values")
+	}
+	if !strings.Contains(result, `"gpuOperator"`) {
+		t.Error("should reference .Values with override key")
+	}
+	if !strings.Contains(result, "chart: gpu-operator") {
+		t.Error("should preserve chart name")
+	}
+	if !strings.Contains(result, "repoURL: https://helm.ngc.nvidia.com/nvidia") {
+		t.Error("should preserve chart repoURL")
+	}
+}
+
+func TestTransformMultiSource_StaticOnly(t *testing.T) {
+	input := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  sources:
+    - repoURL: https://charts.example.com
+      chart: cert-manager
+      targetRevision: v1.14.0
+      helm:
+        valueFiles:
+          - $values/cert-manager/values.yaml
+    - repoURL: 'https://github.com/example/repo.git'
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+`
+
+	result, err := transformMultiSourceToValuesObject(input, "cert-manager", "certmanager", false)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	if !strings.Contains(result, "static/cert-manager.yaml") {
+		t.Error("static-only should reference .Files.Get")
+	}
+	if strings.Contains(result, "mustMergeOverwrite") {
+		t.Error("static-only should NOT use merge (no dynamic values)")
+	}
+}
+
+func TestTransformMultiSource_MissingFields(t *testing.T) {
+	// Application with no sources block — regex won't match
+	noSources := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gpu-operator
+spec:
+  source:
+    repoURL: https://example.com
+  destination:
+    server: https://kubernetes.default.svc
+`
+	_, err := transformMultiSourceToValuesObject(noSources, "gpu-operator", "gpuOperator", true)
+	if err == nil {
+		t.Error("expected error when sources block is missing")
+	}
+
+	// Application with sources but missing chart field
+	noChart := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  sources:
+    - repoURL: https://example.com
+      targetRevision: v1.0.0
+      helm:
+        valueFiles:
+          - $values/test/values.yaml
+    - repoURL: 'https://github.com/example/repo.git'
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+`
+	_, err = transformMultiSourceToValuesObject(noChart, "test", "test", true)
+	if err == nil {
+		t.Error("expected error when chart field is missing from source")
+	}
+}
+
+func TestSetStubValue(t *testing.T) {
+	m := map[string]any{
+		"driver": map[string]any{"version": "580", "registry": "nvcr.io"},
+	}
+	setStubValue(m, "driver.version")
+
+	driver := m["driver"].(map[string]any)
+	if driver["version"] != "" {
+		t.Errorf("expected empty stub, got %v", driver["version"])
+	}
+	if driver["registry"] != "nvcr.io" {
+		t.Error("should not affect sibling keys")
+	}
+}
+
+func TestDeepCopyMap(t *testing.T) {
+	original := map[string]any{
+		"driver": map[string]any{"version": "580"},
+	}
+	copied := deepCopyMap(original)
+
+	if inner, ok := copied["driver"].(map[string]any); ok {
+		inner["version"] = "changed"
+	}
+	if original["driver"].(map[string]any)["version"] != "580" {
+		t.Error("deepCopyMap should produce independent copy")
+	}
+}

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -134,7 +134,7 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 		{
-			name: "transformed template uses valuesObject",
+			name: "transformed template uses values",
 			input: &Generator{
 				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
 					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
@@ -156,8 +156,8 @@ func TestGenerate(t *testing.T) {
 				}
 				tmplStr := string(tmplContent)
 
-				if !strings.Contains(tmplStr, "valuesObject") {
-					t.Error("template should contain valuesObject")
+				if !strings.Contains(tmplStr, "values:") {
+					t.Error("template should contain values:")
 				}
 				if !strings.Contains(tmplStr, "static/gpu-operator.yaml") {
 					t.Error("template should load static values via .Files.Get")
@@ -252,126 +252,139 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
-func TestTransformMultiSourceToValuesObject(t *testing.T) {
-	input := `apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: gpu-operator
-spec:
-  project: default
-  sources:
-    - repoURL: https://helm.ngc.nvidia.com/nvidia
-      chart: gpu-operator
-      targetRevision: v24.9.0
-      helm:
-        valueFiles:
-          - $values/gpu-operator/values.yaml
-    - repoURL: 'https://github.com/example/repo.git'
-      targetRevision: main
-      ref: values
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: gpu-operator
-`
+// TestConvertToSingleSourceWithValues verifies the structured YAML
+// transformation from multi-source to single-source with helm.values.
+func TestConvertToSingleSourceWithValues(t *testing.T) {
+	// Build a valid multi-source Application map
+	app := map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "gpu-operator"},
+		"spec": map[string]any{
+			"project": "default",
+			"sources": []any{
+				map[string]any{
+					"repoURL":        "https://helm.ngc.nvidia.com/nvidia",
+					"chart":          "gpu-operator",
+					"targetRevision": "v24.9.0",
+				},
+				map[string]any{
+					"repoURL": "https://github.com/example/repo.git",
+					"ref":     "values",
+				},
+			},
+			"destination": map[string]any{
+				"server":    "https://kubernetes.default.svc",
+				"namespace": "gpu-operator",
+			},
+		},
+	}
 
-	result, err := transformMultiSourceToValuesObject(input, "gpu-operator", "gpuOperator", true)
+	err := convertToSingleSourceWithValues(app, "gpu-operator", "gpuOperator")
 	if err != nil {
-		t.Fatalf("transformMultiSourceToValuesObject() error = %v", err)
+		t.Fatalf("convertToSingleSourceWithValues() error = %v", err)
 	}
 
-	if strings.Contains(result, "sources:") {
-		t.Error("should not contain multi-source 'sources:'")
+	spec := app["spec"].(map[string]any)
+
+	// Should have single "source", not "sources"
+	if _, hasSources := spec["sources"]; hasSources {
+		t.Error("should remove multi-source 'sources'")
 	}
-	if !strings.Contains(result, "source:") {
-		t.Error("should contain single 'source:'")
+	source, ok := spec["source"].(map[string]any)
+	if !ok {
+		t.Fatal("should have single 'source' map")
 	}
-	if !strings.Contains(result, "valuesObject") {
-		t.Error("should contain valuesObject")
+
+	// Verify chart fields preserved
+	if source["repoURL"] != "https://helm.ngc.nvidia.com/nvidia" {
+		t.Errorf("repoURL = %v, want nvidia repo", source["repoURL"])
 	}
-	if !strings.Contains(result, "static/gpu-operator.yaml") {
-		t.Error("should reference static values file")
+	if source["chart"] != "gpu-operator" {
+		t.Errorf("chart = %v, want gpu-operator", source["chart"])
 	}
-	if !strings.Contains(result, "mustMergeOverwrite") {
-		t.Error("should merge static + dynamic values")
+	if source["targetRevision"] != "v24.9.0" {
+		t.Errorf("targetRevision = %v, want v24.9.0", source["targetRevision"])
 	}
-	if !strings.Contains(result, `"gpuOperator"`) {
-		t.Error("should reference .Values with override key")
+
+	// Verify helm.values contains template expressions
+	helm, ok := source["helm"].(map[string]any)
+	if !ok {
+		t.Fatal("source should have 'helm' map")
 	}
-	if !strings.Contains(result, "chart: gpu-operator") {
-		t.Error("should preserve chart name")
+	valuesStr, ok := helm["values"].(string)
+	if !ok {
+		t.Fatal("helm should have 'values' string")
 	}
-	if !strings.Contains(result, "repoURL: https://helm.ngc.nvidia.com/nvidia") {
-		t.Error("should preserve chart repoURL")
+	if !strings.Contains(valuesStr, "static/gpu-operator.yaml") {
+		t.Error("values should reference static file")
+	}
+	if !strings.Contains(valuesStr, "mustMergeOverwrite") {
+		t.Error("values should use merge pattern")
+	}
+	if !strings.Contains(valuesStr, `"gpuOperator"`) {
+		t.Error("values should reference override key")
+	}
+	// Should NOT use valuesObject (that expects a YAML object, not a string)
+	if _, hasValuesObject := helm["valuesObject"]; hasValuesObject {
+		t.Error("should use 'values' (string), not 'valuesObject' (object)")
+	}
+
+	// Destination should be untouched
+	dest := spec["destination"].(map[string]any)
+	if dest["namespace"] != "gpu-operator" {
+		t.Error("destination should be preserved")
 	}
 }
 
-func TestTransformMultiSource_StaticOnly(t *testing.T) {
-	input := `apiVersion: argoproj.io/v1alpha1
-kind: Application
-spec:
-  sources:
-    - repoURL: https://charts.example.com
-      chart: cert-manager
-      targetRevision: v1.14.0
-      helm:
-        valueFiles:
-          - $values/cert-manager/values.yaml
-    - repoURL: 'https://github.com/example/repo.git'
-      targetRevision: main
-      ref: values
-  destination:
-    server: https://kubernetes.default.svc
-`
-
-	result, err := transformMultiSourceToValuesObject(input, "cert-manager", "certmanager", false)
-	if err != nil {
-		t.Fatalf("error = %v", err)
+// TestConvertToSingleSource_MissingFields verifies error handling when the
+// Application manifest is missing required fields.
+func TestConvertToSingleSource_MissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		app  map[string]any
+	}{
+		{
+			name: "missing spec",
+			app:  map[string]any{"apiVersion": "v1"},
+		},
+		{
+			name: "missing sources",
+			app: map[string]any{
+				"spec": map[string]any{
+					"source": map[string]any{"repoURL": "https://example.com"},
+				},
+			},
+		},
+		{
+			name: "empty sources",
+			app: map[string]any{
+				"spec": map[string]any{"sources": []any{}},
+			},
+		},
+		{
+			name: "missing chart in first source",
+			app: map[string]any{
+				"spec": map[string]any{
+					"sources": []any{
+						map[string]any{
+							"repoURL":        "https://example.com",
+							"targetRevision": "v1.0.0",
+							// chart is missing
+						},
+					},
+				},
+			},
+		},
 	}
 
-	if !strings.Contains(result, "static/cert-manager.yaml") {
-		t.Error("static-only should reference .Files.Get")
-	}
-	if strings.Contains(result, "mustMergeOverwrite") {
-		t.Error("static-only should NOT use merge (no dynamic values)")
-	}
-}
-
-func TestTransformMultiSource_MissingFields(t *testing.T) {
-	// Application with no sources block — regex won't match
-	noSources := `apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: gpu-operator
-spec:
-  source:
-    repoURL: https://example.com
-  destination:
-    server: https://kubernetes.default.svc
-`
-	_, err := transformMultiSourceToValuesObject(noSources, "gpu-operator", "gpuOperator", true)
-	if err == nil {
-		t.Error("expected error when sources block is missing")
-	}
-
-	// Application with sources but missing chart field
-	noChart := `apiVersion: argoproj.io/v1alpha1
-kind: Application
-spec:
-  sources:
-    - repoURL: https://example.com
-      targetRevision: v1.0.0
-      helm:
-        valueFiles:
-          - $values/test/values.yaml
-    - repoURL: 'https://github.com/example/repo.git'
-      targetRevision: main
-      ref: values
-  destination:
-    server: https://kubernetes.default.svc
-`
-	_, err = transformMultiSourceToValuesObject(noChart, "test", "test", true)
-	if err == nil {
-		t.Error("expected error when chart field is missing from source")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := convertToSingleSourceWithValues(tt.app, "test", "test")
+			if err == nil {
+				t.Error("expected error for malformed application")
+			}
+		})
 	}
 }
 
@@ -390,11 +403,52 @@ func TestSetValueByPath_StubBehavior(t *testing.T) {
 	}
 }
 
+// TestFixValuesTemplate verifies that the raw Helm template expression in
+// helm.values survives yaml.Marshal → fixValuesTemplate without being
+// quoted or escaped. This is critical: ArgoCD needs the raw template text, not
+// a YAML string literal.
+func TestFixValuesTemplate(t *testing.T) {
+	tmpl := `{{- $static := (.Files.Get "static/gpu-operator.yaml") | fromYaml -}}
+{{- $dynamic := index .Values "gpuOperator" | default dict -}}
+{{- mustMergeOverwrite $static $dynamic | toYaml | nindent 8 }}`
+
+	app := map[string]any{
+		"spec": map[string]any{
+			"source": map[string]any{
+				"helm": map[string]any{
+					"values": tmpl,
+				},
+			},
+		},
+	}
+
+	// yaml.Marshal will quote the template (it contains {{ }})
+	marshaled, err := yaml.Marshal(app)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error: %v", err)
+	}
+
+	// Apply the fix
+	fixed := fixValuesTemplate(marshaled, app)
+
+	// The fixed output should contain the raw template as a block scalar
+	fixedStr := string(fixed)
+	if !strings.Contains(fixedStr, "values: |-") {
+		t.Error("fixed output should use block scalar (|-) for values")
+	}
+	if !strings.Contains(fixedStr, "{{- $static") {
+		t.Error("fixed output should contain raw template expression")
+	}
+	if !strings.Contains(fixedStr, "mustMergeOverwrite") {
+		t.Error("fixed output should contain mustMergeOverwrite")
+	}
+}
+
 func TestDeepCopyMap(t *testing.T) {
 	original := map[string]any{
 		"driver": map[string]any{"version": "580"},
 	}
-	copied := deepCopyMap(original)
+	copied := component.DeepCopyMap(original)
 
 	if inner, ok := copied["driver"].(map[string]any); ok {
 		inner["version"] = "changed"

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
+	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
@@ -100,7 +101,10 @@ func TestGenerate(t *testing.T) {
 				}
 
 				// Root values.yaml should ONLY have dynamic stubs
-				key := resolveOverrideKey("gpu-operator")
+				key, keyErr := resolveOverrideKey("gpu-operator")
+				if keyErr != nil {
+					t.Fatalf("resolveOverrideKey failed: %v", keyErr)
+				}
 				compValues, ok := values[key].(map[string]any)
 				if !ok {
 					t.Fatalf("expected dynamic stubs under key %q", key)
@@ -371,11 +375,11 @@ spec:
 	}
 }
 
-func TestSetStubValue(t *testing.T) {
+func TestSetValueByPath_StubBehavior(t *testing.T) {
 	m := map[string]any{
 		"driver": map[string]any{"version": "580", "registry": "nvcr.io"},
 	}
-	setStubValue(m, "driver.version")
+	component.SetValueByPath(m, "driver.version", "")
 
 	driver := m["driver"].(map[string]any)
 	if driver["version"] != "" {

--- a/pkg/bundler/deployer/deployer.go
+++ b/pkg/bundler/deployer/deployer.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deployer defines the shared interface and types for bundle deployers.
+//
+// Each deployer (helm, argocd, argocdhelm) produces deployment artifacts from
+// a configured recipe. Deployers are configured as structs with all required
+// data, then Generate is called to produce the output.
+//
+// The Deployer interface enables mockability in bundler tests and provides a
+// consistent contract across deployer implementations. Existing deployers
+// (helm, argocd) do not yet implement this interface — argocdhelm is the first.
+package deployer
+
+import (
+	"context"
+	"time"
+)
+
+// Output contains the result of deployer generation.
+type Output struct {
+	// Files contains the paths of generated files.
+	Files []string
+
+	// TotalSize is the total size of all generated files.
+	TotalSize int64
+
+	// Duration is the time taken to generate the output.
+	Duration time.Duration
+
+	// DeploymentSteps contains ordered deployment instructions for the user.
+	DeploymentSteps []string
+
+	// DeploymentNotes contains optional deployment notes or warnings.
+	DeploymentNotes []string
+}
+
+// Deployer generates deployment bundles from configured inputs.
+// Implementations are configured as structs, then Generate is called.
+type Deployer interface {
+	Generate(ctx context.Context, outputDir string) (*Output, error)
+
+	// HasDynamicValues reports whether this deployer has install-time value
+	// paths that will be split out for the user to fill in at deploy time.
+	HasDynamicValues() bool
+}

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/manifest"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -49,18 +50,19 @@ const criteriaAny = "any"
 
 // ComponentData contains data for rendering per-component templates.
 type ComponentData struct {
-	Name         string
-	Namespace    string
-	Repository   string
-	ChartName    string
-	Version      string // Original version string (preserves 'v' prefix) for helm install --version
-	ChartVersion string // Normalized version (no 'v' prefix) for chart metadata labels
-	HasManifests bool
-	HasChart     bool
-	IsOCI        bool
-	IsKustomize  bool   // True when the component uses Kustomize instead of Helm
-	Tag          string // Git ref for Kustomize components (tag, branch, or commit)
-	Path         string // Path within the repository to the kustomization
+	Name             string
+	Namespace        string
+	Repository       string
+	ChartName        string
+	Version          string // Original version string (preserves 'v' prefix) for helm install --version
+	ChartVersion     string // Normalized version (no 'v' prefix) for chart metadata labels
+	HasManifests     bool
+	HasChart         bool
+	IsOCI            bool
+	IsKustomize      bool   // True when the component uses Kustomize instead of Helm
+	HasDynamicValues bool   // True when the component has dynamic value paths in cluster-values.yaml
+	Tag              string // Git ref for Kustomize components (tag, branch, or commit)
+	Path             string // Path within the repository to the kustomization
 }
 
 // GeneratorInput contains all data needed to generate a per-component Helm bundle.
@@ -85,6 +87,10 @@ type GeneratorInput struct {
 	// DataFiles lists additional file paths (relative to output dir) to include
 	// in checksum generation. Used for external data files copied into the bundle.
 	DataFiles []string
+
+	// DynamicValues maps component names to their dynamic value paths.
+	// These paths are removed from values.yaml and written to cluster-values.yaml.
+	DynamicValues map[string][]string
 }
 
 // GeneratorOutput contains the result of Helm bundle generation.
@@ -249,18 +255,19 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 		version := ref.Version
 
 		components = append(components, ComponentData{
-			Name:         ref.Name,
-			Namespace:    ref.Namespace,
-			Repository:   ref.Source,
-			ChartName:    chartName,
-			Version:      version,
-			ChartVersion: shared.NormalizeVersionWithDefault(ref.Version),
-			HasManifests: hasManifests,
-			HasChart:     !isKustomize && ref.Source != "",
-			IsOCI:        isOCI,
-			IsKustomize:  isKustomize,
-			Tag:          ref.Tag,
-			Path:         ref.Path,
+			Name:             ref.Name,
+			Namespace:        ref.Namespace,
+			Repository:       ref.Source,
+			ChartName:        chartName,
+			Version:          version,
+			ChartVersion:     shared.NormalizeVersionWithDefault(ref.Version),
+			HasManifests:     hasManifests,
+			HasChart:         !isKustomize && ref.Source != "",
+			IsOCI:            isOCI,
+			IsKustomize:      isKustomize,
+			HasDynamicValues: len(input.DynamicValues[ref.Name]) > 0,
+			Tag:              ref.Tag,
+			Path:             ref.Path,
 		})
 	}
 
@@ -288,11 +295,22 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 				fmt.Sprintf("failed to create directory for %s", comp.Name), mkdirErr)
 		}
 
-		// Write values.yaml
+		// Write values.yaml (and cluster-values.yaml for dynamic paths)
 		values := input.ComponentValues[comp.Name]
 		if values == nil {
 			values = make(map[string]any)
 		}
+
+		// Split dynamic values into cluster-values.yaml
+		if dynamicPaths, ok := input.DynamicValues[comp.Name]; ok && len(dynamicPaths) > 0 {
+			clusterFiles, clusterSize, clusterErr := writeDynamicValuesFile(values, dynamicPaths, componentDir, comp.Name)
+			if clusterErr != nil {
+				return nil, 0, clusterErr
+			}
+			files = append(files, clusterFiles...)
+			totalSize += clusterSize
+		}
+
 		valuesPath, valuesSize, err := shared.WriteValuesFile(values, componentDir, "values.yaml")
 		if err != nil {
 			return nil, 0, errors.Wrap(errors.ErrCodeInternal,
@@ -518,6 +536,51 @@ func uniqueNamespaces(components []ComponentData) []string {
 		}
 	}
 	return namespaces
+}
+
+// writeDynamicValuesFile extracts dynamic paths from values and writes them to cluster-values.yaml.
+// The dynamic paths are removed from values (mutated in place) and written as stubs.
+func writeDynamicValuesFile(values map[string]any, dynamicPaths []string, componentDir, componentName string) ([]string, int64, error) {
+	stubValues := make(map[string]any)
+	for _, path := range dynamicPaths {
+		val, found := component.GetValueByPath(values, path)
+		if found {
+			component.RemoveValueByPath(values, path)
+		} else {
+			val = ""
+		}
+		setNestedValue(stubValues, path, val)
+	}
+
+	clusterPath, clusterSize, err := shared.WriteValuesFile(stubValues, componentDir, "cluster-values.yaml")
+	if err != nil {
+		return nil, 0, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to write cluster-values.yaml for %s", componentName), err)
+	}
+
+	slog.Debug("wrote cluster-values.yaml", "component", componentName, "paths", dynamicPaths)
+	return []string{clusterPath}, clusterSize, nil
+}
+
+// setNestedValue sets a value in a nested map using dot-notation path,
+// creating intermediate maps as needed.
+func setNestedValue(m map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	current := m
+
+	for _, part := range parts[:len(parts)-1] {
+		if next, ok := current[part]; ok {
+			if nextMap, ok := next.(map[string]any); ok {
+				current = nextMap
+				continue
+			}
+		}
+		newMap := make(map[string]any)
+		current[part] = newMap
+		current = newMap
+	}
+
+	current[parts[len(parts)-1]] = value
 }
 
 // hasYAMLObjects returns true if content contains at least one YAML object

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -50,19 +50,18 @@ const criteriaAny = "any"
 
 // ComponentData contains data for rendering per-component templates.
 type ComponentData struct {
-	Name             string
-	Namespace        string
-	Repository       string
-	ChartName        string
-	Version          string // Original version string (preserves 'v' prefix) for helm install --version
-	ChartVersion     string // Normalized version (no 'v' prefix) for chart metadata labels
-	HasManifests     bool
-	HasChart         bool
-	IsOCI            bool
-	IsKustomize      bool   // True when the component uses Kustomize instead of Helm
-	HasDynamicValues bool   // True when the component has dynamic value paths in cluster-values.yaml
-	Tag              string // Git ref for Kustomize components (tag, branch, or commit)
-	Path             string // Path within the repository to the kustomization
+	Name         string
+	Namespace    string
+	Repository   string
+	ChartName    string
+	Version      string // Original version string (preserves 'v' prefix) for helm install --version
+	ChartVersion string // Normalized version (no 'v' prefix) for chart metadata labels
+	HasManifests bool
+	HasChart     bool
+	IsOCI        bool
+	IsKustomize  bool   // True when the component uses Kustomize instead of Helm
+	Tag          string // Git ref for Kustomize components (tag, branch, or commit)
+	Path         string // Path within the repository to the kustomization
 }
 
 // GeneratorInput contains all data needed to generate a per-component Helm bundle.
@@ -255,19 +254,18 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 		version := ref.Version
 
 		components = append(components, ComponentData{
-			Name:             ref.Name,
-			Namespace:        ref.Namespace,
-			Repository:       ref.Source,
-			ChartName:        chartName,
-			Version:          version,
-			ChartVersion:     shared.NormalizeVersionWithDefault(ref.Version),
-			HasManifests:     hasManifests,
-			HasChart:         !isKustomize && ref.Source != "",
-			IsOCI:            isOCI,
-			IsKustomize:      isKustomize,
-			HasDynamicValues: len(input.DynamicValues[ref.Name]) > 0,
-			Tag:              ref.Tag,
-			Path:             ref.Path,
+			Name:         ref.Name,
+			Namespace:    ref.Namespace,
+			Repository:   ref.Source,
+			ChartName:    chartName,
+			Version:      version,
+			ChartVersion: shared.NormalizeVersionWithDefault(ref.Version),
+			HasManifests: hasManifests,
+			HasChart:     !isKustomize && ref.Source != "",
+			IsOCI:        isOCI,
+			IsKustomize:  isKustomize,
+			Tag:          ref.Tag,
+			Path:         ref.Path,
 		})
 	}
 
@@ -295,21 +293,19 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 				fmt.Sprintf("failed to create directory for %s", comp.Name), mkdirErr)
 		}
 
-		// Write values.yaml (and cluster-values.yaml for dynamic paths)
-		values := input.ComponentValues[comp.Name]
-		if values == nil {
-			values = make(map[string]any)
-		}
+		// Deep-copy component values so writeClusterValuesFile can safely
+		// remove dynamic paths without mutating the caller's map.
+		values := component.DeepCopyMap(input.ComponentValues[comp.Name])
 
-		// Split dynamic values into cluster-values.yaml
-		if dynamicPaths, ok := input.DynamicValues[comp.Name]; ok && len(dynamicPaths) > 0 {
-			clusterFiles, clusterSize, clusterErr := writeDynamicValuesFile(values, dynamicPaths, componentDir, comp.Name)
-			if clusterErr != nil {
-				return nil, 0, clusterErr
-			}
-			files = append(files, clusterFiles...)
-			totalSize += clusterSize
+		// Extract dynamic paths (if any) from values into cluster-values.yaml.
+		// Every component gets a cluster-values.yaml — dynamic paths are pre-populated,
+		// and users can add any additional overrides. deploy.sh always passes it.
+		clusterFiles, clusterSize, clusterErr := writeClusterValuesFile(values, input.DynamicValues[comp.Name], componentDir, comp.Name)
+		if clusterErr != nil {
+			return nil, 0, clusterErr
 		}
+		files = append(files, clusterFiles...)
+		totalSize += clusterSize
 
 		valuesPath, valuesSize, err := shared.WriteValuesFile(values, componentDir, "values.yaml")
 		if err != nil {
@@ -538,10 +534,13 @@ func uniqueNamespaces(components []ComponentData) []string {
 	return namespaces
 }
 
-// writeDynamicValuesFile extracts dynamic paths from values and writes them to cluster-values.yaml.
-// The dynamic paths are removed from values (mutated in place) and written as stubs.
-func writeDynamicValuesFile(values map[string]any, dynamicPaths []string, componentDir, componentName string) ([]string, int64, error) {
-	stubValues := make(map[string]any)
+// writeClusterValuesFile writes a cluster-values.yaml for per-cluster overrides.
+// If dynamicPaths is non-empty, those paths are extracted from values and pre-populated.
+// WARNING: This function mutates the values map in place (removes dynamic paths via
+// RemoveValueByPath). Callers must pass a deep copy if the original map must be preserved.
+// The file is always written — even when empty — so users can add any overrides.
+func writeClusterValuesFile(values map[string]any, dynamicPaths []string, componentDir, componentName string) ([]string, int64, error) {
+	clusterValues := make(map[string]any)
 	for _, path := range dynamicPaths {
 		val, found := component.GetValueByPath(values, path)
 		if found {
@@ -549,16 +548,16 @@ func writeDynamicValuesFile(values map[string]any, dynamicPaths []string, compon
 		} else {
 			val = ""
 		}
-		component.SetValueByPath(stubValues, path, val)
+		component.SetValueByPath(clusterValues, path, val)
 	}
 
-	clusterPath, clusterSize, err := shared.WriteValuesFile(stubValues, componentDir, "cluster-values.yaml")
+	clusterPath, clusterSize, err := shared.WriteValuesFile(clusterValues, componentDir, "cluster-values.yaml")
 	if err != nil {
 		return nil, 0, errors.Wrap(errors.ErrCodeInternal,
 			fmt.Sprintf("failed to write cluster-values.yaml for %s", componentName), err)
 	}
 
-	slog.Debug("wrote cluster-values.yaml", "component", componentName, "paths", dynamicPaths)
+	slog.Debug("wrote cluster-values.yaml", "component", componentName, "dynamic_paths", len(dynamicPaths))
 	return []string{clusterPath}, clusterSize, nil
 }
 

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -549,7 +549,7 @@ func writeDynamicValuesFile(values map[string]any, dynamicPaths []string, compon
 		} else {
 			val = ""
 		}
-		setNestedValue(stubValues, path, val)
+		component.SetValueByPath(stubValues, path, val)
 	}
 
 	clusterPath, clusterSize, err := shared.WriteValuesFile(stubValues, componentDir, "cluster-values.yaml")
@@ -560,27 +560,6 @@ func writeDynamicValuesFile(values map[string]any, dynamicPaths []string, compon
 
 	slog.Debug("wrote cluster-values.yaml", "component", componentName, "paths", dynamicPaths)
 	return []string{clusterPath}, clusterSize, nil
-}
-
-// setNestedValue sets a value in a nested map using dot-notation path,
-// creating intermediate maps as needed.
-func setNestedValue(m map[string]any, path string, value any) {
-	parts := strings.Split(path, ".")
-	current := m
-
-	for _, part := range parts[:len(parts)-1] {
-		if next, ok := current[part]; ok {
-			if nextMap, ok := next.(map[string]any); ok {
-				current = nextMap
-				continue
-			}
-		}
-		newMap := make(map[string]any)
-		current[part] = newMap
-		current = newMap
-	}
-
-	current[parts[len(parts)-1]] = value
 }
 
 // hasYAMLObjects returns true if content contains at least one YAML object

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -1634,17 +1634,17 @@ func TestGenerate_DynamicValues(t *testing.T) {
 		wantDeployClusterValues bool   // whether deploy.sh should contain cluster-values.yaml for gpu-operator
 	}{
 		{
-			name:          "no dynamic values",
+			name:          "no dynamic values — cluster-values.yaml still generated (empty)",
 			dynamicValues: nil,
 			componentValues: map[string]map[string]any{
 				"cert-manager": {"crds": map[string]any{"enabled": true}},
 				"gpu-operator": {"driver": map[string]any{"version": testDriverVersion, "enabled": true}},
 			},
-			wantClusterValues:       false,
-			wantDeployClusterValues: false,
+			wantClusterValues:       true,
+			wantDeployClusterValues: true,
 		},
 		{
-			name: "dynamic values present",
+			name: "dynamic values present — extracted into cluster-values.yaml",
 			dynamicValues: map[string][]string{
 				"gpu-operator": {"driver.version"},
 			},
@@ -1718,13 +1718,13 @@ func TestGenerate_DynamicValues(t *testing.T) {
 				}
 			}
 
-			// cert-manager should never have cluster-values.yaml
+			// cert-manager should also have cluster-values.yaml (all components get one)
 			certClusterPath := filepath.Join(outputDir, "cert-manager", "cluster-values.yaml")
-			if _, certStatErr := os.Stat(certClusterPath); !os.IsNotExist(certStatErr) {
-				t.Error("cert-manager should not have cluster-values.yaml")
+			if _, certStatErr := os.Stat(certClusterPath); os.IsNotExist(certStatErr) {
+				t.Error("cert-manager should have cluster-values.yaml (all components get one)")
 			}
 
-			// Verify deploy.sh content
+			// Verify deploy.sh content — all components always reference cluster-values.yaml
 			deployContent, readErr := os.ReadFile(filepath.Join(outputDir, "deploy.sh"))
 			if readErr != nil {
 				t.Fatalf("failed to read deploy.sh: %v", readErr)
@@ -1736,16 +1736,12 @@ func TestGenerate_DynamicValues(t *testing.T) {
 				if !strings.Contains(deployScript, gpuClusterRef) {
 					t.Error("deploy.sh should contain cluster-values.yaml reference for gpu-operator")
 				}
-			} else {
-				if strings.Contains(deployScript, gpuClusterRef) {
-					t.Error("deploy.sh should NOT contain cluster-values.yaml reference for gpu-operator")
-				}
 			}
 
-			// cert-manager should never have cluster-values.yaml in deploy.sh
+			// All components always have cluster-values.yaml in deploy.sh
 			certClusterRef := `cert-manager/cluster-values.yaml`
-			if strings.Contains(deployScript, certClusterRef) {
-				t.Error("deploy.sh should NOT contain cluster-values.yaml reference for cert-manager")
+			if !strings.Contains(deployScript, certClusterRef) {
+				t.Error("deploy.sh should contain cluster-values.yaml reference for all components")
 			}
 		})
 	}
@@ -2215,5 +2211,42 @@ func TestReverseComponents(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGenerate_DoesNotMutateComponentValues verifies that Generate deep-copies
+// component values before extracting dynamic paths, so the input map is preserved.
+func TestGenerate_DoesNotMutateComponentValues(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	originalValues := map[string]map[string]any{
+		"gpu-operator": {
+			"driver": map[string]any{"version": testDriverVersion, "enabled": true},
+		},
+	}
+
+	input := &GeneratorInput{
+		RecipeResult:    createTestRecipeResult(),
+		ComponentValues: originalValues,
+		Version:         "test",
+		DynamicValues: map[string][]string{
+			"gpu-operator": {"driver.version"},
+		},
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Original values should NOT be mutated — driver.version should still exist
+	driver, ok := originalValues["gpu-operator"]["driver"].(map[string]any)
+	if !ok {
+		t.Fatal("original driver should still be a map")
+	}
+	if _, hasVersion := driver["version"]; !hasVersion {
+		t.Error("original driver.version was mutated (removed) — deep copy is missing")
 	}
 }

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
@@ -1844,7 +1845,7 @@ func TestSetNestedValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := make(map[string]any)
-			setNestedValue(m, tt.path, tt.value)
+			component.SetValueByPath(m, tt.path, tt.value)
 
 			for _, key := range tt.wantKeys {
 				if _, ok := m[key]; !ok {
@@ -1857,7 +1858,7 @@ func TestSetNestedValue(t *testing.T) {
 	// Verify full structure for nested path
 	t.Run("verify nested structure", func(t *testing.T) {
 		m := make(map[string]any)
-		setNestedValue(m, "driver.version", testDriverVersion)
+		component.SetValueByPath(m, "driver.version", testDriverVersion)
 
 		driver, ok := m["driver"].(map[string]any)
 		if !ok {
@@ -1875,8 +1876,8 @@ func TestSetNestedValue(t *testing.T) {
 	// Verify multiple paths into same parent
 	t.Run("multiple paths same parent", func(t *testing.T) {
 		m := make(map[string]any)
-		setNestedValue(m, "driver.version", testDriverVersion)
-		setNestedValue(m, "driver.enabled", true)
+		component.SetValueByPath(m, "driver.version", testDriverVersion)
+		component.SetValueByPath(m, "driver.enabled", true)
 
 		driver, ok := m["driver"].(map[string]any)
 		if !ok {

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -21,9 +21,14 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
+
+// testDriverVersion is a test constant for driver version strings to satisfy goconst.
+const testDriverVersion = "570.86.16"
 
 func TestNewGenerator(t *testing.T) {
 	g := NewGenerator()
@@ -1615,6 +1620,547 @@ func TestGenerateUndeployScript(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerate_DynamicValues(t *testing.T) {
+	tests := []struct {
+		name                    string
+		dynamicValues           map[string][]string
+		componentValues         map[string]map[string]any
+		wantClusterValues       bool   // whether cluster-values.yaml should exist for gpu-operator
+		wantClusterContains     string // substring expected in cluster-values.yaml
+		wantValuesLacksPath     string // dot path that should NOT be in values.yaml
+		wantDeployClusterValues bool   // whether deploy.sh should contain cluster-values.yaml for gpu-operator
+	}{
+		{
+			name:          "no dynamic values",
+			dynamicValues: nil,
+			componentValues: map[string]map[string]any{
+				"cert-manager": {"crds": map[string]any{"enabled": true}},
+				"gpu-operator": {"driver": map[string]any{"version": testDriverVersion, "enabled": true}},
+			},
+			wantClusterValues:       false,
+			wantDeployClusterValues: false,
+		},
+		{
+			name: "dynamic values present",
+			dynamicValues: map[string][]string{
+				"gpu-operator": {"driver.version"},
+			},
+			componentValues: map[string]map[string]any{
+				"cert-manager": {"crds": map[string]any{"enabled": true}},
+				"gpu-operator": {"driver": map[string]any{"version": testDriverVersion, "enabled": true}},
+			},
+			wantClusterValues:       true,
+			wantClusterContains:     "version",
+			wantValuesLacksPath:     "version: \"570.86.16\"",
+			wantDeployClusterValues: true,
+		},
+		{
+			name: "dynamic path not in values",
+			dynamicValues: map[string][]string{
+				"gpu-operator": {"nonexistent.path"},
+			},
+			componentValues: map[string]map[string]any{
+				"cert-manager": {"crds": map[string]any{"enabled": true}},
+				"gpu-operator": {"driver": map[string]any{"enabled": true}},
+			},
+			wantClusterValues:       true,
+			wantClusterContains:     "nonexistent",
+			wantDeployClusterValues: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGenerator()
+			ctx := context.Background()
+			outputDir := t.TempDir()
+
+			input := &GeneratorInput{
+				RecipeResult:    createTestRecipeResult(),
+				ComponentValues: tt.componentValues,
+				Version:         "v1.0.0",
+				DynamicValues:   tt.dynamicValues,
+			}
+
+			_, err := g.Generate(ctx, input, outputDir)
+			if err != nil {
+				t.Fatalf("Generate failed: %v", err)
+			}
+
+			clusterValuesPath := filepath.Join(outputDir, "gpu-operator", "cluster-values.yaml")
+			_, statErr := os.Stat(clusterValuesPath)
+			clusterExists := !os.IsNotExist(statErr)
+
+			if clusterExists != tt.wantClusterValues {
+				t.Errorf("cluster-values.yaml exists = %v, want %v", clusterExists, tt.wantClusterValues)
+			}
+
+			if tt.wantClusterContains != "" && clusterExists {
+				content, readErr := os.ReadFile(clusterValuesPath)
+				if readErr != nil {
+					t.Fatalf("failed to read cluster-values.yaml: %v", readErr)
+				}
+				if !strings.Contains(string(content), tt.wantClusterContains) {
+					t.Errorf("cluster-values.yaml missing %q, got:\n%s", tt.wantClusterContains, string(content))
+				}
+			}
+
+			if tt.wantValuesLacksPath != "" {
+				valuesContent, readErr := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "values.yaml"))
+				if readErr != nil {
+					t.Fatalf("failed to read values.yaml: %v", readErr)
+				}
+				if strings.Contains(string(valuesContent), tt.wantValuesLacksPath) {
+					t.Errorf("values.yaml should not contain %q after dynamic split, got:\n%s", tt.wantValuesLacksPath, string(valuesContent))
+				}
+			}
+
+			// cert-manager should never have cluster-values.yaml
+			certClusterPath := filepath.Join(outputDir, "cert-manager", "cluster-values.yaml")
+			if _, certStatErr := os.Stat(certClusterPath); !os.IsNotExist(certStatErr) {
+				t.Error("cert-manager should not have cluster-values.yaml")
+			}
+
+			// Verify deploy.sh content
+			deployContent, readErr := os.ReadFile(filepath.Join(outputDir, "deploy.sh"))
+			if readErr != nil {
+				t.Fatalf("failed to read deploy.sh: %v", readErr)
+			}
+			deployScript := string(deployContent)
+
+			gpuClusterRef := `gpu-operator/cluster-values.yaml`
+			if tt.wantDeployClusterValues {
+				if !strings.Contains(deployScript, gpuClusterRef) {
+					t.Error("deploy.sh should contain cluster-values.yaml reference for gpu-operator")
+				}
+			} else {
+				if strings.Contains(deployScript, gpuClusterRef) {
+					t.Error("deploy.sh should NOT contain cluster-values.yaml reference for gpu-operator")
+				}
+			}
+
+			// cert-manager should never have cluster-values.yaml in deploy.sh
+			certClusterRef := `cert-manager/cluster-values.yaml`
+			if strings.Contains(deployScript, certClusterRef) {
+				t.Error("deploy.sh should NOT contain cluster-values.yaml reference for cert-manager")
+			}
+		})
+	}
+}
+
+func TestGenerate_DynamicValuesContentVerification(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	input := &GeneratorInput{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {"crds": map[string]any{"enabled": true}},
+			"gpu-operator": {
+				"driver": map[string]any{
+					"version": testDriverVersion,
+					"enabled": true,
+				},
+				"toolkit": map[string]any{
+					"version": "1.17.4",
+				},
+			},
+		},
+		Version: "v1.0.0",
+		DynamicValues: map[string][]string{
+			"gpu-operator": {"driver.version", "toolkit.version"},
+		},
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify cluster-values.yaml has the extracted values
+	clusterContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "cluster-values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cluster-values.yaml: %v", err)
+	}
+	clusterStr := string(clusterContent)
+
+	if !strings.Contains(clusterStr, testDriverVersion) {
+		t.Errorf("cluster-values.yaml missing driver.version value, got:\n%s", clusterStr)
+	}
+	if !strings.Contains(clusterStr, "1.17.4") {
+		t.Errorf("cluster-values.yaml missing toolkit.version value, got:\n%s", clusterStr)
+	}
+
+	// Verify values.yaml no longer has the dynamic values
+	valuesContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read values.yaml: %v", err)
+	}
+	valuesStr := string(valuesContent)
+
+	if strings.Contains(valuesStr, testDriverVersion) {
+		t.Errorf("values.yaml should not contain driver version after dynamic split, got:\n%s", valuesStr)
+	}
+	if strings.Contains(valuesStr, "1.17.4") {
+		t.Errorf("values.yaml should not contain toolkit version after dynamic split, got:\n%s", valuesStr)
+	}
+
+	// driver.enabled should still be in values.yaml
+	if !strings.Contains(valuesStr, "enabled") {
+		t.Errorf("values.yaml should still contain driver.enabled, got:\n%s", valuesStr)
+	}
+}
+
+func TestSetNestedValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		value    any
+		wantKeys []string
+	}{
+		{
+			name:     "single level",
+			path:     "version",
+			value:    "1.0.0",
+			wantKeys: []string{"version"},
+		},
+		{
+			name:     "nested path",
+			path:     "driver.version",
+			value:    testDriverVersion,
+			wantKeys: []string{"driver"},
+		},
+		{
+			name:     "deeply nested",
+			path:     "a.b.c",
+			value:    "deep",
+			wantKeys: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := make(map[string]any)
+			setNestedValue(m, tt.path, tt.value)
+
+			for _, key := range tt.wantKeys {
+				if _, ok := m[key]; !ok {
+					t.Errorf("missing key %q in result map", key)
+				}
+			}
+		})
+	}
+
+	// Verify full structure for nested path
+	t.Run("verify nested structure", func(t *testing.T) {
+		m := make(map[string]any)
+		setNestedValue(m, "driver.version", testDriverVersion)
+
+		driver, ok := m["driver"].(map[string]any)
+		if !ok {
+			t.Fatal("driver should be a map")
+		}
+		version, ok := driver["version"]
+		if !ok {
+			t.Fatal("driver.version should exist")
+		}
+		if version != testDriverVersion {
+			t.Errorf("driver.version = %v, want 570.86.16", version)
+		}
+	})
+
+	// Verify multiple paths into same parent
+	t.Run("multiple paths same parent", func(t *testing.T) {
+		m := make(map[string]any)
+		setNestedValue(m, "driver.version", testDriverVersion)
+		setNestedValue(m, "driver.enabled", true)
+
+		driver, ok := m["driver"].(map[string]any)
+		if !ok {
+			t.Fatal("driver should be a map")
+		}
+		if driver["version"] != testDriverVersion {
+			t.Errorf("driver.version = %v, want 570.86.16", driver["version"])
+		}
+		if driver["enabled"] != true {
+			t.Errorf("driver.enabled = %v, want true", driver["enabled"])
+		}
+	})
+}
+
+func TestGenerate_DynamicValuesDeeplyNested(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	input := &GeneratorInput{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {"crds": map[string]any{"enabled": true}},
+			"gpu-operator": {
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": map[string]any{
+							"d": "deep-value",
+						},
+					},
+				},
+				"driver": map[string]any{"enabled": true},
+			},
+		},
+		Version: "v1.0.0",
+		DynamicValues: map[string][]string{
+			"gpu-operator": {"a.b.c.d"},
+		},
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify cluster-values.yaml was created with the deeply nested path
+	clusterContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "cluster-values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cluster-values.yaml: %v", err)
+	}
+	clusterStr := string(clusterContent)
+
+	if !strings.Contains(clusterStr, "deep-value") {
+		t.Errorf("cluster-values.yaml missing deeply nested value, got:\n%s", clusterStr)
+	}
+
+	// Parse cluster-values.yaml and verify the YAML structure
+	var clusterMap map[string]any
+	// Strip the header comment and --- separator
+	yamlContent := strings.TrimPrefix(clusterStr, "# Generated by Cloud Native Stack\n---\n")
+	if unmarshalErr := yaml.Unmarshal([]byte(yamlContent), &clusterMap); unmarshalErr != nil {
+		t.Fatalf("failed to parse cluster-values.yaml: %v", unmarshalErr)
+	}
+
+	// Walk the nested path a.b.c.d
+	a, ok := clusterMap["a"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'a' to be a map in cluster-values.yaml")
+	}
+	b, ok := a["b"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'a.b' to be a map in cluster-values.yaml")
+	}
+	c, ok := b["c"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'a.b.c' to be a map in cluster-values.yaml")
+	}
+	d, ok := c["d"]
+	if !ok {
+		t.Fatal("expected 'a.b.c.d' to exist in cluster-values.yaml")
+	}
+	if d != "deep-value" {
+		t.Errorf("a.b.c.d = %v, want 'deep-value'", d)
+	}
+
+	// Verify values.yaml no longer contains the extracted value
+	valuesContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read values.yaml: %v", err)
+	}
+	if strings.Contains(string(valuesContent), "deep-value") {
+		t.Errorf("values.yaml should not contain deep-value after dynamic split, got:\n%s", string(valuesContent))
+	}
+
+	// driver.enabled should still be in values.yaml
+	if !strings.Contains(string(valuesContent), "enabled") {
+		t.Errorf("values.yaml should still contain driver.enabled, got:\n%s", string(valuesContent))
+	}
+}
+
+func TestGenerate_DynamicValuesWithSetOverride(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	// Simulate --set gpuoperator:driver.version=999.99.99 by providing the value
+	// in ComponentValues (--set is applied before dynamic extraction).
+	// Then --dynamic gpuoperator:driver.version should extract the --set value.
+	input := &GeneratorInput{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {"crds": map[string]any{"enabled": true}},
+			"gpu-operator": {
+				"driver": map[string]any{
+					"version": "999.99.99",
+					"enabled": true,
+				},
+			},
+		},
+		Version: "v1.0.0",
+		DynamicValues: map[string][]string{
+			"gpu-operator": {"driver.version"},
+		},
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// cluster-values.yaml should contain the --set value
+	clusterContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "cluster-values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cluster-values.yaml: %v", err)
+	}
+	if !strings.Contains(string(clusterContent), "999.99.99") {
+		t.Errorf("cluster-values.yaml should contain --set value 999.99.99, got:\n%s", string(clusterContent))
+	}
+
+	// values.yaml should NOT contain the extracted value
+	valuesContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read values.yaml: %v", err)
+	}
+	if strings.Contains(string(valuesContent), "999.99.99") {
+		t.Errorf("values.yaml should not contain 999.99.99 after dynamic split, got:\n%s", string(valuesContent))
+	}
+
+	// driver.enabled should still be in values.yaml
+	if !strings.Contains(string(valuesContent), "enabled") {
+		t.Errorf("values.yaml should still contain driver.enabled, got:\n%s", string(valuesContent))
+	}
+}
+
+func TestGenerate_DynamicValuesRoundTrip(t *testing.T) {
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	originalValues := map[string]any{
+		"driver": map[string]any{
+			"version": testDriverVersion,
+			"enabled": true,
+		},
+		"toolkit": map[string]any{
+			"version": "1.17.4",
+			"enabled": true,
+		},
+		"gds": map[string]any{
+			"enabled": false,
+		},
+	}
+
+	input := &GeneratorInput{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {"crds": map[string]any{"enabled": true}},
+			"gpu-operator": {
+				"driver": map[string]any{
+					"version": testDriverVersion,
+					"enabled": true,
+				},
+				"toolkit": map[string]any{
+					"version": "1.17.4",
+					"enabled": true,
+				},
+				"gds": map[string]any{
+					"enabled": false,
+				},
+			},
+		},
+		Version: "v1.0.0",
+		DynamicValues: map[string][]string{
+			"gpu-operator": {"driver.version", "toolkit.version"},
+		},
+	}
+
+	_, err := g.Generate(ctx, input, outputDir)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Read and parse values.yaml
+	valuesContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read values.yaml: %v", err)
+	}
+	var staticValues map[string]any
+	if unmarshalErr := yaml.Unmarshal(valuesContent, &staticValues); unmarshalErr != nil {
+		t.Fatalf("failed to parse values.yaml: %v", unmarshalErr)
+	}
+
+	// Read and parse cluster-values.yaml
+	clusterContent, err := os.ReadFile(filepath.Join(outputDir, "gpu-operator", "cluster-values.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cluster-values.yaml: %v", err)
+	}
+	var dynamicValues map[string]any
+	if err := yaml.Unmarshal(clusterContent, &dynamicValues); err != nil {
+		t.Fatalf("failed to parse cluster-values.yaml: %v", err)
+	}
+
+	// Merge static + dynamic values (simulate helm install -f values.yaml -f cluster-values.yaml)
+	merged := deepMerge(staticValues, dynamicValues)
+
+	// Verify the merged result matches the original values
+	// Check driver.version was preserved through the round-trip
+	driverMerged, ok := merged["driver"].(map[string]any)
+	if !ok {
+		t.Fatal("merged result missing 'driver' map")
+	}
+	if driverMerged["version"] != testDriverVersion {
+		t.Errorf("merged driver.version = %v, want 570.86.16", driverMerged["version"])
+	}
+	if driverMerged["enabled"] != true {
+		t.Errorf("merged driver.enabled = %v, want true", driverMerged["enabled"])
+	}
+
+	// Check toolkit.version was preserved
+	toolkitMerged, ok := merged["toolkit"].(map[string]any)
+	if !ok {
+		t.Fatal("merged result missing 'toolkit' map")
+	}
+	if toolkitMerged["version"] != "1.17.4" {
+		t.Errorf("merged toolkit.version = %v, want 1.17.4", toolkitMerged["version"])
+	}
+	if toolkitMerged["enabled"] != true {
+		t.Errorf("merged toolkit.enabled = %v, want true", toolkitMerged["enabled"])
+	}
+
+	// Check gds.enabled was not affected (not a dynamic path)
+	gdsMerged, ok := merged["gds"].(map[string]any)
+	if !ok {
+		t.Fatal("merged result missing 'gds' map")
+	}
+	if gdsMerged["enabled"] != false {
+		t.Errorf("merged gds.enabled = %v, want false", gdsMerged["enabled"])
+	}
+
+	// Verify original values structure is fully recoverable
+	for key := range originalValues {
+		if _, exists := merged[key]; !exists {
+			t.Errorf("merged result missing top-level key %q", key)
+		}
+	}
+}
+
+// deepMerge recursively merges src into dst. src values take precedence.
+// This simulates Helm's behavior of merging multiple -f value files.
+func deepMerge(dst, src map[string]any) map[string]any {
+	result := make(map[string]any)
+	for k, v := range dst {
+		result[k] = v
+	}
+	for k, v := range src {
+		if srcMap, ok := v.(map[string]any); ok {
+			if dstMap, ok := result[k].(map[string]any); ok {
+				result[k] = deepMerge(dstMap, srcMap)
+				continue
+			}
+		}
+		result[k] = v
+	}
+	return result
 }
 
 func TestReverseComponents(t *testing.T) {

--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -368,9 +368,7 @@ helm_retry "{{ .Name }} helm install" "{{ .Namespace }}" \
   {{ end -}}
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
-{{- if .HasDynamicValues }}
   -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
-{{- end }}
   ${COMPONENT_WAIT_ARGS} \
   || helm_failed "{{ .Name }}"
 {{ else -}}
@@ -381,9 +379,7 @@ helm_retry "{{ .Name }} helm install" "{{ .Namespace }}" \
   {{ end -}}
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
-{{- if .HasDynamicValues }}
   -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
-{{- end }}
   ${COMPONENT_WAIT_ARGS} \
   || helm_failed "{{ .Name }}"
 {{ end -}}

--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -368,8 +368,9 @@ helm_retry "{{ .Name }} helm install" "{{ .Namespace }}" \
   {{ end -}}
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
-{{ if .HasDynamicValues }}  -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
-{{ end -}}
+{{- if .HasDynamicValues }}
+  -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
+{{- end }}
   ${COMPONENT_WAIT_ARGS} \
   || helm_failed "{{ .Name }}"
 {{ else -}}
@@ -380,8 +381,9 @@ helm_retry "{{ .Name }} helm install" "{{ .Namespace }}" \
   {{ end -}}
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
-{{ if .HasDynamicValues }}  -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
-{{ end -}}
+{{- if .HasDynamicValues }}
+  -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
+{{- end }}
   ${COMPONENT_WAIT_ARGS} \
   || helm_failed "{{ .Name }}"
 {{ end -}}

--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -368,6 +368,8 @@ helm_retry "{{ .Name }} helm install" "{{ .Namespace }}" \
   {{ end -}}
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
+{{ if .HasDynamicValues }}  -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
+{{ end -}}
   ${COMPONENT_WAIT_ARGS} \
   || helm_failed "{{ .Name }}"
 {{ else -}}
@@ -378,6 +380,8 @@ helm_retry "{{ .Name }} helm install" "{{ .Namespace }}" \
   {{ end -}}
   -n {{ .Namespace }} --create-namespace \
   -f "${SCRIPT_DIR}/{{ .Name }}/values.yaml" \
+{{ if .HasDynamicValues }}  -f "${SCRIPT_DIR}/{{ .Name }}/cluster-values.yaml" \
+{{ end -}}
   ${COMPONENT_WAIT_ARGS} \
   || helm_failed "{{ .Name }}"
 {{ end -}}

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -393,8 +393,13 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	outputType := "Helm per-component bundle"
-	if opts.deployer == config.DeployerArgoCD {
+	switch opts.deployer {
+	case config.DeployerHelm:
+		// default
+	case config.DeployerArgoCD:
 		outputType = "ArgoCD applications"
+	case config.DeployerArgoCDHelm:
+		outputType = "ArgoCD Helm chart app-of-apps"
 	}
 	slog.Info("generating bundle",
 		slog.String("deployer", opts.deployer.String()),

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -54,6 +54,9 @@ type bundleCmdOptions struct {
 	estimatedNodeCount         int
 	targetRevision             string
 
+	// dynamicValues declares value paths provided at install time.
+	dynamicValues map[string][]string
+
 	// attest enables bundle attestation and binary verification.
 	attest bool
 
@@ -154,6 +157,12 @@ func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
 	opts.valueOverrides, err = config.ParseValueOverrides(cmd.StringSlice("set"))
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --set flag", err)
+	}
+
+	// Parse dynamic value declarations from --dynamic flags
+	opts.dynamicValues, err = config.ParseDynamicValues(cmd.StringSlice("dynamic"))
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --dynamic flag", err)
 	}
 
 	// Parse node selectors
@@ -272,6 +281,14 @@ Package with explicit tag (overrides CLI version):
 	(format: component:path.to.field=value, e.g., --set gpuoperator:gds.enabled=true).
 	Use the special 'enabled' key to include/exclude components at bundle time
 	(e.g., --set awsebscsidriver:enabled=false to skip aws-ebs-csi-driver)`,
+				Category: "Deployment",
+			},
+			&cli.StringSliceFlag{
+				Name: "dynamic",
+				Usage: `Declare value paths as install-time parameters
+	(format: component:path.to.field, e.g., --dynamic alloy:clusterName).
+	Dynamic paths are removed from values.yaml and placed in cluster-values.yaml
+	for the user to fill in at install time.`,
 				Category: "Deployment",
 			},
 			&cli.StringSliceFlag{
@@ -410,6 +427,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		config.WithAttest(opts.attest),
 		config.WithCertificateIdentityRegexp(opts.certificateIdentityRegexp),
 		config.WithValueOverrides(opts.valueOverrides),
+		config.WithDynamicValues(opts.dynamicValues),
 		config.WithSystemNodeSelector(opts.systemNodeSelector),
 		config.WithSystemNodeTolerations(opts.systemNodeTolerations),
 		config.WithAcceleratedNodeSelector(opts.acceleratedNodeSelector),

--- a/pkg/component/helpers.go
+++ b/pkg/component/helpers.go
@@ -116,3 +116,31 @@ const (
 func parseBoolString(s string) bool {
 	return s == StrTrue || s == "1"
 }
+
+// DeepCopyMap returns a deep copy of a map[string]any by recursively copying
+// nested maps and slices. Preserves original types (no serialization roundtrip).
+func DeepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return make(map[string]any)
+	}
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[k] = deepCopyAny(v)
+	}
+	return result
+}
+
+func deepCopyAny(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		return DeepCopyMap(val)
+	case []any:
+		cp := make([]any, len(val))
+		for i, item := range val {
+			cp[i] = deepCopyAny(item)
+		}
+		return cp
+	default:
+		return v
+	}
+}

--- a/pkg/component/helpers_test.go
+++ b/pkg/component/helpers_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 )
 
+const testMutatedValue = "changed"
+
 func Test_computeChecksum(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -253,6 +255,102 @@ func Test_parseBoolString(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDeepCopyMap verifies deep copy produces an independent copy that
+// preserves types and structure, and mutations to the copy don't leak.
+func TestDeepCopyMap(t *testing.T) {
+	t.Run("nil returns empty map", func(t *testing.T) {
+		result := DeepCopyMap(nil)
+		if result == nil {
+			t.Error("nil input should return non-nil empty map")
+		}
+		if len(result) != 0 {
+			t.Errorf("nil input should return empty map, got %v", result)
+		}
+	})
+
+	t.Run("nested maps are independent", func(t *testing.T) {
+		original := map[string]any{
+			"driver": map[string]any{
+				"version":  "580",
+				"registry": "nvcr.io",
+			},
+			"enabled": true,
+		}
+		copied := DeepCopyMap(original)
+
+		copied["driver"].(map[string]any)["version"] = testMutatedValue
+		copied["enabled"] = false
+
+		if original["driver"].(map[string]any)["version"] != "580" {
+			t.Error("mutation leaked to original nested map")
+		}
+		if original["enabled"] != true {
+			t.Error("mutation leaked to original scalar")
+		}
+	})
+
+	t.Run("slices are independent", func(t *testing.T) {
+		original := map[string]any{
+			"items": []any{
+				map[string]any{"key": "nvidia.com/gpu", "effect": "NoSchedule"},
+			},
+		}
+		copied := DeepCopyMap(original)
+
+		copied["items"].([]any)[0].(map[string]any)["key"] = testMutatedValue
+
+		origKey := original["items"].([]any)[0].(map[string]any)["key"]
+		if origKey != "nvidia.com/gpu" {
+			t.Errorf("mutation leaked to original slice element, got %v", origKey)
+		}
+	})
+
+	t.Run("preserves types without drift", func(t *testing.T) {
+		original := map[string]any{
+			"count":   42,
+			"ratio":   3.14,
+			"name":    "test",
+			"enabled": true,
+			"empty":   nil,
+		}
+		copied := DeepCopyMap(original)
+
+		if v, ok := copied["count"].(int); !ok || v != 42 {
+			t.Errorf("count type/value wrong: %T %v", copied["count"], copied["count"])
+		}
+		if v, ok := copied["ratio"].(float64); !ok || v != 3.14 {
+			t.Errorf("ratio type/value wrong: %T %v", copied["ratio"], copied["ratio"])
+		}
+		if v, ok := copied["name"].(string); !ok || v != "test" {
+			t.Errorf("name type/value wrong: %T %v", copied["name"], copied["name"])
+		}
+		if v, ok := copied["enabled"].(bool); !ok || !v {
+			t.Errorf("enabled type/value wrong: %T %v", copied["enabled"], copied["enabled"])
+		}
+		if copied["empty"] != nil {
+			t.Errorf("empty should be nil, got %v", copied["empty"])
+		}
+	})
+
+	t.Run("deeply nested structure", func(t *testing.T) {
+		original := map[string]any{
+			"a": map[string]any{
+				"b": map[string]any{
+					"c": map[string]any{"d": "deep"},
+				},
+			},
+		}
+		copied := DeepCopyMap(original)
+
+		copied["a"].(map[string]any)["b"].(map[string]any)["c"].(map[string]any)["d"] = testMutatedValue
+
+		origVal := original["a"].(map[string]any)["b"].(map[string]any)["c"].(map[string]any)["d"]
+		if origVal != "deep" {
+			t.Error("mutation leaked through deeply nested maps")
+		}
+	})
 }
 
 func TestMarshalYAMLWithHeader(t *testing.T) {

--- a/pkg/component/overrides.go
+++ b/pkg/component/overrides.go
@@ -690,6 +690,27 @@ func RemoveValueByPath(target map[string]any, path string) bool {
 	return true
 }
 
+// SetValueByPath sets a value in a nested map at the given dot-notation path,
+// creating intermediate maps as needed.
+func SetValueByPath(target map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	current := target
+
+	for _, part := range parts[:len(parts)-1] {
+		if next, ok := current[part]; ok {
+			if nextMap, ok := next.(map[string]any); ok {
+				current = nextMap
+				continue
+			}
+		}
+		newMap := make(map[string]any)
+		current[part] = newMap
+		current = newMap
+	}
+
+	current[parts[len(parts)-1]] = value
+}
+
 // nodeSelectorToMatchExpressions converts a map of node selectors to matchExpressions format.
 // This format is used by some CRDs like Skyhook that use label selector syntax.
 // Each key=value pair becomes a matchExpression with operator "In" and single value.

--- a/pkg/component/overrides.go
+++ b/pkg/component/overrides.go
@@ -642,6 +642,54 @@ func TolerationsToPodSpec(tolerations []corev1.Toleration) []map[string]any {
 	return result
 }
 
+// GetValueByPath retrieves a value from a nested map using dot-notation path.
+// Returns the value and true if found, or nil and false if any path segment is missing.
+func GetValueByPath(target map[string]any, path string) (any, bool) {
+	parts := strings.Split(path, ".")
+	current := target
+
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		nextMap, ok := next.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = nextMap
+	}
+
+	val, ok := current[parts[len(parts)-1]]
+	return val, ok
+}
+
+// RemoveValueByPath removes a value from a nested map at the given dot-notation path.
+// Returns true if the value existed and was removed, false otherwise.
+func RemoveValueByPath(target map[string]any, path string) bool {
+	parts := strings.Split(path, ".")
+	current := target
+
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part]
+		if !ok {
+			return false
+		}
+		nextMap, ok := next.(map[string]any)
+		if !ok {
+			return false
+		}
+		current = nextMap
+	}
+
+	key := parts[len(parts)-1]
+	if _, ok := current[key]; !ok {
+		return false
+	}
+	delete(current, key)
+	return true
+}
+
 // nodeSelectorToMatchExpressions converts a map of node selectors to matchExpressions format.
 // This format is used by some CRDs like Skyhook that use label selector syntax.
 // Each key=value pair becomes a matchExpression with operator "In" and single value.

--- a/pkg/component/overrides_test.go
+++ b/pkg/component/overrides_test.go
@@ -15,6 +15,7 @@
 package component
 
 import (
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1724,6 +1725,182 @@ func TestApplyValueOverrides_MultiSegmentPaths(t *testing.T) {
 				t.Fatalf("ApplyValueOverrides() unexpected error = %v", err)
 			}
 			tt.verify(t, s)
+		})
+	}
+}
+
+func TestGetValueByPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		target map[string]any
+		path   string
+		want   any
+		found  bool
+	}{
+		{
+			name:   "top-level key",
+			target: map[string]any{"clusterName": "prod"},
+			path:   "clusterName",
+			want:   "prod",
+			found:  true,
+		},
+		{
+			name: "nested key",
+			target: map[string]any{
+				"driver": map[string]any{
+					"version": "580.105.08",
+				},
+			},
+			path:  "driver.version",
+			want:  "580.105.08",
+			found: true,
+		},
+		{
+			name: "deeply nested key",
+			target: map[string]any{
+				"network": map[string]any{
+					"subnet": map[string]any{
+						"id": "subnet-123",
+					},
+				},
+			},
+			path:  "network.subnet.id",
+			want:  "subnet-123",
+			found: true,
+		},
+		{
+			name:   "missing top-level key",
+			target: map[string]any{"other": "value"},
+			path:   "missing",
+			want:   nil,
+			found:  false,
+		},
+		{
+			name: "missing intermediate key",
+			target: map[string]any{
+				"driver": map[string]any{
+					"version": "580",
+				},
+			},
+			path:  "driver.missing.field",
+			want:  nil,
+			found: false,
+		},
+		{
+			name: "intermediate is not a map",
+			target: map[string]any{
+				"driver": "scalar-value",
+			},
+			path:  "driver.version",
+			want:  nil,
+			found: false,
+		},
+		{
+			name: "value is a map",
+			target: map[string]any{
+				"driver": map[string]any{
+					"config": map[string]any{"a": "b"},
+				},
+			},
+			path:  "driver.config",
+			want:  map[string]any{"a": "b"},
+			found: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := GetValueByPath(tt.target, tt.path)
+			if found != tt.found {
+				t.Errorf("GetValueByPath() found = %v, want %v", found, tt.found)
+			}
+			if !tt.found {
+				return
+			}
+			// Use fmt.Sprintf for comparison to handle map types
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tt.want) {
+				t.Errorf("GetValueByPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveValueByPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  map[string]any
+		path    string
+		removed bool
+		verify  func(t *testing.T, m map[string]any)
+	}{
+		{
+			name:    "remove top-level key",
+			target:  map[string]any{"clusterName": "prod", "other": "keep"},
+			path:    "clusterName",
+			removed: true,
+			verify: func(t *testing.T, m map[string]any) {
+				if _, ok := m["clusterName"]; ok {
+					t.Error("clusterName should have been removed")
+				}
+				if m["other"] != "keep" {
+					t.Error("other key should still exist")
+				}
+			},
+		},
+		{
+			name: "remove nested key",
+			target: map[string]any{
+				"driver": map[string]any{
+					"version":  "580",
+					"registry": "nvcr.io",
+				},
+			},
+			path:    "driver.version",
+			removed: true,
+			verify: func(t *testing.T, m map[string]any) {
+				driver := m["driver"].(map[string]any)
+				if _, ok := driver["version"]; ok {
+					t.Error("driver.version should have been removed")
+				}
+				if driver["registry"] != "nvcr.io" {
+					t.Error("driver.registry should still exist")
+				}
+			},
+		},
+		{
+			name:    "missing top-level key",
+			target:  map[string]any{"other": "value"},
+			path:    "missing",
+			removed: false,
+			verify:  func(t *testing.T, m map[string]any) {},
+		},
+		{
+			name: "missing intermediate key",
+			target: map[string]any{
+				"driver": map[string]any{"version": "580"},
+			},
+			path:    "missing.version",
+			removed: false,
+			verify:  func(t *testing.T, m map[string]any) {},
+		},
+		{
+			name: "intermediate is not a map",
+			target: map[string]any{
+				"driver": "scalar",
+			},
+			path:    "driver.version",
+			removed: false,
+			verify:  func(t *testing.T, m map[string]any) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			removed := RemoveValueByPath(tt.target, tt.path)
+			if removed != tt.removed {
+				t.Errorf("RemoveValueByPath() = %v, want %v", removed, tt.removed)
+			}
+			tt.verify(t, tt.target)
 		})
 	}
 }

--- a/pkg/component/overrides_test.go
+++ b/pkg/component/overrides_test.go
@@ -1904,3 +1904,87 @@ func TestRemoveValueByPath(t *testing.T) {
 		})
 	}
 }
+
+// TestSetValueByPath verifies setting values at dot-notation paths,
+// including creating intermediate maps and overwriting existing values.
+func TestSetValueByPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		target map[string]any
+		path   string
+		value  any
+		verify func(t *testing.T, m map[string]any)
+	}{
+		{
+			name:   "set top-level key",
+			target: map[string]any{},
+			path:   "clusterName",
+			value:  "prod",
+			verify: func(t *testing.T, m map[string]any) {
+				if m["clusterName"] != "prod" {
+					t.Errorf("got %v, want prod", m["clusterName"])
+				}
+			},
+		},
+		{
+			name:   "creates intermediate maps",
+			target: map[string]any{},
+			path:   "driver.version",
+			value:  "580",
+			verify: func(t *testing.T, m map[string]any) {
+				driver, ok := m["driver"].(map[string]any)
+				if !ok {
+					t.Fatal("driver should be a map")
+				}
+				if driver["version"] != "580" {
+					t.Errorf("got %v, want 580", driver["version"])
+				}
+			},
+		},
+		{
+			name:   "deeply nested path",
+			target: map[string]any{},
+			path:   "network.subnet.id",
+			value:  "subnet-123",
+			verify: func(t *testing.T, m map[string]any) {
+				val, found := GetValueByPath(m, "network.subnet.id")
+				if !found || val != "subnet-123" {
+					t.Errorf("got %v (found=%v), want subnet-123", val, found)
+				}
+			},
+		},
+		{
+			name:   "overwrites existing value",
+			target: map[string]any{"driver": map[string]any{"version": "old"}},
+			path:   "driver.version",
+			value:  "new",
+			verify: func(t *testing.T, m map[string]any) {
+				if m["driver"].(map[string]any)["version"] != "new" {
+					t.Error("should overwrite existing value")
+				}
+			},
+		},
+		{
+			name:   "preserves sibling keys",
+			target: map[string]any{"driver": map[string]any{"version": "580", "registry": "nvcr.io"}},
+			path:   "driver.version",
+			value:  "",
+			verify: func(t *testing.T, m map[string]any) {
+				driver := m["driver"].(map[string]any)
+				if driver["version"] != "" {
+					t.Errorf("version should be empty, got %v", driver["version"])
+				}
+				if driver["registry"] != "nvcr.io" {
+					t.Error("registry should be preserved")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetValueByPath(tt.target, tt.path, tt.value)
+			tt.verify(t, tt.target)
+		})
+	}
+}

--- a/tests/chainsaw/cli/bundle-dynamic/assert-cluster-values.yaml
+++ b/tests/chainsaw/cli/bundle-dynamic/assert-cluster-values.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert that cluster-values.yaml contains the dynamic path stub.
+# The driver.version path should be present (extracted from values.yaml).
+#
+# NOTE: chainsaw assert --resource requires apiVersion/kind. These are
+# prepended by the test script and are not part of the actual file.
+apiVersion: helm/v1
+kind: Values
+driver:
+  # version should exist in cluster-values.yaml (value may be a resolved
+  # default or empty string — we only assert the key is present)
+  (version != null): true

--- a/tests/chainsaw/cli/bundle-dynamic/assert-helm-chart.yaml
+++ b/tests/chainsaw/cli/bundle-dynamic/assert-helm-chart.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert that Chart.yaml has correct Helm chart metadata.
+# NOTE: chainsaw assert requires apiVersion/kind. We prepend a synthetic
+# kind in the test script since Chart.yaml uses Helm's apiVersion v2.
+apiVersion: helm/v1
+kind: ChartMeta
+name: aicr-bundle
+type: application
+(description != null): true
+(version != null): true

--- a/tests/chainsaw/cli/bundle-dynamic/assert-values-no-dynamic.yaml
+++ b/tests/chainsaw/cli/bundle-dynamic/assert-values-no-dynamic.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assert that values.yaml still contains the driver section after dynamic split.
+# The driver section should exist (with driver.enabled) but driver.version
+# should have been extracted to cluster-values.yaml.
+#
+# This assertion verifies the driver section is present and has enabled key.
+# The absence of driver.version is verified by the shell script in the
+# chainsaw test step (chainsaw v0.2.x lacks negative key assertions).
+#
+# NOTE: chainsaw assert --resource requires apiVersion/kind. These are
+# prepended by the test script and are not part of the actual file.
+apiVersion: helm/v1
+kind: Values
+driver:
+  # driver.enabled should still be in values.yaml (not a dynamic path)
+  (enabled != null): true

--- a/tests/chainsaw/cli/bundle-dynamic/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/bundle-dynamic/chainsaw-test.yaml
@@ -1,0 +1,299 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-bundle-dynamic
+spec:
+  description: |
+    Tests --dynamic flag for install-time values in bundle output.
+    Covers Helm deployer (cluster-values.yaml split) and ArgoCD deployer
+    (Helm chart app-of-apps with valuesObject). No cluster needed.
+  timeouts:
+    exec: 60s
+  steps:
+    - name: setup
+      description: Generate recipe used by all dynamic value tests.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              rm -rf "${WORK}" && mkdir -p "${WORK}"
+              ${AICR_BIN} recipe --service eks --accelerator gb200 --os ubuntu \
+                --intent training -o "${WORK}/recipe.yaml"
+
+    - name: helm-dynamic-generates-cluster-values
+      description: --dynamic creates cluster-values.yaml with the extracted value.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-dynamic" \
+                --dynamic gpuoperator:driver.version
+              test -f "${WORK}/helm-dynamic/gpu-operator/cluster-values.yaml"
+
+    - name: assert-cluster-values-structure
+      description: cluster-values.yaml has the dynamic path at the correct YAML location.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              printf 'apiVersion: helm/v1\nkind: Values\n' > "${WORK}/cluster-values-check.yaml"
+              sed '/^---$/d' "${WORK}/helm-dynamic/gpu-operator/cluster-values.yaml" >> "${WORK}/cluster-values-check.yaml"
+              chainsaw assert \
+                --resource "${WORK}/cluster-values-check.yaml" \
+                --file ./assert-cluster-values.yaml \
+                --no-color --timeout 5s
+
+    - name: helm-no-cluster-values-for-other-components
+      description: Components without --dynamic do not get cluster-values.yaml.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              for dir in "${WORK}"/helm-dynamic/*/; do
+                comp=$(basename "$dir")
+                [ "$comp" = "gpu-operator" ] && continue
+                if [ -f "${dir}cluster-values.yaml" ]; then
+                  echo "unexpected cluster-values.yaml in ${comp}" >&2; exit 1
+                fi
+              done
+            check:
+              ($error == null): true
+
+    - name: helm-deploy-script-references-cluster-values
+      description: deploy.sh includes -f cluster-values.yaml for dynamic components.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              grep -q "cluster-values.yaml" "${WORK}/helm-dynamic/deploy.sh"
+            check:
+              ($error == null): true
+
+    - name: helm-no-dynamic-backwards-compatible
+      description: Without --dynamic, no cluster-values.yaml anywhere (backwards compatible).
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-nodynamic"
+              found=false
+              for f in "${WORK}"/helm-nodynamic/*/cluster-values.yaml; do
+                [ -f "$f" ] && { found=true; break; }
+              done
+              [ "$found" = "false" ]
+              ! grep -q "cluster-values.yaml" "${WORK}/helm-nodynamic/deploy.sh"
+            check:
+              ($error == null): true
+
+    - name: argocd-dynamic-creates-helm-chart
+      description: --dynamic with ArgoCD produces Helm chart (Chart.yaml + templates/).
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/argocd-dynamic" \
+                --deployer argocd \
+                --dynamic gpuoperator:driver.version
+              test -d "${WORK}/argocd-dynamic/templates"
+              # Flat ArgoCD artifacts should NOT exist
+              ! test -f "${WORK}/argocd-dynamic/app-of-apps.yaml"
+
+    - name: assert-argocd-chart-yaml
+      description: Chart.yaml has valid Helm chart metadata.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              # Prepend synthetic apiVersion/kind for chainsaw assert (Chart.yaml uses Helm's apiVersion v2)
+              printf 'apiVersion: helm/v1\nkind: ChartMeta\n' > "${WORK}/chart-check.yaml"
+              sed '/^apiVersion:/d; /^---$/d' "${WORK}/argocd-dynamic/Chart.yaml" >> "${WORK}/chart-check.yaml"
+              chainsaw assert \
+                --resource "${WORK}/chart-check.yaml" \
+                --file ./assert-helm-chart.yaml \
+                --no-color --timeout 5s
+
+    - name: argocd-template-has-values-object
+      description: At least one ArgoCD Application template references valuesObject.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              found=false
+              for tmpl in "${WORK}"/argocd-dynamic/templates/*.yaml; do
+                [ -f "$tmpl" ] || continue
+                grep -q "valuesObject" "$tmpl" && { found=true; break; }
+              done
+              [ "$found" = "true" ]
+            check:
+              ($error == null): true
+
+    - name: argocd-no-dynamic-backwards-compatible
+      description: ArgoCD without --dynamic produces flat manifests (backwards compatible).
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/argocd-nodynamic" \
+                --deployer argocd
+              test -f "${WORK}/argocd-nodynamic/app-of-apps.yaml"
+              ! test -f "${WORK}/argocd-nodynamic/Chart.yaml"
+            check:
+              ($error == null): true
+
+    - name: argocd-helm-template-roundtrip
+      description: Generated ArgoCD Helm chart is valid — helm template renders without errors.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              # helm template validates Chart.yaml, values.yaml, and all templates
+              # are syntactically correct and renderable
+              output=$(helm template test-release "${WORK}/argocd-dynamic" 2>&1)
+              if [ $? -ne 0 ]; then
+                echo "helm template failed:" >&2
+                echo "$output" >&2
+                exit 1
+              fi
+              # Output should contain ArgoCD Application resources
+              echo "$output" | grep -q "kind: Application" \
+                || { echo "rendered output should contain ArgoCD Applications" >&2; exit 1; }
+              # Output should contain valuesObject (proves template references resolve)
+              echo "$output" | grep -q "valuesObject" \
+                || { echo "rendered output should contain valuesObject" >&2; exit 1; }
+            check:
+              ($error == null): true
+
+    - name: helm-dynamic-combined-with-set
+      description: --dynamic and --set flags work together correctly.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-combined" \
+                --dynamic gpuoperator:driver.version \
+                --set gpuoperator:gds.enabled=true
+              test -f "${WORK}/helm-combined/gpu-operator/cluster-values.yaml"
+              grep -q "gds" "${WORK}/helm-combined/gpu-operator/values.yaml"
+            check:
+              ($error == null): true
+
+    - name: helm-multiple-dynamic-components
+      description: --dynamic on two different components creates cluster-values.yaml for each.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-multi-dynamic" \
+                --dynamic gpuoperator:driver.version \
+                --dynamic certmanager:crds.enabled
+              # Both components should have cluster-values.yaml
+              test -f "${WORK}/helm-multi-dynamic/gpu-operator/cluster-values.yaml"
+              test -f "${WORK}/helm-multi-dynamic/cert-manager/cluster-values.yaml"
+              # Verify content in each
+              grep -q "driver" "${WORK}/helm-multi-dynamic/gpu-operator/cluster-values.yaml"
+              grep -q "crds" "${WORK}/helm-multi-dynamic/cert-manager/cluster-values.yaml"
+              # Other components should NOT have cluster-values.yaml
+              for dir in "${WORK}"/helm-multi-dynamic/*/; do
+                comp=$(basename "$dir")
+                [ "$comp" = "gpu-operator" ] && continue
+                [ "$comp" = "cert-manager" ] && continue
+                if [ -f "${dir}cluster-values.yaml" ]; then
+                  echo "unexpected cluster-values.yaml in ${comp}" >&2; exit 1
+                fi
+              done
+            check:
+              ($error == null): true
+
+    - name: helm-dynamic-nonexistent-path
+      description: --dynamic with a path not in recipe values creates cluster-values.yaml with empty stub.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-nonexistent" \
+                --dynamic gpuoperator:nonexistent.field
+              test -f "${WORK}/helm-nonexistent/gpu-operator/cluster-values.yaml"
+              grep -q "nonexistent" "${WORK}/helm-nonexistent/gpu-operator/cluster-values.yaml"
+              # The nonexistent path should be stubbed to empty string
+              grep -q 'field: ""' "${WORK}/helm-nonexistent/gpu-operator/cluster-values.yaml" \
+                || grep -q "field: ''" "${WORK}/helm-nonexistent/gpu-operator/cluster-values.yaml"
+            check:
+              ($error == null): true
+
+    - name: helm-disabled-component-with-dynamic
+      description: Disabled component with --dynamic should NOT appear in output at all.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-disabled-dynamic" \
+                --set awsebscsidriver:enabled=false \
+                --dynamic awsebscsidriver:controller.replicaCount
+              # Disabled component directory should NOT exist
+              ! test -d "${WORK}/helm-disabled-dynamic/aws-ebs-csi-driver"
+              # No cluster-values.yaml for disabled component
+              ! test -f "${WORK}/helm-disabled-dynamic/aws-ebs-csi-driver/cluster-values.yaml"
+              # deploy.sh should not mention disabled component
+              ! grep -q "aws-ebs-csi-driver" "${WORK}/helm-disabled-dynamic/deploy.sh"
+              # Enabled component should still work
+              test -f "${WORK}/helm-disabled-dynamic/gpu-operator/values.yaml"
+            check:
+              ($error == null): true
+
+    - name: assert-values-no-dynamic-key
+      description: values.yaml for dynamic component should NOT contain the extracted path.
+      try:
+        - script:
+            content: |
+              WORK="/tmp/chainsaw-bundle-dynamic"
+              VALUES="${WORK}/helm-dynamic/gpu-operator/values.yaml"
+              CLUSTER="${WORK}/helm-dynamic/gpu-operator/cluster-values.yaml"
+              # 1. driver section should still exist in values.yaml (driver.enabled remains)
+              grep -q "driver:" "${VALUES}"
+              # 2. driver.version must NOT appear anywhere in values.yaml
+              if yq e '.driver.version' "${VALUES}" 2>/dev/null | grep -qv "null"; then
+                echo "values.yaml still contains driver.version after dynamic split" >&2
+                exit 1
+              fi
+              # 3. driver.version must be present in cluster-values.yaml
+              yq e '.driver.version' "${CLUSTER}" | grep -qv "null"
+              # 4. Structural assert: driver.enabled still present in values.yaml
+              printf 'apiVersion: helm/v1\nkind: Values\n' > "${WORK}/values-check.yaml"
+              sed '/^---$/d; /^#/d' "${VALUES}" >> "${WORK}/values-check.yaml"
+              chainsaw assert \
+                --resource "${WORK}/values-check.yaml" \
+                --file ./assert-values-no-dynamic.yaml \
+                --no-color --timeout 5s
+            check:
+              ($error == null): true
+
+    - name: cleanup
+      description: Remove test artifacts.
+      try:
+        - script:
+            content: |
+              rm -rf /tmp/chainsaw-bundle-dynamic

--- a/tests/chainsaw/cli/bundle-dynamic/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/bundle-dynamic/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
   description: |
     Tests --dynamic flag for install-time values in bundle output.
     Covers Helm deployer (cluster-values.yaml split) and ArgoCD deployer
-    (Helm chart app-of-apps with valuesObject). No cluster needed.
+    (Helm chart app-of-apps with helm.values). No cluster needed.
   timeouts:
     exec: 60s
   steps:
@@ -60,19 +60,19 @@ spec:
                 --file ./assert-cluster-values.yaml \
                 --no-color --timeout 5s
 
-    - name: helm-no-cluster-values-for-other-components
-      description: Components without --dynamic do not get cluster-values.yaml.
+    - name: helm-all-components-have-cluster-values
+      description: All components get cluster-values.yaml for per-cluster overrides.
       try:
         - script:
             content: |
               WORK="/tmp/chainsaw-bundle-dynamic"
               for dir in "${WORK}"/helm-dynamic/*/; do
                 comp=$(basename "$dir")
-                [ "$comp" = "gpu-operator" ] && continue
-                if [ -f "${dir}cluster-values.yaml" ]; then
-                  echo "unexpected cluster-values.yaml in ${comp}" >&2; exit 1
-                fi
+                test -f "${dir}cluster-values.yaml" \
+                  || { echo "${comp} missing cluster-values.yaml" >&2; exit 1; }
               done
+              # Only gpu-operator's should have dynamic content
+              grep -q "driver" "${WORK}/helm-dynamic/gpu-operator/cluster-values.yaml"
             check:
               ($error == null): true
 
@@ -86,32 +86,33 @@ spec:
             check:
               ($error == null): true
 
-    - name: helm-no-dynamic-backwards-compatible
-      description: Without --dynamic, no cluster-values.yaml anywhere (backwards compatible).
+    - name: helm-no-dynamic-still-has-cluster-values
+      description: Without --dynamic, cluster-values.yaml exists (empty) for all components.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-bundle-dynamic"
               ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/helm-nodynamic"
-              found=false
-              for f in "${WORK}"/helm-nodynamic/*/cluster-values.yaml; do
-                [ -f "$f" ] && { found=true; break; }
+              # Every component should have cluster-values.yaml
+              for dir in "${WORK}"/helm-nodynamic/*/; do
+                test -f "${dir}cluster-values.yaml" \
+                  || { echo "$(basename "$dir") missing cluster-values.yaml" >&2; exit 1; }
               done
-              [ "$found" = "false" ]
-              ! grep -q "cluster-values.yaml" "${WORK}/helm-nodynamic/deploy.sh"
+              # deploy.sh should always reference cluster-values.yaml
+              grep -q "cluster-values.yaml" "${WORK}/helm-nodynamic/deploy.sh"
             check:
               ($error == null): true
 
-    - name: argocd-dynamic-creates-helm-chart
-      description: --dynamic with ArgoCD produces Helm chart (Chart.yaml + templates/).
+    - name: argocd-helm-creates-helm-chart
+      description: --deployer argocd-helm produces Helm chart (Chart.yaml + templates/).
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-bundle-dynamic"
               ${AICR_BIN} bundle -r "${WORK}/recipe.yaml" -o "${WORK}/argocd-dynamic" \
-                --deployer argocd \
+                --deployer argocd-helm \
                 --dynamic gpuoperator:driver.version
               test -d "${WORK}/argocd-dynamic/templates"
               # Flat ArgoCD artifacts should NOT exist
@@ -132,7 +133,7 @@ spec:
                 --no-color --timeout 5s
 
     - name: argocd-template-has-values-object
-      description: At least one ArgoCD Application template references valuesObject.
+      description: At least one ArgoCD Application template references helm.values.
       try:
         - script:
             content: |
@@ -140,7 +141,7 @@ spec:
               found=false
               for tmpl in "${WORK}"/argocd-dynamic/templates/*.yaml; do
                 [ -f "$tmpl" ] || continue
-                grep -q "valuesObject" "$tmpl" && { found=true; break; }
+                grep -q "values:" "$tmpl" && { found=true; break; }
               done
               [ "$found" = "true" ]
             check:
@@ -177,9 +178,9 @@ spec:
               # Output should contain ArgoCD Application resources
               echo "$output" | grep -q "kind: Application" \
                 || { echo "rendered output should contain ArgoCD Applications" >&2; exit 1; }
-              # Output should contain valuesObject (proves template references resolve)
-              echo "$output" | grep -q "valuesObject" \
-                || { echo "rendered output should contain valuesObject" >&2; exit 1; }
+              # Output should contain values: (proves template references resolve)
+              echo "$output" | grep -q "values:" \
+                || { echo "rendered output should contain values:" >&2; exit 1; }
             check:
               ($error == null): true
 
@@ -211,17 +212,13 @@ spec:
               # Both components should have cluster-values.yaml
               test -f "${WORK}/helm-multi-dynamic/gpu-operator/cluster-values.yaml"
               test -f "${WORK}/helm-multi-dynamic/cert-manager/cluster-values.yaml"
-              # Verify content in each
+              # Dynamic components should have pre-populated content
               grep -q "driver" "${WORK}/helm-multi-dynamic/gpu-operator/cluster-values.yaml"
               grep -q "crds" "${WORK}/helm-multi-dynamic/cert-manager/cluster-values.yaml"
-              # Other components should NOT have cluster-values.yaml
+              # All components should have cluster-values.yaml (empty for non-dynamic)
               for dir in "${WORK}"/helm-multi-dynamic/*/; do
-                comp=$(basename "$dir")
-                [ "$comp" = "gpu-operator" ] && continue
-                [ "$comp" = "cert-manager" ] && continue
-                if [ -f "${dir}cluster-values.yaml" ]; then
-                  echo "unexpected cluster-values.yaml in ${comp}" >&2; exit 1
-                fi
+                test -f "${dir}cluster-values.yaml" \
+                  || { echo "$(basename "$dir") missing cluster-values.yaml" >&2; exit 1; }
               done
             check:
               ($error == null): true


### PR DESCRIPTION
## Summary
Closes #515 
- Add --dynamic component:path flag to aicr bundle that declares value paths as install-time parameters
- Helm deployer: splits into values.yaml (static) + cluster-values.yaml (dynamic stubs), deploy.sh passes both
- ArgoCD deployer: auto-detects --dynamic and generates a Helm chart app-of-apps instead of flat manifests — static values baked 
as chart files, dynamic values in root values.yaml, merged at render time via mustMergeOverwrite
- Introduces deployer.Deployer interface for mockability
- New argocdhelm deployer delegates to existing ArgoCD deployer then transforms output (no logic duplication)
- Validates --dynamic component keys against the registry (catches typos)
- Fully backwards compatible — no --dynamic = identical output

## Test plan

- make qualify passes (unit tests, lint, e2e, scan)
- make e2e — 19 tests pass including new bundle-dynamic (12 steps)
- Helm smoke: aicr bundle -r recipe.yaml --dynamic gpuoperator:driver.version -o /tmp/test
- ArgoCD smoke: aicr bundle -r recipe.yaml --deployer argocd --dynamic gpuoperator:driver.version -o /tmp/test && helm template
test /tmp/test
- Backwards compat: aicr bundle -r recipe.yaml -o /tmp/test (no cluster-values.yaml, no Chart.yaml)
 
## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
