### PR TITLE
refactor(ci): reorder and rename GPU workflow steps

### DIFF
--- a/.github/workflows/gpu-h100-conformance-test.yaml
+++ b/.github/workflows/gpu-h100-conformance-test.yaml
@@ -99,7 +99,7 @@ jobs:
           accelerator: h100
           intent: training
 
-      # --- Snapshot and validation ---
+      # --- Snapshot and resource verification ---
 
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
@@ -108,32 +108,28 @@ jobs:
           min_gpu_count: '2'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
-      # --- Install Karpenter before validation so cluster-autoscaling check passes ---
+      - name: Check expected resources exist
+        run: |
+          go run ./tests/chainsaw/ai-conformance/ \
+            --dir tests/chainsaw/ai-conformance/kind-training \
+            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+            --kubeconfig="${HOME}/.kube/config" \
+            --debug
 
-      - name: Install Karpenter + KWOK (setup)
+      # --- Install Karpenter + KWOK early to give monitoring stack settle time ---
+
+      - name: Install Karpenter + KWOK
         uses: ./.github/actions/install-karpenter-kwok
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
-      # --- Validate cluster (Go conformance checks run inside K8s Jobs) ---
-      # DRA and gang scheduling exercises are self-contained within the
-      # conformance checks — they create their own resources and clean up.
+      # --- Health checks ---
 
-      - name: Validate cluster
-        run: |
-          AICR_VALIDATOR_IMAGE_REGISTRY=ko.local \
-          ./aicr validate \
-            --recipe recipe.yaml \
-            --phase conformance \
-            --namespace gpu-operator \
-            --kubeconfig="${HOME}/.kube/config" \
-            --require-gpu \
-            --image=ko.local:smoke-test \
-            --timeout=10m \
-            --output=validation-result.yaml \
-            --evidence-dir=conformance-evidence
-
-      - name: Load versions
+      - name: Prepare chainsaw
         id: versions
         uses: ./.github/actions/load-versions
 
@@ -149,22 +145,26 @@ jobs:
             --test-dir tests/chainsaw/ai-conformance/kind-training \
             --config tests/chainsaw/chainsaw-config.yaml
 
-      # --- Evidence collection ---
+      # --- CNCF AI Conformance validation ---
+      # Runs last to ensure the DCGM → Prometheus → adapter pipeline
+      # has had time to bootstrap (pod-autoscaling check needs live metric data).
 
-      - name: Collect AI conformance evidence
+      - name: Validate CNCF AI Conformance
         if: always() && steps.bundle-install.outcome == 'success'
         run: |
-          go run ./tests/chainsaw/ai-conformance/ \
-            --dir tests/chainsaw/ai-conformance/kind-training \
-            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+          AICR_VALIDATOR_IMAGE_REGISTRY=ko.local \
+          ./aicr validate \
+            --recipe recipe.yaml \
+            --phase conformance \
+            --namespace gpu-operator \
             --kubeconfig="${HOME}/.kube/config" \
-            --debug
+            --require-gpu \
+            --image=ko.local:smoke-test \
+            --timeout=10m \
+            --output=validation-result.yaml \
+            --evidence-dir=conformance-evidence
 
-      - name: Upload conformance evidence
+      - name: Collect and upload validation artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/gpu-h100-conformance-test.yaml
+++ b/.github/workflows/gpu-h100-conformance-test.yaml
@@ -99,7 +99,7 @@ jobs:
           accelerator: h100
           intent: training
 
-      # --- Snapshot and resource verification ---
+      # --- Snapshot and GPU validation ---
 
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
@@ -107,18 +107,6 @@ jobs:
           gpu_model: H100
           min_gpu_count: '2'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
-
-      - name: Check expected resources exist
-        run: |
-          go run ./tests/chainsaw/ai-conformance/ \
-            --dir tests/chainsaw/ai-conformance/kind-training \
-            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
-            --kubeconfig="${HOME}/.kube/config" \
-            --debug
 
       # --- Install Karpenter + KWOK early to give monitoring stack settle time ---
 
@@ -144,6 +132,18 @@ jobs:
           chainsaw test \
             --test-dir tests/chainsaw/ai-conformance/kind-training \
             --config tests/chainsaw/chainsaw-config.yaml
+
+      - name: Verify expected resources exist
+        run: |
+          go run ./tests/chainsaw/ai-conformance/ \
+            --dir tests/chainsaw/ai-conformance/kind-training \
+            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+            --kubeconfig="${HOME}/.kube/config" \
+            --debug
 
       # --- CNCF AI Conformance validation ---
       # Runs last to ensure the DCGM → Prometheus → adapter pipeline

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -98,7 +98,7 @@ jobs:
           accelerator: h100
           platform: dynamo
 
-      # --- Snapshot and resource verification ---
+      # --- Snapshot and GPU validation ---
 
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
@@ -106,21 +106,6 @@ jobs:
           gpu_model: H100
           min_gpu_count: '1'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
-
-      - name: Check expected resources exist
-        run: |
-          go run ./tests/chainsaw/ai-conformance/ \
-            --dir tests/chainsaw/ai-conformance/kind \
-            --file tests/chainsaw/ai-conformance/cluster/assert-crds.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-kgateway.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml \
-            --kubeconfig="${HOME}/.kube/config" \
-            --debug
 
       # --- Install Karpenter + KWOK early to give monitoring stack settle time ---
 
@@ -146,6 +131,21 @@ jobs:
           chainsaw test \
             --test-dir tests/chainsaw/ai-conformance/kind \
             --config tests/chainsaw/chainsaw-config.yaml
+
+      - name: Verify expected resources exist
+        run: |
+          go run ./tests/chainsaw/ai-conformance/ \
+            --dir tests/chainsaw/ai-conformance/kind \
+            --file tests/chainsaw/ai-conformance/cluster/assert-crds.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kgateway.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml \
+            --kubeconfig="${HOME}/.kube/config" \
+            --debug
 
       # --- CNCF AI Conformance validation ---
       # Runs before Dynamo: the dra-support check needs to allocate a GPU via

--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -98,7 +98,7 @@ jobs:
           accelerator: h100
           platform: dynamo
 
-      # --- Snapshot and validation ---
+      # --- Snapshot and resource verification ---
 
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
@@ -107,33 +107,31 @@ jobs:
           min_gpu_count: '1'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
-      # --- Install Karpenter before validation so cluster-autoscaling check passes ---
+      - name: Check expected resources exist
+        run: |
+          go run ./tests/chainsaw/ai-conformance/ \
+            --dir tests/chainsaw/ai-conformance/kind \
+            --file tests/chainsaw/ai-conformance/cluster/assert-crds.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kgateway.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml \
+            --kubeconfig="${HOME}/.kube/config" \
+            --debug
 
-      - name: Install Karpenter + KWOK (setup)
+      # --- Install Karpenter + KWOK early to give monitoring stack settle time ---
+
+      - name: Install Karpenter + KWOK
         uses: ./.github/actions/install-karpenter-kwok
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
-      # --- Validate cluster (Go conformance checks run inside K8s Jobs) ---
-      # Includes self-contained secure-accelerator-access check (creates its own
-      # DRA test resources, validates, and cleans up automatically).
+      # --- Health checks ---
 
-      - name: Validate cluster
-        run: |
-          AICR_VALIDATOR_IMAGE_REGISTRY=ko.local \
-          ./aicr validate \
-            --recipe recipe.yaml \
-            --phase deployment \
-            --phase conformance \
-            --namespace gpu-operator \
-            --kubeconfig="${HOME}/.kube/config" \
-            --require-gpu \
-            --image=ko.local:smoke-test \
-            --timeout=10m \
-            --output=validation-result.yaml \
-            --evidence-dir=conformance-evidence
-
-      - name: Load versions
+      - name: Prepare chainsaw
         id: versions
         uses: ./.github/actions/load-versions
 
@@ -149,7 +147,29 @@ jobs:
             --test-dir tests/chainsaw/ai-conformance/kind \
             --config tests/chainsaw/chainsaw-config.yaml
 
+      # --- CNCF AI Conformance validation ---
+      # Runs before Dynamo: the dra-support check needs to allocate a GPU via
+      # ResourceClaim, which conflicts with Dynamo's vllm-smoke-gpu-claim if
+      # Dynamo is deployed first (only 1 GPU on H100 x1).
+
+      - name: Validate CNCF AI Conformance
+        run: |
+          AICR_VALIDATOR_IMAGE_REGISTRY=ko.local \
+          ./aicr validate \
+            --recipe recipe.yaml \
+            --phase deployment \
+            --phase conformance \
+            --namespace gpu-operator \
+            --kubeconfig="${HOME}/.kube/config" \
+            --require-gpu \
+            --image=ko.local:smoke-test \
+            --timeout=10m \
+            --output=validation-result.yaml \
+            --evidence-dir=conformance-evidence
+
       # --- Dynamo vLLM inference smoke test ---
+      # Runs after conformance: Dynamo's DRA ResourceClaim consumes the GPU,
+      # which would block dra-support validation if deployed first.
 
       - name: Deploy Dynamo vLLM smoke test
         run: |

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -94,9 +94,7 @@ jobs:
           accelerator: h100
           intent: training
 
-      # --- Snapshot and validation ---
-
-      # --- Snapshot and resource verification ---
+      # --- Snapshot and GPU validation ---
 
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
@@ -104,18 +102,6 @@ jobs:
           gpu_model: H100
           min_gpu_count: '2'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
-
-      - name: Check expected resources exist
-        run: |
-          go run ./tests/chainsaw/ai-conformance/ \
-            --dir tests/chainsaw/ai-conformance/kind-training \
-            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
-            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
-            --kubeconfig="${HOME}/.kube/config" \
-            --debug
 
       # --- Install Karpenter + KWOK early to give monitoring stack settle time ---
 
@@ -141,6 +127,18 @@ jobs:
           chainsaw test \
             --test-dir tests/chainsaw/ai-conformance/kind-training \
             --config tests/chainsaw/chainsaw-config.yaml
+
+      - name: Verify expected resources exist
+        run: |
+          go run ./tests/chainsaw/ai-conformance/ \
+            --dir tests/chainsaw/ai-conformance/kind-training \
+            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+            --kubeconfig="${HOME}/.kube/config" \
+            --debug
 
       # --- CNCF AI Conformance validation ---
       # Runs last to ensure the DCGM → Prometheus → adapter pipeline

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -96,6 +96,8 @@ jobs:
 
       # --- Snapshot and validation ---
 
+      # --- Snapshot and resource verification ---
+
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
         with:
@@ -103,16 +105,28 @@ jobs:
           min_gpu_count: '2'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
-      # --- Install Karpenter before validation so cluster-autoscaling check passes ---
+      - name: Check expected resources exist
+        run: |
+          go run ./tests/chainsaw/ai-conformance/ \
+            --dir tests/chainsaw/ai-conformance/kind-training \
+            --file tests/chainsaw/ai-conformance/cluster/assert-cert-manager.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-monitoring.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-skyhook.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-dra-driver.yaml \
+            --file tests/chainsaw/ai-conformance/cluster/assert-kai-scheduler.yaml \
+            --kubeconfig="${HOME}/.kube/config" \
+            --debug
 
-      - name: Install Karpenter + KWOK (setup)
+      # --- Install Karpenter + KWOK early to give monitoring stack settle time ---
+
+      - name: Install Karpenter + KWOK
         uses: ./.github/actions/install-karpenter-kwok
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
-      # --- Health checks (run before conformance to give metrics pipeline time) ---
+      # --- Health checks ---
 
-      - name: Load versions
+      - name: Prepare chainsaw
         id: versions
         uses: ./.github/actions/load-versions
 
@@ -128,13 +142,11 @@ jobs:
             --test-dir tests/chainsaw/ai-conformance/kind-training \
             --config tests/chainsaw/chainsaw-config.yaml
 
-      # --- Validate cluster (Go conformance checks run inside K8s Jobs) ---
-      # Runs after chainsaw to ensure the DCGM → Prometheus → adapter pipeline
+      # --- CNCF AI Conformance validation ---
+      # Runs last to ensure the DCGM → Prometheus → adapter pipeline
       # has had time to bootstrap (pod-autoscaling check needs live metric data).
-      # Gang scheduling (PodGroup + 2 GPU pods) is exercised by the self-contained
-      # gang-scheduling conformance check — no separate deploy step needed.
 
-      - name: Validate cluster
+      - name: Validate CNCF AI Conformance
         run: |
           AICR_VALIDATOR_IMAGE_REGISTRY=ko.local \
           ./aicr validate \


### PR DESCRIPTION
## Summary

Standardize GPU workflow step ordering and naming across the three H100 workflows, with a consistent post-settle resource verification point before conformance validation.

## Motivation / Context

The GPU workflow step ordering evolved organically, resulting in inconsistent ordering across workflows and misleading step names. Training already ran health checks before `aicr validate`, while conformance and inference ran validation before Chainsaw. This PR standardizes the flow so health checks run first, resource verification happens only after the bundle has had time to settle, and conformance validation stays ahead of intent-specific GPU-consuming steps.

Related: #541

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/gpu-h100-{conformance,training,inference}-test.yaml`

## Implementation Notes

**Canonical step order** (consistent across all 3 workflows):

| # | Step | Purpose |
|---|------|---------|
| 1 | Snapshot and validate GPU | Capture cluster state, verify GPU detection |
| 2 | Install Karpenter + KWOK | Setup for cluster-autoscaling checks and give the monitoring stack additional settle time |
| 3 | Prepare + Install + Run Chainsaw health checks | Deployment health/readiness assertions |
| 4 | Verify expected resources exist | Explicit resource inventory check after async bundle installation has settled |
| 5 | Validate CNCF AI Conformance | Behavioral conformance checks |
| 6 | *(Inference only)* Deploy + validate Dynamo inference | Intent-specific smoke test |
| 7 | Collect/upload artifacts | Preserve validation outputs and evidence |

**Settle-point fix:** `gpu-operator-install` intentionally deploys bundles with `--no-wait --best-effort`, so cert-manager, monitoring, Skyhook, DRA, KAI, and Dynamo resources may still be coming up immediately after bundle install. The resource existence probe now runs after Chainsaw instead of immediately after bundle install to avoid turning normal startup latency into false failures.

**Inference ordering constraint:** Conformance validation must run before Dynamo deployment because the `dra-support` check allocates a GPU via DRA `ResourceClaim`, and the Dynamo vLLM worker also consumes a GPU claim. On H100 x1, running Dynamo first can cause `dra-support` to fail due to claim contention.

**Step renames:**
- `Collect AI conformance evidence` → `Verify expected resources exist` for the hard-fail post-Chainsaw verification step
- `Validate cluster` → `Validate CNCF AI Conformance`
- `Upload conformance evidence` → `Collect and upload validation artifacts`
- `Load versions` → `Prepare chainsaw`
- `Install Karpenter + KWOK (setup)` → `Install Karpenter + KWOK`

**Split verification/evidence pattern:**
- Training and inference keep an `if: always()` late evidence collection step for debug artifact capture.
- The hard-fail resource verification now runs once, after Chainsaw, at the point where the bundle is expected to be settled.

## Testing

Validated by:
- `unset GITLAB_TOKEN && make lint` — passed locally
- Manual review of step dependencies, async bundle-install behavior, and DRA resource constraints

`unset GITLAB_TOKEN && make qualify` did not complete cleanly in this workspace due an unrelated Go toolchain mismatch:

```text
compile: version "go1.26.1" does not match go tool version "go1.25.6"
```

## Risk Assessment

- [x] **Low** — Easy to revert

**Risks:**
- Chainsaw health-check flakes still gate conformance validation by design, but the resource verification step no longer races the intentionally asynchronous bundle install.

**Rollout notes:** N/A — CI workflow changes only.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
