### PR TITLE
feat(ci): replace AICR-bot top-level Slack posts with daily-thread cadence

### DIFF
--- a/.github/actions/slack-thread-post/action.yml
+++ b/.github/actions/slack-thread-post/action.yml
@@ -99,8 +99,20 @@ runs:
           if [[ "${ok}" != "true" ]]; then
             local err
             err=$(printf '%s' "${response}" | jq -r '.error // "unknown_error"')
-            echo "::error::Slack ${method} failed: ${err}" >&2
             printf '%s' "${response}" | jq . >&2 || true
+            # Permanent misconfiguration — operator must fix; do not lazy-create.
+            case "${err}" in
+              invalid_auth|not_authed|token_revoked|token_expired|\
+              missing_scope|invalid_scope|not_allowed_token_type|\
+              channel_not_found|not_in_channel)
+                echo "::error::Slack ${method} failed: ${err} — fix Slack app config or repo secrets/vars" >&2
+                exit 1
+                ;;
+            esac
+            # Transient (rate_limited, request_timeout, internal_error,
+            # fatal_error, service_unavailable, 5xx) — caller decides whether
+            # to lazy-create.
+            echo "::warning::Slack ${method} transient failure: ${err}" >&2
             return 1
           fi
           printf '%s' "${response}"

--- a/.github/actions/slack-thread-post/action.yml
+++ b/.github/actions/slack-thread-post/action.yml
@@ -1,0 +1,154 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Slack Thread Post'
+description: 'Post messages to Slack with daily-thread coordination via marker pattern'
+
+inputs:
+  bot-token:
+    description: 'Slack bot token (xoxb-...)'
+    required: true
+  channel-id:
+    description: 'Slack channel ID (e.g. C012ABC3DEF)'
+    required: true
+  body:
+    description: 'Message text. Required when mode=reply or mode=top-level; ignored when mode=heartbeat-only.'
+    required: false
+    default: ''
+  mode:
+    description: 'heartbeat-only | reply | top-level'
+    required: true
+
+outputs:
+  parent-ts:
+    description: "Timestamp of today's daily parent (set in heartbeat-only and reply modes)"
+    value: ${{ steps.post.outputs.parent_ts }}
+  posted-ts:
+    description: 'Timestamp of the posted message (set in reply and top-level modes)'
+    value: ${{ steps.post.outputs.posted_ts }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post to Slack
+      id: post
+      shell: bash
+      env:
+        BOT_TOKEN: ${{ inputs.bot-token }}
+        CHANNEL_ID: ${{ inputs.channel-id }}
+        BODY: ${{ inputs.body }}
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+
+        # ---- Input validation -----------------------------------------------
+        if [[ -z "${BOT_TOKEN}" ]]; then
+          echo "::error::SLACK_BOT_TOKEN is empty — set the secret in repo settings"
+          exit 1
+        fi
+        if [[ -z "${CHANNEL_ID}" ]]; then
+          echo "::error::SLACK_CHANNEL_ID is empty — set the variable in repo settings"
+          exit 1
+        fi
+        case "${MODE}" in
+          heartbeat-only|reply|top-level) ;;
+          *)
+            echo "::error::invalid mode: '${MODE}' (must be heartbeat-only, reply, or top-level)"
+            exit 1
+            ;;
+        esac
+        if [[ "${MODE}" != "heartbeat-only" && -z "${BODY}" ]]; then
+          echo "::error::input 'body' is required when mode=${MODE}"
+          exit 1
+        fi
+
+        # ---- Daily marker (UTC) — internal, not caller-controlled ----------
+        MARKER="Daily AICR-bot status — $(date -u +%Y-%m-%d)"
+
+        # ---- Slack API helper -----------------------------------------------
+        # Calls https://slack.com/api/<method>, fails on response.ok != true.
+        # Echoes the full response on success so the caller can jq it.
+        slack_api() {
+          local method="$1"; shift
+          local response
+          response=$(curl -sS --max-time 30 --connect-timeout 10 \
+            -H "Authorization: Bearer ${BOT_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            "$@" \
+            "https://slack.com/api/${method}")
+          local ok
+          ok=$(printf '%s' "${response}" | jq -r '.ok')
+          if [[ "${ok}" != "true" ]]; then
+            local err
+            err=$(printf '%s' "${response}" | jq -r '.error // "unknown_error"')
+            echo "::error::Slack ${method} failed: ${err}" >&2
+            printf '%s' "${response}" | jq . >&2 || true
+            return 1
+          fi
+          printf '%s' "${response}"
+        }
+
+        # ---- Top-level mode: post and exit ----------------------------------
+        if [[ "${MODE}" == "top-level" ]]; then
+          payload=$(jq -n --arg ch "${CHANNEL_ID}" --arg t "${BODY}" \
+            '{channel: $ch, text: $t}')
+          response=$(slack_api chat.postMessage --data "${payload}")
+          posted_ts=$(printf '%s' "${response}" | jq -r '.ts')
+          echo "posted_ts=${posted_ts}" >> "${GITHUB_OUTPUT}"
+          echo "Posted top-level message: ts=${posted_ts}"
+          exit 0
+        fi
+
+        # ---- heartbeat-only / reply: find or lazy-create today's parent -----
+        # conversations.history may rate-limit; on failure we treat as "no parent
+        # found" and fall through to lazy-create. Worst case is a duplicate
+        # parent, which self-heals next day.
+        parent_ts=""
+        if history=$(slack_api conversations.history --get \
+              --data-urlencode "channel=${CHANNEL_ID}" \
+              --data-urlencode "limit=20"); then
+          parent_ts=$(printf '%s' "${history}" \
+            | jq -r --arg m "${MARKER}" \
+                '[.messages[]? | select(.text != null and (.text | startswith($m)))] | .[0].ts // empty')
+        else
+          echo "::warning::conversations.history failed — proceeding with lazy-create"
+        fi
+
+        if [[ -z "${parent_ts}" ]]; then
+          payload=$(jq -n --arg ch "${CHANNEL_ID}" --arg t "${MARKER}" \
+            '{channel: $ch, text: $t}')
+          response=$(slack_api chat.postMessage --data "${payload}")
+          parent_ts=$(printf '%s' "${response}" | jq -r '.ts')
+          echo "Created parent: ts=${parent_ts}"
+        else
+          echo "Found existing parent: ts=${parent_ts}"
+        fi
+
+        echo "parent_ts=${parent_ts}" >> "${GITHUB_OUTPUT}"
+
+        # ---- heartbeat-only: stop after parent is ensured -------------------
+        if [[ "${MODE}" == "heartbeat-only" ]]; then
+          exit 0
+        fi
+
+        # ---- reply: post body as thread reply -------------------------------
+        payload=$(jq -n \
+          --arg ch "${CHANNEL_ID}" \
+          --arg t "${BODY}" \
+          --arg ts "${parent_ts}" \
+          '{channel: $ch, text: $t, thread_ts: $ts}')
+        response=$(slack_api chat.postMessage --data "${payload}")
+        posted_ts=$(printf '%s' "${response}" | jq -r '.ts')
+        echo "posted_ts=${posted_ts}" >> "${GITHUB_OUTPUT}"
+        echo "Posted thread reply: ts=${posted_ts} (parent=${parent_ts})"

--- a/.github/actions/slack-thread-post/action.yml
+++ b/.github/actions/slack-thread-post/action.yml
@@ -76,6 +76,13 @@ runs:
         # ---- Daily marker (UTC) — internal, not caller-controlled ----------
         MARKER="Daily AICR-bot status — $(date -u +%Y-%m-%d)"
 
+        # Unix timestamp at 00:00:00 UTC today. Used as 'oldest' on
+        # conversations.history so the lookup window is exactly today's UTC
+        # day — independent of channel chatter volume.
+        TODAY_START_TS=$(date -u -d 'today 00:00:00' +%s 2>/dev/null \
+          || date -u -j -f '%Y-%m-%d %H:%M:%S' \
+              "$(date -u +%Y-%m-%d) 00:00:00" +%s)
+
         # ---- Slack API helper -----------------------------------------------
         # Calls https://slack.com/api/<method>, fails on response.ok != true.
         # Echoes the full response on success so the caller can jq it.
@@ -117,7 +124,8 @@ runs:
         parent_ts=""
         if history=$(slack_api conversations.history --get \
               --data-urlencode "channel=${CHANNEL_ID}" \
-              --data-urlencode "limit=20"); then
+              --data-urlencode "limit=100" \
+              --data-urlencode "oldest=${TODAY_START_TS}"); then
           parent_ts=$(printf '%s' "${history}" \
             | jq -r --arg m "${MARKER}" \
                 '[.messages[]? | select(.text != null and (.text | startswith($m)))] | .[0].ts // empty')

--- a/.github/workflows/daily-status.yaml
+++ b/.github/workflows/daily-status.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Daily AICR-Bot Status
+
+on:
+  schedule:
+    - cron: '0 5 * * 1-5'   # Mon-Fri 05:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  heartbeat:
+    name: Ensure Daily Parent Message
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Post heartbeat
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          mode: heartbeat-only

--- a/.github/workflows/issue-report.yaml
+++ b/.github/workflows/issue-report.yaml
@@ -16,10 +16,8 @@ name: Daily Issue Report
 
 on:
   schedule:
-    # 5:30 AM Pacific (12:30 UTC during PDT Mar–Nov).
-    # During PST (Nov–Mar) this fires at 4:30 AM Pacific since
-    # GitHub Actions cron is UTC-only.
-    - cron: '30 12 * * *'
+    # 5:30 AM Pacific (12:30 UTC during PDT Mar–Nov, Mon-Fri only).
+    - cron: '30 12 * * 1-5'
   workflow_dispatch: {}
 
 permissions:
@@ -39,6 +37,11 @@ jobs:
       contents: read
       issues: read
     steps:
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Collect issue metrics
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
@@ -263,16 +266,19 @@ jobs:
             }
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md.join('\n') + '\n');
 
-      - name: Post to Slack
-        env:
-          SLACK_SERVICE: ${{ secrets.SLACK_SERVICE }}
+      - name: Stage Slack message
         run: |
           set -euo pipefail
-          if [[ -z "${SLACK_SERVICE}" ]]; then
-            echo "::error::SLACK_SERVICE secret is not configured"
-            exit 1
-          fi
-          curl -sSf -X POST \
-            -H 'Content-type: application/json' \
-            --data @slack-payload.json \
-            "https://hooks.slack.com/services/${SLACK_SERVICE}"
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            jq -r '.text' slack-payload.json
+            echo "SLACK_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: reply

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -510,9 +510,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Post to Slack
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build message and choose mode
         env:
-          SLACK_SERVICE: ${{ secrets.SLACK_SERVICE }}
           TAG: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
           SERVER: ${{ github.server_url }}
@@ -524,10 +528,30 @@ jobs:
             RELEASE_TYPE="pre-release"
           fi
           RELEASE_URL="${SERVER}/${REPO}/releases/tag/${TAG}"
-          curl -sSf -X POST \
-            -H 'Content-type: application/json' \
-            --data "{\"text\":\"AICR ${TAG} has been released (${RELEASE_TYPE}): ${RELEASE_URL}\"}" \
-            "https://hooks.slack.com/services/${SLACK_SERVICE}"
+          MESSAGE="AICR ${TAG} has been released (${RELEASE_TYPE}): ${RELEASE_URL}"
+
+          # date -u +%u: 1=Mon … 7=Sun
+          DOW=$(date -u +%u)
+          if [[ "${DOW}" -le 5 ]]; then
+            MODE="reply"
+          else
+            MODE="top-level"
+          fi
+
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            echo "${MESSAGE}"
+            echo "SLACK_EOF"
+            echo "SLACK_MODE=${MODE}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: ${{ env.SLACK_MODE }}
 
   # =============================================================================
   # Summary: Release pipeline report (always runs, even on failure)

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -530,8 +530,14 @@ jobs:
           RELEASE_URL="${SERVER}/${REPO}/releases/tag/${TAG}"
           MESSAGE="AICR ${TAG} has been released (${RELEASE_TYPE}): ${RELEASE_URL}"
 
-          # date -u +%u: 1=Mon … 7=Sun
-          DOW=$(date -u +%u)
+          # Derive DOW from the commit's committer timestamp, not the
+          # notify-job runner clock. A tag pushed late on Friday UTC whose
+          # notify job runs after midnight would otherwise post top-level
+          # on Saturday instead of replying under Friday's daily parent.
+          # TZ=UTC + git's --date=format-local:%u gives UTC day-of-week
+          # (1=Mon..7=Sun) without invoking the date binary, sidestepping
+          # GNU/BSD portability differences.
+          DOW=$(TZ=UTC git log -1 --format=%cd --date=format-local:%u HEAD)
           if [[ "${DOW}" -le 5 ]]; then
             MODE="reply"
           else

--- a/.github/workflows/vuln-scan-images.yaml
+++ b/.github/workflows/vuln-scan-images.yaml
@@ -16,7 +16,7 @@ name: Daily Image Vulnerability Scan
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # Daily at 6:00 AM UTC
+    - cron: '0 6 * * 1-5'  # Mon-Fri 06:00 UTC
   workflow_dispatch: {}
 
 permissions:
@@ -266,6 +266,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Download all scan results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -273,9 +278,8 @@ jobs:
           merge-multiple: true
           path: scan-results
 
-      - name: Post to Slack
+      - name: Build Slack message
         env:
-          SLACK_SERVICE: ${{ secrets.SLACK_SERVICE }}
           SHA: ${{ github.sha }}
           SERVER: ${{ github.server_url }}
           REPO: ${{ github.repository }}
@@ -286,24 +290,26 @@ jobs:
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M')
           RUN_URL="${SERVER}/${REPO}/actions/runs/${RUN_ID}"
 
-          RESULTS=""
+          MESSAGE="Vulnerability Scan: ${TIMESTAMP} (${SHORT_SHA})"
           for f in scan-results/*.txt; do
             [[ -f "$f" ]] || continue
-            LINE=$(cat "$f")
-            RESULTS="${RESULTS}\\n• ${LINE}"
+            MESSAGE="${MESSAGE}"$'\n'"• $(cat "$f")"
           done
+          MESSAGE="${MESSAGE}"$'\n'"<${RUN_URL}|View run>"
 
-          MESSAGE="Vulnerability Scan: ${TIMESTAMP} (${SHORT_SHA})${RESULTS}\\n<${RUN_URL}|View run>"
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            echo "${MESSAGE}"
+            echo "SLACK_EOF"
+          } >> "${GITHUB_ENV}"
 
-          if [[ -n "${SLACK_SERVICE}" ]]; then
-            curl -sSf -X POST \
-              -H 'Content-type: application/json' \
-              --data "{\"text\":\"${MESSAGE}\"}" \
-              "https://hooks.slack.com/services/${SLACK_SERVICE}"
-          else
-            echo "SLACK_SERVICE not set, skipping notification"
-            echo -e "${MESSAGE}"
-          fi
+      - name: Post to Slack
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: reply
 
   # =============================================================================
   # Cleanup: Delete all scan-* images from GHCR (always runs)

--- a/.github/workflows/weekly-summary.yaml
+++ b/.github/workflows/weekly-summary.yaml
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Weekly AICR Summary
+
+on:
+  schedule:
+    - cron: '0 14 * * 6'   # Saturday 14:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+
+  summary:
+    name: Post Weekly Summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      actions: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Collect releases (last 7 days)
+        id: releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Window: now - 7 days, UTC
+          SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+
+          RELEASES_JSON=$(gh release list --repo "${REPO}" --limit 20 \
+            --json tagName,publishedAt)
+
+          # Filter to publishedAt >= SINCE
+          FILTERED=$(printf '%s' "${RELEASES_JSON}" \
+            | jq --arg since "${SINCE}" \
+                '[.[] | select(.publishedAt >= $since)]')
+
+          COUNT=$(printf '%s' "${FILTERED}" | jq 'length')
+
+          if [[ "${COUNT}" -eq 0 ]]; then
+            BLOCK="*Releases (0):* _none this week_"
+          else
+            BULLETS=$(printf '%s' "${FILTERED}" | jq -r \
+              --arg repo "${REPO}" \
+              '.[] | "• <https://github.com/\($repo)/releases/tag/\(.tagName)|\(.tagName)> (\(.publishedAt | sub("T.*"; "")))"')
+            BLOCK="*Releases (${COUNT}):*"$'\n'"${BULLETS}"
+          fi
+
+          {
+            echo "RELEASES_BLOCK<<REL_EOF"
+            echo "${BLOCK}"
+            echo "REL_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Collect issue movement (last 7 days)
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const fs = require('fs');
+            const TYPE_LABELS = ['bug', 'feature', 'documentation'];
+            const PRIORITY_LABELS = ['P0', 'P1', 'P2'];
+            const SLA = {
+              P0: { days: 30 },
+              P1: { days: 180 },
+            };
+            const SEVEN_DAYS_MS = 7 * 86400000;
+            const since = new Date(Date.now() - SEVEN_DAYS_MS).toISOString();
+
+            const hasLabel = (i, n) => i.labels.some(l => l.name === n);
+            const ageDays = (i) =>
+              Math.floor((Date.now() - new Date(i.created_at)) / 86400000);
+
+            const open = (await github.paginate(
+              github.rest.issues.listForRepo,
+              { ...context.repo, state: 'open', per_page: 100 },
+            )).filter(i => !i.pull_request);
+
+            const closed = (await github.paginate(
+              github.rest.issues.listForRepo,
+              { ...context.repo, state: 'closed', since, per_page: 100 },
+            )).filter(i => !i.pull_request &&
+                          new Date(i.closed_at) >= new Date(since)).length;
+
+            const total = open.length;
+            const newCount = open.filter(
+              i => new Date(i.created_at) >= new Date(since)).length;
+
+            const types = TYPE_LABELS
+              .map(l => [l, open.filter(i => hasLabel(i, l)).length])
+              .filter(([, c]) => c > 0);
+
+            let prioritized = 0;
+            const pri = PRIORITY_LABELS.map(l => {
+              const c = open.filter(i => hasLabel(i, l)).length;
+              prioritized += c;
+              return [l, c];
+            });
+            const noPri = total - prioritized;
+
+            const unowned = open.filter(i =>
+              (hasLabel(i, 'P0') || hasLabel(i, 'P1')) &&
+              (!i.assignees || i.assignees.length === 0)).length;
+
+            const breaches = [];
+            for (const i of open) {
+              const age = ageDays(i);
+              for (const [k, sla] of Object.entries(SLA)) {
+                if (hasLabel(i, k) && age > sla.days) {
+                  breaches.push({ num: i.number, pri: k, over: age - sla.days });
+                }
+              }
+            }
+
+            const lines = [
+              '*Issue movement (7d):*',
+              `${total} open, +${newCount} new, -${closed} closed`,
+            ];
+            const priParts = pri
+              .filter(([, c]) => c > 0)
+              .map(([l, c]) => `${l}: ${c}`);
+            if (noPri > 0) priParts.push(`none: ${noPri}`);
+            lines.push(`Priority: ${priParts.join(', ')}`);
+            if (types.length > 0) {
+              lines.push(`Type: ${types.map(([l, c]) => `${l}: ${c}`).join(', ')}`);
+            }
+            if (unowned > 0) {
+              lines.push(`Unowned P0/P1: *${unowned}*`);
+            }
+            if (breaches.length > 0) {
+              lines.push(`:rotating_light: ${breaches.length} SLA breach${breaches.length === 1 ? '' : 'es'}`);
+            }
+
+            const block = lines.join('\n');
+            fs.appendFileSync(process.env.GITHUB_ENV,
+              `ISSUES_BLOCK<<ISS_EOF\n${block}\nISS_EOF\n`);
+
+      - name: Collect latest vuln scan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RUN_JSON=$(gh run list --repo "${REPO}" \
+            --workflow=vuln-scan-images.yaml --status=success --limit=1 \
+            --json databaseId,createdAt,url)
+
+          COUNT=$(printf '%s' "${RUN_JSON}" | jq 'length')
+          if [[ "${COUNT}" -eq 0 ]]; then
+            BLOCK="*Latest vuln scan:* _no successful run found — see Actions tab_"
+          else
+            URL=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].url')
+            CREATED=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].createdAt')
+            DAY=$(date -u -d "${CREATED}" '+%a %H:%M UTC' 2>/dev/null \
+              || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "${CREATED}" '+%a %H:%M UTC')
+            BLOCK="*Latest vuln scan:* ${DAY} — <${URL}|view run>"
+          fi
+
+          {
+            echo "VULN_BLOCK<<VULN_EOF"
+            echo "${BLOCK}"
+            echo "VULN_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Assemble summary message
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Week-of label: Monday of the current calendar week (UTC)
+          # date -u +%u gives 1=Mon..7=Sun; subtract that minus 1 to get Monday
+          DOW=$(date -u +%u)
+          WEEK_START=$(date -u -d "$((DOW - 1)) days ago" +%Y-%m-%d 2>/dev/null \
+            || date -u -v-$((DOW - 1))d +%Y-%m-%d)
+
+          MESSAGE="*AICR weekly* — week of ${WEEK_START}"$'\n\n'
+          MESSAGE+="${RELEASES_BLOCK}"$'\n\n'
+          MESSAGE+="${ISSUES_BLOCK}"$'\n\n'
+          MESSAGE+="${VULN_BLOCK}"
+
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            echo "${MESSAGE}"
+            echo "SLACK_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack (top-level)
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: top-level

--- a/.github/workflows/weekly-summary.yaml
+++ b/.github/workflows/weekly-summary.yaml
@@ -53,7 +53,10 @@ jobs:
           SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
             || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
 
-          RELEASES_JSON=$(gh release list --repo "${REPO}" --limit 20 \
+          # --limit 200 covers ~6 months at AICR's release cadence; the
+          # publishedAt >= SINCE filter below trims to the 7-day window.
+          # Pagination is YAGNI for this volume.
+          RELEASES_JSON=$(gh release list --repo "${REPO}" --limit 200 \
             --json tagName,publishedAt)
 
           # Filter to publishedAt >= SINCE

--- a/.github/workflows/weekly-summary.yaml
+++ b/.github/workflows/weekly-summary.yaml
@@ -172,7 +172,16 @@ jobs:
               lines.push(`Unowned P0/P1: *${unowned}*`);
             }
             if (breaches.length > 0) {
-              lines.push(`:rotating_light: ${breaches.length} SLA breach${breaches.length === 1 ? '' : 'es'}`);
+              const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+              const SHOW = 5;
+              const shown = breaches
+                .slice(0, SHOW)
+                .map(b => `<${repoUrl}/issues/${b.num}|#${b.num}> (${b.pri}, +${b.over}d over)`);
+              const overflow = breaches.length > SHOW
+                ? ` _+${breaches.length - SHOW} more_`
+                : '';
+              const word = breaches.length === 1 ? 'breach' : 'breaches';
+              lines.push(`:rotating_light: ${breaches.length} SLA ${word}: ${shown.join(', ')}${overflow}`);
             }
 
             const block = lines.join('\n');

--- a/.github/workflows/weekly-summary.yaml
+++ b/.github/workflows/weekly-summary.yaml
@@ -171,13 +171,23 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          RUN_JSON=$(gh run list --repo "${REPO}" \
-            --workflow=vuln-scan-images.yaml --status=success --limit=1 \
+          # Pull the last 50 successful runs so the 7-day filter has plenty
+          # to choose from even if the workflow runs >1x/day.
+          ALL_RUNS=$(gh run list --repo "${REPO}" \
+            --workflow=vuln-scan-images.yaml --status=success --limit=50 \
             --json databaseId,createdAt,url)
+
+          # 7-day-ago threshold (UTC), with macOS BSD-date fallback.
+          THRESHOLD=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+
+          RUN_JSON=$(printf '%s' "${ALL_RUNS}" \
+            | jq --arg t "${THRESHOLD}" \
+                '[.[] | select(.createdAt >= $t)] | sort_by(.createdAt) | reverse | .[0:1]')
 
           COUNT=$(printf '%s' "${RUN_JSON}" | jq 'length')
           if [[ "${COUNT}" -eq 0 ]]; then
-            BLOCK="*Latest vuln scan:* _no successful run found — see Actions tab_"
+            BLOCK="*Latest vuln scan:* _no successful run this week — see Actions tab_"
           else
             URL=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].url')
             CREATED=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].createdAt')

--- a/.github/workflows/weekly-summary.yaml
+++ b/.github/workflows/weekly-summary.yaml
@@ -106,15 +106,24 @@ jobs:
               { ...context.repo, state: 'open', per_page: 100 },
             )).filter(i => !i.pull_request);
 
-            const closed = (await github.paginate(
+            // Pull recently-closed issues (not just count) so we can union
+            // their "newly-created in this window" subset with the open
+            // newly-created subset. Without this, an issue opened and
+            // closed in the same 7 days never counts toward "+new".
+            const recentClosed = (await github.paginate(
               github.rest.issues.listForRepo,
               { ...context.repo, state: 'closed', since, per_page: 100 },
             )).filter(i => !i.pull_request &&
-                          new Date(i.closed_at) >= new Date(since)).length;
+                          new Date(i.closed_at) >= new Date(since));
+            const closed = recentClosed.length;
 
             const total = open.length;
-            const newCount = open.filter(
-              i => new Date(i.created_at) >= new Date(since)).length;
+            const sinceMs = new Date(since).getTime();
+            const newOpen = open.filter(
+              i => new Date(i.created_at).getTime() >= sinceMs).length;
+            const newClosed = recentClosed.filter(
+              i => new Date(i.created_at).getTime() >= sinceMs).length;
+            const newCount = newOpen + newClosed;
 
             const types = TYPE_LABELS
               .map(l => [l, open.filter(i => hasLabel(i, l)).length])

--- a/.github/workflows/weekly-summary.yaml
+++ b/.github/workflows/weekly-summary.yaml
@@ -129,13 +129,18 @@ jobs:
               .map(l => [l, open.filter(i => hasLabel(i, l)).length])
               .filter(([, c]) => c > 0);
 
-            let prioritized = 0;
-            const pri = PRIORITY_LABELS.map(l => {
-              const c = open.filter(i => hasLabel(i, l)).length;
-              prioritized += c;
-              return [l, c];
-            });
-            const noPri = total - prioritized;
+            // Per-priority counts (an issue may appear in multiple buckets
+            // if it carries multiple priority labels — that's fine here).
+            const pri = PRIORITY_LABELS.map(l => [
+              l, open.filter(i => hasLabel(i, l)).length,
+            ]);
+            // For the noPri remainder, dedupe by issue number — an issue
+            // with both P0 and P1 counts once toward "prioritized".
+            const prioritizedNums = new Set(
+              open.filter(i => PRIORITY_LABELS.some(l => hasLabel(i, l)))
+                  .map(i => i.number),
+            );
+            const noPri = total - prioritizedNums.size;
 
             const unowned = open.filter(i =>
               (hasLabel(i, 'P0') || hasLabel(i, 'P1')) &&

--- a/docs/superpowers/plans/2026-04-27-aicr-bot-slack-cadence.md
+++ b/docs/superpowers/plans/2026-04-27-aicr-bot-slack-cadence.md
@@ -1,0 +1,1055 @@
+# AICR-Bot Slack Cadence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate AICR-Bot's Slack posting from per-event Incoming Webhooks to a two-cadence Web-API model: a Mon-Fri short heartbeat parent with threaded replies for vuln-scan / issue-report / release events, and a Saturday top-level weekly digest.
+
+**Architecture:** New shared composite action `.github/actions/slack-thread-post/` encapsulates all Slack Web API calls (find or lazy-create today's parent via `conversations.history` + marker pattern, then `chat.postMessage` with `thread_ts` for replies, or no `thread_ts` for top-level). One new heartbeat workflow plus one new weekly-summary workflow are added; three existing workflows (`vuln-scan-images.yaml`, `issue-report.yaml`, `on-tag.yaml`) replace their inline `curl` Slack calls with the composite action.
+
+**Tech Stack:**
+- GitHub Actions (composite actions, scheduled workflows, `workflow_dispatch`)
+- Bash + `curl` + `jq` for Slack Web API calls
+- Slack Web API: `chat.postMessage`, `conversations.history`
+- Linting: `actionlint`, `yamllint`, embedded `shellcheck` (via actionlint)
+
+**Spec:** `docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Purpose |
+|---|---|---|
+| `.github/actions/slack-thread-post/action.yml` | NEW | Composite action: shell + curl + jq for all three Slack post modes |
+| `.github/workflows/daily-status.yaml` | NEW | Mon-Fri 05:00 UTC heartbeat parent post |
+| `.github/workflows/weekly-summary.yaml` | NEW | Saturday 14:00 UTC weekly top-level digest |
+| `.github/workflows/vuln-scan-images.yaml` | MODIFY | Cron → weekday-only; notify job → composite action (mode=reply) |
+| `.github/workflows/issue-report.yaml` | MODIFY | Cron → weekday-only; Slack post step → composite action (mode=reply) |
+| `.github/workflows/on-tag.yaml` | MODIFY | Notify job → composite action; mode determined by day-of-week |
+
+Each file has one responsibility. The composite action absorbs all Slack-protocol complexity so caller workflows stay short and uniform. No mixing of concerns.
+
+---
+
+## Operational Prerequisite (BEFORE PR merge — repo admin task)
+
+This is **not a code task** but must complete before the PR's workflows will succeed in the production channel. Document this in the PR description.
+
+1. Create or reuse a Slack App in the NVIDIA workspace.
+2. Grant OAuth scopes:
+   - `chat:write`
+   - `channels:history` (public channel) **or** `groups:history` (private channel)
+3. Install the app to the workspace; invite the bot to the AICR target channel.
+4. Add repo settings:
+   - **Secret** `SLACK_BOT_TOKEN` (the `xoxb-…` bot token)
+   - **Variable** `SLACK_CHANNEL_ID` (channel ID, e.g., `C012ABC3DEF`; not secret)
+5. Keep existing `SLACK_SERVICE` secret in place — removed in a follow-up cleanup PR after a full week of clean runs.
+
+---
+
+## Task 1: Create the `slack-thread-post` composite action
+
+**Files:**
+- Create: `.github/actions/slack-thread-post/action.yml`
+
+This is the foundation — every other task depends on it. The action encapsulates: input validation, marker computation, Slack API calls with error handling, three modes (`heartbeat-only`, `reply`, `top-level`).
+
+- [ ] **Step 1: Create the directory and action file**
+
+```bash
+mkdir -p .github/actions/slack-thread-post
+```
+
+Then create `.github/actions/slack-thread-post/action.yml` with the following exact content:
+
+```yaml
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Slack Thread Post'
+description: 'Post messages to Slack with daily-thread coordination via marker pattern'
+
+inputs:
+  bot-token:
+    description: 'Slack bot token (xoxb-...)'
+    required: true
+  channel-id:
+    description: 'Slack channel ID (e.g. C012ABC3DEF)'
+    required: true
+  body:
+    description: 'Message text. Required when mode=reply or mode=top-level; ignored when mode=heartbeat-only.'
+    required: false
+    default: ''
+  mode:
+    description: 'heartbeat-only | reply | top-level'
+    required: true
+
+outputs:
+  parent-ts:
+    description: "Timestamp of today's daily parent (set in heartbeat-only and reply modes)"
+    value: ${{ steps.post.outputs.parent_ts }}
+  posted-ts:
+    description: 'Timestamp of the posted message (set in reply and top-level modes)'
+    value: ${{ steps.post.outputs.posted_ts }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post to Slack
+      id: post
+      shell: bash
+      env:
+        BOT_TOKEN: ${{ inputs.bot-token }}
+        CHANNEL_ID: ${{ inputs.channel-id }}
+        BODY: ${{ inputs.body }}
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+
+        # ---- Input validation -----------------------------------------------
+        if [[ -z "${BOT_TOKEN}" ]]; then
+          echo "::error::SLACK_BOT_TOKEN is empty — set the secret in repo settings"
+          exit 1
+        fi
+        if [[ -z "${CHANNEL_ID}" ]]; then
+          echo "::error::SLACK_CHANNEL_ID is empty — set the variable in repo settings"
+          exit 1
+        fi
+        case "${MODE}" in
+          heartbeat-only|reply|top-level) ;;
+          *)
+            echo "::error::invalid mode: '${MODE}' (must be heartbeat-only, reply, or top-level)"
+            exit 1
+            ;;
+        esac
+        if [[ "${MODE}" != "heartbeat-only" && -z "${BODY}" ]]; then
+          echo "::error::input 'body' is required when mode=${MODE}"
+          exit 1
+        fi
+
+        # ---- Daily marker (UTC) — internal, not caller-controlled ----------
+        MARKER="Daily AICR-bot status — $(date -u +%Y-%m-%d)"
+
+        # ---- Slack API helper -----------------------------------------------
+        # Calls https://slack.com/api/<method>, fails on response.ok != true.
+        # Echoes the full response on success so the caller can jq it.
+        slack_api() {
+          local method="$1"; shift
+          local response
+          response=$(curl -sS \
+            -H "Authorization: Bearer ${BOT_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            "$@" \
+            "https://slack.com/api/${method}")
+          local ok
+          ok=$(printf '%s' "${response}" | jq -r '.ok')
+          if [[ "${ok}" != "true" ]]; then
+            local err
+            err=$(printf '%s' "${response}" | jq -r '.error // "unknown_error"')
+            echo "::error::Slack ${method} failed: ${err}"
+            printf '%s' "${response}" | jq . >&2 || true
+            return 1
+          fi
+          printf '%s' "${response}"
+        }
+
+        # ---- Top-level mode: post and exit ----------------------------------
+        if [[ "${MODE}" == "top-level" ]]; then
+          payload=$(jq -n --arg ch "${CHANNEL_ID}" --arg t "${BODY}" \
+            '{channel: $ch, text: $t}')
+          response=$(slack_api chat.postMessage --data "${payload}")
+          posted_ts=$(printf '%s' "${response}" | jq -r '.ts')
+          echo "posted_ts=${posted_ts}" >> "${GITHUB_OUTPUT}"
+          echo "Posted top-level message: ts=${posted_ts}"
+          exit 0
+        fi
+
+        # ---- heartbeat-only / reply: find or lazy-create today's parent -----
+        # conversations.history may rate-limit; on failure we treat as "no parent
+        # found" and fall through to lazy-create. Worst case is a duplicate
+        # parent, which self-heals next day.
+        parent_ts=""
+        if history=$(slack_api conversations.history --get \
+              --data-urlencode "channel=${CHANNEL_ID}" \
+              --data-urlencode "limit=20"); then
+          parent_ts=$(printf '%s' "${history}" \
+            | jq -r --arg m "${MARKER}" \
+                '[.messages[] | select(.text != null and (.text | startswith($m)))] | .[0].ts // empty')
+        else
+          echo "::warning::conversations.history failed — proceeding with lazy-create"
+        fi
+
+        if [[ -z "${parent_ts}" ]]; then
+          payload=$(jq -n --arg ch "${CHANNEL_ID}" --arg t "${MARKER}" \
+            '{channel: $ch, text: $t}')
+          response=$(slack_api chat.postMessage --data "${payload}")
+          parent_ts=$(printf '%s' "${response}" | jq -r '.ts')
+          echo "Created parent: ts=${parent_ts}"
+        else
+          echo "Found existing parent: ts=${parent_ts}"
+        fi
+
+        echo "parent_ts=${parent_ts}" >> "${GITHUB_OUTPUT}"
+
+        # ---- heartbeat-only: stop after parent is ensured -------------------
+        if [[ "${MODE}" == "heartbeat-only" ]]; then
+          exit 0
+        fi
+
+        # ---- reply: post body as thread reply -------------------------------
+        payload=$(jq -n \
+          --arg ch "${CHANNEL_ID}" \
+          --arg t "${BODY}" \
+          --arg ts "${parent_ts}" \
+          '{channel: $ch, text: $t, thread_ts: $ts}')
+        response=$(slack_api chat.postMessage --data "${payload}")
+        posted_ts=$(printf '%s' "${response}" | jq -r '.ts')
+        echo "posted_ts=${posted_ts}" >> "${GITHUB_OUTPUT}"
+        echo "Posted thread reply: ts=${posted_ts} (parent=${parent_ts})"
+```
+
+- [ ] **Step 2: Lint with actionlint**
+
+Run: `actionlint .github/actions/slack-thread-post/action.yml`
+Expected: no output (success).
+
+If errors: read each, fix in the file, re-run. Common issues will be: missing `name:` on a step, wrong indentation, unsupported `runs.using` value (must be `composite`), or shellcheck warnings on the embedded shell.
+
+- [ ] **Step 3: Lint with yamllint**
+
+Run: `yamllint .github/actions/slack-thread-post/action.yml`
+Expected: no output (success).
+
+The project's `.yamllint` (or default config) sets line-length and indentation rules. If a line is flagged for length, prefer breaking strings with shell concatenation over disabling the rule.
+
+- [ ] **Step 4: Lint shell with shellcheck (extracted)**
+
+`actionlint` includes shellcheck on `run:` blocks, so step 2 already covers this. If you want a standalone confirmation:
+
+```bash
+# Extract the shell block and shellcheck it directly
+yq '.runs.steps[] | select(.id == "post") | .run' \
+  .github/actions/slack-thread-post/action.yml \
+  | shellcheck -s bash -
+```
+
+Expected: no output (success). If `yq` is unavailable, skip — actionlint already shellchecks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/actions/slack-thread-post/action.yml
+git commit -s -S -m "feat(ci): add slack-thread-post composite action
+
+Encapsulates Slack Web API calls for daily-thread coordination:
+- mode=heartbeat-only: ensure today's parent exists (find or create)
+- mode=reply: post body as thread reply under today's parent
+  (lazy-creates parent if missing)
+- mode=top-level: post body as top-level message
+
+Marker pattern 'Daily AICR-bot status — YYYY-MM-DD' (UTC) is computed
+internally so every caller agrees on the lookup key. State lives in
+Slack via conversations.history; no external store needed.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md"
+```
+
+---
+
+## Task 2: Add the `daily-status` heartbeat workflow
+
+**Files:**
+- Create: `.github/workflows/daily-status.yaml`
+
+Mon-Fri 05:00 UTC. Calls the composite action with `mode=heartbeat-only` to ensure today's parent message exists in the channel.
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/daily-status.yaml` with the following exact content:
+
+```yaml
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Daily AICR-Bot Status
+
+on:
+  schedule:
+    - cron: '0 5 * * 1-5'   # Mon-Fri 05:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  heartbeat:
+    name: Ensure Daily Parent Message
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Post heartbeat
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          mode: heartbeat-only
+```
+
+- [ ] **Step 2: Lint with actionlint**
+
+Run: `actionlint .github/workflows/daily-status.yaml`
+Expected: no output (success).
+
+- [ ] **Step 3: Lint with yamllint**
+
+Run: `yamllint .github/workflows/daily-status.yaml`
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/daily-status.yaml
+git commit -s -S -m "feat(ci): add daily AICR-bot status heartbeat workflow
+
+Posts a short parent message ('Daily AICR-bot status — YYYY-MM-DD')
+Mon-Fri at 05:00 UTC. Other Slack-posting workflows reply in-thread
+under this parent on weekdays.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md"
+```
+
+---
+
+## Task 3: Migrate `vuln-scan-images.yaml` to threaded reply
+
+**Files:**
+- Modify: `.github/workflows/vuln-scan-images.yaml`
+
+Two changes: (a) cron from daily to weekday-only, (b) replace the inline `curl` in the `notify` job with a call to the composite action.
+
+- [ ] **Step 1: Change the cron to weekday-only**
+
+Open `.github/workflows/vuln-scan-images.yaml`. Find the `on.schedule.cron` line (currently `'0 6 * * *'`) and change it to:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'  # Mon-Fri 06:00 UTC
+  workflow_dispatch: {}
+```
+
+- [ ] **Step 2: Replace the `notify` job's Slack step**
+
+Find the `notify` job (its `name: Slack Notification`). Replace its entire `steps:` block with:
+
+```yaml
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download all scan results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: scan-*
+          merge-multiple: true
+          path: scan-results
+
+      - name: Build Slack message
+        env:
+          SHA: ${{ github.sha }}
+          SERVER: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${SHA:0:7}"
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M')
+          RUN_URL="${SERVER}/${REPO}/actions/runs/${RUN_ID}"
+
+          MESSAGE="Vulnerability Scan: ${TIMESTAMP} (${SHORT_SHA})"
+          for f in scan-results/*.txt; do
+            [[ -f "$f" ]] || continue
+            MESSAGE="${MESSAGE}"$'\n'"• $(cat "$f")"
+          done
+          MESSAGE="${MESSAGE}"$'\n'"<${RUN_URL}|View run>"
+
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            echo "${MESSAGE}"
+            echo "SLACK_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: reply
+```
+
+The previous `Post to Slack` step (which had the inline `curl` to `hooks.slack.com`) is gone. The previous `Download all scan results` step is preserved verbatim.
+
+- [ ] **Step 3: Lint with actionlint**
+
+Run: `actionlint .github/workflows/vuln-scan-images.yaml`
+Expected: no output (success).
+
+- [ ] **Step 4: Lint with yamllint**
+
+Run: `yamllint .github/workflows/vuln-scan-images.yaml`
+Expected: no output (success).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/vuln-scan-images.yaml
+git commit -s -S -m "feat(ci): vuln-scan-images posts as Slack thread reply
+
+- Cron shifts to Mon-Fri only ('0 6 * * 1-5'); weekend signal moves
+  to the new weekly-summary workflow.
+- Replaces the inline webhook curl in the notify job with the new
+  slack-thread-post composite action (mode=reply). Body assembly
+  is moved to a dedicated step that writes to GITHUB_ENV so the
+  multi-line message survives YAML escaping.
+- Drops the SLACK_SERVICE env from the notify job. The webhook
+  secret stays in repo settings until all migrations land.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md"
+```
+
+---
+
+## Task 4: Migrate `issue-report.yaml` to threaded reply
+
+**Files:**
+- Modify: `.github/workflows/issue-report.yaml`
+
+Two changes: (a) cron weekday-only, (b) replace the `Post to Slack` step.
+
+- [ ] **Step 1: Change the cron to weekday-only**
+
+Find the `on.schedule.cron` line (currently `'30 12 * * *'`) and change it to:
+
+```yaml
+on:
+  schedule:
+    # 5:30 AM Pacific (12:30 UTC during PDT Mar–Nov, Mon-Fri only).
+    - cron: '30 12 * * 1-5'
+  workflow_dispatch: {}
+```
+
+(Update the comment to reflect Mon-Fri.)
+
+- [ ] **Step 2: Add a checkout step at the top of the `report` job**
+
+The job currently has no checkout step. Add this as the **first** step in the `report` job's `steps:` block (before the existing `Collect issue metrics` step):
+
+```yaml
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+```
+
+- [ ] **Step 3: Replace the `Post to Slack` step**
+
+Find the existing `Post to Slack` step (the one that runs `curl … hooks.slack.com`). Replace it with these two steps:
+
+```yaml
+      - name: Stage Slack message
+        run: |
+          set -euo pipefail
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            jq -r '.text' slack-payload.json
+            echo "SLACK_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: reply
+```
+
+- [ ] **Step 4: Lint with actionlint**
+
+Run: `actionlint .github/workflows/issue-report.yaml`
+Expected: no output (success).
+
+- [ ] **Step 5: Lint with yamllint**
+
+Run: `yamllint .github/workflows/issue-report.yaml`
+Expected: no output (success).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/issue-report.yaml
+git commit -s -S -m "feat(ci): issue-report posts as Slack thread reply
+
+- Cron shifts to Mon-Fri only ('30 12 * * 1-5'); weekend signal
+  moves to the new weekly-summary workflow.
+- Replaces the inline webhook curl with the slack-thread-post
+  composite action (mode=reply). The existing actions/github-script
+  step still writes slack-payload.json; a small staging step lifts
+  .text into GITHUB_ENV for the action.
+- Adds an actions/checkout step (required for local composite
+  action access).
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md"
+```
+
+---
+
+## Task 5: Migrate `on-tag.yaml` notify job (day-of-week aware)
+
+**Files:**
+- Modify: `.github/workflows/on-tag.yaml`
+
+Weekday releases thread under the daily parent; weekend releases post top-level.
+
+- [ ] **Step 1: Replace the `notify` job's `steps:` block**
+
+Find the `notify` job (`name: Slack Notification`). Replace its entire `steps:` block with:
+
+```yaml
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build message and choose mode
+        env:
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          SERVER: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+          RELEASE_URL="${SERVER}/${REPO}/releases/tag/${TAG}"
+          MESSAGE="AICR ${TAG} has been released: ${RELEASE_URL}"
+
+          # date -u +%u: 1=Mon … 7=Sun
+          DOW=$(date -u +%u)
+          if [[ "${DOW}" -le 5 ]]; then
+            MODE="reply"
+          else
+            MODE="top-level"
+          fi
+
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            echo "${MESSAGE}"
+            echo "SLACK_EOF"
+            echo "SLACK_MODE=${MODE}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: ${{ env.SLACK_MODE }}
+```
+
+The previous step's `SLACK_SERVICE` env and `curl` to `hooks.slack.com` are gone.
+
+- [ ] **Step 2: Lint with actionlint**
+
+Run: `actionlint .github/workflows/on-tag.yaml`
+Expected: no output (success).
+
+- [ ] **Step 3: Lint with yamllint**
+
+Run: `yamllint .github/workflows/on-tag.yaml`
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/on-tag.yaml
+git commit -s -S -m "feat(ci): on-tag release notify uses daily-thread coordination
+
+Mon-Fri release tags reply in-thread under the daily heartbeat
+parent (lazy-creates if a release fires before the 05:00 UTC
+heartbeat). Sat-Sun release tags post top-level (no daily parent
+on weekends — releases are rare and inherently noteworthy).
+
+Day-of-week is computed from 'date -u +%u' (1=Mon … 7=Sun).
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md"
+```
+
+---
+
+## Task 6: Add the `weekly-summary` workflow
+
+**Files:**
+- Create: `.github/workflows/weekly-summary.yaml`
+
+Saturday 14:00 UTC. Aggregates 7-day releases, 7-day issue movement, and a link to the latest vuln scan run; posts a single top-level message.
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/weekly-summary.yaml` with the following exact content:
+
+```yaml
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Weekly AICR Summary
+
+on:
+  schedule:
+    - cron: '0 14 * * 6'   # Saturday 14:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+
+  summary:
+    name: Post Weekly Summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      actions: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Collect releases (last 7 days)
+        id: releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Window: now - 7 days, UTC
+          SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+
+          RELEASES_JSON=$(gh release list --repo "${REPO}" --limit 20 \
+            --json tagName,publishedAt,url)
+
+          # Filter to publishedAt >= SINCE
+          FILTERED=$(printf '%s' "${RELEASES_JSON}" \
+            | jq --arg since "${SINCE}" \
+                '[.[] | select(.publishedAt >= $since)]')
+
+          COUNT=$(printf '%s' "${FILTERED}" | jq 'length')
+
+          if [[ "${COUNT}" -eq 0 ]]; then
+            BLOCK="*Releases (0):* _none this week_"
+          else
+            BULLETS=$(printf '%s' "${FILTERED}" | jq -r \
+              '.[] | "• <\(.url)|\(.tagName)> (\(.publishedAt | sub("T.*"; "")))"')
+            BLOCK="*Releases (${COUNT}):*"$'\n'"${BULLETS}"
+          fi
+
+          {
+            echo "RELEASES_BLOCK<<REL_EOF"
+            echo "${BLOCK}"
+            echo "REL_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Collect issue movement (last 7 days)
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const fs = require('fs');
+            const TYPE_LABELS = ['bug', 'feature', 'documentation'];
+            const PRIORITY_LABELS = ['P0', 'P1', 'P2'];
+            const SLA = {
+              P0: { days: 30 },
+              P1: { days: 180 },
+            };
+            const SEVEN_DAYS_MS = 7 * 86400000;
+            const since = new Date(Date.now() - SEVEN_DAYS_MS).toISOString();
+
+            const hasLabel = (i, n) => i.labels.some(l => l.name === n);
+            const ageDays = (i) =>
+              Math.floor((Date.now() - new Date(i.created_at)) / 86400000);
+
+            const open = (await github.paginate(
+              github.rest.issues.listForRepo,
+              { ...context.repo, state: 'open', per_page: 100 },
+            )).filter(i => !i.pull_request);
+
+            const closed = (await github.paginate(
+              github.rest.issues.listForRepo,
+              { ...context.repo, state: 'closed', since, per_page: 100 },
+            )).filter(i => !i.pull_request &&
+                          new Date(i.closed_at) >= new Date(since)).length;
+
+            const total = open.length;
+            const newCount = open.filter(
+              i => new Date(i.created_at) >= new Date(since)).length;
+
+            const types = TYPE_LABELS
+              .map(l => [l, open.filter(i => hasLabel(i, l)).length])
+              .filter(([, c]) => c > 0);
+
+            let prioritized = 0;
+            const pri = PRIORITY_LABELS.map(l => {
+              const c = open.filter(i => hasLabel(i, l)).length;
+              prioritized += c;
+              return [l, c];
+            });
+            const noPri = total - prioritized;
+
+            const unowned = open.filter(i =>
+              (hasLabel(i, 'P0') || hasLabel(i, 'P1')) &&
+              (!i.assignees || i.assignees.length === 0)).length;
+
+            const breaches = [];
+            for (const i of open) {
+              const age = ageDays(i);
+              for (const [k, sla] of Object.entries(SLA)) {
+                if (hasLabel(i, k) && age > sla.days) {
+                  breaches.push({ num: i.number, pri: k, over: age - sla.days });
+                }
+              }
+            }
+
+            const lines = [
+              '*Issue movement (7d):*',
+              `${total} open, +${newCount} new, -${closed} closed`,
+            ];
+            const priParts = pri
+              .filter(([, c]) => c > 0)
+              .map(([l, c]) => `${l}: ${c}`);
+            if (noPri > 0) priParts.push(`none: ${noPri}`);
+            lines.push(`Priority: ${priParts.join(', ')}`);
+            if (types.length > 0) {
+              lines.push(`Type: ${types.map(([l, c]) => `${l}: ${c}`).join(', ')}`);
+            }
+            if (unowned > 0) {
+              lines.push(`Unowned P0/P1: *${unowned}*`);
+            }
+            if (breaches.length > 0) {
+              lines.push(`:rotating_light: ${breaches.length} SLA breach${breaches.length === 1 ? '' : 'es'}`);
+            }
+
+            const block = lines.join('\n');
+            fs.appendFileSync(process.env.GITHUB_ENV,
+              `ISSUES_BLOCK<<ISS_EOF\n${block}\nISS_EOF\n`);
+
+      - name: Collect latest vuln scan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RUN_JSON=$(gh run list --repo "${REPO}" \
+            --workflow=vuln-scan-images.yaml --status=success --limit=1 \
+            --json databaseId,createdAt,url)
+
+          COUNT=$(printf '%s' "${RUN_JSON}" | jq 'length')
+          if [[ "${COUNT}" -eq 0 ]]; then
+            BLOCK="*Latest vuln scan:* _no successful run this week — see Actions tab_"
+          else
+            URL=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].url')
+            CREATED=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].createdAt')
+            DAY=$(date -u -d "${CREATED}" '+%a %H:%M UTC' 2>/dev/null \
+              || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "${CREATED}" '+%a %H:%M UTC')
+            BLOCK="*Latest vuln scan:* ${DAY} — <${URL}|view run>"
+          fi
+
+          {
+            echo "VULN_BLOCK<<VULN_EOF"
+            echo "${BLOCK}"
+            echo "VULN_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Assemble summary message
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Week-of label: Monday of the current calendar week (UTC)
+          # date -u +%u gives 1=Mon..7=Sun; subtract that minus 1 to get Monday
+          DOW=$(date -u +%u)
+          WEEK_START=$(date -u -d "$((DOW - 1)) days ago" +%Y-%m-%d 2>/dev/null \
+            || date -u -v-$((DOW - 1))d +%Y-%m-%d)
+
+          MESSAGE="*AICR weekly* — week of ${WEEK_START}"$'\n\n'
+          MESSAGE+="${RELEASES_BLOCK}"$'\n\n'
+          MESSAGE+="${ISSUES_BLOCK}"$'\n\n'
+          MESSAGE+="${VULN_BLOCK}"
+
+          {
+            echo "SLACK_MESSAGE<<SLACK_EOF"
+            echo "${MESSAGE}"
+            echo "SLACK_EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Post to Slack (top-level)
+        uses: ./.github/actions/slack-thread-post
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          body: ${{ env.SLACK_MESSAGE }}
+          mode: top-level
+```
+
+- [ ] **Step 2: Lint with actionlint**
+
+Run: `actionlint .github/workflows/weekly-summary.yaml`
+Expected: no output (success).
+
+- [ ] **Step 3: Lint with yamllint**
+
+Run: `yamllint .github/workflows/weekly-summary.yaml`
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/weekly-summary.yaml
+git commit -s -S -m "feat(ci): add weekly AICR summary workflow (Saturday 14:00 UTC)
+
+Top-level Slack post with three sections:
+- Releases this week (gh release list filtered to last 7 days)
+- Issue movement (7-day window of issue-report logic)
+- Latest vuln scan (link to most recent successful run)
+
+Read time: under 30 seconds. Posts via slack-thread-post composite
+action with mode=top-level (no thread coordination needed).
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md"
+```
+
+---
+
+## Task 7: Run the full project lint suite
+
+**Files:** none modified.
+
+Verify the whole working tree still passes the project's lint gate before opening the PR.
+
+- [ ] **Step 1: Run `make lint`**
+
+Run: `make lint`
+Expected: success (exit 0). The output may include yamllint and golangci-lint runs. Yaml-related findings on the new/modified files should be zero.
+
+If `make lint` fails on unrelated existing issues (pre-existing on `upstream/main`), confirm by running `git stash && make lint && git stash pop` — if the unstashed run fails identically, the failure is pre-existing and not blocking. Document any pre-existing failure in the PR description.
+
+- [ ] **Step 2: Run actionlint across all workflows**
+
+Run: `actionlint`
+Expected: no output (success). Catches any cross-file issues missed by per-file linting.
+
+---
+
+## Task 8: Pre-PR smoke test (manual gate)
+
+**Files:** none modified. Operator-driven verification.
+
+This task does not produce a commit. It produces evidence that the migration works end-to-end against a real Slack channel — required before opening the PR for review.
+
+- [ ] **Step 1: Confirm Slack app is set up and bot is in the channel**
+
+Confirm with the repo admin (or perform yourself if you have permissions) that the Operational Prerequisite is complete:
+
+```bash
+# Quick check: does the secret exist?
+gh secret list --repo <fork-or-target-repo> | grep -E '^SLACK_BOT_TOKEN'
+gh variable list --repo <fork-or-target-repo> | grep -E '^SLACK_CHANNEL_ID'
+```
+
+Both should be present. If you want to use a separate test channel for this smoke (recommended), set `SLACK_CHANNEL_ID` on a fork or in a separate test channel for the duration of testing.
+
+- [ ] **Step 2: Push the branch and trigger the heartbeat manually**
+
+```bash
+git push origin feat/aicr-bot-slack-cadence
+gh workflow run daily-status.yaml --ref feat/aicr-bot-slack-cadence
+gh run watch
+```
+
+Expected: workflow succeeds. Open the configured Slack channel; verify a parent message exists with text starting with `Daily AICR-bot status — <today UTC>`.
+
+- [ ] **Step 3: Trigger `vuln-scan-images.yaml` manually**
+
+```bash
+gh workflow run vuln-scan-images.yaml --ref feat/aicr-bot-slack-cadence
+gh run watch
+```
+
+Expected: workflow succeeds. In Slack, the per-image counts message appears as a thread reply under the heartbeat parent (not as a top-level post).
+
+- [ ] **Step 4: Trigger `issue-report.yaml` manually**
+
+```bash
+gh workflow run issue-report.yaml --ref feat/aicr-bot-slack-cadence
+gh run watch
+```
+
+Expected: workflow succeeds. The issue digest appears as a thread reply under the heartbeat parent.
+
+- [ ] **Step 5: Trigger `weekly-summary.yaml` manually**
+
+```bash
+gh workflow run weekly-summary.yaml --ref feat/aicr-bot-slack-cadence
+gh run watch
+```
+
+Expected: workflow succeeds. A top-level post appears in the channel with the three sections (Releases / Issue movement / Latest vuln scan). Not threaded.
+
+- [ ] **Step 6 (optional): Test the on-tag path on a fork**
+
+If you want to verify `on-tag.yaml` end-to-end before merge:
+
+```bash
+# On a fork only — never on the production repo:
+git tag v0.0.0-thread-test
+git push origin v0.0.0-thread-test
+gh run watch
+```
+
+Expected: `notify` job succeeds. On a weekday, the release post appears as a thread reply; on a weekend, top-level. Clean up after:
+
+```bash
+gh release delete v0.0.0-thread-test --yes
+git push --delete origin v0.0.0-thread-test
+git tag -d v0.0.0-thread-test
+```
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+gh pr create --draft --base main --head feat/aicr-bot-slack-cadence \
+  --title "feat(ci): consolidate AICR-Bot Slack posts into daily thread + weekly digest" \
+  --body-file - <<'PR_BODY'
+## Summary
+
+Replaces three independent top-level Slack messages per day with a two-cadence model: weekday daily heartbeat-and-thread, weekend weekly top-level digest. Migrates from Slack Incoming Webhooks (cannot thread) to the Slack Web API via a new shared composite action.
+
+## Operational prerequisite (must be complete before merge)
+
+- [ ] Slack App created with scopes `chat:write` and `channels:history` (or `groups:history`)
+- [ ] Bot installed in the AICR Slack channel
+- [ ] Repo secret `SLACK_BOT_TOKEN` set
+- [ ] Repo variable `SLACK_CHANNEL_ID` set
+
+The existing `SLACK_SERVICE` webhook secret stays in place; removed in a follow-up PR after one full week of clean runs.
+
+## Smoke test results (in fork)
+
+- [x] Heartbeat parent posts with marker
+- [x] vuln-scan threads under parent
+- [x] issue-report threads under parent
+- [x] weekly-summary posts top-level with three sections
+- [x] on-tag (weekday) threads; on-tag (weekend) top-level
+
+## Spec
+
+`docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md`
+
+## Plan
+
+`docs/superpowers/plans/2026-04-27-aicr-bot-slack-cadence.md`
+PR_BODY
+```
+
+After CI passes, mark the PR ready for review (`gh pr ready <number>`).
+
+---
+
+## Self-Review (post-plan, pre-execution)
+
+This section is the author's check — completed once before executing tasks.
+
+- **Spec coverage:**
+  - "Two cadences" → Tasks 2 (daily heartbeat) + 6 (weekly summary) ✓
+  - "Mon-Fri only crons" → Tasks 3, 4 ✓
+  - "Daily heartbeat 05:00 UTC, marker pattern" → Task 2 + Task 1 (marker is internal to the action) ✓
+  - "Weekly summary Sat 14:00 UTC, three sections" → Task 6 ✓
+  - "State via conversations.history" → Task 1 ✓
+  - "Lazy-create on weekday" → Task 1 (mode=reply path) ✓
+  - "Weekend on-tag = top-level" → Task 5 (mode chosen by `date -u +%u`) ✓
+  - "Race tolerance (duplicate parent OK)" → Task 1 (no locking attempted; documented in spec) ✓
+  - "Webhook → bot API migration; SLACK_SERVICE retained during rollout" → Tasks 3-5 drop the env from migrated jobs only; the secret stays in repo settings ✓
+  - "Operational prerequisite (Slack app, scopes, secrets)" → Documented in plan header and PR body template ✓
+  - All edge cases in the spec map to the composite action's error handling (Task 1) ✓
+
+- **Placeholder scan:** No "TBD", "TODO", "implement later". Every code block is complete and self-contained. ✓
+
+- **Type / signature consistency:**
+  - The composite action exposes inputs `bot-token`, `channel-id`, `body`, `mode` and outputs `parent-ts`, `posted-ts`. All caller workflows (Tasks 2-6) pass exactly these inputs.
+  - Mode values are literally one of `heartbeat-only`, `reply`, `top-level` everywhere — no typos.
+  - The marker string `"Daily AICR-bot status — $(date -u +%Y-%m-%d)"` is computed in Task 1 and never duplicated in callers (the spec explicitly mandates this).
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-27-aicr-bot-slack-cadence.md`.**
+
+## Execution choice
+
+Two options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Tell me which approach you'd like.

--- a/docs/superpowers/plans/2026-04-27-pr-697-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-27-pr-697-review-fixes.md
@@ -1,0 +1,776 @@
+# PR #697 Review-Feedback Revision Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address 10 of 11 actionable findings from CodeRabbit + self-review on PR #697 (AICR-bot Slack cadence). 9 commits on the existing PR branch, no functional change to the cadence design — only correctness, robustness, and doc-truthfulness fixes.
+
+**Architecture:** All changes are CI-only (workflow YAML, composite-action shell, design markdown). No application code, no schema. Each commit addresses one finding (with the two doc-only findings batched per the brainstorm decision).
+
+**Tech Stack:** GitHub Actions, bash, jq, `actions/github-script` (Node.js inside YAML), markdown. Lint with `yamllint` and `markdownlint`. Bash hardening verified by extracting the `run:` block and shellchecking it.
+
+**Working location:** `.worktrees/aicr-bot-slack-cadence` on branch `feat/aicr-bot-slack-cadence` (PR #697 head). All `git`/edit commands below assume `cd .worktrees/aicr-bot-slack-cadence` from the repo root, OR direct invocation with absolute paths.
+
+**Out of scope:**
+- Em-dash → ASCII in marker (deferred; not currently broken).
+- "Three-layer composite" rationale comments (CodeRabbit-claimed convention not present in repo CLAUDE.md or `.coderabbit.yaml`; investigate separately).
+
+**Verification posture:** No staging Slack channel. Production verification runs at the next 05:00 UTC heartbeat (Mon-Fri) and next vuln-scan / issue-report / tag-push events. Pre-push verification limited to lint + shellcheck + visual diff inspection.
+
+**Execution method:** solo (single-author CI revision; no parallelizable work).
+
+---
+
+### Task 1: Bound Slack history lookup to today's window (finding #1, part 1/2)
+
+**Why:** `limit=20` on `conversations.history` can miss today's parent on busy channels. Bounding by `oldest=$(today 00:00 UTC)` makes the result deterministic regardless of unrelated chatter and lets us safely raise the limit to the cheap default (100) without scanning multi-day history.
+
+**Files:**
+- Modify: `.github/actions/slack-thread-post/action.yml` — the MARKER computation block (~lines 88-89) and the `conversations.history` call (~lines 118-122).
+
+- [ ] **Step 1: Add `TODAY_START_TS` computation alongside the marker**
+
+Replace the marker block (the comment line plus the single `MARKER=...` line):
+
+```bash
+        # ---- Daily marker (UTC) — internal, not caller-controlled ----------
+        MARKER="Daily AICR-bot status — $(date -u +%Y-%m-%d)"
+```
+
+with:
+
+```bash
+        # ---- Daily marker (UTC) — internal, not caller-controlled ----------
+        MARKER="Daily AICR-bot status — $(date -u +%Y-%m-%d)"
+
+        # Unix timestamp at 00:00:00 UTC today. Used as 'oldest' on
+        # conversations.history so the lookup window is exactly today's UTC
+        # day — independent of channel chatter volume.
+        TODAY_START_TS=$(date -u -d 'today 00:00:00' +%s 2>/dev/null \
+          || date -u -j -f '%Y-%m-%d %H:%M:%S' \
+              "$(date -u +%Y-%m-%d) 00:00:00" +%s)
+```
+
+- [ ] **Step 2: Update the history call to use limit=100 + oldest**
+
+Replace:
+
+```bash
+        if history=$(slack_api conversations.history --get \
+              --data-urlencode "channel=${CHANNEL_ID}" \
+              --data-urlencode "limit=20"); then
+```
+
+with:
+
+```bash
+        if history=$(slack_api conversations.history --get \
+              --data-urlencode "channel=${CHANNEL_ID}" \
+              --data-urlencode "limit=100" \
+              --data-urlencode "oldest=${TODAY_START_TS}"); then
+```
+
+- [ ] **Step 3: Verify yamllint passes**
+
+```bash
+yamllint .github/actions/slack-thread-post/action.yml
+```
+
+Expected: no output (yamllint is silent on success).
+
+- [ ] **Step 4: Verify shell block parses cleanly**
+
+```bash
+yq '.runs.steps[0].run' .github/actions/slack-thread-post/action.yml > /tmp/action.sh
+shellcheck -s bash /tmp/action.sh
+```
+
+Expected: no errors. SC2154-style "referenced but not assigned" warnings on `${BOT_TOKEN}`, `${CHANNEL_ID}`, `${BODY}`, `${MODE}` are acceptable — those are GHA-injected at runtime via the step `env:`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/actions/slack-thread-post/action.yml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): bound Slack history lookup to today's UTC window
+
+Replaces limit=20 with limit=100 + oldest=$(today 00:00 UTC). With the
+lookup window pinned to today's UTC day, channel chatter volume cannot
+push the daily parent out of the result set. The previous limit=20 risked
+missing the parent on busy channels and silently lazy-creating a duplicate.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 2: Classify Slack API errors as permanent vs transient (finding #1, part 2/2)
+
+**Why:** The current `slack_api` helper returns 1 for every error and the caller silently lazy-creates a parent on any history failure. That masks misconfiguration (missing scope, revoked token, bot not in channel) — the workflow runs daily without anyone noticing. Permanent errors should fail loudly so the operator fixes the setup.
+
+**Files:**
+- Modify: `.github/actions/slack-thread-post/action.yml` — the `slack_api` function's error branch (~lines 99-108).
+
+- [ ] **Step 1: Replace the slack_api error branch with classification**
+
+Replace:
+
+```bash
+          if [[ "${ok}" != "true" ]]; then
+            local err
+            err=$(printf '%s' "${response}" | jq -r '.error // "unknown_error"')
+            echo "::error::Slack ${method} failed: ${err}" >&2
+            printf '%s' "${response}" | jq . >&2 || true
+            return 1
+          fi
+```
+
+with:
+
+```bash
+          if [[ "${ok}" != "true" ]]; then
+            local err
+            err=$(printf '%s' "${response}" | jq -r '.error // "unknown_error"')
+            printf '%s' "${response}" | jq . >&2 || true
+            # Permanent misconfiguration — operator must fix; do not lazy-create.
+            case "${err}" in
+              invalid_auth|not_authed|token_revoked|token_expired|\
+              missing_scope|invalid_scope|not_allowed_token_type|\
+              channel_not_found|not_in_channel)
+                echo "::error::Slack ${method} failed: ${err} — fix Slack app config or repo secrets/vars" >&2
+                exit 1
+                ;;
+            esac
+            # Transient (rate_limited, request_timeout, internal_error,
+            # fatal_error, service_unavailable, 5xx) — caller decides whether
+            # to lazy-create.
+            echo "::warning::Slack ${method} transient failure: ${err}" >&2
+            return 1
+          fi
+```
+
+Note: `exit 1` (not `return 1`) inside the function is intentional — it terminates the whole step, since recovery is impossible. The trailing `return 1` is reached only for transient errors and lets the caller fall through to lazy-create.
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/actions/slack-thread-post/action.yml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Verify shellcheck passes**
+
+```bash
+yq '.runs.steps[0].run' .github/actions/slack-thread-post/action.yml > /tmp/action.sh
+shellcheck -s bash /tmp/action.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/actions/slack-thread-post/action.yml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): classify Slack API errors as permanent vs transient
+
+Permanent errors (invalid_auth, missing_scope, token_revoked,
+channel_not_found, not_in_channel, etc.) now exit the step with an
+explicit operator-action message. Transient errors (rate_limited,
+timeout, server errors) still return 1, letting the caller fall through
+to lazy-create as before.
+
+Without this, a misconfigured bot token or missing channel scope would
+silently lazy-create a duplicate parent every day with no signal to the
+operator.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 3: Use full release window in weekly summary (finding #2)
+
+**Why:** `gh release list --limit 20` truncates *before* the `publishedAt >= SINCE` filter, so a high-release week can undercount. AICR's release cadence is at most a few per week; `--limit 200` covers ~6 months and a single page suffices. Full pagination is YAGNI for this volume.
+
+**Files:**
+- Modify: `.github/workflows/weekly-summary.yaml` — the `gh release list` call in the `Collect releases (last 7 days)` step.
+
+- [ ] **Step 1: Replace the limit**
+
+Replace:
+
+```yaml
+          RELEASES_JSON=$(gh release list --repo "${REPO}" --limit 20 \
+            --json tagName,publishedAt)
+```
+
+with:
+
+```yaml
+          # --limit 200 covers ~6 months at AICR's release cadence; the
+          # publishedAt >= SINCE filter below trims to the 7-day window.
+          # Pagination is YAGNI for this volume.
+          RELEASES_JSON=$(gh release list --repo "${REPO}" --limit 200 \
+            --json tagName,publishedAt)
+```
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/workflows/weekly-summary.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/weekly-summary.yaml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): use full release window in weekly summary
+
+Bumps gh release list --limit from 20 to 200. The previous limit
+truncated the result set before the publishedAt >= SINCE filter ran, so
+a busy release week could omit valid releases from the digest.
+
+200 covers ~6 months at AICR's release cadence; pagination is
+unnecessary for this volume.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 4: Bound weekly vuln-scan link to 7-day window (finding #3)
+
+**Why:** The current query picks the most recent successful `vuln-scan-images.yaml` run *across all time*. If every scan in the current week failed, Saturday's digest still links to a green run from a prior week — silently hiding the regression.
+
+**Files:**
+- Modify: `.github/workflows/weekly-summary.yaml` — the entire `Collect latest vuln scan` step.
+
+- [ ] **Step 1: Replace the vuln-scan collection block**
+
+Replace:
+
+```yaml
+      - name: Collect latest vuln scan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RUN_JSON=$(gh run list --repo "${REPO}" \
+            --workflow=vuln-scan-images.yaml --status=success --limit=1 \
+            --json databaseId,createdAt,url)
+
+          COUNT=$(printf '%s' "${RUN_JSON}" | jq 'length')
+          if [[ "${COUNT}" -eq 0 ]]; then
+            BLOCK="*Latest vuln scan:* _no successful run found — see Actions tab_"
+          else
+            URL=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].url')
+            CREATED=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].createdAt')
+            DAY=$(date -u -d "${CREATED}" '+%a %H:%M UTC' 2>/dev/null \
+              || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "${CREATED}" '+%a %H:%M UTC')
+            BLOCK="*Latest vuln scan:* ${DAY} — <${URL}|view run>"
+          fi
+```
+
+with:
+
+```yaml
+      - name: Collect latest vuln scan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Pull the last 50 successful runs so the 7-day filter has plenty
+          # to choose from even if the workflow runs >1x/day.
+          ALL_RUNS=$(gh run list --repo "${REPO}" \
+            --workflow=vuln-scan-images.yaml --status=success --limit=50 \
+            --json databaseId,createdAt,url)
+
+          # 7-day-ago threshold (UTC), with macOS BSD-date fallback.
+          THRESHOLD=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+
+          RUN_JSON=$(printf '%s' "${ALL_RUNS}" \
+            | jq --arg t "${THRESHOLD}" \
+                '[.[] | select(.createdAt >= $t)] | sort_by(.createdAt) | reverse | .[0:1]')
+
+          COUNT=$(printf '%s' "${RUN_JSON}" | jq 'length')
+          if [[ "${COUNT}" -eq 0 ]]; then
+            BLOCK="*Latest vuln scan:* _no successful run this week — see Actions tab_"
+          else
+            URL=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].url')
+            CREATED=$(printf '%s' "${RUN_JSON}" | jq -r '.[0].createdAt')
+            DAY=$(date -u -d "${CREATED}" '+%a %H:%M UTC' 2>/dev/null \
+              || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "${CREATED}" '+%a %H:%M UTC')
+            BLOCK="*Latest vuln scan:* ${DAY} — <${URL}|view run>"
+          fi
+```
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/workflows/weekly-summary.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/weekly-summary.yaml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): bound weekly vuln-scan link to 7-day window
+
+The previous query picked the most recent successful run across all
+time. If every scan in the current week failed, Saturday's digest would
+link to a green run from a prior week and hide the regression.
+
+Now we pull the last 50 successful runs and filter to createdAt >=
+now - 7 days in jq, falling back to "no successful run this week" when
+empty.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 5: Compute on-tag Slack mode from commit timestamp (finding #4)
+
+**Why:** Currently `notify` derives day-of-week from `date -u +%u` at job-runtime. A tag pushed at 23:55 UTC Friday whose `notify` job runs at 00:05 UTC Saturday becomes a top-level weekend post instead of replying to Friday's parent. The `notify` job already checks out the repo, so we can use the commit's committer timestamp via `git log` — independent of any GHA event-payload quirks.
+
+**Files:**
+- Modify: `.github/workflows/on-tag.yaml` — the `Build message and choose mode` step (the DOW computation block, ~lines 533-539).
+
+- [ ] **Step 1: Replace the DOW computation**
+
+Replace:
+
+```bash
+          # date -u +%u: 1=Mon … 7=Sun
+          DOW=$(date -u +%u)
+          if [[ "${DOW}" -le 5 ]]; then
+            MODE="reply"
+          else
+            MODE="top-level"
+          fi
+```
+
+with:
+
+```bash
+          # Derive DOW from the commit's committer timestamp, not the
+          # notify-job runner clock. A tag pushed late on Friday UTC whose
+          # notify job runs after midnight would otherwise post top-level
+          # on Saturday instead of replying under Friday's daily parent.
+          EVENT_TS=$(git log -1 --format=%cI HEAD)
+          DOW=$(date -u -d "${EVENT_TS}" +%u 2>/dev/null \
+            || date -u -j -f '%Y-%m-%dT%H:%M:%S%z' "${EVENT_TS}" +%u)
+          if [[ "${DOW}" -le 5 ]]; then
+            MODE="reply"
+          else
+            MODE="top-level"
+          fi
+```
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/workflows/on-tag.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/on-tag.yaml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): compute on-tag Slack mode from commit timestamp
+
+Derives day-of-week from the commit's committer timestamp (git log -1)
+instead of the notify-job runner clock. A tag pushed at 23:55 UTC Friday
+whose notify job runs at 00:05 UTC Saturday no longer posts top-level on
+Saturday by accident — it correctly replies under Friday's parent.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 6: Include new-and-closed issues in weekly +new count (finding #5)
+
+**Why:** The current `+new` count filters `open` for `created_at >= since`. Issues created and already closed within the same 7-day window aren't counted, even though "new this week" plain-language includes them. The `closed` count is already paginated; reuse that to derive a true "+new" total.
+
+**Files:**
+- Modify: `.github/workflows/weekly-summary.yaml` — inside the `actions/github-script` `script:` block, the `closed`/`total`/`newCount` chunk.
+
+- [ ] **Step 1: Replace the closed/newCount block**
+
+Replace:
+
+```javascript
+            const closed = (await github.paginate(
+              github.rest.issues.listForRepo,
+              { ...context.repo, state: 'closed', since, per_page: 100 },
+            )).filter(i => !i.pull_request &&
+                          new Date(i.closed_at) >= new Date(since)).length;
+
+            const total = open.length;
+            const newCount = open.filter(
+              i => new Date(i.created_at) >= new Date(since)).length;
+```
+
+with:
+
+```javascript
+            // Pull recently-closed issues (not just count) so we can union
+            // their "newly-created in this window" subset with the open
+            // newly-created subset. Without this, an issue opened and
+            // closed in the same 7 days never counts toward "+new".
+            const recentClosed = (await github.paginate(
+              github.rest.issues.listForRepo,
+              { ...context.repo, state: 'closed', since, per_page: 100 },
+            )).filter(i => !i.pull_request &&
+                          new Date(i.closed_at) >= new Date(since));
+            const closed = recentClosed.length;
+
+            const total = open.length;
+            const sinceMs = new Date(since).getTime();
+            const newOpen = open.filter(
+              i => new Date(i.created_at).getTime() >= sinceMs).length;
+            const newClosed = recentClosed.filter(
+              i => new Date(i.created_at).getTime() >= sinceMs).length;
+            const newCount = newOpen + newClosed;
+```
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/workflows/weekly-summary.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/weekly-summary.yaml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): include new-and-closed issues in weekly +new count
+
+The previous +new derivation filtered the open-issue list only, so any
+issue opened and closed within the same 7-day window was excluded. Plain
+reading of "X open, +Y new, -Z closed" implies +Y covers all new issues,
+not just those still open.
+
+We now union the newly-created subset of open and recently-closed
+issues. recentClosed is already paginated for the -closed metric; the
+incremental cost is one extra filter pass.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 7: Deduplicate weekly issue priority counts (finding #6)
+
+**Why:** The current loop accumulates `prioritized += c` across P0/P1/P2 buckets. An issue carrying multiple priority labels (rare but legal in GitHub) is counted in each bucket *and* in `prioritized`, making `noPri = total - prioritized` wrong — possibly negative.
+
+**Files:**
+- Modify: `.github/workflows/weekly-summary.yaml` — inside the `actions/github-script` `script:` block, the `pri`/`prioritized`/`noPri` block.
+
+- [ ] **Step 1: Replace the priority accumulation**
+
+Replace:
+
+```javascript
+            let prioritized = 0;
+            const pri = PRIORITY_LABELS.map(l => {
+              const c = open.filter(i => hasLabel(i, l)).length;
+              prioritized += c;
+              return [l, c];
+            });
+            const noPri = total - prioritized;
+```
+
+with:
+
+```javascript
+            // Per-priority counts (an issue may appear in multiple buckets
+            // if it carries multiple priority labels — that's fine here).
+            const pri = PRIORITY_LABELS.map(l => [
+              l, open.filter(i => hasLabel(i, l)).length,
+            ]);
+            // For the noPri remainder, dedupe by issue number — an issue
+            // with both P0 and P1 counts once toward "prioritized".
+            const prioritizedNums = new Set(
+              open.filter(i => PRIORITY_LABELS.some(l => hasLabel(i, l)))
+                  .map(i => i.number),
+            );
+            const noPri = total - prioritizedNums.size;
+```
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/workflows/weekly-summary.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/weekly-summary.yaml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): deduplicate weekly issue priority counts
+
+Per-priority bucket counts unchanged. For the noPri remainder, we now
+dedupe by issue number using a Set, so an issue carrying multiple
+priority labels (e.g., both P0 and P1) is counted once — not summed
+across buckets, which previously made noPri = total - prioritized
+under-report or go negative.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 8: Link SLA-breach issues in weekly summary (finding #10)
+
+**Why:** The current breach line is just a count (`:rotating_light: 1 SLA breach`). The weekly digest is the highest-attention surface for these issues; readers should be able to click directly. Cap at 5 to avoid wall-of-text.
+
+**Files:**
+- Modify: `.github/workflows/weekly-summary.yaml` — inside the `actions/github-script` `script:` block, the `if (breaches.length > 0)` chunk.
+
+- [ ] **Step 1: Replace the breach line construction**
+
+Replace:
+
+```javascript
+            if (breaches.length > 0) {
+              lines.push(`:rotating_light: ${breaches.length} SLA breach${breaches.length === 1 ? '' : 'es'}`);
+            }
+```
+
+with:
+
+```javascript
+            if (breaches.length > 0) {
+              const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+              const SHOW = 5;
+              const shown = breaches
+                .slice(0, SHOW)
+                .map(b => `<${repoUrl}/issues/${b.num}|#${b.num}> (${b.pri}, +${b.over}d over)`);
+              const overflow = breaches.length > SHOW
+                ? ` _+${breaches.length - SHOW} more_`
+                : '';
+              const word = breaches.length === 1 ? 'breach' : 'breaches';
+              lines.push(`:rotating_light: ${breaches.length} SLA ${word}: ${shown.join(', ')}${overflow}`);
+            }
+```
+
+- [ ] **Step 2: Verify yamllint passes**
+
+```bash
+yamllint .github/workflows/weekly-summary.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/weekly-summary.yaml
+git commit -S -m "$(cat <<'EOF'
+fix(ci): link SLA-breach issues in weekly summary
+
+The breach line previously showed only a count. Each breach now renders
+as a Slack-formatted issue link with priority and over-SLA days. Capped
+at 5 to avoid wall-of-text — anything beyond appears as "+N more".
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 9: Align Slack-cadence design doc with implementation (findings #7 + #8)
+
+**Why:** Two doc-only fixes, batched per the brainstorm decision. (a) Three fenced code blocks have no language identifier — markdownlint MD040. (b) The failure-mode table claims `chat.postMessage` failures log the message body to `$GITHUB_STEP_SUMMARY`; the action does no such write. Removing the claim is cheaper than adding the feature; YAGNI.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md` — opening fences at lines 47, 56, 77, and the failure-mode-table row near line 199.
+
+- [ ] **Step 1: Add `text` language identifier to fenced block 1 (Mon-Fri timeline)**
+
+Replace:
+
+```text
+### Mon-Fri (daily threaded)
+
+```
+```
+
+with:
+
+```text
+### Mon-Fri (daily threaded)
+
+```text
+```
+
+(I.e., the bare opening fence becomes `` ```text ``. The closing fence on line 52 is unchanged.) Use Edit anchored on the heading line so the match is unique to this fence.
+
+- [ ] **Step 2: Add `text` language identifier to fenced block 2 (Sat-Sun timeline)**
+
+Replace:
+
+```text
+### Sat-Sun (weekly only, no daily noise)
+
+```
+```
+
+with:
+
+```text
+### Sat-Sun (weekly only, no daily noise)
+
+```text
+```
+
+- [ ] **Step 3: Add `text` language identifier to fenced block 3 (marker pattern)**
+
+Replace:
+
+```text
+The first line of every weekday parent message is exactly:
+
+```
+```
+
+with:
+
+```text
+The first line of every weekday parent message is exactly:
+
+```text
+```
+
+- [ ] **Step 4: Remove the GITHUB_STEP_SUMMARY claim**
+
+In the failure-mode table, replace the `chat.postMessage` row:
+
+```text
+| `chat.postMessage` fails on the post/reply | Log message body to `$GITHUB_STEP_SUMMARY`, exit non-zero. Matches today's behaviour on webhook failure. |
+```
+
+with:
+
+```text
+| `chat.postMessage` fails on the post/reply | `slack_api` emits the failed response as a workflow `::error::` annotation and exits non-zero. The job fails so the operator sees the run in red. |
+```
+
+- [ ] **Step 5: Verify markdownlint passes**
+
+```bash
+markdownlint docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+```
+
+Expected: no MD040 warnings on the three updated fences. Other warnings (if any) are pre-existing and out of scope.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+git commit -S -m "$(cat <<'EOF'
+docs(superpowers): align Slack-cadence design doc with implementation
+
+- Adds 'text' language identifier to three unlabeled fenced blocks
+  (markdownlint MD040).
+- Removes the failure-mode-table claim that chat.postMessage failures
+  write the message body to GITHUB_STEP_SUMMARY. The action emits an
+  ::error:: annotation and exits non-zero; it does not write to the
+  step summary file. Doc now matches implementation.
+
+Refs: docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+EOF
+)"
+```
+
+---
+
+### Task 10: Push and observe production verification
+
+**Why:** No staging Slack channel. Push the 9 commits and watch the next workflow firings.
+
+- [ ] **Step 1: Push to PR branch**
+
+```bash
+git push origin feat/aicr-bot-slack-cadence
+```
+
+- [ ] **Step 2: Confirm PR head matches**
+
+```bash
+git log --oneline -12
+```
+
+Expected: 9 new fix/docs commits on top of the original 8.
+
+- [ ] **Step 3: Note the verification windows**
+
+Production smoke depends on these triggers (no action required, just expectations):
+
+| Workflow | Next firing | What to verify |
+|---|---|---|
+| `daily-status.yaml` | Next 05:00 UTC Mon-Fri | Heartbeat parent posted; no duplicate from a slow `conversations.history` |
+| `vuln-scan-images.yaml` | Next 06:00 UTC Mon-Fri | Reply lands under today's parent (proves Task 1 oldest filter works) |
+| `issue-report.yaml` | Next 12:30 UTC Mon-Fri | Reply lands under today's parent |
+| `on-tag.yaml` | Next tag push | Mode chosen from commit timestamp (proves Task 5) |
+| `weekly-summary.yaml` | Next Saturday 14:00 UTC | Releases counted from full window, vuln-scan from 7-day window, +new includes new-and-closed, priority deduped, breaches linked |
+
+- [ ] **Step 4: Re-request CodeRabbit review**
+
+Post a comment on PR #697:
+
+```text
+@coderabbitai review
+```
+
+Use the GitHub web UI or, if `gh` TLS is working again, `gh pr comment 697 --body "@coderabbitai review"`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Each of the 10 in-scope findings (#1, #2, #3, #4, #5, #6, #7, #8, #10) maps to a task. Tasks 1+2 cover #1; Task 9 covers #7+#8. Em-dash (#9) and three-layer-composite (#11) are explicitly out of scope. ✓
+
+**Placeholder scan:** No TBDs, no "implement later," every task has exact replacement code. ✓
+
+**Type consistency:** `RUN_JSON`, `ALL_RUNS`, `THRESHOLD`, `recentClosed`, `prioritizedNums`, `EVENT_TS`, `TODAY_START_TS` are introduced in their first use and referenced consistently. ✓
+
+**Cross-file invariants:** Tasks 6, 7, 8 all touch the same `actions/github-script` block in `weekly-summary.yaml`. The Edit anchors are non-overlapping — Task 6 modifies the `closed`/`newCount` chunk, Task 7 modifies the `pri`/`prioritized` chunk, Task 8 modifies the `breaches` chunk. ✓
+
+**Commit-order independence:** Each commit lints clean on its own; if any single commit is reverted, the remaining commits still leave the file in a working state. ✓

--- a/docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+++ b/docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
@@ -1,0 +1,256 @@
+# AICR-Bot Slack Cadence: Daily Thread + Weekly Roll-up
+
+**Date:** 2026-04-27
+**Author:** Carlos Arango Gutierrez (eduardoa@nvidia.com)
+**Origin:** Slack thread with @Mark Chmarny / @Yuan Chen on 2026-04-27, followed by a meeting with Mark refining the cadence.
+**Scope:** CI workflow changes only. No application code, no schema changes.
+
+## Objective
+
+Replace the AICR-Bot's three independent top-level Slack messages per day with a two-cadence model:
+
+- **Weekday daily (Mon-Fri):** a short heartbeat parent + threaded replies for vuln scan, issue report, and release announcements. Low-noise, skim-and-skip.
+- **Weekend weekly (Saturday):** a single full-content top-level post — releases of the week, 7-day issue movement, latest vuln scan snapshot. The "real" digest people read on Monday morning.
+
+Net effect: 1 short top-level post per workday, 1 substantive top-level post per week, zero bot noise on Sundays.
+
+## Current State
+
+Three workflows post **independent top-level messages** to the AICR Slack channel through the same Incoming Webhook (`secrets.SLACK_SERVICE`):
+
+| Workflow | Trigger | Step | Today's payload |
+|---|---|---|---|
+| `.github/workflows/issue-report.yaml` | cron `30 12 * * *` (12:30 UTC daily) | `Post to Slack` (lines 266-278) | `AICR Issues — {date}` digest with SLA flags |
+| `.github/workflows/vuln-scan-images.yaml` | cron `0 6 * * *` (06:00 UTC daily) | `notify` job (lines 276-306) | `Vulnerability Scan: {ts} ({sha})` per-image counts + run link |
+| `.github/workflows/on-tag.yaml` | release tag push | `notify` job (lines 415-435) | `AICR {tag} has been released: {url}` |
+
+All three call `https://hooks.slack.com/services/${SLACK_SERVICE}` with a `text:` payload via `curl`. **Slack Incoming Webhooks cannot post threaded replies** — they always create top-level messages and ignore `thread_ts`. So consolidation is impossible without migrating to the Slack Web API (`chat.postMessage`).
+
+Recent release cadence saw up to ~5 patch releases per workday during release weeks, so on the busiest days the channel can see 7+ top-level bot messages. This is the "chat creep" the proposal targets.
+
+## Decisions (locked in: brainstorm 2026-04-27 + meeting with Mark)
+
+- **Two cadences, not one.** Weekday daily heartbeat-and-thread, weekend weekly full top-level digest.
+- **Weekday daily fires Mon-Fri only.** Crons of `vuln-scan-images.yaml` and `issue-report.yaml` shift from `* * *` to `* * 1-5`. They simply don't run Sat/Sun. (Both workflows' only side effect is the Slack post — Step Summaries are nice-to-have, not load-bearing.)
+- **Weekday daily heartbeat:** new workflow at **05:00 UTC Mon-Fri**. Posts a short parent message: `Daily AICR-bot status — {YYYY-MM-DD UTC}`. No metrics, no children list — a thread anchor.
+- **Weekly summary:** new workflow at **Saturday 14:00 UTC** (~06:00-07:00 Pacific, depending on DST). Posts a single top-level message with three sections (releases of the week, issue movement, latest vuln scan summary). Read time: under 30 seconds.
+- **State mechanism for daily threading:** Slack history lookup at runtime. Each workflow calls `conversations.history` and matches the marker pattern against recent posts. No GitHub Actions variables, no sticky issue.
+- **Pre-parent fallback (weekday):** lazy-create. If a workflow runs before the 05:00 UTC heartbeat (e.g., an `on-tag` release at 04:00 UTC), it creates the parent itself.
+- **Weekend release behaviour:** there is no daily heartbeat on Sat/Sun. Weekend `on-tag` releases post top-level. Weekend releases are rare and inherently noteworthy; one top-level post is not chat creep.
+- **Race tolerance:** if two workflows race to create the parent within seconds (rare), both parents survive; later workflows reply to whichever is most recent. Self-heals next day.
+- **Backwards compatibility during rollout:** `SLACK_SERVICE` (webhook) secret stays until all four workflows are migrated; deleted from repo settings after.
+
+## Architecture & Data Flow
+
+### Mon-Fri (daily threaded)
+
+```
+05:00 UTC   daily-status.yaml      (NEW)        → "Daily AICR-bot status — 2026-04-27"   [parent]
+06:00 UTC   vuln-scan-images.yaml  (modified)   → Vulnerability Scan: …                  [thread reply]
+12:30 UTC   issue-report.yaml      (modified)   → AICR Issues — Mon, Apr 27 …            [thread reply]
+on tag      on-tag.yaml notify     (modified)   → AICR v0.12.0 has been released: …      [thread reply]
+```
+
+### Sat-Sun (weekly only, no daily noise)
+
+```
+Sat 14:00 UTC   weekly-summary.yaml (NEW)       → "AICR weekly — week of 2026-04-21"     [top-level]
+                                                    Releases (5):
+                                                      • v0.12.0 (Mon) — link
+                                                      • v0.12.1 (Wed) — link
+                                                      • …
+                                                    Issue movement (7d):
+                                                      35 open, +6 new, -4 closed
+                                                      P0: 0, P1: 14 (3 unowned), P2: 21
+                                                      :rotating_light: 1 SLA breach: #214 (P1, 192d)
+                                                    Latest vuln scan: Fri 06:00 UTC
+                                                      0 critical, 0 high — all images clean
+                                                      <run link>
+
+(any tag during weekend) on-tag.yaml notify     → AICR v0.12.X released: …               [top-level]
+```
+
+### Marker pattern (daily lookup key)
+
+The first line of every weekday parent message is exactly:
+
+```
+Daily AICR-bot status — {YYYY-MM-DD}
+```
+
+where `{YYYY-MM-DD}` is the UTC date (`date -u +%Y-%m-%d`). Used by every replying workflow to find today's parent.
+
+### Find-or-create algorithm (weekday workflows that thread)
+
+1. Compute `marker = "Daily AICR-bot status — $(date -u +%Y-%m-%d)"`.
+2. Call `conversations.history` with the channel ID and `limit=20`.
+3. Find the most recent message whose `text` starts with `marker`.
+4. If found → use its `ts` as `thread_ts`.
+5. If not found → call `chat.postMessage` (no `thread_ts`) with `text=marker` to create the parent. Use the returned `ts` as `thread_ts`.
+6. Call `chat.postMessage` with `thread_ts` and the workflow's body.
+
+Worst case: 3 API calls (history + create + reply). Best case: 2 (history + reply, when the heartbeat already posted).
+
+## Implementation
+
+### Operational prerequisite (one-time, repo admin, before merge)
+
+1. Create or reuse a Slack App in the NVIDIA workspace.
+2. Grant OAuth scopes:
+   - `chat:write` — to post and reply.
+   - `channels:history` (public channel) **or** `groups:history` (private channel) — to look up today's parent.
+3. Install the app to the workspace; invite the bot to the target channel.
+4. Add two new repo settings:
+   - **Secret** `SLACK_BOT_TOKEN` — the `xoxb-…` bot token.
+   - **Variable** `SLACK_CHANNEL_ID` — the channel ID, e.g., `C012ABC3DEF` (not secret).
+5. Keep the existing `SLACK_SERVICE` secret until all four workflows are migrated.
+
+### NEW: shared composite action `.github/actions/slack-thread-post/action.yml`
+
+Encapsulates all Slack Web API logic so caller workflows stay short.
+
+**Inputs:**
+
+| input | required | purpose |
+|---|---|---|
+| `bot-token` | yes | `SLACK_BOT_TOKEN` |
+| `channel-id` | yes | `SLACK_CHANNEL_ID` |
+| `body` | required when `mode=reply` or `mode=top-level`; ignored when `mode=heartbeat-only` | message text |
+| `mode` | yes | `heartbeat-only`, `reply`, or `top-level` |
+
+The marker (`Daily AICR-bot status — $(date -u +%Y-%m-%d)`) is computed internally by the action and is **not** a caller-controlled input. This guarantees every workflow looks for and creates parents using the exact same string.
+
+**Modes:**
+
+- `heartbeat-only` — execute steps 1-5 of the find-or-create algorithm; exit. The parent's text is the marker itself (no caller-supplied body). Used by the daily heartbeat workflow.
+- `reply` — execute all six steps. Posts `body` as a thread reply under today's daily parent (lazy-creates the parent if missing). Used by Mon-Fri vuln-scan, issue-report, on-tag.
+- `top-level` — skip lookup; post `body` as a top-level message via `chat.postMessage` (no `thread_ts`). Used by weekly-summary and weekend on-tag releases.
+
+**Implementation:** shell + `curl` against `https://slack.com/api/{conversations.history,chat.postMessage}` + `jq` for JSON parsing. Bot token passed as `Authorization: Bearer ${BOT_TOKEN}` header. All Slack API calls check the response `ok` field; on `false`, the action fails with the `error` string for diagnostics.
+
+**Outputs:**
+
+| output | purpose |
+|---|---|
+| `parent-ts` | `ts` of today's parent (created or found) — only set in `heartbeat-only` and `reply` modes |
+| `posted-ts` | `ts` of the posted reply or top-level message |
+
+### NEW: `.github/workflows/daily-status.yaml`
+
+Single job, single step. Triggers:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 5 * * 1-5'   # Mon-Fri 05:00 UTC
+  workflow_dispatch: {}
+```
+
+Body: checks out repo (for the composite action), invokes `slack-thread-post` with `mode=heartbeat-only`. Permissions: `contents: read`. Concurrency group `daily-status` with `cancel-in-progress: true`.
+
+### NEW: `.github/workflows/weekly-summary.yaml`
+
+Triggers:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 14 * * 6'   # Saturday 14:00 UTC
+  workflow_dispatch: {}
+```
+
+Single job, three data-collection steps + one Slack post:
+
+1. **Collect releases (7d).** `gh release list --limit 20 --json tagName,publishedAt,htmlUrl`, filter to `publishedAt >= 7 days ago` UTC. Build the `Releases (N)` block with bullet per release: `• {tag} ({weekday}) — <{url}|link>`.
+2. **Collect issue movement (7d).** Re-use the `actions/github-script` block from `issue-report.yaml`'s `Collect issue metrics` step but with `since = now - 7*86400000`. Output: total open, +new, -closed, type & priority breakdown, SLA flags.
+3. **Collect latest vuln scan.** `gh run list --workflow=vuln-scan-images.yaml --status=success --limit=1 --json databaseId,createdAt,htmlUrl`. The vuln section emits one line: `Latest scan: {weekday} {HH:MM} UTC — <{run_url}|view run>`. **No per-image counts inline:** the existing workflow's `scan-*` artifacts use `retention-days: 1`, which expires before Saturday 14:00 UTC; counts would be unreliable to fetch. The link is sufficient — readers click for the per-image breakdown.
+4. **Post to Slack.** Concatenate the three sections into one message; call `slack-thread-post` with `mode=top-level`.
+
+Permissions: `contents: read`, `issues: read`, `actions: read` (for `gh run list`).
+
+### MODIFIED: `.github/workflows/vuln-scan-images.yaml`
+
+- Cron change: `'0 6 * * *'` → `'0 6 * * 1-5'`.
+- `notify` job: replace the inline `curl` (lines 276-306) with a call to `./.github/actions/slack-thread-post`:
+  - `mode: reply`
+  - `bot-token: ${{ secrets.SLACK_BOT_TOKEN }}`
+  - `channel-id: ${{ vars.SLACK_CHANNEL_ID }}`
+  - `body: ${{ env.MESSAGE }}` (built by the existing message-construction shell)
+- Drop the `SLACK_SERVICE` env from the `notify` job.
+
+### MODIFIED: `.github/workflows/issue-report.yaml`
+
+- Cron change: `'30 12 * * *'` → `'30 12 * * 1-5'`.
+- Replace the `Post to Slack` step (lines 266-278) with a call to `./.github/actions/slack-thread-post`:
+  - `mode: reply`
+  - `body: $(jq -r .text < slack-payload.json)` (the existing `actions/github-script` step already writes the message text into `slack-payload.json`)
+- Drop the `SLACK_SERVICE` env.
+
+### MODIFIED: `.github/workflows/on-tag.yaml`
+
+- `notify` job posts via the composite action with mode determined by day of week:
+  - Mon-Fri: `mode=reply` (threads under today's daily parent; lazy-creates if missing).
+  - Sat-Sun: `mode=top-level`.
+- Day-of-week is computed in the step: `[[ $(date -u +%u) -le 5 ]]` selects weekday vs. weekend.
+- Drop the `SLACK_SERVICE` env.
+
+## Edge Cases & Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Bot not in channel | `chat.postMessage` returns `not_in_channel`. Action fails with explicit error pointing to the operational prerequisite. No retry — operator action required. |
+| `conversations.history` rate-limited or fails | Fall back to creating a fresh parent. Worst case: one orphaned top-level message that day. Workflow does not fail. |
+| `chat.postMessage` fails on the post/reply | Log message body to `$GITHUB_STEP_SUMMARY`, exit non-zero. Matches today's behaviour on webhook failure. |
+| Race producing two daily parents | Both survive; later workflows reply to most recent matching parent. Self-heals next day. |
+| `SLACK_BOT_TOKEN` / `SLACK_CHANNEL_ID` unset | Action fails immediately with explicit message naming the missing setting. |
+| UTC date rollover during a workflow run | Marker is computed once at step start; subsequent calls in the same run use that snapshot. A workflow that begins at 23:59 UTC and posts at 00:01 UTC threads under yesterday's parent — acceptable. |
+| Bot token revoked / rotated | Both APIs return `invalid_auth`. Action fails with that error. Operator rotates the secret. |
+| Weekend `on-tag` release | Posts top-level via `mode=top-level`. No daily parent on weekends. |
+| US public holiday on a weekday (no Slack readers) | Daily heartbeat still posts; the empty-parent cost is one short line per holiday. Acceptable; not worth the holiday-calendar complexity. |
+| Weekly summary fires when no releases happened that week | Section says `Releases (0): _none this week_`. Issue and vuln sections still post. |
+| `gh run list --workflow=vuln-scan-images.yaml --status=success --limit=1` returns no run (e.g., all five Mon-Fri runs failed) | Vuln section says "Latest scan: no successful run this week — see Actions tab." Other sections still post. |
+
+## Rollout Plan
+
+Single PR, five logical commits (squash optional) — landed in this order so each step is independently verifiable:
+
+1. **Composite action + heartbeat workflow.** Verify the parent posts Mon-Fri for one cycle. Other workflows still post via webhook.
+2. **Migrate `vuln-scan-images.yaml`.** Cron change to weekday-only + Slack step swap. Confirm threading.
+3. **Migrate `issue-report.yaml`.** Same pattern.
+4. **Migrate `on-tag.yaml`.** Day-of-week-aware mode. Confirm on next release tag.
+5. **Add `weekly-summary.yaml`.** Confirm on first Saturday after merge.
+6. **Cleanup (separate small PR after one full week of clean runs):** delete the `SLACK_SERVICE` secret in repo settings.
+
+If preferred, all migrations can land as one squash PR — but the staged approach makes rollback trivial (revert the migration commit; webhook path still works).
+
+## Testing
+
+- **Pre-merge smoke test (manual, in author's fork or a test channel):**
+  - `workflow_dispatch` `daily-status.yaml` → confirm parent posts with the marker.
+  - `workflow_dispatch` `vuln-scan-images.yaml` → confirm reply threads under the parent.
+  - `workflow_dispatch` `issue-report.yaml` → confirm reply threads.
+  - `workflow_dispatch` `weekly-summary.yaml` → confirm top-level post with three sections.
+  - Push a test tag (`v0.0.0-test`) on a fork → confirm `on-tag` notify replies in-thread on a weekday, top-level on a weekend (test by running on different days, or by stubbing the day-of-week check).
+- **Test channel isolation (recommended):** add a `SLACK_CHANNEL_ID_TEST` variable; gate via `workflow_dispatch` input so smoke tests don't post to the production channel.
+- **Post-merge monitoring:** watch the AICR channel for one full week (Mon-Sun) — verify Mon-Fri threading, Saturday weekly post, no Sunday bot noise.
+
+## Out of Scope (deliberate YAGNI)
+
+- Editing the parent post to embed running counts (e.g., "Releases today: v0.12.0, v0.12.1"). Adds concurrent-edit complexity without clear value over reading the thread.
+- Retention or archival of past day threads — Slack's own UI handles this.
+- Cross-repo coordination — only the AICR repo's bot posts to this channel.
+- Migrating other potential bot consumers (none currently exist in `NVIDIA/aicr`).
+- Replacing the issue-report or vuln-scan payload contents — only the transport changes.
+- US-holiday awareness for the daily heartbeat. Empty parent on a holiday is acceptable.
+- Backfilling weekly summaries for prior weeks — first Saturday after merge is the first weekly post.
+
+## References
+
+- Slack Web API — `chat.postMessage`: https://api.slack.com/methods/chat.postMessage
+- Slack Web API — `conversations.history`: https://api.slack.com/methods/conversations.history
+- Slack Web API — best practices for threaded posts: https://api.slack.com/messaging/sending#threading
+- Existing workflows on `upstream/main`:
+  - `1caf2607 feat(ci): add daily Slack issue status report`
+  - `7b0dbb1f fix(ci): make issue report counts clickable Slack links`
+  - `ad682efe feat(ci): add daily image vulnerability scan workflow`
+  - `14178870 ci: add Slack release notification to on-tag workflow`

--- a/docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
+++ b/docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md
@@ -44,7 +44,7 @@ Recent release cadence saw up to ~5 patch releases per workday during release we
 
 ### Mon-Fri (daily threaded)
 
-```
+```text
 05:00 UTC   daily-status.yaml      (NEW)        → "Daily AICR-bot status — 2026-04-27"   [parent]
 06:00 UTC   vuln-scan-images.yaml  (modified)   → Vulnerability Scan: …                  [thread reply]
 12:30 UTC   issue-report.yaml      (modified)   → AICR Issues — Mon, Apr 27 …            [thread reply]
@@ -53,7 +53,7 @@ on tag      on-tag.yaml notify     (modified)   → AICR v0.12.0 has been releas
 
 ### Sat-Sun (weekly only, no daily noise)
 
-```
+```text
 Sat 14:00 UTC   weekly-summary.yaml (NEW)       → "AICR weekly — week of 2026-04-21"     [top-level]
                                                     Releases (5):
                                                       • v0.12.0 (Mon) — link
@@ -74,7 +74,7 @@ Sat 14:00 UTC   weekly-summary.yaml (NEW)       → "AICR weekly — week of 202
 
 The first line of every weekday parent message is exactly:
 
-```
+```text
 Daily AICR-bot status — {YYYY-MM-DD}
 ```
 
@@ -200,7 +200,7 @@ Permissions: `contents: read`, `issues: read`, `actions: read` (for `gh run list
 |---|---|
 | Bot not in channel | `chat.postMessage` returns `not_in_channel`. Action fails with explicit error pointing to the operational prerequisite. No retry — operator action required. |
 | `conversations.history` rate-limited or fails | Fall back to creating a fresh parent. Worst case: one orphaned top-level message that day. Workflow does not fail. |
-| `chat.postMessage` fails on the post/reply | Log message body to `$GITHUB_STEP_SUMMARY`, exit non-zero. Matches today's behaviour on webhook failure. |
+| `chat.postMessage` fails on the post/reply | `slack_api` emits the failed response as a workflow `::error::` annotation and exits non-zero. The job fails so the operator sees the run in red. |
 | Race producing two daily parents | Both survive; later workflows reply to most recent matching parent. Self-heals next day. |
 | `SLACK_BOT_TOKEN` / `SLACK_CHANNEL_ID` unset | Action fails immediately with explicit message naming the missing setting. |
 | UTC date rollover during a workflow run | Marker is computed once at step start; subsequent calls in the same run use that snapshot. A workflow that begins at 23:59 UTC and posts at 00:01 UTC threads under yesterday's parent — acceptable. |


### PR DESCRIPTION
## Summary

Replaces the AICR-Bot's three independent top-level Slack messages per workday with a Mon-Fri threaded cadence (heartbeat at 05:00 UTC + threaded replies for vuln-scan, issue-report, releases) and a Saturday 14:00 UTC weekly digest. Migrates from Slack Incoming Webhooks (which cannot thread) to the Slack Web API via a new shared composite action `slack-thread-post`. Sundays have zero bot noise.

## Approach

- New shared composite action `.github/actions/slack-thread-post/` encapsulates all Slack Web API logic (find or lazy-create today's parent via `conversations.history` + marker pattern, then `chat.postMessage` with `thread_ts` for replies, or no `thread_ts` for top-level).
- New workflow `daily-status.yaml` posts the daily heartbeat (Mon-Fri 05:00 UTC).
- New workflow `weekly-summary.yaml` posts a Saturday top-level digest with releases / 7-day issue movement / latest vuln scan link.
- Existing workflows (`vuln-scan-images.yaml`, `issue-report.yaml`, `on-tag.yaml`) replace their inline `curl` Slack calls with the composite action; their crons shift to Mon-Fri only.
- Marker pattern `Daily AICR-bot status — YYYY-MM-DD` (UTC) computed internally by the action so all callers agree without an external store.

## Operational prerequisite (repo admin, BEFORE merge)

- [ ] Create or reuse a Slack App with OAuth scopes `chat:write` + `channels:history` (or `groups:history` if private channel)
- [ ] Install the app to the workspace; invite the bot to the AICR Slack channel
- [ ] Set repo **secret** `SLACK_BOT_TOKEN` (the `xoxb-…` bot token)
- [ ] Set repo **variable** `SLACK_CHANNEL_ID` (channel ID like `C012ABC3DEF`; not secret)

The legacy `SLACK_SERVICE` webhook secret stays in repo settings during rollout; can be deleted in a follow-up PR after a full week of clean runs.

## Testing

- ✅ `make lint`: PASS (golangci-lint, yamllint, license header, AGENTS.md sync)
- ✅ `make test`: PASS (73.2% coverage; no Go code touched)
- ✅ `actionlint` on all changed/new files: clean (pre-existing findings on unrelated files only)
- ⏳ End-to-end smoke test (`workflow_dispatch` against a test channel): requires the operational prerequisite above to be completed first

## Files

| Status | File |
|---|---|
| NEW | `.github/actions/slack-thread-post/action.yml` (composite action, 154 lines) |
| NEW | `.github/workflows/daily-status.yaml` (heartbeat, Mon-Fri 05:00 UTC) |
| NEW | `.github/workflows/weekly-summary.yaml` (Sat 14:00 UTC digest) |
| MOD | `.github/workflows/vuln-scan-images.yaml` (cron Mon-Fri, threaded reply) |
| MOD | `.github/workflows/issue-report.yaml` (cron Mon-Fri, threaded reply) |
| MOD | `.github/workflows/on-tag.yaml` (notify uses day-of-week mode; preserves stable/pre-release qualifier) |
| NEW | `docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md` |
| NEW | `docs/superpowers/plans/2026-04-27-aicr-bot-slack-cadence.md` |

## Breaking changes

None. The transport change is invisible to Slack readers; message content is preserved or improved (release qualifier preserved; Sunday noise eliminated).

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-27-aicr-bot-slack-cadence-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-aicr-bot-slack-cadence.md`

Origin: Slack thread on 2026-04-27 with @Mark Chmarny / @Yuan Chen, followed by a meeting with Mark refining the cadence.