### PR TITLE
fix(recipes): use cert-manager for dynamo-operator webhook certificates

### DIFF
--- a/recipes/components/dynamo-platform/values.yaml
+++ b/recipes/components/dynamo-platform/values.yaml
@@ -37,6 +37,19 @@ dynamo-operator:
         repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
         tag: v0.15.0
 
+  # Use cert-manager for the dynamo-operator admission webhook instead of the
+  # chart's default Helm-hook bootstrap. The default flow creates the
+  # ValidatingWebhookConfiguration before the post-install CA-inject job
+  # populates the caBundle, which makes Helm log a noisy
+  # "tls: failed to find any PEM data in certificate input" warning on every
+  # install and leaves a brief window where admission requests would be
+  # rejected. cert-manager.io/inject-ca-from removes both problems. Every
+  # dynamo overlay already lists cert-manager in dependencyRefs, so it is
+  # guaranteed to be installed first.
+  webhook:
+    certManager:
+      enabled: true
+
   # Use Kubernetes-native service discovery (operator-level only;
   # runtime pods still require DYN_STORE_KV=mem to skip etcd leases)
   discoveryBackend: "kubernetes"


### PR DESCRIPTION
## Summary

Set `dynamo-operator.webhook.certManager.enabled: true` in `recipes/components/dynamo-platform/values.yaml` so the Dynamo chart issues its admission-webhook serving certificate via cert-manager and uses `cert-manager.io/inject-ca-from` to populate the caBundle on the ValidatingWebhookConfiguration.

## Motivation/Context

Every dynamo-platform install logs:

```
Warning: tls: failed to find any PEM data in certificate input
```

The chart default flow renders the ValidatingWebhookConfiguration with no `caBundle`, then relies on a post-install Helm hook job to patch the CA bundle in. During the gap, admission would reject any request, and the warning is emitted on every install — noise that can hide real Dynamo install problems.

cert-manager is already a `dependencyRef` on every dynamo overlay (`h100-kind`, `h100-eks`, `h100-aks`, `h100-gke`, `gb200-eks`, `gb200-oke`), so it is guaranteed to be installed before dynamo-platform.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Components Affected

- [x] Recipes / overlays

## Implementation Notes

13-line change in `recipes/components/dynamo-platform/values.yaml`.

Verified via `helm template` against the new values:
- ValidatingWebhookConfiguration carries `cert-manager.io/inject-ca-from: <release>-dynamo-operator-serving-cert`.
- Chart renders cert-manager Issuer (selfsigned) + Root CA Certificate + CA Issuer + serving Certificate. cert-manager will auto-renew going forward.
- `webhook-cert-gen-job.yaml` and `webhook-ca-inject-job.yaml` templates render no resources (gated by `not .Values.webhook.certManager.enabled`).

## Testing

Recipe-config change, not Go-code change.
- `yamllint recipes/components/dynamo-platform/values.yaml` -> clean
- `helm template` diff: 15 -> 3 hook-job-related references in rendered output
- `go test ./pkg/recipe/...`, `./pkg/bundler/registry/...`, `./pkg/bundler/validations/...`, `./pkg/bundler/verifier/...`, `./pkg/bundler/deployer/helm/...` -> all pass

Skipping full `make qualify` per CLAUDE.local.md infra-only rule: tests, e2e, and Go lint cannot regress from a values-only change in a component overlay; the recipe loader and deployer template tests both exercise this file and pass.

## Risk Assessment

Low. The chart already supports this code path, gated by a single documented value. cert-manager is already required and installed ahead of dynamo-platform via `dependencyRefs`.

## Checklist

- [x] Commit cryptographically signed
- [x] Branched off `origin/main`
- [x] Helm render verified before/after
- [x] No new lint or test failures in affected packages