### PR TITLE
docs(agents): flag enum/constant additions in doc-update rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -556,6 +556,7 @@ net. When renaming or removing a heading:
 - Registry component → `docs/user/component-catalog.md`
 - Recipe / overlay / mixin structure → `docs/integrator/recipe-development.md` and `docs/contributor/data.md`
 - Internal package or architecture → `docs/contributor/<area>.md`
+- **Enum/constant value added** (e.g., new accelerator, service, OS, intent, platform, error code) → the value is usually enumerated in *many* files, not one, and grepping for the *new* value returns nothing. Start from the authoritative Go type (e.g., `pkg/recipe/criteria.go` for `CriteriaAccelerator*`), list every current value, and verify each appears wherever the enum is documented — typically the OpenAPI contract at `api/aicr/v1/server.yaml` (every `enum:` block) and the doc pages `docs/README.md` (glossary), `docs/user/cli-reference.md`, `docs/user/api-reference.md`, `docs/contributor/api-server.md`, `docs/contributor/cli.md`, `docs/contributor/data.md`, and `docs/contributor/validations.md`. Grepping `docs/` for an already-documented sibling value (e.g., `gb200`) catches forward additions but misses pre-existing drift — check against the Go type, not a known-good sibling.
 
 Follow the heading conventions in the `## Documentation Style` section above. Doc-only PRs (label `documentation`) are still subject to the full `make qualify` gate.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,6 +556,7 @@ net. When renaming or removing a heading:
 - Registry component → `docs/user/component-catalog.md`
 - Recipe / overlay / mixin structure → `docs/integrator/recipe-development.md` and `docs/contributor/data.md`
 - Internal package or architecture → `docs/contributor/<area>.md`
+- **Enum/constant value added** (e.g., new accelerator, service, OS, intent, platform, error code) → the value is usually enumerated in *many* files, not one, and grepping for the *new* value returns nothing. Start from the authoritative Go type (e.g., `pkg/recipe/criteria.go` for `CriteriaAccelerator*`), list every current value, and verify each appears wherever the enum is documented — typically the OpenAPI contract at `api/aicr/v1/server.yaml` (every `enum:` block) and the doc pages `docs/README.md` (glossary), `docs/user/cli-reference.md`, `docs/user/api-reference.md`, `docs/contributor/api-server.md`, `docs/contributor/cli.md`, `docs/contributor/data.md`, and `docs/contributor/validations.md`. Grepping `docs/` for an already-documented sibling value (e.g., `gb200`) catches forward additions but misses pre-existing drift — check against the Go type, not a known-good sibling.
 
 Follow the heading conventions in the `## Documentation Style` section above. Doc-only PRs (label `documentation`) are still subject to the full `make qualify` gate.
 


### PR DESCRIPTION
## Summary

Add a dedicated bullet to the "Documentation updates" rule in `.claude/CLAUDE.md` / `AGENTS.md` for enum/constant additions. Two things the new bullet prescribes that the generic per-kind bullets don't: (1) start from the authoritative Go type, not from an already-documented sibling value, and (2) include the OpenAPI contract at `api/aicr/v1/server.yaml` alongside the `docs/` pages.

## Motivation / Context

The existing per-kind table pushes each change type to a single file. Enum additions don't fit that shape — the value ends up enumerated across many unrelated files, including the OpenAPI spec.

PR #625 had to add two accelerators (`b200`, `rtx-pro-6000`) to nine places each. The first iteration of this rule (earlier commit on this branch) said "grep `docs/` for an existing sibling value (e.g., `gb200` when adding `b200`)". That heuristic works for *forward* additions, but it misses **pre-existing drift**: `rtx-pro-6000` had been supported in `pkg/recipe/criteria.go` and four real overlays for months, yet grepping `docs/` for it returned nothing — because it was never documented anywhere. Cross-review caught it on PR #625 and forced a re-push.

The strengthened wording tells contributors to enumerate every current value of the authoritative Go type and verify each appears wherever the enum is documented, including `api/aicr/v1/server.yaml`. That's the check that would have caught `rtx-pro-6000` the first time.

Fixes: N/A
Related: #625 (the concrete drift this rule prevents)

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`) — specifically agent instruction files (`.claude/CLAUDE.md`, `AGENTS.md`)

## Implementation Notes

- `.claude/CLAUDE.md` is the canonical source; `AGENTS.md` is the auto-synced mirror enforced by `tools/check-agents-sync`. Both are updated identically on the same bullet.
- Considered a vaguer top-level rule ("always update related docs for user-visible changes") but rejected: the per-kind rule already covers that, and it wasn't the gap. The specific gap was "enum drift doesn't reveal itself through a docs-only grep" — addressed here by pointing at the Go type as the start of every enum audit and explicitly listing `server.yaml` as a target.

## Testing

Doc-only change touching only `.claude/CLAUDE.md` and `AGENTS.md`:

```bash
./tools/check-agents-sync
# OK: AGENTS.md is in sync with .claude/CLAUDE.md
```

Skipped the rest of `make qualify` (no Go, no YAML, no other docs, no CI touched). Per the doc-only verification policy, `check-agents-sync` is the only check that could plausibly regress from this change.

## Risk Assessment

- [x] **Low** — Adds one (revised) bullet to agent instructions; no code, no CI, no user-visible product behavior affected.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, doc-only
- [x] Linter passes (`make lint`) — scoped: `tools/check-agents-sync` only
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — the PR is the doc update
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)