### PR TITLE
fix(kwok): remove broken --set array-index lines from validate-scheduling.sh

### DIFF
--- a/kwok/scripts/validate-scheduling.sh
+++ b/kwok/scripts/validate-scheduling.sh
@@ -363,10 +363,6 @@ generate_bundle() {
         --set "kubeprometheusstack:defaultRules.create=false" \
         --set "kubeprometheusstack:alertmanager.enabled=false" \
         --set "skyhook-customizations:enabled=false" \
-        --set "networkoperator:operator.tolerations[2].key=aicr.nvidia.com/kwok-test" \
-        --set "networkoperator:operator.tolerations[2].operator=Equal" \
-        --set "networkoperator:operator.tolerations[2].value=true" \
-        --set "networkoperator:operator.tolerations[2].effect=NoSchedule" \
         --set "dynamoplatform:etcd.persistence.enabled=false" \
         --set "dynamoplatform:nats.config.jetstream.fileStore.enabled=false" 2>&1); then
         log_error "Bundle generation failed"

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -550,6 +550,36 @@ func TestParseValueOverrides(t *testing.T) {
 			t.Error("ParseValueOverrides() expected error for unsafe path segment, got nil")
 		}
 	})
+
+	t.Run("helm-style array index rejected", func(t *testing.T) {
+		// Helm's `foo.bar[N].baz` list-indexing syntax is intentionally
+		// rejected at parse time. The downstream path walker in
+		// pkg/component/overrides.go (`getOrCreateNestedMap` / `setMapValueByPath`)
+		// splits on `.` only and treats `tolerations[2]` as a literal map key
+		// — so permitting the syntax here would silently produce bundles with
+		// a stringly-keyed `"tolerations[2]"` field instead of the indexed
+		// list element the user intended. Rejecting up front fails loudly.
+		tests := []struct {
+			name  string
+			input string
+		}{
+			{
+				name:  "tolerations index",
+				input: "networkoperator:operator.tolerations[2].key=aicr.nvidia.com/kwok-test",
+			},
+			{
+				name:  "env index",
+				input: "gpuoperator:driver.env[3].name=CUDA_VISIBLE_DEVICES",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if _, err := ParseValueOverrides([]string{tt.input}); err == nil {
+					t.Errorf("ParseValueOverrides(%q) should have rejected Helm array index syntax — downstream walker can't interpret it", tt.input)
+				}
+			})
+		}
+	})
 }
 
 // TestWithDynamicValues verifies the functional option sets dynamic value paths


### PR DESCRIPTION
## Summary

Remove four dead `--set networkoperator:operator.tolerations[N]...` lines from `kwok/scripts/validate-scheduling.sh`. These lines tried to append a KWOK-test-specific toleration using Helm's list-index syntax, but `aicr bundle` has never supported that syntax and never will as part of this PR.

## Motivation / Context

KWOK Tier 1 / Tier 2 CI jobs fail at the bundle step on any PR whose path-trigger fires:

```
invalid path segment "tolerations[2]" in "networkoperator:operator.tolerations[2].key=...":
must contain only alphanumeric, dot, hyphen, or underscore characters
```

The surface symptom is loud rejection at parse time (added by #603), but the underlying cause goes deeper: even if the parser accepted `[N]`, the downstream path walker in `pkg/component/overrides.go` (`getOrCreateNestedMap`, called from `setMapValueByPath` and thus from `ApplyMapOverrides`) splits on `.` only. `tolerations[2]` becomes a literal map key — the generated values file emits `{operator: {"tolerations[2]": {key: ...}}}`, which Helm silently ignores while keeping the upstream `tolerations` list's defaults.

So the 4 `--set` lines have never done what the KWOK script thought they were doing. Before #603 they produced silently-wrong bundles; after #603 they fail loudly. Either way, nothing depends on them — the adjacent `--accelerated-node-toleration kwok.x-k8s.io/node=fake:NoSchedule` already propagates a tolerate-the-fake-node rule to every accelerated workload (including network-operator) via each component's `nodeScheduling` overlay.

The fix is to drop the dead lines. No functional regression.

> **First revision of this PR** attempted to extend `safePathPattern` to permit Helm-style `[N]` suffixes. CodeRabbit flagged the error-message and test-preservation gaps in that approach ([r3126044835](https://github.com/NVIDIA/aicr/pull/643#discussion_r3126044835), [r3126044843](https://github.com/NVIDIA/aicr/pull/643#discussion_r3126044843)), and Codex's subsequent review ([top-level comment](https://github.com/NVIDIA/aicr/pull/643)) correctly pointed out that the downstream walker in `ApplyMapOverrides` / `writeClusterValuesFile` would have treated `tolerations[2]` as a literal map key regardless — turning a loud parse-time failure into a silent bundle-generation bug. Reverted the regex change, instead fixing the actual source of the broken invocation (the KWOK script).

Fixes: N/A
Related: #641 (inference-perf validator — blocked on this CI unblock)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: KWOK test harness (`kwok/scripts/validate-scheduling.sh`)
- [x] Tests: `pkg/bundler/config/config_test.go` (negative test documenting the parse rejection)

## Implementation Notes

### Script change (the real fix)

```diff
 --set "skyhook-customizations:enabled=false" \
-    --set "networkoperator:operator.tolerations[2].key=aicr.nvidia.com/kwok-test" \
-    --set "networkoperator:operator.tolerations[2].operator=Equal" \
-    --set "networkoperator:operator.tolerations[2].value=true" \
-    --set "networkoperator:operator.tolerations[2].effect=NoSchedule" \
 --set "dynamoplatform:etcd.persistence.enabled=false" \
```

### Negative test (defensive documentation)

Adds `helm-style array index rejected` to `TestParseValueOverrides`. It explicitly asserts that `--set foo:bar.tolerations[N].key=x` syntax remains rejected at parse time, with a comment explaining that the downstream path walker can't interpret `[N]` as a list index. The test exists so a future contributor doesn't re-loosen the regex without first teaching `getOrCreateNestedMap` (and the dynamic-values extractor) to handle indexed paths — a substantive feature intentionally out of scope here.

### `safePathPattern` unchanged

`pkg/bundler/config/component_path.go` matches `origin/main` exactly — the regex from #603 is preserved.

## Testing

```bash
make qualify
```

All green. Targeted:

```bash
go test -run TestParseValueOverrides -v ./pkg/bundler/config/...
# 12 subtests PASS, including the new helm-style_array_index_rejected
```

## Risk Assessment

- [x] **Low** — Removes 4 lines from a CI-only test harness that have been producing wrong output (pre-#603) or failing loudly (post-#603) the entire time they've been present. Adds one negative test that codifies current parser behavior. No production code path changes.

**Rollout notes:** None. The KWOK script's scheduling semantics are preserved via the existing `--accelerated-node-toleration` lines.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (CI-only script + internal test)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
