### PR TITLE
fix(ci): fix fern instances URL basepath and surface publish URL in step summary

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -59,4 +59,10 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
         working-directory: ./fern
-        run: fern generate --docs
+        run: |
+          OUTPUT=$(fern generate --docs 2>&1)
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          if [ -n "$URL" ]; then
+            echo "### Published: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 instances:
-  - url: https://aicr.docs.buildwithfern.com
+  - url: https://aicr.docs.buildwithfern.com/aicr
 
 title: NVIDIA AI Cluster Runtime
 


### PR DESCRIPTION
## Summary

Fix two bugs in the Fern docs CI configuration: missing basepath in `instances.url` and publish step not surfacing the published URL.

## Motivation / Context

Fixes: #567
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

1. `fern/docs.yml` `instances.url` was `https://aicr.docs.buildwithfern.com` — missing the `/aicr` basepath required by `basepath-aware: true`. Verified by running `fern generate --docs --preview` locally; the correct URL is `https://aicr.docs.buildwithfern.com/aicr`.

2. `publish-fern-docs.yml` ran `fern generate --docs` as a bare command. Now captures output, extracts the published URL (stripping the duplicate parenthesised copy that breaks GitHub's auto-linker), and writes it to the job step summary.

## Testing

Verified `fern generate --docs --preview` locally — preview published successfully at `https://nvidia-preview-test-preview.docs.buildwithfern.com/aicr`. URL extraction regex confirmed against actual output.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)