### PR TITLE
fix(ci): add -mod=vendor to snapshot agent build

### DIFF
--- a/.github/actions/aicr-build/action.yml
+++ b/.github/actions/aicr-build/action.yml
@@ -27,6 +27,8 @@ runs:
 
     - name: Build snapshot agent image and load into kind
       shell: bash
+      env:
+        GOFLAGS: -mod=vendor
       run: |
         # Build snapshot agent image with CUDA base (provides nvidia-smi for GPU detection).
         # Uses cuda:base (~250MB) instead of cuda:runtime (~1.8GB) — only nvidia-smi is needed.


### PR DESCRIPTION
## Summary

Add missing `GOFLAGS: -mod=vendor` to the "Build snapshot agent" step in `aicr-build` action, matching the other two build steps.

## Motivation / Context

GPU CI tests (training, conformance) fail consistently on cold runners because `go build` in the snapshot agent step downloads all dependencies from the network instead of using vendored sources. This causes the build to hang silently until the 45-minute job timeout.

Fixes: N/A
Related: #290 (introduced the bug), #505 (similar CI build fix)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/actions/aicr-build/action.yml`

## Implementation Notes

The "Build snapshot agent" step was the only build step missing `GOFLAGS: -mod=vendor`. The "Build validator images" and "Build aicr binary" steps already had it. On warm runners (cached Go modules) the missing flag was harmless; on cold runners it caused `go build` to silently fetch all deps, exhausting the job timeout.

**Note:** The `go run` calls in the GPU workflow files (`gpu-h100-conformance-test.yaml#L154`, `gpu-h100-training-test.yaml#L153`, `gpu-h100-inference-test.yaml#L270`) also lack an explicit `-mod=vendor`, but these are **not** the same bug. With Go 1.26 and a `vendor/` directory present, `go run` [defaults to vendor mode automatically](https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies). Adding explicit flags there would be a consistency hardening follow-up, not a bug fix.

## Testing

One-line CI-only change. Verified by inspecting the action file — the fix makes the snapshot agent step consistent with the other two build steps. Cherry-picked onto PR #523 to validate on GPU runners.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)