### PR TITLE
fix(recipes): disable Dynamo ssh-keygen on Kind

### DIFF
--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -51,6 +51,15 @@ spec:
         - kube-prometheus-stack
         - kai-scheduler
       overrides:
+        # Kind inference CI uses a plain DynamoGraphDeployment vLLM workload,
+        # not the MPI launch path. Disable the chart's ssh-keygen pre-install
+        # hook here so fresh Kind runners do not spend hook budget creating an
+        # unused MPI SSH secret.
+        dynamo-operator:
+          dynamo:
+            mpiRun:
+              sshKeygen:
+                enabled: false
         # Use kind's local-path-provisioner instead of EBS gp2
         etcd:
           persistence:


### PR DESCRIPTION
## Summary

Disable Dynamo's MPI ssh-keygen Helm hook in the Kind inference recipe overlay so fresh Kind CI runs do not block on generating an unused SSH secret.

## Motivation / Context

The `h100-kind-inference-dynamo` overlay deploys a plain `DynamoGraphDeployment` vLLM workload, not the MPI launch path. The upstream chart's ssh-keygen pre-install hook is unnecessary there and can time out on fresh Kind runners.

Fixes: N/A
Related: #641

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: recipe overlays (`recipes/overlays`)

## Implementation Notes

- This change is scoped to the Kind H100 inference Dynamo overlay.
- It sets `dynamo-operator.dynamo.mpiRun.sshKeygen.enabled=false` only for that overlay.
- Other Dynamo overlays and non-Kind deployments keep the upstream ssh-keygen behavior unchanged.

## Testing

```bash
make qualify
```

`make qualify` passed locally.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
