### PR TITLE
ci: switch GPU smoke test runner from T4 to L40G

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -16,4 +16,4 @@ self-hosted-runner:
   labels:
     - linux-amd64-gpu-h100-latest-1
     - linux-amd64-gpu-h100-latest-2
-    - linux-amd64-gpu-t4-latest-1
+    - linux-amd64-gpu-l40g-latest-1

--- a/.github/workflows/gpu-smoke-test.yaml
+++ b/.github/workflows/gpu-smoke-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: GPU Smoke Test (nvkind + T4)
+name: GPU Smoke Test (nvkind + L40G)
 
 on:
   schedule:
@@ -69,11 +69,11 @@ jobs:
         (github.event_name == 'pull_request' && github.event.label.name == 'run-gpu-tests') ||
         (github.event_name == 'push' && needs.check-paths.outputs.should-run == 'true')
       )
-    name: GPU Smoke Test (nvkind + T4)
+    name: GPU Smoke Test (nvkind + L40G)
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
       cancel-in-progress: true
-    runs-on: linux-amd64-gpu-t4-latest-1
+    runs-on: linux-amd64-gpu-l40g-latest-1
     timeout-minutes: 30
 
     env:
@@ -131,7 +131,7 @@ jobs:
       - name: Snapshot and validate GPU
         uses: ./.github/actions/gpu-snapshot-validate
         with:
-          gpu_model: T4
+          gpu_model: L40G
           min_gpu_count: '1'
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 


### PR DESCRIPTION
## Summary

- Switches the nvkind GPU smoke test runner from T4 (`linux-amd64-gpu-t4-latest-1`) to L40G (`linux-amd64-gpu-l40g-latest-1`).
- Updates the workflow/job display names, the `gpu_model` substring assertion passed to `gpu-snapshot-validate` (T4 → L40G), and the self-hosted-runner allowlist in `.github/actionlint.yaml`.

## Motivation / Context

Follow-up to the action item on #553 — [this comment](https://github.com/NVIDIA/aicr/issues/553#issuecomment-4291615326) asked for the smoke test to move onto a better runner.

Fixes: N/A
Related: #553

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: GitHub Actions workflows / self-hosted runner selection

## Implementation Notes

- `gpu_model` in `.github/actions/gpu-snapshot-validate/action.yml` is a substring match against `nvidia-smi` output, so the value is updated to `L40G` to match the device name the new runner is expected to report.
- Runner label `linux-amd64-gpu-l40g-latest-1` must be provisioned in the shared runner pool for the job to schedule. If the label is not yet available, the smoke-test job will queue indefinitely until it is.

## Testing

CI-only change — no Go/test code touched. Validation is the smoke-test job scheduling and passing on the new runner once L40G capacity is available.

## Risk Assessment

- [x] **Low** — Isolated CI change, easy to revert by reversing the label swap.

**Rollout notes:** Revert-only. If the L40G runner is not provisioned when this merges, the smoke-test job will queue — unblock by reverting this PR (or temporarily swapping back to the T4 label).

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase (same label convention as the H100 workflows, parallel update to `actionlint.yaml`)
- [x] Commits are cryptographically signed (`git commit -S`)
- [ ] Tests/lint — N/A for this diff; `make lint` has a pre-existing unrelated gosec finding (`pkg/bundler/deployer/argocdhelm/argocdhelm.go:475`) that should be tracked in its own PR
