### PR TITLE
fix(bundler): make undeploy.sh resilient to transient kubectl failures

### DIFF
--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -15,8 +15,10 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -2318,5 +2320,124 @@ func TestGenerate_DoesNotMutateComponentValues(t *testing.T) {
 	}
 	if _, hasVersion := driver["version"]; !hasVersion {
 		t.Error("original driver.version was mutated (removed) — deep copy is missing")
+	}
+}
+
+// TestUndeployScript_TransientFailureWarnsAndContinues asserts that the three
+// post-uninstall cleanup pipelines tolerate a transient kubectl failure instead
+// of letting set -euo pipefail kill the script.
+//
+// Sites covered (matching the warn-on-failure pattern added in this PR):
+//   - delete_release_cluster_resources (per-release per-kind cleanup helper)
+//   - force_clear_namespace_finalizers (last-resort namespace unstick helper)
+//   - per-component orphan-CRD cleanup loop in the script body
+//
+// Setup: stub `kubectl` to always exit non-zero (simulating a 502/timeout/auth
+// hiccup). For each site, source the relevant section of the generated script,
+// invoke it, and assert (a) the wrapper exits 0 — proving set -e was not
+// triggered — and (b) the descriptive `Warning:` is on stderr — proving the
+// failure was visible to the operator.
+func TestUndeployScript_TransientFailureWarnsAndContinues(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-behavior test")
+	}
+	if _, err := exec.LookPath("awk"); err != nil {
+		t.Skip("awk not available; skipping shell-behavior test")
+	}
+	if _, err := exec.LookPath("sed"); err != nil {
+		t.Skip("sed not available; skipping shell-behavior test")
+	}
+
+	g := NewGenerator()
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	input := &GeneratorInput{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, input, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	// Stub kubectl: `api-resources` succeeds with a minimal kind list (so the
+	// helpers reach the inner pipeline we want to exercise); every other
+	// invocation fails to simulate a transient API hiccup. Placed at the
+	// front of PATH so it shadows the real kubectl. jq is left alone — the
+	// pipelines pipe-fail at the kubectl stage either way.
+	stubDir := t.TempDir()
+	stubKubectl := filepath.Join(stubDir, "kubectl")
+	stubScript := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"api-resources\" ]; then\n" +
+		"  echo configmaps\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo 'simulated transient API failure' >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(stubKubectl, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		bashSnippet string
+		wantStderr  string
+	}{
+		{
+			// L97-L103 in template: the helper's outer pipeline must end in `done || echo "Warning: ..." >&2`.
+			name: "delete_release_cluster_resources",
+			bashSnippet: `
+                source <(awk '/^delete_release_cluster_resources\(\) \{/,/^}/' "$UNDEPLOY")
+                HELM_TIMEOUT=10
+                delete_release_cluster_resources "gpu-operator" "gpu-operator"
+            `,
+			wantStderr: "Warning: customresourcedefinitions cleanup pipeline for release gpu-operator/gpu-operator failed",
+		},
+		{
+			// L150-L154 in template: same pattern in the namespace finalizer-unstick helper.
+			name: "force_clear_namespace_finalizers",
+			bashSnippet: `
+                source <(awk '/^force_clear_namespace_finalizers\(\) \{/,/^}/' "$UNDEPLOY")
+                force_clear_namespace_finalizers "gpu-operator"
+            `,
+			wantStderr: "Warning: finalizer-clear pipeline for",
+		},
+		{
+			// L296-L302 in template: the per-Helm-component orphan-CRD loop in the script body.
+			// Extract from the section header through (but not including) the next section.
+			name: "orphan_crd_inline_loop",
+			bashSnippet: `
+                snippet=$(sed -n '/^# Clean up orphaned CRDs that were owned by this bundle/,/^# Clean up CRDs created by operators at runtime/p' "$UNDEPLOY" | sed '$d')
+                eval "$snippet"
+            `,
+			wantStderr: "Warning: orphan-CRD cleanup for",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.CommandContext(ctx, "bash", "-c", "set -euo pipefail\n"+tt.bashSnippet)
+			cmd.Env = append(os.Environ(),
+				"PATH="+stubDir+":"+os.Getenv("PATH"),
+				"UNDEPLOY="+undeployPath,
+			)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			if err != nil {
+				t.Fatalf("regression: cleanup pipeline killed the script with set -e instead of warning.\nerr: %v\nstdout: %s\nstderr: %s",
+					err, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Errorf("expected %q in stderr (proves operators get a visible signal on transient failure), got:\nstderr: %s",
+					tt.wantStderr, stderr.String())
+			}
+		})
 	}
 }

--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -100,7 +100,7 @@ delete_release_cluster_resources() {
       | while read -r name; do
           echo "Deleting ${kind}/${name}..."
           kubectl delete "${kind}" "${name}" --ignore-not-found --timeout="${HELM_TIMEOUT}s" || true
-        done
+        done || echo "Warning: ${kind} cleanup pipeline for release ${release}/${ns} failed (kubectl get / jq error); leftovers will surface in post-flight" >&2
   done
 }
 
@@ -151,7 +151,7 @@ force_clear_namespace_finalizers() {
       | jq -r '.items[] | select(.metadata.finalizers // [] | length > 0) | .kind + "/" + .metadata.name' 2>/dev/null \
       | while read -r resource; do
           kubectl patch "${resource}" -n "${ns}" --type merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
-        done
+        done || echo "Warning: finalizer-clear pipeline for ${kind} in ${ns} failed (kubectl get / jq error); namespace may stay Terminating" >&2
   done
 }
 
@@ -298,8 +298,8 @@ kubectl get crd -o json 2>/dev/null \
     '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns) | .metadata.name' 2>/dev/null \
   | while read -r name; do
       echo "Deleting CRD ${name} (owned by {{ .Name }}/{{ .Namespace }})..."
-      kubectl delete crd "${name}" --ignore-not-found --wait=false
-    done
+      kubectl delete crd "${name}" --ignore-not-found --wait=false || true
+    done || echo "Warning: orphan-CRD cleanup for {{ .Name }}/{{ .Namespace }} failed (kubectl get / jq error); leftovers will surface in post-flight" >&2
 {{- end }}{{ end }}
 
 # Clean up CRDs created by operators at runtime (not Helm-managed).


### PR DESCRIPTION
## Summary

Add a trailing `|| true` to three `kubectl | jq | while` pipelines in the generated `undeploy.sh` so a transient API failure during post-uninstall cleanup no longer kills the script before namespace deletion.

## Motivation / Context

With `set -euo pipefail` (already at the top of the generated script), a single `kubectl get crd`/`kubectl get <kind>` returning non-zero — even a brief EKS control-plane 502 or an auth refresh hiccup — fails the entire pipeline and exits the script. In a typical run with ~15 components the orphaned-CRD cleanup pipeline executes 15 times back-to-back, so any momentary control-plane flap kills `undeploy.sh` after the Helm uninstalls succeeded but before taint removal / orphan-CRD cleanup / namespace deletion. The cluster ends up half-cleaned and the user has to finish manually.

Hit live today on `aicr-cuj2`: all 15 Helm releases uninstalled, then the script exited 1 immediately after `Removing skyhook.nvidia.com node taints…`, leaving every component namespace `Active`.

The two helper functions `delete_release_cluster_resources` and `force_clear_namespace_finalizers` carry the same pipeline shape and the same exposure.

The adjacent `ORPHANED_CRD_GROUPS` loop and `stuck_crds=$(…)` extraction already use the `… || true` pattern; this PR brings the three remaining sites into line.

Fixes: N/A
Related: #477 (introduced the per-component CRD cleanup pipeline)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Three single-token additions (`done` → `done || true`) plus one `|| true` on a single `kubectl delete crd` call, all in `pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl`:

- `delete_release_cluster_resources` (line 103)
- `force_clear_namespace_finalizers` (line 154)
- per-component orphan-CRD cleanup (lines 301–302)

The `delete_orphaned_webhooks_for_ns` helper at line 117 already wraps its inner pipeline in `{ … || true; }`, so it doesn't need the same treatment.

Trade-off: cleanup steps that fail due to a real (non-transient) API problem will now be silently skipped. The post-flight verification block at the end of the script already warns about leftover namespaces / stuck CRDs / stale webhooks, so a real cleanup failure surfaces there instead of as `set -e` exit 1 in the middle.

## Testing

```bash
make lint   # go vet + golangci-lint clean; pre-existing yamllint errors are in untracked .codex-worktrees/
GOFLAGS=-mod=vendor go test -race -count=1 ./pkg/bundler/...
```

- `pkg/bundler/...` tests pass with `-race` (all subpackages green).
- Re-built the CLI, regenerated a bundle, and confirmed the four new `|| true` guards appear at the expected positions in `bundles/undeploy.sh`.
- Live re-test on `aicr-cuj2` after the patch is pending — will run once the cluster's intermittent 502s settle.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Generated-script change only. No API surface, no data migration. Reverting is a one-commit revert of this PR; existing bundles can either be regenerated or hand-patched.

## Checklist

- [x] Tests pass locally (`make test` with `-race` on `pkg/bundler/...`)
- [x] Linter passes (`make lint` — go vet + golangci-lint clean; yamllint failures are in pre-existing untracked `.codex-worktrees/`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (no new functionality; behavior change is "tolerate transient failure")
- [ ] I updated docs if user-facing behavior changed (no user-facing behavior change beyond resilience)
- [x] Changes follow existing patterns in the codebase (matches the `… || true` pattern already used in the same file)
- [x] Commits are cryptographically signed (`git commit -S`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Undeployment now tolerates transient failures during resource and CRD cleanup: cleanup continues instead of aborting, and non-fatal issues emit warnings so undeploy completes more reliably.

* **Tests**
  * Added an integration-style test ensuring transient kubectl failures produce warnings and do not stop the undeploy flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->