### PR TITLE
chore(ci): remove auto-assignment of issues during triage

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -53,34 +53,6 @@ jobs:
             const body = context.payload.issue.body || '';
             const existingLabels = new Set((context.payload.issue.labels || []).map(label => label.name));
 
-            async function loadAreaAssignees() {
-              const { data: file } = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: '.settings.yaml',
-              });
-              const content = Buffer.from(file.content, 'base64').toString('utf8');
-
-              const assignees = {};
-              let inBlock = false;
-              for (const line of content.split('\n')) {
-                if (line.startsWith('area_assignees:')) {
-                  inBlock = true;
-                  continue;
-                }
-                if (inBlock) {
-                  const m = line.match(/^\s+(area\/\S+):\s*(.+)/);
-                  if (m) {
-                    assignees[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
-                  } else if (/^\S/.test(line)) {
-                    break;
-                  }
-                }
-              }
-
-              return assignees;
-            }
-
             const componentPatterns = [
               { pattern: /\bcli\b/, label: 'area/cli' },
               { pattern: /\bapi server\b|\baicrd\b/, label: 'area/api' },
@@ -247,21 +219,6 @@ jobs:
               core.info(`Issue already has ${areaLabel}`);
             }
 
-            const assignees = await loadAreaAssignees();
-            const value = assignees[areaLabel];
-            if (value) {
-              const users = [...new Set(value.split(',').map(u => u.trim()).filter(Boolean))];
-              core.info(`Assigning issue to [${users.join(', ')}] for ${areaLabel}`);
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                assignees: users,
-              });
-            } else {
-              core.info(`No assignee configured for ${areaLabel}`);
-            }
-
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
@@ -297,64 +254,4 @@ jobs:
                 issue_number: context.issue.number,
                 name: 'needs-triage',
               });
-            }
-
-      - name: Assign by area label
-        if: >-
-          github.event.action == 'labeled' &&
-          startsWith(github.event.label.name, 'area/')
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            try {
-              const label = context.payload.label.name;
-              const issue = context.issue.number;
-              core.info(`[assign] label=${label} issue=#${issue}`);
-
-              const { data: file } = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: '.settings.yaml',
-              });
-              core.info(`[assign] fetched .settings.yaml (${file.size} bytes, encoding=${file.encoding})`);
-
-              const content = Buffer.from(file.content, 'base64').toString('utf8');
-
-              // Parse area_assignees from .settings.yaml
-              const assignees = {};
-              let inBlock = false;
-              for (const line of content.split('\n')) {
-                if (line.startsWith('area_assignees:')) {
-                  inBlock = true;
-                  continue;
-                }
-                if (inBlock) {
-                  const m = line.match(/^\s+(area\/\S+):\s*(.+)/);
-                  if (m) {
-                    assignees[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
-                  } else if (/^\S/.test(line)) {
-                    break;
-                  }
-                }
-              }
-              core.info(`[assign] parsed map: ${JSON.stringify(assignees)}`);
-
-              const value = assignees[label];
-              if (!value) {
-                core.warning(`[assign] no assignee configured for label "${label}"`);
-                return;
-              }
-
-              const users = [...new Set(value.split(',').map(u => u.trim()).filter(Boolean))];
-              core.info(`[assign] assigning [${users.join(', ')}] to issue #${issue}`);
-
-              const result = await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue,
-                assignees: users,
-              });
-              core.info(`[assign] API status=${result.status}, assignees=${result.data.assignees.map(a => a.login).join(',')}`);
-            } catch (err) {
-              core.setFailed(`[assign] failed: ${err.message} (status=${err.status || 'n/a'})`);
             }

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -53,20 +53,6 @@ testing_tools:
   yq: 'v4.52.4'
   karpenter: 'v1.8.0'
 
-# Area Assignees (GitHub usernames assigned to issues by area label)
-area_assignees:
-  area/api: cullenmcdermott,mchmarny
-  area/bundler: ArangoGutierrez,mchmarny
-  area/ci: mchmarny,mchmarny
-  area/cli: lockwobr,mchmarny
-  area/collector: ayuskauskas,mchmarny
-  area/docs: dims,mchmarny
-  area/infra: mchmarny,dims
-  area/recipes: yuanchen8911,mchmarny
-  area/security: mchmarny,dims
-  area/tests: atif1996,mchmarny
-  area/validator: xdu31,mchmarny
-
 # Quality Thresholds
 quality:
   coverage_threshold: '70'


### PR DESCRIPTION
## Summary

Remove automatic issue assignment by area label during triage. The Kanban project board replaces the need for auto-assignment on issue creation.

## Motivation / Context

Fixes: #652
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI workflows, project settings

## Implementation Notes

- Deleted `area_assignees` map from `.settings.yaml`
- Removed `loadAreaAssignees()` function and assignment call from the "Infer area label" step
- Removed the standalone "Assign by area label" step (triggered on `labeled` events)
- Area label inference and `needs-triage` removal are preserved unchanged

## Testing

```bash
yamllint -d relaxed .github/workflows/triage.yaml .settings.yaml
```

No Go changes — YAML-only, validated with yamllint (warnings are pre-existing line-length).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — removes behavior, no migration needed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)