### PR TITLE
docs: fix VitePress Helm examples and Pages triggers

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -19,14 +19,18 @@ on:
     branches:
       - main
     paths:
+      - 'docs/**'
       - 'site/**'
+      - 'tools/sync-site-docs'
       - '.github/workflows/gh-pages.yaml'
       - '.github/actions/build-versioned-site/**'
   pull_request:
     branches:
       - main
     paths:
+      - 'docs/**'
       - 'site/**'
+      - 'tools/sync-site-docs'
       - '.github/workflows/gh-pages.yaml'
       - '.github/actions/build-versioned-site/**'
   workflow_call: {}

--- a/docs/contributor/component.md
+++ b/docs/contributor/component.md
@@ -191,8 +191,8 @@ The component registry (`recipes/registry.yaml`) supports these fields:
 
 - Only add custom manifests when the Helm chart doesn't provide needed functionality
 - Use Helm template syntax (not Go templates) for manifest files
-- Reference values via `{{ index .Values "component-name" }}`
-- Make manifests conditional with `{{- if }}` blocks
+- Reference values via <code>&#123;&#123; index .Values "component-name" &#125;&#125;</code>
+- Make manifests conditional with <code>&#123;&#123;- if &#125;&#125;</code> blocks
 
 ### Testing
 


### PR DESCRIPTION
## Summary

Escape inline Helm template examples in the contributor component guide so VitePress does not parse them as Vue expressions during site builds. Also update the Pages workflow to trigger on `docs/**` and `tools/sync-site-docs`, since `site` syncs from `docs/` at build time.

## Motivation / Context

`#552` exposed a latent docs build failure in `docs/contributor/component.md`. The dependency bump was not the cause; the site build was failing because raw `{{ ... }}` appeared in inline Markdown and got parsed by Vue during `vitepress build`.

There was also a workflow gap: docs-only changes did not trigger the Pages build even though `site/package.json` runs `prebuild` sync from `docs/`.

Fixes: N/A
Related: #552

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Pages workflow

## Implementation Notes

- Replace the two inline Helm examples with escaped brace HTML so VitePress renders them as literal text.
- Add `docs/**` and `tools/sync-site-docs` to the `gh-pages` workflow path filters so docs source changes trigger site validation.

## Testing

```bash
./tools/sync-site-docs
unset GITLAB_TOKEN && make qualify
```

- `./tools/sync-site-docs` passed.
- `make qualify` failed in this workspace due an unrelated Go toolchain mismatch: compiled stdlib artifacts expect `go1.26.1`, while the local tool reports `go1.25.6`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
