### PR TITLE
fix: keep priority labels off PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -577,6 +577,7 @@ This rule does not apply to non-Go changes (YAML, docs, CI workflows). Note: CI 
 - Do NOT add "Generated with Claude Code", "Created by Codex", or similar attribution
 - Add appropriate type labels: `enhancement`, `bug`, `documentation`
 - Area labels are auto-assigned by `.github/labeler.yml` based on changed file paths (e.g., `area/recipes`, `area/ci`, `area/api`, `area/cli`, `area/bundler`, `area/collector`, `area/validator`, `area/docs`, `area/infra`, `area/tests`). You may also add them manually when the auto-labeler wouldn't match (e.g., issue-only PRs or cross-cutting changes).
+- Do NOT add issue priority labels `P0`, `P1`, or `P2` to PRs; they are reserved for issues and automation removes them from pull requests
 - Do NOT add `size/*` labels (auto-assigned by bot)
 - Keep the PR title under 70 characters; use the description for details
 

--- a/.github/actions/remove-issue-only-priority-labels/action.yml
+++ b/.github/actions/remove-issue-only-priority-labels/action.yml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Remove Issue-Only Priority Labels'
+description: 'Remove P<number> priority labels from a pull request'
+
+inputs:
+  issue-number:
+    description: 'Pull request number to inspect'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Remove issue-only priority labels from PR
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      env:
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+      with:
+        script: |
+          const issueNumber = Number(process.env.ISSUE_NUMBER);
+          if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+            core.setFailed(`invalid issue number: ${process.env.ISSUE_NUMBER}`);
+            return;
+          }
+
+          const priorityLabelPattern = /^P\d+$/;
+          const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issueNumber,
+          });
+
+          const present = labels
+            .map(label => label.name)
+            .filter(name => priorityLabelPattern.test(name));
+
+          if (present.length === 0) {
+            core.info('No issue-only priority labels found on this PR');
+            return;
+          }
+
+          for (const name of present) {
+            core.info(`Removing issue-only priority label from PR: ${name}`);
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name,
+            });
+          }

--- a/.github/workflows/pr-label-guard.yaml
+++ b/.github/workflows/pr-label-guard.yaml
@@ -35,32 +35,15 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     steps:
-      - name: Remove issue-only priority labels from PR
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      # Required so `uses: ./.github/actions/...` can resolve the local
+      # composite action. On pull_request_target the default ref is the
+      # base branch (target of the merge), so no PR code is checked out.
+      - name: Checkout base repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          script: |
-            const priorityLabelPattern = /^P\d+$/;
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+          persist-credentials: false
 
-            const present = labels
-              .map(label => label.name)
-              .filter(name => priorityLabelPattern.test(name));
-
-            if (present.length === 0) {
-              core.info('No issue-only priority labels found on this PR');
-              return;
-            }
-
-            for (const name of present) {
-              core.info(`Removing issue-only priority label from PR: ${name}`);
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name,
-              });
-            }
+      - name: Remove issue-only priority labels from PR
+        uses: ./.github/actions/remove-issue-only-priority-labels
+        with:
+          issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-label-guard.yaml
+++ b/.github/workflows/pr-label-guard.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR Label Guard
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  remove-issue-only-priority-labels:
+    name: Remove Issue-Only Priority Labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Remove issue-only priority labels from PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const priorityLabelPattern = /^P\d+$/;
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const present = labels
+              .map(label => label.name)
+              .filter(name => priorityLabelPattern.test(name));
+
+            if (present.length === 0) {
+              core.info('No issue-only priority labels found on this PR');
+              return;
+            }
+
+            for (const name of present) {
+              core.info(`Removing issue-only priority label from PR: ${name}`);
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name,
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,6 +577,7 @@ This rule does not apply to non-Go changes (YAML, docs, CI workflows). Note: CI 
 - Do NOT add "Generated with Claude Code", "Created by Codex", or similar attribution
 - Add appropriate type labels: `enhancement`, `bug`, `documentation`
 - Area labels are auto-assigned by `.github/labeler.yml` based on changed file paths (e.g., `area/recipes`, `area/ci`, `area/api`, `area/cli`, `area/bundler`, `area/collector`, `area/validator`, `area/docs`, `area/infra`, `area/tests`). You may also add them manually when the auto-labeler wouldn't match (e.g., issue-only PRs or cross-cutting changes).
+- Do NOT add issue priority labels `P0`, `P1`, or `P2` to PRs; they are reserved for issues and automation removes them from pull requests
 - Do NOT add `size/*` labels (auto-assigned by bot)
 - Keep the PR title under 70 characters; use the description for details
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,7 @@ Trust is established through evidence, not assertions. Every released artifact c
    - **Type of Change**: Bug fix, feature, breaking change, etc.
    - **Testing**: What testing was performed
    - **Checklist**: Verify all items
+3. Do not use the issue priority labels `P0`, `P1`, or `P2` on PRs. They are reserved for issues and are automatically removed from pull requests by automation.
 
 ### Review Process
 


### PR DESCRIPTION
## Summary

Prevent PRs from carrying issue-only priority labels by removing `P<number>` labels automatically, and document that behavior for contributors and coding agents.

## Motivation / Context

Priority labels in AICR are used for issue triage and SLA tracking, but GitHub does not provide a native way to reserve them for issues only. This adds repo automation so PRs cannot retain those labels.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub workflows / contributor automation

## Implementation Notes

Added a `pull_request_target` workflow that removes labels matching the repo's `P<number>` priority-label convention whenever a PR is opened, reopened, or labeled. Updated `CONTRIBUTING.md`, `.claude/CLAUDE.md`, and `AGENTS.md` so contributors and agents know those labels are issue-only and auto-removed from PRs.

## Testing

```bash
make qualify
actionlint .github/workflows/pr-label-guard.yaml
yamllint .github/workflows/pr-label-guard.yaml
git diff --check -- .github/workflows/pr-label-guard.yaml CONTRIBUTING.md .claude/CLAUDE.md AGENTS.md
```

All commands passed locally.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
