### PR TITLE
chore: configure CodeRabbit for all branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,16 +16,29 @@ language: en-US
 
 reviews:
   profile: assertive
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: false
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - ".*"
   path_filters:
     - "!vendor/**"
     - "!testdata/**"
     - "!dist/**"
+    - "!**/*_generated.go"
+    - "!**/zz_generated_*.go"
   tools:
     golangci-lint:
-      enabled: true
+      enabled: false
+    yamllint:
+      enabled: false
     shellcheck:
       enabled: true
 


### PR DESCRIPTION
## Summary

Configure CodeRabbit to auto-review PRs targeting any branch, reduce review noise, and avoid duplicate tool findings already covered by CI.

## Motivation / Context

CodeRabbit was skipping reviews on PRs targeting non-default branches, posting a noisy "Review skipped" comment instead. Several default output sections (poems, summaries, sequence diagrams) add clutter without value for this project.

Fixes: #597
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.coderabbit.yaml`

## Implementation Notes

- `base_branches: [".*"]` — review PRs targeting any branch
- `review_status: false` — suppress status comments
- `request_changes_workflow: false` — don't block merges
- `high_level_summary`, `poem`, `changed_files_summary`, `sequence_diagrams` — disabled to reduce noise
- `collapse_walkthrough: true` — collapse walkthrough by default
- `golangci-lint` and `yamllint` disabled (already in `make qualify`)
- `shellcheck` kept (not in `make qualify`)
- Added path filters for generated Go files

## Testing

```bash
# Config-only change — validated YAML syntax
yamllint .coderabbit.yaml
```

No Go code changed.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)