### PR TITLE
ci: enable CodeRabbit auto-review on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,7 +25,7 @@ reviews:
   sequence_diagrams: false
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - ".*"
   path_filters:


### PR DESCRIPTION
## Summary

- Flip `reviews.auto_review.drafts` from `false` to `true` in `.coderabbit.yaml`.
- CodeRabbit will now run auto-review on draft PRs in addition to ready-for-review PRs.

## Motivation / Context

Authors who open a PR as draft (to share work-in-progress, run CI, or invite early collaboration) currently get no CodeRabbit feedback until the PR is marked ready-for-review. Enabling `drafts: true` provides early CodeRabbit feedback on draft PRs so issues can be caught and fixed before the PR is promoted to ready-for-review.

Per [CodeRabbit configuration docs](https://docs.coderabbit.ai/configure-coderabbit), the `.coderabbit.yaml` on the feature branch is what governs that PR's review, and reviews are triggered on new PRs or incremental commits. Existing draft PRs opened before this change may need a new push or an `@coderabbitai review` comment to pick up the new behavior; new draft PRs (and any draft PR rebased onto `main` after this lands) will be auto-reviewed.

Fixes: N/A
Related: N/A

## Type of Change

- [x] CI / build configuration

## Components Affected

- `.coderabbit.yaml`

## Implementation Notes

Single-line change: `drafts: false` → `drafts: true`.

## Testing

- `yamllint .coderabbit.yaml` — clean.
- Full `make qualify` skipped: this is a CI/config-only change to `.coderabbit.yaml` that does not affect Go code, tests, e2e, sidebar docs, or `tools/check-agents-sync` inputs. Per the doc-only / infra-only verification policy, the smallest applicable check (yamllint) was run.

## Risk Assessment

Low. Reversible by flipping the flag back. CodeRabbit will simply produce additional reviews on draft PRs; no production behavior changes.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the change
- [x] Updated relevant documentation (none needed — internal CI tool config)
- [x] Verified no secrets or sensitive info added