### PR TITLE
refactor(deployer): unify deployer interface across helm, argocd, argocd-helm (#571)

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -29,10 +29,12 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocd"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocdhelm"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/helm"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
+	"github.com/NVIDIA/aicr/pkg/bundler/types"
 	"github.com/NVIDIA/aicr/pkg/bundler/validations"
 	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
 	"github.com/NVIDIA/aicr/pkg/component"
@@ -247,256 +249,162 @@ func (b *DefaultBundler) Make(ctx context.Context, input recipe.RecipeInput, dir
 	}
 
 	// Run component-specific validations
-	if err := b.runComponentValidations(ctx, recipeResult); err != nil {
+	if validationErr := b.runComponentValidations(ctx, recipeResult); validationErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-			"component validation failed", err)
+			"component validation failed", validationErr)
 	}
 
-	// Route based on deployer
+	// Copy external data files before deployer construction so the file list
+	// is available for both the deployer (checksum tracking) and post-generation
+	// attestation. This is a no-op when --data is not set.
+	dataFiles, err := b.copyDataFiles(dir)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal,
+			"failed to copy external data files", err)
+	}
+
+	// Build the deployer and run it
+	d, err := b.buildDeployer(ctx, recipeResult, componentValues, dataFiles)
+	if err != nil {
+		return nil, err
+	}
+	return b.runDeployer(ctx, d, recipeResult, dir, dataFiles, start)
+}
+
+// buildDeployer constructs the appropriate deployer.Deployer based on config.
+// It handles deployer-specific pre-flight validation and data collection.
+func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dataFiles []string) (deployer.Deployer, error) {
+	dynamicValues, err := b.buildDynamicValuesMap()
+	if err != nil {
+		return nil, err
+	}
+
 	switch b.Config.Deployer() {
 	case config.DeployerArgoCDHelm:
-		return b.makeArgoCDHelmChart(ctx, recipeResult, componentValues, dir, start)
+		if b.Config.Attest() {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				"--attest is not yet supported with --deployer argocd-helm")
+		}
+		if provider := recipe.GetDataProvider(); provider != nil {
+			if layered, ok := provider.(*recipe.LayeredDataProvider); ok && len(layered.ExternalFiles()) > 0 {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					"--data is not yet supported with --deployer argocd-helm")
+			}
+		}
+
+		slog.Debug("generating argocd helm chart app-of-apps",
+			"component_count", len(recipeResult.ComponentRefs),
+			"dynamic_components", len(dynamicValues),
+		)
+
+		return &argocdhelm.Generator{
+			RecipeResult:     recipeResult,
+			ComponentValues:  componentValues,
+			Version:          b.Config.Version(),
+			RepoURL:          b.Config.RepoURL(),
+			TargetRevision:   b.Config.TargetRevision(),
+			IncludeChecksums: b.Config.IncludeChecksums(),
+			DynamicValues:    dynamicValues,
+		}, nil
+
 	case config.DeployerArgoCD:
 		if b.Config.HasDynamicValues() {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
 				"--dynamic is not supported with --deployer argocd; use --deployer argocd-helm instead")
 		}
-		return b.makeArgoCD(ctx, recipeResult, componentValues, dir, start)
+
+		slog.Debug("generating argocd applications",
+			"component_count", len(recipeResult.ComponentRefs),
+		)
+
+		return &argocd.Generator{
+			RecipeResult:     recipeResult,
+			ComponentValues:  componentValues,
+			Version:          b.Config.Version(),
+			RepoURL:          b.Config.RepoURL(),
+			TargetRevision:   b.Config.TargetRevision(),
+			IncludeChecksums: b.Config.IncludeChecksums(),
+		}, nil
+
 	case config.DeployerHelm:
-		return b.makeHelmBundle(ctx, recipeResult, componentValues, dir, start)
+		componentManifests, manifestErr := b.collectComponentManifests(ctx, recipeResult)
+		if manifestErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal,
+				"failed to collect component manifests", manifestErr)
+		}
+
+		slog.Debug("generating helm bundle",
+			"component_count", len(recipeResult.ComponentRefs),
+		)
+
+		return &helm.Generator{
+			RecipeResult:       recipeResult,
+			ComponentValues:    componentValues,
+			Version:            b.Config.Version(),
+			IncludeChecksums:   b.Config.IncludeChecksums(),
+			ComponentManifests: componentManifests,
+			DataFiles:          dataFiles,
+			DynamicValues:      dynamicValues,
+		}, nil
+
 	default:
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("unsupported deployer type: %s", b.Config.Deployer()))
 	}
 }
 
-// makeHelmBundle generates a Helm per-component bundle.
-func (b *DefaultBundler) makeHelmBundle(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dir string, start time.Time) (*result.Output, error) {
-	slog.Debug("generating helm bundle",
-		"component_count", len(recipeResult.ComponentRefs),
-		"output_dir", dir,
-	)
-
-	// Collect manifest contents from components (keyed by component name)
-	componentManifests, err := b.collectComponentManifests(ctx, recipeResult)
+// runDeployer executes a deployer and builds the result output.
+// dataFiles is the list of external data file paths already copied by Make().
+func (b *DefaultBundler) runDeployer(ctx context.Context, d deployer.Deployer, recipeResult *recipe.RecipeResult, dir string, dataFiles []string, start time.Time) (*result.Output, error) {
+	output, err := d.Generate(ctx, dir)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to collect component manifests", err)
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate bundle", err)
 	}
 
-	// Copy external data files into bundle (before checksums so they're included)
-	dataFiles, err := b.copyDataFiles(dir)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to copy external data files", err)
+	totalFiles := len(output.Files)
+	totalSize := output.TotalSize
+
+	// Write recipe file (helm-only, preserves original behavior)
+	if b.Config.Deployer() == config.DeployerHelm {
+		recipeSize, writeErr := b.writeRecipeFile(recipeResult, dir)
+		if writeErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write recipe file", writeErr)
+		}
+		totalFiles++
+		totalSize += recipeSize
 	}
 
-	// Resolve dynamic values for Helm deployer
-	dynamicValues, dynErr := b.buildDynamicValuesMap()
-	if dynErr != nil {
-		return nil, dynErr
-	}
-
-	// Generate per-component bundle
-	generator := helm.NewGenerator()
-	generatorInput := &helm.GeneratorInput{
-		RecipeResult:       recipeResult,
-		ComponentValues:    componentValues,
-		Version:            b.Config.Version(),
-		IncludeChecksums:   b.Config.IncludeChecksums(),
-		ComponentManifests: componentManifests,
-		DataFiles:          dataFiles,
-		DynamicValues:      dynamicValues,
-	}
-
-	output, err := generator.Generate(ctx, generatorInput, dir)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to generate helm bundle", err)
-	}
-
-	// Write recipe file
-	recipeSize, err := b.writeRecipeFile(recipeResult, dir)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to write recipe file", err)
-	}
-
-	// Attest bundle (after checksums are generated by the deployer)
+	// Attest bundle (skips internally when not configured)
 	attestFiles, err := b.attestBundle(ctx, dir, dataFiles, recipeResult)
 	if err != nil {
 		return nil, err
 	}
+	totalFiles += len(attestFiles)
 
-	// Build result output
-	totalFiles := len(output.Files) + 1 + len(attestFiles) // +1 for recipe.yaml
+	// Map deployer type to result and deployment names
+	resultType, deploymentType := deployerResultNames(b.Config.Deployer())
+
+	// Build result
 	resultOutput := &result.Output{
 		Results:       make([]*result.Result, 0),
 		Errors:        make([]result.BundleError, 0),
 		TotalDuration: time.Since(start),
-		TotalSize:     output.TotalSize + recipeSize,
+		TotalSize:     totalSize,
 		TotalFiles:    totalFiles,
 		OutputDir:     dir,
 	}
 
-	// Add a single result for the helm bundle
-	helmResult := &result.Result{
-		Type:     "helm-bundle",
+	bundleResult := &result.Result{
+		Type:     resultType,
 		Success:  true,
 		Files:    append(output.Files, attestFiles...),
 		Size:     output.TotalSize,
 		Duration: output.Duration,
 	}
-	resultOutput.Results = append(resultOutput.Results, helmResult)
+	resultOutput.Results = append(resultOutput.Results, bundleResult)
 
-	// Populate deployment info from generator output
+	// Deployment info
 	var notes []string
-	if len(b.warnings) > 0 {
-		notes = append(notes, b.warnings...)
-	}
-	resultOutput.Deployment = &result.DeploymentInfo{
-		Type:  "Helm per-component bundle",
-		Steps: output.DeploymentSteps,
-		Notes: notes,
-	}
-
-	slog.Debug("helm bundle generation complete",
-		"files", len(output.Files),
-		"size_bytes", output.TotalSize,
-		"duration", output.Duration,
-	)
-
-	return resultOutput, nil
-}
-
-// makeArgoCDHelmChart generates a Helm chart app-of-apps for ArgoCD with dynamic install-time values.
-func (b *DefaultBundler) makeArgoCDHelmChart(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dir string, start time.Time) (*result.Output, error) {
-	// Reject flags not yet supported by the argocd-helm deployer.
-	if b.Config.Attest() {
-		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			"--attest is not yet supported with --deployer argocd-helm")
-	}
-	if provider := recipe.GetDataProvider(); provider != nil {
-		if layered, ok := provider.(*recipe.LayeredDataProvider); ok && len(layered.ExternalFiles()) > 0 {
-			return nil, errors.New(errors.ErrCodeInvalidRequest,
-				"--data is not yet supported with --deployer argocd-helm")
-		}
-	}
-
-	dynamicValues, dynErr := b.buildDynamicValuesMap()
-	if dynErr != nil {
-		return nil, dynErr
-	}
-
-	slog.Debug("generating argocd helm chart app-of-apps",
-		"component_count", len(recipeResult.ComponentRefs),
-		"dynamic_components", len(dynamicValues),
-		"output_dir", dir,
-	)
-
-	generator := &argocdhelm.Generator{
-		RecipeResult:     recipeResult,
-		ComponentValues:  componentValues,
-		Version:          b.Config.Version(),
-		RepoURL:          b.Config.RepoURL(),
-		TargetRevision:   b.Config.TargetRevision(),
-		IncludeChecksums: b.Config.IncludeChecksums(),
-		DynamicValues:    dynamicValues,
-	}
-
-	output, err := generator.Generate(ctx, dir)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to generate argocd helm chart", err)
-	}
-
-	resultOutput := &result.Output{
-		Results:       make([]*result.Result, 0),
-		Errors:        make([]result.BundleError, 0),
-		TotalDuration: time.Since(start),
-		TotalSize:     output.TotalSize,
-		TotalFiles:    len(output.Files),
-		OutputDir:     dir,
-	}
-
-	argocdResult := &result.Result{
-		Type:     "argocd-helm-chart",
-		Success:  true,
-		Files:    output.Files,
-		Size:     output.TotalSize,
-		Duration: output.Duration,
-	}
-	resultOutput.Results = append(resultOutput.Results, argocdResult)
-
-	resultOutput.Deployment = &result.DeploymentInfo{
-		Type:  "ArgoCD Helm chart app-of-apps",
-		Steps: output.DeploymentSteps,
-		Notes: b.warnings,
-	}
-
-	return resultOutput, nil
-}
-
-// makeArgoCD generates ArgoCD Application manifests.
-func (b *DefaultBundler) makeArgoCD(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dir string, start time.Time) (*result.Output, error) {
-	slog.Debug("generating argocd applications",
-		"component_count", len(recipeResult.ComponentRefs),
-		"output_dir", dir,
-	)
-
-	// Generate ArgoCD applications
-	generator := argocd.NewGenerator()
-	generatorInput := &argocd.GeneratorInput{
-		RecipeResult:     recipeResult,
-		ComponentValues:  componentValues,
-		Version:          b.Config.Version(),
-		RepoURL:          b.Config.RepoURL(),
-		TargetRevision:   b.Config.TargetRevision(),
-		IncludeChecksums: b.Config.IncludeChecksums(),
-	}
-
-	output, err := generator.Generate(ctx, generatorInput, dir)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to generate argocd applications", err)
-	}
-
-	// Copy external data files into bundle (before attestation so they're included in checksums)
-	dataFiles, err := b.copyDataFiles(dir)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			"failed to copy external data files", err)
-	}
-
-	// Attest bundle (after checksums are generated by the deployer)
-	attestFiles, err := b.attestBundle(ctx, dir, dataFiles, recipeResult)
-	if err != nil {
-		return nil, err
-	}
-
-	// Build result output
-	totalFiles := len(output.Files) + len(attestFiles)
-	resultOutput := &result.Output{
-		Results:       make([]*result.Result, 0),
-		Errors:        make([]result.BundleError, 0),
-		TotalDuration: time.Since(start),
-		TotalSize:     output.TotalSize,
-		TotalFiles:    totalFiles,
-		OutputDir:     dir,
-	}
-
-	// Add a single result for the ArgoCD applications
-	argocdResult := &result.Result{
-		Type:     "argocd-applications",
-		Success:  true,
-		Files:    output.Files,
-		Size:     output.TotalSize,
-		Duration: output.Duration,
-	}
-	resultOutput.Results = append(resultOutput.Results, argocdResult)
-
-	// Populate deployment info from generator output
-	notes := make([]string, 0)
 	if len(output.DeploymentNotes) > 0 {
 		notes = append(notes, output.DeploymentNotes...)
 	}
@@ -504,18 +412,34 @@ func (b *DefaultBundler) makeArgoCD(ctx context.Context, recipeResult *recipe.Re
 		notes = append(notes, b.warnings...)
 	}
 	resultOutput.Deployment = &result.DeploymentInfo{
-		Type:  "ArgoCD applications",
+		Type:  deploymentType,
 		Steps: output.DeploymentSteps,
 		Notes: notes,
 	}
 
-	slog.Debug("argocd applications generation complete",
+	slog.Debug("bundle generation complete",
+		"deployer", b.Config.Deployer(),
 		"files", len(output.Files),
 		"size_bytes", output.TotalSize,
 		"duration", output.Duration,
 	)
 
 	return resultOutput, nil
+}
+
+// deployerResultNames returns the result type and deployment type display names
+// for a given deployer type, preserving the human-readable names used in output.
+func deployerResultNames(dt config.DeployerType) (types.BundleType, string) {
+	switch dt {
+	case config.DeployerHelm:
+		return "helm-bundle", "Helm per-component bundle"
+	case config.DeployerArgoCD:
+		return "argocd-applications", "ArgoCD applications"
+	case config.DeployerArgoCDHelm:
+		return "argocd-helm-chart", "ArgoCD Helm chart app-of-apps"
+	default:
+		return types.BundleType(dt), string(dt)
+	}
 }
 
 // extractComponentValues extracts and processes values for each component in the recipe.

--- a/pkg/bundler/deployer/argocd/argocd.go
+++ b/pkg/bundler/deployer/argocd/argocd.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
-	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
@@ -67,8 +67,12 @@ type ReadmeData struct {
 	Components     []ApplicationData
 }
 
-// GeneratorInput contains all data needed to generate ArgoCD Applications.
-type GeneratorInput struct {
+// compile-time interface check
+var _ deployer.Deployer = (*Generator)(nil)
+
+// Generator creates ArgoCD Applications from recipe results.
+// Configure it with the required fields, then call Generate.
+type Generator struct {
 	// RecipeResult contains the recipe metadata and component references.
 	RecipeResult *recipe.RecipeResult
 
@@ -89,56 +93,30 @@ type GeneratorInput struct {
 	IncludeChecksums bool
 }
 
-// GeneratorOutput contains the result of ArgoCD Application generation.
-type GeneratorOutput struct {
-	// Files contains the paths of generated files.
-	Files []string
-
-	// TotalSize is the total size of all generated files.
-	TotalSize int64
-
-	// Duration is the time taken to generate the applications.
-	Duration time.Duration
-
-	// DeploymentSteps contains ordered deployment instructions for the user.
-	DeploymentSteps []string
-
-	// DeploymentNotes contains optional notes (e.g., "Update repo URL").
-	DeploymentNotes []string
-}
-
-// Generator creates ArgoCD Applications from recipe results.
-type Generator struct{}
-
-// NewGenerator creates a new ArgoCD application generator.
-func NewGenerator() *Generator {
-	return &Generator{}
-}
-
 // resolveRepoSettings returns the effective repoURL and targetRevision,
 // applying defaults when the input values are empty.
-func resolveRepoSettings(input *GeneratorInput) (repoURL, targetRevision string) {
-	repoURL = input.RepoURL
+func resolveRepoSettings(g *Generator) (repoURL, targetRevision string) {
+	repoURL = g.RepoURL
 	if repoURL == "" {
 		repoURL = "https://github.com/YOUR-ORG/YOUR-REPO.git"
 	}
-	targetRevision = input.TargetRevision
+	targetRevision = g.TargetRevision
 	if targetRevision == "" {
 		targetRevision = "main"
 	}
 	return repoURL, targetRevision
 }
 
-// Generate creates ArgoCD Applications from the given input.
-func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputDir string) (*GeneratorOutput, error) {
+// Generate creates ArgoCD Applications from the configured generator fields.
+func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.Output, error) {
 	start := time.Now()
 
-	output := &GeneratorOutput{
+	output := &deployer.Output{
 		Files: make([]string, 0),
 	}
 
-	if input == nil || input.RecipeResult == nil {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "input and recipe result are required")
+	if g.RecipeResult == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "RecipeResult is required")
 	}
 
 	// Create output directory
@@ -147,18 +125,18 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 			"failed to create output directory", err)
 	}
 
-	repoURL, targetRevision := resolveRepoSettings(input)
+	repoURL, targetRevision := resolveRepoSettings(g)
 
 	// Sort components by deployment order
-	components := shared.SortComponentRefsByDeploymentOrder(
-		input.RecipeResult.ComponentRefs,
-		input.RecipeResult.DeploymentOrder,
+	components := deployer.SortComponentRefsByDeploymentOrder(
+		g.RecipeResult.ComponentRefs,
+		g.RecipeResult.DeploymentOrder,
 	)
 
 	// Generate application data for each component (validate names early)
 	appDataList := make([]ApplicationData, 0, len(components))
 	for i, comp := range components {
-		if !shared.IsSafePathComponent(comp.Name) {
+		if !deployer.IsSafePathComponent(comp.Name) {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", comp.Name))
 		}
@@ -175,7 +153,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 			Namespace:      comp.Namespace,
 			Repository:     comp.Source,
 			Chart:          chartName,
-			Version:        shared.NormalizeVersion(comp.Version),
+			Version:        deployer.NormalizeVersion(comp.Version),
 			SyncWave:       i, // Use index as sync wave
 			IsKustomize:    isKustomize,
 			Tag:            comp.Tag,
@@ -194,7 +172,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		default:
 		}
 
-		componentDir, err := shared.SafeJoin(outputDir, appData.Name)
+		componentDir, err := deployer.SafeJoin(outputDir, appData.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +182,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		}
 
 		// Generate application.yaml
-		appPath, appSize, err := shared.GenerateFromTemplate(applicationTemplate, appData, componentDir, "application.yaml")
+		appPath, appSize, err := deployer.GenerateFromTemplate(applicationTemplate, appData, componentDir, "application.yaml")
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInternal,
 				fmt.Sprintf("failed to generate application.yaml for %s", appData.Name), err)
@@ -214,11 +192,11 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 
 		// Generate values.yaml only for Helm components (kustomize uses source directly)
 		if !appData.IsKustomize {
-			values := input.ComponentValues[appData.Name]
+			values := g.ComponentValues[appData.Name]
 			if values == nil {
 				values = make(map[string]any)
 			}
-			valuesPath, valuesSize, err := shared.WriteValuesFile(values, componentDir, "values.yaml")
+			valuesPath, valuesSize, err := deployer.WriteValuesFile(values, componentDir, "values.yaml")
 			if err != nil {
 				return nil, errors.Wrap(errors.ErrCodeInternal,
 					fmt.Sprintf("failed to generate values.yaml for %s", appData.Name), err)
@@ -234,7 +212,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		TargetRevision: targetRevision,
 		Path:           ".",
 	}
-	appOfAppsPath, appOfAppsSize, err := shared.GenerateFromTemplate(appOfAppsTemplate, appOfAppsData, outputDir, "app-of-apps.yaml")
+	appOfAppsPath, appOfAppsSize, err := deployer.GenerateFromTemplate(appOfAppsTemplate, appOfAppsData, outputDir, "app-of-apps.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate app-of-apps.yaml", err)
 	}
@@ -243,11 +221,11 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 
 	// Generate README.md
 	readmeData := ReadmeData{
-		RecipeVersion:  input.RecipeResult.Metadata.Version,
-		BundlerVersion: input.Version,
+		RecipeVersion:  g.RecipeResult.Metadata.Version,
+		BundlerVersion: g.Version,
 		Components:     appDataList,
 	}
-	readmePath, readmeSize, err := shared.GenerateFromTemplate(readmeTemplate, readmeData, outputDir, "README.md")
+	readmePath, readmeSize, err := deployer.GenerateFromTemplate(readmeTemplate, readmeData, outputDir, "README.md")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate README.md", err)
 	}
@@ -255,7 +233,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	output.TotalSize += readmeSize
 
 	// Generate checksums if requested
-	if input.IncludeChecksums {
+	if g.IncludeChecksums {
 		if err := checksum.GenerateChecksums(ctx, outputDir, output.Files); err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate checksums", err)
 		}
@@ -276,7 +254,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 		fmt.Sprintf("kubectl apply -f %s/app-of-apps.yaml", outputDir),
 	}
 	// Add note if repo URL needs to be updated
-	if input.RepoURL == "" {
+	if g.RepoURL == "" {
 		output.DeploymentNotes = []string{
 			"Update app-of-apps.yaml with your repository URL before applying",
 		}

--- a/pkg/bundler/deployer/argocd/argocd_test.go
+++ b/pkg/bundler/deployer/argocd/argocd_test.go
@@ -23,21 +23,13 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 const testVersion = "v1.0.0"
 
-func TestNewGenerator(t *testing.T) {
-	g := NewGenerator()
-	if g == nil {
-		t.Fatal("NewGenerator() returned nil")
-	}
-}
-
 func TestGenerate_Success(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -63,7 +55,7 @@ func TestGenerate_Success(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"cert-manager", "gpu-operator"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {
@@ -78,7 +70,7 @@ func TestGenerate_Success(t *testing.T) {
 		Version: "v0.9.0",
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -155,35 +147,20 @@ func TestGenerate_Success(t *testing.T) {
 	}
 }
 
-func TestGenerate_NilInput(t *testing.T) {
-	g := NewGenerator()
-	ctx := context.Background()
-	outputDir := t.TempDir()
-
-	_, err := g.Generate(ctx, nil, outputDir)
-	if err == nil {
-		t.Fatal("Generate() should return error for nil input")
-	}
-}
-
 func TestGenerate_NilRecipeResult(t *testing.T) {
-	g := NewGenerator()
+	g := &Generator{
+		Version: "v0.9.0",
+	}
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
-		RecipeResult: nil,
-		Version:      "v0.9.0",
-	}
-
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err == nil {
 		t.Fatal("Generate() should return error for nil recipe result")
 	}
 }
 
 func TestGenerate_EmptyComponents(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -191,12 +168,12 @@ func TestGenerate_EmptyComponents(t *testing.T) {
 	recipeResult.Metadata.Version = testVersion
 	recipeResult.ComponentRefs = []recipe.ComponentRef{}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		Version:      "v0.9.0",
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -221,7 +198,6 @@ func TestGenerate_EmptyComponents(t *testing.T) {
 }
 
 func TestGenerate_WithRepoURL(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -240,13 +216,13 @@ func TestGenerate_WithRepoURL(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		Version:      "v0.9.0",
 		RepoURL:      customRepoURL,
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -273,7 +249,6 @@ func TestGenerate_WithRepoURL(t *testing.T) {
 }
 
 func TestGenerate_WithOCIRepoURL(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -293,7 +268,7 @@ func TestGenerate_WithOCIRepoURL(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult:    recipeResult,
 		ComponentValues: map[string]map[string]any{"gpu-operator": {}},
 		Version:         "v0.9.0",
@@ -301,7 +276,7 @@ func TestGenerate_WithOCIRepoURL(t *testing.T) {
 		TargetRevision:  ociTag,
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -336,7 +311,6 @@ func TestGenerate_WithOCIRepoURL(t *testing.T) {
 }
 
 func TestGenerate_DefaultRepoURL_InChildApplications(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -353,13 +327,13 @@ func TestGenerate_DefaultRepoURL_InChildApplications(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult:    recipeResult,
 		ComponentValues: map[string]map[string]any{"gpu-operator": {}},
 		Version:         "v0.9.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -378,7 +352,6 @@ func TestGenerate_DefaultRepoURL_InChildApplications(t *testing.T) {
 }
 
 func TestGenerate_WithChecksums(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -404,13 +377,13 @@ func TestGenerate_WithChecksums(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"cert-manager", "gpu-operator"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult:     recipeResult,
 		Version:          "v0.9.0",
 		IncludeChecksums: true,
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -448,7 +421,6 @@ func TestGenerate_WithChecksums(t *testing.T) {
 }
 
 func TestGenerate_ContextCancellation(t *testing.T) {
-	g := NewGenerator()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
@@ -467,12 +439,12 @@ func TestGenerate_ContextCancellation(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		Version:      "v0.9.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err == nil {
 		t.Fatal("Generate() should return error for cancelled context")
 	}
@@ -527,7 +499,7 @@ func TestSortComponentRefsByDeploymentOrder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := shared.SortComponentRefsByDeploymentOrder(tt.refs, tt.order)
+			result := deployer.SortComponentRefsByDeploymentOrder(tt.refs, tt.order)
 
 			if len(result) != len(tt.expected) {
 				t.Fatalf("Expected %d components, got %d", len(tt.expected), len(result))
@@ -562,20 +534,19 @@ func TestSafeJoin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := shared.SafeJoin(tt.dir, tt.input)
+			result, err := deployer.SafeJoin(tt.dir, tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("shared.SafeJoin(%q, %q) error = %v, wantErr %v", tt.dir, tt.input, err, tt.wantErr)
+				t.Errorf("deployer.SafeJoin(%q, %q) error = %v, wantErr %v", tt.dir, tt.input, err, tt.wantErr)
 				return
 			}
 			if err == nil && result == "" {
-				t.Errorf("shared.SafeJoin(%q, %q) returned empty path", tt.dir, tt.input)
+				t.Errorf("deployer.SafeJoin(%q, %q) returned empty path", tt.dir, tt.input)
 			}
 		})
 	}
 }
 
 func TestApplicationData_NamespaceFromComponentRef(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -593,12 +564,12 @@ func TestApplicationData_NamespaceFromComponentRef(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"gpu-operator"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		Version:      "v0.9.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -633,8 +604,8 @@ func TestIsSafePathComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shared.IsSafePathComponent(tt.input); got != tt.want {
-				t.Errorf("shared.IsSafePathComponent(%q) = %v, want %v", tt.input, got, tt.want)
+			if got := deployer.IsSafePathComponent(tt.input); got != tt.want {
+				t.Errorf("deployer.IsSafePathComponent(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -653,7 +624,7 @@ func TestNormalizeVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			result := shared.NormalizeVersion(tt.input)
+			result := deployer.NormalizeVersion(tt.input)
 			if result != tt.expected {
 				t.Errorf("NormalizeVersion(%s) = %s, want %s", tt.input, result, tt.expected)
 			}
@@ -662,7 +633,6 @@ func TestNormalizeVersion(t *testing.T) {
 }
 
 func TestGenerate_KustomizeOnly(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -680,13 +650,13 @@ func TestGenerate_KustomizeOnly(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"my-kustomize-app"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult:    recipeResult,
 		ComponentValues: map[string]map[string]any{},
 		Version:         "v0.9.0",
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -741,7 +711,6 @@ func TestGenerate_KustomizeOnly(t *testing.T) {
 }
 
 func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -767,7 +736,7 @@ func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"cert-manager", "my-kustomize-app"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		ComponentValues: map[string]map[string]any{
 			"cert-manager":     {"crds": map[string]any{"enabled": true}},
@@ -776,7 +745,7 @@ func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
 		Version: "v0.9.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -827,7 +796,6 @@ func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
 // TestGenerate_Reproducible verifies that ArgoCD bundle generation is deterministic.
 // Running Generate() twice with the same input should produce identical output files.
 func TestGenerate_Reproducible(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 
 	recipeResult := &recipe.RecipeResult{}
@@ -852,7 +820,7 @@ func TestGenerate_Reproducible(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"cert-manager", "gpu-operator"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {
@@ -874,7 +842,7 @@ func TestGenerate_Reproducible(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		outputDir := t.TempDir()
 
-		_, err := g.Generate(ctx, input, outputDir)
+		_, err := g.Generate(ctx, outputDir)
 		if err != nil {
 			t.Fatalf("iteration %d: Generate() error = %v", i, err)
 		}
@@ -1014,7 +982,6 @@ func TestGenerate_ApplicationYAMLStructure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGenerator()
 			ctx := context.Background()
 			outputDir := t.TempDir()
 
@@ -1023,13 +990,13 @@ func TestGenerate_ApplicationYAMLStructure(t *testing.T) {
 			recipeResult.ComponentRefs = tt.refs
 			recipeResult.DeploymentOrder = []string{tt.refs[0].Name}
 
-			input := &GeneratorInput{
+			g := &Generator{
 				RecipeResult:    recipeResult,
 				ComponentValues: map[string]map[string]any{tt.refs[0].Name: {}},
 				Version:         "v0.9.0",
 			}
 
-			_, err := g.Generate(ctx, input, outputDir)
+			_, err := g.Generate(ctx, outputDir)
 			if err != nil {
 				t.Fatalf("Generate() error = %v", err)
 			}
@@ -1052,7 +1019,6 @@ func TestGenerate_ApplicationYAMLStructure(t *testing.T) {
 
 // TestGenerate_NoTimestampInOutput verifies that generated files don't contain timestamps.
 func TestGenerate_NoTimestampInOutput(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -1070,7 +1036,7 @@ func TestGenerate_NoTimestampInOutput(t *testing.T) {
 	}
 	recipeResult.DeploymentOrder = []string{"gpu-operator"}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: recipeResult,
 		ComponentValues: map[string]map[string]any{
 			"gpu-operator": {},
@@ -1079,7 +1045,7 @@ func TestGenerate_NoTimestampInOutput(t *testing.T) {
 		RepoURL: "https://github.com/test/repo.git",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}

--- a/pkg/bundler/deployer/argocd/doc.go
+++ b/pkg/bundler/deployer/argocd/doc.go
@@ -34,9 +34,7 @@ sync-wave annotations starting from 0.
 
 # Usage
 
-	generator := argocd.NewGenerator()
-
-	input := &argocd.GeneratorInput{
+	generator := &argocd.Generator{
 		RecipeResult:     recipeResult,
 		ComponentValues:  componentValues,
 		Version:          "v0.9.0",
@@ -44,7 +42,7 @@ sync-wave annotations starting from 0.
 		IncludeChecksums: true,
 	}
 
-	output, err := generator.Generate(ctx, input, "/path/to/output")
+	output, err := generator.Generate(ctx, "/path/to/output")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -69,7 +67,7 @@ sync-wave annotations starting from 0.
 
 # Configuration
 
-The RepoURL field in GeneratorInput sets the Git repository URL in the
+The RepoURL field in Generator sets the Git repository URL in the
 app-of-apps.yaml manifest. If not provided, a placeholder URL is used
 that must be updated manually before deployment.
 */

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -54,7 +54,6 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocd"
-	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
 	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -62,11 +61,6 @@ import (
 
 // compile-time interface check
 var _ deployer.Deployer = (*Generator)(nil)
-
-// HasDynamicValues reports whether this deployer has dynamic install-time values.
-func (g *Generator) HasDynamicValues() bool {
-	return len(g.DynamicValues) > 0
-}
 
 // Generator creates Helm chart app-of-apps bundles by transforming flat ArgoCD output.
 // Configure it with the required fields, then call Generate.
@@ -99,7 +93,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	}
 	defer os.RemoveAll(tmpDir)
 
-	argocdInput := &argocd.GeneratorInput{
+	argocdGen := &argocd.Generator{
 		RecipeResult:     g.RecipeResult,
 		ComponentValues:  g.ComponentValues,
 		Version:          g.Version,
@@ -108,8 +102,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 		IncludeChecksums: false, // we generate our own checksums
 	}
 
-	argocdGen := argocd.NewGenerator()
-	if _, genErr := argocdGen.Generate(ctx, argocdInput, tmpDir); genErr != nil {
+	if _, genErr := argocdGen.Generate(ctx, tmpDir); genErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate base ArgoCD output", genErr)
 	}
 
@@ -121,7 +114,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	output := &deployer.Output{Files: make([]string, 0)}
 
 	// Write Chart.yaml
-	chartPath, chartSize, err := writeChartYAML(outputDir, shared.NormalizeVersionWithDefault(g.RecipeResult.Metadata.Version))
+	chartPath, chartSize, err := writeChartYAML(outputDir, deployer.NormalizeVersionWithDefault(g.RecipeResult.Metadata.Version))
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write Chart.yaml", err)
 	}
@@ -136,7 +129,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	output.Files = append(output.Files, staticFiles...)
 	output.TotalSize += staticSize
 
-	valuesPath, valuesSize, err := shared.WriteValuesFile(dynamicOnlyValues, outputDir, "values.yaml")
+	valuesPath, valuesSize, err := deployer.WriteValuesFile(dynamicOnlyValues, outputDir, "values.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write root values.yaml", err)
 	}
@@ -144,7 +137,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	output.TotalSize += valuesSize
 
 	// Step 4: Transform Application manifests into Helm templates
-	templatesDir, err := shared.SafeJoin(outputDir, "templates")
+	templatesDir, err := deployer.SafeJoin(outputDir, "templates")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to resolve templates directory", err)
 	}
@@ -231,7 +224,7 @@ func (g *Generator) finalizeOutput(ctx context.Context, output *deployer.Output,
 // writeStaticValuesAndBuildStubs writes each component's values to static/<name>.yaml
 // and builds the dynamic-only stubs map for the root values.yaml.
 func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, int64, map[string]any, error) {
-	staticDir, err := shared.SafeJoin(outputDir, "static")
+	staticDir, err := deployer.SafeJoin(outputDir, "static")
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -280,7 +273,7 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		}
 
 		// Write static values (dynamic paths removed)
-		staticPath, staticSize, staticErr := shared.WriteValuesFile(staticValues, staticDir, ref.Name+".yaml")
+		staticPath, staticSize, staticErr := deployer.WriteValuesFile(staticValues, staticDir, ref.Name+".yaml")
 		if staticErr != nil {
 			return nil, 0, nil, errors.Wrap(errors.ErrCodeInternal,
 				fmt.Sprintf("failed to write static values for %s", ref.Name), staticErr)
@@ -296,15 +289,15 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 // structured YAML, replaces the multi-source block with a single-source +
 // helm.values Helm template, and writes the result as a chart template file.
 func transformApplication(srcDir, templatesDir, componentName, overrideKey string) (string, int64, error) {
-	if !shared.IsSafePathComponent(componentName) {
+	if !deployer.IsSafePathComponent(componentName) {
 		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", componentName))
 	}
-	componentDir, joinErr := shared.SafeJoin(srcDir, componentName)
+	componentDir, joinErr := deployer.SafeJoin(srcDir, componentName)
 	if joinErr != nil {
 		return "", 0, joinErr
 	}
-	srcPath, joinErr := shared.SafeJoin(componentDir, "application.yaml")
+	srcPath, joinErr := deployer.SafeJoin(componentDir, "application.yaml")
 	if joinErr != nil {
 		return "", 0, joinErr
 	}
@@ -337,7 +330,7 @@ func transformApplication(srcDir, templatesDir, componentName, overrideKey strin
 	}
 	out = fixValuesTemplate(out, app)
 
-	destPath, pathErr := shared.SafeJoin(templatesDir, componentName+".yaml")
+	destPath, pathErr := deployer.SafeJoin(templatesDir, componentName+".yaml")
 	if pathErr != nil {
 		return "", 0, pathErr
 	}
@@ -456,15 +449,15 @@ func fixValuesTemplate(marshaled []byte, app map[string]any) []byte {
 }
 
 func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, error) {
-	if !shared.IsSafePathComponent(componentName) {
+	if !deployer.IsSafePathComponent(componentName) {
 		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", componentName))
 	}
-	componentDir, joinErr := shared.SafeJoin(srcDir, componentName)
+	componentDir, joinErr := deployer.SafeJoin(srcDir, componentName)
 	if joinErr != nil {
 		return "", 0, joinErr
 	}
-	srcPath, joinErr := shared.SafeJoin(componentDir, "application.yaml")
+	srcPath, joinErr := deployer.SafeJoin(componentDir, "application.yaml")
 	if joinErr != nil {
 		return "", 0, joinErr
 	}
@@ -474,7 +467,7 @@ func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, 
 			fmt.Sprintf("failed to read application.yaml for %s", componentName), err)
 	}
 
-	destPath, pathErr := shared.SafeJoin(templatesDir, componentName+".yaml")
+	destPath, pathErr := deployer.SafeJoin(templatesDir, componentName+".yaml")
 	if pathErr != nil {
 		return "", 0, pathErr
 	}
@@ -487,7 +480,7 @@ func copyAsTemplate(srcDir, templatesDir, componentName string) (string, int64, 
 }
 
 func writeChartYAML(outputDir, version string) (string, int64, error) {
-	chartPath, err := shared.SafeJoin(outputDir, "Chart.yaml")
+	chartPath, err := deployer.SafeJoin(outputDir, "Chart.yaml")
 	if err != nil {
 		return "", 0, err
 	}
@@ -507,7 +500,7 @@ func writeChartYAML(outputDir, version string) (string, int64, error) {
 }
 
 func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
-	readmePath, err := shared.SafeJoin(outputDir, "README.md")
+	readmePath, err := deployer.SafeJoin(outputDir, "README.md")
 	if err != nil {
 		return "", 0, err
 	}

--- a/pkg/bundler/deployer/deployer.go
+++ b/pkg/bundler/deployer/deployer.go
@@ -19,8 +19,8 @@
 // data, then Generate is called to produce the output.
 //
 // The Deployer interface enables mockability in bundler tests and provides a
-// consistent contract across deployer implementations. Existing deployers
-// (helm, argocd) do not yet implement this interface — argocdhelm is the first.
+// consistent contract across deployer implementations. All three deployers
+// (helm, argocd, argocdhelm) implement this interface.
 package deployer
 
 import (
@@ -50,8 +50,4 @@ type Output struct {
 // Implementations are configured as structs, then Generate is called.
 type Deployer interface {
 	Generate(ctx context.Context, outputDir string) (*Output, error)
-
-	// HasDynamicValues reports whether this deployer has install-time value
-	// paths that will be split out for the user to fill in at deploy time.
-	HasDynamicValues() bool
 }

--- a/pkg/bundler/deployer/helm/doc.go
+++ b/pkg/bundler/deployer/helm/doc.go
@@ -25,12 +25,11 @@
 //
 // Usage:
 //
-//	generator := helm.NewGenerator()
-//	input := &helm.GeneratorInput{
+//	generator := &helm.Generator{
 //	    RecipeResult:     recipeResult,
 //	    ComponentValues:  componentValues,
 //	    Version:          "1.0.0",
 //	    IncludeChecksums: true,
 //	}
-//	output, err := generator.Generate(ctx, input, "/path/to/output")
+//	output, err := generator.Generate(ctx, "/path/to/output")
 package helm

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
-	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/manifest"
@@ -64,8 +64,12 @@ type ComponentData struct {
 	Path         string // Path within the repository to the kustomization
 }
 
-// GeneratorInput contains all data needed to generate a per-component Helm bundle.
-type GeneratorInput struct {
+// compile-time interface check
+var _ deployer.Deployer = (*Generator)(nil)
+
+// Generator creates per-component Helm bundles from recipe results.
+// Configure it with the required fields, then call Generate.
+type Generator struct {
 	// RecipeResult contains the recipe metadata and component references.
 	RecipeResult *recipe.RecipeResult
 
@@ -92,39 +96,16 @@ type GeneratorInput struct {
 	DynamicValues map[string][]string
 }
 
-// GeneratorOutput contains the result of Helm bundle generation.
-type GeneratorOutput struct {
-	// Files contains the paths of generated files.
-	Files []string
-
-	// TotalSize is the total size of all generated files.
-	TotalSize int64
-
-	// Duration is the time taken to generate the bundle.
-	Duration time.Duration
-
-	// DeploymentSteps contains ordered deployment instructions for the user.
-	DeploymentSteps []string
-}
-
-// Generator creates per-component Helm bundles from recipe results.
-type Generator struct{}
-
-// NewGenerator creates a new Helm bundle generator.
-func NewGenerator() *Generator {
-	return &Generator{}
-}
-
-// Generate creates a per-component Helm bundle from the given input.
-func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputDir string) (*GeneratorOutput, error) {
+// Generate creates a per-component Helm bundle from the configured generator fields.
+func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.Output, error) {
 	start := time.Now()
 
-	output := &GeneratorOutput{
+	output := &deployer.Output{
 		Files: make([]string, 0),
 	}
 
-	if input == nil || input.RecipeResult == nil {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "input and recipe result are required")
+	if g.RecipeResult == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "RecipeResult is required")
 	}
 
 	// Create output directory
@@ -134,13 +115,13 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	}
 
 	// Build sorted component data list (validates component names)
-	components, err := g.buildComponentDataList(input)
+	components, err := g.buildComponentDataList()
 	if err != nil {
 		return nil, err
 	}
 
 	// Generate per-component directories
-	files, size, err := g.generateComponentDirectories(ctx, input, components, outputDir)
+	files, size, err := g.generateComponentDirectories(ctx, components, outputDir)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to generate component directories", err)
@@ -149,7 +130,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	output.TotalSize += size
 
 	// Generate root README.md
-	readmePath, readmeSize, err := g.generateRootREADME(ctx, input, components, outputDir)
+	readmePath, readmeSize, err := g.generateRootREADME(ctx, components, outputDir)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to generate README.md", err)
@@ -158,7 +139,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	output.TotalSize += readmeSize
 
 	// Generate deploy.sh
-	deployPath, deploySize, err := g.generateDeployScript(ctx, input, components, outputDir)
+	deployPath, deploySize, err := g.generateDeployScript(ctx, components, outputDir)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to generate deploy.sh", err)
@@ -167,7 +148,7 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	output.TotalSize += deploySize
 
 	// Generate undeploy.sh
-	undeployPath, undeploySize, err := g.generateUndeployScript(ctx, input, components, outputDir)
+	undeployPath, undeploySize, err := g.generateUndeployScript(ctx, components, outputDir)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to generate undeploy.sh", err)
@@ -176,13 +157,13 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 	output.TotalSize += undeploySize
 
 	// Include external data files in the file list (for checksums)
-	for _, dataFile := range input.DataFiles {
+	for _, dataFile := range g.DataFiles {
 		absPath := filepath.Join(outputDir, dataFile)
 		output.Files = append(output.Files, absPath)
 	}
 
 	// Generate checksums.txt if requested
-	if input.IncludeChecksums {
+	if g.IncludeChecksums {
 		if err := checksum.GenerateChecksums(ctx, outputDir, output.Files); err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInternal,
 				"failed to generate checksums", err)
@@ -215,28 +196,28 @@ func (g *Generator) Generate(ctx context.Context, input *GeneratorInput, outputD
 
 // buildComponentDataList builds a sorted list of ComponentData from the recipe.
 // It validates that all component names are safe for use as directory names.
-func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentData, error) {
+func (g *Generator) buildComponentDataList() ([]ComponentData, error) {
 	componentMap := make(map[string]recipe.ComponentRef)
-	for _, ref := range input.RecipeResult.ComponentRefs {
+	for _, ref := range g.RecipeResult.ComponentRefs {
 		componentMap[ref.Name] = ref
 	}
 
 	// Sort by deployment order
-	sorted := shared.SortComponentRefsByDeploymentOrder(
-		input.RecipeResult.ComponentRefs,
-		input.RecipeResult.DeploymentOrder,
+	sorted := deployer.SortComponentRefsByDeploymentOrder(
+		g.RecipeResult.ComponentRefs,
+		g.RecipeResult.DeploymentOrder,
 	)
 
 	components := make([]ComponentData, 0, len(sorted))
 	for _, ref := range sorted {
-		if !shared.IsSafePathComponent(ref.Name) {
+		if !deployer.IsSafePathComponent(ref.Name) {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", ref.Name))
 		}
 
 		hasManifests := false
-		if input.ComponentManifests != nil {
-			if m, ok := input.ComponentManifests[ref.Name]; ok && len(m) > 0 {
+		if g.ComponentManifests != nil {
+			if m, ok := g.ComponentManifests[ref.Name]; ok && len(m) > 0 {
 				hasManifests = true
 			}
 		}
@@ -259,7 +240,7 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 			Repository:   ref.Source,
 			ChartName:    chartName,
 			Version:      version,
-			ChartVersion: shared.NormalizeVersionWithDefault(ref.Version),
+			ChartVersion: deployer.NormalizeVersionWithDefault(ref.Version),
 			HasManifests: hasManifests,
 			HasChart:     !isKustomize && ref.Source != "",
 			IsOCI:        isOCI,
@@ -273,7 +254,7 @@ func (g *Generator) buildComponentDataList(input *GeneratorInput) ([]ComponentDa
 }
 
 // generateComponentDirectories creates per-component directories with values.yaml, README.md, and optional manifests.
-func (g *Generator) generateComponentDirectories(ctx context.Context, input *GeneratorInput, components []ComponentData, outputDir string) ([]string, int64, error) {
+func (g *Generator) generateComponentDirectories(ctx context.Context, components []ComponentData, outputDir string) ([]string, int64, error) {
 	files := make([]string, 0, len(components)*3)
 	var totalSize int64
 
@@ -284,7 +265,7 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 		default:
 		}
 
-		componentDir, err := shared.SafeJoin(outputDir, comp.Name)
+		componentDir, err := deployer.SafeJoin(outputDir, comp.Name)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -295,19 +276,19 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 
 		// Deep-copy component values so writeClusterValuesFile can safely
 		// remove dynamic paths without mutating the caller's map.
-		values := component.DeepCopyMap(input.ComponentValues[comp.Name])
+		values := component.DeepCopyMap(g.ComponentValues[comp.Name])
 
 		// Extract dynamic paths (if any) from values into cluster-values.yaml.
 		// Every component gets a cluster-values.yaml — dynamic paths are pre-populated,
 		// and users can add any additional overrides. deploy.sh always passes it.
-		clusterFiles, clusterSize, clusterErr := writeClusterValuesFile(values, input.DynamicValues[comp.Name], componentDir, comp.Name)
+		clusterFiles, clusterSize, clusterErr := writeClusterValuesFile(values, g.DynamicValues[comp.Name], componentDir, comp.Name)
 		if clusterErr != nil {
 			return nil, 0, clusterErr
 		}
 		files = append(files, clusterFiles...)
 		totalSize += clusterSize
 
-		valuesPath, valuesSize, err := shared.WriteValuesFile(values, componentDir, "values.yaml")
+		valuesPath, valuesSize, err := deployer.WriteValuesFile(values, componentDir, "values.yaml")
 		if err != nil {
 			return nil, 0, errors.Wrap(errors.ErrCodeInternal,
 				fmt.Sprintf("failed to write values.yaml for %s", comp.Name), err)
@@ -316,7 +297,7 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 		totalSize += valuesSize
 
 		// Write component README.md
-		readmePath, readmeSize, err := shared.GenerateFromTemplate(componentReadmeTemplate, comp, componentDir, "README.md")
+		readmePath, readmeSize, err := deployer.GenerateFromTemplate(componentReadmeTemplate, comp, componentDir, "README.md")
 		if err != nil {
 			return nil, 0, errors.Wrap(errors.ErrCodeInternal,
 				fmt.Sprintf("failed to write README.md for %s", comp.Name), err)
@@ -325,9 +306,9 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 		totalSize += readmeSize
 
 		// Write manifests if present
-		if input.ComponentManifests != nil {
-			if manifests, ok := input.ComponentManifests[comp.Name]; ok && len(manifests) > 0 {
-				manifestDir, manifestDirErr := shared.SafeJoin(componentDir, "manifests")
+		if g.ComponentManifests != nil {
+			if manifests, ok := g.ComponentManifests[comp.Name]; ok && len(manifests) > 0 {
+				manifestDir, manifestDirErr := deployer.SafeJoin(componentDir, "manifests")
 				if manifestDirErr != nil {
 					return nil, 0, manifestDirErr
 				}
@@ -347,7 +328,7 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 				for _, manifestPath := range manifestPaths {
 					content := manifests[manifestPath]
 					filename := filepath.Base(manifestPath)
-					outputPath, pathErr := shared.SafeJoin(manifestDir, filename)
+					outputPath, pathErr := deployer.SafeJoin(manifestDir, filename)
 					if pathErr != nil {
 						return nil, 0, errors.New(errors.ErrCodeInvalidRequest,
 							fmt.Sprintf("invalid manifest filename %q in component %s", filename, comp.Name))
@@ -358,7 +339,7 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 						Namespace:     comp.Namespace,
 						ChartName:     comp.ChartName,
 						ChartVersion:  comp.ChartVersion,
-						Values:        input.ComponentValues[comp.Name],
+						Values:        g.ComponentValues[comp.Name],
 					})
 					if renderErr != nil {
 						return nil, 0, errors.WrapWithContext(errors.ErrCodeInternal, "failed to render manifest template", renderErr,
@@ -397,15 +378,15 @@ func (g *Generator) generateComponentDirectories(ctx context.Context, input *Gen
 }
 
 // generateRootREADME creates the root README.md with deployment instructions.
-func (g *Generator) generateRootREADME(ctx context.Context, input *GeneratorInput, components []ComponentData, outputDir string) (string, int64, error) {
+func (g *Generator) generateRootREADME(ctx context.Context, components []ComponentData, outputDir string) (string, int64, error) {
 	if err := ctx.Err(); err != nil {
 		return "", 0, err
 	}
 
 	// Build criteria lines
 	criteriaLines := []string{}
-	if input.RecipeResult.Criteria != nil {
-		c := input.RecipeResult.Criteria
+	if g.RecipeResult.Criteria != nil {
+		c := g.RecipeResult.Criteria
 		if c.Service != "" && c.Service != criteriaAny {
 			criteriaLines = append(criteriaLines, fmt.Sprintf("- **Service**: %s", c.Service))
 		}
@@ -421,15 +402,15 @@ func (g *Generator) generateRootREADME(ctx context.Context, input *GeneratorInpu
 	}
 
 	data := readmeTemplateData{
-		RecipeVersion:      input.RecipeResult.Metadata.Version,
-		BundlerVersion:     input.Version,
+		RecipeVersion:      g.RecipeResult.Metadata.Version,
+		BundlerVersion:     g.Version,
 		Components:         components,
 		ComponentsReversed: reverseComponents(components),
 		Criteria:           criteriaLines,
-		Constraints:        input.RecipeResult.Constraints,
+		Constraints:        g.RecipeResult.Constraints,
 	}
 
-	readmePath, readmeSize, err := shared.GenerateFromTemplate(readmeTemplate, data, outputDir, "README.md")
+	readmePath, readmeSize, err := deployer.GenerateFromTemplate(readmeTemplate, data, outputDir, "README.md")
 	if err != nil {
 		return "", 0, err
 	}
@@ -438,17 +419,17 @@ func (g *Generator) generateRootREADME(ctx context.Context, input *GeneratorInpu
 }
 
 // generateDeployScript creates the deploy.sh automation script.
-func (g *Generator) generateDeployScript(ctx context.Context, input *GeneratorInput, components []ComponentData, outputDir string) (string, int64, error) {
+func (g *Generator) generateDeployScript(ctx context.Context, components []ComponentData, outputDir string) (string, int64, error) {
 	if err := ctx.Err(); err != nil {
 		return "", 0, err
 	}
 
 	data := deployTemplateData{
-		BundlerVersion: input.Version,
+		BundlerVersion: g.Version,
 		Components:     components,
 	}
 
-	deployPath, deploySize, err := shared.GenerateFromTemplate(deployScriptTemplate, data, outputDir, "deploy.sh")
+	deployPath, deploySize, err := deployer.GenerateFromTemplate(deployScriptTemplate, data, outputDir, "deploy.sh")
 	if err != nil {
 		return "", 0, err
 	}
@@ -462,19 +443,19 @@ func (g *Generator) generateDeployScript(ctx context.Context, input *GeneratorIn
 }
 
 // generateUndeployScript creates the undeploy.sh automation script.
-func (g *Generator) generateUndeployScript(ctx context.Context, input *GeneratorInput, components []ComponentData, outputDir string) (string, int64, error) {
+func (g *Generator) generateUndeployScript(ctx context.Context, components []ComponentData, outputDir string) (string, int64, error) {
 	if err := ctx.Err(); err != nil {
 		return "", 0, err
 	}
 
 	reversed := reverseComponents(components)
 	data := undeployTemplateData{
-		BundlerVersion:     input.Version,
+		BundlerVersion:     g.Version,
 		ComponentsReversed: reversed,
 		Namespaces:         uniqueNamespaces(reversed),
 	}
 
-	undeployPath, undeploySize, err := shared.GenerateFromTemplate(undeployScriptTemplate, data, outputDir, "undeploy.sh")
+	undeployPath, undeploySize, err := deployer.GenerateFromTemplate(undeployScriptTemplate, data, outputDir, "undeploy.sh")
 	if err != nil {
 		return "", 0, err
 	}
@@ -551,7 +532,7 @@ func writeClusterValuesFile(values map[string]any, dynamicPaths []string, compon
 		component.SetValueByPath(clusterValues, path, val)
 	}
 
-	clusterPath, clusterSize, err := shared.WriteValuesFile(clusterValues, componentDir, "cluster-values.yaml")
+	clusterPath, clusterSize, err := deployer.WriteValuesFile(clusterValues, componentDir, "cluster-values.yaml")
 	if err != nil {
 		return nil, 0, errors.Wrap(errors.ErrCodeInternal,
 			fmt.Sprintf("failed to write cluster-values.yaml for %s", componentName), err)

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -23,7 +23,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/NVIDIA/aicr/pkg/bundler/deployer/shared"
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
@@ -31,19 +31,11 @@ import (
 // testDriverVersion is a test constant for driver version strings to satisfy goconst.
 const testDriverVersion = "570.86.16"
 
-func TestNewGenerator(t *testing.T) {
-	g := NewGenerator()
-	if g == nil {
-		t.Fatal("NewGenerator returned nil")
-	}
-}
-
 func TestGenerate_Success(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {
@@ -58,7 +50,7 @@ func TestGenerate_Success(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -114,53 +106,40 @@ func TestGenerate_Success(t *testing.T) {
 	}
 }
 
-func TestGenerate_NilInput(t *testing.T) {
-	g := NewGenerator()
-	ctx := context.Background()
-
-	_, err := g.Generate(ctx, nil, t.TempDir())
-	if err == nil {
-		t.Error("expected error for nil input")
-	}
-}
-
 func TestGenerate_NilRecipeResult(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: nil,
 	}
 
-	_, err := g.Generate(ctx, input, t.TempDir())
+	_, err := g.Generate(ctx, t.TempDir())
 	if err == nil {
 		t.Error("expected error for nil recipe result")
 	}
 }
 
 func TestGenerate_ContextCancellation(t *testing.T) {
-	g := NewGenerator()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult:    createEmptyRecipeResult(),
 		ComponentValues: map[string]map[string]any{},
 		Version:         "v1.0.0",
 	}
 
-	_, err := g.Generate(ctx, input, t.TempDir())
+	_, err := g.Generate(ctx, t.TempDir())
 	if err == nil {
 		t.Error("expected error for cancelled context")
 	}
 }
 
 func TestGenerate_WithChecksums(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {"crds": map[string]any{"enabled": true}},
@@ -170,7 +149,7 @@ func TestGenerate_WithChecksums(t *testing.T) {
 		IncludeChecksums: true,
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -222,13 +201,12 @@ func TestGenerate_WithChecksums(t *testing.T) {
 }
 
 func TestGenerate_WithManifests(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
 	manifestContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: {{ .Release.Namespace }}\n  labels:\n    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}\n"
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {},
@@ -242,7 +220,7 @@ func TestGenerate_WithManifests(t *testing.T) {
 		},
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -297,14 +275,13 @@ func TestHasYAMLObjects(t *testing.T) {
 }
 
 func TestGenerate_EmptyManifestsSkipped(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
 	// Template that renders to empty when enabled=false
 	emptyTemplate := "# Comment\n{{- $cust := index .Values \"gpu-operator\" }}\n{{- if ne (toString (index $cust \"enabled\")) \"false\" }}\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n{{- end }}\n"
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {},
@@ -318,7 +295,7 @@ func TestGenerate_EmptyManifestsSkipped(t *testing.T) {
 		},
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -349,11 +326,10 @@ func TestGenerate_EmptyManifestsSkipped(t *testing.T) {
 }
 
 func TestGenerate_DeployScriptExecutable(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {},
@@ -362,7 +338,7 @@ func TestGenerate_DeployScriptExecutable(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -417,11 +393,10 @@ func TestGenerate_DeployScriptExecutable(t *testing.T) {
 }
 
 func TestGenerate_DeployScriptKaiSchedulerTimeout(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: &recipe.RecipeResult{
 			Kind:       "RecipeResult",
 			APIVersion: "aicr.nvidia.com/v1alpha1",
@@ -443,7 +418,7 @@ func TestGenerate_DeployScriptKaiSchedulerTimeout(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -478,11 +453,10 @@ func TestGenerate_DeployScriptKaiSchedulerTimeout(t *testing.T) {
 }
 
 func TestGenerate_UndeployScriptExecutable(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {},
@@ -491,7 +465,7 @@ func TestGenerate_UndeployScriptExecutable(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -712,7 +686,7 @@ func TestNormalizeVersionWithDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			result := shared.NormalizeVersionWithDefault(tt.input)
+			result := deployer.NormalizeVersionWithDefault(tt.input)
 			if result != tt.expected {
 				t.Errorf("NormalizeVersionWithDefault(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
@@ -731,7 +705,7 @@ func TestSortComponentNamesByDeploymentOrder(t *testing.T) {
 		components := []string{gpuOperator, certManager, networkOperator}
 		deploymentOrder := []string{certManager, gpuOperator, networkOperator}
 
-		sorted := shared.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
+		sorted := deployer.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
 
 		if sorted[0] != certManager {
 			t.Errorf("expected first %s, got %s", certManager, sorted[0])
@@ -750,7 +724,7 @@ func TestSortComponentNamesByDeploymentOrder(t *testing.T) {
 		components := []string{"alpha", gpuOperator}
 		deploymentOrder := []string{gpuOperator}
 
-		sorted := shared.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
+		sorted := deployer.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
 		if sorted[0] != gpuOperator {
 			t.Errorf("expected ordered component first, got %s", sorted[0])
 		}
@@ -763,7 +737,7 @@ func TestSortComponentNamesByDeploymentOrder(t *testing.T) {
 		components := []string{certManager, "zebra"}
 		deploymentOrder := []string{certManager}
 
-		sorted := shared.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
+		sorted := deployer.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
 		if sorted[0] != certManager {
 			t.Errorf("expected ordered component first, got %s", sorted[0])
 		}
@@ -774,7 +748,7 @@ func TestSortComponentNamesByDeploymentOrder(t *testing.T) {
 		components := []string{"zebra", "alpha"}
 		deploymentOrder := []string{gpuOperator}
 
-		sorted := shared.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
+		sorted := deployer.SortComponentNamesByDeploymentOrder(components, deploymentOrder)
 		if sorted[0] != "alpha" {
 			t.Errorf("expected alphabetical first, got %s", sorted[0])
 		}
@@ -785,7 +759,7 @@ func TestSortComponentNamesByDeploymentOrder(t *testing.T) {
 
 	t.Run("empty deployment order", func(t *testing.T) {
 		components := []string{"b", "a"}
-		sorted := shared.SortComponentNamesByDeploymentOrder(components, nil)
+		sorted := deployer.SortComponentNamesByDeploymentOrder(components, nil)
 		if sorted[0] != "b" {
 			t.Errorf("expected original order preserved with empty order, got %s", sorted[0])
 		}
@@ -811,9 +785,9 @@ func TestIsSafePathComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := shared.IsSafePathComponent(tt.input)
+			result := deployer.IsSafePathComponent(tt.input)
 			if result != tt.expected {
-				t.Errorf("shared.IsSafePathComponent(%q) = %v, want %v", tt.input, result, tt.expected)
+				t.Errorf("deployer.IsSafePathComponent(%q) = %v, want %v", tt.input, result, tt.expected)
 			}
 		})
 	}
@@ -839,21 +813,20 @@ func TestSafeJoin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := shared.SafeJoin(tt.dir, tt.input)
+			result, err := deployer.SafeJoin(tt.dir, tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("shared.SafeJoin(%q, %q) error = %v, wantErr %v", tt.dir, tt.input, err, tt.wantErr)
+				t.Errorf("deployer.SafeJoin(%q, %q) error = %v, wantErr %v", tt.dir, tt.input, err, tt.wantErr)
 				return
 			}
 			if err == nil && result == "" {
-				t.Errorf("shared.SafeJoin(%q, %q) returned empty path", tt.dir, tt.input)
+				t.Errorf("deployer.SafeJoin(%q, %q) returned empty path", tt.dir, tt.input)
 			}
 		})
 	}
 }
 
 func TestBuildComponentDataListRejectsUnsafeNames(t *testing.T) {
-	g := NewGenerator()
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: &recipe.RecipeResult{
 			ComponentRefs: []recipe.ComponentRef{
 				{Name: "../etc/passwd", Version: "v1.0.0", Source: "https://evil.com"},
@@ -861,7 +834,7 @@ func TestBuildComponentDataListRejectsUnsafeNames(t *testing.T) {
 		},
 	}
 
-	_, err := g.buildComponentDataList(input)
+	_, err := g.buildComponentDataList()
 	if err == nil {
 		t.Error("expected error for unsafe component name, got nil")
 	}
@@ -874,8 +847,7 @@ func TestBuildComponentDataList_NamespaceAndChart(t *testing.T) {
 		unknown = "unknown"
 	)
 
-	g := NewGenerator()
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: &recipe.RecipeResult{
 			ComponentRefs: []recipe.ComponentRef{
 				{Name: gpuOp, Namespace: gpuOp, Chart: gpuOp, Version: "v1.0.0", Source: "https://example.com"},
@@ -885,7 +857,7 @@ func TestBuildComponentDataList_NamespaceAndChart(t *testing.T) {
 		},
 	}
 
-	components, err := g.buildComponentDataList(input)
+	components, err := g.buildComponentDataList()
 	if err != nil {
 		t.Fatalf("buildComponentDataList failed: %v", err)
 	}
@@ -915,11 +887,10 @@ func TestBuildComponentDataList_NamespaceAndChart(t *testing.T) {
 }
 
 func TestGenerate_KustomizeOnly(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createKustomizeRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"my-kustomize-app": {},
@@ -927,7 +898,7 @@ func TestGenerate_KustomizeOnly(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -1002,11 +973,10 @@ func TestGenerate_KustomizeOnly(t *testing.T) {
 }
 
 func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createMixedRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager":     {"crds": map[string]any{"enabled": true}},
@@ -1015,7 +985,7 @@ func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	output, err := g.Generate(ctx, input, outputDir)
+	output, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -1075,9 +1045,7 @@ func TestGenerate_MixedHelmAndKustomize(t *testing.T) {
 }
 
 func TestBuildComponentDataList_Kustomize(t *testing.T) {
-	g := NewGenerator()
-
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: &recipe.RecipeResult{
 			ComponentRefs: []recipe.ComponentRef{
 				{
@@ -1092,7 +1060,7 @@ func TestBuildComponentDataList_Kustomize(t *testing.T) {
 		},
 	}
 
-	components, err := g.buildComponentDataList(input)
+	components, err := g.buildComponentDataList()
 	if err != nil {
 		t.Fatalf("buildComponentDataList failed: %v", err)
 	}
@@ -1120,9 +1088,7 @@ func TestBuildComponentDataList_Kustomize(t *testing.T) {
 }
 
 func TestBuildComponentDataList_MixedTypes(t *testing.T) {
-	g := NewGenerator()
-
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: &recipe.RecipeResult{
 			ComponentRefs: []recipe.ComponentRef{
 				{
@@ -1145,7 +1111,7 @@ func TestBuildComponentDataList_MixedTypes(t *testing.T) {
 		},
 	}
 
-	components, err := g.buildComponentDataList(input)
+	components, err := g.buildComponentDataList()
 	if err != nil {
 		t.Fatalf("buildComponentDataList failed: %v", err)
 	}
@@ -1298,10 +1264,9 @@ func createEmptyRecipeResult() *recipe.RecipeResult {
 // TestGenerate_Reproducible verifies that Helm bundle generation is deterministic.
 // Running Generate() twice with the same input should produce identical output files.
 func TestGenerate_Reproducible(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {
@@ -1322,7 +1287,7 @@ func TestGenerate_Reproducible(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		outputDir := t.TempDir()
 
-		_, err := g.Generate(ctx, input, outputDir)
+		_, err := g.Generate(ctx, outputDir)
 		if err != nil {
 			t.Fatalf("iteration %d: Generate() error = %v", i, err)
 		}
@@ -1375,11 +1340,10 @@ func TestGenerate_Reproducible(t *testing.T) {
 
 // TestGenerate_NoTimestampInOutput verifies that generated files don't contain timestamps.
 func TestGenerate_NoTimestampInOutput(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {},
@@ -1388,7 +1352,7 @@ func TestGenerate_NoTimestampInOutput(t *testing.T) {
 		Version: "v1.0.0",
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -1471,7 +1435,6 @@ func TestGenerateDeployScript(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGenerator()
 			ctx := context.Background()
 			if tt.cancelCtx {
 				var cancel context.CancelFunc
@@ -1484,11 +1447,11 @@ func TestGenerateDeployScript(t *testing.T) {
 				dir = t.TempDir()
 			}
 
-			input := &GeneratorInput{
+			g := &Generator{
 				Version: "v1.0.0",
 			}
 
-			path, size, err := g.generateDeployScript(ctx, input, tt.components, dir)
+			path, size, err := g.generateDeployScript(ctx, tt.components, dir)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1515,7 +1478,6 @@ func TestGenerateDeployScript(t *testing.T) {
 }
 
 func TestGenerateDeployScript_EmptyVersionOmitsFlag(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	dir := t.TempDir()
 
@@ -1530,8 +1492,8 @@ func TestGenerateDeployScript_EmptyVersionOmitsFlag(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{Version: "v1.0.0"}
-	path, _, err := g.generateDeployScript(ctx, input, components, dir)
+	g := &Generator{Version: "v1.0.0"}
+	path, _, err := g.generateDeployScript(ctx, components, dir)
 	if err != nil {
 		t.Fatalf("generateDeployScript failed: %v", err)
 	}
@@ -1551,7 +1513,6 @@ func TestGenerateDeployScript_EmptyVersionOmitsFlag(t *testing.T) {
 }
 
 func TestGenerateDeployScript_WithVersionIncludesFlag(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	dir := t.TempDir()
 
@@ -1566,8 +1527,8 @@ func TestGenerateDeployScript_WithVersionIncludesFlag(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{Version: "v1.0.0"}
-	path, _, err := g.generateDeployScript(ctx, input, components, dir)
+	g := &Generator{Version: "v1.0.0"}
+	path, _, err := g.generateDeployScript(ctx, components, dir)
 	if err != nil {
 		t.Fatalf("generateDeployScript failed: %v", err)
 	}
@@ -1634,7 +1595,6 @@ func TestGenerateUndeployScript(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGenerator()
 			ctx := context.Background()
 			if tt.cancelCtx {
 				var cancel context.CancelFunc
@@ -1647,11 +1607,11 @@ func TestGenerateUndeployScript(t *testing.T) {
 				dir = t.TempDir()
 			}
 
-			input := &GeneratorInput{
+			g := &Generator{
 				Version: "v1.0.0",
 			}
 
-			path, size, err := g.generateUndeployScript(ctx, input, tt.components, dir)
+			path, size, err := g.generateUndeployScript(ctx, tt.components, dir)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1744,18 +1704,17 @@ func TestGenerate_DynamicValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGenerator()
 			ctx := context.Background()
 			outputDir := t.TempDir()
 
-			input := &GeneratorInput{
+			g := &Generator{
 				RecipeResult:    createTestRecipeResult(),
 				ComponentValues: tt.componentValues,
 				Version:         "v1.0.0",
 				DynamicValues:   tt.dynamicValues,
 			}
 
-			_, err := g.Generate(ctx, input, outputDir)
+			_, err := g.Generate(ctx, outputDir)
 			if err != nil {
 				t.Fatalf("Generate failed: %v", err)
 			}
@@ -1818,11 +1777,10 @@ func TestGenerate_DynamicValues(t *testing.T) {
 }
 
 func TestGenerate_DynamicValuesContentVerification(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {"crds": map[string]any{"enabled": true}},
@@ -1842,7 +1800,7 @@ func TestGenerate_DynamicValuesContentVerification(t *testing.T) {
 		},
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -1959,11 +1917,10 @@ func TestSetNestedValue(t *testing.T) {
 }
 
 func TestGenerate_DynamicValuesDeeplyNested(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {"crds": map[string]any{"enabled": true}},
@@ -1984,7 +1941,7 @@ func TestGenerate_DynamicValuesDeeplyNested(t *testing.T) {
 		},
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -2045,14 +2002,13 @@ func TestGenerate_DynamicValuesDeeplyNested(t *testing.T) {
 }
 
 func TestGenerate_DynamicValuesWithSetOverride(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
 	// Simulate --set gpuoperator:driver.version=999.99.99 by providing the value
 	// in ComponentValues (--set is applied before dynamic extraction).
 	// Then --dynamic gpuoperator:driver.version should extract the --set value.
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {"crds": map[string]any{"enabled": true}},
@@ -2069,7 +2025,7 @@ func TestGenerate_DynamicValuesWithSetOverride(t *testing.T) {
 		},
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -2099,7 +2055,6 @@ func TestGenerate_DynamicValuesWithSetOverride(t *testing.T) {
 }
 
 func TestGenerate_DynamicValuesRoundTrip(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -2117,7 +2072,7 @@ func TestGenerate_DynamicValuesRoundTrip(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
 		ComponentValues: map[string]map[string]any{
 			"cert-manager": {"crds": map[string]any{"enabled": true}},
@@ -2141,7 +2096,7 @@ func TestGenerate_DynamicValuesRoundTrip(t *testing.T) {
 		},
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -2287,7 +2242,6 @@ func TestReverseComponents(t *testing.T) {
 // TestGenerate_DoesNotMutateComponentValues verifies that Generate deep-copies
 // component values before extracting dynamic paths, so the input map is preserved.
 func TestGenerate_DoesNotMutateComponentValues(t *testing.T) {
-	g := NewGenerator()
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
@@ -2297,7 +2251,7 @@ func TestGenerate_DoesNotMutateComponentValues(t *testing.T) {
 		},
 	}
 
-	input := &GeneratorInput{
+	g := &Generator{
 		RecipeResult:    createTestRecipeResult(),
 		ComponentValues: originalValues,
 		Version:         "test",
@@ -2306,7 +2260,7 @@ func TestGenerate_DoesNotMutateComponentValues(t *testing.T) {
 		},
 	}
 
-	_, err := g.Generate(ctx, input, outputDir)
+	_, err := g.Generate(ctx, outputDir)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}

--- a/pkg/bundler/deployer/helpers.go
+++ b/pkg/bundler/deployer/helpers.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package deployer
 
 import (
 	"fmt"

--- a/pkg/bundler/deployer/helpers_test.go
+++ b/pkg/bundler/deployer/helpers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package deployer
 
 import (
 	"os"


### PR DESCRIPTION
## Summary

Migrate all three deployers (helm, argocd, argocd-helm) to the `deployer.Deployer` interface and unify bundler routing through a single `Generate(ctx, outputDir)` contract.

## Motivation / Context

PR #527 introduced `deployer.Deployer` and `deployer.Output` but only `argocdhelm` implemented the interface. The `helm` and `argocd` deployers still used their own `GeneratorInput`/`GeneratorOutput` types and were called via concrete methods in `bundler.go`. This meant deployers weren't mockable, each had redundant output types, and the `shared/` sub-package added unnecessary indirection.

Fixes: #571
Related: #527, #515

Fixes: <!-- #123 or N/A -->
Related: <!-- #123 or N/A -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Consolidated `deployer/shared/` utilities into `deployer/` package
- Absorbed `GeneratorInput` fields into `Generator` structs for helm and argocd ("Generator IS the input" pattern matching argocdhelm)
- Deleted `GeneratorInput`, `GeneratorOutput`, and `NewGenerator` from helm and argocd packages
- Replaced three `makeHelmBundle`/`makeArgoCD`/`makeArgoCDHelmChart` methods with `buildDeployer` (factory) + `runDeployer` (common post-generation)
- Removed `HasDynamicValues()` from the interface — it was never called through the interface; dynamic value checks use `bundler.Config` directly
- The interface is now a single method: `Generate(ctx, outputDir) (*Output, error)`
- The external `Make()` API is unchanged
## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined internal deployer implementation for improved maintainability and consistency across bundling processes.
  * Consolidated bundler logic to enhance how external data files and deployment configurations are handled during bundle creation.
  * Reorganized helper utilities for better code organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->