### PR TITLE
test(ci): use distroless base for snapshot agent image

### DIFF
--- a/.github/actions/aicr-build/action.yml
+++ b/.github/actions/aicr-build/action.yml
@@ -30,18 +30,19 @@ runs:
       env:
         GOFLAGS: -mod=vendor
       run: |
-        # Build snapshot agent image with CUDA base (provides nvidia-smi for GPU detection).
-        # Uses cuda:base (~250MB) instead of cuda:runtime (~1.8GB) — only nvidia-smi is needed.
-        # GPU test workflows use --image=ko.local:smoke-test for aicr snapshot.
+        # Build snapshot agent image with distroless base (~2MB vs ~250MB CUDA base).
+        # Test: GPU detection uses NFD PCI enumeration (Phase 1), nvidia-smi (Phase 2) is optional.
+        # If conformance checks pass without nvidia-smi in the image, we can eliminate the
+        # 250MB cold-pull that causes kind load timeouts on slow runners.
         CGO_ENABLED=0 go build -trimpath -o dist/aicr ./cmd/aicr
         docker build -t ko.local:smoke-test -f - . <<'DOCKERFILE'
-        FROM nvcr.io/nvidia/cuda:13.1.0-base-ubuntu24.04
+        FROM gcr.io/distroless/static-debian12:nonroot
         COPY dist/aicr /usr/local/bin/aicr
         ENTRYPOINT ["/usr/local/bin/aicr"]
         DOCKERFILE
 
         # Load onto all nodes (validator Jobs tolerate all taints and may schedule on
-        # control-plane). The cuda:base image is ~250MB so 3-node loads are fast.
+        # control-plane). The distroless image is ~2MB so loads are near-instant.
         timeout 300 kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}" || {
           echo "::warning::kind load attempt 1 failed for ko.local:smoke-test, retrying..."
           timeout 300 kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}"


### PR DESCRIPTION
## Summary

Test whether the snapshot agent image can use `distroless/static` (~2MB) instead of `cuda:base` (~250MB).

## Motivation

The `kind load` step times out on cold runners because the 250MB CUDA base image takes too long to pull and transfer to Kind nodes. The CUDA image is only needed for `nvidia-smi`, but GPU detection Phase 1 (NFD PCI enumeration) works without it. Phase 2 (`nvidia-smi`) gracefully falls back when the binary is absent.

If all GPU tests pass with this change, we can permanently eliminate the cold-pull bottleneck.

## What Changed

```dockerfile
# Before (~250MB)
FROM nvcr.io/nvidia/cuda:13.1.0-base-ubuntu24.04

# After (~2MB)
FROM gcr.io/distroless/static-debian12:nonroot
```

## Test Plan

- [ ] GPU Smoke Test passes
- [ ] GPU Training Test passes (including `aicr validate --phase conformance`)
- [ ] GPU Inference Test passes (including Dynamo deployment)
- [ ] GPU Conformance Test passes

If any test fails due to missing nvidia-smi, we'll see it in the snapshot/validate step or conformance checks.

Related: #541