### PR TITLE
feat(cli): add skill command for AI agent integration

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1447,6 +1447,55 @@ aicr trust update
 
 ---
 
+### aicr skill
+
+Generate an AI agent skill file that teaches a coding agent how to use the AICR CLI. The generated file is written to the agent's standard configuration directory.
+
+**Synopsis:**
+
+```shell
+aicr skill --agent <agent> [flags]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--agent` | string | (required) | Target coding agent: `claude-code`, `codex` |
+| `--stdout` | bool | false | Print to stdout instead of writing to disk |
+| `--force` | bool | false | Overwrite an existing skill file without prompting |
+
+**Install Locations:**
+
+| Agent | Path |
+|-------|------|
+| `claude-code` | `~/.claude/skills/aicr/SKILL.md` |
+| `codex` | `~/.codex/skills/aicr/SKILL.md` |
+
+**Behavior:**
+- Without `--stdout`: writes the file to disk and prints the path
+- With `--stdout`: prints the generated content to stdout
+- If the target file already exists: prompts `overwrite? [y/N]` when stdin is a terminal; aborts on non-interactive stdin unless `--force` is set
+- Creates parent directories as needed
+
+**Examples:**
+
+```shell
+# Install Claude Code skill file
+aicr skill --agent claude-code
+
+# Install Codex skill file
+aicr skill --agent codex
+
+# Overwrite an existing skill file without prompting (e.g., in CI)
+aicr skill --agent claude-code --force
+
+# Print to stdout (e.g., for review before installing)
+aicr skill --agent claude-code --stdout
+```
+
+---
+
 ## Complete Workflow Examples
 
 ### File-Based Workflow

--- a/pkg/cli/doc.go
+++ b/pkg/cli/doc.go
@@ -88,6 +88,20 @@
 // per-component bundle with individual values.yaml per component. Use
 // --deployer argocd for Argo CD Application manifests.
 //
+// skill - Generate AI agent skill file (Utility):
+//
+//	aicr skill --agent claude-code
+//	aicr skill --agent codex
+//	aicr skill --agent claude-code --force
+//	aicr skill --agent claude-code --stdout
+//
+// Generates a skill file that teaches a coding agent how to use the
+// AICR CLI. The file is written to the agent's standard configuration directory
+// (~/.claude/skills/aicr/SKILL.md for Claude Code, ~/.codex/skills/aicr/SKILL.md for Codex).
+// Use --stdout to print the content instead of writing to disk. If the target file
+// already exists, you will be prompted to confirm overwrite when stdin is a terminal;
+// pass --force to overwrite without prompting (e.g., in CI).
+//
 // # Global Flags
 //
 //	--output, -o   Output file path (default: stdout)

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -159,6 +159,7 @@ func newRootCmd() *cli.Command {
 			bundleVerifyCmd(),
 			validateCmd(),
 			trustCmd(),
+			skillCmd(),
 		},
 		ShellComplete: completeWithAllFlags,
 	}

--- a/pkg/cli/skill.go
+++ b/pkg/cli/skill.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// skillCmdFlags returns the flags for the skill command.
+func skillCmdFlags() []cli.Flag {
+	return []cli.Flag{
+		withCompletions(&cli.StringFlag{
+			Name:     "agent",
+			Usage:    "target coding agent",
+			Required: true,
+		}, supportedAgents),
+		&cli.BoolFlag{
+			Name:  "stdout",
+			Usage: "print generated skill file to stdout instead of writing to disk",
+		},
+		&cli.BoolFlag{
+			Name:  "force",
+			Usage: "overwrite an existing skill file without prompting",
+		},
+	}
+}
+
+// skillCmd returns the CLI command for generating agent skill files.
+func skillCmd() *cli.Command {
+	return &cli.Command{
+		Name:     "skill",
+		Category: "Utilities",
+		Usage:    "Generate AI agent skill file for AICR CLI.",
+		Description: `Generates a skill file that teaches a coding agent
+how to use the AICR CLI. The file is written to the agent's
+standard configuration directory.
+
+If the target file already exists, you will be prompted to confirm
+overwrite when stdin is a terminal. Use --force to overwrite without
+prompting (e.g., in CI).
+
+Examples:
+  # Generate Claude Code skill file
+  aicr skill --agent claude-code
+
+  # Generate Codex skill file
+  aicr skill --agent codex
+
+  # Overwrite an existing skill file without prompting
+  aicr skill --agent claude-code --force
+
+  # Print to stdout instead of writing to disk
+  aicr skill --agent claude-code --stdout`,
+		Flags:  skillCmdFlags(),
+		Action: runSkillCmd,
+	}
+}
+
+// runSkillCmd generates and writes (or prints) the agent skill file.
+func runSkillCmd(_ context.Context, cmd *cli.Command) error {
+	agentName := cmd.String("agent")
+
+	at, err := parseAgentType(agentName)
+	if err != nil {
+		return err
+	}
+
+	generators := map[agentType]skillGenerator{
+		agentClaudeCode: &claudeCodeGenerator{},
+		agentCodex:      &codexGenerator{},
+	}
+
+	gen, ok := generators[at]
+	if !ok {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("no generator registered for agent %q", at))
+	}
+
+	slog.Info("generating skill file", "agent", string(at))
+
+	meta := extractCLIMeta(cmd.Root())
+
+	content, err := gen.generate(meta)
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to generate skill file", err)
+	}
+
+	if cmd.Bool("stdout") {
+		_, err = cmd.Root().Writer.Write(content)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write to stdout", err)
+		}
+		return nil
+	}
+
+	path, err := gen.installPath()
+	if err != nil {
+		return err
+	}
+
+	if !cmd.Bool("force") {
+		// Only "file does not exist" should silently bypass the prompt; any
+		// other stat error (permission denied, I/O failure, ...) needs to
+		// surface so we don't quietly clobber a file we couldn't inspect.
+		_, statErr := os.Stat(path)
+		switch {
+		case statErr == nil:
+			ok, err := confirmOverwrite(path, os.Stdin, cmd.Root().Writer)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintf(cmd.Root().Writer, "Aborted; %s left unchanged.\n", path)
+				return nil
+			}
+		case !os.IsNotExist(statErr):
+			return errors.Wrap(errors.ErrCodeInternal,
+				fmt.Sprintf("failed to inspect existing skill file %s", path), statErr)
+		}
+	}
+
+	if err := writeSkillFile(path, content); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.Root().Writer, "Skill file written to %s\n", path)
+
+	return nil
+}

--- a/pkg/cli/skill_claude_code.go
+++ b/pkg/cli/skill_claude_code.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// cmdNameRecipe is the urfave/cli command name for the recipe command.
+const cmdNameRecipe = "recipe"
+
+// Compile-time interface check.
+var _ skillGenerator = (*claudeCodeGenerator)(nil)
+
+// claudeCodeGenerator produces a Claude Code SKILL.md from CLI metadata.
+type claudeCodeGenerator struct{}
+
+func (g *claudeCodeGenerator) generate(meta *cliMeta) ([]byte, error) {
+	var buf bytes.Buffer
+
+	writeSkillFrontmatter(&buf, true)
+
+	// Heading.
+	fmt.Fprintf(&buf, "# AICR CLI (%s)\n\n", meta.Version)
+
+	writePrerequisites(&buf)
+	writeCommandReference(&buf, meta)
+	writeCriteriaValues(&buf, meta)
+	writeOutputFormatGuidance(&buf)
+	writeWorkflowExamples(&buf)
+	writeErrorHandling(&buf)
+	writeBestPractices(&buf)
+
+	return buf.Bytes(), nil
+}
+
+func (g *claudeCodeGenerator) installPath() (string, error) {
+	return skillInstallPath(".claude/skills/aicr/SKILL.md")
+}
+
+func writeSkillFrontmatter(buf *bytes.Buffer, userInvocable bool) {
+	fmt.Fprintf(buf, "---\n")
+	fmt.Fprintf(buf, "name: aicr\n")
+	fmt.Fprintf(buf, "description: |\n")
+	fmt.Fprintf(buf, "  NVIDIA AI Cluster Runtime (AICR) CLI skill.\n")
+	fmt.Fprintf(buf, "  Use when the user asks to generate a GPU recipe,\n")
+	fmt.Fprintf(buf, "  snapshot a cluster, bundle Helm values, validate a recipe,\n")
+	fmt.Fprintf(buf, "  query AICR configuration, or verify bundle provenance.\n")
+	if userInvocable {
+		fmt.Fprintf(buf, "user_invocable: true\n")
+	}
+	fmt.Fprintf(buf, "---\n\n")
+}
+
+// ---------------------------------------------------------------------------
+// Shared content helpers (reused by codex generator)
+// ---------------------------------------------------------------------------
+
+// writePrerequisites writes the prerequisites section.
+func writePrerequisites(buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "## Prerequisites\n\n")
+	fmt.Fprintf(buf, "Verify the CLI is available before running commands:\n\n")
+	fmt.Fprintf(buf, "```bash\n")
+	fmt.Fprintf(buf, "aicr --version\n")
+	fmt.Fprintf(buf, "```\n\n")
+}
+
+// writeCommandReference writes a dynamic command reference from CLI metadata.
+func writeCommandReference(buf *bytes.Buffer, meta *cliMeta) {
+	fmt.Fprintf(buf, "## Command Reference\n\n")
+
+	if len(meta.Flags) > 0 {
+		fmt.Fprintf(buf, "### Global Flags\n\n")
+		fmt.Fprintf(buf, "Available on every `%s` invocation:\n\n", meta.Name)
+		for _, f := range meta.Flags {
+			writeFlagEntry(buf, f)
+		}
+		fmt.Fprintf(buf, "\n")
+	}
+
+	for _, cmd := range meta.Commands {
+		writeCommandEntry(buf, meta.Name, cmd, 0)
+	}
+}
+
+// writeCommandEntry writes a single command with its flags, recursing into subcommands.
+func writeCommandEntry(buf *bytes.Buffer, parent string, cmd cmdMeta, depth int) {
+	full := parent + " " + cmd.Name
+	heading := strings.Repeat("#", depth+3)
+
+	header := full
+	if argsUsage := normalizeMarkdownText(cmd.ArgsUsage); argsUsage != "" {
+		header = full + " " + argsUsage
+	}
+	fmt.Fprintf(buf, "%s `%s`\n\n", heading, header)
+
+	if cmd.Usage != "" {
+		fmt.Fprintf(buf, "%s\n\n", cmd.Usage)
+	}
+
+	if len(cmd.Flags) > 0 {
+		fmt.Fprintf(buf, "**Flags:**\n\n")
+		for _, f := range cmd.Flags {
+			writeFlagEntry(buf, f)
+		}
+		fmt.Fprintf(buf, "\n")
+	}
+
+	for _, sub := range cmd.Subcommands {
+		writeCommandEntry(buf, full, sub, depth+1)
+	}
+}
+
+// writeFlagEntry writes a single flag as a markdown list item.
+func writeFlagEntry(buf *bytes.Buffer, f flagMeta) {
+	aliases := ""
+	if len(f.Aliases) > 0 {
+		parts := make([]string, len(f.Aliases))
+		for i, a := range f.Aliases {
+			if len(a) == 1 {
+				parts[i] = "-" + a
+			} else {
+				parts[i] = "--" + a
+			}
+		}
+		aliases = " (" + strings.Join(parts, ", ") + ")"
+	}
+
+	line := fmt.Sprintf("- `--%s`%s", f.Name, aliases)
+
+	if f.Type != "" && f.Type != flagTypeString {
+		line += fmt.Sprintf(" [%s]", f.Type)
+	}
+
+	// Flag Usage strings can carry embedded newlines/tabs (e.g. recipe's
+	// --snapshot/--criteria multi-line descriptions); collapse whitespace
+	// so the markdown bullet renders as a single line.
+	if usage := normalizeMarkdownText(f.Usage); usage != "" {
+		line += " — " + usage
+	}
+
+	if f.Default != "" {
+		line += fmt.Sprintf(" (default: `%s`)", f.Default)
+	}
+
+	if f.Required {
+		line += " **required**"
+	}
+
+	if len(f.Completions) > 0 {
+		line += fmt.Sprintf("  \n  Values: `%s`", strings.Join(f.Completions, "`, `"))
+	}
+
+	fmt.Fprintf(buf, "%s\n", line)
+}
+
+// normalizeMarkdownText collapses any run of whitespace (including newlines
+// and tabs) to single spaces so the result is safe to inline into a single
+// markdown line. Leading/trailing whitespace is trimmed.
+func normalizeMarkdownText(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// criteriaFlagAllowlist is the set of recipe flags that represent recipe
+// selection criteria. Other completable flags on the recipe command (e.g.
+// --format, which advertises yaml/json/table) must be excluded here so the
+// generated skill does not mislabel them as criteria for agent consumers.
+var criteriaFlagAllowlist = map[string]struct{}{
+	"service":     {},
+	"accelerator": {},
+	"intent":      {},
+	"os":          {},
+	"platform":    {},
+}
+
+// writeCriteriaValues writes the dynamic criteria values section extracted
+// from the recipe command's criteria flag completions.
+func writeCriteriaValues(buf *bytes.Buffer, meta *cliMeta) {
+	var recipeMeta *cmdMeta
+	for i := range meta.Commands {
+		if meta.Commands[i].Name == cmdNameRecipe {
+			recipeMeta = &meta.Commands[i]
+			break
+		}
+	}
+	if recipeMeta == nil {
+		return
+	}
+
+	type criteriaField struct {
+		name   string
+		values []string
+	}
+
+	var fields []criteriaField
+	for _, f := range recipeMeta.Flags {
+		if len(f.Completions) == 0 {
+			continue
+		}
+		if _, ok := criteriaFlagAllowlist[f.Name]; !ok {
+			continue
+		}
+		fields = append(fields, criteriaField{name: f.Name, values: f.Completions})
+	}
+
+	if len(fields) == 0 {
+		return
+	}
+
+	fmt.Fprintf(buf, "## Criteria Values\n\n")
+	fmt.Fprintf(buf, "Valid values for recipe criteria flags:\n\n")
+
+	for _, cf := range fields {
+		fmt.Fprintf(buf, "- **%s**: `%s`\n", cf.name, strings.Join(cf.values, "`, `"))
+	}
+
+	fmt.Fprintf(buf, "\n")
+}
+
+// writeOutputFormatGuidance writes static output format guidance.
+func writeOutputFormatGuidance(buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "## Output Format\n\n")
+	fmt.Fprintf(buf, "Use `--format json` for machine-readable output. Pipe through `jq` for field extraction:\n\n")
+	fmt.Fprintf(buf, "```bash\n")
+	fmt.Fprintf(buf, "aicr recipe --service eks --accelerator h100 --intent training --os ubuntu --format json | jq '.componentRefs[].name'\n")
+	fmt.Fprintf(buf, "```\n\n")
+	fmt.Fprintf(buf, "Default output format is YAML.\n\n")
+}
+
+// writeWorkflowExamples writes static workflow example content.
+func writeWorkflowExamples(buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "## Workflow Examples\n\n")
+
+	fmt.Fprintf(buf, "**Full pipeline:**\n\n")
+	fmt.Fprintf(buf, "```bash\n")
+	fmt.Fprintf(buf, "# Capture cluster state\n")
+	fmt.Fprintf(buf, "aicr snapshot --output snapshot.yaml\n\n")
+	fmt.Fprintf(buf, "# Generate optimized recipe\n")
+	fmt.Fprintf(buf, "aicr recipe --snapshot snapshot.yaml --intent training --output recipe.yaml\n\n")
+	fmt.Fprintf(buf, "# Validate recipe against cluster\n")
+	fmt.Fprintf(buf, "aicr validate --recipe recipe.yaml --snapshot snapshot.yaml\n\n")
+	fmt.Fprintf(buf, "# Create deployment bundle\n")
+	fmt.Fprintf(buf, "aicr bundle --recipe recipe.yaml --output ./bundles\n")
+	fmt.Fprintf(buf, "```\n\n")
+
+	fmt.Fprintf(buf, "**Query specific values:**\n\n")
+	fmt.Fprintf(buf, "```bash\n")
+	fmt.Fprintf(buf, "aicr query --service eks --accelerator gb200 --intent training --os ubuntu \\\n")
+	fmt.Fprintf(buf, "  --format json --selector components.gpu-operator.values.driver\n")
+	fmt.Fprintf(buf, "```\n\n")
+
+	fmt.Fprintf(buf, "**Bundle with value overrides:**\n\n")
+	fmt.Fprintf(buf, "```bash\n")
+	fmt.Fprintf(buf, "aicr bundle -r recipe.yaml --set gpuoperator:driver.version=580.105.08 -o ./bundles\n")
+	fmt.Fprintf(buf, "```\n\n")
+
+	fmt.Fprintf(buf, "**Verify bundle:**\n\n")
+	fmt.Fprintf(buf, "```bash\n")
+	fmt.Fprintf(buf, "aicr verify ./bundles\n")
+	fmt.Fprintf(buf, "```\n\n")
+}
+
+// writeErrorHandling writes static error handling guidance.
+func writeErrorHandling(buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "## Error Handling\n\n")
+	fmt.Fprintf(buf, "- Exit code 0 indicates success; non-zero indicates failure\n")
+	fmt.Fprintf(buf, "- Use `--debug` for verbose diagnostic output\n")
+	fmt.Fprintf(buf, "- Errors are structured with codes: check the `code` field in JSON error output\n")
+	fmt.Fprintf(buf, "- Common failures:\n")
+	fmt.Fprintf(buf, "  - Cluster unreachable — verify kubeconfig and connectivity\n")
+	fmt.Fprintf(buf, "  - Invalid recipe criteria — check valid values in the Criteria Values section\n")
+	fmt.Fprintf(buf, "  - Missing snapshot — generate one with `aicr snapshot` first\n\n")
+}
+
+// writeBestPractices writes static best practices guidance.
+func writeBestPractices(buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "## Best Practices\n\n")
+	fmt.Fprintf(buf, "- Always use `--format json` when parsing output programmatically\n")
+	fmt.Fprintf(buf, "- Pipe JSON output through `jq` for field extraction\n")
+	fmt.Fprintf(buf, "- Use `--debug` when troubleshooting unexpected behavior\n")
+	fmt.Fprintf(buf, "- Check `aicr --version` before running commands to ensure the expected version\n")
+}

--- a/pkg/cli/skill_codex.go
+++ b/pkg/cli/skill_codex.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+// Compile-time interface check.
+var _ skillGenerator = (*codexGenerator)(nil)
+
+// codexGenerator produces a Codex SKILL.md from CLI metadata.
+// Its content intentionally matches the Claude Code skill content so the two
+// agents stay aligned; only the install path differs.
+type codexGenerator struct{}
+
+func (g *codexGenerator) generate(meta *cliMeta) ([]byte, error) {
+	return (&claudeCodeGenerator{}).generate(meta)
+}
+
+func (g *codexGenerator) installPath() (string, error) {
+	return skillInstallPath(".codex/skills/aicr/SKILL.md")
+}

--- a/pkg/cli/skill_generator.go
+++ b/pkg/cli/skill_generator.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// agentType identifies a supported coding agent.
+type agentType string
+
+const (
+	agentClaudeCode agentType = "claude-code"
+	agentCodex      agentType = "codex"
+)
+
+// supportedAgents returns the string names of all recognized agent types.
+// The return type is []string so it can be passed directly to withCompletions.
+func supportedAgents() []string {
+	return []string{string(agentClaudeCode), string(agentCodex)}
+}
+
+// parseAgentType validates and returns the agentType for the given string.
+func parseAgentType(s string) (agentType, error) {
+	for _, a := range supportedAgents() {
+		if s == a {
+			return agentType(a), nil
+		}
+	}
+	return "", errors.New(errors.ErrCodeInvalidRequest,
+		fmt.Sprintf("unsupported agent type %q: must be one of %v", s, supportedAgents()))
+}
+
+// skillGenerator produces an agent-specific skill file from CLI metadata.
+// Implementations are registered per agentType (see claude_code_generator.go,
+// codex_generator.go).
+type skillGenerator interface {
+	// generate renders the skill file content from the given CLI metadata.
+	generate(meta *cliMeta) ([]byte, error)
+	// installPath returns the absolute path where the skill file should be written.
+	installPath() (string, error)
+}
+
+// cliMeta captures the full CLI command tree for skill generation.
+type cliMeta struct {
+	Name     string
+	Version  string
+	Flags    []flagMeta
+	Commands []cmdMeta
+}
+
+// cmdMeta captures a single CLI command. ArgsUsage carries positional
+// argument syntax (e.g. "<bundle-dir>" for `aicr verify <bundle-dir>`) so the
+// generated skill can show full command shapes, not just the command name.
+type cmdMeta struct {
+	Name        string
+	ArgsUsage   string
+	Usage       string
+	Flags       []flagMeta
+	Subcommands []cmdMeta
+}
+
+const (
+	flagTypeString      = "string"
+	flagTypeBool        = "bool"
+	flagTypeInt         = "int"
+	flagTypeDuration    = "duration"
+	flagTypeStringSlice = "stringSlice"
+)
+
+// flagMeta captures a single CLI flag.
+type flagMeta struct {
+	Name        string
+	Aliases     []string
+	Usage       string
+	Type        string
+	Default     string
+	Required    bool
+	Completions []string
+}
+
+// Auto-injected command names from urfave/cli/v3. The per-command help child
+// is added by ensureHelp during setupDefaults; the shell-completion command
+// is added when EnableShellCompletion is true. Both surface as regular
+// commands in the tree but are framework plumbing, not AICR workflow.
+const (
+	cmdNameHelp       = "help"
+	cmdNameCompletion = "completion"
+)
+
+// isFrameworkCommand reports whether a command name belongs to one of the
+// urfave/cli auto-injected commands listed above and should not appear in
+// the skill output. The skill teaches AICR workflows; framework plumbing
+// is noise that misleads agent consumers.
+func isFrameworkCommand(name string) bool {
+	return name == cmdNameHelp || name == cmdNameCompletion
+}
+
+// extractCLIMeta walks the urfave/cli command tree rooted at root and returns
+// a cliMeta snapshot. Hidden commands, the "skill" command itself, and
+// auto-injected framework commands ("help", "completion") are excluded;
+// root-level (global) flags such as --debug and --log-json are captured on
+// cliMeta.Flags so they appear in the generated skill output.
+func extractCLIMeta(root *cli.Command) *cliMeta {
+	meta := &cliMeta{
+		Name:    root.Name,
+		Version: version,
+	}
+
+	for _, f := range root.Flags {
+		fm := extractFlagMeta(f)
+		if fm == nil {
+			continue
+		}
+		meta.Flags = append(meta.Flags, *fm)
+	}
+
+	for _, cmd := range root.Commands {
+		if cmd.Hidden || cmd.Name == "skill" || isFrameworkCommand(cmd.Name) {
+			continue
+		}
+		meta.Commands = append(meta.Commands, extractCmdMeta(cmd))
+	}
+
+	return meta
+}
+
+// extractCmdMeta builds a cmdMeta from a single urfave/cli command,
+// recursively extracting subcommands and flags.
+func extractCmdMeta(cmd *cli.Command) cmdMeta {
+	m := cmdMeta{
+		Name:      cmd.Name,
+		ArgsUsage: cmd.ArgsUsage,
+		Usage:     cmd.Usage,
+	}
+
+	for _, f := range cmd.Flags {
+		fm := extractFlagMeta(f)
+		if fm == nil {
+			continue
+		}
+		m.Flags = append(m.Flags, *fm)
+	}
+
+	for _, sub := range cmd.Commands {
+		if sub.Hidden || isFrameworkCommand(sub.Name) {
+			continue
+		}
+		m.Subcommands = append(m.Subcommands, extractCmdMeta(sub))
+	}
+
+	return m
+}
+
+// extractFlagMeta converts a urfave/cli Flag into a flagMeta.
+// Returns nil for help and version flags which are auto-generated.
+func extractFlagMeta(f cli.Flag) *flagMeta {
+	names := f.Names()
+	if len(names) == 0 {
+		return nil
+	}
+
+	primary := names[0]
+	if primary == "help" || primary == "version" {
+		return nil
+	}
+
+	fm := &flagMeta{
+		Name: primary,
+	}
+
+	if len(names) > 1 {
+		fm.Aliases = names[1:]
+	}
+
+	// completableStringFlag wraps *cli.StringFlag, so the inner StringFlag is
+	// the source of truth for Usage/Default/Required. Match it before the
+	// generic *cli.StringFlag case so all string-flag fields are captured.
+	if cs, ok := f.(*completableStringFlag); ok {
+		fm.Type = flagTypeString
+		fm.Usage = cs.Usage
+		fm.Default = cs.Value
+		fm.Required = cs.Required
+		fm.Completions = cs.Completions()
+		return fm
+	}
+
+	switch tf := f.(type) {
+	case *cli.StringFlag:
+		fm.Type = flagTypeString
+		fm.Usage = tf.Usage
+		fm.Default = tf.Value
+		fm.Required = tf.Required
+	case *cli.BoolFlag:
+		fm.Type = flagTypeBool
+		fm.Usage = tf.Usage
+		if tf.Value {
+			fm.Default = "true"
+		}
+	case *cli.IntFlag:
+		fm.Type = flagTypeInt
+		fm.Usage = tf.Usage
+		if tf.Value != 0 {
+			fm.Default = fmt.Sprintf("%d", tf.Value)
+		}
+	case *cli.DurationFlag:
+		fm.Type = flagTypeDuration
+		fm.Usage = tf.Usage
+		if tf.Value != 0 {
+			fm.Default = tf.Value.String()
+		}
+	case *cli.StringSliceFlag:
+		fm.Type = flagTypeStringSlice
+		fm.Usage = tf.Usage
+	default:
+		if u, ok := f.(interface{ GetUsage() string }); ok {
+			fm.Usage = u.GetUsage()
+		}
+	}
+
+	// Check if flag provides shell completions.
+	if cf, ok := f.(CompletableFlag); ok {
+		fm.Completions = cf.Completions()
+	}
+
+	return fm
+}
+
+// userHomeDir returns the current user's home directory.
+func userHomeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to determine home directory", err)
+	}
+	return home, nil
+}
+
+// skillInstallPath builds an absolute path relative to the user's home directory.
+// Each generator provides its own relative path (e.g. ".claude/skills/aicr/SKILL.md").
+func skillInstallPath(relPath string) (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, filepath.FromSlash(relPath)), nil
+}
+
+// writeSkillFile writes content to the given path, creating parent
+// directories as needed. The write is atomic and TOCTOU-safe:
+//
+//  1. Lstat is used to refuse overwriting a symlink at the target — without
+//     this, an attacker (or a stale dotfile setup) could redirect the write
+//     after confirmation by swapping in a symlink before the final replace.
+//  2. Content is written to a temp file in the same directory and committed
+//     via os.Rename, so callers either see the previous content or the new
+//     content, never a partially written file.
+//
+// The caller is responsible for any pre-write existence/confirmation checks
+// (the rename itself unconditionally replaces a regular file).
+func writeSkillFile(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to create directory %s", dir), err)
+	}
+
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("refusing to overwrite symlink at skill path %s", path))
+	}
+
+	tmp, err := os.CreateTemp(dir, ".skill-*.tmp")
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to create temp file in %s", dir), err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to write temp skill file %s", tmpPath), err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to close temp skill file %s", tmpPath), err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil { //nolint:gosec // G703: tmpPath is the path returned by os.CreateTemp(dir, ...), constrained to dir
+		cleanup()
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to chmod temp skill file %s", tmpPath), err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil { //nolint:gosec // G703: tmpPath from os.CreateTemp; path validated upstream by skillInstallPath
+		cleanup()
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to rename temp skill file to %s", path), err)
+	}
+
+	return nil
+}
+
+// confirmOverwrite prompts the user to confirm overwriting an existing file.
+// Returns true only when the user answers y/yes (case-insensitive).
+//
+// If in is a non-terminal *os.File (pipe, redirected file, /dev/null), the
+// function returns an error instead of silently defaulting — this protects
+// non-interactive runs (CI, scripts) from accidental overwrites; the caller
+// should use --force to opt in. Other reader types (e.g., a bytes.Buffer in
+// tests) bypass the TTY check and are read directly.
+func confirmOverwrite(path string, in io.Reader, out io.Writer) (bool, error) {
+	if f, ok := in.(*os.File); ok && !term.IsTerminal(int(f.Fd())) { //nolint:gosec // G115: os file descriptors fit safely in int
+		return false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("skill file already exists: %s (use --force to overwrite, or remove it first)", path))
+	}
+
+	fmt.Fprintf(out, "skill file already exists: %s\noverwrite? [y/N]: ", path)
+
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, errors.Wrap(errors.ErrCodeInternal, "failed to read user confirmation", err)
+		}
+		return false, nil
+	}
+	response := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	return response == "y" || response == "yes", nil
+}

--- a/pkg/cli/skill_test.go
+++ b/pkg/cli/skill_test.go
@@ -1,0 +1,787 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func TestExtractCLIMeta(t *testing.T) {
+	root := newRootCmd()
+	meta := extractCLIMeta(root)
+
+	if meta.Name != name {
+		t.Errorf("name = %q, want %q", meta.Name, name)
+	}
+	if meta.Version == "" {
+		t.Error("version must not be empty")
+	}
+
+	// All top-level commands should be captured (snapshot, recipe, query,
+	// bundle, verify, validate, trust). Hidden commands and the "skill"
+	// command itself (if registered) must be excluded.
+	wantCmds := []string{"snapshot", "recipe", "query", "bundle", "verify", "validate", "trust"}
+	got := make(map[string]bool)
+	for _, c := range meta.Commands {
+		got[c.Name] = true
+	}
+	for _, w := range wantCmds {
+		if !got[w] {
+			t.Errorf("expected command %q in meta, got commands: %v", w, keys(got))
+		}
+	}
+
+	// The "skill" command must NOT appear (self-reference avoidance).
+	if got["skill"] {
+		t.Error("skill command must be excluded from meta")
+	}
+
+	// Recipe command must have flags with completions (e.g. --service, --intent).
+	var recipeMeta *cmdMeta
+	for i := range meta.Commands {
+		if meta.Commands[i].Name == "recipe" {
+			recipeMeta = &meta.Commands[i]
+			break
+		}
+	}
+	if recipeMeta == nil {
+		t.Fatal("recipe command not found in meta")
+	}
+
+	completionFound := false
+	for _, f := range recipeMeta.Flags {
+		if len(f.Completions) > 0 {
+			completionFound = true
+			break
+		}
+	}
+	if !completionFound {
+		t.Error("expected at least one flag with completions on recipe command")
+	}
+
+	// Verify help and version flags are excluded.
+	for _, c := range meta.Commands {
+		for _, f := range c.Flags {
+			if f.Name == "help" || f.Name == "version" {
+				t.Errorf("flag %q must be excluded from command %q", f.Name, c.Name)
+			}
+		}
+	}
+
+	// Trust command should have a subcommand "update".
+	var trustMeta *cmdMeta
+	for i := range meta.Commands {
+		if meta.Commands[i].Name == "trust" {
+			trustMeta = &meta.Commands[i]
+			break
+		}
+	}
+	if trustMeta == nil {
+		t.Fatal("trust command not found in meta")
+	}
+	subFound := false
+	for _, sub := range trustMeta.Subcommands {
+		if sub.Name == "update" {
+			subFound = true
+			break
+		}
+	}
+	if !subFound {
+		t.Error("expected trust subcommand 'update' in meta")
+	}
+
+	// Root-level (global) flags must be captured on cliMeta.Flags so they
+	// appear in the generated skill output.
+	rootFlags := make(map[string]bool, len(meta.Flags))
+	for _, f := range meta.Flags {
+		rootFlags[f.Name] = true
+	}
+	for _, want := range []string{"debug", "log-json"} {
+		if !rootFlags[want] {
+			t.Errorf("expected root flag %q in meta.Flags, got: %v", want, keys(rootFlags))
+		}
+	}
+	if rootFlags["help"] || rootFlags["version"] {
+		t.Errorf("auto-generated flags must be excluded from meta.Flags, got: %v", keys(rootFlags))
+	}
+}
+
+// TestExtractCLIMetaAfterRun exercises the post-Run() command tree, which is
+// the state the skill command actually sees in production. urfave/cli/v3
+// injects an unhidden "help" subcommand into every non-leaf command (via
+// setupDefaults -> ensureHelp) and a "completion" command at the root (with
+// Hidden=false because root.go's ConfigureShellCompletionCommand flips it).
+// extractCLIMeta must filter both, otherwise the generated SKILL.md ends up
+// with `aicr <cmd> help` and `aicr completion` noise that misleads agents.
+func TestExtractCLIMetaAfterRun(t *testing.T) {
+	root := newRootCmd()
+	// Run with --version to trigger setupDefaults without doing real work;
+	// urfave returns immediately after printing version, but the command tree
+	// is fully set up by then.
+	if err := root.Run(context.Background(), []string{name, "--version"}); err != nil {
+		t.Fatalf("root.Run failed: %v", err)
+	}
+
+	meta := extractCLIMeta(root)
+
+	for _, c := range meta.Commands {
+		if isFrameworkCommand(c.Name) {
+			t.Errorf("framework command %q must be excluded from meta.Commands", c.Name)
+		}
+		assertNoFrameworkSubcommand(t, c, c.Name)
+	}
+}
+
+func assertNoFrameworkSubcommand(t *testing.T, c cmdMeta, path string) {
+	t.Helper()
+	for _, sub := range c.Subcommands {
+		full := path + " " + sub.Name
+		if isFrameworkCommand(sub.Name) {
+			t.Errorf("framework subcommand %q must be excluded (under %q)", sub.Name, full)
+		}
+		assertNoFrameworkSubcommand(t, sub, full)
+	}
+}
+
+// TestWriteFlagEntryNormalizesUsage verifies that flag Usage strings carrying
+// embedded newlines or tabs (e.g. recipe's --snapshot/--criteria multi-line
+// descriptions) are collapsed onto a single markdown bullet so the generated
+// SKILL.md does not get its layout broken.
+func TestWriteFlagEntryNormalizesUsage(t *testing.T) {
+	root := newRootCmd()
+	if err := root.Run(context.Background(), []string{name, "--version"}); err != nil {
+		t.Fatalf("root.Run failed: %v", err)
+	}
+	meta := extractCLIMeta(root)
+
+	out, err := (&claudeCodeGenerator{}).generate(meta)
+	if err != nil {
+		t.Fatalf("generate() unexpected error: %v", err)
+	}
+	body := string(out)
+
+	// Recipe --snapshot has a multi-line Usage; assert the bullet line for
+	// it contains no embedded newlines or tabs and stays on one line.
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.Contains(line, "`--snapshot`") {
+			continue
+		}
+		if strings.ContainsAny(line, "\t") {
+			t.Errorf("--snapshot bullet contains tab; not normalized: %q", line)
+		}
+		// strings.Split already removed the trailing \n, but a multi-line
+		// Usage would have produced multiple lines starting with " — ...";
+		// look for the marker inside this single line.
+		if !strings.Contains(line, "—") {
+			t.Errorf("--snapshot bullet missing usage separator: %q", line)
+		}
+		return
+	}
+	t.Error("did not find --snapshot bullet in generated skill")
+}
+
+// TestExtractCmdMetaCarriesArgsUsage verifies that cmd.ArgsUsage is captured
+// onto cmdMeta so positional argument syntax is preserved for downstream
+// rendering. None of the current commands declare ArgsUsage, so this also
+// guards against the field silently disappearing on a future refactor.
+func TestExtractCmdMetaCarriesArgsUsage(t *testing.T) {
+	cmd := &cli.Command{
+		Name:      "demo",
+		ArgsUsage: "<bundle-dir>",
+		Usage:     "demo command",
+	}
+	m := extractCmdMeta(cmd)
+	if m.ArgsUsage != "<bundle-dir>" {
+		t.Errorf("ArgsUsage = %q, want %q", m.ArgsUsage, "<bundle-dir>")
+	}
+}
+
+// TestWriteCommandEntryRendersArgsUsage verifies the command heading shows
+// positional arg syntax when ArgsUsage is set, so e.g. `aicr verify` would
+// render as `aicr verify <bundle-dir>` once that command opts in.
+func TestWriteCommandEntryRendersArgsUsage(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := cmdMeta{
+		Name:      "verify",
+		ArgsUsage: "<bundle-dir>",
+		Usage:     "Verify a bundle.",
+	}
+	writeCommandEntry(&buf, "aicr", cmd, 0)
+	out := buf.String()
+	if !strings.Contains(out, "`aicr verify <bundle-dir>`") {
+		t.Errorf("command heading missing ArgsUsage: %q", out)
+	}
+}
+
+// TestWriteCriteriaValuesAllowlist verifies the criteria values section only
+// includes the recipe selection criteria flags, not other completable flags
+// like --format whose completions are output formats, not criteria values.
+func TestWriteCriteriaValuesAllowlist(t *testing.T) {
+	root := newRootCmd()
+	if err := root.Run(context.Background(), []string{name, "--version"}); err != nil {
+		t.Fatalf("root.Run failed: %v", err)
+	}
+	meta := extractCLIMeta(root)
+
+	out, err := (&claudeCodeGenerator{}).generate(meta)
+	if err != nil {
+		t.Fatalf("generate() unexpected error: %v", err)
+	}
+	body := string(out)
+
+	// Find the Criteria Values section bounds.
+	start := strings.Index(body, "## Criteria Values")
+	if start < 0 {
+		t.Fatal("Criteria Values section missing from generated skill")
+	}
+	rest := body[start:]
+	end := strings.Index(rest[len("## Criteria Values"):], "\n## ")
+	if end < 0 {
+		end = len(rest)
+	} else {
+		end += len("## Criteria Values")
+	}
+	section := rest[:end]
+
+	for _, want := range []string{"service", "accelerator", "intent", "os", "platform"} {
+		if !strings.Contains(section, "**"+want+"**") {
+			t.Errorf("criteria values section missing real criterion %q", want)
+		}
+	}
+	// --format is a completable recipe flag too, but it is not a criterion.
+	if strings.Contains(section, "**format**") {
+		t.Errorf("criteria values section must not include --format (output format, not a criterion)")
+	}
+}
+
+func TestParseAgentType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    agentType
+		wantErr bool
+	}{
+		{"claude-code", "claude-code", agentClaudeCode, false},
+		{"codex", "codex", agentCodex, false},
+		{"empty string", "", "", true},
+		{"unknown agent", "gemini", "", true},
+		{"case sensitive", "Claude-Code", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAgentType(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAgentType(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseAgentType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportedAgents(t *testing.T) {
+	agents := supportedAgents()
+	if len(agents) == 0 {
+		t.Fatal("supportedAgents() must return at least one agent")
+	}
+
+	// Verify known agents are present.
+	found := make(map[string]bool, len(agents))
+	for _, a := range agents {
+		found[a] = true
+	}
+	if !found[string(agentClaudeCode)] {
+		t.Error("expected claude-code in supported agents")
+	}
+	if !found[string(agentCodex)] {
+		t.Error("expected codex in supported agents")
+	}
+}
+
+func TestWriteSkillFile(t *testing.T) {
+	dir := t.TempDir()
+	// Nested path to verify MkdirAll.
+	path := filepath.Join(dir, "nested", "dir", "skill.md")
+
+	content := []byte("# test skill content")
+	if err := writeSkillFile(path, content); err != nil {
+		t.Fatalf("writeSkillFile() unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("file content = %q, want %q", got, content)
+	}
+}
+
+func TestWriteSkillFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "victim.md")
+	if err := os.WriteFile(target, []byte("victim content"), 0o600); err != nil {
+		t.Fatalf("failed to seed victim file: %v", err)
+	}
+	link := filepath.Join(dir, "skill.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	err := writeSkillFile(link, []byte("attacker content"))
+	if err == nil {
+		t.Fatal("writeSkillFile() expected error when target is a symlink")
+	}
+	if !strings.Contains(err.Error(), "refusing to overwrite symlink") {
+		t.Errorf("error = %q, want containing 'refusing to overwrite symlink'", err.Error())
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read victim: %v", err)
+	}
+	if string(got) != "victim content" {
+		t.Errorf("victim was clobbered through symlink: got %q", got)
+	}
+}
+
+func TestWriteSkillFileOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skill.md")
+
+	if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("failed to create existing file: %v", err)
+	}
+
+	if err := writeSkillFile(path, []byte("new content")); err != nil {
+		t.Fatalf("writeSkillFile() unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	if string(got) != "new content" {
+		t.Errorf("file content = %q, want %q", got, "new content")
+	}
+}
+
+func TestConfirmOverwrite(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"yes lower", "y\n", true},
+		{"yes word", "yes\n", true},
+		{"yes uppercase", "Y\n", true},
+		{"yes word mixed case", "Yes\n", true},
+		{"no lower", "n\n", false},
+		{"empty defaults to no", "\n", false},
+		{"eof defaults to no", "", false},
+		{"unrecognized defaults to no", "maybe\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			got, err := confirmOverwrite("/tmp/skill.md", strings.NewReader(tt.input), &out)
+			if err != nil {
+				t.Fatalf("confirmOverwrite() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("confirmOverwrite(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			if !strings.Contains(out.String(), "overwrite? [y/N]") {
+				t.Errorf("prompt missing from output: %q", out.String())
+			}
+		})
+	}
+}
+
+func TestConfirmOverwriteNonTTY(t *testing.T) {
+	// Use /dev/null as a non-terminal *os.File.
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("failed to open /dev/null: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	_, err = confirmOverwrite("/tmp/skill.md", f, io.Discard)
+	if err == nil {
+		t.Fatal("confirmOverwrite() expected error for non-TTY input")
+	}
+	if !strings.Contains(err.Error(), "use --force to overwrite") {
+		t.Errorf("error message = %q, want containing '--force' hint", err.Error())
+	}
+}
+
+func TestUserHomeDir(t *testing.T) {
+	dir, err := userHomeDir()
+	if err != nil {
+		t.Fatalf("userHomeDir() unexpected error: %v", err)
+	}
+	if dir == "" {
+		t.Error("userHomeDir() returned empty string")
+	}
+}
+
+func TestSkillInstallPath(t *testing.T) {
+	path, err := skillInstallPath(".claude/skills/aicr/SKILL.md")
+	if err != nil {
+		t.Fatalf("skillInstallPath() unexpected error: %v", err)
+	}
+	if path == "" {
+		t.Error("skillInstallPath() returned empty string")
+	}
+	// Must end with the expected suffix.
+	want := filepath.Join(".claude", "skills", "aicr", "SKILL.md")
+	if !strings.HasSuffix(path, want) {
+		t.Errorf("skillInstallPath() = %q, want suffix %q", path, want)
+	}
+}
+
+func TestExtractFlagMeta(t *testing.T) {
+	meta := extractCLIMeta(newRootCmd())
+
+	// Find snapshot command to check flag type extraction.
+	var snapMeta *cmdMeta
+	for i := range meta.Commands {
+		if meta.Commands[i].Name == "snapshot" {
+			snapMeta = &meta.Commands[i]
+			break
+		}
+	}
+	if snapMeta == nil {
+		t.Fatal("snapshot command not found in meta")
+	}
+
+	// Check that boolean flags are typed correctly.
+	flagTypes := make(map[string]string)
+	for _, f := range snapMeta.Flags {
+		flagTypes[f.Name] = f.Type
+	}
+
+	if flagTypes["no-cleanup"] != flagTypeBool {
+		t.Errorf("no-cleanup type = %q, want %q", flagTypes["no-cleanup"], flagTypeBool)
+	}
+	if flagTypes["timeout"] != flagTypeDuration {
+		t.Errorf("timeout type = %q, want %q", flagTypes["timeout"], flagTypeDuration)
+	}
+	if flagTypes["namespace"] != flagTypeString {
+		t.Errorf("namespace type = %q, want %q", flagTypes["namespace"], flagTypeString)
+	}
+}
+
+// TestExtractFlagMetaCompletableStringFlag verifies that completableStringFlag
+// (the only known wrapper today) has all StringFlag fields captured: Usage,
+// Default, Required, AND the wrapper's Completions().
+func TestExtractFlagMetaCompletableStringFlag(t *testing.T) {
+	wrapped := withCompletions(&cli.StringFlag{
+		Name:     "agent",
+		Usage:    "target coding agent",
+		Value:    "claude-code",
+		Required: true,
+	}, func() []string { return []string{"claude-code", "codex"} })
+
+	fm := extractFlagMeta(wrapped)
+	if fm == nil {
+		t.Fatal("extractFlagMeta() returned nil for completableStringFlag")
+	}
+	if fm.Name != "agent" {
+		t.Errorf("Name = %q, want %q", fm.Name, "agent")
+	}
+	if fm.Type != flagTypeString {
+		t.Errorf("Type = %q, want %q", fm.Type, flagTypeString)
+	}
+	if fm.Usage != "target coding agent" {
+		t.Errorf("Usage = %q, want %q", fm.Usage, "target coding agent")
+	}
+	if fm.Default != "claude-code" {
+		t.Errorf("Default = %q, want %q", fm.Default, "claude-code")
+	}
+	if !fm.Required {
+		t.Error("Required = false, want true")
+	}
+	wantCompletions := []string{"claude-code", "codex"}
+	if len(fm.Completions) != len(wantCompletions) {
+		t.Fatalf("Completions = %v, want %v", fm.Completions, wantCompletions)
+	}
+	for i, c := range wantCompletions {
+		if fm.Completions[i] != c {
+			t.Errorf("Completions[%d] = %q, want %q", i, fm.Completions[i], c)
+		}
+	}
+}
+
+func TestSkillGenerateClaudeCode(t *testing.T) {
+	root := newRootCmd()
+	meta := extractCLIMeta(root)
+
+	gen := &claudeCodeGenerator{}
+	content, err := gen.generate(meta)
+	if err != nil {
+		t.Fatalf("generate() unexpected error: %v", err)
+	}
+
+	out := string(content)
+
+	// Must start with YAML frontmatter.
+	if !strings.HasPrefix(out, "---\n") {
+		t.Error("output must start with YAML frontmatter delimiter '---'")
+	}
+
+	// Frontmatter fields.
+	mustContain := []string{
+		"name: aicr",
+		"user_invocable: true",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("output missing frontmatter field %q", s)
+		}
+	}
+
+	// All functional commands must appear.
+	wantCmds := []string{"snapshot", "recipe", "query", "bundle", "validate"}
+	for _, cmd := range wantCmds {
+		if !strings.Contains(out, cmd) {
+			t.Errorf("output missing command %q", cmd)
+		}
+	}
+
+	// Workflow examples.
+	wantExamples := []string{
+		"aicr snapshot",
+		"aicr recipe",
+		"aicr bundle",
+		"aicr validate",
+	}
+	for _, ex := range wantExamples {
+		if !strings.Contains(out, ex) {
+			t.Errorf("output missing workflow example %q", ex)
+		}
+	}
+
+	// Output format guidance.
+	if !strings.Contains(out, "--format json") {
+		t.Error("output missing --format json guidance")
+	}
+
+	// Prerequisites.
+	if !strings.Contains(out, "aicr --version") {
+		t.Error("output missing prerequisite 'aicr --version'")
+	}
+
+	// Error handling section.
+	if !strings.Contains(out, "Error Handling") {
+		t.Error("output missing error handling section")
+	}
+
+	// Best practices section.
+	if !strings.Contains(out, "Best Practices") {
+		t.Error("output missing best practices section")
+	}
+
+	// Criteria values section should contain dynamic values from recipe flags.
+	if !strings.Contains(out, "Criteria Values") {
+		t.Error("output missing criteria values section")
+	}
+
+	// Global flags section must list root-level flags so agents discover them.
+	if !strings.Contains(out, "Global Flags") {
+		t.Error("output missing 'Global Flags' section")
+	}
+	for _, want := range []string{"--debug", "--log-json"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing global flag %q", want)
+		}
+	}
+}
+
+func TestSkillClaudeCodeInstallPath(t *testing.T) {
+	gen := &claudeCodeGenerator{}
+	path, err := gen.installPath()
+	if err != nil {
+		t.Fatalf("installPath() unexpected error: %v", err)
+	}
+
+	want := filepath.Join(".claude", "skills", "aicr", "SKILL.md")
+	if !strings.HasSuffix(path, want) {
+		t.Errorf("installPath() = %q, want suffix %q", path, want)
+	}
+}
+
+func TestSkillGenerateCodex(t *testing.T) {
+	root := newRootCmd()
+	meta := extractCLIMeta(root)
+
+	gen := &codexGenerator{}
+	content, err := gen.generate(meta)
+	if err != nil {
+		t.Fatalf("generate() unexpected error: %v", err)
+	}
+
+	claudeContent, err := (&claudeCodeGenerator{}).generate(meta)
+	if err != nil {
+		t.Fatalf("claude generate() unexpected error: %v", err)
+	}
+
+	out := string(content)
+
+	// Must start with YAML frontmatter for Codex skill discovery.
+	if !strings.HasPrefix(out, "---\n") {
+		t.Error("output must start with YAML frontmatter delimiter '---'")
+	}
+
+	if !strings.Contains(out, "name: aicr") {
+		t.Error("output missing Codex skill frontmatter name")
+	}
+
+	if out != string(claudeContent) {
+		t.Error("Codex skill content must exactly match Claude Code skill content")
+	}
+
+	// Must start with a markdown heading.
+	if !strings.Contains(out, "\n# ") {
+		t.Error("output must start with markdown heading '# '")
+	}
+
+	// All functional commands must appear.
+	wantCmds := []string{"snapshot", "recipe", "query", "bundle", "validate"}
+	for _, cmd := range wantCmds {
+		if !strings.Contains(out, cmd) {
+			t.Errorf("output missing command %q", cmd)
+		}
+	}
+
+	// Output format guidance.
+	if !strings.Contains(out, "--format json") {
+		t.Error("output missing --format json guidance")
+	}
+}
+
+func TestSkillCodexInstallPath(t *testing.T) {
+	gen := &codexGenerator{}
+	path, err := gen.installPath()
+	if err != nil {
+		t.Fatalf("installPath() unexpected error: %v", err)
+	}
+
+	want := filepath.Join(".codex", "skills", "aicr", "SKILL.md")
+	if !strings.HasSuffix(path, want) {
+		t.Errorf("installPath() = %q, want suffix %q", path, want)
+	}
+}
+
+func TestSkillCmd_CommandStructure(t *testing.T) {
+	cmd := skillCmd()
+
+	if cmd.Name != "skill" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "skill")
+	}
+	if cmd.Category != "Utilities" {
+		t.Errorf("Category = %q, want %q", cmd.Category, "Utilities")
+	}
+	if cmd.Action == nil {
+		t.Error("Action must not be nil")
+	}
+
+	flagNames := make(map[string]bool)
+	for _, f := range cmd.Flags {
+		for _, n := range f.Names() {
+			flagNames[n] = true
+		}
+	}
+	if !flagNames["agent"] {
+		t.Error("expected --agent flag")
+	}
+	if !flagNames["stdout"] {
+		t.Error("expected --stdout flag")
+	}
+	if !flagNames["force"] {
+		t.Error("expected --force flag")
+	}
+}
+
+func TestSkillCmd_Stdout(t *testing.T) {
+	// Use the real root command so runSkillCmd reads the same cmd.Root() as
+	// production. A stripped-down root would miss regressions in top-level
+	// metadata extraction (e.g., framework-command leaks, missing global
+	// flags, criteria filtering) and stdout cleanliness.
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.Writer = &buf
+
+	err := root.Run(context.Background(), []string{name, "skill", "--agent", "claude-code", "--stdout"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "---\n") {
+		t.Error("output must start with YAML frontmatter '---'")
+	}
+	// The real command tree must show through to stdout — assert a real
+	// top-level command appears, not just the literal "aicr" substring.
+	for _, want := range []string{"aicr snapshot", "aicr recipe", "aicr bundle"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing real command entry %q", want)
+		}
+	}
+	// And the framework-command filter must hold here too.
+	for _, leak := range []string{"aicr snapshot help", "aicr completion"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("output leaked framework command %q", leak)
+		}
+	}
+}
+
+func TestSkillCmd_MissingAgent(t *testing.T) {
+	var buf bytes.Buffer
+
+	root := &cli.Command{
+		Name:   "aicr",
+		Writer: &buf,
+		Commands: []*cli.Command{
+			skillCmd(),
+		},
+	}
+
+	err := root.Run(context.Background(), []string{"aicr", "skill"})
+	if err == nil {
+		t.Fatal("expected error when --agent is missing")
+	}
+}
+
+// keys returns sorted map keys for diagnostic output.
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Adds `aicr skill --agent <claude-code|codex>` which generates a skill file from the live CLI command tree and installs it to the agent's standard discovery location, with `--stdout` for preview, `--force` for non-interactive overwrite, and a `[y/N]` prompt on TTY when the target file exists.

## Motivation / Context

Coding agents (Claude Code, Codex) need a structured "skill" file to discover and correctly invoke the AICR CLI. Hand-maintained skill files drift from the CLI flag/criteria surface; this command generates the file from the same urfave/cli command tree the user runs, so it stays in sync automatically.

Fixes: N/A
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- **Single source of truth.** `claudeCodeGenerator` produces the canonical content; `codexGenerator.generate` delegates to it. Only the install path differs (`~/.claude/skills/aicr/SKILL.md` vs `~/.codex/skills/aicr/SKILL.md`), so the two skills cannot drift.
- **Self-reference avoidance.** `extractCLIMeta` excludes the `skill` command itself and any hidden commands; `extractFlagMeta` excludes auto-generated `help`/`version` flags.
- **Wrapper-aware flag extraction.** `extractFlagMeta` matches `*completableStringFlag` explicitly so Usage/Default/Required/Completions are captured. (Without this, the wrapper falls through to a generic default branch and those fields are dropped.)
- **Overwrite safety.** When the target exists and `--force` is not set: prompt `overwrite? [y/N]` on TTY (empty/EOF/unknown answers default to no); on non-TTY stdin (CI, piped), refuse with a hint to use `--force` rather than silently clobber.
- **Pure write.** `writeSkillFile` is a pure write; existence/confirmation lives in the caller so test-only writes don't fight the prompt logic.

## Testing

```bash
make qualify          # pass
make lint             # pass (Go + YAML)
go test -race ./pkg/cli/...   # pass
```

**Coverage (pkg/cli):** 37.5% → 50.5% (**+13.0%**); no new exported symbols.

End-to-end smoke test on this branch:

```bash
aicr skill --agent claude-code --stdout    # prints SKILL.md to stdout
aicr skill --agent claude-code             # interactive: prompts on existing file
echo n | aicr skill --agent claude-code    # non-TTY: errors with --force hint
aicr skill --agent claude-code --force     # overwrites without prompting
aicr skill --agent codex --force           # produces byte-identical content
diff ~/.claude/skills/aicr/SKILL.md ~/.codex/skills/aicr/SKILL.md   # no diff
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** New command in the `Utilities` category; no existing behavior touched. `aicr skill` writes only to the user's home directory (`~/.claude/...` or `~/.codex/...`), never to the repo. No flags, env vars, or APIs renamed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)