### PR TITLE
fix(bundler): v0.12 rc1 smoke-test follow-ups

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -991,7 +991,7 @@ aicr bundle -r recipe.yaml --nodes 8 -o ./bundles
 
 # Day 2 options: workload-gate and workload-selector for nodewright
 aicr bundle -r recipe.yaml \
-  --workload-gate skyhook.io/runtime-required=true:NoSchedule \
+  --workload-gate skyhook.nvidia.com/runtime-required=true:NoSchedule \
   --workload-selector workload-type=training \
   -o ./bundles
 
@@ -1230,7 +1230,7 @@ aicr bundle -r recipe.yaml \
 ```shell
 # Generate bundle with day 2 options for training workloads
 aicr bundle -r recipe.yaml \
-  --workload-gate skyhook.io/runtime-required=true:NoSchedule \
+  --workload-gate skyhook.nvidia.com/runtime-required=true:NoSchedule \
   --workload-selector workload-type=training \
   --workload-selector intent=training \
   --accelerated-node-selector accelerator=nvidia-h100 \

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -831,7 +831,7 @@ func TestDeployerTypeString(t *testing.T) {
 func TestWorkloadGateTaintOptions(t *testing.T) {
 	t.Run("WithWorkloadGateTaint with valid taint", func(t *testing.T) {
 		taint := &corev1.Taint{
-			Key:    "skyhook.io/runtime-required",
+			Key:    "skyhook.nvidia.com/runtime-required",
 			Value:  "true",
 			Effect: corev1.TaintEffectNoSchedule,
 		}
@@ -841,8 +841,8 @@ func TestWorkloadGateTaintOptions(t *testing.T) {
 		if got == nil {
 			t.Fatal("WorkloadGateTaint() returned nil")
 		}
-		if got.Key != "skyhook.io/runtime-required" {
-			t.Errorf("WorkloadGateTaint().Key = %s, want skyhook.io/runtime-required", got.Key)
+		if got.Key != "skyhook.nvidia.com/runtime-required" {
+			t.Errorf("WorkloadGateTaint().Key = %s, want skyhook.nvidia.com/runtime-required", got.Key)
 		}
 		if got.Value != "true" {
 			t.Errorf("WorkloadGateTaint().Value = %s, want true", got.Value)

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -277,6 +277,8 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 					component.RemoveValueByPath(staticValues, path)
 					component.SetValueByPath(stubs, path, val)
 				} else {
+					slog.Warn("dynamic path not found in component values; introducing empty placeholder",
+						"component", ref.Name, "path", path)
 					component.SetValueByPath(stubs, path, "")
 				}
 			}

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -520,6 +520,8 @@ func writeClusterValuesFile(values map[string]any, dynamicPaths []string, compon
 			component.RemoveValueByPath(values, path)
 		} else {
 			val = ""
+			slog.Warn("dynamic path not found in component values; introducing empty placeholder",
+				"component", componentName, "path", path)
 		}
 		component.SetValueByPath(clusterValues, path, val)
 	}

--- a/pkg/bundler/deployer/helm/templates/README.md.tmpl
+++ b/pkg/bundler/deployer/helm/templates/README.md.tmpl
@@ -80,6 +80,7 @@ helm upgrade --install {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f {{ .Name }}/values.yaml \
+  -f {{ .Name }}/cluster-values.yaml \
   --wait --timeout 10m
 {{ else -}}
 helm upgrade --install {{ .Name }} {{ .ChartName }} \
@@ -87,6 +88,7 @@ helm upgrade --install {{ .Name }} {{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f {{ .Name }}/values.yaml \
+  -f {{ .Name }}/cluster-values.yaml \
   --wait --timeout 10m
 {{ end -}}
 ```
@@ -100,19 +102,27 @@ kubectl apply -f {{ .Name }}/manifests/
 
 ## Customization
 
-Each Helm component has its own `values.yaml` in its directory.
-Edit the file before deploying to customize component configuration:
+Each Helm component has two values files in its directory:
 
-```bash
-vim gpu-operator/values.yaml
-```
+- `values.yaml` — resolved configuration from the recipe. Edit to override defaults:
+
+  ```bash
+  vim gpu-operator/values.yaml
+  ```
+
+- `cluster-values.yaml` — install-time parameters. Any paths declared with
+  `aicr bundle --dynamic <component>:<path>` are pulled out of `values.yaml`
+  and placed here for you to fill in. The file is always created (empty if
+  no dynamic paths were declared) and passed to `helm upgrade --install`
+  alongside `values.yaml` by both `deploy.sh` and the per-component commands
+  in the "Manual Installation" section above.
 
 ## Upgrade
 
 To upgrade a specific Helm component:
 
 ```bash
-helm upgrade <component> <chart> --version <version> -n <namespace> -f <component>/values.yaml --wait --timeout 10m
+helm upgrade <component> <chart> --version <version> -n <namespace> -f <component>/values.yaml -f <component>/cluster-values.yaml --wait --timeout 10m
 ```
 
 ## Uninstall

--- a/pkg/bundler/deployer/helm/templates/component-README.md.tmpl
+++ b/pkg/bundler/deployer/helm/templates/component-README.md.tmpl
@@ -46,6 +46,7 @@ helm upgrade --install {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f values.yaml \
+  -f cluster-values.yaml \
   --wait --timeout 10m
 {{ else -}}
 helm upgrade --install {{ .Name }} {{ .ChartName }} \
@@ -53,6 +54,7 @@ helm upgrade --install {{ .Name }} {{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} --create-namespace \
   -f values.yaml \
+  -f cluster-values.yaml \
   --wait --timeout 10m
 {{ end -}}
 ```
@@ -71,6 +73,7 @@ helm upgrade {{ .Name }} {{ .Repository }}/{{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} \
   -f values.yaml \
+  -f cluster-values.yaml \
   --wait --timeout 10m
 {{ else -}}
 helm upgrade {{ .Name }} {{ .ChartName }} \
@@ -78,6 +81,7 @@ helm upgrade {{ .Name }} {{ .ChartName }} \
   --version {{ .Version }} \
   -n {{ .Namespace }} \
   -f values.yaml \
+  -f cluster-values.yaml \
   --wait --timeout 10m
 {{ end -}}
 ```

--- a/pkg/snapshotter/agent_test.go
+++ b/pkg/snapshotter/agent_test.go
@@ -141,9 +141,9 @@ func TestParseTaint(t *testing.T) {
 	}{
 		{
 			name:     "taint with key, value, and effect",
-			taintStr: "skyhook.io/runtime-required=true:NoSchedule",
+			taintStr: "skyhook.nvidia.com/runtime-required=true:NoSchedule",
 			want: &corev1.Taint{
-				Key:    "skyhook.io/runtime-required",
+				Key:    "skyhook.nvidia.com/runtime-required",
 				Value:  "true",
 				Effect: corev1.TaintEffectNoSchedule,
 			},


### PR DESCRIPTION
## Summary

  Fix three minor issues found during 0.12.rc1 testing: wrong Skyhook taint
  domain in docs/tests, missing `cluster-values.yaml` in generated helm
  command snippets, and silent fallthrough when a `--dynamic` path is absent
  from component values.

  ## Motivation / Context

  Shaking out the 0.12.rc1 bundle output surfaced three small but user-visible
  defects:

  1. **Wrong Skyhook taint domain.** The docs and tests still referenced the
     legacy `skyhook.io/runtime-required` key. The NVIDIA Skyhook operator
     uses `skyhook.nvidia.com/runtime-required`, so copy-pasting the
     documented `--workload-gate` value produced a taint no Skyhook install
     would ever match.
  2. **Generated helm commands omitted `cluster-values.yaml`.** The Helm
     deployer writes dynamic paths into a separate `cluster-values.yaml`, but
     the rendered README templates only referenced `values.yaml`. Users who
     declared `--dynamic` paths and then ran the command from the README
     would silently lose those install-time overrides.
  3. **Silent placeholder injection.** When `--dynamic <component>:<path>`
     names a path that isn't present in the component's values, both the
     `helm` and `argocd-helm` deployers fall back to writing an empty string
     stub. That fallback is load-bearing (empty declarations are legitimate),
     but producing it without any operator-visible signal made typos in
     dynamic paths impossible to diagnose from the bundle alone.


## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [ ] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
