### PR TITLE
feat: GB200 EKS NET/NVLS NCCL validation and driver bump

### DIFF
--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -40,9 +40,21 @@ any phase. If pre-flight fails, no validator Jobs are deployed.
 
 ## Training performance validation
 
-Training performance runs the `nccl-all-reduce-bw` check — a Kubeflow `TrainJob`
-that runs the canonical `all_reduce_perf` benchmark across all GPU nodes and
-measures aggregate bus bandwidth.
+Training performance runs an NCCL all-reduce benchmark — a Kubeflow `TrainJob`
+that runs `all_reduce_perf` across GPU nodes and measures aggregate bus
+bandwidth. Three check variants are available; the recipe picks the one (or
+ones) that match the target fabric:
+
+| Check | Transport | When it's selected |
+|---|---|---|
+| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | Default for H100 on EKS/GKE, and for GB200/B200 on non-EKS services. Preserves the pre-variant behavior. |
+| `nccl-all-reduce-bw-net` | NET (EFA on EKS) | GB200 + EKS. Asserts EFA actually carried traffic — catches silent fallback to Socket when the NVIDIA driver is missing `NVreg_GrdmaPciTopoCheckOverride=1`. |
+| `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA when the IMEX domain is misconfigured. |
+
+GB200/EKS recipes (both `training` and `inference` intents) enable `-net` and
+`-nvls` together rather than the auto-detect variant, because those nodes
+expose two inter-node fabrics simultaneously and a single auto-detect test
+would only exercise one of them.
 
 ```bash
 # Capture snapshot, generate training recipe, validate the performance phase.
@@ -55,24 +67,26 @@ aicr recipe --service eks --accelerator h100 --os ubuntu \
 aicr validate --recipe recipe.yaml --snapshot snapshot.yaml --phase performance
 ```
 
-The generated recipe lists `nccl-all-reduce-bw` under
+The generated recipe lists the selected variant(s) under
 `validation.performance.checks` with a platform-tuned bandwidth constraint
-(example: `>= 300 GB/s` for H100 + EFA).
+(example: `>= 300 GB/s` for H100 + EFA; `>= 40 GB/s` NET and `>= 500 GB/s`
+NVLS for GB200 + EFA, each sized for a 2-node pair).
 
-Expected flow (~5–10 min): readiness pre-flight → deploy `TrainingRuntime` +
-`TrainJob` in `aicr-validation` → worker pods reach `Running` → run
-`all_reduce_perf` → parse peak bus bandwidth → compare to recipe constraint
-(10 % tolerance) → cleanup.
+Expected flow (~5–10 min per variant): readiness pre-flight → deploy
+`TrainingRuntime` + `TrainJob` in `aicr-validation` → worker pods reach
+`Running` → run `all_reduce_perf` → parse peak bus bandwidth → verify the
+intended transport actually carried traffic (for `-net` / `-nvls`) → compare
+to recipe constraint (10 % tolerance) → cleanup.
 
 A passing CTRF entry:
 
 ```json
 {
-  "name": "nccl-all-reduce-bw",
+  "name": "nccl-all-reduce-bw-net",
   "status": "passed",
   "suite": ["performance"],
   "stdout": [
-    "NCCL All Reduce bandwidth: <actual> GB/s",
+    "NCCL All Reduce bandwidth (nccl-all-reduce-bw-net): <actual> GB/s",
     "Constraint: >= <threshold> → true"
   ]
 }

--- a/recipes/overlays/gb200-eks-inference.yaml
+++ b/recipes/overlays/gb200-eks-inference.yaml
@@ -33,13 +33,30 @@ spec:
       value: ">= 1.32.4"
 
   componentRefs:
+    # GB200+EKS GPU Operator prerequisites. Keep in sync with the same block
+    # in gb200-eks-training.yaml. The NVreg flag and cdi+gdrcopy are needed
+    # for multi-node inference that crosses EFA — tensor-parallel serving
+    # over the network has the same dma-buf attach requirement as training
+    # all-reduce. The mixin system can't extend componentRefs already
+    # declared in the inheritance chain, so this lives per-leaf for now.
     - name: gpu-operator
       type: Helm
+      manifestFiles:
+        - components/gpu-operator/manifests/kernel-module-params.yaml
       dependencyRefs:
         - nfd
         - cert-manager
         - kube-prometheus-stack
         - nodewright-customizations
+      overrides:
+        cdi:
+          enabled: true
+        gdrcopy:
+          enabled: true
+        driver:
+          version: 580.126.20
+          kernelModuleConfig:
+            name: nvidia-kernel-module-params
 
     # GB200 uses nodewright no-op: the H100 tuning packages (nvidia-setup,
     # nvidia-tuned) are not compatible with GB200's ARM64 host CPU and
@@ -55,3 +72,20 @@ spec:
         intent: inference
       dependencyRefs:
         - nodewright-operator
+
+  # NCCL fabric health checks. NET exercises EFA (inter-node), NVLS exercises
+  # MNNVL (intra-NVL72). Both matter for multi-node inference that spans the
+  # fabric (tensor-parallel serving, MoE expert parallelism); single-node
+  # deployments hit the WorkerCount < 2 skip path gracefully. Thresholds sized
+  # for a 2-node GB200 pair — will be raised once production NVL72 data is
+  # available.
+  validation:
+    performance:
+      checks:
+        - nccl-all-reduce-bw-net
+        - nccl-all-reduce-bw-nvls
+      constraints:
+        - name: nccl-all-reduce-bw-net
+          value: ">= 40"
+        - name: nccl-all-reduce-bw-nvls
+          value: ">= 500"

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -36,6 +36,13 @@ spec:
     # GB200-specific GPU Operator overrides (inherits valuesFile from eks-training)
     - name: gpu-operator
       type: Helm
+      manifestFiles:
+        # Ships a ConfigMap with options nvidia NVreg_GrdmaPciTopoCheckOverride=1.
+        # driver.kernelModuleConfig.name (below) points the ClusterPolicy at it,
+        # so the driver DaemonSet mounts nvidia.conf and the kernel loads with
+        # the flag set — required on GB200+EFA for EFA dma-buf attach to the
+        # Grace PCI topology. Without it, NCCL silently falls back to Socket.
+        - components/gpu-operator/manifests/kernel-module-params.yaml
       dependencyRefs:
         - nfd
         - cert-manager
@@ -46,6 +53,9 @@ spec:
           enabled: true
         gdrcopy:
           enabled: true
+        driver:
+          kernelModuleConfig:
+            name: nvidia-kernel-module-params
 
     # GB200 uses nodewright no-op: the H100 tuning packages (nvidia-setup,
     # nvidia-tuned) are not compatible with GB200's ARM64 host CPU and

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -54,6 +54,10 @@ spec:
         gdrcopy:
           enabled: true
         driver:
+          # 580.126.20 is NVIDIA's recommended floor for GB200+EFA; the global
+          # default (580.105.08 in components/gpu-operator/values.yaml) stays
+          # unchanged for H100/B200 and non-EKS GB200 recipes.
+          version: 580.126.20
           kernelModuleConfig:
             name: nvidia-kernel-module-params
 

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -79,6 +79,20 @@ spec:
   # Validation checks for GB200 on EKS training workloads.
   # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
   validation:
+    performance:
+      # NET exercises EFA (the external interconnect) and NVLS exercises MNNVL
+      # across the NVL72 IMEX domain — each variant asserts its transport
+      # actually carried traffic, so a silent fallback to Socket or NET does
+      # not masquerade as a pass. Thresholds are sized for a 2-node GB200 pair
+      # and will be raised once production NVL72 data is available.
+      checks:
+        - nccl-all-reduce-bw-net
+        - nccl-all-reduce-bw-nvls
+      constraints:
+        - name: nccl-all-reduce-bw-net
+          value: ">= 40"
+        - name: nccl-all-reduce-bw-nvls
+          value: ">= 500"
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -33,7 +33,10 @@ spec:
       value: ">= 1.32.4"
 
   componentRefs:
-    # GB200-specific GPU Operator overrides (inherits valuesFile from eks-training)
+    # GB200+EKS GPU Operator prerequisites. Keep in sync with the same block
+    # in gb200-eks-inference.yaml — the mixin system can't extend componentRefs
+    # already declared in the inheritance chain (gpu-operator comes from
+    # eks-training / eks-inference), so this lives per-leaf for now.
     - name: gpu-operator
       type: Helm
       manifestFiles:


### PR DESCRIPTION
## Summary

Wire the GB200/EKS overlays (`training` and `inference`) to self-fulfill the `NVreg_GrdmaPciTopoCheckOverride=1` kernel module flag, pin the driver to the NVIDIA-recommended floor for GB200+EFA (580.126.20), and adopt the transport-specific `nccl-all-reduce-bw-net` / `-nvls` performance checks that were introduced in #640.

## Motivation / Context

After #640 landed, the NET + NVLS NCCL variants existed in the validator catalog but no shipped overlay referenced them — GB200/EKS users still ran the legacy auto-detect `nccl-all-reduce-bw` and got no transport-specific signal. Separately, GB200/EKS has two operator-side prerequisites that the existing overlay left as manual configuration:

1. **`NVreg_GrdmaPciTopoCheckOverride=1`** — required on the NVIDIA driver so EFA can attach dma-buf to the Grace PCI topology. Without it, NCCL silently falls back to Socket on NET.
2. **Driver version floor** — NVIDIA's recommended driver for GB200+EFA is 580.126.20; the repo-wide default stayed on 580.105.08 for H100/B200.

This PR closes both gaps declaratively in the overlay, so GB200/EKS recipes come up correctly out of the box, and both the training and inference intents assert the two fabrics (EFA + MNNVL) actually carry traffic.

Fixes: N/A
Related: #640 (validator-side NET/NVLS implementation)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Four commits, each independently revertable:

1. **`feat(recipes/gb200-eks): self-fulfill NVreg_GrdmaPciTopoCheckOverride=1`** — Adds `manifestFiles: [components/gpu-operator/manifests/kernel-module-params.yaml]` (existing template, already in the component directory) and points `ClusterPolicy.spec.driver.kernelModuleConfig.name` at the resulting ConfigMap. The NVIDIA driver DaemonSet then mounts `nvidia.conf` at load time and the kernel comes up with the flag already set. The existing NVreg preflight check stays in place as a belt-and-suspenders guard for operators who override the module config at a higher layer.

2. **`feat(recipes/gb200-eks): bump driver to 580.126.20`** — Override `gpu-operator.driver.version` at the GB200/EKS overlay layer only. H100/B200 and non-EKS GB200 (OKE, GKE, AKS) keep the global 580.105.08 default from `components/gpu-operator/values.yaml`. The version recommendation is GB200+EFA-specific on EKS; narrower blast radius than a global bump.

3. **`feat(recipes/gb200-eks): adopt nccl-all-reduce-bw-net and -nvls constraints`** — Replaces the inherited `nccl-all-reduce-bw >= 720` from `gb200-any-training` with `nccl-all-reduce-bw-net >= 40` and `nccl-all-reduce-bw-nvls >= 500` on `gb200-eks-training`. `ValidationPhase` replaces rather than merges, so this is a clean swap on GB200/EKS recipes only; non-EKS GB200 and non-GB200 accelerators keep the legacy entry unchanged. Thresholds are deliberately conservative, sized for a 2-node GB200 pair — will be raised once production NVL72 data is available.

4. **`feat(recipes/gb200-eks): extend NCCL variants + NVreg fulfillment to inference`** — Mirrors the above into `gb200-eks-inference.yaml`. NCCL all-reduce-bw is fabric-health, not training-specific: multi-node inference (tensor-parallel serving, MoE expert parallelism) crosses the same EFA + MNNVL fabrics and has the same dma-buf attach requirement. Also updates `docs/user/validation.md` with a 3-variant table documenting when each check is selected.

**Mixin alternative, rejected.** Initially tried extracting the shared GB200/EKS GPU-operator block into a mixin, but the mixin system is strictly additive — it can introduce new `componentRef` names but cannot extend a `componentRef` already declared upstream in the inheritance chain (`gpu-operator` comes from `eks-training` / `eks-inference`). Per-leaf duplication with a "keep in sync" comment is the pragmatic choice until the mixin system gains extension semantics; concretely that's ~10 duplicated lines across two files vs. a much larger refactor.

## Testing

```bash
# Static verification
make qualify                                    # passes, 0 lint issues

# Recipe hydration
aicr query --service eks --accelerator gb200 --intent training --os ubuntu --platform kubeflow \
  --selector components.gpu-operator.values.driver            # → version 580.126.20, kernelModuleConfig.name nvidia-kernel-module-params
aicr query --service eks --accelerator gb200 --intent inference --os ubuntu \
  --selector components.gpu-operator.values.driver            # → same
aicr query --service oke --accelerator gb200 --intent training --os ubuntu \
  --selector components.gpu-operator.values.driver.version    # → 580.105.08 (unchanged)
aicr query --service eks --accelerator h100 --intent training --os ubuntu \
  --selector components.gpu-operator.values.driver.version    # → 580.105.08 (unchanged)
```

**End-to-end on real GB200/EKS hardware** (EKS 1.34, Ubuntu 24.04, 2× `p6e-gb200.36xlarge`, ASG-terminated before redeploy for a clean-boot driver rollout):

| Check                          | Measured    | Threshold |
|--------------------------------|-------------|-----------|
| `nccl-all-reduce-bw-net`       | 329.59 GB/s | ≥ 40      |
| `nccl-all-reduce-bw-nvls`      | 841.49 GB/s | ≥ 500     |
| 8 conformance checks           | all pass    | —         |

On-cluster verification of the NVreg self-fulfillment:
- `nvidia-kernel-module-params` ConfigMap present in `gpu-operator` namespace with `options nvidia NVreg_GrdmaPciTopoCheckOverride=1`
- Driver DaemonSet image: `nvcr.io/nvidia/driver:580.126.20-ubuntu24.04`; ConfigMap mounted at `/drivers/nvidia.conf`
- `/proc/driver/nvidia/params` on both GB200 nodes reports `GrdmaPciTopoCheckOverride: 1` — flag is live in the loaded kernel module, not just declared

## Risk Assessment

- [x] **Low** — Isolated to two GB200/EKS overlays + one user-doc page. No CLI, API, or validator-engine code changes.

**Rollout notes:**
- The three behavior changes (driver 580.126.20, NVreg ConfigMap, NCCL variants) are scoped to GB200/EKS via overlay path, verified by `aicr query` against OKE/H100 recipes showing no drift.
- The driver bump redeploys the `nvidia-driver` DaemonSet on GB200/EKS clusters that regenerate their bundle; plan this alongside a rolling-replace of GPU nodes (ASG terminate with `--no-should-decrement-desired-capacity`) so the new driver lands on clean-boot replacements rather than reinstalling over running kernel state.
- No migration needed for non-GB200 or non-EKS recipes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint` — `golangci-lint run ./...` → 0 issues)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (validator-side tests for the new NCCL variants landed in #640; this PR is recipe/doc only)
- [x] I updated docs if user-facing behavior changed (`docs/user/validation.md` 3-variant table)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
