### PR TITLE
docs: fix Pages dead links for design docs

### DIFF
--- a/docs/design/002-validatorv2-adr.md
+++ b/docs/design/002-validatorv2-adr.md
@@ -259,4 +259,4 @@ managed via Server-Side Apply and cleaned up after each run.
 - [CTRF Specification](https://ctrf.io/)
 - [CTRF JSON Schema](https://github.com/ctrf-io/ctrf/blob/main/schema/ctrf.schema.json)
 - [Kubernetes Termination Messages](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/)
-- [Current validator implementation](../../pkg/validator/)
+- [Current validator implementation](https://github.com/NVIDIA/aicr/tree/main/pkg/validator)

--- a/docs/design/003-scaling-recipe-tests.md
+++ b/docs/design/003-scaling-recipe-tests.md
@@ -239,7 +239,7 @@ regular regressions.
 
 ## References
 
-- [KWOK recipes workflow](../../.github/workflows/kwok-recipes.yaml)
-- [KWOK test action](../../.github/actions/kwok-test/)
-- [Recipe overlays](../../recipes/overlays/)
+- [KWOK recipes workflow](https://github.com/NVIDIA/aicr/blob/main/.github/workflows/kwok-recipes.yaml)
+- [KWOK test action](https://github.com/NVIDIA/aicr/tree/main/.github/actions/kwok-test)
+- [Recipe overlays](https://github.com/NVIDIA/aicr/tree/main/recipes/overlays)
 - [KWOK project](https://kwok.sigs.k8s.io/)

--- a/docs/design/004-query-command.md
+++ b/docs/design/004-query-command.md
@@ -309,7 +309,7 @@ command keeps the contract clean and lets `query` optimize for human-readable ou
 
 ## References
 
-- [Recipe command](../../pkg/cli/recipe.go)
-- [Recipe resolution](../../pkg/recipe/metadata_store.go)
-- [Value hydration](../../pkg/recipe/adapter.go)
-- [Component registry](../../recipes/registry.yaml)
+- [Recipe command](https://github.com/NVIDIA/aicr/blob/main/pkg/cli/recipe.go)
+- [Recipe resolution](https://github.com/NVIDIA/aicr/blob/main/pkg/recipe/metadata_store.go)
+- [Value hydration](https://github.com/NVIDIA/aicr/blob/main/pkg/recipe/adapter.go)
+- [Component registry](https://github.com/NVIDIA/aicr/blob/main/recipes/registry.yaml)

--- a/tools/sync-site-docs
+++ b/tools/sync-site-docs
@@ -5,7 +5,7 @@
 # Sync docs/ (source of truth) into site/docs/ for VitePress.
 # This eliminates manual duplication — docs/ is the single source.
 #
-# Synced sections: user, integrator, contributor, conformance
+# Synced sections: user, integrator, contributor, conformance, design
 # Site-only content (getting-started, project, index.md) is NOT touched.
 #
 # Run before: site dev, site build
@@ -33,6 +33,7 @@ echo "Syncing docs/ → site/docs/..."
 sync_section "${DOCS}/user" "${SITE_DOCS}/user"
 sync_section "${DOCS}/integrator" "${SITE_DOCS}/integrator"
 sync_section "${DOCS}/contributor" "${SITE_DOCS}/contributor"
+sync_section "${DOCS}/design" "${SITE_DOCS}/design"
 
 # Conformance: flatten cncf/ prefix (docs/conformance/cncf/ → site/docs/conformance/).
 # Copies the entire cncf/ subtree so new subdirectories (e.g., v1.35/) are picked up

--- a/tools/sync-site-docs
+++ b/tools/sync-site-docs
@@ -22,9 +22,15 @@ sync_section() {
   local src="$1"
   local dst="$2"
 
+  if [[ ! -d "${src}" ]]; then
+    echo "sync_section: source directory not found: ${src}" >&2
+    return 1
+  fi
+
   rm -rf "${dst}"
   mkdir -p "${dst}"
-  cp -R "${src}/"* "${dst}/"
+  # Copy all contents, including dotfiles; an empty source stays empty.
+  cp -R "${src}/." "${dst}/"
 }
 
 echo "Syncing docs/ → site/docs/..."


### PR DESCRIPTION
## Summary

Fix the GitHub Pages/VitePress dead-link failures for `docs/design/**` by syncing the design ADR pages into `site/docs/`, converting design-doc links to repo source/workflow paths into GitHub URLs, and hardening the sync helper for empty or hidden-content directories.

## Motivation / Context

The ADR PR (`#631`) exposed a latent site-build problem: once `docs/design` is included in the VitePress sync, several existing ADR/design docs contain repo-relative links (`../../pkg/...`, `../../recipes/...`, `../../.github/...`) that are valid in the GitHub repo tree but dead in the site build. This PR fixes that independently so the Pages build is not blocked on the ADR PR.

Fixes: N/A
Related: #631

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: site docs sync (`tools/sync-site-docs`)

## Implementation Notes

- `tools/sync-site-docs` now syncs `docs/design` into `site/docs/design` so ADR/design pages exist in the VitePress build.
- The sync helper was hardened to copy dotfiles and handle empty source directories safely.
- Existing design-doc links to repo source/workflow paths were converted to GitHub URLs because VitePress can only resolve pages under `site/docs/`, not arbitrary repo paths.
- This intentionally keeps the fix independent of ADR-006 content changes.

## Testing

```bash
tools/sync-site-docs
unset GITLAB_TOKEN && make lint
```

- `tools/sync-site-docs`: passed, and `site/docs/design/` is created in the synced site tree.
- `unset GITLAB_TOKEN && make lint`: passed.
- Full `make qualify` was skipped because this is a doc/site-sync-only fix. The relevant failure mode is the Pages/VitePress dead-link build, which will be validated by CI on the PR.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
