### PR TITLE
fix(ci): drop base:main from GPU paths-filter to avoid post-merge ref race

### DIFF
--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -43,7 +43,10 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
-          base: main
+          # No `base:` — on push events dorny/paths-filter defaults to diffing
+          # against github.event.before (the pre-push SHA). That avoids the
+          # race where `base: main` forced a fetch of `pull-request/<N>` and
+          # raced GitHub's post-merge ref cleanup on synthetic merge pushes.
           filters: |
             matched:
               - '.github/workflows/gpu-h100-inference-test.yaml'

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -43,7 +43,10 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
-          base: main
+          # No `base:` — on push events dorny/paths-filter defaults to diffing
+          # against github.event.before (the pre-push SHA). That avoids the
+          # race where `base: main` forced a fetch of `pull-request/<N>` and
+          # raced GitHub's post-merge ref cleanup on synthetic merge pushes.
           filters: |
             matched:
               - '.github/workflows/gpu-h100-training-test.yaml'

--- a/.github/workflows/gpu-smoke-test.yaml
+++ b/.github/workflows/gpu-smoke-test.yaml
@@ -43,7 +43,10 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
-          base: main
+          # No `base:` — on push events dorny/paths-filter defaults to diffing
+          # against github.event.before (the pre-push SHA). That avoids the
+          # race where `base: main` forced a fetch of `pull-request/<N>` and
+          # raced GitHub's post-merge ref cleanup on synthetic merge pushes.
           filters: |
             matched:
               - '.github/workflows/gpu-smoke-test.yaml'


### PR DESCRIPTION
## Summary

The `check-paths` job in `gpu-h100-training-test.yaml`, `gpu-h100-inference-test.yaml`, and `gpu-smoke-test.yaml` invokes `dorny/paths-filter` with `base: main`. On the synthetic push event GitHub generates for a PR merge, that forces the action to `git fetch origin main pull-request/<N>` at runtime — and if the job runs after GitHub has cleaned up the temporary `pull-request/<N>` ref, the fetch fails with `fatal: couldn't find remote ref pull-request/<N>`.

Drop `base: main` from all three workflows. On push events, `dorny/paths-filter` defaults to diffing against `github.event.before` (the pre-push SHA), which isn't a ref and can't be cleaned up — no race.

## Motivation / Context

Observed on [PR #612](https://github.com/NVIDIA/aicr/pull/612) (merge commit `62cf8ad5`). Three `check-paths` runs triggered for the same merge commit:

| Run | Started | Completed | Result |
|---|---|---|---|
| 1 | `19:30:05Z` | `19:30:11Z` | ✅ SUCCESS |
| 2 | `19:30:06Z` | `19:30:12Z` | ❌ FAILURE (raced cleanup) |
| 3 | `19:30:08Z` | `19:30:16Z` | ❌ FAILURE (after cleanup) |

Merge completed at `19:30:07Z`. The first job fetched the ref before GitHub removed it; the others lost the race and failed with exit 128.

**Regression introduced by [#558](https://github.com/NVIDIA/aicr/pull/558)** (2026-04-14), which replaced GitHub-native `paths:` triggers with a runtime path gate to work around the required-status-check "pending forever" papercut. The native `paths:` approach evaluates at webhook dispatch time and never touches git refs, so it wasn't vulnerable. The runtime gate is still the right approach for the problem #558 solved — only the `base: main` part is fragile.

Surveyed 8 recently merged PRs (#604, #598, #570, #606, #587, #583, #579, #568): none hit this. PR #612 is the only observed instance so far — timing-dependent, latent since 2026-04-14.

Related:
- Introduced by: [#558](https://github.com/NVIDIA/aicr/pull/558)
- Observed on: [#612](https://github.com/NVIDIA/aicr/pull/612) — failing check-runs [1](https://github.com/NVIDIA/aicr/actions/runs/24686122093) and [2](https://github.com/NVIDIA/aicr/actions/runs/24686122087)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions workflows (`.github/workflows/gpu-*.yaml`)

## Implementation Notes

### The fix

```diff
   - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
     id: filter
     with:
-      base: main
+      # No `base:` — on push events dorny/paths-filter defaults to diffing
+      # against github.event.before (the pre-push SHA). That avoids the
+      # race where `base: main` forced a fetch of `pull-request/<N>` and
+      # raced GitHub's post-merge ref cleanup on synthetic merge pushes.
       filters: |
```

Applied to all three workflow files.

### Behavior changes

| Scenario | Behavior |
|---|---|
| Normal merge to main | Unchanged — `github.event.before` is main's previous tip, same diff |
| Squash-merge | Unchanged — single-commit diff against the squash parent |
| Force-push to main | `github.event.before` still points at the pre-push HEAD; diff correct |
| First push to a new branch | `github.event.before` is `0000000...`; `dorny/paths-filter` treats every file as changed — conservative (false positive, not a missed regression) |
| `pull_request` events | Unchanged — `check-paths` already has `if: github.event_name == 'push'` |
| Required-status-check semantics | Unchanged — workflow still always runs on push; `check-paths` still gates the expensive downstream jobs |

### Alternatives considered and rejected

1. **Skip `check-paths` entirely on `pull-request/*` refs.** Would make the GPU workflow run unconditionally on every merge — exactly what #558 set out to avoid.
2. **Revert #558 to native `paths:` triggers.** Brings back the required-status-check papercut (skipped workflows leave required checks pending forever and block merges). #558 was introduced specifically to solve that.
3. **Pass `ref: ${{ github.sha }}` explicitly.** Works but more invasive than the default-behavior fix.

## Testing

CI-only change; correctness proven by the next merge to main not producing the failure. No local `make qualify` run required (no Go / YAML-linted-by-repo files changed — only `.github/workflows/*.yaml`, which pass `yamllint`).

- `yamllint` on the three touched files: clean.
- The next merge to `main` on a PR that touches GPU-workflow-matched paths should see three green `check-paths` runs (instead of 1 green + 2 red).

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert, affects only CI path-filter evaluation
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration or flag changes. If this fix misbehaves for any reason (unlikely — it only changes what git object is used as the diff base), the workflows can be reverted in isolation without affecting anything else in the repo.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, CI-only
- [x] Linter passes (`make lint`) — `yamllint` clean on the three touched files
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, CI config fix
- [x] I updated docs if user-facing behavior changed — N/A, no user-facing behavior
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
