### PR TITLE
fix(ci): add MDX safety check for non-self-closing img tags

### DIFF
--- a/.github/workflows/fern-docs-ci.yaml
+++ b/.github/workflows/fern-docs-ci.yaml
@@ -45,8 +45,9 @@ jobs:
         run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
       - name: Check MDX safety
+        # Intentionally inline — a composite action would add indirection without benefit for a single grep.
         run: |
-          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ --include="*.md" || true)
+          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
           if [ -n "$BAD" ]; then
             echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
             echo "$BAD"

--- a/.github/workflows/fern-docs-ci.yaml
+++ b/.github/workflows/fern-docs-ci.yaml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Check MDX safety
         # Intentionally inline — a composite action would add indirection without benefit for a single grep.
+        # Single-line grep is intentional — multiline <img> tags do not occur in practice in markdown docs.
         run: |
           BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
           if [ -n "$BAD" ]; then

--- a/.github/workflows/fern-docs-ci.yaml
+++ b/.github/workflows/fern-docs-ci.yaml
@@ -44,6 +44,15 @@ jobs:
       - name: Install Fern CLI
         run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
+      - name: Check MDX safety
+        run: |
+          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ --include="*.md" || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
+            echo "$BAD"
+            exit 1
+          fi
+
       - name: Fern check
         run: fern check
 


### PR DESCRIPTION
## Summary

Add a grep-based MDX safety step to `fern-docs-ci.yaml` that catches non-self-closing `<img>` tags before merge.

## Motivation / Context

Fixes: #619
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

`fern check` validates Fern configuration only — it does not parse MDX content. Non-self-closing `<img>` tags (e.g. `<img src="foo.png">`) pass `fern check` but cause `fern generate` to fail with `Unexpected closing tag </p>`. The new step greps for this pattern and fails the job with an actionable error message before merge.

Root-caused from a live failure in NVIDIA/topograph#281.

## Testing

Step runs on all PRs touching `docs/**` or `fern/**`. No existing docs files contain non-self-closing `<img>` tags.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)