### PR TITLE
fix(validator): resolve dev-build images to SHA-tagged images

### DIFF
--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -245,6 +245,7 @@ func runValidation(
 
 	v := validator.New(
 		validator.WithVersion(version),
+		validator.WithCommit(commit),
 		validator.WithNamespace(cfg.validationNamespace),
 		validator.WithCleanup(cfg.cleanup),
 		validator.WithImagePullSecrets(cfg.imagePullSecrets),

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -134,6 +134,7 @@ func Load(version, commit string) (*ValidatorCatalog, error) {
 //
 // Images with explicit version tags are not modified by steps 1-2.
 func ResolveImage(image, version, commit string) string {
+	commit = strings.ToLower(commit)
 	if isReleaseVersion(version) {
 		image = replaceLatestTag(image, version)
 	} else if isValidCommit(commit) {

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -100,10 +100,12 @@ type EnvVar struct {
 // Image tag resolution (applied in order):
 //  1. If a catalog entry uses :latest and version is a release (vX.Y.Z),
 //     the tag is replaced with the CLI version for reproducibility.
-//  2. If AICR_VALIDATOR_IMAGE_REGISTRY is set, the registry prefix is replaced.
+//  2. If version is a non-release dev build and commit is a valid short SHA,
+//     the tag is replaced with :sha-<commit> to match on-push.yaml image tags.
+//  3. If AICR_VALIDATOR_IMAGE_REGISTRY is set, the registry prefix is replaced.
 //
 // Entries with explicit version tags (e.g., :v1.2.3) are never modified.
-func Load(version string) (*ValidatorCatalog, error) {
+func Load(version, commit string) (*ValidatorCatalog, error) {
 	data, err := recipe.GetDataProvider().ReadFile("validators/catalog.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read catalog", err)
@@ -115,7 +117,7 @@ func Load(version string) (*ValidatorCatalog, error) {
 	}
 
 	for i := range cat.Validators {
-		cat.Validators[i].Image = ResolveImage(cat.Validators[i].Image, version)
+		cat.Validators[i].Image = ResolveImage(cat.Validators[i].Image, version, commit)
 	}
 
 	return cat, nil
@@ -127,12 +129,15 @@ func Load(version string) (*ValidatorCatalog, error) {
 // inference-perf validator). Applies, in order:
 //
 //  1. :latest tag replacement with version if version is a release (vX.Y.Z).
-//  2. Registry prefix override if AICR_VALIDATOR_IMAGE_REGISTRY is set.
+//  2. If non-release and commit is a valid SHA, :latest → :sha-<commit>.
+//  3. Registry prefix override if AICR_VALIDATOR_IMAGE_REGISTRY is set.
 //
-// Images with explicit version tags are not modified by step 1.
-func ResolveImage(image, version string) string {
+// Images with explicit version tags are not modified by steps 1-2.
+func ResolveImage(image, version, commit string) string {
 	if isReleaseVersion(version) {
 		image = replaceLatestTag(image, version)
+	} else if isValidCommit(commit) {
+		image = replaceLatestWithSHA(image, commit)
 	}
 	if override := os.Getenv("AICR_VALIDATOR_IMAGE_REGISTRY"); override != "" {
 		image = replaceRegistry(image, override)
@@ -160,6 +165,34 @@ func replaceLatestTag(image, version string) string {
 			tag = "v" + tag
 		}
 		return strings.TrimSuffix(image, ":latest") + ":" + tag
+	}
+	return image
+}
+
+// isValidCommit returns true for non-empty strings that look like a git short
+// or full SHA (7-40 hex characters). The sentinel value "unknown" (set by
+// ldflags default) is explicitly rejected.
+func isValidCommit(commit string) bool {
+	if commit == "" || commit == "unknown" {
+		return false
+	}
+	if len(commit) < 7 || len(commit) > 40 {
+		return false
+	}
+	for _, c := range commit {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// replaceLatestWithSHA replaces :latest with :sha-<commit> to match the
+// image tags pushed by the on-push CI workflow.
+// Images with explicit version tags are not modified.
+func replaceLatestWithSHA(image, commit string) string {
+	if strings.HasSuffix(image, ":latest") {
+		return strings.TrimSuffix(image, ":latest") + ":sha-" + commit
 	}
 	return image
 }

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -20,6 +20,7 @@ package catalog
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -146,13 +147,16 @@ func ResolveImage(image, version, commit string) string {
 	return image
 }
 
-// isReleaseVersion returns true for semantic version strings (vX.Y.Z),
-// false for dev builds ("dev", "v0.0.0-next", empty).
+// releaseVersionPattern matches strict semantic versions: vX.Y.Z or X.Y.Z
+// with no pre-release suffix. This ensures snapshot strings like
+// v0.0.0-12-gabc1234 or pre-release tags like v1.0.0-rc1 are not treated
+// as releases.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// isReleaseVersion returns true for strict semantic version strings (vX.Y.Z),
+// false for dev builds, pre-release suffixes, snapshots, and empty strings.
 func isReleaseVersion(version string) bool {
-	if version == "" || version == "dev" || strings.Contains(version, "-next") {
-		return false
-	}
-	return true
+	return releaseVersionPattern.MatchString(version)
 }
 
 // replaceLatestTag replaces :latest with the given version tag.

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestLoadEmbeddedCatalog(t *testing.T) {
-	catalog, err := Load("")
+	catalog, err := Load("", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -156,7 +156,7 @@ validators:
 }
 
 func TestForPhaseNoMatch(t *testing.T) {
-	catalog, err := Load("")
+	catalog, err := Load("", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -337,7 +337,7 @@ func TestReplaceRegistry(t *testing.T) {
 func TestLoadWithRegistryOverride(t *testing.T) {
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "localhost:5001")
 
-	cat, err := Load("")
+	cat, err := Load("", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestLoadWithRegistryOverride(t *testing.T) {
 func TestLoadWithoutRegistryOverride(t *testing.T) {
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
 
-	cat, err := Load("")
+	cat, err := Load("", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -414,7 +414,7 @@ validators:
 	defer recipe.SetDataProvider(originalProvider)
 
 	// Load catalog — should merge embedded + external
-	cat, err := Load("")
+	cat, err := Load("", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -458,6 +458,7 @@ func TestResolveImage(t *testing.T) {
 		name     string
 		image    string
 		version  string
+		commit   string
 		registry string // if non-empty, sets AICR_VALIDATOR_IMAGE_REGISTRY for the test
 		want     string
 	}{
@@ -505,6 +506,56 @@ func TestResolveImage(t *testing.T) {
 			registry: "localhost:5001",
 			want:     "localhost:5001/aicr-validators/aiperf-bench:v0.11.1",
 		},
+		{
+			name:    "dev version with valid commit resolves to sha tag",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "abc1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abc1234",
+		},
+		{
+			name:    "dev version with unknown commit keeps latest",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "unknown",
+			want:    imgLatest,
+		},
+		{
+			name:    "dev version with empty commit keeps latest",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "",
+			want:    imgLatest,
+		},
+		{
+			name:    "-next version with valid commit resolves to sha tag",
+			image:   imgLatest,
+			version: "v0.11.1-next",
+			commit:  "abc1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abc1234",
+		},
+		{
+			name:    "release version ignores commit (release takes precedence)",
+			image:   imgLatest,
+			version: "v0.11.1",
+			commit:  "abc1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:v0.11.1",
+		},
+		{
+			name:    "explicit tag not modified by commit",
+			image:   imgPinned,
+			version: "dev",
+			commit:  "abc1234",
+			want:    imgPinned,
+		},
+		{
+			name:     "dev + commit + registry override compose",
+			image:    imgLatest,
+			version:  "dev",
+			commit:   "abc1234",
+			registry: "localhost:5001",
+			want:     "localhost:5001/aicr-validators/aiperf-bench:sha-abc1234",
+		},
 	}
 
 	for _, tt := range tests {
@@ -514,9 +565,9 @@ func TestResolveImage(t *testing.T) {
 			} else {
 				t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
 			}
-			got := ResolveImage(tt.image, tt.version)
+			got := ResolveImage(tt.image, tt.version, tt.commit)
 			if got != tt.want {
-				t.Errorf("ResolveImage(%q, %q) = %q, want %q", tt.image, tt.version, got, tt.want)
+				t.Errorf("ResolveImage(%q, %q, %q) = %q, want %q", tt.image, tt.version, tt.commit, got, tt.want)
 			}
 		})
 	}

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -556,6 +556,13 @@ func TestResolveImage(t *testing.T) {
 			registry: "localhost:5001",
 			want:     "localhost:5001/aicr-validators/aiperf-bench:sha-abc1234",
 		},
+		{
+			name:    "uppercase commit is normalized to lowercase",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "ABC1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abc1234",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -554,10 +554,17 @@ func TestResolveImage(t *testing.T) {
 			want:    imgLatest,
 		},
 		{
-			name:    "dev version with too-long commit keeps latest",
+			name:    "dev version with 40-char full SHA resolves",
 			image:   imgLatest,
 			version: "dev",
-			commit:  "abc1234abc1234abc1234abc1234abc1234abc1234x",
+			commit:  "abcdef1234abcdef1234abcdef1234abcdef1234", // exactly 40 hex chars
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abcdef1234abcdef1234abcdef1234abcdef1234",
+		},
+		{
+			name:    "dev version with 41-char commit keeps latest",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "abcdef1234abcdef1234abcdef1234abcdef12345", // 41 hex chars
 			want:    imgLatest,
 		},
 		{

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -528,6 +528,27 @@ func TestResolveImage(t *testing.T) {
 			want:    imgLatest,
 		},
 		{
+			name:    "dev version with too-short commit keeps latest",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "abc12",
+			want:    imgLatest,
+		},
+		{
+			name:    "dev version with too-long commit keeps latest",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "abc1234abc1234abc1234abc1234abc1234abc1234x",
+			want:    imgLatest,
+		},
+		{
+			name:    "dev version with non-hex commit keeps latest",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "xyz1234",
+			want:    imgLatest,
+		},
+		{
 			name:    "-next version with valid commit resolves to sha tag",
 			image:   imgLatest,
 			version: "v0.11.1-next",

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -475,6 +475,25 @@ func TestResolveImage(t *testing.T) {
 			want:    imgLatest,
 		},
 		{
+			name:    "git-describe snapshot is not a release",
+			image:   imgLatest,
+			version: "v0.0.0-12-gabc1234",
+			want:    imgLatest,
+		},
+		{
+			name:    "pre-release rc suffix is not a release",
+			image:   imgLatest,
+			version: "v1.0.0-rc1",
+			want:    imgLatest,
+		},
+		{
+			name:    "snapshot with valid commit resolves to sha tag",
+			image:   imgLatest,
+			version: "v0.0.0-12-gabc1234",
+			commit:  "abc1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abc1234",
+		},
+		{
 			name:    "release version rewrites :latest to :vX.Y.Z",
 			image:   imgLatest,
 			version: "v0.11.1",

--- a/pkg/validator/job/deployer.go
+++ b/pkg/validator/job/deployer.go
@@ -48,6 +48,7 @@ type Deployer struct {
 	namespace        string
 	runID            string
 	cliVersion       string // CLI version — forwarded to validator containers via AICR_CLI_VERSION for inner-image resolution
+	cliCommit        string // CLI commit SHA — forwarded via AICR_CLI_COMMIT for dev-build image resolution
 	entry            catalog.ValidatorEntry
 	jobName          string // Unique name generated client-side (set by DeployJob)
 	imagePullSecrets []string
@@ -61,11 +62,12 @@ type Deployer struct {
 // and is forwarded to the validator container via the AICR_CLI_VERSION env var so
 // the validator can resolve images it references outside the catalog (e.g. the
 // AIPerf benchmark image used by inference-perf) using the same rewriting
-// rules as catalog.Load.
+// rules as catalog.Load. cliCommit is the git commit SHA, forwarded via
+// AICR_CLI_COMMIT for SHA-based image tag resolution in dev builds.
 func NewDeployer(
 	clientset kubernetes.Interface,
 	factory informers.SharedInformerFactory,
-	namespace, runID, cliVersion string,
+	namespace, runID, cliVersion, cliCommit string,
 	entry catalog.ValidatorEntry,
 	imagePullSecrets []string,
 	tolerations []corev1.Toleration,
@@ -78,6 +80,7 @@ func NewDeployer(
 		namespace:        namespace,
 		runID:            runID,
 		cliVersion:       cliVersion,
+		cliCommit:        cliCommit,
 		entry:            entry,
 		imagePullSecrets: imagePullSecrets,
 		tolerations:      tolerations,
@@ -224,6 +227,9 @@ func (d *Deployer) buildEnvApply() []*applycorev1.EnvVarApplyConfiguration {
 	// registry override that catalog.Load applies to catalog entries.
 	if d.cliVersion != "" {
 		env = append(env, applycorev1.EnvVar().WithName("AICR_CLI_VERSION").WithValue(d.cliVersion))
+	}
+	if d.cliCommit != "" {
+		env = append(env, applycorev1.EnvVar().WithName("AICR_CLI_COMMIT").WithValue(d.cliCommit))
 	}
 	if override := os.Getenv("AICR_VALIDATOR_IMAGE_REGISTRY"); override != "" {
 		env = append(env, applycorev1.EnvVar().WithName("AICR_VALIDATOR_IMAGE_REGISTRY").WithValue(override))

--- a/pkg/validator/job/deployer_test.go
+++ b/pkg/validator/job/deployer_test.go
@@ -55,7 +55,7 @@ func deployAndGet(t *testing.T, d *Deployer) *batchv1.Job {
 }
 
 func TestJobNameEmptyBeforeDeploy(t *testing.T) {
-	d := NewDeployer(nil, nil, "default", "run123", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(nil, nil, "default", "run123", "", "", testEntry(), nil, nil, nil)
 	if d.JobName() != "" {
 		t.Errorf("JobName() before deploy = %q, want empty", d.JobName())
 	}
@@ -63,7 +63,7 @@ func TestJobNameEmptyBeforeDeploy(t *testing.T) {
 
 func TestGenerateJobName(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 	job := deployAndGet(t, d)
 
 	if !strings.HasPrefix(job.Name, "aicr-gpu-operator-health-") {
@@ -78,8 +78,8 @@ func TestDeployJobUniqueNames(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d1 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
-	d2 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d1 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
+	d2 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 
 	if err := d1.DeployJob(ctx); err != nil {
 		t.Fatalf("first DeployJob() failed: %v", err)
@@ -95,7 +95,7 @@ func TestDeployJobUniqueNames(t *testing.T) {
 
 func TestDeployJobSSAFieldManager(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	found := false
 	for _, ref := range job.ManagedFields {
@@ -111,7 +111,7 @@ func TestDeployJobSSAFieldManager(t *testing.T) {
 
 func TestDeployJobLabels(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	expectedLabels := map[string]string{
 		"app.kubernetes.io/name":       "aicr",
@@ -138,7 +138,7 @@ func TestDeployJobLabels(t *testing.T) {
 
 func TestDeployJobTimeouts(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 120 {
 		t.Errorf("ActiveDeadlineSeconds = %v, want 120", job.Spec.ActiveDeadlineSeconds)
@@ -163,7 +163,7 @@ func TestDeployJobDefaultTimeout(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	entry := testEntry()
 	entry.Timeout = 0
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", entry, nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", entry, nil, nil, nil))
 
 	expected := int64(defaults.ValidatorDefaultTimeout.Seconds())
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != expected {
@@ -173,7 +173,7 @@ func TestDeployJobDefaultTimeout(t *testing.T) {
 
 func TestDeployJobContainer(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	containers := job.Spec.Template.Spec.Containers
 	if len(containers) != 1 {
@@ -203,7 +203,7 @@ func TestDeployJobContainer(t *testing.T) {
 
 func TestDeployJobResources(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	c := job.Spec.Template.Spec.Containers[0]
 	if c.Resources.Requests.Cpu().String() != "1" {
@@ -222,7 +222,7 @@ func TestDeployJobResources(t *testing.T) {
 
 func TestDeployJobEnvVars(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	envMap := make(map[string]corev1.EnvVar)
@@ -260,6 +260,12 @@ func TestDeployJobEnvVars(t *testing.T) {
 		t.Errorf("AICR_CLI_VERSION should not be set when cliVersion is empty; got %q",
 			envMap["AICR_CLI_VERSION"].Value)
 	}
+
+	// Empty cliCommit — AICR_CLI_COMMIT env var should not be injected.
+	if _, ok := envMap["AICR_CLI_COMMIT"]; ok {
+		t.Errorf("AICR_CLI_COMMIT should not be set when cliCommit is empty; got %q",
+			envMap["AICR_CLI_COMMIT"].Value)
+	}
 }
 
 // TestDeployJobCLIVersionInjected exercises the production code path where
@@ -270,7 +276,7 @@ func TestDeployJobEnvVars(t *testing.T) {
 func TestDeployJobCLIVersionInjected(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	const wantVersion = "v0.11.1-test"
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", wantVersion, testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", wantVersion, "", testEntry(), nil, nil, nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	var got *corev1.EnvVar
@@ -288,9 +294,33 @@ func TestDeployJobCLIVersionInjected(t *testing.T) {
 	}
 }
 
+// TestDeployJobCLICommitInjected exercises the production code path where
+// validator.go passes v.Commit (non-empty) so the inner validator container
+// can resolve SHA-based image tags in dev builds via AICR_CLI_COMMIT.
+func TestDeployJobCLICommitInjected(t *testing.T) {
+	ns := createUniqueNamespace(t)
+	const wantCommit = "abc1234"
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", wantCommit, testEntry(), nil, nil, nil))
+
+	env := job.Spec.Template.Spec.Containers[0].Env
+	var got *corev1.EnvVar
+	for i := range env {
+		if env[i].Name == "AICR_CLI_COMMIT" {
+			got = &env[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("AICR_CLI_COMMIT not found in env; have %d vars", len(env))
+	}
+	if got.Value != wantCommit {
+		t.Errorf("AICR_CLI_COMMIT = %q, want %q", got.Value, wantCommit)
+	}
+}
+
 func TestDeployJobVolumes(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	volumes := job.Spec.Template.Spec.Volumes
 	if len(volumes) != 2 {
@@ -315,7 +345,7 @@ func TestDeployJobVolumes(t *testing.T) {
 
 func TestDeployJobAffinity(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	affinity := job.Spec.Template.Spec.Affinity
 	if affinity == nil || affinity.NodeAffinity == nil {
@@ -339,7 +369,7 @@ func TestDeployJobAffinity(t *testing.T) {
 func TestDeployJobImagePullSecrets(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	secrets := []string{"registry-creds", "other-secret"}
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), secrets, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), secrets, nil, nil))
 
 	ips := job.Spec.Template.Spec.ImagePullSecrets
 	if len(ips) != 2 {
@@ -364,7 +394,7 @@ func TestDeployJobOrchestratorToleratesTolerateAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := createUniqueNamespace(t)
-			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, tt.tolerations, nil))
+			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, tt.tolerations, nil))
 			tols := job.Spec.Template.Spec.Tolerations
 			if len(tols) != 1 || tols[0].Operator != corev1.TolerationOpExists || tols[0].Key != "" {
 				t.Errorf("orchestrator tolerations = %v, want single tolerate-all {Operator: Exists}", tols)
@@ -377,7 +407,7 @@ func TestDeployJobNodeSelectorEnvVar(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	// Use a single-key selector to avoid map ordering issues in serialization.
 	nodeSelector := map[string]string{"my-org/gpu-pool": "true"}
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nodeSelector))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nodeSelector))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	envMap := make(map[string]corev1.EnvVar)
@@ -399,7 +429,7 @@ func TestDeployJobNodeSelectorEnvVar(t *testing.T) {
 
 func TestDeployJobNodeSelectorEnvVarAbsent(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
 		if e.Name == "AICR_NODE_SELECTOR" {
@@ -413,7 +443,7 @@ func TestDeployJobTolerationsEnvVar(t *testing.T) {
 	tolerations := []corev1.Toleration{
 		{Key: "gpu-type", Value: "h100", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual},
 	}
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, tolerations, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, tolerations, nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	envMap := make(map[string]corev1.EnvVar)
@@ -429,7 +459,7 @@ func TestDeployJobTolerationsEnvVar(t *testing.T) {
 
 func TestDeployJobPodSpec(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	podSpec := job.Spec.Template.Spec
 	if podSpec.ServiceAccountName != ServiceAccountName {
@@ -444,7 +474,7 @@ func TestCleanupJob(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 	if err := d.DeployJob(ctx); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -465,7 +495,7 @@ func TestCleanupJob(t *testing.T) {
 }
 
 func TestCleanupJobNotFound(t *testing.T) {
-	d := NewDeployer(testClientset, nil, "default", "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, nil, "default", "run1", "", "", testEntry(), nil, nil, nil)
 	// jobName is empty — CleanupJob should return nil
 	if err := d.CleanupJob(context.Background()); err != nil {
 		t.Fatalf("CleanupJob() on empty jobName should not error, got: %v", err)
@@ -541,7 +571,7 @@ func TestWaitForCompletionFastPath(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 	if err := d.DeployJob(ctx); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -579,7 +609,7 @@ func TestWaitForCompletionFastPathFailed(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 	if err := d.DeployJob(ctx); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -605,7 +635,7 @@ func TestWaitForCompletionFastPathFailed(t *testing.T) {
 func TestWaitForCompletionJobNotFound(t *testing.T) {
 	ns := createUniqueNamespace(t)
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 	d.jobName = "nonexistent-job"
 
 	err := d.WaitForCompletion(context.Background(), 1*time.Minute)
@@ -643,7 +673,7 @@ func TestImagePullPolicy(t *testing.T) {
 func TestWaitForCompletionTimeout(t *testing.T) {
 	ns := createUniqueNamespace(t)
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", testEntry(), nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil)
 	if err := d.DeployJob(context.Background()); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}

--- a/pkg/validator/job/result_test.go
+++ b/pkg/validator/job/result_test.go
@@ -60,7 +60,7 @@ func createPodForJob(t *testing.T, ns, jobName string, status corev1.PodStatus) 
 // deployTestJob deploys a Job via envtest and returns the Deployer.
 func deployTestJob(t *testing.T, ns string, entry catalog.ValidatorEntry) *Deployer {
 	t.Helper()
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", entry, nil, nil, nil)
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", entry, nil, nil, nil)
 	if err := d.DeployJob(context.Background()); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}

--- a/pkg/validator/options.go
+++ b/pkg/validator/options.go
@@ -26,6 +26,14 @@ func WithVersion(version string) Option {
 	}
 }
 
+// WithCommit sets the git commit SHA (typically the CLI build commit).
+// Used for resolving dev-build validator images to SHA-tagged images.
+func WithCommit(commit string) Option {
+	return func(v *Validator) {
+		v.Commit = commit
+	}
+}
+
 // WithNamespace sets the Kubernetes namespace for validation Jobs.
 // Default: "aicr-validation".
 func WithNamespace(namespace string) Option {

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -31,6 +31,10 @@ type Validator struct {
 	// Version is the validator version (typically the CLI version).
 	Version string
 
+	// Commit is the git commit SHA from the CLI build. Used to resolve
+	// dev-build validator images to SHA-tagged images pushed by on-push CI.
+	Commit string
+
 	// Namespace is the Kubernetes namespace for validation Jobs.
 	Namespace string
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -165,7 +165,7 @@ func (v *Validator) ValidatePhases(
 		return nil, err
 	}
 
-	cat, err := catalog.Load(v.Version)
+	cat, err := catalog.Load(v.Version, v.Commit)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog", err)
 	}
@@ -223,7 +223,7 @@ func (v *Validator) ValidatePhase(
 	snap *snapshotter.Snapshot,
 ) (*PhaseResult, error) {
 
-	cat, err := catalog.Load(v.Version)
+	cat, err := catalog.Load(v.Version, v.Commit)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog", err)
 	}
@@ -322,7 +322,7 @@ func (v *Validator) runPhase(
 		slog.Info("running validator", "name", entry.Name, "phase", phase)
 
 		deployer := job.NewDeployer(
-			clientset, factory, v.Namespace, v.RunID, v.Version, entry,
+			clientset, factory, v.Namespace, v.RunID, v.Version, v.Commit, entry,
 			v.ImagePullSecrets, v.Tolerations, v.NodeSelector,
 		)
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -99,7 +99,7 @@ func TestGenerateRunID(t *testing.T) {
 
 func loadEmbeddedCatalog(t *testing.T) *catalog.ValidatorCatalog {
 	t.Helper()
-	cat, err := catalog.Load("")
+	cat, err := catalog.Load("", "")
 	if err != nil {
 		t.Fatalf("failed to load catalog: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestPhaseOrder(t *testing.T) {
 // in recipe overlays exists in the validator catalog for the correct phase.
 // Catches typos and drift between recipes and catalog at PR time.
 func TestRecipeCheckNamesMatchCatalog(t *testing.T) {
-	cat, err := catalog.Load("")
+	cat, err := catalog.Load("", "")
 	if err != nil {
 		t.Fatalf("failed to load catalog: %v", err)
 	}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -54,6 +54,7 @@ func TestNewDefaults(t *testing.T) {
 func TestNewWithOptions(t *testing.T) {
 	v := New(
 		WithVersion("1.0.0"),
+		WithCommit("abc1234"),
 		WithNamespace("custom-ns"),
 		WithRunID("test-run"),
 		WithCleanup(false),
@@ -64,6 +65,9 @@ func TestNewWithOptions(t *testing.T) {
 
 	if v.Version != "1.0.0" {
 		t.Errorf("Version = %q, want %q", v.Version, "1.0.0")
+	}
+	if v.Commit != "abc1234" {
+		t.Errorf("Commit = %q, want %q", v.Commit, "abc1234")
 	}
 	if v.Namespace != "custom-ns" {
 		t.Errorf("Namespace = %q, want %q", v.Namespace, "custom-ns")

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1125,7 +1125,7 @@ func runAIPerfJob(ctx *validators.Context, endpoint string, concurrency int, job
 // mirrored/private-registry deployments and release-version pinning reach
 // this inner workload too.
 func resolveAiperfImage() string {
-	return catalog.ResolveImage(aiperfBaseImage, os.Getenv("AICR_CLI_VERSION"))
+	return catalog.ResolveImage(aiperfBaseImage, os.Getenv("AICR_CLI_VERSION"), os.Getenv("AICR_CLI_COMMIT"))
 }
 
 // getOwnPullSecrets returns the imagePullSecrets attached to the pod this


### PR DESCRIPTION
## Summary

When version is a non-release (dev, -next) and a valid commit SHA is available, `ResolveImage` now resolves `:latest` to `:sha-<commit>` matching the tags `on-push.yaml` already pushes. This allows validation from main to use its own validator images without requiring a release or manual override.

## Motivation / Context

Validator images on main are unreachable by default — `catalog.yaml` hardcodes `:latest`, but `on-push.yaml` only pushes SHA-tagged images and `:latest` is reserved for stable releases. Running validation from main always pulls the last released image, not what was just built.

Fixes: #654
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Resolution order in `ResolveImage(image, version, commit)`:
1. Release version (vX.Y.Z) → `:vX.Y.Z` (unchanged)
2. Non-release + valid commit SHA → `:sha-<commit>` (new)
3. Non-release + no commit → `:latest` (unchanged fallback)
4. Registry override applied last (unchanged)

The commit SHA is threaded from CLI ldflags (`pkg/cli.commit`) through:
- `validator.WithCommit(commit)` option → `Validator.Commit` field
- `catalog.Load(version, commit)` → `ResolveImage(image, version, commit)`
- `job.NewDeployer(..., cliCommit, ...)` → `AICR_CLI_COMMIT` env var
- Inner validators (e.g. inference-perf) read `AICR_CLI_COMMIT` for their own image resolution

`isValidCommit()` accepts 7-40 hex chars, rejects `""` and `"unknown"` (the ldflags default).

## Testing

```bash
go test -race ./pkg/validator/catalog/... ./pkg/validator/job/... ./pkg/validator/... ./validators/performance/...
golangci-lint run -c .golangci.yaml ./pkg/validator/... ./pkg/cli/... ./validators/performance/...
```

All tests pass, zero lint issues. New test cases cover:
- dev + valid commit → SHA tag
- dev + unknown/empty commit → stays `:latest`
- `-next` + valid commit → SHA tag
- release + commit → release takes precedence
- explicit tag + commit → not modified
- dev + commit + registry override → both compose
- `AICR_CLI_COMMIT` env injection in deployer

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No migration needed. Release builds are completely unaffected — the new code path only activates for non-release versions with a valid commit SHA. Existing dev builds without a commit SHA (`"unknown"`) continue using `:latest` as before.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)