### PR TITLE
docs: remove redundant verify step from Option 3 installation

### DIFF
--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -66,12 +66,6 @@ sudo mv aicr /usr/local/bin/
 sudo chmod +x /usr/local/bin/aicr
 ```
 
-3. **Verify installation**
-
-```shell
-aicr --version
-```
-
 ### Option 4: Build from Source
 
 **Requirements:**


### PR DESCRIPTION
## Summary

Remove the redundant \"Verify installation\" step from Option 3 (Manual Installation). The top-level `## Verify Installation` section already covers all installation paths, and Options 1, 2, and 4 do not have their own verify steps.

## Motivation / Context

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Testing

```bash
# Documentation-only change, no code affected
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase