### PR TITLE
fix(ci): move GPU concurrency to test jobs

### DIFF
--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -27,10 +27,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   # Gate GPU tests on actual PR diff (against main), not the push diff.
@@ -89,6 +85,9 @@ jobs:
         (github.event_name == 'push' && needs.check-paths.outputs.should-run == 'true')
       )
     name: GPU Inference Test (nvkind + H100)
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: linux-amd64-gpu-h100-latest-1
     timeout-minutes: 90
 

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -27,10 +27,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   # Gate GPU tests on actual PR diff (against main), not the push diff.
@@ -94,6 +90,9 @@ jobs:
         (github.event_name == 'push' && needs.check-paths.outputs.should-run == 'true')
       )
     name: GPU Training Test (nvkind + H100 x2)
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: linux-amd64-gpu-h100-latest-2
     timeout-minutes: 120
 

--- a/.github/workflows/gpu-smoke-test.yaml
+++ b/.github/workflows/gpu-smoke-test.yaml
@@ -27,10 +27,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   # Gate GPU tests on actual PR diff (against main), not the push diff.
@@ -74,6 +70,9 @@ jobs:
         (github.event_name == 'push' && needs.check-paths.outputs.should-run == 'true')
       )
     name: GPU Smoke Test (nvkind + T4)
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: linux-amd64-gpu-t4-latest-1
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

Move GPU workflow concurrency from the workflow level down to the heavyweight GPU job so the lightweight `check-paths` gate can always start and surface a visible check on PR updates.

## Motivation / Context

GPU workflows on `pull-request/*` branches currently apply concurrency at the workflow level. When an older GPU run is still in progress, a newer workflow run can remain `pending` with `jobs: []`, which means the PR checks UI may not show the new training or inference run at all until the older run clears.

Moving the same concurrency group to the actual GPU job preserves the “latest run wins” behavior for expensive runner usage while still allowing `check-paths` to execute immediately and materialize a visible check.

Fixes: N/A
Related: https://github.com/NVIDIA/aicr/pull/558

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: GPU CI workflows

## Implementation Notes

- Removes workflow-level `concurrency` from `gpu-smoke-test.yaml`, `gpu-h100-inference-test.yaml`, and `gpu-h100-training-test.yaml`.
- Reattaches the same `concurrency.group` and `cancel-in-progress: true` settings to the heavyweight GPU test job in each workflow.
- Keeps the existing event-aware concurrency key (`${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}`), so manual `workflow_dispatch` runs remain isolated from push-driven runs.
- Leaves the `check-paths` gate unconstrained so it can start immediately, compute the PR diff, and surface a visible status even while an older GPU run is still tearing down.

## Testing

```bash
git diff --check
yamllint .github/workflows/gpu-h100-training-test.yaml \
  .github/workflows/gpu-h100-inference-test.yaml \
  .github/workflows/gpu-smoke-test.yaml
```

- `git diff --check` passed.
- `yamllint` passed on the three changed workflow files.
- `make lint` could not complete cleanly in this sandbox because a prior local `golangci-lint` process left the global parallel lock in place (`parallel golangci-lint is running`).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** This only changes when concurrency is applied, not the concurrency key itself. The expensive GPU jobs still cancel older same-branch runs; the `check-paths` gate is what becomes immediately runnable and visible.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
