### PR TITLE
fix(recipes): disable Dynamo ssh-keygen on Kind

### DIFF
--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -51,6 +51,14 @@ spec:
         - kube-prometheus-stack
         - kai-scheduler
       overrides:
+        # Kind inference CI does not require Dynamo's MPI SSH secret. Disable
+        # the chart's ssh-keygen pre-install hook here so fresh Kind runners do
+        # not spend hook budget creating an unused secret.
+        dynamo-operator:
+          dynamo:
+            mpiRun:
+              sshKeygen:
+                enabled: false
         # Use kind's local-path-provisioner instead of EBS gp2
         etcd:
           persistence:


### PR DESCRIPTION
## Summary

Disable the Dynamo MPI ssh-keygen Helm hook only for the `h100-kind-inference-dynamo` recipe.

## Motivation / Context

The Kind GPU inference CI workload does not exercise Dynamo's MPI launch path, but the upstream chart still runs a pre-install/pre-upgrade ssh-keygen hook that pulls `bitnamisecure/git:latest`. In run 24889208608, that hook repeatedly timed out and consumed most of the GPU job budget before the snapshot step was canceled.

Fixes: N/A
Related: https://github.com/NVIDIA/aicr/actions/runs/24889208608/job/72876842190?pr=666

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Adds an inline override under the Kind Dynamo leaf recipe:

```yaml
dynamo-operator:
  dynamo:
    mpiRun:
      sshKeygen:
        enabled: false
```

This is intentionally scoped to `h100-kind-inference-dynamo`; cloud Dynamo overlays continue to use the chart default.

## Testing

```bash
go test ./pkg/recipe/...
make lint-yaml
aicr query --service kind --accelerator h100 --intent inference --platform dynamo --data recipes --selector components.dynamo-platform.values.dynamo-operator.dynamo.mpiRun.sshKeygen.enabled
unset GITLAB_TOKEN && make qualify
```

Results:

- `go test ./pkg/recipe/...` passed
- `make lint-yaml` passed
- Query returned `false`
- `make qualify` passed, including race tests, coverage, lint, e2e, scan, and license checks

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
