### PR TITLE
fix(recipes): use NFD chart version 0.18.3 without v prefix

### DIFF
--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -28,7 +28,7 @@ spec:
     - name: nfd
       type: Helm
       source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-      version: v0.18.3
+      version: 0.18.3
       valuesFile: components/nfd/values.yaml
 
     - name: cert-manager


### PR DESCRIPTION
## Summary

Drop the `v` prefix from the `nfd` componentRef version in `recipes/overlays/base.yaml` so it matches the chart version published in the upstream Helm index (`0.18.3`, with `appVersion: v0.18.3`).

## Motivation/Context

CI was logging:

```
Installing nfd (node-feature-discovery)...
Release "nfd" does not exist. Installing it now.
level=WARN msg="unable to find exact version requested; falling back to closest available version" chart=node-feature-discovery requested=v0.18.3 selected=0.18.3
```

Verified against the published chart index (`https://kubernetes-sigs.github.io/node-feature-discovery/charts/index.yaml`):

```
appVersion: v0.18.3
version: 0.18.3
```

`--version` to Helm should be the chart version (`0.18.3`), not the appVersion (`v0.18.3`). Other charts in the same recipe that publish without a `v` prefix (kube-prometheus-stack, k8s-ephemeral-storage-metrics, nvidia-dra-driver-gpu) already follow this convention.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Components Affected

- [x] Recipes / overlays

## Implementation Notes

One-line change: \`version: v0.18.3\` -> \`version: 0.18.3\`.

## Testing

This is a recipe-config change, not a Go-code change.
- \`yamllint recipes/overlays/base.yaml\` -> clean
- \`go test ./pkg/recipe/...\` -> ok
- \`go test ./pkg/bundler/deployer/helm/...\` -> ok

Skipping full \`make qualify\` per CLAUDE.local.md infra-only rule: tests, e2e, and Go lint cannot regress from a single value change in a recipe overlay; the recipe loader and the helm bundler tests both exercise this file and pass.

## Risk Assessment

Low. Helm was already installing the same chart via fuzzy fallback. This change only removes the warning by asking for the exact published version.

## Checklist

- [x] Commit cryptographically signed
- [x] Rebased onto \`origin/main\`
- [x] No new lint or test failures in affected packages