### PR TITLE
chore(gitignore): add /CLAUDE.local.md for Claude Code overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ docs/plans
 # Per-clone local agent overlay (see AGENTS.md "Local Overlay" section)
 /AGENTS.local.md
 
+# Per-clone Claude Code personal overlay (auto-loaded alongside .claude/CLAUDE.md)
+/CLAUDE.local.md
+
 # Validator generator scaffolding output
 pkg/validator/checks/**/*_README.md
 pkg/validator/checks/**/*_recipe.yaml


### PR DESCRIPTION
## Summary

Adds `/CLAUDE.local.md` to `.gitignore` next to the existing `/AGENTS.local.md` entry, blessing `CLAUDE.local.md` at the repo root as the canonical name for per-clone, personal Claude Code overlays.

## Motivation / Context

Claude Code auto-loads `CLAUDE.local.md` at the repo root as a personal, working-copy-specific instruction overlay (docs: https://code.claude.com/docs/en/memory.md). The repo already blesses `/AGENTS.local.md` for Codex and other agents that follow the AGENTS.md convention — this PR does the same for Claude's native local-overlay file so developers who want Claude-only personal rules have a drop-in path and don't accidentally commit them.

Only the ignore rule is shared; the `CLAUDE.local.md` file itself stays on each developer's clone.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.gitignore` only

## Implementation Notes

Single 3-line addition to `.gitignore` — the comment follows the same style as the existing `/AGENTS.local.md` entry. No changes to `CLAUDE.md`, `AGENTS.md`, or the `check-agents-sync` tooling.

## Testing

```bash
# Verify new entry ignores a local file:
touch CLAUDE.local.md && git check-ignore -v CLAUDE.local.md
# .gitignore:143:/CLAUDE.local.md	CLAUDE.local.md
```

Skipped full `make qualify` — change is infra-only and touches no Go / YAML / docs files and cannot affect tests, linting, or agents sync.

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert

**Rollout notes:** N/A — purely additive gitignore entry.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, infra change
- [x] Linter passes (`make lint`) — N/A, no code changes
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase (mirrors `/AGENTS.local.md` entry)
- [x] Commits are cryptographically signed (`git commit -S`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->