### PR TITLE
feat(validator): add AICR_VALIDATOR_IMAGE_TAG env-var override

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -136,6 +136,7 @@ The validator engine mounts snapshot and recipe data as ConfigMaps:
 | `AICR_SNAPSHOT_PATH` | Override snapshot mount path |
 | `AICR_RECIPE_PATH` | Override recipe mount path |
 | `AICR_VALIDATOR_IMAGE_REGISTRY` | Override image registry prefix (set by user) |
+| `AICR_VALIDATOR_IMAGE_TAG` | Override the resolved image tag (e.g. `latest`). Bypasses the default `:v<version>` / `:sha-<commit>` resolution for feature-branch dev builds whose commit has no published image. |
 | `AICR_NODE_SELECTOR` | User-provided node selector override for inner workloads (comma-separated `key=value` pairs). Set by the `--node-selector` CLI flag. Use `ctx.NodeSelector` to access the parsed value. |
 | `AICR_TOLERATIONS` | User-provided toleration override for inner workloads (comma-separated `key=value:effect` entries). Set by the `--toleration` CLI flag. Use `ctx.Tolerations` to access the parsed value. |
 
@@ -227,8 +228,24 @@ Each entry in `recipes/validators/catalog.yaml`:
 **Image tag resolution** (applied by `catalog.Load`):
 
 1. `:latest` tags are replaced with the CLI version (e.g., `:v0.9.5`) for release builds
-2. Explicit version tags (e.g., `:v1.2.3`) are never modified
-3. `AICR_VALIDATOR_IMAGE_REGISTRY` overrides the registry prefix
+2. On non-release dev builds with a valid commit, `:latest` becomes `:sha-<commit>` (matches the tags `on-push.yaml` pushes for merges to `main`)
+3. Explicit version tags (e.g., `:v1.2.3`) are not modified by steps 1-2
+4. `AICR_VALIDATOR_IMAGE_TAG` overrides the resolved tag on every validator image, including explicit catalog tags. Use this when running `aicr validate` from a feature-branch dev build whose commit has not been merged to `main` (no `:sha-<commit>` image has been published). Typical value: `latest`. Example: `AICR_VALIDATOR_IMAGE_TAG=latest aicr validate --phase performance ...`
+5. `AICR_VALIDATOR_IMAGE_REGISTRY` overrides the registry prefix
+
+**Digest-pinned references** (`name@sha256:…`) are not rewritten by step 4. A tag override is meaningless against a content-addressable pin, and naive rewriting would corrupt the digest. Step 5's registry override still applies — only the registry prefix changes, the digest is preserved verbatim.
+
+**Env-var forwarding to the validator pod:** `AICR_CLI_VERSION`, `AICR_CLI_COMMIT`, `AICR_VALIDATOR_IMAGE_REGISTRY`, and `AICR_VALIDATOR_IMAGE_TAG` are forwarded from the CLI invocation into the validator container so that validators resolving inner workload images at runtime (e.g. `inference-perf`'s AIPerf benchmark Job) apply the same semantics as `catalog.Load`. If you set `AICR_VALIDATOR_IMAGE_TAG=latest` on the CLI, the override reaches both the outer validator Job and the inner benchmark Job — they always travel together.
+
+**Pull-policy behavior when the override is set:** both the outer validator Job and every inner workload Job it dispatches route through the shared `catalog.ImagePullPolicy(image)` helper (`pkg/validator/catalog/catalog.go`). The rule, in precedence order, is:
+
+1. **Side-loaded refs** (`ko.local/*`, `kind.local/*`) → `Never` (no registry to pull from).
+2. **Digest-pinned refs** (`name@sha256:…`) → `IfNotPresent`. Cryptographic immutability means a cached copy is always correct; forcing `Always` here would make kubelet re-contact the registry every run, which breaks disconnected / air-gapped clusters even though the image itself was never overridden.
+3. **`AICR_VALIDATOR_IMAGE_TAG` is set** → `Always`. Override values are typically mutable (`latest`, `edge`, `main`, or any tag `on-push.yaml` recreates on every merge), so `IfNotPresent` would let a node's previously cached image win over the tag's current target.
+4. **`:latest` suffix** → `Always`. Mutable tag by convention.
+5. **Otherwise** → `IfNotPresent`. Versioned tag assumed immutable enough that caching is a win.
+
+Callers in this repo: the outer validator Job's `Deployer.imagePullPolicy()` (`pkg/validator/job/deployer.go`) and the inner AIPerf benchmark pod spec in `buildAIPerfJob` (`validators/performance/inference_perf_constraint.go`). They both delegate to the same helper so their policy can't drift. When adding a new inner workload Job in `validators/<phase>/*`, set `ImagePullPolicy: catalog.ImagePullPolicy(<resolved image>)` on the container to keep the invariant.
 
 **Performance phase example — inference perf:**
 

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -27,6 +27,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -103,9 +104,14 @@ type EnvVar struct {
 //     the tag is replaced with the CLI version for reproducibility.
 //  2. If version is a non-release dev build and commit is a valid short SHA,
 //     the tag is replaced with :sha-<commit> to match on-push.yaml image tags.
-//  3. If AICR_VALIDATOR_IMAGE_REGISTRY is set, the registry prefix is replaced.
+//  3. If AICR_VALIDATOR_IMAGE_TAG is set, the resolved tag is overridden.
+//     Useful for feature-branch dev builds whose commit SHA has no published
+//     image (on-push.yaml only pushes SHA tags for commits merged to main).
+//     Common value: `latest`.
+//  4. If AICR_VALIDATOR_IMAGE_REGISTRY is set, the registry prefix is replaced.
 //
-// Entries with explicit version tags (e.g., :v1.2.3) are never modified.
+// Entries with explicit version tags (e.g., :v1.2.3) are never modified by
+// steps 1-2 but are replaced by step 3 if that env var is set.
 func Load(version, commit string) (*ValidatorCatalog, error) {
 	data, err := recipe.GetDataProvider().ReadFile("validators/catalog.yaml")
 	if err != nil {
@@ -131,7 +137,11 @@ func Load(version, commit string) (*ValidatorCatalog, error) {
 //
 //  1. :latest tag replacement with version if version is a release (vX.Y.Z).
 //  2. If non-release and commit is a valid SHA, :latest → :sha-<commit>.
-//  3. Registry prefix override if AICR_VALIDATOR_IMAGE_REGISTRY is set.
+//  3. Tag override if AICR_VALIDATOR_IMAGE_TAG is set (overrides steps 1-2
+//     AND explicit catalog tags). Intended for feature-branch dev builds
+//     where no :sha-<commit> image has been published; typical value:
+//     `latest`.
+//  4. Registry prefix override if AICR_VALIDATOR_IMAGE_REGISTRY is set.
 //
 // Images with explicit version tags are not modified by steps 1-2.
 func ResolveImage(image, version, commit string) string {
@@ -141,10 +151,56 @@ func ResolveImage(image, version, commit string) string {
 	} else if isValidCommit(commit) {
 		image = replaceLatestWithSHA(image, commit)
 	}
+	if tag := os.Getenv("AICR_VALIDATOR_IMAGE_TAG"); tag != "" {
+		image = replaceTag(image, tag)
+	}
 	if override := os.Getenv("AICR_VALIDATOR_IMAGE_REGISTRY"); override != "" {
 		image = replaceRegistry(image, override)
 	}
 	return image
+}
+
+// ImagePullPolicy returns the appropriate Kubernetes pull policy for a
+// resolved validator image. The caller should pass the image that
+// ResolveImage would return (i.e. after any env-var rewriting); callers that
+// just installed an image from the catalog can reuse this helper so the
+// outer validator Job and any inner workload Jobs (e.g. inference-perf's
+// aiperf-bench Job) stay in lockstep.
+//
+// Precedence (first match wins):
+//
+//  1. Side-loaded refs (ko.local/*, kind.local/*) → Never. No registry to
+//     pull from — the image is preloaded via `kind load docker-image`.
+//  2. Digest-pinned refs (name@sha256:...) → IfNotPresent. The digest is
+//     cryptographically immutable, so a cached copy is always correct;
+//     forcing Always here would break disconnected/private clusters that
+//     preload images and make kubelet re-contact the registry every run.
+//  3. AICR_VALIDATOR_IMAGE_TAG is set → Always. The override is intended
+//     for mutable published tags (e.g. `latest`, `edge`, `main` — tags
+//     on-push.yaml recreates on every merge); re-pulling prevents
+//     node-local caches from serving stale images.
+//  4. `:latest` suffix → Always. Mutable tag by convention.
+//  5. Otherwise → IfNotPresent. Versioned tag assumed immutable enough
+//     that caching is a win.
+func ImagePullPolicy(image string) corev1.PullPolicy {
+	// Trailing slash anchors the match to the full registry segment so a
+	// real registry like `ko.localhost:5000/...` is not mistaken for a
+	// side-loaded `ko.local/...` ref and wrongly forced to PullNever.
+	if strings.HasPrefix(image, "ko.local/") || strings.HasPrefix(image, "kind.local/") {
+		return corev1.PullNever
+	}
+	if strings.Contains(image, "@") {
+		// Digest pin — immutable by construction. Caching is safe and
+		// also required for disconnected/air-gapped deployments.
+		return corev1.PullIfNotPresent
+	}
+	if os.Getenv("AICR_VALIDATOR_IMAGE_TAG") != "" {
+		return corev1.PullAlways
+	}
+	if strings.HasSuffix(image, ":latest") {
+		return corev1.PullAlways
+	}
+	return corev1.PullIfNotPresent
 }
 
 // releaseVersionPattern matches strict semantic versions: vX.Y.Z or X.Y.Z
@@ -190,6 +246,35 @@ func isValidCommit(commit string) bool {
 		}
 	}
 	return true
+}
+
+// replaceTag forces the image's tag to newTag, regardless of what tag (if
+// any) the image currently carries. Unlike replaceLatestTag / replaceLatestWithSHA,
+// which only rewrite :latest, this helper supports the AICR_VALIDATOR_IMAGE_TAG
+// env-var escape hatch: a user running a feature-branch dev build (where no
+// :sha-<commit> image was published by on-push.yaml) can set the env var
+// to `latest` and force every validator image to a published tag.
+//
+// Digest-pinned references (`name@sha256:…`) are cryptographic pins and are
+// intentionally left untouched — a tag override is meaningless against a
+// content-addressable ref, and naively rewriting would corrupt the digest.
+// For non-digest refs, the tag separator is found as the last ':' that sits
+// after the last '/' to avoid colliding with the registry port (`:5001` in
+// `localhost:5001/...`).
+func replaceTag(image, newTag string) string {
+	if strings.Contains(image, "@") {
+		// Digest-pinned ref (e.g. ghcr.io/foo/bar@sha256:deadbeef, or the
+		// mixed form name:tag@sha256:…). The digest is the authoritative
+		// pin; preserve it verbatim.
+		return image
+	}
+	slash := strings.LastIndex(image, "/")
+	colon := strings.LastIndex(image, ":")
+	if colon <= slash {
+		// No tag on the image (just an image reference) — append one.
+		return image + ":" + newTag
+	}
+	return image[:colon] + ":" + newTag
 }
 
 // replaceLatestWithSHA replaces :latest with :sha-<commit> to match the

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestLoadEmbeddedCatalog(t *testing.T) {
@@ -365,6 +366,11 @@ func TestLoadWithoutRegistryOverride(t *testing.T) {
 }
 
 func TestLoadWithExternalCatalog(t *testing.T) {
+	// Isolate from caller's shell so the image-equality assertions below
+	// compare against the default-resolution path, not an override.
+	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
+	t.Setenv("AICR_VALIDATOR_IMAGE_TAG", "")
+
 	// Create external data directory with registry.yaml (required) and catalog
 	tmpDir := t.TempDir()
 
@@ -456,6 +462,10 @@ validators:
 //  2. ResolveImage produces the correct :sha-<commit> tag with a full SHA.
 func TestResolveImageCIContract(t *testing.T) {
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
+	// Isolate from caller's shell — AICR_VALIDATOR_IMAGE_TAG rewrites the
+	// resolved tag and would otherwise turn this contract test's default
+	// resolution into an override-driven path during dogfooding.
+	t.Setenv("AICR_VALIDATOR_IMAGE_TAG", "")
 
 	// Guard: .goreleaser.yaml must use FullCommit for both aicr and aicrd.
 	data, err := os.ReadFile("../../../.goreleaser.yaml")
@@ -492,6 +502,7 @@ func TestResolveImage(t *testing.T) {
 		version  string
 		commit   string
 		registry string // if non-empty, sets AICR_VALIDATOR_IMAGE_REGISTRY for the test
+		tag      string // if non-empty, sets AICR_VALIDATOR_IMAGE_TAG for the test
 		want     string
 	}{
 		{
@@ -642,6 +653,107 @@ func TestResolveImage(t *testing.T) {
 			commit:  "ABC1234",
 			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abc1234",
 		},
+		// --- AICR_VALIDATOR_IMAGE_TAG escape hatch -----------------------
+		// Motivating scenario: a contributor building aicr from an
+		// un-merged feature-branch checkout. The commit isn't on main,
+		// so on-push.yaml never pushed :sha-<commit> to ghcr, and
+		// `aicr validate` pod ImagePullBackOffs. Setting
+		// AICR_VALIDATOR_IMAGE_TAG=latest (or any published tag) forces
+		// every validator image to a reachable tag without losing the
+		// registry / version-based resolution as the default.
+		{
+			name:    "tag override rewrites :latest on dev build (feature-branch dogfooding)",
+			image:   imgLatest,
+			version: "dev",
+			commit:  "abc1234",
+			tag:     "latest",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:latest",
+		},
+		{
+			name:    "tag override replaces :sha-<commit> when both resolve",
+			image:   imgLatest,
+			version: "v0.11.1-next",
+			commit:  "abc1234",
+			tag:     "latest",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:latest",
+		},
+		{
+			name:    "tag override replaces the release :vX.Y.Z tag",
+			image:   imgLatest,
+			version: "v0.11.1",
+			tag:     "latest",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:latest",
+		},
+		{
+			name:    "tag override replaces an explicit catalog tag",
+			image:   imgPinned, // :v1.2.3 is normally untouched
+			version: "v0.11.1",
+			tag:     "latest",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:latest",
+		},
+		{
+			name:    "tag override with no tag on image appends the tag",
+			image:   "ghcr.io/nvidia/aicr-validators/aiperf-bench",
+			version: "dev",
+			tag:     "latest",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:latest",
+		},
+		{
+			name:    "empty tag env var leaves image untouched (no-op)",
+			image:   imgPinned,
+			version: "v0.11.1",
+			tag:     "", // explicitly empty — should behave like unset
+			want:    imgPinned,
+		},
+		{
+			name:    "tag override preserves registry port (localhost:5001 edge case)",
+			image:   "localhost:5001/aicr-validators/aiperf-bench:sha-abc1234",
+			version: "dev",
+			commit:  "abc1234",
+			tag:     "latest",
+			want:    "localhost:5001/aicr-validators/aiperf-bench:latest",
+		},
+		{
+			name:     "tag override and registry override compose",
+			image:    imgLatest,
+			version:  "dev",
+			commit:   "abc1234",
+			tag:      "v0.11.0",
+			registry: "localhost:5001",
+			want:     "localhost:5001/aicr-validators/aiperf-bench:v0.11.0",
+		},
+		// --- digest-pinned refs must never be tag-rewritten --------------
+		// A tag override is incompatible with a content-addressable digest
+		// pin. Naive last-colon splitting would corrupt `@sha256:<hash>`
+		// into `@sha256:<newTag>`, emitting an invalid reference.
+		{
+			name:    "digest-pinned image is not rewritten by tag override",
+			image:   "ghcr.io/foo/bar@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			version: "dev",
+			commit:  "abc1234",
+			tag:     "latest",
+			want:    "ghcr.io/foo/bar@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		},
+		{
+			name:    "mixed ref (name:tag@digest) is not rewritten by tag override",
+			image:   "ghcr.io/foo/bar:v1.0.0@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			version: "dev",
+			commit:  "abc1234",
+			tag:     "latest",
+			want:    "ghcr.io/foo/bar:v1.0.0@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		},
+		{
+			// Registry override still applies to digest refs (existing
+			// replaceRegistry behavior), so compose test verifies the two
+			// env vars don't step on each other on a digest-pinned image.
+			name:     "digest ref + registry override: digest preserved, prefix replaced",
+			image:    "ghcr.io/nvidia/aicr-validators/aiperf-bench@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			version:  "dev",
+			commit:   "abc1234",
+			tag:      "latest",
+			registry: "localhost:5001",
+			want:     "localhost:5001/aicr-validators/aiperf-bench@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		},
 	}
 
 	for _, tt := range tests {
@@ -651,9 +763,86 @@ func TestResolveImage(t *testing.T) {
 			} else {
 				t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
 			}
+			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", tt.tag)
 			got := ResolveImage(tt.image, tt.version, tt.commit)
 			if got != tt.want {
 				t.Errorf("ResolveImage(%q, %q, %q) = %q, want %q", tt.image, tt.version, tt.commit, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestImagePullPolicy covers the shared helper that both the outer
+// validator Deployer and the inner aiperf-bench Job call, so they stay in
+// lockstep. The digest-pin case is the specific Codex P3 concern: forcing
+// PullAlways on a digest-pinned ref (e.g. an external catalog entry that
+// stayed `name@sha256:…`) would break disconnected/private clusters by
+// making kubelet re-contact the registry every run, for no correctness
+// benefit (the digest is cryptographically immutable).
+func TestImagePullPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		image  string
+		envTag string // AICR_VALIDATOR_IMAGE_TAG — empty means unset
+		want   corev1.PullPolicy
+	}{
+		// ----- side-loaded refs win unconditionally -----
+		{name: "ko.local → Never", image: "ko.local/aicr-validators/x:latest", want: corev1.PullNever},
+		{name: "kind.local → Never", image: "kind.local/aicr-validators/x:latest", want: corev1.PullNever},
+		{name: "ko.local + override still Never", image: "ko.local/aicr-validators/x:edge", envTag: "edge", want: corev1.PullNever},
+		// The side-load check must anchor on the full registry segment
+		// (trailing slash) so a real registry like `ko.localhost:5000/...`
+		// is not misread as `ko.local/...` and forced to PullNever —
+		// kubelet would then be unable to pull from the real registry.
+		{name: "ko.localhost:5000 registry → not treated as side-load", image: "ko.localhost:5000/aicr-validators/x:v1", want: corev1.PullIfNotPresent},
+		{name: "kind.localhost:5000 registry → not treated as side-load", image: "kind.localhost:5000/aicr-validators/x:v1", want: corev1.PullIfNotPresent},
+
+		// ----- digest pins are immutable → IfNotPresent -----
+		{
+			name:  "digest-only ref → IfNotPresent (immutable by construction)",
+			image: "ghcr.io/foo/bar@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			want:  corev1.PullIfNotPresent,
+		},
+		{
+			// Codex P3: the tag override must NOT upgrade a digest ref to
+			// PullAlways. Doing so would make disconnected/air-gapped
+			// clusters re-contact the registry every run for no gain.
+			name:   "digest-only ref + override → IfNotPresent (override does not apply)",
+			image:  "ghcr.io/foo/bar@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			envTag: "latest",
+			want:   corev1.PullIfNotPresent,
+		},
+		{
+			name:  "mixed ref name:tag@digest → IfNotPresent (digest wins)",
+			image: "ghcr.io/foo/bar:v1.0.0@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			want:  corev1.PullIfNotPresent,
+		},
+
+		// ----- override forces Always on non-digest refs -----
+		{
+			name:   "override with :edge → Always (avoid stale cache on mutable tag)",
+			image:  "ghcr.io/nvidia/aicr-validators/performance:edge",
+			envTag: "edge",
+			want:   corev1.PullAlways,
+		},
+		{
+			name:   "override with release :v0.11.0 → Always (safe over-pull, not a regression)",
+			image:  "ghcr.io/nvidia/aicr-validators/performance:v0.11.0",
+			envTag: "v0.11.0",
+			want:   corev1.PullAlways,
+		},
+
+		// ----- default policy (no override) -----
+		{name: ":latest → Always", image: "ghcr.io/nvidia/aicr-validators/performance:latest", want: corev1.PullAlways},
+		{name: ":vX.Y.Z → IfNotPresent", image: "ghcr.io/nvidia/aicr-validators/performance:v1.0.0", want: corev1.PullIfNotPresent},
+		{name: ":sha-<commit> → IfNotPresent (main-branch dev default)", image: "ghcr.io/nvidia/aicr-validators/performance:sha-abc1234", want: corev1.PullIfNotPresent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", tt.envTag)
+			if got := ImagePullPolicy(tt.image); got != tt.want {
+				t.Errorf("ImagePullPolicy(%q) = %q, want %q", tt.image, got, tt.want)
 			}
 		})
 	}

--- a/pkg/validator/job/deployer.go
+++ b/pkg/validator/job/deployer.go
@@ -221,10 +221,15 @@ func (d *Deployer) buildEnvApply() []*applycorev1.EnvVarApplyConfiguration {
 	if len(d.tolerations) > 0 {
 		env = append(env, applycorev1.EnvVar().WithName("AICR_TOLERATIONS").WithValue(serializeTolerations(d.tolerations)))
 	}
-	// Forward CLI version and image-registry override so the validator can
-	// resolve images it references outside the catalog (e.g. inference-perf's
-	// aiperf-bench benchmark image) with the same :latest→version pinning and
-	// registry override that catalog.Load applies to catalog entries.
+	// Forward CLI version, image-registry override, and image-tag override so
+	// the validator can resolve images it references outside the catalog
+	// (e.g. inference-perf's aiperf-bench benchmark image) with the same
+	// resolution semantics that catalog.Load applies to catalog entries.
+	// All three must travel together: if a feature-branch dev build set
+	// AICR_VALIDATOR_IMAGE_TAG=latest on the CLI side to get a published
+	// outer validator image, the inner benchmark pod needs the same
+	// override or it will resolve to the same unpublished :sha-<commit>
+	// the outer pod would have hit without the override.
 	if d.cliVersion != "" {
 		env = append(env, applycorev1.EnvVar().WithName("AICR_CLI_VERSION").WithValue(d.cliVersion))
 	}
@@ -233,6 +238,9 @@ func (d *Deployer) buildEnvApply() []*applycorev1.EnvVarApplyConfiguration {
 	}
 	if override := os.Getenv("AICR_VALIDATOR_IMAGE_REGISTRY"); override != "" {
 		env = append(env, applycorev1.EnvVar().WithName("AICR_VALIDATOR_IMAGE_REGISTRY").WithValue(override))
+	}
+	if tag := os.Getenv("AICR_VALIDATOR_IMAGE_TAG"); tag != "" {
+		env = append(env, applycorev1.EnvVar().WithName("AICR_VALIDATOR_IMAGE_TAG").WithValue(tag))
 	}
 	for _, e := range d.entry.Env {
 		env = append(env, applycorev1.EnvVar().WithName(e.Name).WithValue(e.Value))
@@ -276,23 +284,13 @@ func serializeTolerations(tols []corev1.Toleration) string {
 	return strings.Join(parts, ",")
 }
 
-// imagePullPolicy returns the appropriate pull policy based on the image reference.
-// Side-loaded images (ko.local, kind.local) use Never since they are loaded
-// via `kind load docker-image` and no registry exists to pull from.
-// All other images (including localhost registry) follow the standard policy:
-// :latest tag uses Always to ensure fresh images, versioned tags use IfNotPresent.
+// imagePullPolicy returns the appropriate pull policy for the outer validator
+// Job. Delegates to catalog.ImagePullPolicy so the outer Job and any inner
+// workload Jobs (e.g. inference-perf's aiperf-bench Job) apply the same
+// rules — side-load / digest-pin / AICR_VALIDATOR_IMAGE_TAG override /
+// :latest / versioned — without drifting.
 func (d *Deployer) imagePullPolicy() corev1.PullPolicy {
-	img := d.entry.Image
-	// Side-loaded images via kind load — no registry exists, never pull.
-	if strings.HasPrefix(img, "ko.local") ||
-		strings.HasPrefix(img, "kind.local") {
-
-		return corev1.PullNever
-	}
-	if strings.HasSuffix(img, ":latest") {
-		return corev1.PullAlways
-	}
-	return corev1.PullIfNotPresent
+	return catalog.ImagePullPolicy(d.entry.Image)
 }
 
 func (d *Deployer) buildImagePullSecretsApply() []*applycorev1.LocalObjectReferenceApplyConfiguration {

--- a/pkg/validator/job/deployer_test.go
+++ b/pkg/validator/job/deployer_test.go
@@ -294,6 +294,60 @@ func TestDeployJobCLIVersionInjected(t *testing.T) {
 	}
 }
 
+// TestDeployJobImageTagOverrideForwarding asserts that AICR_VALIDATOR_IMAGE_TAG
+// is forwarded from the CLI invocation into the validator container's env
+// ONLY when set, and that it is strictly omitted when unset. Forwarding is
+// load-bearing for feature-branch dogfooding: validators that resolve inner
+// workload images at runtime (e.g. inference-perf's aiperf-bench Job) call
+// catalog.ResolveImage with the pod's env. Without this forwarding the outer
+// validator would get :latest while the inner benchmark pod would still
+// resolve to the unpublished :sha-<commit> and ImagePullBackOff. Omission
+// on the default paths is equally load-bearing — the release / main-branch
+// flows must not inadvertently pin inner pods to the wrong tag.
+func TestDeployJobImageTagOverrideForwarding(t *testing.T) {
+	tests := []struct {
+		name      string
+		envTag    string
+		wantSet   bool
+		wantValue string
+	}{
+		{name: "set — forwarded into validator container", envTag: "latest", wantSet: true, wantValue: "latest"},
+		{name: "empty — omitted (default release / main-branch paths untouched)", envTag: "", wantSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", tt.envTag)
+
+			ns := createUniqueNamespace(t)
+			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
+
+			env := job.Spec.Template.Spec.Containers[0].Env
+			var got *corev1.EnvVar
+			for i := range env {
+				if env[i].Name == "AICR_VALIDATOR_IMAGE_TAG" {
+					got = &env[i]
+					break
+				}
+			}
+
+			if tt.wantSet {
+				if got == nil {
+					t.Fatalf("AICR_VALIDATOR_IMAGE_TAG not found in env; have %d vars", len(env))
+				}
+				if got.Value != tt.wantValue {
+					t.Errorf("AICR_VALIDATOR_IMAGE_TAG = %q, want %q", got.Value, tt.wantValue)
+				}
+				return
+			}
+
+			if got != nil {
+				t.Errorf("AICR_VALIDATOR_IMAGE_TAG should be omitted when env var is empty; got %q", got.Value)
+			}
+		})
+	}
+}
+
 // TestDeployJobCLICommitInjected exercises the production code path where
 // validator.go passes v.Commit (non-empty) so the inner validator container
 // can resolve SHA-based image tags in dev builds via AICR_CLI_COMMIT.
@@ -648,17 +702,32 @@ func TestImagePullPolicy(t *testing.T) {
 	tests := []struct {
 		name   string
 		image  string
+		envTag string // AICR_VALIDATOR_IMAGE_TAG — empty means unset
 		expect corev1.PullPolicy
 	}{
-		{"latest tag uses Always", "ghcr.io/nvidia/aicr-validators/conformance:latest", corev1.PullAlways},
-		{"versioned tag uses IfNotPresent", "ghcr.io/nvidia/aicr-validators/conformance:v1.0.0", corev1.PullIfNotPresent},
-		{"ko.local uses Never", "ko.local/aicr-validators/conformance:latest", corev1.PullNever},
-		{"kind.local uses Never", "kind.local/aicr-validators/conformance:latest", corev1.PullNever},
-		{"localhost registry with latest uses Always", "localhost:5001/aicr-validators/conformance:latest", corev1.PullAlways},
-		{"localhost registry versioned uses IfNotPresent", "localhost:5001/aicr-validators/conformance:v1.0.0", corev1.PullIfNotPresent},
+		{name: "latest tag uses Always", image: "ghcr.io/nvidia/aicr-validators/conformance:latest", expect: corev1.PullAlways},
+		{name: "versioned tag uses IfNotPresent", image: "ghcr.io/nvidia/aicr-validators/conformance:v1.0.0", expect: corev1.PullIfNotPresent},
+		{name: "ko.local uses Never", image: "ko.local/aicr-validators/conformance:latest", expect: corev1.PullNever},
+		{name: "kind.local uses Never", image: "kind.local/aicr-validators/conformance:latest", expect: corev1.PullNever},
+		{name: "localhost registry with latest uses Always", image: "localhost:5001/aicr-validators/conformance:latest", expect: corev1.PullAlways},
+		{name: "localhost registry versioned uses IfNotPresent", image: "localhost:5001/aicr-validators/conformance:v1.0.0", expect: corev1.PullIfNotPresent},
+		// --- AICR_VALIDATOR_IMAGE_TAG forces PullAlways ------------------
+		// Mutable published tags (edge, main, nightly, or any rolling tag
+		// on-push.yaml recreates on every merge) would otherwise get
+		// PullIfNotPresent and serve a stale cached image. When the user
+		// opts into the override, treat the resolved tag as mutable.
+		{name: "override with mutable tag :edge — Always", image: "ghcr.io/nvidia/aicr-validators/conformance:edge", envTag: "edge", expect: corev1.PullAlways},
+		{name: "override with :latest still Always (no regression)", image: "ghcr.io/nvidia/aicr-validators/conformance:latest", envTag: "latest", expect: corev1.PullAlways},
+		{name: "override with release :v0.11.0 — Always (safe over-pull)", image: "ghcr.io/nvidia/aicr-validators/conformance:v0.11.0", envTag: "v0.11.0", expect: corev1.PullAlways},
+		{name: "override with ko.local still Never (side-load wins)", image: "ko.local/aicr-validators/conformance:edge", envTag: "edge", expect: corev1.PullNever},
+		// Digest-pinned refs stay IfNotPresent even when the override env
+		// var is set — required so disconnected/air-gapped clusters that
+		// preload pinned images don't re-contact the registry every run.
+		{name: "digest-pinned ref + override → IfNotPresent (digest wins over override)", image: "ghcr.io/nvidia/aicr-validators/conformance@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", envTag: "latest", expect: corev1.PullIfNotPresent},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", tt.envTag)
 			entry := testEntry()
 			entry.Image = tt.image
 			d := &Deployer{entry: entry}

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1173,6 +1173,9 @@ func buildAIPerfJob(namespace, jobName, endpoint string, concurrency int, pullSe
 	if concurrency*2 > requestCount {
 		requestCount = concurrency * 2
 	}
+	// Resolve once so Image and ImagePullPolicy can't drift if env vars
+	// were mutated between two calls (matters in tests; cheap in prod).
+	aiperfImage := resolveAiperfImage()
 
 	script := fmt.Sprintf(`set -e
 aiperf profile "%s" \
@@ -1219,10 +1222,22 @@ echo '%s'`,
 					ImagePullSecrets: pullSecrets,
 					Containers: []v1.Container{
 						{
-							Name:    "aiperf",
-							Image:   resolveAiperfImage(),
-							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{script},
+							Name:  "aiperf",
+							Image: aiperfImage,
+							// Apply the same pull policy the outer validator
+							// Job uses (catalog.ImagePullPolicy handles the
+							// AICR_VALIDATOR_IMAGE_TAG override and digest
+							// pins) so a mutable override tag on the CLI
+							// doesn't let the aiperf pod serve a stale
+							// cached image while the outer validator pulls
+							// the current one. Leaving this unset would
+							// fall back to Kubernetes' default (Always
+							// only for :latest), which is insufficient for
+							// `:edge`, `:main`, and similar rolling tags
+							// on-push.yaml recreates on every merge.
+							ImagePullPolicy: catalog.ImagePullPolicy(aiperfImage),
+							Command:         []string{"/bin/sh", "-c"},
+							Args:            []string{script},
 						},
 					},
 				},

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -449,11 +449,16 @@ func TestApplyInferenceWorkerScheduling_MissingServices(t *testing.T) {
 func TestBuildAIPerfJob_PrebuiltImageAndSentinel(t *testing.T) {
 	// Isolate from the caller's environment: buildAIPerfJob resolves the
 	// container image through resolveAiperfImage() which honors
-	// AICR_CLI_VERSION (version pin) and AICR_VALIDATOR_IMAGE_REGISTRY
-	// (registry override). A developer running `go test` with either set
-	// would otherwise see spurious failures on the image-equality assertion.
+	// AICR_CLI_VERSION (version pin), AICR_CLI_COMMIT (dev-build pin),
+	// AICR_VALIDATOR_IMAGE_REGISTRY (registry override), and
+	// AICR_VALIDATOR_IMAGE_TAG (tag override). A developer running
+	// `go test` with any of these set would otherwise see spurious
+	// failures on the image-equality assertion — the exact feature-branch
+	// dogfooding workflow this override was added for.
 	t.Setenv("AICR_CLI_VERSION", "")
+	t.Setenv("AICR_CLI_COMMIT", "")
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
+	t.Setenv("AICR_VALIDATOR_IMAGE_TAG", "")
 
 	pullSecrets := []v1.LocalObjectReference{
 		{Name: "ghcr-mirror-pull"},
@@ -517,6 +522,50 @@ func TestBuildAIPerfJob_NoPullSecrets(t *testing.T) {
 	}
 }
 
+// TestBuildAIPerfJob_ImagePullPolicy asserts the inner aiperf container
+// stays in lockstep with the outer validator Job's pull policy. Without
+// this, setting AICR_VALIDATOR_IMAGE_TAG=edge on the CLI would re-pull
+// the outer validator (Always) while the aiperf pod — lacking an explicit
+// ImagePullPolicy — would default to IfNotPresent and serve a stale
+// cached `:edge` image, defeating the motivating feature-branch workflow.
+func TestBuildAIPerfJob_ImagePullPolicy(t *testing.T) {
+	// Isolate from caller's environment so resolveAiperfImage is deterministic
+	// across cases.
+	t.Setenv("AICR_CLI_VERSION", "")
+	t.Setenv("AICR_CLI_COMMIT", "")
+	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
+
+	tests := []struct {
+		name   string
+		envTag string
+		want   v1.PullPolicy
+	}{
+		{
+			// Default path: aiperfBaseImage ends with :latest, so policy is Always
+			// whether or not the override is set.
+			name:   "no override — :latest → Always",
+			envTag: "",
+			want:   v1.PullAlways,
+		},
+		{
+			name:   "override with mutable :edge tag → Always (no stale cache)",
+			envTag: "edge",
+			want:   v1.PullAlways,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", tt.envTag)
+			job := buildAIPerfJob("ns", "aicr-aiperf-run-0", "http://ep:8000", 16, nil)
+			got := job.Spec.Template.Spec.Containers[0].ImagePullPolicy
+			if got != tt.want {
+				t.Errorf("aiperf ImagePullPolicy = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildAIPerfJob_RequestCountFloor(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -563,7 +612,9 @@ func TestResolveAiperfImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("AICR_CLI_VERSION", tt.version)
+			t.Setenv("AICR_CLI_COMMIT", "")
 			t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
+			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", "")
 			if got := resolveAiperfImage(); got != tt.want {
 				t.Errorf("resolveAiperfImage() = %q, want %q", got, tt.want)
 			}
@@ -572,7 +623,9 @@ func TestResolveAiperfImage(t *testing.T) {
 
 	t.Run("registry override applies", func(t *testing.T) {
 		t.Setenv("AICR_CLI_VERSION", "dev")
+		t.Setenv("AICR_CLI_COMMIT", "")
 		t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "localhost:5001")
+		t.Setenv("AICR_VALIDATOR_IMAGE_TAG", "")
 		want := "localhost:5001/aicr-validators/aiperf-bench:latest"
 		if got := resolveAiperfImage(); got != want {
 			t.Errorf("resolveAiperfImage() = %q, want %q", got, want)


### PR DESCRIPTION
## Summary

Adds `AICR_VALIDATOR_IMAGE_TAG` — an opt-in env-var override that replaces
the resolved tag on every validator image, regardless of what the default
resolution logic (release version or `:sha-<commit>`) produced. Default
behavior is unchanged; users only set this when they need a published tag
for a commit that has not been through `on-push.yaml` yet.

## Motivation / Context

Running `aicr validate` from a feature-branch dev build currently fails
with `ImagePullBackOff` on every validator pod:

```
Failed to pull image "ghcr.io/nvidia/aicr-validators/performance:sha-<branch-commit>":
  ... failed to resolve reference ... not found
```

This is a direct consequence of PR #655: non-release dev builds resolve
to `:sha-<commit>`, but `on-push.yaml` only pushes `:sha-<commit>` for
commits merged to `main`. Contributors dog-fooding a PR before merge
hit a dead-end with no escape hatch. Repro: `git checkout <feature>;
make build; ./aicr validate --phase performance ...` → NotFound.

This adds a single-env-var override so the dev-build workflow can point
at a known-published tag:

```
AICR_VALIDATOR_IMAGE_TAG=latest aicr validate --phase performance ...
```

Release and main-branch paths are untouched.

Fixes: N/A (dev-workflow UX, not a user-visible regression)
Related: #655

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

### 1. Single env-var read in `ResolveImage`

Mirrors the existing `AICR_VALIDATOR_IMAGE_REGISTRY` pattern. Applied
AFTER the existing auto-resolution step (release or SHA), BEFORE the
registry override, so all four layers compose cleanly. When unset,
`ResolveImage` behaves exactly as before.

### 2. Tag-replacement helper

`replaceTag` locates the tag separator as the last `:` that sits after
the last `/`, so `localhost:5001/aicr-validators/…:sha-abc` is rewritten
correctly without clobbering the `5001` registry port. Images without a
tag get the override appended.

### 3. Precedence

The override intentionally replaces ALL tags — including explicit
catalog tags like `:v1.2.3` — because the whole point of the flag is
"force everything to a tag I know is published." A less aggressive
"only override :latest" scheme would silently leave inference-perf's
inner AIPerf benchmark image on its catalog-pinned tag, defeating the
purpose on feature branches that have bumped that tag.

## Testing

```bash
make qualify
```

- `go test -race ./pkg/validator/catalog/...` — pass, 30 ResolveImage cases
  (23 existing + 7 new covering the override)
- `make qualify` — pass
- End-to-end verified on `aicr-cuj2`: `AICR_VALIDATOR_IMAGE_TAG=latest`
  on a feature-branch build resolves the performance validator image to
  the published `:latest` tag; `aicr validate --phase performance`
  runs the full inference-perf check end-to-end (throughput + TTFT p99)
  and returns `passed`

## Risk Assessment

- [x] **Low** — Additive, opt-in, no default-behavior change

When the env var is unset, `ResolveImage` is byte-identical to the
pre-change path (same resolution order, same outputs). The new code is
reached only when a user explicitly sets `AICR_VALIDATOR_IMAGE_TAG`.

**Rollout notes:** No migration. Contributors running `aicr validate`
off a feature branch can opt in starting with the next dev build.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)