### PR TITLE
docs(agents): add errorlint rule, lint gate, and local overlay

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,6 +3,10 @@
 This file is the canonical source for coding-agent rules. `AGENTS.md` is an auto-synced mirror (CI enforced).
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Local Overlay
+
+If present, also read `AGENTS.local.md` at the repo root. The file is gitignored repo-wide so personal overlays stay local — agents must check the exact path directly (e.g., `Read` or `cat`), not rely on ignore-respecting discovery tools such as `rg`, `fd`, or `git ls-files`. Treat it as a local overlay for this working copy: follow it when it does not conflict with higher-priority instructions or this shared `AGENTS.md`.
+
 ## Role & Expertise
 
 Act as a Principal Distributed Systems Architect with deep expertise in Go and cloud-native architectures. Focus on correctness, resiliency, and operational simplicity. All code must be production-grade, not illustrative pseudo-code.
@@ -296,6 +300,18 @@ return err
 
 **Exception:** Wrapping is unnecessary for read-only `Close()` returns and K8s helpers like `k8s.IgnoreNotFound(err)`.
 
+**Always use `errors.Is()` for sentinel error checks.** `golangci-lint` enforces the `errorlint` rule — comparing errors with `==` fails on wrapped errors and will be rejected by CI:
+
+```go
+// BAD - fails errorlint, breaks on wrapped errors
+if err == io.EOF {
+
+// GOOD - works with wrapped errors, passes linter
+if errors.Is(err, io.EOF) {
+```
+
+Note: in files that import `pkg/errors`, the standard library `errors` package is aliased as `stderrors`, so use `stderrors.Is(...)` there.
+
 **Writable file handles must check `Close()` errors.** If a file handle is writable (e.g., from `os.Create` or `os.OpenFile`), closing it may flush buffered data; always capture and check the error:
 ```go
 // BAD - writable Close() error ignored
@@ -470,6 +486,7 @@ ${AICR_BIN} validate -r recipe.yaml -s snapshot.yaml --no-cluster
 | Guess at missing parameters | Ask for clarification |
 | Continue after 3 failed fix attempts | Stop, reassess approach, explain blockers |
 | Use polling loops for K8s operations | Use watch API for efficiency |
+| Compare errors with `==` (e.g., `err == io.EOF`) | Use `errors.Is(err, io.EOF)` (`stderrors.Is` in files that alias stdlib errors) — `errorlint` enforced by CI |
 | Duplicate K8s utilities across packages | Use shared utilities from `pkg/k8s/pod` |
 | Run tests that connect to live clusters | Always use `--no-cluster` flag in tests |
 | Use boolean flags to track options | Use pointer pattern (nil = not set, &value = set) |
@@ -481,6 +498,8 @@ ${AICR_BIN} validate -r recipe.yaml -s snapshot.yaml --no-cluster
 ## Pull Request Requirements
 
 **Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers tests, linting (golangci-lint + yamllint), e2e, vulnerability scan, and repo-specific checks (docs sidebar, agents sync). Do not substitute a subset of commands — if `make qualify` passes locally, CI will pass.
+
+**Mandatory lint gate for Go changes:** If your PR changes any `.go` files, you MUST run `golangci-lint run -c .golangci.yaml` on each affected package path (e.g., `./pkg/recipe/...`, `./cmd/aicr/...`, `./tests/chainsaw/...`) and confirm zero issues before creating or pushing the PR. For a full module scan, use `./...`. Do not rely on CI to catch lint failures — fix them locally first. This applies even to PRs labeled as "documentation only" if they include Go code changes.
 
 **Branch hygiene:**
 - Always rebase onto the target branch before pushing: `git fetch origin main && git rebase origin/main`

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ site/docs/conformance/index.md
 docs/plans
 .worktrees/
 
+# Per-clone local agent overlay (see AGENTS.md "Local Overlay" section)
+/AGENTS.local.md
+
 # Validator generator scaffolding output
 pkg/validator/checks/**/*_README.md
 pkg/validator/checks/**/*_recipe.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 This file provides guidance to Codex and other coding agents when working with code in this repository.
 <!-- AUTO-SYNCED: canonical source is .claude/CLAUDE.md. Only the first 4 lines differ. CI enforced sync. -->
 
+## Local Overlay
+
+If present, also read `AGENTS.local.md` at the repo root. The file is gitignored repo-wide so personal overlays stay local — agents must check the exact path directly (e.g., `Read` or `cat`), not rely on ignore-respecting discovery tools such as `rg`, `fd`, or `git ls-files`. Treat it as a local overlay for this working copy: follow it when it does not conflict with higher-priority instructions or this shared `AGENTS.md`.
+
 ## Role & Expertise
 
 Act as a Principal Distributed Systems Architect with deep expertise in Go and cloud-native architectures. Focus on correctness, resiliency, and operational simplicity. All code must be production-grade, not illustrative pseudo-code.
@@ -296,6 +300,18 @@ return err
 
 **Exception:** Wrapping is unnecessary for read-only `Close()` returns and K8s helpers like `k8s.IgnoreNotFound(err)`.
 
+**Always use `errors.Is()` for sentinel error checks.** `golangci-lint` enforces the `errorlint` rule — comparing errors with `==` fails on wrapped errors and will be rejected by CI:
+
+```go
+// BAD - fails errorlint, breaks on wrapped errors
+if err == io.EOF {
+
+// GOOD - works with wrapped errors, passes linter
+if errors.Is(err, io.EOF) {
+```
+
+Note: in files that import `pkg/errors`, the standard library `errors` package is aliased as `stderrors`, so use `stderrors.Is(...)` there.
+
 **Writable file handles must check `Close()` errors.** If a file handle is writable (e.g., from `os.Create` or `os.OpenFile`), closing it may flush buffered data; always capture and check the error:
 ```go
 // BAD - writable Close() error ignored
@@ -470,6 +486,7 @@ ${AICR_BIN} validate -r recipe.yaml -s snapshot.yaml --no-cluster
 | Guess at missing parameters | Ask for clarification |
 | Continue after 3 failed fix attempts | Stop, reassess approach, explain blockers |
 | Use polling loops for K8s operations | Use watch API for efficiency |
+| Compare errors with `==` (e.g., `err == io.EOF`) | Use `errors.Is(err, io.EOF)` (`stderrors.Is` in files that alias stdlib errors) — `errorlint` enforced by CI |
 | Duplicate K8s utilities across packages | Use shared utilities from `pkg/k8s/pod` |
 | Run tests that connect to live clusters | Always use `--no-cluster` flag in tests |
 | Use boolean flags to track options | Use pointer pattern (nil = not set, &value = set) |
@@ -481,6 +498,8 @@ ${AICR_BIN} validate -r recipe.yaml -s snapshot.yaml --no-cluster
 ## Pull Request Requirements
 
 **Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers tests, linting (golangci-lint + yamllint), e2e, vulnerability scan, and repo-specific checks (docs sidebar, agents sync). Do not substitute a subset of commands — if `make qualify` passes locally, CI will pass.
+
+**Mandatory lint gate for Go changes:** If your PR changes any `.go` files, you MUST run `golangci-lint run -c .golangci.yaml` on each affected package path (e.g., `./pkg/recipe/...`, `./cmd/aicr/...`, `./tests/chainsaw/...`) and confirm zero issues before creating or pushing the PR. For a full module scan, use `./...`. Do not rely on CI to catch lint failures — fix them locally first. This applies even to PRs labeled as "documentation only" if they include Go code changes.
 
 **Branch hygiene:**
 - Always rebase onto the target branch before pushing: `git fetch origin main && git rebase origin/main`


### PR DESCRIPTION
## Summary

Add three rules to CLAUDE.md and AGENTS.md:

1. **`errorlint` rule** with BAD/GOOD examples for sentinel error checks (`errors.Is` instead of `==`).
2. **Mandatory pre-PR `golangci-lint` gate** for any Go change, including PRs labeled as documentation-only.
3. **Local Overlay support** — agents should also read `AGENTS.local.md` in the repo when present, and treat it as a per-clone additive layer.

Also gitignore `AGENTS.local.md` so personal overlays stay out of the shared repo.

## Motivation / Context

- **errorlint**: Discovered during review of #587 — `referencedAssertFiles` used `err == io.EOF` which was rejected by `golangci-lint`. The rule was only mentioned in the Troubleshooting table as a hint, not as an explicit coding pattern.
- **Lint gate**: PR #590 originally shipped Go changes labeled as "docs only" without running `make qualify`, so the lint error was not caught before push. The mandatory gate prevents this class of oversight for both Claude Code and Codex agents.
- **Local Overlay**: Codex has no native "per-project + personal + local" instruction layer like Claude's memory system. A small convention — read `AGENTS.local.md` if present, treat as additive and lower-priority than the shared `AGENTS.md` — gives both Claude and Codex a consistent way to pick up personal preferences (e.g., per-user issue-filing conventions) without committing them to the shared repo.

Related: #587

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Added `errors.Is()` rule to Error Wrapping Rules section with BAD/GOOD code examples and a note about `stderrors.Is()` aliasing in files importing `pkg/errors`
- Added corresponding anti-pattern table entry
- Added mandatory lint gate rule to Pull Request Requirements
- Added a short "Local Overlay" section near the top of both files pointing to `AGENTS.local.md`
- Added `AGENTS.local.md` to `.gitignore`
- Verified `tools/check-agents-sync` still passes

## Testing

N/A — documentation only, no code changes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a local-overlay rule: a per-clone overlay file can override shared guidance when present.
  * Strengthened error-handling guidance: sentinel checks must use the language's error-is pattern; anti-patterns and CI enforcement updated.
* **Chores**
  * Updated ignore rules to exclude the per-clone local overlay file.
* **Process**
  * New mandatory pre-submit lint gate: PRs that modify Go code must run and resolve local lint checks before pushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->