### PR TITLE
fix(ci): pin e2e goreleaser and exclude local build artifacts

### DIFF
--- a/.github/actions/cli-e2e/action.yml
+++ b/.github/actions/cli-e2e/action.yml
@@ -19,6 +19,9 @@ inputs:
   go_version:
     description: 'Go version (e.g., 1.25)'
     required: true
+  goreleaser_version:
+    description: 'GoReleaser version (e.g., v2.15.3)'
+    required: true
   chainsaw_version:
     description: 'Chainsaw version (e.g., v0.2.14)'
     required: true
@@ -42,6 +45,7 @@ runs:
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0
       with:
+        version: ${{ inputs.goreleaser_version }}
         install-only: true
 
     - name: Install Chainsaw

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -106,6 +106,7 @@ jobs:
         uses: ./.github/actions/cli-e2e
         with:
           go_version: ${{ steps.versions.outputs.go }}
+          goreleaser_version: ${{ steps.versions.outputs.goreleaser }}
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
 

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -15,3 +15,8 @@
 exclude:
   - '**/.terraform/**'
   - '**/node_modules/**'
+  # Exclude generated local binaries and release output from source scans.
+  - './bin/**'
+  - './aicr'
+  - './aicrd'
+  - './dist/**'

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -14,11 +14,11 @@
 
 # Language Versions
 languages:
-  go: '1.26.1'
+  go: '1.26.2'
 
 # Build Tools
 build_tools:
-  goreleaser: 'v2'
+  goreleaser: 'v2.15.3'
   ko: 'v0.18.0'
   crane: 'v0.21.0'
   git_cliff: '2.12.0'

--- a/docs/contributor/cli.md
+++ b/docs/contributor/cli.md
@@ -2007,10 +2007,11 @@ pods, err := clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
 
 ```bash
 # Build with profiling enabled
-go build -o aicr cmd/aicr/main.go
+mkdir -p bin
+go build -o bin/aicr cmd/aicr/main.go
 
 # Capture CPU profile
-./aicr snapshot --cpuprofile=cpu.prof
+./bin/aicr snapshot --cpuprofile=cpu.prof
 
 # Analyze profile
 go tool pprof cpu.prof
@@ -2034,7 +2035,7 @@ go tool pprof cpu.prof
 
 ```bash
 # Capture memory profile
-./aicr snapshot --memprofile=mem.prof
+./bin/aicr snapshot --memprofile=mem.prof
 
 # Analyze allocations
 go tool pprof -alloc_space mem.prof

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -287,6 +287,7 @@ HELM_VERSION=$(yq '.testing_tools.helm' .settings.yaml)
 CHAINSAW_VERSION=$(yq '.testing_tools.chainsaw' .settings.yaml)
 KO_VERSION=$(yq '.build_tools.ko' .settings.yaml)
 CRANE_VERSION=$(yq '.build_tools.crane' .settings.yaml)
+GORELEASER_VERSION=$(yq '.build_tools.goreleaser' .settings.yaml)
 GIT_CLIFF_VERSION=$(yq '.build_tools.git_cliff' .settings.yaml)
 
 echo ""
@@ -301,6 +302,7 @@ echo "  kubectl:         ${KUBECTL_VERSION}"
 echo "  tilt:            ${TILT_VERSION}"
 echo "  helm:            ${HELM_VERSION}"
 echo "  chainsaw:        ${CHAINSAW_VERSION}"
+echo "  goreleaser:      ${GORELEASER_VERSION}"
 echo "  git-cliff:       ${GIT_CLIFF_VERSION}"
 echo ""
 
@@ -680,13 +682,13 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
     if command_exists goreleaser && [[ "${UPGRADE}" != "true" ]]; then
         log_success "goreleaser already installed: $(goreleaser --version 2>/dev/null | sed -n 's/^GitVersion:[[:space:]]*//p')"
     else
-        log_info "Installing goreleaser..."
+        log_info "Installing goreleaser ${GORELEASER_VERSION}..."
         if prompt_continue; then
             if [[ "${OS}" == "darwin" ]]; then
                 brew install goreleaser
             elif [[ "${OS}" == "linux" ]]; then
                 if command_exists go; then
-                    go install github.com/goreleaser/goreleaser/v2@latest
+                    go install github.com/goreleaser/goreleaser/v2@"${GORELEASER_VERSION}"
                     sudo cp "$(go env GOPATH)/bin/goreleaser" /usr/local/bin/
                 else
                     log_warning "Go not installed, skipping goreleaser"


### PR DESCRIPTION
## Summary

Pin the Linux E2E GoReleaser install path so qualification does not drift with upstream releases, and exclude generated local build artifacts from `make scan`.

## Motivation / Context

`make scan` runs `grype dir:.`, and Grype scans files on disk rather than honoring `.gitignore`. That means stale locally built binaries can trigger false-positive stdlib findings during local scans.

Separately, the Linux E2E path still installed GoReleaser via an unpinned `@latest` path through `tools/setup-tools`, which can break qualification when a new GoReleaser release raises its Go requirement before CI has moved.

Fixes: N/A
Related: https://github.com/NVIDIA/aicr/pull/579

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: local scan configuration and E2E tooling setup

## Implementation Notes

- Adds `./aicr`, `./aicrd`, `./bin/**`, and `./dist/**` to `.grype.yaml` exclusions so local scans ignore generated binaries and release output.
- Updates `docs/contributor/cli.md` profiling examples to build `bin/aicr` instead of `./aicr`.
- Bumps `.settings.yaml` to Go `1.26.2` and GoReleaser `v2.15.3` so the qualification path uses compatible pinned versions.
- Pins Linux `tools/setup-tools` to `go install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}`.
- Threads `goreleaser_version` into the `cli-e2e` action from `qualification.yaml` so attested CLI builds do not float on `@latest`.

## Testing

```bash
make scan
git diff --check origin/main...HEAD
```

- `make scan` passed locally with stale `./aicr` and `./bin/aicr` binaries present.
- `git diff --check origin/main...HEAD` passed.
- I did not rerun full `make qualify` in this sandbox; CI is the right signal for the E2E path.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** This keeps PR #580 limited to the local scan fix plus the minimal qualification-path pin needed to stop the known Linux E2E drift.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
