### PR TITLE
fix(bundler): pre-flight should discover CRDs by Helm annotation, not just chart manifest

### DIFF
--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -188,16 +188,33 @@ check_crd_for_stuck_resources() {
 }
 
 # Check a Helm release for CRDs whose custom resources have active finalizers.
-# Extracts CRD names from the release manifest and checks each one.
-# Silently skips releases that are not installed (helm get manifest fails).
+# Discovers CRDs from two sources:
+#   1. The chart's templates/ section, via `helm get manifest`. Misses CRDs
+#      installed from the chart's crds/ directory (the Helm-recommended layout
+#      that most operator charts use), which never appear in `helm get manifest`.
+#   2. CRDs annotated with meta.helm.sh/release-name == this release. Catches
+#      crds/-installed CRDs and any CRD owned by the release at runtime, so
+#      workload CRs (e.g., NIMService) get scanned for finalizers before the
+#      operator is removed.
+# Silently skips releases that are not installed.
 # Args: $1 = release name, $2 = namespace
 check_release_for_stuck_crds() {
   local release="$1"
   local ns="$2"
-  local manifest
+  local manifest manifest_crds annotated_crds
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null) || return 0
-  echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}' \
+  manifest_crds=$(echo "${manifest}" \
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+  annotated_crds=$(kubectl get crd -o json 2>/dev/null \
+    | jq -r --arg rel "${release}" --arg ns "${ns}" \
+      '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns) | .metadata.name' 2>/dev/null || true)
+  # awk 'NF' drops empty lines without the exit-1-on-no-match behavior of
+  # `grep -v '^$'`, which would abort under `set -euo pipefail` when a release
+  # has no CRDs (e.g., chart ships none, installed with --skip-crds, already
+  # cleaned up).
+  printf '%s\n%s\n' "${manifest_crds}" "${annotated_crds}" \
+    | awk 'NF' \
+    | sort -u \
     | while read -r crd_name; do
         check_crd_for_stuck_resources "${crd_name}" "${release}"
       done


### PR DESCRIPTION
## Summary

Fix `undeploy.sh`'s pre-flight finalizer check so that CRDs installed from a Helm chart's `crds/` directory are discovered and their CR instances scanned. Today only CRDs declared in the chart's `templates/` section (and therefore visible to `helm get manifest`) are checked, so most operator-managed CRDs slip through and the script can be tricked into removing the operator before its CRs are cleaned up.

## Motivation / Context

Hit live on `aicr-cuj2` today: I left a `NIMService` (`demos/workloads/inference/nimservice-llama-3-2-1b.yaml`) on the cluster, ran `./undeploy.sh`, the pre-flight check passed, the NIM operator got uninstalled, and the script then "completed" — but the `nimservices.apps.nvidia.com` CRD's `customresourcecleanup` finalizer was waiting on the leftover NIMService CR, whose own NIM-operator finalizer could no longer be processed. The CRD stayed `Terminating` indefinitely, the `nim-workload` namespace stayed `Terminating`, and recovery required manual `kubectl patch ... finalizers:null` on the CR.

The pre-flight check exists exactly to prevent that scenario, but it didn't fire. Investigating: `check_release_for_stuck_crds` discovers CRDs by parsing the output of `helm get manifest` — which Helm restricts to `templates/` content. The k8s-nim-operator, gpu-operator, kai-scheduler, etc. charts all ship their CRDs under `crds/` (the Helm-recommended layout). Those CRDs are *never* visible to `helm get manifest`, so their CR instances are never scanned during pre-flight, and the script proceeds to remove the operator that was the only thing capable of clearing those CRs' finalizers.

Add a second discovery source: query CRDs annotated with `meta.helm.sh/release-name` matching the release (and `meta.helm.sh/release-namespace` matching the namespace). This is the same annotation the per-component cleanup loop in this file already filters by, and the same one #600 uses for the post-flight verification check. Bringing pre-flight into line means workload CRs get caught before the operator is removed, and the user is told (via the existing pre-flight error message) to delete them first.

Fixes: N/A (no GitHub issue filed)
Related: #599 (cleanup-pipeline resilience for the same code path), #600 (post-flight verification using the same annotation filter)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

Single function rewrite in `pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl`:

```sh
check_release_for_stuck_crds() {
  local release="$1"
  local ns="$2"
  local manifest manifest_crds annotated_crds
  manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null) || return 0
  manifest_crds=$(echo "${manifest}" \
    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
  annotated_crds=$(kubectl get crd -o json 2>/dev/null \
    | jq -r --arg rel "${release}" --arg ns "${ns}" \
      '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns) | .metadata.name' 2>/dev/null || true)
  printf '%s\n%s\n' "${manifest_crds}" "${annotated_crds}" \
    | sort -u \
    | grep -v '^$' \
    | while read -r crd_name; do
        check_crd_for_stuck_resources "${crd_name}" "${release}"
      done
  return 0
}
```

Notes:

- The two sources are deduplicated by `sort -u`, so CRDs visible to `helm get manifest` (e.g., a chart that declares its CRDs in templates/) are still scanned exactly once and existing behavior is preserved.
- The annotation-based query is `|| true`-guarded so a transient API failure during pre-flight doesn't false-negative the whole check.
- The early `return 0` if `helm get manifest` fails is intentional: it means the release isn't installed and there's nothing to check. Same guarantee as before.

## Testing

```bash
GOFLAGS=-mod=vendor go test -race -count=1 ./pkg/bundler/deployer/helm/...
make build
./dist/aicr_<host>/aicr bundle --recipe recipe.yaml --output /tmp/...
bash -n /tmp/.../undeploy.sh   # syntax check
```

- Unit tests in `pkg/bundler/deployer/helm/...` pass with `-race`.
- Regenerated a real bundle and inspected the rendered function — both discovery branches present, dedup logic in place.
- `bash -n` on the generated script: clean.
- Live re-test on `aicr-cuj2` with a deliberately-applied NIMService is the next step (out of scope for this PR; will verify after merge).

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** Generated-script change only. No API surface, no migration. Worst-case failure mode is "pre-flight reports stuck CR for a CRD it would have ignored before" — which is the *correct* behavior; user follows the existing `kubectl delete <cr>` remediation hint or `--skip-preflight` to override. Reverting is a one-commit revert.

## Checklist

- [x] Tests pass locally (`make test` with `-race` on `pkg/bundler/...`)
- [ ] Linter passes — local `make lint` has pre-existing yamllint failures in untracked `.codex-worktrees/`; `go vet` + `golangci-lint` clean on the changed package
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (template-only change exercised by the existing helm bundler tests; the new discovery branch is bash + `kubectl get crd`, both runtime-only)
- [ ] I updated docs if user-facing behavior changed (pre-flight error message wording is unchanged; only the *coverage* of which CRDs trigger it has been broadened)
- [x] Changes follow existing patterns in the codebase (the `meta.helm.sh/release-name`/`-namespace` filter is already used by the per-component cleanup loop and by #600's post-flight check)
- [x] Commits are cryptographically signed (`git commit -S`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undeployment reliability by expanding CRD discovery to multiple sources (release manifests and cluster records). This ensures more complete identification and cleanup of custom resources, reducing the risk of orphaned resources or stuck CRDs remaining after undeploy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->