### PR TITLE
feat(bundler): add Helm-annotation post-flight check to undeploy.sh

### DIFF
--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -434,6 +434,30 @@ if [[ -n "${orphaned_crds}" ]]; then
   postflight_issues=true
 fi
 
+# Check for Helm-annotated CRDs from uninstalled releases.
+# Mirrors the per-component CRD deletion loop above: if cleanup succeeded,
+# every annotated CRD is gone and this check stays silent. Catches cases
+# where the deletion loop logged a transient kubectl/jq warning and moved on.
+# CRDs already being deleted (non-null .metadata.deletionTimestamp) are excluded --
+# the earlier `kubectl delete crd ... --wait=false` returns immediately, so a slow
+# finalizer can leave the CRD still listed here even though it is being cleaned up
+# normally. Only truly stuck (not-yet-terminating) CRDs should be surfaced.
+helm_orphaned_crds=""
+{{- range .ComponentsReversed }}{{ if .HasChart }}
+remaining_helm_crds=$(kubectl get crd -o json 2>/dev/null \
+  | jq -r --arg rel "{{ .Name }}" --arg ns "{{ .Namespace }}" \
+    '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns and .metadata.deletionTimestamp==null) | .metadata.name' 2>/dev/null || true)
+if [[ -n "${remaining_helm_crds}" ]]; then
+  helm_orphaned_crds="${helm_orphaned_crds} ${remaining_helm_crds}"
+fi
+{{- end }}{{ end }}
+if [[ -n "${helm_orphaned_crds}" ]]; then
+  echo "WARNING: Helm-annotated CRDs from uninstalled releases still present:${helm_orphaned_crds}"
+  echo "  Cleanup did not remove all CRDs owned by this bundle's releases."
+  echo "  Delete with: kubectl delete crd <name>"
+  postflight_issues=true
+fi
+
 if [[ "${postflight_issues}" == "true" ]]; then
   echo ""
   echo "Post-flight: some stale resources remain. Run deploy.sh pre-flight checks to verify before redeploying."


### PR DESCRIPTION
## Summary

Add a post-flight verification pass that re-enumerates CRDs filtered by the same `meta.helm.sh/release-name` annotation used during the per-component CRD deletion loop, and reports any leftovers as a `WARNING` (also flips `postflight_issues=true`).

## Motivation / Context

Today the `undeploy.sh` post-flight section checks for:

- terminating namespaces,
- unavailable API services,
- operator-runtime CRDs in `ORPHANED_CRD_GROUPS` (e.g. `nvidia.com`, `nfd.k8s-sigs.io`, `kai.scheduler`).

Helm-managed CRDs that survive the per-release deletion loop are not surfaced anywhere — they go unnoticed until the next `deploy.sh` run rejects them.

After #599, the per-component CRD cleanup pipelines no longer kill the script on a transient kubectl/jq failure; they emit a `Warning:` to stderr and continue. That makes a verification check at the end of the script the natural complement: confirm the warnings did not correspond to real leftovers, and warn (with deletion command) if they did.

Suggested by CodeRabbit review on #599 (suggestion #2). I deferred it in #599 to keep that PR focused on the immediate `set -e` exit fix; this PR is the dedicated follow-up.

Fixes: N/A
Related: #599 (warn-on-failure resilience for the same pipelines), #477 (introduced the per-component cleanup loop)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

Single block added to `pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl` immediately after the existing `ORPHANED_CRD_GROUPS` post-flight check, mirroring its style:

```sh
helm_orphaned_crds=""
{{- range .ComponentsReversed }}{{ if .HasChart }}
remaining_helm_crds=$(kubectl get crd -o json 2>/dev/null \
  | jq -r --arg rel "{{ .Name }}" --arg ns "{{ .Namespace }}" \
    '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns) | .metadata.name' 2>/dev/null || true)
if [[ -n "${remaining_helm_crds}" ]]; then
  helm_orphaned_crds="${helm_orphaned_crds} ${remaining_helm_crds}"
fi
{{- end }}{{ end }}
if [[ -n "${helm_orphaned_crds}" ]]; then
  echo "WARNING: Helm-annotated CRDs from uninstalled releases still present:${helm_orphaned_crds}"
  echo "  Cleanup did not remove all CRDs owned by this bundle's releases."
  echo "  Delete with: kubectl delete crd <name>"
  postflight_issues=true
fi
```

Notes:

- One stanza per Helm component (matches the existing per-component delete loop's templating).
- Each per-release `kubectl|jq` is `|| true`-guarded so a transient API failure during post-flight doesn't itself trip `set -e`.
- On a clean undeploy (cleanup succeeded), no annotated CRDs are found, the variable stays empty, and the check is silent.
- Only fires when one of the cleanup pipelines either silently failed (pre-#599) or warned-and-continued (#599 onward) but the underlying CRDs are still on the cluster.

## Testing

```bash
GOFLAGS=-mod=vendor go test -race -count=1 ./pkg/bundler/deployer/helm/...
make build
./dist/aicr_<host>/aicr bundle --recipe recipe.yaml --output /tmp/...
bash -n /tmp/.../undeploy.sh   # syntax check
```

- Unit tests in `pkg/bundler/deployer/helm/...` pass with `-race`.
- Regenerated a real bundle (15-component recipe), confirmed one stanza per HelmChart component is emitted into the post-flight section.
- `bash -n` on the generated script: clean.

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** Generated-script change only. No API surface, no migration. Failure mode is "warning printed where there shouldn't have been one" (false positive if a CRD legitimately keeps its Helm annotation post-uninstall — none of the bundle's components do this today). Reverting is a one-commit revert.

## Checklist

- [x] Tests pass locally (`make test` with `-race` on `pkg/bundler/...`)
- [ ] Linter passes — local `make lint` has pre-existing yamllint failures in untracked `.codex-worktrees/`; `go vet` + `golangci-lint` clean on the changed package
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (the change is template-only and exercised by the existing helm bundler tests; no new behavior to assert in Go)
- [ ] I updated docs if user-facing behavior changed (post-flight warnings surface in the same `WARNING:` block already documented)
- [x] Changes follow existing patterns in the codebase (mirrors the `ORPHANED_CRD_GROUPS` post-flight check directly above)
- [x] Commits are cryptographically signed (`git commit -S`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved undeploy post-flight checks for chart-based components: scans for remaining Custom Resource Definitions, excludes those already terminating, aggregates any leftovers, lists their names in a warning, and flags the post-flight as having issues so stale resources are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->