### PR TITLE
fix(bundler): fix undeploy template pre/post-flight checks

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1302,6 +1302,7 @@ The undeploy script removes components in reverse deployment order.
 |------|-------------|
 | `--keep-namespaces` | Skip namespace deletion after component removal |
 | `--delete-pvcs` | Delete all PVCs in component namespaces (default: **off**) |
+| `--skip-preflight` | Skip pre-flight CRD/finalizer checks (use with caution) |
 | `--timeout SECONDS` | Helm uninstall timeout per component (default: 120) |
 
 **PVC preservation (default):**

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -15,11 +15,14 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -617,6 +620,16 @@ func TestGenerate_UndeployScriptExecutable(t *testing.T) {
 	}
 	if !strings.Contains(script, "CRDs stuck in deleting state") {
 		t.Error("undeploy.sh missing warning about stuck CRDs")
+	}
+
+	// Verify API-group discovery is not reused for destructive cleanup.
+	// Without bundle-specific ownership metadata, deleting CRDs by group can
+	// remove another tenant's CRD on a shared cluster.
+	if strings.Contains(script, "ORPHANED_CRD_GROUPS=") {
+		t.Error("undeploy.sh should not build group-based CRD delete lists")
+	}
+	if strings.Contains(script, `grep "\.${group}$"`) {
+		t.Error("undeploy.sh should not match CRDs by API group for destructive cleanup or post-flight stale warnings")
 	}
 }
 
@@ -2338,4 +2351,997 @@ func TestGenerate_DataFiles(t *testing.T) {
 			t.Errorf("expected 'unsafe data file path' error, got: %v", err)
 		}
 	})
+}
+
+// TestUndeployScript_TransientFailureWarnsAndContinues asserts that the three
+// post-uninstall cleanup pipelines tolerate a transient kubectl failure instead
+// of letting set -euo pipefail kill the script.
+//
+// Sites covered (matching the warn-on-failure pattern added in this PR):
+//   - delete_release_cluster_resources (per-release per-kind cleanup helper)
+//   - force_clear_namespace_finalizers (last-resort namespace unstick helper)
+//   - per-component orphan-CRD cleanup loop in the script body
+//
+// Setup: stub `kubectl` to always exit non-zero (simulating a 502/timeout/auth
+// hiccup). For each site, source the relevant section of the generated script,
+// invoke it, and assert (a) the wrapper exits 0 — proving set -e was not
+// triggered — and (b) the descriptive `Warning:` is on stderr — proving the
+// failure was visible to the operator.
+func TestUndeployScript_TransientFailureWarnsAndContinues(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-behavior test")
+	}
+	if _, err := exec.LookPath("awk"); err != nil {
+		t.Skip("awk not available; skipping shell-behavior test")
+	}
+	if _, err := exec.LookPath("sed"); err != nil {
+		t.Skip("sed not available; skipping shell-behavior test")
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	// Stub kubectl: `api-resources` succeeds with a minimal kind list (so the
+	// helpers reach the inner pipeline we want to exercise); every other
+	// invocation fails to simulate a transient API hiccup. Placed at the
+	// front of PATH so it shadows the real kubectl. jq is left alone — the
+	// pipelines pipe-fail at the kubectl stage either way.
+	stubDir := t.TempDir()
+	stubKubectl := filepath.Join(stubDir, "kubectl")
+	stubScript := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"api-resources\" ]; then\n" +
+		"  echo configmaps\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo 'simulated transient API failure' >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(stubKubectl, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		bashSnippet string
+		wantStderr  string
+	}{
+		{
+			// L97-L103 in template: the helper's outer pipeline must end in `done || echo "Warning: ..." >&2`.
+			// sed+eval (not `source <(awk ...)` process substitution) for portability
+			// across bash environments where <(...) is flaky.
+			name: "delete_release_cluster_resources",
+			bashSnippet: `
+                snippet=$(sed -n '/^delete_release_cluster_resources()/,/^}/p' "$UNDEPLOY")
+                eval "$snippet"
+                HELM_TIMEOUT=10
+                delete_release_cluster_resources "gpu-operator" "gpu-operator"
+            `,
+			wantStderr: "Warning: customresourcedefinitions cleanup pipeline for release gpu-operator/gpu-operator failed",
+		},
+		{
+			// L150-L154 in template: same pattern in the namespace finalizer-unstick helper.
+			name: "force_clear_namespace_finalizers",
+			bashSnippet: `
+                snippet=$(sed -n '/^force_clear_namespace_finalizers()/,/^}/p' "$UNDEPLOY")
+                eval "$snippet"
+                force_clear_namespace_finalizers "gpu-operator"
+            `,
+			wantStderr: "Warning: finalizer-clear pipeline for",
+		},
+		{
+			// L296-L302 in template: the per-Helm-component orphan-CRD loop in the script body.
+			// Extract from the section header through (but not including) the
+			// manual-review note that now replaces the old group-delete block.
+			name: "orphan_crd_inline_loop",
+			bashSnippet: `
+                snippet=$(sed -n '/^# Clean up orphaned CRDs that were owned by this bundle/,/^# Intentionally skip automatic deletion of unannotated CRDs matched only by/p' "$UNDEPLOY" | sed '$d')
+                eval "$snippet"
+            `,
+			wantStderr: "Warning: orphan-CRD cleanup for",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Bound each bash invocation to 30s so a wedged subprocess (kubectl
+			// stub mis-fire, deadlocked pipeline, etc.) cannot hang `go test`.
+			subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+tt.bashSnippet)
+			cmd.Env = append(os.Environ(),
+				"PATH="+stubDir+":"+os.Getenv("PATH"),
+				"UNDEPLOY="+undeployPath,
+			)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			if err != nil {
+				t.Fatalf("regression: cleanup pipeline killed the script with set -e instead of warning.\nerr: %v\nstdout: %s\nstderr: %s",
+					err, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Errorf("expected %q in stderr (proves operators get a visible signal on transient failure), got:\nstderr: %s",
+					tt.wantStderr, stderr.String())
+			}
+		})
+	}
+}
+
+// TestUndeployScript_PreflightDiscoversExplicitExtraCRDs proves the simplified
+// pre-flight still catches a small set of known crds/-installed operator CRDs
+// without scanning whole API groups. Here helm get manifest is empty and the
+// CRD is unannotated, so only extra_crds_for_release can surface it.
+func TestUndeployScript_PreflightDiscoversExplicitExtraCRDs(t *testing.T) {
+	for _, bin := range []string{"bash", "awk", "sed", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	helmStub := "#!/bin/sh\n# helm get manifest returns empty (no templated CRDs)\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "helm"), []byte(helmStub), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo '{"items":[{"metadata":{"name":"clusterpolicies.nvidia.com"},"spec":{"group":"nvidia.com","names":{"plural":"clusterpolicies"},"scope":"Cluster"}}]}'
+    ;;
+  "get crd clusterpolicies.nvidia.com -o json")
+    echo '{"spec":{"names":{"plural":"clusterpolicies"},"group":"nvidia.com","scope":"Cluster"}}'
+    ;;
+  "get clusterpolicies.nvidia.com -o json")
+    # One CR with an operator finalizer (non-kubernetes.io/*) — the exact
+    # case pre-flight is supposed to catch before the operator is removed.
+    echo '{"items":[{"metadata":{"name":"cluster-policy","finalizers":["nvidia.com/clusterpolicy"]}}]}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json check_crd_for_stuck_resources check_release_for_stuck_crds; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        PREFLIGHT_DETAILS=$(mktemp)
+        check_release_for_stuck_crds "gpu-operator" "gpu-operator"
+        cat "$PREFLIGHT_DETAILS"
+        rm -f "$PREFLIGHT_DETAILS"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "cluster-policy") {
+		t.Errorf("expected pre-flight to detect cluster-policy CR via explicit CRD overrides; got stdout: %q\nstderr: %q",
+			stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "clusterpolicies.nvidia.com") {
+		t.Errorf("expected pre-flight output to name the source CRD clusterpolicies.nvidia.com; got: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "nvidia.com/clusterpolicy") {
+		t.Errorf("expected pre-flight to surface the unreconciled finalizer; got: %q", stdout.String())
+	}
+}
+
+// TestUndeployScript_PreflightDiscoversPrometheusExplicitCRDs proves the
+// expanded exact-name override list now covers kube-prometheus-stack CRDs that
+// are commonly installed outside Helm manifest/annotation discovery.
+func TestUndeployScript_PreflightDiscoversPrometheusExplicitCRDs(t *testing.T) {
+	for _, bin := range []string{"bash", "awk", "sed", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: &recipe.RecipeResult{
+			Kind:       "RecipeResult",
+			APIVersion: "aicr.nvidia.com/v1alpha1",
+			Metadata: struct {
+				Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
+				AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
+				ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+				ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
+			}{
+				Version: "v0.1.0",
+			},
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:      "kube-prometheus-stack",
+					Namespace: "monitoring",
+					Chart:     "prometheus-community/kube-prometheus-stack",
+					Version:   "82.8.0",
+					Source:    "https://prometheus-community.github.io/helm-charts",
+				},
+			},
+			DeploymentOrder: []string{"kube-prometheus-stack"},
+		},
+		ComponentValues: map[string]map[string]any{
+			"kube-prometheus-stack": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	helmStub := "#!/bin/sh\n# helm get manifest returns empty (no templated CRDs)\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "helm"), []byte(helmStub), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo '{"items":[{"metadata":{"name":"prometheuses.monitoring.coreos.com"},"spec":{"group":"monitoring.coreos.com","names":{"plural":"prometheuses"},"scope":"Namespaced"}}]}'
+    ;;
+  "get crd prometheuses.monitoring.coreos.com -o json")
+    echo '{"spec":{"names":{"plural":"prometheuses"},"group":"monitoring.coreos.com","scope":"Namespaced"}}'
+    ;;
+  "get prometheuses.monitoring.coreos.com -A -o json")
+    echo '{"items":[{"metadata":{"namespace":"monitoring","name":"aicr-prometheus","finalizers":["monitoring.coreos.com/operator"]}}]}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json check_crd_for_stuck_resources check_release_for_stuck_crds; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        PREFLIGHT_DETAILS=$(mktemp)
+        check_release_for_stuck_crds "kube-prometheus-stack" "monitoring"
+        cat "$PREFLIGHT_DETAILS"
+        rm -f "$PREFLIGHT_DETAILS"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "prometheuses.monitoring.coreos.com") {
+		t.Errorf("expected pre-flight output to name the explicit CRD prometheuses.monitoring.coreos.com; got: %q", out)
+	}
+	if !strings.Contains(out, "monitoring/aicr-prometheus") {
+		t.Errorf("expected pre-flight to report the explicit CR instance; got: %q", out)
+	}
+	if !strings.Contains(out, "monitoring.coreos.com/operator") {
+		t.Errorf("expected pre-flight to surface the unreconciled finalizer; got: %q", out)
+	}
+}
+
+// TestUndeployScript_PreflightDiscoversAnnotatedCRDs proves the retained
+// annotation-based discovery still catches release-owned CRDs even when
+// helm get manifest is empty (e.g. chart stores CRDs outside templates/).
+func TestUndeployScript_PreflightDiscoversAnnotatedCRDs(t *testing.T) {
+	for _, bin := range []string{"bash", "awk", "sed", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	helmStub := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "helm"), []byte(helmStub), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo '{"items":[{"metadata":{"name":"challenges.acme.cert-manager.io","annotations":{"meta.helm.sh/release-name":"cert-manager","meta.helm.sh/release-namespace":"cert-manager"}},"spec":{"group":"acme.cert-manager.io","names":{"plural":"challenges"},"scope":"Namespaced"}}]}'
+    ;;
+  "get crd challenges.acme.cert-manager.io -o json")
+    echo '{"spec":{"names":{"plural":"challenges"},"group":"acme.cert-manager.io","scope":"Namespaced"}}'
+    ;;
+  "get challenges.acme.cert-manager.io -A -o json")
+    echo '{"items":[{"metadata":{"namespace":"cert-manager","name":"test-challenge","finalizers":["acme.cert-manager.io/finalizer"]}}]}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json check_crd_for_stuck_resources check_release_for_stuck_crds; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        PREFLIGHT_DETAILS=$(mktemp)
+        check_release_for_stuck_crds "cert-manager" "cert-manager"
+        cat "$PREFLIGHT_DETAILS"
+        rm -f "$PREFLIGHT_DETAILS"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "challenges.acme.cert-manager.io") {
+		t.Errorf("expected pre-flight output to name the annotated CRD challenges.acme.cert-manager.io; got: %q", out)
+	}
+	if !strings.Contains(out, "cert-manager/test-challenge") {
+		t.Errorf("expected pre-flight to report the annotated CR instance; got: %q", out)
+	}
+	if !strings.Contains(out, "acme.cert-manager.io/finalizer") {
+		t.Errorf("expected pre-flight to surface the unreconciled finalizer; got: %q", out)
+	}
+}
+
+// TestUndeployScript_PreflightSkipListCoversManifestDeletedReleases keeps the
+// simplified fix explicit: releases whose bundle-managed CRs are deleted from
+// manifests before controller uninstall are skipped at pre-flight instead of
+// reintroducing manifest parsing and ownership inference.
+func TestUndeployScript_PreflightSkipListCoversManifestDeletedReleases(t *testing.T) {
+	for _, bin := range []string{"bash", "sed"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: &recipe.RecipeResult{
+			Kind:       "RecipeResult",
+			APIVersion: "aicr.nvidia.com/v1alpha1",
+			Metadata: struct {
+				Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
+				AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
+				ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+				ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
+			}{
+				Version: "v0.1.0",
+			},
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+					Chart:     "cert-manager",
+					Version:   "v1.17.2",
+					Source:    "https://charts.jetstack.io",
+				},
+				{
+					Name:      "kgateway",
+					Namespace: "kgateway-system",
+					Chart:     "kgateway",
+					Version:   "v0.1.0",
+					Source:    "https://example.invalid/charts",
+				},
+				{
+					Name:      "skyhook-operator",
+					Namespace: "skyhook",
+					Chart:     "skyhook-operator",
+					Version:   "v0.1.0",
+					Source:    "https://example.invalid/charts",
+				},
+			},
+			DeploymentOrder: []string{"cert-manager", "kgateway", "skyhook-operator"},
+		},
+		ComponentValues: map[string]map[string]any{
+			"cert-manager":     {},
+			"kgateway":         {},
+			"skyhook-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	bashSnippet := `
+        snippet=$(sed -n '/^skip_preflight_for_release()/,/^}/p' "$UNDEPLOY")
+        eval "$snippet"
+        skip_preflight_for_release "skyhook-operator" && echo "skip:skyhook-operator"
+        skip_preflight_for_release "kgateway" && echo "skip:kgateway"
+        if skip_preflight_for_release "cert-manager"; then
+            echo "unexpected:cert-manager"
+            exit 1
+        fi
+        echo "check:cert-manager"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(), "UNDEPLOY="+undeployPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "skip:skyhook-operator") {
+		t.Errorf("expected skip list to include skyhook-operator; stdout: %q stderr: %q", out, stderr.String())
+	}
+	if !strings.Contains(out, "skip:kgateway") {
+		t.Errorf("expected skip list to include kgateway; stdout: %q stderr: %q", out, stderr.String())
+	}
+	if !strings.Contains(out, "check:cert-manager") {
+		t.Errorf("expected cert-manager to remain pre-flight checked; stdout: %q stderr: %q", out, stderr.String())
+	}
+}
+
+// TestUndeployScript_PreflightSkipsForeignAnnotatedExtraCRDs preserves the
+// shared-cluster safety property for explicit CRD overrides: if a known CRD
+// name is clearly annotated to a different Helm release, pre-flight must not
+// scan its CRs for this release.
+func TestUndeployScript_PreflightSkipsForeignAnnotatedExtraCRDs(t *testing.T) {
+	for _, bin := range []string{"bash", "awk", "sed", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	helmStub := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "helm"), []byte(helmStub), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo '{"items":[{"metadata":{"name":"clusterpolicies.nvidia.com","annotations":{"meta.helm.sh/release-name":"other-release","meta.helm.sh/release-namespace":"other-ns"}},"spec":{"group":"nvidia.com","names":{"plural":"clusterpolicies"},"scope":"Cluster"}}]}'
+    ;;
+  "get crd clusterpolicies.nvidia.com -o json")
+    echo '{"spec":{"names":{"plural":"clusterpolicies"},"group":"nvidia.com","scope":"Cluster"}}'
+    ;;
+  "get clusterpolicies.nvidia.com -o json")
+    echo '{"items":[{"metadata":{"name":"foreign-policy","finalizers":["nvidia.com/clusterpolicy"]}}]}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json check_crd_for_stuck_resources check_release_for_stuck_crds; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        PREFLIGHT_DETAILS=$(mktemp)
+        check_release_for_stuck_crds "gpu-operator" "gpu-operator"
+        cat "$PREFLIGHT_DETAILS"
+        rm -f "$PREFLIGHT_DETAILS"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	leaked := strings.Contains(out, "clusterpolicies.nvidia.com") ||
+		strings.Contains(out, "foreign-policy") ||
+		strings.Contains(out, "nvidia.com/clusterpolicy")
+	if leaked {
+		t.Errorf("pre-flight scanned an explicit override CRD annotated to a different Helm release.\nstdout: %q\nstderr: %q",
+			out, stderr.String())
+	}
+}
+
+// TestUndeployScript_PreflightFailsClosedOnKubectlError asserts that a
+// transient `kubectl get crd` failure (API 502, auth hiccup, etc.) causes
+// pre-flight to fail closed with a clear error message — NOT silently treat
+// "API error" as "no CRDs to check" and proceed to uninstall the operator.
+func TestUndeployScript_PreflightFailsClosedOnKubectlError(t *testing.T) {
+	for _, bin := range []string{"bash", "awk", "sed", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	helmStub := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "helm"), []byte(helmStub), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+
+	// Simulate a transient API failure on the CRD list call that both retained
+	// discovery sources depend on. Before the fail-closed fix, this could
+	// silently return "" and let pre-flight fast-path to success.
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo "error: the server is currently unable to handle the request (get customresourcedefinitions.apiextensions.k8s.io)" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json check_crd_for_stuck_resources check_release_for_stuck_crds; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        PREFLIGHT_DETAILS=$(mktemp)
+        check_release_for_stuck_crds "gpu-operator" "gpu-operator"
+        echo "UNREACHABLE: fast-path silently passed despite API error" >&2
+        rm -f "$PREFLIGHT_DETAILS"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err == nil {
+		t.Fatalf("regression: check_release_for_stuck_crds returned 0 despite kubectl error — pre-flight would silently pass on transient API failure.\nstdout: %q\nstderr: %q",
+			stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "UNREACHABLE") {
+		t.Fatalf("regression: execution continued past check_release_for_stuck_crds on kubectl error.\nstderr: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "ERROR: Pre-flight could not list CRDs") {
+		t.Errorf("expected clear ERROR message about pre-flight failing closed; stderr: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gpu-operator") {
+		t.Errorf("expected ERROR to name the release; stderr: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--skip-preflight") {
+		t.Errorf("expected ERROR to point the operator to --skip-preflight bypass; stderr: %q", stderr.String())
+	}
+}
+
+// TestUndeployScript_PreflightPreservesJSONWhenKubectlWarnsOnStderr asserts
+// that successful `kubectl ... -o json` calls remain parseable even when
+// kubectl emits warnings on stderr.
+func TestUndeployScript_PreflightPreservesJSONWhenKubectlWarnsOnStderr(t *testing.T) {
+	for _, bin := range []string{"bash", "awk", "sed", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	helmStub := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "helm"), []byte(helmStub), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo "warning: cached discovery response" >&2
+    echo '{"items":[{"metadata":{"name":"clusterpolicies.nvidia.com"},"spec":{"group":"nvidia.com","names":{"plural":"clusterpolicies"},"scope":"Cluster"}}]}'
+    ;;
+  "get crd clusterpolicies.nvidia.com -o json")
+    echo "warning: cached CRD read" >&2
+    echo '{"spec":{"names":{"plural":"clusterpolicies"},"group":"nvidia.com","scope":"Cluster"}}'
+    ;;
+  "get clusterpolicies.nvidia.com -o json")
+    echo "warning: cached CR list" >&2
+    echo '{"items":[{"metadata":{"name":"cluster-policy","finalizers":["nvidia.com/clusterpolicy"]}}]}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json check_crd_for_stuck_resources check_release_for_stuck_crds; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        PREFLIGHT_DETAILS=$(mktemp)
+        check_release_for_stuck_crds "gpu-operator" "gpu-operator"
+        cat "$PREFLIGHT_DETAILS"
+        rm -f "$PREFLIGHT_DETAILS"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "cluster-policy") {
+		t.Errorf("expected pre-flight to keep parsing JSON despite kubectl stderr warnings; got stdout: %q\nstderr: %q",
+			stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "warning: cached discovery response") {
+		t.Errorf("expected kubectl stderr warning to remain visible to operators; stderr: %q", stderr.String())
+	}
+}
+
+// TestUndeployScript_PostflightWarnsOnExplicitExtraCRDs proves post-flight now
+// surfaces leftover exact-name CRDs from known crds/-installed releases even
+// when they are unannotated and therefore invisible to the Helm-only warning.
+func TestUndeployScript_PostflightWarnsOnExplicitExtraCRDs(t *testing.T) {
+	for _, bin := range []string{"bash", "sed", "jq", "awk", "sort", "tr"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: &recipe.RecipeResult{
+			Kind:       "RecipeResult",
+			APIVersion: "aicr.nvidia.com/v1alpha1",
+			Metadata: struct {
+				Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
+				AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
+				ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+				ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
+			}{
+				Version: "v0.1.0",
+			},
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:      "kube-prometheus-stack",
+					Namespace: "monitoring",
+					Chart:     "prometheus-community/kube-prometheus-stack",
+					Version:   "82.8.0",
+					Source:    "https://prometheus-community.github.io/helm-charts",
+				},
+			},
+			DeploymentOrder: []string{"kube-prometheus-stack"},
+		},
+		ComponentValues: map[string]map[string]any{
+			"kube-prometheus-stack": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	stubDir := t.TempDir()
+
+	kubectlStub := `#!/bin/sh
+case "$*" in
+  "get crd -o json")
+    echo '{"items":[{"metadata":{"name":"prometheuses.monitoring.coreos.com"},"spec":{"group":"monitoring.coreos.com","names":{"plural":"prometheuses"},"scope":"Namespaced"}}]}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(kubectlStub), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+
+	bashSnippet := `
+        for fn in extra_crds_for_release capture_kubectl_json; do
+            snippet=$(sed -n "/^${fn}()/,/^}/p" "$UNDEPLOY")
+            eval "$snippet"
+        done
+        snippet=$(sed -n '/^# Check for Helm-annotated CRDs from uninstalled releases\./,/^if \[\[ "\${postflight_issues}" == "true" \]\]/p' "$UNDEPLOY" | sed '$d')
+        helm_orphaned_crds=""
+        explicit_orphaned_crds=""
+        postflight_all_crds_json=""
+        postflight_issues=false
+        eval "$snippet"
+        [[ "${postflight_issues}" == "true" ]]
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "WARNING: explicit CRDs from this bundle still present:") {
+		t.Errorf("expected post-flight explicit CRD warning; got stdout: %q stderr: %q", out, stderr.String())
+	}
+	if !strings.Contains(out, "prometheuses.monitoring.coreos.com") {
+		t.Errorf("expected post-flight warning to name the leftover CRD; got stdout: %q stderr: %q", out, stderr.String())
+	}
+}
+
+func TestUndeployScript_KustomizeOnlyBundleIsBashSyntaxValid(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-syntax test")
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createKustomizeRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"my-kustomize-app": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-n", undeployPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated undeploy.sh is not bash-syntax valid for Kustomize-only bundle.\nerr: %v\noutput: %s",
+			err, string(output))
+	}
+}
+
+func TestUndeployScript_DynamoPlatformOwnsExplicitGroveCRDs(t *testing.T) {
+	for _, bin := range []string{"bash", "sed"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell-behavior test", bin)
+		}
+	}
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: &recipe.RecipeResult{
+			Kind:       "RecipeResult",
+			APIVersion: "aicr.nvidia.com/v1alpha1",
+			Metadata: struct {
+				Version            string                     `json:"version,omitempty" yaml:"version,omitempty"`
+				AppliedOverlays    []string                   `json:"appliedOverlays,omitempty" yaml:"appliedOverlays,omitempty"`
+				ExcludedOverlays   []recipe.ExcludedOverlay   `json:"excludedOverlays,omitempty" yaml:"excludedOverlays,omitempty"`
+				ConstraintWarnings []recipe.ConstraintWarning `json:"constraintWarnings,omitempty" yaml:"constraintWarnings,omitempty"`
+			}{
+				Version: "v0.1.0",
+			},
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:      "dynamo-platform",
+					Namespace: "dynamo-platform",
+					Chart:     "oci://example.com/dynamo-platform",
+					Version:   "0.9.1",
+					Source:    "oci://example.com",
+				},
+			},
+			DeploymentOrder: []string{"dynamo-platform"},
+		},
+		ComponentValues: map[string]map[string]any{
+			"dynamo-platform": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	bashSnippet := `
+        snippet=$(sed -n '/^extra_crds_for_release()/,/^}/p' "$UNDEPLOY")
+        eval "$snippet"
+        platform_crds=$(extra_crds_for_release "dynamo-platform")
+        printf '%s\n' "$platform_crds"
+        test -n "$platform_crds"
+        test -z "$(extra_crds_for_release "dynamo-crds")"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -euo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(), "UNDEPLOY="+undeployPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	for _, crd := range []string{
+		"podcliques.grove.io",
+		"podcliquescalinggroups.grove.io",
+		"podcliquesets.grove.io",
+		"podgangs.scheduler.grove.io",
+	} {
+		if !strings.Contains(stdout.String(), crd) {
+			t.Errorf("expected dynamo-platform explicit CRD list to include %s; stdout: %q stderr: %q",
+				crd, stdout.String(), stderr.String())
+		}
+	}
 }

--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -100,7 +100,7 @@ delete_release_cluster_resources() {
       | while read -r name; do
           echo "Deleting ${kind}/${name}..."
           kubectl delete "${kind}" "${name}" --ignore-not-found --timeout="${HELM_TIMEOUT}s" || true
-        done
+        done || echo "Warning: ${kind} cleanup pipeline for release ${release}/${ns} failed (kubectl get / jq error); leftovers will surface in post-flight" >&2
   done
 }
 
@@ -145,14 +145,137 @@ force_clear_namespace_finalizers() {
   local ns="$1"
   echo "Force-removing finalizers in namespace ${ns}..."
   local kinds
-  kinds=$(kubectl api-resources --verbs=list --namespaced -o name 2>/dev/null) || return
+  kinds=$(kubectl api-resources --verbs=list --namespaced -o name 2>/dev/null) || {
+    echo "Warning: failed to enumerate namespaced resource kinds in ${ns}; namespace may stay Terminating" >&2
+    return
+  }
   for kind in ${kinds}; do
     kubectl get "${kind}" -n "${ns}" -o json 2>/dev/null \
       | jq -r '.items[] | select(.metadata.finalizers // [] | length > 0) | .kind + "/" + .metadata.name' 2>/dev/null \
       | while read -r resource; do
           kubectl patch "${resource}" -n "${ns}" --type merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
-        done
+        done || echo "Warning: finalizer-clear pipeline for ${kind} in ${ns} failed (kubectl get / jq error); namespace may stay Terminating" >&2
   done
+}
+
+# Return a small, explicit list of known crds/-installed CRDs whose
+# finalizer-bearing custom resources must still be caught before the operator
+# is removed. Keep this list intentionally tiny and exact: if a release is not
+# listed here, pre-flight relies on chart-manifest and Helm-annotation discovery
+# only instead of trying to infer ownership across the whole cluster.
+extra_crds_for_release() {
+  case "$1" in
+    gpu-operator)
+      printf '%s\n' \
+        "clusterpolicies.nvidia.com" \
+        "nvidiadrivers.nvidia.com" \
+        "nodefeaturegroups.nfd.k8s-sigs.io" \
+        "nodefeaturerules.nfd.k8s-sigs.io" \
+        "nodefeatures.nfd.k8s-sigs.io"
+      ;;
+    kai-scheduler)
+      printf '%s\n' \
+        "bindrequests.scheduling.run.ai" \
+        "configs.kai.scheduler" \
+        "podgroups.scheduling.run.ai" \
+        "queues.scheduling.run.ai" \
+        "schedulingshards.kai.scheduler" \
+        "topologies.kai.scheduler"
+      ;;
+    k8s-nim-operator)
+      printf '%s\n' \
+        "nemocustomizers.apps.nvidia.com" \
+        "nemodatastores.apps.nvidia.com" \
+        "nemoentitystores.apps.nvidia.com" \
+        "nemoevaluators.apps.nvidia.com" \
+        "nemoguardrails.apps.nvidia.com" \
+        "nimbuilds.apps.nvidia.com" \
+        "nimcaches.apps.nvidia.com" \
+        "nimpipelines.apps.nvidia.com" \
+        "nimservices.apps.nvidia.com"
+      ;;
+    kubeflow-trainer)
+      printf '%s\n' \
+        "clustertrainingruntimes.trainer.kubeflow.org" \
+        "trainjobs.trainer.kubeflow.org" \
+        "trainingruntimes.trainer.kubeflow.org" \
+        "jobsets.jobset.x-k8s.io"
+      ;;
+    kube-prometheus-stack)
+      printf '%s\n' \
+        "alertmanagerconfigs.monitoring.coreos.com" \
+        "alertmanagers.monitoring.coreos.com" \
+        "podmonitors.monitoring.coreos.com" \
+        "probes.monitoring.coreos.com" \
+        "prometheusagents.monitoring.coreos.com" \
+        "prometheuses.monitoring.coreos.com" \
+        "prometheusrules.monitoring.coreos.com" \
+        "scrapeconfigs.monitoring.coreos.com" \
+        "servicemonitors.monitoring.coreos.com" \
+        "thanosrulers.monitoring.coreos.com"
+      ;;
+    dynamo-platform)
+      printf '%s\n' \
+        "podcliques.grove.io" \
+        "podcliquescalinggroups.grove.io" \
+        "podcliquesets.grove.io" \
+        "podgangs.scheduler.grove.io"
+      ;;
+    network-operator)
+      # This explicit list matches the CRDs enabled by the bundled values:
+      # nfd=false, sriovNetworkOperator=false, maintenance-operator disabled.
+      # Intentionally exclude networkattachmentdefinitions.k8s.cni.cncf.io:
+      # it is a broadly shared CRD, so surfacing or deleting it based only on
+      # this release would create cross-cluster noise.
+      printf '%s\n' \
+        "nicclusterpolicies.mellanox.com" \
+        "hostdevicenetworks.mellanox.com" \
+        "ipoibnetworks.mellanox.com" \
+        "macvlannetworks.mellanox.com"
+      ;;
+    *) ;;
+  esac
+}
+
+# Skip pre-flight for releases whose bundle-managed custom resources are
+# deleted from manifests before the controller is uninstalled. Those CRs may
+# carry operator finalizers safely because undeploy removes them while the
+# controller is still running, so scanning them here would false-positive the
+# happy path.
+skip_preflight_for_release() {
+  case "$1" in
+    skyhook-operator|kgateway) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# On failure, stores kubectl stderr in the destination variable and returns non-zero.
+# On success, replays any stderr warnings to the terminal without contaminating JSON.
+# Args: $1 = destination variable name, $2.. = kubectl args
+capture_kubectl_json() {
+  local out_var="$1"
+  shift
+  local stderr_file output kubectl_err=""
+
+  if ! stderr_file=$(mktemp "${TMPDIR:-/tmp}/.aicr_kubectl_stderr_XXXXXX"); then
+    printf -v "${out_var}" '%s' 'mktemp failed while capturing kubectl stderr'
+    return 1
+  fi
+
+  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+    kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
+    rm -f "${stderr_file}"
+    printf -v "${out_var}" '%s' "${kubectl_err}"
+    return 1
+  fi
+
+  if [[ -s "${stderr_file}" ]]; then
+    cat "${stderr_file}" >&2 || true
+  fi
+  rm -f "${stderr_file}"
+  printf -v "${out_var}" '%s' "${output}"
+  return 0
 }
 
 # Check a single CRD for custom resource instances with active finalizers.
@@ -161,9 +284,22 @@ force_clear_namespace_finalizers() {
 check_crd_for_stuck_resources() {
   local crd_name="$1"
   local component="$2"
-  local crd_json plural group scope resource stuck
+  local crd_json plural group scope resource stuck stuck_json kubectl_err
+  local item_name item_namespace item_finalizers
 
-  crd_json=$(kubectl get crd "${crd_name}" -o json 2>/dev/null) || return 0
+  # Fail-closed on kubectl errors so a transient API/auth hiccup cannot let
+  # pre-flight silently pass. capture_kubectl_json keeps stdout parseable
+  # even when kubectl prints warnings on stderr during a successful call.
+  if ! capture_kubectl_json crd_json get crd "${crd_name}" -o json; then
+    kubectl_err="${crd_json}"
+    echo "" >&2
+    echo "ERROR: Pre-flight could not inspect CRD '${crd_name}' (release ${component})." >&2
+    echo "  kubectl output: ${kubectl_err}" >&2
+    echo "  Failing closed: if this is a transient API/auth error the script" >&2
+    echo "  may remove the operator before finalizers are reconciled." >&2
+    echo "  Re-run after the API recovers, or use --skip-preflight to bypass." >&2
+    return 1
+  fi
   read -r plural group scope < <(echo "${crd_json}" | jq -r '[.spec.names.plural, .spec.group, .spec.scope] | @tsv' 2>/dev/null) || return 0
   [[ -z "${plural}" || "${plural}" == "null" ]] && return 0
 
@@ -171,33 +307,111 @@ check_crd_for_stuck_resources() {
   # Filter out kubernetes.io/* finalizers — those are handled by K8s controllers
   # and will be processed regardless of whether the operator is running.
   local jq_filter='[.metadata.finalizers // [] | .[] | select(startswith("kubernetes.io/") | not)]'
+  stuck=""
   if [[ "${scope}" == "Namespaced" ]]; then
-    stuck=$(kubectl get "${resource}" -A -o json 2>/dev/null \
-      | jq -r --arg f "${jq_filter}" '.items[] | ('"${jq_filter}"') as $f | select(($f | length) > 0) | "    " + .metadata.namespace + "/" + .metadata.name + "  finalizers=[" + ($f | join(",")) + "]"' 2>/dev/null || true)
+    if ! capture_kubectl_json stuck_json get "${resource}" -A -o json; then
+      echo "" >&2
+      echo "ERROR: Pre-flight could not list '${resource}' (release ${component})." >&2
+      echo "  kubectl output: ${stuck_json}" >&2
+      echo "  Failing closed so we do not silently miss a stuck CR." >&2
+      echo "  Re-run after the API recovers, or use --skip-preflight to bypass." >&2
+      return 1
+    fi
+    while IFS=$'\x1f' read -r item_namespace item_name item_finalizers; do
+      stuck="${stuck}    ${item_namespace}/${item_name}  finalizers=[${item_finalizers}]"$'\n'
+    done < <(echo "${stuck_json}" \
+      | jq -r '.items[] | ('"${jq_filter}"') as $f | select(($f | length) > 0) | [(.metadata.namespace // ""), .metadata.name, ($f | join(","))] | join("\u001f")' 2>/dev/null || true)
   else
-    stuck=$(kubectl get "${resource}" -o json 2>/dev/null \
-      | jq -r '.items[] | ('"${jq_filter}"') as $f | select(($f | length) > 0) | "    " + .metadata.name + "  finalizers=[" + ($f | join(",")) + "]"' 2>/dev/null || true)
+    if ! capture_kubectl_json stuck_json get "${resource}" -o json; then
+      echo "" >&2
+      echo "ERROR: Pre-flight could not list '${resource}' (release ${component})." >&2
+      echo "  kubectl output: ${stuck_json}" >&2
+      echo "  Failing closed so we do not silently miss a stuck CR." >&2
+      echo "  Re-run after the API recovers, or use --skip-preflight to bypass." >&2
+      return 1
+    fi
+    while IFS=$'\x1f' read -r item_name item_finalizers; do
+      stuck="${stuck}    ${item_name}  finalizers=[${item_finalizers}]"$'\n'
+    done < <(echo "${stuck_json}" \
+      | jq -r '.items[] | ('"${jq_filter}"') as $f | select(($f | length) > 0) | [.metadata.name, ($f | join(","))] | join("\u001f")' 2>/dev/null || true)
   fi
 
   if [[ -n "${stuck}" ]]; then
     {
       echo "  ${component} — ${crd_name}:"
-      echo "${stuck}"
+      printf '%s' "${stuck}"
     } >> "${PREFLIGHT_DETAILS}"
   fi
 }
 
 # Check a Helm release for CRDs whose custom resources have active finalizers.
-# Extracts CRD names from the release manifest and checks each one.
-# Silently skips releases that are not installed (helm get manifest fails).
+# Discovery intentionally stays narrow:
+#   1. The chart's templates/ section, via `helm get manifest`
+#   2. CRDs annotated with this Helm release
+#   3. A tiny exact-name override list for known crds/-installed operator CRDs
+# This keeps the guard understandable and avoids broad cluster-wide ownership
+# inference while still catching the high-risk operator CRs that motivated the
+# pre-flight in the first place.
 # Args: $1 = release name, $2 = namespace
 check_release_for_stuck_crds() {
   local release="$1"
   local ns="$2"
-  local manifest
-  manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null) || return 0
-  echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}' \
+  local manifest manifest_crds annotated_crds explicit_crds
+  local all_crds_json kubectl_err crd_name
+  # `helm get manifest` is best-effort: if it fails (release missing, helm
+  # transient error), keep going and let the annotation- and exact-CRD
+  # discovery still run. Returning early here would re-introduce a false-
+  # negative path where a flaky helm hides CRDs that are still present.
+  manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
+  manifest_crds=$(echo "${manifest}" \
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+
+  all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
+  if [[ -z "${all_crds_json}" ]]; then
+    if ! capture_kubectl_json all_crds_json get crd -o json; then
+      kubectl_err="${all_crds_json}"
+      echo "" >&2
+      echo "ERROR: Pre-flight could not list CRDs for release '${release}'." >&2
+      echo "  kubectl output: ${kubectl_err}" >&2
+      echo "  Failing closed: if this is a transient API/auth error the script" >&2
+      echo "  may remove the operator before finalizers are reconciled." >&2
+      echo "  Re-run after the API recovers, or use --skip-preflight to bypass." >&2
+      return 1
+    fi
+  fi
+
+  annotated_crds=$(echo "${all_crds_json}" \
+    | jq -r --arg rel "${release}" --arg ns "${ns}" \
+      '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns) | .metadata.name' 2>/dev/null || true)
+  explicit_crds=""
+  while read -r crd_name; do
+    [[ -z "${crd_name}" ]] && continue
+    explicit_crds="${explicit_crds}$(echo "${all_crds_json}" \
+      | jq -r --arg name "${crd_name}" --arg rel "${release}" --arg ns "${ns}" \
+        '.items[]
+         | select(.metadata.name == $name)
+         | select(
+             ((.metadata.annotations["meta.helm.sh/release-name"] // "") == "")
+             or
+             (
+               .metadata.annotations["meta.helm.sh/release-name"] == $rel
+               and
+               .metadata.annotations["meta.helm.sh/release-namespace"] == $ns
+             )
+           )
+         | .metadata.name' 2>/dev/null || true)"$'\n'
+  done < <(extra_crds_for_release "${release}")
+  # All three sources empty → release isn't installed and no leftover CRDs.
+  # (Distinct from the API-error path above: here kubectl succeeded and we
+  # genuinely observed no relevant CRDs.)
+  [[ -z "${manifest_crds}" && -z "${annotated_crds}" && -z "${explicit_crds}" ]] && return 0
+  # awk 'NF' drops empty lines without the exit-1-on-no-match behavior of
+  # `grep -v '^$'`, which would abort under `set -euo pipefail` when a release
+  # has no CRDs (e.g., chart ships none, installed with --skip-crds, already
+  # cleaned up).
+  printf '%s\n%s\n%s\n' "${manifest_crds}" "${annotated_crds}" "${explicit_crds}" \
+    | awk 'NF' \
+    | sort -u \
     | while read -r crd_name; do
         check_crd_for_stuck_resources "${crd_name}" "${release}"
       done
@@ -216,10 +430,26 @@ if [[ "${SKIP_PREFLIGHT}" == "true" ]]; then
 else
   echo "Running pre-flight checks..."
   PREFLIGHT_DETAILS=$(mktemp "${TMPDIR:-/tmp}/.aicr_preflight_XXXXXX")
+  PREFLIGHT_ALL_CRDS_JSON=""
 
+  if ! capture_kubectl_json PREFLIGHT_ALL_CRDS_JSON get crd -o json; then
+    echo "" >&2
+    echo "ERROR: Pre-flight could not list CRDs." >&2
+    echo "  kubectl output: ${PREFLIGHT_ALL_CRDS_JSON}" >&2
+    echo "  Failing closed: if this is a transient API/auth error the script" >&2
+    echo "  may remove an operator before finalizers are reconciled." >&2
+    echo "  Re-run after the API recovers, or use --skip-preflight to bypass." >&2
+    rm -f "${PREFLIGHT_DETAILS}"
+    exit 1
+  fi
   {{ range .ComponentsReversed -}}
   {{ if .HasChart -}}
-  check_release_for_stuck_crds "{{ .Name }}" "{{ .Namespace }}"
+  if skip_preflight_for_release "{{ .Name }}"; then
+    echo "  Skipping {{ .Name }} ({{ .Namespace }}): bundle deletes dependent manifests before controller uninstall."
+  else
+    echo "  Checking {{ .Name }} ({{ .Namespace }})..."
+    check_release_for_stuck_crds "{{ .Name }}" "{{ .Namespace }}"
+  fi
   {{ end -}}
   {{ end }}
   if [[ -s "${PREFLIGHT_DETAILS}" ]]; then
@@ -298,28 +528,19 @@ kubectl get crd -o json 2>/dev/null \
     '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns) | .metadata.name' 2>/dev/null \
   | while read -r name; do
       echo "Deleting CRD ${name} (owned by {{ .Name }}/{{ .Namespace }})..."
-      kubectl delete crd "${name}" --ignore-not-found --wait=false
-    done
+      # Per-CRD `|| echo Warning:` keeps the loop making best-effort progress
+      # across the remaining CRDs while surfacing each delete failure
+      # (RBAC, timeout) with the specific CRD name -- post-flight's
+      # Helm-annotation re-check catches any that still linger.
+      kubectl delete crd "${name}" --ignore-not-found --wait=false \
+        || echo "Warning: failed to delete CRD ${name} (owned by {{ .Name }}/{{ .Namespace }}); leftovers will surface in post-flight" >&2
+    done || echo "Warning: orphan-CRD cleanup for {{ .Name }}/{{ .Namespace }} failed (kubectl get / jq error); leftovers will surface in post-flight" >&2
 {{- end }}{{ end }}
 
-# Clean up CRDs created by operators at runtime (not Helm-managed).
-# Only includes groups whose parent operator was part of this bundle.
-ORPHANED_CRD_GROUPS=""
-{{- range .ComponentsReversed }}
-{{- if eq .Name "kai-scheduler" }} ORPHANED_CRD_GROUPS="${ORPHANED_CRD_GROUPS} kai.scheduler scheduling.run.ai"{{ end }}
-{{- if eq .Name "gpu-operator" }} ORPHANED_CRD_GROUPS="${ORPHANED_CRD_GROUPS} nvidia.com nfd.k8s-sigs.io"{{ end }}
-{{- if eq .Name "dynamo-platform" }} ORPHANED_CRD_GROUPS="${ORPHANED_CRD_GROUPS} grove.io scheduler.grove.io"{{ end }}
-{{- if eq .Name "kube-prometheus-stack" }} ORPHANED_CRD_GROUPS="${ORPHANED_CRD_GROUPS} monitoring.coreos.com"{{ end }}
-{{- if eq .Name "k8s-nim-operator" }} ORPHANED_CRD_GROUPS="${ORPHANED_CRD_GROUPS} apps.nvidia.com"{{ end }}
-{{- if eq .Name "kubeflow-trainer" }} ORPHANED_CRD_GROUPS="${ORPHANED_CRD_GROUPS} trainer.kubeflow.org jobset.x-k8s.io"{{ end }}
-{{- end }}
-for group in ${ORPHANED_CRD_GROUPS}; do
-  crds=$(kubectl get crd -o name 2>/dev/null | grep "\.${group}$" || true)
-  for crd in ${crds}; do
-    echo "Deleting ${crd}..."
-    kubectl delete "${crd}" --ignore-not-found --wait=false
-  done
-done
+# Intentionally skip automatic deletion of unannotated CRDs matched only by
+# API group. On shared clusters, those CRDs may be serving another tenant's
+# release in the same group, and we do not have bundle-specific ownership
+# metadata to distinguish "ours" from "theirs" safely.
 
 # Warn about CRDs stuck in deleting state (e.g., customresourcecleanup finalizer
 # can't be resolved because CR instances still have controller-managed finalizers).
@@ -421,16 +642,58 @@ if [[ -n "${stale_apis}" ]]; then
   postflight_issues=true
 fi
 
-# Check for orphaned CRDs from bundle components
-orphaned_crds=""
-for group in ${ORPHANED_CRD_GROUPS}; do
-  remaining=$(kubectl get crd -o name 2>/dev/null | grep "\.${group}$" || true)
-  if [[ -n "${remaining}" ]]; then
-    orphaned_crds="${orphaned_crds} ${remaining}"
+# Check for Helm-annotated CRDs from uninstalled releases.
+# Mirrors the per-component CRD deletion loop above: if cleanup succeeded,
+# every annotated CRD is gone and this check stays silent. Catches cases
+# where the deletion loop logged a transient kubectl/jq warning and moved on.
+# CRDs already being deleted (non-null .metadata.deletionTimestamp) are excluded --
+# the earlier `kubectl delete crd ... --wait=false` returns immediately, so a slow
+# finalizer can leave the CRD still listed here even though it is being cleaned up
+# normally. Only truly stuck (not-yet-terminating) CRDs should be surfaced.
+helm_orphaned_crds=""
+explicit_orphaned_crds=""
+postflight_all_crds_json=""
+if capture_kubectl_json postflight_all_crds_json get crd -o json; then
+  :
+{{- range .ComponentsReversed }}{{ if .HasChart }}
+  remaining_helm_crds=$(echo "${postflight_all_crds_json}" \
+    | jq -r --arg rel "{{ .Name }}" --arg ns "{{ .Namespace }}" \
+      '.items[] | select(.metadata.annotations["meta.helm.sh/release-name"]==$rel and .metadata.annotations["meta.helm.sh/release-namespace"]==$ns and .metadata.deletionTimestamp==null) | .metadata.name' 2>/dev/null || true)
+  if [[ -n "${remaining_helm_crds}" ]]; then
+    helm_orphaned_crds="${helm_orphaned_crds} ${remaining_helm_crds}"
   fi
-done
-if [[ -n "${orphaned_crds}" ]]; then
-  echo "WARNING: orphaned CRDs still present:${orphaned_crds}"
+{{- end }}{{ end }}
+{{- range .ComponentsReversed }}{{ if .HasChart }}
+  while read -r crd_name; do
+    [[ -z "${crd_name}" ]] && continue
+    remaining_explicit_crd=$(echo "${postflight_all_crds_json}" \
+      | jq -r --arg name "${crd_name}" \
+        '.items[] | select(.metadata.name==$name and .metadata.deletionTimestamp==null) | .metadata.name' 2>/dev/null || true)
+    if [[ -n "${remaining_explicit_crd}" ]]; then
+      explicit_orphaned_crds="${explicit_orphaned_crds}${remaining_explicit_crd}"$'\n'
+    fi
+  done < <(extra_crds_for_release "{{ .Name }}")
+{{- end }}{{ end }}
+else
+  echo "Warning: failed to enumerate post-flight CRDs; kubectl output: ${postflight_all_crds_json}" >&2
+  postflight_issues=true
+fi
+if [[ -n "${helm_orphaned_crds}" ]]; then
+  echo "WARNING: Helm-annotated CRDs from uninstalled releases still present:${helm_orphaned_crds}"
+  echo "  Cleanup did not remove all CRDs owned by this bundle's releases."
+  echo "  Delete with: kubectl delete crd <name>"
+  postflight_issues=true
+fi
+
+# Check for exact-name CRDs from known crds/-installed releases.
+# These CRDs are intentionally tracked by explicit name instead of API group so
+# post-flight can surface leftovers without risking cross-tenant cleanup on
+# shared clusters.
+explicit_orphaned_crds=$(printf '%s' "${explicit_orphaned_crds}" | awk 'NF' | sort -u | tr '\n' ' ')
+if [[ -n "${explicit_orphaned_crds}" ]]; then
+  echo "WARNING: explicit CRDs from this bundle still present: ${explicit_orphaned_crds}"
+  echo "  These CRDs are installed outside Helm manifest/annotation discovery."
+  echo "  Delete with: kubectl delete crd <name>"
   postflight_issues=true
 fi
 


### PR DESCRIPTION
## Summary

Fixes bugs in [`pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl`](https://github.com/NVIDIA/aicr/blob/73f09b9cf8b390298d8f3d19161876b08e93297f/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl), which generates the bundle `undeploy.sh`, by hardening pre-flight checks, cleanup behavior, and post-flight diagnostics.

## Motivation / Context

The generated `undeploy.sh` had a few real correctness gaps:

- transient `kubectl` / `jq` failures in cleanup could abort the script mid-run under `set -euo pipefail`
- pre-flight could miss some release-owned CRDs, or falsely block safe undeploys for bundle-managed resources that are deleted before controller uninstall
- post-flight did not clearly surface all leftover Helm-owned CRDs after uninstall

This PR fixes those behaviors in the `undeploy.sh` template so newly generated bundles get the corrected undeploy flow.

Fixes: N/A
Related:
- issue `#406`: https://github.com/NVIDIA/aicr/issues/406
- PR `#561`: https://github.com/NVIDIA/aicr/pull/561

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

### 1. Cleanup pipelines are now best-effort under `set -euo pipefail`

The template now emits warning-and-continue wrappers for cleanup pipelines that were previously able to abort `undeploy.sh` mid-run on a single transient API failure.

That applies to:

- `delete_release_cluster_resources`
- `force_clear_namespace_finalizers`
- the inline Helm-owned orphan-CRD cleanup loop

This keeps undeploy moving into later cleanup phases and post-flight reporting instead of exiting halfway through cleanup.

### 2. Pre-flight CRD discovery is release-scoped and explicit

The final pre-flight design intentionally stays narrow. The template now checks CRDs from only these sources:

- CRDs present in `helm get manifest`
- CRDs annotated to the Helm release via `meta.helm.sh/release-*`
- a small explicit `extra_crds_for_release()` list for known `crds/`-installed operator CRDs that matter for undeploy safety

The explicit override list is currently limited to:

- `gpu-operator`
- `kai-scheduler`
- `k8s-nim-operator`
- `kubeflow-trainer`
- `kube-prometheus-stack`
- `dynamo-platform`
- `network-operator`

This preserves the safety value of pre-flight without reintroducing broader API-group ownership inference across the cluster.

### 3. Pre-flight now skips known manifest-managed false-positive cases

Some releases in the bundle create custom resources from `manifests/` that undeploy deletes before uninstalling the controller. Those resources can safely carry controller finalizers during undeploy, so pre-flight should not block on them.

The template now handles those cases with an explicit `skip_preflight_for_release()` helper instead of trying to infer manifest ownership dynamically:

- `skyhook-operator`
- `kgateway`

That is the deliberate simplification: explicit known skips instead of broader manifest-parsing / ownership inference.

### 4. Retained pre-flight checks now fail closed and are easier to diagnose

For the remaining pre-flight checks, the generated script now:

- caches `kubectl get crd -o json` once per run
- preserves successful `kubectl ... -o json` stderr warnings without poisoning JSON parsing
- surfaces discovery failures instead of silently treating them as "no CRDs"
- prints per-release progress during pre-flight

The intent is: if the script cannot safely determine whether retained release-owned CRDs still have stuck finalizers, it should say so clearly instead of silently passing pre-flight.

### 5. Shared-cluster cleanup is intentionally conservative

The template no longer emits destructive cleanup that deletes unannotated CRDs based only on API-group matching.

Destructive cleanup is limited to CRDs that can be attributed to a just-uninstalled Helm release. Post-flight then reports leftover Helm-owned CRDs still present after uninstall.

That is the intended shared-cluster safety tradeoff: avoid deleting foreign-tenant CRDs just because they share an API group.

### 6. Post-flight now uses one cached CRD listing for both warning paths

The post-flight section now fetches CRDs once and reuses that cached JSON for:

- leftover Helm-annotated CRD warnings
- leftover explicit-name `crds/` CRD warnings

That keeps post-flight cheaper and avoids repeating the same cluster-wide CRD fetch inside the component loop.

### 7. Namespace finalizer clearing now warns on discovery failure

`force_clear_namespace_finalizers` no longer silently returns when `kubectl api-resources` fails. It now emits a warning so operators can see why a namespace may remain stuck in `Terminating`.

### 8. `--skip-preflight` is now documented

The CLI reference now documents `--skip-preflight`, which the script already supports and which fail-closed pre-flight errors point operators to explicitly.

## Testing

```bash
go test -race ./pkg/bundler/deployer/helm/...
make qualify
```

- `go test -race ./pkg/bundler/deployer/helm/...` passed.
- `make qualify` was rerun in a clean temporary worktree and passed through tests, coverage, vet, lint, and e2e.
- The final `grype` vulnerability scan was still running when I stopped waiting on that earlier clean-worktree run, so I am not claiming a fully completed `make qualify` for the code changes.
- Subsequent PR title/body-only edits did not rerun full `make qualify`, because they did not change the repo code.
- `pkg/bundler/deployer/helm` coverage remains `88.1%`, unchanged from `origin/main`.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** This changes undeploy safety checks and cleanup behavior in the generated bundle script, but it does not change the bundle format or deploy path. The main user-visible differences are: safer handling of transient cleanup failures, better pre-flight coverage for release-owned CRDs, explicit skipping of known manifest-managed cases, and clearer post-flight leftover diagnostics.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
