### PR TITLE
chore(infra): disable CodeRabbit docstring check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,6 +41,9 @@ reviews:
       enabled: false
     shellcheck:
       enabled: true
+  pre_merge_checks:
+    docstrings:
+      mode: off
 
 knowledge_base:
   opt_out: false


### PR DESCRIPTION
## Summary

Disable CodeRabbit's built-in docstring pre-merge check in `.coderabbit.yaml`.

Why this repo-level change makes sense:
- it’s a coarse repo-wide heuristic
- it doesn’t distinguish exported/public API work from internal implementation work
- most AICR PRs are internal validator/bundler/recipe changes, so the warning is often noise
- the repo already has stronger real gates: tests, lint, e2e, coverage, review

## Motivation / Context

This warning came up in reviews of all my recent PRs, e.g., `#611`. It's noise because these PRs are internal implementation changes rather than public API additions.

Fixes: N/A


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: repo tooling configuration (`.coderabbit.yaml`)

## Implementation Notes

- Set `reviews.pre_merge_checks.docstrings.mode: off` in `.coderabbit.yaml`.
- This only affects CodeRabbit's built-in advisory pre-merge check; it does not change GitHub Actions or branch protection.
- Longer-term better option: replace it with a narrower custom check aimed at public API / CLI / docs changes only.

## Testing

```bash
yamllint .coderabbit.yaml
git diff --check
```

- `yamllint .coderabbit.yaml`: passed
- `git diff --check`: passed
- Full `make lint` was not used for this infra-only change because current `origin/main` already has an unrelated `gosec` finding in `pkg/bundler/bundler.go`; this PR does not touch that code path.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
