### PR TITLE
fix(ci): remove dangling steps.capacity.outcome reference in uat-gcp

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -210,7 +210,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Phase | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Capacity | ${{ steps.capacity.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Dependencies | ${{ steps.deps.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Config | ${{ steps.config.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Cluster | ${{ steps.infra.outcome }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Remove a dangling `${{ steps.capacity.outcome }}` reference in `.github/workflows/uat-gcp.yaml` left over from [1caf06b9](https://github.com/NVIDIA/aicr/commit/1caf06b9) (\"chore: update uat config\"), which removed the `Check GPU node pool capacity` step (`id: capacity`) but did not update the Test Summary block that referenced its outcome.

## Motivation / Context

Since 1caf06b9 landed (direct push to \`main\`, ~2h ago), every push to main and every PR rebased onto main has been failing the \`Lint GitHub Actions\` job with:

\`\`\`
.github/workflows/uat-gcp.yaml:206:354: property \"capacity\" is not defined in object type
  {auth, client, config, deps, infra, tests, versions} [expression]
\`\`\`

Run history confirms the regression point:

| Commit | Lint GitHub Actions |
|---|---|
| [5785d81e](https://github.com/NVIDIA/aicr/commit/5785d81e) — kept the \`capacity\` step, only gutted its body | pass |
| [550017b6](https://github.com/NVIDIA/aicr/commit/550017b6), [40bb85d7](https://github.com/NVIDIA/aicr/commit/40bb85d7) | pass |
| [1caf06b9](https://github.com/NVIDIA/aicr/commit/1caf06b9) — removed the step entirely | **fail** |
| HEAD (inherits the break) | fail |

Fixes: N/A (no issue filed)
Related: #641 (inference-perf validator — rebases onto main will pick this up automatically once merged)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] CI/CD
- [x] Other: UAT GCP nightly workflow (\`.github/workflows/uat-gcp.yaml\`)

## Implementation Notes

Drop the \`| Capacity | … |\` row from the Test Summary table — the \`capacity\` step no longer exists, so the row is not actionable. The summary now reports the remaining phases (Dependencies, Config, Cluster, Connection, Tests) that still have step IDs.

\`\`\`diff
           echo \"| Phase | Status |\" >> \$GITHUB_STEP_SUMMARY
           echo \"|-------|--------|\" >> \$GITHUB_STEP_SUMMARY
-          echo \"| Capacity | \${{ steps.capacity.outcome }} |\" >> \$GITHUB_STEP_SUMMARY
           echo \"| Dependencies | \${{ steps.deps.outcome }} |\" >> \$GITHUB_STEP_SUMMARY
\`\`\`

No runtime behavior change — this touches only the human-readable Step Summary emitted after tests run.

## Testing

\`\`\`bash
actionlint -color -shellcheck= .github/workflows/uat-gcp.yaml
# (exit 0, no output)
\`\`\`

Doc/CI-only change — no code paths touched, so \`make qualify\` is not required per repo convention for non-code YAML changes. Actionlint is the specific gate that flagged the regression and is the specific gate that now passes.

## Risk Assessment

- [x] **Low** — deletes one dangling expression reference; no runtime behavior change; unblocks all PRs currently inheriting the actionlint failure.

## Checklist

- [x] Tests pass locally (\`actionlint\` clean)
- [x] Linter passes
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (\`git commit -S\`)