### PR TITLE
docs: clarify undeploy.sh orphan-CRD behavior and manual cleanup

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1367,6 +1367,29 @@ If a Helm release is in a `pending-install` or `pending-upgrade` state (from an 
 
 After uninstalling each component, the script checks for orphaned validating/mutating webhooks whose backing service no longer exists. Fail-closed webhooks with missing services block all pod creation, so these are deleted proactively.
 
+**Orphan-CRD behavior (by design):**
+
+By default, the script deletes only CRDs whose `meta.helm.sh/release-name` **and** `meta.helm.sh/release-namespace` annotations both match an in-bundle release. CRDs installed outside Helm annotation discovery — shipped via a chart's `crds/` directory, installed by an operator at runtime, or added out-of-band — are surfaced as a post-flight warning but **not deleted**. This is the shared-cluster safety default: removing a CRD that another tenant shares the API group with would delete their resources too.
+
+**Consequence for redeploy on single-tenant clusters:** these orphan CRDs survive `undeploy.sh`. They can block a subsequent `deploy.sh` in two ways: (1) `helm upgrade --install` refuses to adopt a pre-existing CRD that carries no release annotation, and (2) a CR with an unreconciled finalizer (controller already uninstalled) prevents `kubectl delete crd` from ever completing. On a single-tenant cluster where clean teardown-then-redeploy is required, clear the orphans manually after `undeploy.sh` — the post-flight warning lists which CRDs survived:
+
+```shell
+# For each orphan CRD, clear finalizers on any remaining CRs first,
+# otherwise the CRD delete will hang on the resource-in-use marker.
+kubectl get <plural>.<group> -A -o json \
+  | jq -r '.items[] | "\(.metadata.namespace // "") \(.metadata.name)"' \
+  | while read -r ns name; do
+      [[ -z "${name}" ]] && continue
+      kubectl patch "<plural>.<group>" "${name}" ${ns:+-n "${ns}"} \
+        --type=merge -p '{"metadata":{"finalizers":[]}}'
+    done
+
+# Then delete the CRD.
+kubectl delete crd <crd-name> --ignore-not-found
+```
+
+Do not run these commands on a shared/multi-tenant cluster — they do not re-check ownership and may remove another tenant's resources if the API group is shared.
+
 ---
 
 ### aicr verify

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1369,16 +1369,18 @@ After uninstalling each component, the script checks for orphaned validating/mut
 
 **Orphan-CRD behavior (by design):**
 
-By default, the script deletes only CRDs whose `meta.helm.sh/release-name` **and** `meta.helm.sh/release-namespace` annotations both match an in-bundle release. CRDs installed outside Helm annotation discovery — shipped via a chart's `crds/` directory, installed by an operator at runtime, or added out-of-band — are surfaced as a post-flight warning but **not deleted**. This is the shared-cluster safety default: removing a CRD that another tenant shares the API group with would delete their resources too.
+By default, the script deletes only CRDs whose `meta.helm.sh/release-name` **and** `meta.helm.sh/release-namespace` annotations both match an in-bundle release. CRDs installed outside Helm annotation discovery — shipped via a chart's `crds/` directory or installed by an operator at runtime — survive undeploy and are surfaced as a post-flight warning only when their exact name appears in the script's internal `extra_crds_for_release` list (one entry per component this bundle ships). CRDs added fully out-of-band are not surfaced by post-flight. This is the shared-cluster safety default: removing a CRD whose API group another tenant also uses would delete their resources too.
 
 **Consequence for redeploy on single-tenant clusters:** these orphan CRDs survive `undeploy.sh`. They can block a subsequent `deploy.sh` in two ways: (1) `helm upgrade --install` refuses to adopt a pre-existing CRD that carries no release annotation, and (2) a CR with an unreconciled finalizer (controller already uninstalled) prevents `kubectl delete crd` from ever completing. On a single-tenant cluster where clean teardown-then-redeploy is required, clear the orphans manually after `undeploy.sh` — the post-flight warning lists which CRDs survived:
 
 ```shell
 # For each orphan CRD, clear finalizers on any remaining CRs first,
 # otherwise the CRD delete will hang on the resource-in-use marker.
+# Name is emitted first so cluster-scoped CRs (where namespace is empty)
+# still bind correctly under `read -r name ns`.
 kubectl get <plural>.<group> -A -o json \
-  | jq -r '.items[] | "\(.metadata.namespace // "") \(.metadata.name)"' \
-  | while read -r ns name; do
+  | jq -r '.items[] | "\(.metadata.name) \(.metadata.namespace // "")"' \
+  | while read -r name ns; do
       [[ -z "${name}" ]] && continue
       kubectl patch "<plural>.<group>" "${name}" ${ns:+-n "${ns}"} \
         --type=merge -p '{"metadata":{"finalizers":[]}}'


### PR DESCRIPTION
## Summary

Document that `undeploy.sh` intentionally leaves behind CRDs not covered by Helm annotation discovery, and give users the manual cleanup recipe required before a clean redeploy on single-tenant clusters.

## Motivation / Context

`undeploy.sh` (since #602) only deletes CRDs whose `meta.helm.sh/release-name` **and** `meta.helm.sh/release-namespace` annotations both match an in-bundle release. That is the correct shared-cluster safety default — but it means CRDs installed via a chart's `crds/` subdir, installed by an operator at runtime, or added out-of-band survive undeploy. These orphan CRDs block a subsequent `deploy.sh` on single-tenant clusters in two concrete ways:

1. `helm upgrade --install` refuses to adopt a pre-existing CRD that carries no release annotation.
2. A remaining CR with an unreconciled finalizer (its controller is already uninstalled) prevents `kubectl delete crd` from ever completing.

Today's docs don't mention this at all — the only orphan-related section under `undeploy.sh` covers webhooks. Users discovering the failure have no documented recovery path.

Fixes: N/A
Related: #602, #661 (closed — superseded by this docs-only clarification after maintainer feedback preferred keeping cleanup out of the generated bundle artifact)

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Adds one new subsection — `**Orphan-CRD behavior (by design):**` — under the existing `Undeploy Script Behavior (undeploy.sh)` block in `docs/user/cli-reference.md`. The section:

- States why these CRDs are left behind and ties the decision back to shared-cluster safety.
- Names the two redeploy failure modes (helm import refusal, CRD delete hang on finalizers).
- Provides the minimal finalizer-clear + CRD-delete recipe, scoped per `<plural>.<group>`, handling both cluster-scoped and namespaced CRs via shell parameter expansion (`${ns:+-n "${ns}"}`).
- Explicitly warns against running the recipe on shared/multi-tenant clusters, since the manual steps do not re-check Helm release/namespace ownership.

No code changes.

## Testing

```bash
tools/check-docs-sidebar   # OK: all docs files have sidebar entries
```

Doc-only change — no user-visible behavior, no Go/YAML/CI touched. Per the `CLAUDE.local.md` "Doc-only and infra-only verification" guidance, the scoped sidebar check is sufficient here; `make qualify` is skipped because test/e2e/Go-lint cannot regress from a single-file markdown addition.

## Risk Assessment

- [x] **Low** — Documentation addition, no behavior change, trivially reversible.

**Rollout notes:** N/A.

## Checklist

- [x] Tests pass locally (doc-only change; scoped sidebar check run instead of full `make qualify` — see Testing)
- [x] Linter passes (N/A for markdown-only change; no YAML/Go touched)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A)
- [x] I updated docs if user-facing behavior changed (this PR *is* the doc update)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)