### PR TITLE
enhance(validator): add targeted post-deployment GPU readiness checks

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -600,7 +600,7 @@ The `deployment` phase verifies that the cluster is actually ready for GPU workl
 
 - Enabled component namespaces are `Active`.
 - Declared `expectedResources` (Deployments, DaemonSets, etc.) exist and are healthy.
-- When `skyhook-customizations` is enabled: every Skyhook CR the recipe declares reports `status.status == complete`. The set of expected CR names is extracted from the recipe's own `ComponentRef.ManifestFiles` for this component, so unrelated Skyhook CRs on the cluster (stale from prior deploys, or owned by another tenant) are ignored.
+- When `skyhook-customizations` is enabled: every Skyhook CR the recipe declares reports `status.status == complete`. The set of expected CR names is extracted from the recipe's own `ComponentRef.ManifestFiles` for this component, so unrelated Skyhook CRs on the cluster (stale from prior deploys, or owned by another tenant) are ignored. If no Skyhook names can be extracted from those `ManifestFiles`, deployment validation fails closed as a recipe/configuration error instead of skipping.
 - When `gpu-operator` is enabled: `ClusterPolicy` reports `status.state == ready`.
 - When `nvidia-dra-driver-gpu` is enabled: the kubelet-plugin DaemonSet is ready. Discovery is by the upstream chart's role-suffix convention — the validator finds the single DaemonSet in the component namespace whose name ends in `-kubelet-plugin`, so custom `fullnameOverride` values are handled automatically.
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -587,12 +587,26 @@ Validation can be run in different phases to validate different aspects of the d
 
 | Phase | Description | When to Run |
 |-------|-------------|-------------|
-| `deployment` | Validates component deployment health and expected resources | After deploying components |
+| `deployment` | Validates component deployment completeness plus post-install GPU readiness signals (see below) | After deploying components |
 | `performance` | Validates system performance and network fabric health | After components are running |
 | `conformance` | Validates workload-specific requirements and conformance | Before running production workloads |
 | `all` | Runs all phases sequentially with dependency logic | Complete end-to-end validation |
 
 > **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs.
+
+**Deployment phase checks:**
+
+The `deployment` phase verifies that the cluster is actually ready for GPU workloads — not just that install commands returned successfully. It covers:
+
+- Enabled component namespaces are `Active`.
+- Declared `expectedResources` (Deployments, DaemonSets, etc.) exist and are healthy.
+- When `skyhook-customizations` is enabled: every Skyhook CR the recipe declares reports `status.status == complete`. The set of expected CR names is extracted from the recipe's own `ComponentRef.ManifestFiles` for this component, so unrelated Skyhook CRs on the cluster (stale from prior deploys, or owned by another tenant) are ignored.
+- When `gpu-operator` is enabled: `ClusterPolicy` reports `status.state == ready`.
+- When `nvidia-dra-driver-gpu` is enabled: the kubelet-plugin DaemonSet is ready. Discovery is by the upstream chart's role-suffix convention — the validator finds the single DaemonSet in the component namespace whose name ends in `-kubelet-plugin`, so custom `fullnameOverride` values are handled automatically.
+
+**Graceful skip:** If a component is declared in the recipe but its CRD is not yet registered on the cluster (e.g., fresh cluster, operator chart not installed), the corresponding readiness check is skipped rather than failing. Once the CRD is present, the check runs and a missing CR is treated as a real failure — for example, if the `gpu-operator` CRD is registered but no `ClusterPolicy` CR exists, deployment validation fails with a "CR missing" diagnostic rather than silently passing. Other errors still fail closed: an RBAC denial on `skyhooks.skyhook.nvidia.com` returns HTTP 403 (not a `NoMatch`), so the validator surfaces it as a failure instead of silently skipping the Skyhook check.
+
+**Day-N re-verification:** Because this is a read-only check against live cluster state, re-running `aicr validate --phase deployment` after scale-up, upgrade, or other runtime changes is safe and answers the same "is this cluster ready for GPU workloads now?" question.
 
 **Phase Dependencies:**
 - Phases run sequentially when using `--phase all`
@@ -744,7 +758,7 @@ Results are output in CTRF (Common Test Report Format) — an industry-standard 
         "status": "passed",
         "duration": 0,
         "suite": ["deployment"],
-        "stdout": ["All expected resources are healthy"]
+        "stdout": ["All deployment resources and required readiness signals are healthy"]
       },
       {
         "name": "nccl-all-reduce-bw",

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -630,33 +630,60 @@ test_validate() {
 # Deployment Phase Constraint Tests
 # =============================================================================
 
-test_validate_deployment_checks() {
-  msg "=========================================="
-  msg "Testing deployment checks (constraints, expected-resources, chainsaw)"
-  msg "=========================================="
-
-  # Create validation namespace for tests
-  kubectl create namespace aicr-validation 2>&1 || true
-
-  if [ "$FAKE_GPU_ENABLED" != "true" ]; then
-    skip "validate/deployment-constraints" "Fake GPU not enabled"
-    skip "validate/expected-resources" "Fake GPU not enabled"
-    skip "validate/chainsaw-healthcheck" "Fake GPU not enabled"
-    return 0
-  fi
-
-  local validate_dir="${OUTPUT_DIR}/validate-deployment-checks"
-  mkdir -p "$validate_dir"
-
-  # -----------------------------------------------------------------------
-  # Shared setup: Create fake GPU operator deployment ONCE
-  # -----------------------------------------------------------------------
-  msg "--- Setup: Create fake GPU operator deployment ---"
+setup_fake_gpu_operator_fixture() {
   kubectl create namespace gpu-operator --dry-run=client -o yaml | kubectl apply -f - 2>&1 || true
-  # Clean up leftover validator pods from previous tests that ran in gpu-operator namespace.
   kubectl delete jobs,pods -n gpu-operator -l app=aicr-validator --ignore-not-found 2>&1 || true
 
-  cat <<YAML | kubectl apply -f - 2>&1
+  # Deliberate: the CRD below does NOT declare `subresources: { status: {} }`.
+  # We want kubectl apply on the ClusterPolicy CR that follows to persist the
+  # literal .status.state: ready field, so the validator's
+  # verifyClusterPolicyReady check sees the fixture as "ready". If a status
+  # subresource were declared, kubectl apply would silently drop .status
+  # updates (status is then only writable via PATCH on the /status
+  # subresource), and every deployment-phase test that depends on this
+  # fixture would start failing. If you need to add a status subresource
+  # later, also update the fixture to write .status via `kubectl patch
+  # --subresource=status`.
+  if ! cat <<YAML | kubectl apply -f - 2>&1; then
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterpolicies.nvidia.com
+spec:
+  group: nvidia.com
+  scope: Cluster
+  names:
+    plural: clusterpolicies
+    singular: clusterpolicy
+    kind: ClusterPolicy
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+YAML
+    return 1
+  fi
+
+  if ! kubectl wait --for=condition=Established crd/clusterpolicies.nvidia.com --timeout=60s 2>&1; then
+    return 1
+  fi
+
+  if ! cat <<YAML | kubectl apply -f - 2>&1; then
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-policy
+status:
+  state: ready
+YAML
+    return 1
+  fi
+
+  if ! cat <<YAML | kubectl apply -f - 2>&1; then
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -680,10 +707,43 @@ spec:
         image: nvcr.io/nvidia/gpu-operator:v24.6.0
         imagePullPolicy: IfNotPresent
 YAML
-  apply_rc=$?
+    return 1
+  fi
 
-  if [ $apply_rc -eq 0 ]; then
-    detail "Created fake GPU operator deployment (v24.6.0)"
+  kubectl wait --for=condition=available deployment/gpu-operator -n gpu-operator --timeout=60s 2>&1 || true
+}
+
+cleanup_fake_gpu_operator_fixture() {
+  kubectl delete deployment gpu-operator -n gpu-operator --ignore-not-found 2>&1 || true
+  kubectl delete clusterpolicy cluster-policy --ignore-not-found 2>&1 || true
+  kubectl delete crd clusterpolicies.nvidia.com --ignore-not-found 2>&1 || true
+}
+
+test_validate_deployment_checks() {
+  msg "=========================================="
+  msg "Testing deployment checks (constraints, expected-resources, chainsaw)"
+  msg "=========================================="
+
+  # Create validation namespace for tests
+  kubectl create namespace aicr-validation 2>&1 || true
+
+  if [ "$FAKE_GPU_ENABLED" != "true" ]; then
+    skip "validate/deployment-constraints" "Fake GPU not enabled"
+    skip "validate/expected-resources" "Fake GPU not enabled"
+    skip "validate/chainsaw-healthcheck" "Fake GPU not enabled"
+    return 0
+  fi
+
+  local validate_dir="${OUTPUT_DIR}/validate-deployment-checks"
+  mkdir -p "$validate_dir"
+
+  # -----------------------------------------------------------------------
+  # Shared setup: Create fake GPU operator readiness fixture ONCE
+  # -----------------------------------------------------------------------
+  msg "--- Setup: Create fake GPU operator readiness fixture ---"
+
+  if setup_fake_gpu_operator_fixture; then
+    detail "Created fake GPU operator deployment and ready ClusterPolicy fixture"
   else
     skip "validate/deployment-constraint-pass" "Could not create GPU operator deployment"
     skip "validate/deployment-constraint-fail" "Could not create GPU operator deployment"
@@ -694,9 +754,6 @@ YAML
     skip "validate/chainsaw-healthcheck-fail" "Could not create GPU operator deployment"
     return 0
   fi
-
-  # Wait for deployment to be available (needed for chainsaw and expected-resources tests)
-  kubectl wait --for=condition=available deployment/gpu-operator -n gpu-operator --timeout=60s 2>&1 || true
 
   # -----------------------------------------------------------------------
   # Constraint tests
@@ -1005,7 +1062,7 @@ RECIPE
   if ! kubectl wait --for=condition=available deployment/gpu-operator -n gpu-operator --timeout=60s 2>&1; then
     skip "validate/chainsaw-healthcheck-pass" "GPU operator deployment not available"
     skip "validate/chainsaw-healthcheck-fail" "GPU operator deployment not available"
-    kubectl delete deployment gpu-operator -n gpu-operator 2>&1 || true
+    cleanup_fake_gpu_operator_fixture
     return 0
   fi
 
@@ -1117,8 +1174,8 @@ RECIPE
   # -----------------------------------------------------------------------
   # Single cleanup for ALL deployment check tests
   # -----------------------------------------------------------------------
-  msg "--- Cleanup: Removing fake GPU operator deployment ---"
-  kubectl delete deployment gpu-operator -n gpu-operator 2>&1 || true
+  msg "--- Cleanup: Removing fake GPU operator readiness fixture ---"
+  cleanup_fake_gpu_operator_fixture
 }
 
 test_validate_job_deployment() {
@@ -1133,6 +1190,21 @@ test_validate_job_deployment() {
 
   local validate_dir="${OUTPUT_DIR}/validate-jobs"
   mkdir -p "$validate_dir"
+
+  msg "--- Setup: Create fake GPU operator readiness fixture ---"
+  if setup_fake_gpu_operator_fixture; then
+    detail "Created fake GPU operator deployment and ready ClusterPolicy fixture"
+  else
+    skip "validate/job-rbac-serviceaccount" "Could not create GPU operator readiness fixture"
+    skip "validate/job-rbac-role" "Could not create GPU operator readiness fixture"
+    skip "validate/job-creation" "Could not create GPU operator readiness fixture"
+    skip "validate/job-success" "Could not create GPU operator readiness fixture"
+    skip "validate/command-success" "Could not create GPU operator readiness fixture"
+    skip "validate/job-custom-namespace" "Could not create GPU operator readiness fixture"
+    skip "validate/job-cleanup" "Could not create GPU operator readiness fixture"
+    skip "validate/job-result-format" "Could not create GPU operator readiness fixture"
+    return 0
+  fi
 
   # Create a recipe with explicit deployment checks so Jobs are created.
   local recipe_file="${validate_dir}/recipe.yaml"
@@ -1306,6 +1378,7 @@ RECIPE
   # Cleanup test namespaces
   kubectl delete namespace aicr-validation 2>&1 || true
   kubectl delete namespace custom-validation 2>&1 || true
+  cleanup_fake_gpu_operator_fixture
 }
 
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -52,6 +52,9 @@ AICR_VALIDATOR_IMAGE="${AICR_VALIDATOR_IMAGE:-localhost:5001/aicr-validator:loca
 SNAPSHOT_NAMESPACE="${SNAPSHOT_NAMESPACE:-default}"
 SNAPSHOT_CM="${SNAPSHOT_CM:-aicr-e2e-snapshot}"
 FAKE_GPU_ENABLED="${FAKE_GPU_ENABLED:-false}"
+CREATED_FAKE_GPU_OPERATOR_DEPLOYMENT=false
+CREATED_FAKE_CLUSTER_POLICY=false
+CREATED_FAKE_CLUSTER_POLICY_CRD=false
 
 # Test counters
 TOTAL_TESTS=0
@@ -631,8 +634,25 @@ test_validate() {
 # =============================================================================
 
 setup_fake_gpu_operator_fixture() {
+  CREATED_FAKE_GPU_OPERATOR_DEPLOYMENT=false
+  CREATED_FAKE_CLUSTER_POLICY=false
+  CREATED_FAKE_CLUSTER_POLICY_CRD=false
+
   kubectl create namespace gpu-operator --dry-run=client -o yaml | kubectl apply -f - 2>&1 || true
   kubectl delete jobs,pods -n gpu-operator -l app=aicr-validator --ignore-not-found 2>&1 || true
+
+  if kubectl get deployment gpu-operator -n gpu-operator >/dev/null 2>&1; then
+    warn "Skipping fake GPU operator fixture: deployment/gpu-operator already exists in namespace gpu-operator"
+    return 1
+  fi
+  if kubectl get clusterpolicy cluster-policy >/dev/null 2>&1; then
+    warn "Skipping fake GPU operator fixture: ClusterPolicy cluster-policy already exists"
+    return 1
+  fi
+  if kubectl get crd clusterpolicies.nvidia.com >/dev/null 2>&1; then
+    warn "Skipping fake GPU operator fixture: CRD clusterpolicies.nvidia.com already exists"
+    return 1
+  fi
 
   # Deliberate: the CRD below does NOT declare `subresources: { status: {} }`.
   # We want kubectl apply on the ClusterPolicy CR that follows to persist the
@@ -667,8 +687,10 @@ spec:
 YAML
     return 1
   fi
+  CREATED_FAKE_CLUSTER_POLICY_CRD=true
 
   if ! kubectl wait --for=condition=Established crd/clusterpolicies.nvidia.com --timeout=60s 2>&1; then
+    cleanup_fake_gpu_operator_fixture
     return 1
   fi
 
@@ -680,8 +702,10 @@ metadata:
 status:
   state: ready
 YAML
+    cleanup_fake_gpu_operator_fixture
     return 1
   fi
+  CREATED_FAKE_CLUSTER_POLICY=true
 
   if ! cat <<YAML | kubectl apply -f - 2>&1; then
 apiVersion: apps/v1
@@ -707,16 +731,30 @@ spec:
         image: nvcr.io/nvidia/gpu-operator:v24.6.0
         imagePullPolicy: IfNotPresent
 YAML
+    cleanup_fake_gpu_operator_fixture
     return 1
   fi
+  CREATED_FAKE_GPU_OPERATOR_DEPLOYMENT=true
 
-  kubectl wait --for=condition=available deployment/gpu-operator -n gpu-operator --timeout=60s 2>&1 || true
+  if ! kubectl wait --for=condition=available deployment/gpu-operator -n gpu-operator --timeout=60s 2>&1; then
+    cleanup_fake_gpu_operator_fixture
+    return 1
+  fi
 }
 
 cleanup_fake_gpu_operator_fixture() {
-  kubectl delete deployment gpu-operator -n gpu-operator --ignore-not-found 2>&1 || true
-  kubectl delete clusterpolicy cluster-policy --ignore-not-found 2>&1 || true
-  kubectl delete crd clusterpolicies.nvidia.com --ignore-not-found 2>&1 || true
+  if [ "${CREATED_FAKE_GPU_OPERATOR_DEPLOYMENT}" = "true" ]; then
+    kubectl delete deployment gpu-operator -n gpu-operator --ignore-not-found 2>&1 || true
+    CREATED_FAKE_GPU_OPERATOR_DEPLOYMENT=false
+  fi
+  if [ "${CREATED_FAKE_CLUSTER_POLICY}" = "true" ]; then
+    kubectl delete clusterpolicy cluster-policy --ignore-not-found 2>&1 || true
+    CREATED_FAKE_CLUSTER_POLICY=false
+  fi
+  if [ "${CREATED_FAKE_CLUSTER_POLICY_CRD}" = "true" ]; then
+    kubectl delete crd clusterpolicies.nvidia.com --ignore-not-found 2>&1 || true
+    CREATED_FAKE_CLUSTER_POLICY_CRD=false
+  fi
 }
 
 test_validate_deployment_checks() {

--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -171,7 +171,9 @@ func verifyNamespacesActive(ctx *validators.Context, refs []recipe.ComponentRef)
 		}
 		seen[ref.Namespace] = true
 
-		ns, err := ctx.Clientset.CoreV1().Namespaces().Get(ctx.Ctx, ref.Namespace, metav1.GetOptions{})
+		verifyCtx, cancel := ctx.Timeout(defaults.ResourceVerificationTimeout)
+		ns, err := ctx.Clientset.CoreV1().Namespaces().Get(verifyCtx, ref.Namespace, metav1.GetOptions{})
+		cancel()
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("namespace %s: %v", ref.Namespace, err))
 			continue
@@ -270,7 +272,9 @@ func verifySkyhookReady(ctx *validators.Context, ref recipe.ComponentRef) error 
 
 	var failures []string
 	for _, name := range expectedNames {
-		sk, getErr := dynClient.Resource(skyhookGVR).Get(ctx.Ctx, name, metav1.GetOptions{})
+		verifyCtx, cancel := ctx.Timeout(defaults.ResourceVerificationTimeout)
+		sk, getErr := dynClient.Resource(skyhookGVR).Get(verifyCtx, name, metav1.GetOptions{})
+		cancel()
 		if getErr != nil {
 			if apierrors.IsNotFound(getErr) {
 				failures = append(failures, fmt.Sprintf("Skyhook %s: not found (recipe declared it but the cluster has no such CR)", name))
@@ -406,7 +410,9 @@ func verifyClusterPolicyReady(ctx *validators.Context) error {
 		return err
 	}
 
-	clusterPolicy, err := dynClient.Resource(clusterPolicyGVR).Get(ctx.Ctx, clusterPolicyName, metav1.GetOptions{})
+	verifyCtx, cancel := ctx.Timeout(defaults.ResourceVerificationTimeout)
+	clusterPolicy, err := dynClient.Resource(clusterPolicyGVR).Get(verifyCtx, clusterPolicyName, metav1.GetOptions{})
+	cancel()
 	if err != nil {
 		// CRD is registered (we just checked). Any Get error here — including
 		// IsNotFound on the CR itself — signals that gpu-operator is installed

--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -17,16 +17,63 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/validators"
 	"github.com/NVIDIA/aicr/validators/chainsaw"
 	"github.com/NVIDIA/aicr/validators/helper"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
+)
+
+const (
+	gpuOperatorComponent = "gpu-operator"
+	skyhookComponent     = "skyhook-customizations"
+	draDriverComponent   = "nvidia-dra-driver-gpu"
+	clusterPolicyName    = "cluster-policy"
+
+	// draKubeletPluginSuffix is the chart-template-defined name suffix for
+	// the NVIDIA DRA driver's kubelet-plugin DaemonSet. The upstream chart
+	// renders its DaemonSet name as "<fullname>-kubelet-plugin", where
+	// "<fullname>" is controlled by chart values. Discovering by suffix is
+	// deployer-neutral: it reads only a live Kubernetes object name shape,
+	// makes no assumption about release identity or the deployer that
+	// installed the chart.
+	draKubeletPluginSuffix = "-kubelet-plugin"
+
+	// aicrCreatedBy{Key,Value} document the label convention AICR manifests
+	// apply to resources they create ("app.kubernetes.io/created-by=aicr").
+	// The deployment-phase checks no longer use this label as a live-cluster
+	// filter — Skyhook readiness scopes by the exact CR names declared in
+	// the recipe's ManifestFiles, which is stronger than a label match —
+	// but tests still reference the constants when synthesizing fixture CRs
+	// that mirror production manifests.
+	aicrCreatedByLabelKey   = "app.kubernetes.io/created-by"
+	aicrCreatedByLabelValue = "aicr"
+
+	clusterPolicyReadyState = "ready"
+	skyhookCompleteState    = "complete"
+)
+
+var (
+	clusterPolicyGVR = schema.GroupVersionResource{
+		Group: "nvidia.com", Version: "v1", Resource: "clusterpolicies",
+	}
+	skyhookGVR = schema.GroupVersionResource{
+		Group: "skyhook.nvidia.com", Version: "v1alpha1", Resource: "skyhooks",
+	}
 )
 
 // checkExpectedResources verifies that all expected Kubernetes resources declared
@@ -35,11 +82,17 @@ func checkExpectedResources(ctx *validators.Context) error {
 	if ctx.Recipe == nil {
 		return errors.New(errors.ErrCodeInvalidRequest, "recipe is not available")
 	}
+	if ctx.Clientset == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
+	}
 
 	var chainsawAsserts []chainsaw.ComponentAssert
 	var failures []string
+	enabledRefs := enabledComponentRefs(ctx.Recipe.ComponentRefs)
 
-	for _, ref := range ctx.Recipe.ComponentRefs {
+	failures = append(failures, verifyNamespacesActive(ctx, enabledRefs)...)
+
+	for _, ref := range enabledRefs {
 		if ref.HealthCheckAsserts != "" && len(ref.ExpectedResources) == 0 {
 			chainsawAsserts = append(chainsawAsserts, chainsaw.ComponentAssert{
 				Name:       ref.Name,
@@ -57,6 +110,8 @@ func checkExpectedResources(ctx *validators.Context) error {
 			}
 		}
 	}
+
+	failures = append(failures, verifyGPUReadinessSignals(ctx, enabledRefs)...)
 
 	if len(chainsawAsserts) > 0 {
 		slog.Info("running health check assertions", "components", len(chainsawAsserts))
@@ -92,13 +147,369 @@ func checkExpectedResources(ctx *validators.Context) error {
 				len(failures), strings.Join(failures, "\n  ")))
 	}
 
-	fmt.Println("All expected resources are healthy")
+	fmt.Println("All deployment resources and required readiness signals are healthy")
 	return nil
+}
+
+func enabledComponentRefs(refs []recipe.ComponentRef) []recipe.ComponentRef {
+	enabled := make([]recipe.ComponentRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref.IsEnabled() {
+			enabled = append(enabled, ref)
+		}
+	}
+	return enabled
+}
+
+func verifyNamespacesActive(ctx *validators.Context, refs []recipe.ComponentRef) []string {
+	var failures []string
+	seen := make(map[string]bool, len(refs))
+
+	for _, ref := range refs {
+		if ref.Namespace == "" || seen[ref.Namespace] {
+			continue
+		}
+		seen[ref.Namespace] = true
+
+		ns, err := ctx.Clientset.CoreV1().Namespaces().Get(ctx.Ctx, ref.Namespace, metav1.GetOptions{})
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("namespace %s: %v", ref.Namespace, err))
+			continue
+		}
+		if ns.Status.Phase != corev1.NamespaceActive {
+			failures = append(failures, fmt.Sprintf("namespace %s: phase=%s (want %s)", ref.Namespace, ns.Status.Phase, corev1.NamespaceActive))
+			continue
+		}
+
+		fmt.Printf("  Namespace %s: Active\n", ref.Namespace)
+	}
+
+	return failures
+}
+
+func verifyGPUReadinessSignals(ctx *validators.Context, refs []recipe.ComponentRef) []string {
+	var failures []string
+
+	if ref, ok := findEnabledComponent(refs, skyhookComponent); ok {
+		if err := verifySkyhookReady(ctx, ref); err != nil {
+			failures = append(failures, err.Error())
+		}
+	}
+
+	if _, ok := findEnabledComponent(refs, gpuOperatorComponent); ok {
+		if err := verifyClusterPolicyReady(ctx); err != nil {
+			failures = append(failures, err.Error())
+		}
+	}
+
+	if ref, ok := findEnabledComponent(refs, draDriverComponent); ok {
+		if err := verifyDRAKubeletPluginReady(ctx, ref.Namespace); err != nil {
+			failures = append(failures, err.Error())
+		}
+	}
+
+	return failures
+}
+
+func findEnabledComponent(refs []recipe.ComponentRef, name string) (recipe.ComponentRef, bool) {
+	for _, ref := range refs {
+		if ref.Name == name {
+			return ref, true
+		}
+	}
+	return recipe.ComponentRef{}, false
+}
+
+// verifySkyhookReady checks that the specific Skyhook CR(s) this recipe
+// declares are present and have reached status.status == "complete".
+//
+// Deployer-neutrality stance: no Helm API calls, no reads of release
+// metadata, no dependence on release-scoped labels. The set of Skyhook CRs
+// to verify is derived from the recipe's own ComponentRef.ManifestFiles —
+// the validator reads those manifests from the embedded data provider and
+// extracts each Skyhook resource's metadata.name. At runtime it then looks
+// those exact names up on the cluster via the Kubernetes API. Unrelated
+// Skyhook CRs on the cluster (stale from previous deploys, or from other
+// tenants) are explicitly ignored.
+func verifySkyhookReady(ctx *validators.Context, ref recipe.ComponentRef) error {
+	expectedNames, err := expectedSkyhookNames(ref)
+	if err != nil {
+		return err
+	}
+	if len(expectedNames) == 0 {
+		// The recipe enabled skyhook-customizations but declared no Skyhook
+		// manifests, so we cannot prove readiness. Fail closed rather than
+		// silently pass — treating this as a recipe misconfiguration that the
+		// user should see.
+		return errors.New(errors.ErrCodeNotFound,
+			fmt.Sprintf("no Skyhook CR names could be extracted from component %s manifestFiles=%v",
+				ref.Name, ref.ManifestFiles))
+	}
+
+	// Discovery-gate the CRD before attempting Get by name. Matches the
+	// verifyClusterPolicyReady pattern: CRD not registered → skip per #607;
+	// any other discovery error (RBAC, 5xx, timeout) → fail closed so a
+	// transient discovery failure cannot mask readiness.
+	gv := skyhookGVR.GroupVersion().String()
+	_, discErr := ctx.Clientset.Discovery().ServerResourcesForGroupVersion(gv)
+	switch {
+	case discErr == nil:
+		// fall through to per-CR checks
+	case apierrors.IsNotFound(discErr):
+		fmt.Printf("  Skyhook: %s not registered, skipping\n", gv)
+		return nil
+	default:
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to discover %s resources (is the API server reachable and RBAC in order?)", gv), discErr)
+	}
+
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	var failures []string
+	for _, name := range expectedNames {
+		sk, getErr := dynClient.Resource(skyhookGVR).Get(ctx.Ctx, name, metav1.GetOptions{})
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				failures = append(failures, fmt.Sprintf("Skyhook %s: not found (recipe declared it but the cluster has no such CR)", name))
+				continue
+			}
+			failures = append(failures, fmt.Sprintf("Skyhook %s: failed to get: %v", name, getErr))
+			continue
+		}
+		status, found, statusErr := unstructured.NestedString(sk.Object, "status", "status")
+		if statusErr != nil {
+			failures = append(failures, fmt.Sprintf("Skyhook %s: failed to read status.status: %v", name, statusErr))
+			continue
+		}
+		if !found {
+			failures = append(failures, fmt.Sprintf("Skyhook %s: missing status.status", name))
+			continue
+		}
+		if status != skyhookCompleteState {
+			failures = append(failures, fmt.Sprintf("Skyhook %s: status=%s (want %s)", name, status, skyhookCompleteState))
+			continue
+		}
+		fmt.Printf("  Skyhook %s: %s\n", name, skyhookCompleteState)
+	}
+
+	if len(failures) > 0 {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("%d of %d expected Skyhook(s) not ready:\n  %s",
+				len(failures), len(expectedNames), strings.Join(failures, "\n  ")))
+	}
+	return nil
+}
+
+// expectedSkyhookNames derives the set of Skyhook CR names that this
+// component is expected to deploy, by reading each ManifestFile through the
+// recipe data provider and extracting the metadata.name of every Skyhook
+// resource declared in those files.
+func expectedSkyhookNames(ref recipe.ComponentRef) ([]string, error) {
+	seen := make(map[string]bool)
+	var names []string
+	for _, path := range ref.ManifestFiles {
+		content, err := recipe.GetManifestContent(path)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal,
+				fmt.Sprintf("failed to load manifest %s for component %s", path, ref.Name), err)
+		}
+		for _, name := range extractSkyhookNamesFromManifest(content) {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// skyhookKindRE and skyhookMetadataNameRE are narrow extractors for Skyhook
+// CR names out of a manifest file that may contain Helm template directives
+// ({{ ... }}). A full YAML parse is not an option: templated lines are not
+// valid YAML on their own, and evaluating Helm templates at validate time
+// would require chart values the validator does not have.
+//
+// These patterns make three chart-shape assumptions that hold across every
+// manifest AICR ships today (tuning, no-op, tuning-gke in
+// recipes/components/skyhook-customizations/manifests/):
+//   - "kind: Skyhook" sits at column 0.
+//   - The metadata.name of each Skyhook is a literal string (not templated)
+//     at exactly 2-space indent under a top-level "metadata:" block.
+//   - Document separators use a bare "---" on its own line.
+//
+// If those shapes change, the helper's direct unit tests fail loudly.
+var (
+	skyhookKindRE         = regexp.MustCompile(`(?m)^kind:\s*Skyhook\s*$`)
+	skyhookDocSeparatorRE = regexp.MustCompile(`(?m)^---\s*$`)
+	skyhookMetadataNameRE = regexp.MustCompile(`(?m)^  name:\s+(\S+)\s*$`)
+)
+
+// extractSkyhookNamesFromManifest returns the metadata.name of every Skyhook
+// CR declared in a (possibly Helm-templated) manifest file. Names that are
+// themselves templated (e.g. "{{ .Chart.Name }}") are skipped — the
+// validator cannot evaluate them, and a templated name is never what a
+// concrete AICR recipe declares today.
+func extractSkyhookNamesFromManifest(content []byte) []string {
+	var names []string
+	for _, doc := range skyhookDocSeparatorRE.Split(string(content), -1) {
+		if !skyhookKindRE.MatchString(doc) {
+			continue
+		}
+		m := skyhookMetadataNameRE.FindStringSubmatch(doc)
+		if m == nil {
+			continue
+		}
+		name := strings.Trim(m[1], `"'`)
+		if strings.Contains(name, "{{") {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func verifyClusterPolicyReady(ctx *validators.Context) error {
+	// Use discovery to distinguish two cases the dynamic-client Get conflates:
+	//   1. CRD not registered ("CustomResourceDefinition clusterpolicies
+	//      does not exist") — the recipe declares gpu-operator but the
+	//      operator chart is not installed yet. Skip per #607.
+	//   2. CRD registered but the cluster-policy CR is absent — gpu-operator
+	//      is installed but its singleton CR was never created or has been
+	//      manually deleted. The operator cannot reconcile the GPU stack in
+	//      that state, so this is a real misconfiguration — fail.
+	// A bare Get() that returns IsNotFound cannot tell these apart. Explicit
+	// discovery lookup does.
+	//
+	// Critically, only skip on IsNotFound from discovery. Anything else
+	// (403 from RBAC, 5xx from an overloaded API server, network timeout) is
+	// a real signal that we cannot prove readiness, and silently passing would
+	// hide a broken cluster. Fail closed on those.
+	gv := clusterPolicyGVR.GroupVersion().String()
+	_, discErr := ctx.Clientset.Discovery().ServerResourcesForGroupVersion(gv)
+	switch {
+	case discErr == nil:
+		// fall through to the CR check
+	case apierrors.IsNotFound(discErr):
+		fmt.Printf("  ClusterPolicy: %s not registered, skipping\n", gv)
+		return nil
+	default:
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to discover %s resources (is the API server reachable and RBAC in order?)", gv), discErr)
+	}
+
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	clusterPolicy, err := dynClient.Resource(clusterPolicyGVR).Get(ctx.Ctx, clusterPolicyName, metav1.GetOptions{})
+	if err != nil {
+		// CRD is registered (we just checked). Any Get error here — including
+		// IsNotFound on the CR itself — signals that gpu-operator is installed
+		// but not reconciled. Surface it rather than silently skipping.
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"failed to get ClusterPolicy cluster-policy (gpu-operator installed but CR missing?)", err)
+	}
+
+	state, found, stateErr := unstructured.NestedString(clusterPolicy.Object, "status", "state")
+	if stateErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to read ClusterPolicy status.state", stateErr)
+	}
+	if !found {
+		return errors.New(errors.ErrCodeInternal, "ClusterPolicy status.state not found")
+	}
+	if state != clusterPolicyReadyState {
+		return errors.New(errors.ErrCodeInternal, fmt.Sprintf("ClusterPolicy state=%s (want %s)", state, clusterPolicyReadyState))
+	}
+
+	fmt.Printf("  ClusterPolicy %s: %s\n", clusterPolicyName, clusterPolicyReadyState)
+	return nil
+}
+
+// verifyDRAKubeletPluginReady locates the kubelet-plugin DaemonSet by
+// Kubernetes object shape — not by Helm release identity — and gates on pod
+// readiness.
+//
+// Deployer-neutrality stance: no Helm API calls, no reads of release
+// metadata, no dependence on release-scoped labels like
+// app.kubernetes.io/instance. The check lists DaemonSets in the component's
+// namespace and selects the one whose name ends in the chart's hard-coded
+// role suffix "-kubelet-plugin". This is a *chart-shape* assumption (the
+// upstream nvidia-dra-driver-gpu chart names that DaemonSet
+// "<fullname>-kubelet-plugin" regardless of how fullname resolves), not a
+// deployer assumption. If the upstream chart ever renames the component,
+// this constant moves with it.
+func verifyDRAKubeletPluginReady(ctx *validators.Context, namespace string) error {
+	verifyCtx, cancel := ctx.Timeout(defaults.ResourceVerificationTimeout)
+	defer cancel()
+
+	dsList, err := ctx.Clientset.AppsV1().DaemonSets(namespace).List(verifyCtx, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to list DaemonSets in namespace %s", namespace), err)
+	}
+
+	var matches []appsv1.DaemonSet
+	var seenNames []string
+	for _, ds := range dsList.Items {
+		seenNames = append(seenNames, ds.Name)
+		if strings.HasSuffix(ds.Name, draKubeletPluginSuffix) {
+			matches = append(matches, ds)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return errors.New(errors.ErrCodeNotFound,
+			fmt.Sprintf("no kubelet-plugin DaemonSet (name suffix %q) found in namespace %s (DaemonSets in namespace: %s)",
+				draKubeletPluginSuffix, namespace, formatNames(seenNames)))
+	case 1:
+		// proceed
+	default:
+		matchedNames := make([]string, 0, len(matches))
+		for _, ds := range matches {
+			matchedNames = append(matchedNames, ds.Name)
+		}
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("ambiguous: %d DaemonSets in namespace %s match kubelet-plugin role suffix %q: %s",
+				len(matches), namespace, draKubeletPluginSuffix, formatNames(matchedNames)))
+	}
+
+	ds := matches[0]
+	if ds.Status.DesiredNumberScheduled == 0 || ds.Status.NumberReady == 0 {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("DaemonSet %s/%s: no ready kubelet-plugin pods scheduled (%d/%d pods ready)",
+				namespace, ds.Name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled))
+	}
+	if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled {
+		return errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("DaemonSet %s/%s: not healthy: %d/%d pods ready",
+				namespace, ds.Name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled))
+	}
+
+	fmt.Printf("  DaemonSet %s/%s: healthy\n", namespace, ds.Name)
+	return nil
+}
+
+func formatNames(names []string) string {
+	if len(names) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(names, ", ") + "]"
 }
 
 func buildResourceFetcher(ctx *validators.Context) (chainsaw.ResourceFetcher, error) {
 	if ctx.RESTConfig == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "no kubernetes client configuration available")
+	}
+
+	dynClient, err := getDynamicClient(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	discoveryClient, err := kubernetes.NewForConfig(ctx.RESTConfig)
@@ -110,5 +521,20 @@ func buildResourceFetcher(ctx *validators.Context) (chainsaw.ResourceFetcher, er
 		memory.NewMemCacheClient(discoveryClient.Discovery()),
 	)
 
-	return chainsaw.NewClusterFetcher(ctx.DynamicClient, mapper), nil
+	return chainsaw.NewClusterFetcher(dynClient, mapper), nil
+}
+
+func getDynamicClient(ctx *validators.Context) (dynamic.Interface, error) {
+	if ctx.DynamicClient != nil {
+		return ctx.DynamicClient, nil
+	}
+	if ctx.RESTConfig == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "RESTConfig is not available")
+	}
+
+	dynClient, err := dynamic.NewForConfig(ctx.RESTConfig)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create dynamic client", err)
+	}
+	return dynClient, nil
 }

--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -53,16 +53,6 @@ const (
 	// installed the chart.
 	draKubeletPluginSuffix = "-kubelet-plugin"
 
-	// aicrCreatedBy{Key,Value} document the label convention AICR manifests
-	// apply to resources they create ("app.kubernetes.io/created-by=aicr").
-	// The deployment-phase checks no longer use this label as a live-cluster
-	// filter — Skyhook readiness scopes by the exact CR names declared in
-	// the recipe's ManifestFiles, which is stronger than a label match —
-	// but tests still reference the constants when synthesizing fixture CRs
-	// that mirror production manifests.
-	aicrCreatedByLabelKey   = "app.kubernetes.io/created-by"
-	aicrCreatedByLabelValue = "aicr"
-
 	clusterPolicyReadyState = "ready"
 	skyhookCompleteState    = "complete"
 )
@@ -542,5 +532,6 @@ func getDynamicClient(ctx *validators.Context) (dynamic.Interface, error) {
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create dynamic client", err)
 	}
+	ctx.DynamicClient = dynClient
 	return dynClient, nil
 }

--- a/validators/deployment/expected_resources_test.go
+++ b/validators/deployment/expected_resources_test.go
@@ -1,0 +1,1118 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/validators"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// testDefaultDRADSName is the kubelet-plugin DaemonSet name the upstream
+// nvidia-dra-driver-gpu chart renders when no fullname override is in play.
+// Tests use it as a sane default fixture name, and a separate test exercises
+// an intentionally-different name to prove the role-suffix discovery works.
+const testDefaultDRADSName = "nvidia-dra-driver-gpu-kubelet-plugin"
+
+// testSkyhookManifest is the path of the Skyhook manifest the AICR embedded
+// data provider ships for the eks/h100/inference recipe used in most tests.
+// Declaring it once here keeps test setup aligned with the recipe defaults.
+const testSkyhookManifest = "components/skyhook-customizations/manifests/tuning.yaml"
+
+// TestMain forces the global recipe data provider to initialize before any
+// parallel t.Parallel() tests start. GetDataProvider() in pkg/recipe
+// performs lazy, unsynchronized initialization of the package-level
+// globalDataProvider — safe at normal runtime (the CLI initializes it on
+// startup), but racy under parallel unit tests that each call
+// recipe.GetManifestContent simultaneously. Calling it once here from the
+// test goroutine serializes the init.
+func TestMain(m *testing.M) {
+	_ = recipe.GetDataProvider()
+	os.Exit(m.Run())
+}
+
+func TestCheckExpectedResources_IncludesDeploymentCompletenessAndGPUReadiness(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("gpu-operator"),
+			activeNamespace("skyhook"),
+			activeNamespace("nvidia-dra-driver"),
+			activeNamespace("app-ns"),
+			readyDeployment("app-ns", "app-deployment", 1),
+			readyDaemonSet("nvidia-dra-driver", testDefaultDRADSName, 2),
+		},
+		[]runtime.Object{
+			clusterPolicyWithState(clusterPolicyReadyState),
+			skyhookWithStatus("tuning", skyhookCompleteState),
+		},
+		[]recipe.ComponentRef{
+			{Name: gpuOperatorComponent, Namespace: "gpu-operator"},
+			{Name: skyhookComponent, Namespace: "skyhook", ManifestFiles: []string{testSkyhookManifest}},
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+			{
+				Name:      "app-component",
+				Namespace: "app-ns",
+				ExpectedResources: []recipe.ExpectedResource{
+					{Kind: "Deployment", Namespace: "app-ns", Name: "app-deployment"},
+				},
+			},
+		},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil", err)
+	}
+}
+
+func TestCheckExpectedResources_FailsWhenSkyhookIncomplete(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("gpu-operator"),
+			activeNamespace("skyhook"),
+			activeNamespace("nvidia-dra-driver"),
+			readyDaemonSet("nvidia-dra-driver", testDefaultDRADSName, 1),
+		},
+		[]runtime.Object{
+			clusterPolicyWithState(clusterPolicyReadyState),
+			skyhookWithStatus("tuning", "waiting"),
+		},
+		[]recipe.ComponentRef{
+			{Name: gpuOperatorComponent, Namespace: "gpu-operator"},
+			{Name: skyhookComponent, Namespace: "skyhook", ManifestFiles: []string{testSkyhookManifest}},
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when Skyhook is not complete")
+	}
+	if !strings.Contains(err.Error(), "Skyhook tuning: status=waiting") {
+		t.Fatalf("expected Skyhook readiness failure, got: %v", err)
+	}
+}
+
+func TestCheckExpectedResources_FailsWhenNamespaceNotActive(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			inactiveNamespace("app-ns"),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: "app-component", Namespace: "app-ns"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when namespace is not Active")
+	}
+	if !strings.Contains(err.Error(), "namespace app-ns: phase=Terminating") {
+		t.Fatalf("expected namespace readiness failure, got: %v", err)
+	}
+}
+
+func TestCheckExpectedResources_SkipsDisabledComponents(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("app-ns"),
+			readyDeployment("app-ns", "app-deployment", 1),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{
+				Name:      skyhookComponent,
+				Namespace: "skyhook",
+				Overrides: map[string]any{"enabled": false},
+			},
+			{
+				Name:      draDriverComponent,
+				Namespace: "nvidia-dra-driver",
+				Overrides: map[string]any{"enabled": false},
+			},
+			{
+				Name:      "app-component",
+				Namespace: "app-ns",
+				ExpectedResources: []recipe.ExpectedResource{
+					{Kind: "Deployment", Namespace: "app-ns", Name: "app-deployment"},
+				},
+			},
+		},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil for disabled optional components", err)
+	}
+}
+
+// Regression test: Skyhook is a cluster-scoped CR. The validator must list it
+// without a namespace; otherwise the API server returns 404 even when the
+// resource exists on a real cluster.
+func TestVerifySkyhookReady_ListsClusterScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{activeNamespace("skyhook")},
+		[]runtime.Object{skyhookWithStatus("tuning", skyhookCompleteState)},
+		[]recipe.ComponentRef{{Name: skyhookComponent, Namespace: "skyhook", ManifestFiles: []string{testSkyhookManifest}}},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil for cluster-scoped Skyhook", err)
+	}
+}
+
+// Issue #607 acceptance: Skyhook check must skip gracefully when the CRD is
+// not registered on the cluster, even when skyhook-customizations is declared
+// in the recipe's componentRefs.
+func TestCheckExpectedResources_SkipsSkyhookWhenCRDNotRegistered(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContextWithUnregistered(t,
+		[]runtime.Object{activeNamespace("skyhook")},
+		nil,
+		[]schema.GroupVersionResource{skyhookGVR},
+		[]recipe.ComponentRef{{Name: skyhookComponent, Namespace: "skyhook", ManifestFiles: []string{testSkyhookManifest}}},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil when Skyhook CRD is not registered", err)
+	}
+}
+
+// Issue #607 acceptance (by symmetry): the gpu-operator readiness check must
+// skip gracefully when the ClusterPolicy CRD is not registered, so a recipe
+// can declare gpu-operator before the operator's CRDs are installed.
+func TestCheckExpectedResources_SkipsClusterPolicyWhenCRDNotRegistered(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContextWithUnregistered(t,
+		[]runtime.Object{activeNamespace("gpu-operator")},
+		nil,
+		[]schema.GroupVersionResource{clusterPolicyGVR},
+		[]recipe.ComponentRef{{Name: gpuOperatorComponent, Namespace: "gpu-operator"}},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil when ClusterPolicy CRD is not registered", err)
+	}
+}
+
+// Fail-closed test: when the discovery API itself returns a non-NotFound
+// error (e.g., 403 from RBAC, 5xx from an overloaded API server, network
+// timeout), the ClusterPolicy check must NOT treat that as "CRD not
+// registered" and skip. Anything other than IsNotFound means we cannot
+// prove readiness, so the check must surface a failure.
+func TestCheckExpectedResources_FailsWhenDiscoveryReturnsNonNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContextWithDiscovery(t,
+		[]runtime.Object{activeNamespace("gpu-operator")},
+		nil,
+		nil,
+		nil,
+		[]recipe.ComponentRef{{Name: gpuOperatorComponent, Namespace: "gpu-operator"}},
+	)
+
+	clientset, ok := ctx.Clientset.(*k8sfake.Clientset)
+	if !ok {
+		t.Fatalf("expected *k8sfake.Clientset, got %T", ctx.Clientset)
+	}
+	// Resource name is the literal string "resource" (not "apiresources") —
+	// that is the string FakeDiscovery hard-codes when synthesizing the
+	// testing.Action for ServerResourcesForGroupVersion. See
+	// vendor/k8s.io/client-go/discovery/fake/discovery.go: the action is built
+	// with schema.GroupVersionResource{Resource: "resource"}. A tighter-looking
+	// "apiresources" would not match anything, the reactor would not fire, and
+	// the test would fall through to the default 404 path (IsNotFound) instead
+	// of exercising the fail-closed branch.
+	clientset.PrependReactor("get", "resource", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "nvidia.com", Resource: "apiresources"},
+			"",
+			stderrors.New("forbidden: user cannot list apiresources"))
+	})
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when discovery returns a non-NotFound error (fail-closed)")
+	}
+	if !strings.Contains(err.Error(), "failed to discover") {
+		t.Fatalf("expected discovery failure to surface, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "not registered, skipping") {
+		t.Fatalf("discovery failure must not be treated as CRD-not-registered skip, got: %v", err)
+	}
+}
+
+// Disambiguation test: when the ClusterPolicy CRD *is* registered on the
+// cluster but the cluster-policy CR itself is absent, the check must fail
+// rather than skip. That state means gpu-operator is installed but has no
+// singleton to reconcile — a real misconfiguration the user should see, not
+// silently treat as "not applicable".
+func TestCheckExpectedResources_FailsWhenClusterPolicyCRMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContextWithDiscovery(t,
+		[]runtime.Object{activeNamespace("gpu-operator")},
+		nil,
+		[]schema.GroupVersion{clusterPolicyGVR.GroupVersion()},
+		nil,
+		[]recipe.ComponentRef{{Name: gpuOperatorComponent, Namespace: "gpu-operator"}},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when ClusterPolicy CR is missing but CRD is registered")
+	}
+	if !strings.Contains(err.Error(), "failed to get ClusterPolicy cluster-policy") {
+		t.Fatalf("expected ClusterPolicy-missing failure, got: %v", err)
+	}
+}
+
+// TestCheckExpectedResources_IgnoresStaleUnrelatedSkyhook pins the fix for
+// Codex review comment #2: an unrelated Skyhook CR left on the cluster from
+// a prior deploy (or from a different tenant) must NOT influence this
+// recipe's readiness result. The check is scoped to the Skyhook name(s) the
+// recipe itself declares via ComponentRef.ManifestFiles.
+func TestCheckExpectedResources_IgnoresStaleUnrelatedSkyhook(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("skyhook"),
+		},
+		[]runtime.Object{
+			// The recipe's manifestFiles point at tuning.yaml → expected name "tuning".
+			skyhookWithStatus("tuning", skyhookCompleteState),
+			// A stale "no-op" Skyhook lingering on the cluster in waiting state
+			// (simulating a partially-cleaned previous deploy). It happens to
+			// carry the AICR label — under the pre-fix implementation this would
+			// have failed the check.
+			skyhookWithStatus("no-op", "waiting"),
+		},
+		[]recipe.ComponentRef{
+			{Name: skyhookComponent, Namespace: "skyhook", ManifestFiles: []string{testSkyhookManifest}},
+		},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil — stale unrelated Skyhook must not affect the result", err)
+	}
+}
+
+// TestCheckExpectedResources_FailsWhenNoExpectedSkyhookNames pins the
+// fail-closed behavior when an enabled skyhook-customizations ref declares
+// no manifest files (or the manifests contain no Skyhook CRs). Rather than
+// silently pass, the check must surface this as a recipe misconfiguration.
+func TestCheckExpectedResources_FailsWhenNoExpectedSkyhookNames(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("skyhook"),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			// Intentionally no ManifestFiles — simulates a misconfigured recipe.
+			{Name: skyhookComponent, Namespace: "skyhook"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when enabled skyhook-customizations ref has no expected Skyhook names")
+	}
+	if !strings.Contains(err.Error(), "no Skyhook CR names could be extracted") {
+		t.Fatalf("expected 'no Skyhook CR names could be extracted' failure, got: %v", err)
+	}
+}
+
+func TestCheckExpectedResources_FailsWhenClusterPolicyMissingState(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("gpu-operator"),
+		},
+		[]runtime.Object{
+			clusterPolicyWithoutState(),
+		},
+		[]recipe.ComponentRef{
+			{Name: gpuOperatorComponent, Namespace: "gpu-operator"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when ClusterPolicy status.state is missing")
+	}
+	if !strings.Contains(err.Error(), "ClusterPolicy status.state not found") {
+		t.Fatalf("expected ClusterPolicy readiness failure, got: %v", err)
+	}
+}
+
+func TestCheckExpectedResources_FailsWhenDRAKubeletPluginMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("nvidia-dra-driver"),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when DRA kubelet plugin DaemonSet is missing")
+	}
+	if !strings.Contains(err.Error(), "no kubelet-plugin DaemonSet") {
+		t.Fatalf("expected DRA missing DaemonSet failure, got: %v", err)
+	}
+}
+
+func TestCheckExpectedResources_FailsWhenDRAKubeletPluginIsUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("nvidia-dra-driver"),
+			unreadyDaemonSet("nvidia-dra-driver", testDefaultDRADSName, 2, 1),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when DRA kubelet plugin DaemonSet is unhealthy")
+	}
+	if !strings.Contains(err.Error(), "DaemonSet nvidia-dra-driver/"+testDefaultDRADSName) {
+		t.Fatalf("expected DRA DaemonSet context in failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not healthy: 1/2 pods ready") {
+		t.Fatalf("expected unhealthy DaemonSet detail, got: %v", err)
+	}
+}
+
+func TestCheckExpectedResources_FailsWhenDRAKubeletPluginHasNoScheduledPods(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("nvidia-dra-driver"),
+			unreadyDaemonSet("nvidia-dra-driver", testDefaultDRADSName, 0, 0),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when DRA kubelet plugin DaemonSet has no scheduled pods")
+	}
+	if !strings.Contains(err.Error(), "no ready kubelet-plugin pods scheduled (0/0 pods ready)") {
+		t.Fatalf("expected zero-pod DaemonSet detail, got: %v", err)
+	}
+}
+
+// TestCheckExpectedResources_DRAKubeletPluginCustomName pins the fix for
+// Codex review comment #1: the check must locate the kubelet-plugin
+// DaemonSet by its chart-template role suffix ("-kubelet-plugin"), not by
+// its hard-coded default name. This lets it find the DaemonSet even when a
+// user overrides fullnameOverride (or the chart renders a different
+// fullname for any reason).
+func TestCheckExpectedResources_DRAKubeletPluginCustomName(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("nvidia-dra-driver"),
+			// DaemonSet named after a custom fullnameOverride; still ends in
+			// the upstream chart's hard-coded role suffix.
+			readyDaemonSet("nvidia-dra-driver", "my-custom-gpu-kubelet-plugin", 2),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil for custom-named kubelet-plugin DaemonSet", err)
+	}
+}
+
+// TestCheckExpectedResources_FailsWhenMultipleKubeletPluginDaemonSets pins
+// the ambiguity guard: two DaemonSets in the same namespace both ending in
+// the role suffix must produce an explicit failure listing their names,
+// rather than silently picking one.
+func TestCheckExpectedResources_FailsWhenMultipleKubeletPluginDaemonSets(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("nvidia-dra-driver"),
+			readyDaemonSet("nvidia-dra-driver", "alpha-kubelet-plugin", 2),
+			readyDaemonSet("nvidia-dra-driver", "beta-kubelet-plugin", 2),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when multiple kubelet-plugin DaemonSets match")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity failure, got: %v", err)
+	}
+	for _, name := range []string{"alpha-kubelet-plugin", "beta-kubelet-plugin"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("expected matched DaemonSet name %q in failure, got: %v", name, err)
+		}
+	}
+}
+
+// TestCheckExpectedResources_IgnoresUnrelatedDaemonSetInNamespace pins the
+// scoping guarantee: DaemonSets in the same namespace that don't match the
+// kubelet-plugin role suffix must be ignored entirely.
+func TestCheckExpectedResources_IgnoresUnrelatedDaemonSetInNamespace(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("nvidia-dra-driver"),
+			// An unrelated DaemonSet (e.g. monitoring agent) sharing the
+			// namespace — must not interfere.
+			unreadyDaemonSet("nvidia-dra-driver", "node-exporter", 3, 0),
+			// The real kubelet-plugin, healthy.
+			readyDaemonSet("nvidia-dra-driver", testDefaultDRADSName, 2),
+		},
+		nil,
+		[]recipe.ComponentRef{
+			{Name: draDriverComponent, Namespace: "nvidia-dra-driver"},
+		},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil — unrelated DaemonSet must be ignored", err)
+	}
+}
+
+// TestCheckExpectedResources_SurfacesMultipleSkyhookFailures pins Codex's
+// non-blocking observation #1: when a recipe declares multiple Skyhook CRs
+// and several are non-complete, all failures must surface in the error so
+// the user can diagnose the whole state, not just the first issue.
+func TestCheckExpectedResources_SurfacesMultipleSkyhookFailures(t *testing.T) {
+	t.Parallel()
+
+	// Use a synthetic recipe ref whose ManifestFiles point at the two real
+	// manifests that declare different names. tuning.yaml yields "tuning";
+	// no-op.yaml yields "no-op". The check must report both failures.
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{activeNamespace("skyhook")},
+		[]runtime.Object{
+			skyhookWithStatus("tuning", "waiting"),
+			skyhookWithStatus("no-op", "erroring"),
+		},
+		[]recipe.ComponentRef{
+			{
+				Name:      skyhookComponent,
+				Namespace: "skyhook",
+				ManifestFiles: []string{
+					"components/skyhook-customizations/manifests/tuning.yaml",
+					"components/skyhook-customizations/manifests/no-op.yaml",
+				},
+			},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when multiple expected Skyhooks are non-complete")
+	}
+	for _, needle := range []string{
+		"Skyhook tuning: status=waiting",
+		"Skyhook no-op: status=erroring",
+	} {
+		if !strings.Contains(err.Error(), needle) {
+			t.Fatalf("expected %q in failure, got: %v", needle, err)
+		}
+	}
+}
+
+// TestExtractSkyhookNamesFromManifest exercises the narrow manifest parser
+// directly. The most important case is Codex's: tuning-gke.yaml's filename
+// suggests "tuning-gke" but the actual metadata.name is "tuning".
+func TestExtractSkyhookNamesFromManifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content []byte
+		want    []string
+	}{
+		{
+			name: "simple single-document manifest",
+			content: []byte(`---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: tuning
+spec:
+  runtimeRequired: true
+`),
+			want: []string{"tuning"},
+		},
+		{
+			name: "multi-document manifest — both Skyhook names captured",
+			content: []byte(`---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: first
+---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: second
+`),
+			want: []string{"first", "second"},
+		},
+		{
+			name: "mixed kinds — non-Skyhook documents ignored",
+			content: []byte(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: tuning
+`),
+			want: []string{"tuning"},
+		},
+		{
+			name: "Helm template preamble — not-valid-YAML lines do not break extraction",
+			content: []byte(`{{- $cust := index .Values "skyhook-customizations" }}
+{{- if ne (toString (index $cust "enabled")) "false" }}
+---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+  labels:
+    app.kubernetes.io/part-of: skyhook-operator
+  name: tuning
+  namespace: {{ .Release.Namespace }}
+spec:
+  runtimeRequired: true
+  additionalTolerations:
+    {{- if $cust.acceleratedTolerations }}
+    {{- toYaml $cust.acceleratedTolerations | nindent 4 }}
+    {{- end }}
+{{- end }}
+`),
+			want: []string{"tuning"},
+		},
+		{
+			name:    "empty content",
+			content: []byte(""),
+			want:    nil,
+		},
+		{
+			name: "templated name — skipped (validator cannot evaluate Helm at validate time)",
+			content: []byte(`---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: {{ .Chart.Name }}
+`),
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractSkyhookNamesFromManifest(tc.content)
+			if !stringSlicesEqual(got, tc.want) {
+				t.Fatalf("extractSkyhookNamesFromManifest(...) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractSkyhookNamesFromManifest_TuningGke is the regression test for
+// Codex's explicit ask: tuning-gke.yaml's metadata.name is "tuning", not
+// "tuning-gke". A basename-derived heuristic would get this wrong.
+func TestExtractSkyhookNamesFromManifest_TuningGke(t *testing.T) {
+	t.Parallel()
+
+	content, err := recipe.GetManifestContent("components/skyhook-customizations/manifests/tuning-gke.yaml")
+	if err != nil {
+		t.Fatalf("failed to load tuning-gke manifest: %v", err)
+	}
+
+	got := extractSkyhookNamesFromManifest(content)
+	want := []string{"tuning"}
+	if !stringSlicesEqual(got, want) {
+		t.Fatalf("extractSkyhookNamesFromManifest(tuning-gke.yaml) = %v, want %v (metadata.name is 'tuning', not the filename basename)", got, want)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func newDeploymentTestContext(t *testing.T, kubeObjects, dynamicObjects []runtime.Object, refs []recipe.ComponentRef) *validators.Context {
+	t.Helper()
+	return newDeploymentTestContextWithUnregistered(t, kubeObjects, dynamicObjects, nil, refs)
+}
+
+// newDeploymentTestContextWithUnregistered builds a test context where the
+// given GVRs are treated as unregistered on the cluster. List/Get against
+// them return a meta.NoKindMatchError on the dynamic client, and the fake
+// clientset's discovery service does not advertise their GroupVersion —
+// mirroring what a real client sees when the CRD has not been installed.
+// Used by CRD-missing skip tests.
+//
+// Discovery registration for the *present* GVRs is inferred automatically
+// from dynamicObjects: every GVR that has at least one object in that slice
+// has its GroupVersion advertised (unless it also appears in unregistered).
+// Tests that need to advertise a GV without any objects should use
+// newDeploymentTestContextWithDiscovery below.
+func newDeploymentTestContextWithUnregistered(
+	t *testing.T,
+	kubeObjects, dynamicObjects []runtime.Object,
+	unregistered []schema.GroupVersionResource,
+	refs []recipe.ComponentRef,
+) *validators.Context {
+
+	t.Helper()
+	return newDeploymentTestContextWithDiscovery(t, kubeObjects, dynamicObjects, nil, unregistered, refs)
+}
+
+// newDeploymentTestContextWithDiscovery is the fully-explicit variant: callers
+// pass the exact list of GroupVersions the fake discovery service should
+// advertise. Needed by the "CRD present but CR missing" test, where we need
+// nvidia.com/v1 to appear in discovery without any ClusterPolicy object.
+func newDeploymentTestContextWithDiscovery(
+	t *testing.T,
+	kubeObjects, dynamicObjects []runtime.Object,
+	extraRegistered []schema.GroupVersion,
+	unregistered []schema.GroupVersionResource,
+	refs []recipe.ComponentRef,
+) *validators.Context {
+
+	t.Helper()
+
+	clientset := k8sfake.NewClientset(kubeObjects...)
+	configureFakeDiscovery(t, clientset, dynamicObjects, extraRegistered, unregistered)
+	dynClient := newFakeDynamicClient(dynamicObjects, unregistered...)
+
+	return &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: dynClient,
+		Recipe: &recipe.RecipeResult{
+			ComponentRefs: refs,
+		},
+	}
+}
+
+// configureFakeDiscovery wires the fake clientset's Discovery service so that
+// ServerResourcesForGroupVersion returns a non-error result for the
+// GroupVersions represented by dynamicObjects (minus any unregistered GVRs)
+// plus any extraRegistered GVs that the test declares explicitly.
+func configureFakeDiscovery(
+	t *testing.T,
+	clientset *k8sfake.Clientset,
+	dynamicObjects []runtime.Object,
+	extraRegistered []schema.GroupVersion,
+	unregistered []schema.GroupVersionResource,
+) {
+
+	t.Helper()
+
+	unregSet := make(map[schema.GroupVersion]bool, len(unregistered))
+	for _, gvr := range unregistered {
+		unregSet[gvr.GroupVersion()] = true
+	}
+
+	gvSet := make(map[schema.GroupVersion]bool)
+	for _, object := range dynamicObjects {
+		u, ok := object.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		gv := u.GroupVersionKind().GroupVersion()
+		if unregSet[gv] {
+			continue
+		}
+		gvSet[gv] = true
+	}
+	for _, gv := range extraRegistered {
+		if unregSet[gv] {
+			continue
+		}
+		gvSet[gv] = true
+	}
+
+	fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
+	if !ok {
+		t.Fatalf("expected *fakediscovery.FakeDiscovery, got %T", clientset.Discovery())
+	}
+	for gv := range gvSet {
+		fakeDisc.Resources = append(fakeDisc.Resources, &metav1.APIResourceList{
+			GroupVersion: gv.String(),
+		})
+	}
+}
+
+type fakeDynamicClient struct {
+	objects      map[schema.GroupVersionResource][]*unstructured.Unstructured
+	unregistered map[schema.GroupVersionResource]bool
+}
+
+func newFakeDynamicClient(objects []runtime.Object, unregistered ...schema.GroupVersionResource) dynamic.Interface {
+	store := make(map[schema.GroupVersionResource][]*unstructured.Unstructured)
+	for _, object := range objects {
+		item := object.(*unstructured.Unstructured)
+		gvk := item.GroupVersionKind()
+		gvr := gvrForTestObject(gvk)
+		store[gvr] = append(store[gvr], item.DeepCopy())
+	}
+	unregSet := make(map[schema.GroupVersionResource]bool, len(unregistered))
+	for _, gvr := range unregistered {
+		unregSet[gvr] = true
+	}
+	return &fakeDynamicClient{objects: store, unregistered: unregSet}
+}
+
+func gvrForTestObject(gvk schema.GroupVersionKind) schema.GroupVersionResource {
+	switch {
+	case gvk.Group == clusterPolicyGVR.Group && gvk.Version == clusterPolicyGVR.Version && gvk.Kind == "ClusterPolicy":
+		return clusterPolicyGVR
+	case gvk.Group == skyhookGVR.Group && gvk.Version == skyhookGVR.Version && gvk.Kind == "Skyhook":
+		return skyhookGVR
+	default:
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: strings.ToLower(gvk.Kind) + "s",
+		}
+	}
+}
+
+func (f *fakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	if f.unregistered[resource] {
+		return &fakeResourceClient{
+			resource:     resource,
+			unregistered: true,
+		}
+	}
+	return &fakeResourceClient{
+		resource: resource,
+		objects:  f.objects[resource],
+	}
+}
+
+// clusterScopedGVRs mirrors the API server's scope model so the fake fails
+// loudly if production code calls .Namespace(x) on a cluster-scoped resource
+// (which real k8s answers with a 404 "server could not find the requested
+// resource", not a silently empty list).
+var clusterScopedGVRs = map[schema.GroupVersionResource]bool{
+	clusterPolicyGVR: true,
+	skyhookGVR:       true,
+}
+
+type fakeResourceClient struct {
+	resource         schema.GroupVersionResource
+	namespace        string
+	objects          []*unstructured.Unstructured
+	unregistered     bool
+	invalidScopeCall bool
+}
+
+func (f *fakeResourceClient) Namespace(namespace string) dynamic.ResourceInterface {
+	if f.unregistered {
+		return f
+	}
+	if clusterScopedGVRs[f.resource] && namespace != "" {
+		// Any op on this client returns a "not found" error, matching the real
+		// API server's behavior for a namespaced request against a
+		// cluster-scoped resource.
+		return &fakeResourceClient{
+			resource:         f.resource,
+			invalidScopeCall: true,
+		}
+	}
+	return &fakeResourceClient{
+		resource:  f.resource,
+		namespace: namespace,
+		objects:   f.objects,
+	}
+}
+
+func (f *fakeResourceClient) Create(context.Context, *unstructured.Unstructured, metav1.CreateOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) Update(context.Context, *unstructured.Unstructured, metav1.UpdateOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) UpdateStatus(context.Context, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) Delete(context.Context, string, metav1.DeleteOptions, ...string) error {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) noKindMatchError() error {
+	return &meta.NoKindMatchError{
+		GroupKind:        schema.GroupKind{Group: f.resource.Group, Kind: f.resource.Resource},
+		SearchedVersions: []string{f.resource.Version},
+	}
+}
+
+func (f *fakeResourceClient) Get(_ context.Context, name string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+	if f.unregistered {
+		return nil, f.noKindMatchError()
+	}
+	if f.invalidScopeCall {
+		return nil, stderrors.New("the server could not find the requested resource")
+	}
+	for _, object := range f.objects {
+		if object.GetName() != name {
+			continue
+		}
+		if f.namespace != "" && object.GetNamespace() != f.namespace {
+			continue
+		}
+		return object.DeepCopy(), nil
+	}
+	return nil, stderrors.New("object not found")
+}
+
+func (f *fakeResourceClient) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if f.unregistered {
+		return nil, f.noKindMatchError()
+	}
+	if f.invalidScopeCall {
+		return nil, stderrors.New("the server could not find the requested resource")
+	}
+	list := &unstructured.UnstructuredList{
+		Items: make([]unstructured.Unstructured, 0, len(f.objects)),
+	}
+
+	for _, object := range f.objects {
+		if f.namespace != "" && object.GetNamespace() != f.namespace {
+			continue
+		}
+		if opts.LabelSelector != "" && !matchesLabelSelector(object, opts.LabelSelector) {
+			continue
+		}
+		list.Items = append(list.Items, *object.DeepCopy())
+	}
+
+	return list, nil
+}
+
+func (f *fakeResourceClient) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) Patch(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) Apply(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (f *fakeResourceClient) ApplyStatus(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func matchesLabelSelector(object *unstructured.Unstructured, selector string) bool {
+	parts := strings.SplitN(selector, "=", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	return object.GetLabels()[parts[0]] == parts[1]
+}
+
+func activeNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+}
+
+func inactiveNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceTerminating,
+		},
+	}
+}
+
+func readyDeployment(namespace, name string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: replicas,
+		},
+	}
+}
+
+//nolint:unparam // namespace is a meaningful test input even if current call sites all happen to use the same namespace
+func readyDaemonSet(namespace, name string, ready int32) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: ready,
+			NumberReady:            ready,
+		},
+	}
+}
+
+func unreadyDaemonSet(namespace, name string, desired, ready int32) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: desired,
+			NumberReady:            ready,
+		},
+	}
+}
+
+func clusterPolicyWithState(state string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nvidia.com/v1",
+			"kind":       "ClusterPolicy",
+			"metadata": map[string]interface{}{
+				"name": clusterPolicyName,
+			},
+			"status": map[string]interface{}{
+				"state": state,
+			},
+		},
+	}
+}
+
+// skyhookWithStatus builds a Skyhook fixture. Skyhook is a cluster-scoped CR,
+// so metadata.namespace is intentionally not set.
+func skyhookWithStatus(name, status string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "skyhook.nvidia.com/v1alpha1",
+			"kind":       "Skyhook",
+			"metadata": map[string]interface{}{
+				"name": name,
+				"labels": map[string]interface{}{
+					aicrCreatedByLabelKey: aicrCreatedByLabelValue,
+				},
+			},
+			"status": map[string]interface{}{
+				"status": status,
+			},
+		},
+	}
+}
+
+func clusterPolicyWithoutState() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nvidia.com/v1",
+			"kind":       "ClusterPolicy",
+			"metadata": map[string]interface{}{
+				"name": clusterPolicyName,
+			},
+			"status": map[string]interface{}{},
+		},
+	}
+}

--- a/validators/deployment/expected_resources_test.go
+++ b/validators/deployment/expected_resources_test.go
@@ -219,6 +219,29 @@ func TestCheckExpectedResources_SkipsSkyhookWhenCRDNotRegistered(t *testing.T) {
 	}
 }
 
+// When the Skyhook CRD is registered but the specific CR declared by the
+// recipe is absent, verifySkyhookReady should take the explicit IsNotFound
+// branch and surface the recipe-scoped "declared but missing" diagnostic.
+func TestCheckExpectedResources_FailsWhenSkyhookCRMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContextWithDiscovery(t,
+		[]runtime.Object{activeNamespace("skyhook")},
+		nil,
+		[]schema.GroupVersion{skyhookGVR.GroupVersion()},
+		nil,
+		[]recipe.ComponentRef{{Name: skyhookComponent, Namespace: "skyhook", ManifestFiles: []string{testSkyhookManifest}}},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error when Skyhook CR is missing but CRD is registered")
+	}
+	if !strings.Contains(err.Error(), "Skyhook tuning: not found (recipe declared it but the cluster has no such CR)") {
+		t.Fatalf("expected recipe-scoped Skyhook not-found failure, got: %v", err)
+	}
+}
+
 // Issue #607 acceptance (by symmetry): the gpu-operator readiness check must
 // skip gracefully when the ClusterPolicy CRD is not registered, so a recipe
 // can declare gpu-operator before the operator's CRDs are installed.
@@ -958,7 +981,10 @@ func (f *fakeResourceClient) Get(_ context.Context, name string, _ metav1.GetOpt
 		}
 		return object.DeepCopy(), nil
 	}
-	return nil, stderrors.New("object not found")
+	return nil, apierrors.NewNotFound(
+		schema.GroupResource{Group: f.resource.Group, Resource: f.resource.Resource},
+		name,
+	)
 }
 
 func (f *fakeResourceClient) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {

--- a/validators/deployment/expected_resources_test.go
+++ b/validators/deployment/expected_resources_test.go
@@ -50,6 +50,13 @@ const testDefaultDRADSName = "nvidia-dra-driver-gpu-kubelet-plugin"
 // Declaring it once here keeps test setup aligned with the recipe defaults.
 const testSkyhookManifest = "components/skyhook-customizations/manifests/tuning.yaml"
 
+// testAICRCreatedBy{Key,Value} mirror the label convention AICR manifests
+// apply to synthesized fixtures that should look like real production objects.
+const (
+	testAICRCreatedByLabelKey   = "app.kubernetes.io/created-by"
+	testAICRCreatedByLabelValue = "aicr"
+)
+
 // TestMain forces the global recipe data provider to initialize before any
 // parallel t.Parallel() tests start. GetDataProvider() in pkg/recipe
 // performs lazy, unsynchronized initialization of the package-level
@@ -1120,7 +1127,7 @@ func skyhookWithStatus(name, status string) *unstructured.Unstructured {
 			"metadata": map[string]interface{}{
 				"name": name,
 				"labels": map[string]interface{}{
-					aicrCreatedByLabelKey: aicrCreatedByLabelValue,
+					testAICRCreatedByLabelKey: testAICRCreatedByLabelValue,
 				},
 			},
 			"status": map[string]interface{}{


### PR DESCRIPTION
## Summary

Strengthen `aicr validate --phase deployment` by adding the targeted GPU-workload readiness signals the current validator misses — Skyhook customizations, NVIDIA DRA driver, and GPU Operator (`ClusterPolicy`) — on top of the existing namespace and `expectedResources` checks.

Concretely, this PR:
- keeps using the existing deployment phase
- preserves the existing baseline checks:
  - enabled namespaces are `Active`
  - declared `expectedResources` are healthy
- adds the targeted GPU-specific readiness checks the phase was missing:
  - `skyhook-customizations`: Skyhook CR completion
  - `nvidia-dra-driver-gpu`: kubelet-plugin readiness
  - `gpu-operator`: `ClusterPolicy.status.state == ready`

So the main new value is the addition of the targeted Skyhook, DRA, and GPU Operator deep readiness checks on top of the preserved baseline deployment checks.

> Follow-up note: the broader registry-driven work to make deployment-phase validation symmetric and deep for **all** components is now tracked in [#622](https://github.com/NVIDIA/aicr/issues/622). This PR remains intentionally scoped to the targeted GPU readiness gap narrowed in `#607`.

The check stays strictly deployer-neutral: no Helm API calls, no dependence on Argo CD or any other deployer, no reads of release metadata, no release-identity assumptions. Every lookup is a plain Kubernetes API call against live-cluster object shape, so the command can be used as a standalone tool to verify any Kubernetes cluster's runtime install regardless of how the bundle was deployed (`deploy.sh`, Argo CD, kapp, helmfile, plain `kubectl apply`). Validated end-to-end on a real EKS H100 cluster.

## Motivation / Context

`#607` narrowed this follow-up to reusing and enhancing the existing deployment validator path instead of adding a new phase, flag, or Chainsaw runtime dependency. The previous deployment phase verified install/resource existence, but it did not cover the late-converging readiness signals that explain the post-install gap on fresh GPU clusters.

Fixes: #607
Related:
- #602
- #609
- #622
- #516

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`validators/deployment`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`)
- [x] Other: E2E test harness (`tests/e2e`)

## Implementation Notes

### Deployer-neutrality stance

The deployment-phase check stays strictly deployer-agnostic:
- No Helm API calls.
- No reads of Helm release metadata (secrets, ConfigMaps, or `helm list`).
- No dependence on release-scoped labels such as `app.kubernetes.io/instance`.

Every lookup is a plain Kubernetes API call against live-cluster object shape — labels, discovery, name conventions written into the chart templates themselves. The check is valid regardless of whether the bundle was deployed via `deploy.sh` (Helm), Argo CD (Helm or Kustomize), kapp, helmfile, or plain `kubectl apply`.

### Checks added or extended

- Enabled component namespaces must be `Active`.
- Declared `expectedResources` (Deployments, DaemonSets, etc.) must exist and be healthy.
- **Skyhook readiness (scope-limited to the recipe's own declarations):** the validator parses each `ComponentRef.ManifestFiles` of the `skyhook-customizations` component through the recipe data provider, extracts the `metadata.name` of every Skyhook resource declared, and verifies each one exists on the cluster with `status.status == "complete"`. A narrow Helm-template-tolerant regex extractor is used because manifests contain Helm `{{ ... }}` directives that break a full YAML parse. Skyhook CRs present on the cluster that are **not** declared by this recipe (stale from prior deploys, other tenants) are ignored. Fails closed when an enabled `skyhook-customizations` ref declares no extractable Skyhook names (recipe misconfiguration).
- **ClusterPolicy readiness:** Discovery on `nvidia.com/v1` is used up-front to disambiguate three cases the dynamic-client `Get` conflates:
  - CRD not registered (`IsNotFound` from discovery) → skip per `#607` acceptance.
  - CRD registered but `cluster-policy` CR absent → fail closed (gpu-operator installed but not reconciled).
  - Any other discovery error (RBAC 403, API 5xx, network timeout) → fail closed with a diagnostic pointing at RBAC / API reachability, so a transient discovery failure cannot silently mask readiness.
- **DRA kubelet-plugin readiness (role-suffix discovery):** the validator lists DaemonSets in the component namespace (timeout-bounded) and selects the one whose name ends in the upstream chart's hard-coded role suffix `-kubelet-plugin`. 0 matches → fail with the DaemonSets seen in the namespace. >1 matches → fail with the matched names. This is a chart-shape assumption (the upstream `nvidia-dra-driver-gpu` chart always names that DaemonSet `<fullname>-kubelet-plugin`), not a release-identity assumption — it survives `fullnameOverride` and non-Helm deployers. Readiness gate: both `DesiredNumberScheduled > 0` and `NumberReady == DesiredNumberScheduled`.

Skyhook is a cluster-scoped CR; the name-based `Get` path is cluster-scoped by construction, avoiding the namespaced-List-against-cluster-scoped-kind 404 that an earlier approach would have hit.

### Supporting changes

- `tests/e2e/run.sh` seeds a fake `ClusterPolicy` CRD (no status subresource — deliberate, and commented) plus a ready `cluster-policy` CR so deployment-phase E2E exercises the strengthened validator behavior.
- `docs/user/cli-reference.md` documents the expanded deployment phase: the full list of checks, the graceful-skip path when a CRD is absent, the fail-closed path for a missing CR with the CRD present, and the fail-closed path for non-NotFound discovery errors (with a concrete RBAC 403 example).

## Testing

```bash
# Local package run + coverage
GOFLAGS="-mod=vendor" go test -race -coverprofile=cover.out ./validators/deployment/...
go tool cover -func=cover.out | tail -1

# Repo coverage gate + full local gate
make test-coverage
unset GITLAB_TOKEN && make qualify
```

- `go test -race ./validators/deployment/...`: passed.
- `validators/deployment` coverage: substantially improved vs `origin/main` (new tests span the full behavioral surface below).
- `make test-coverage`: passed (above the `70%` project-wide threshold).
- `unset GITLAB_TOKEN && make qualify`: passed.

Added / updated regression coverage:

**DRA kubelet-plugin discovery**
- Happy path with the default chart name.
- Custom fullname-override name (e.g., `my-custom-gpu-kubelet-plugin`) still passes — proves the role-suffix approach is not coupled to the default name.
- Two DaemonSets with matching suffix fails with an ambiguity diagnostic listing both names.
- Unrelated DaemonSet in the same namespace (e.g., `node-exporter`) is ignored.
- Missing DaemonSet fails with a diagnostic that lists the DaemonSets actually seen in the namespace (for debugging).
- `0/0` and under-scheduled DaemonSet fail the readiness gate.

**Skyhook readiness**
- Cluster-scoped Get contract (regression against the earlier namespaced-List 404).
- CRD not registered → skip.
- Unrelated stale Skyhook CR on the cluster (even with the AICR label) does not affect the result when the expected CR is complete.
- Multiple expected Skyhooks with mixed failures → all failures surface in one error (not first-return).
- Enabled `skyhook-customizations` ref with no extractable Skyhook names → fail closed.
- Direct unit tests for `extractSkyhookNamesFromManifest`, including the `tuning-gke.yaml` case (metadata.name is `"tuning"`, not `"tuning-gke"`), Helm-template preamble tolerance, and templated-name skip.

**ClusterPolicy readiness**
- CRD-missing skip (via discovery).
- CRD present but CR missing → fail closed with "gpu-operator installed but CR missing?" diagnostic.
- Discovery returns non-NotFound (RBAC 403) → fail closed.
- Missing `status.state` → fail.

**Other**
- Namespace-not-`Active` → fail.
- `TestMain` forces the global recipe data provider to initialize before any `t.Parallel()` test calls `recipe.GetManifestContent`, working around a pre-existing race on lazy init in `pkg/recipe/provider.go`.

### Live-cluster validation

Ran `aicr validate --recipe recipe.yaml --phase deployment` against a real EKS H100 cluster (`aws-us-east-1-aicr-cuj2`) with the dynamo-platform inference recipe:

```text
phase=deployment status=passed validators=4 passed=4 failed=0 duration=26.824s
```

| Validator | Status |
|---|---|
| `operator-health` | passed |
| `expected-resources` | passed — exercised namespace `Active` for 10 namespaces, Skyhook `tuning` `status.status==complete` (name-based from the recipe's manifestFiles), `ClusterPolicy.status.state==ready` (discovery-gated), and the DRA kubelet-plugin DaemonSet via `-kubelet-plugin` suffix match |
| `gpu-operator-version` | passed |
| `check-nvidia-smi` | passed — 2/2 GPU nodes usable |

Exit code was `0`; CTRF report archived locally.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration or flag changes. This strengthens deployment-phase validation only.
- Skyhook and ClusterPolicy checks skip only when the corresponding CRD is not registered.
- Once the CRD exists, missing readiness objects are surfaced as real failures; non-NotFound discovery errors are never treated as skips.
- DRA kubelet-plugin discovery works for default-named and fullname-override'd deployments alike, and is deployer-neutral (no Helm or release-identity dependency).
- Skyhook readiness is scoped to the Skyhook CRs the recipe itself declares via `ManifestFiles`; unrelated Skyhooks on the cluster are ignored.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

