### PR TITLE
test(ci): targeted node loading — CUDA to control-plane, validators to worker

### DIFF
--- a/.github/actions/aicr-build/action.yml
+++ b/.github/actions/aicr-build/action.yml
@@ -40,11 +40,13 @@ runs:
         ENTRYPOINT ["/usr/local/bin/aicr"]
         DOCKERFILE
 
-        # Load onto all nodes (validator Jobs tolerate all taints and may schedule on
-        # control-plane). The cuda:base image is ~250MB so 3-node loads are fast.
-        timeout 300 kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}" || {
-          echo "::warning::kind load attempt 1 failed for ko.local:smoke-test, retrying..."
-          timeout 300 kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}"
+        # Load CUDA image to control-plane only. The orchestrator Job (aicr validate)
+        # prefers CPU nodes via preferCPUNodeAffinityApply() and needs nvidia-smi for
+        # snapshot. Loading to 1 node instead of 2 halves the ~250MB transfer time.
+        CP_NODE="${KIND_CLUSTER_NAME}-control-plane"
+        timeout 300 kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}" --nodes "${CP_NODE}" || {
+          echo "::warning::kind load attempt 1 failed for ko.local:smoke-test on ${CP_NODE}, retrying..."
+          timeout 300 kind load docker-image ko.local:smoke-test --name "${KIND_CLUSTER_NAME}" --nodes "${CP_NODE}"
         }
 
     - name: Build validator images and load into kind
@@ -68,9 +70,12 @@ runs:
         USER nonroot
         ENTRYPOINT ["/${phase}"]
         DOCKERFILE
-          timeout 300 kind load docker-image "ko.local/aicr-validators/${phase}:latest" --name "${KIND_CLUSTER_NAME}" || {
-            echo "::warning::kind load attempt 1 failed for ko.local/aicr-validators/${phase}:latest, retrying..."
-            timeout 300 kind load docker-image "ko.local/aicr-validators/${phase}:latest" --name "${KIND_CLUSTER_NAME}"
+          # Load validator images to worker node only. Inner conformance check pods
+          # need GPUs and schedule on worker via resource requests/DRA claims.
+          WORKER_NODE="${KIND_CLUSTER_NAME}-worker"
+          timeout 120 kind load docker-image "ko.local/aicr-validators/${phase}:latest" --name "${KIND_CLUSTER_NAME}" --nodes "${WORKER_NODE}" || {
+            echo "::warning::kind load attempt 1 failed for ko.local/aicr-validators/${phase}:latest on ${WORKER_NODE}, retrying..."
+            timeout 120 kind load docker-image "ko.local/aicr-validators/${phase}:latest" --name "${KIND_CLUSTER_NAME}" --nodes "${WORKER_NODE}"
           }
         done
 


### PR DESCRIPTION
## Summary

Test targeted `kind load` — load each image to only the node that needs it instead of all nodes.

## Motivation

`kind load` transfers images to every node sequentially. The ~250MB CUDA image loading to 2 nodes is the #1 cause of Build aicr timeouts on cold runners. By loading to only the node that actually runs the image, we halve the transfer time.

## Architecture

- **Orchestrator Job** (`ko.local:smoke-test`, CUDA ~250MB) → runs `aicr validate/snapshot`, prefers CPU nodes via `preferCPUNodeAffinityApply()` → **load to control-plane only**
- **Validator Jobs** (`ko.local/aicr-validators/*`, distroless ~10MB) → inner conformance checks that create GPU pods → **load to worker only**

## What Changed

```yaml
# CUDA image: all nodes → control-plane only
kind load docker-image ko.local:smoke-test --nodes "${KIND_CLUSTER_NAME}-control-plane"

# Validator images: all nodes → worker only  
kind load docker-image ko.local/aicr-validators/${phase}:latest --nodes "${KIND_CLUSTER_NAME}-worker"
```

## Risk

If the orchestrator Job schedules on worker instead of control-plane (soft preference, not guaranteed), it would get `ErrImagePull`. This is unlikely because:
1. Control-plane has no GPU labels → matches the `nvidia.com/gpu.present DoesNotExist` preference
2. Control-plane is always available (no resource contention)

If this fails, we'll see it clearly in the logs and know the soft preference isn't reliable enough.

## Test Plan

- [ ] GPU Smoke Test passes (uses snapshot image)
- [ ] GPU Inference Test passes (uses both image types)
- [ ] GPU Training Test passes
- [ ] GPU Conformance Test passes

Related: #541