### PR TITLE
feat(nodewright-customizations): add gb200 eks support

### DIFF
--- a/recipes/components/nodewright-customizations/manifests/tuning.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning.yaml
@@ -65,8 +65,8 @@ spec:
   packages:
     # Check for kernel being >= to 6.14.0-1018 and if not install
     nvidia-setup-kernel:
-      image: ghcr.io/nvidia/skyhook-packages/nvidia-setup
-      version: "0.2.1"
+      image: ghcr.io/nvidia/nodewright-packages/nvidia-setup
+      version: "0.2.2"
       configMap:
         {{- if $cust.service }}
         service: {{ $cust.service }}
@@ -84,8 +84,8 @@ spec:
         memoryRequest: 4096Mi
 
     nvidia-tuned:
-      image: ghcr.io/nvidia/skyhook-packages/nvidia-tuned
-      version: "0.2.3"
+      image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
+      version: "0.3.0"
       interrupt:
         type: reboot
       env:
@@ -100,12 +100,12 @@ spec:
         service: {{ $cust.service }}
         {{- end }}
       dependsOn:
-        nvidia-setup-kernel: "0.2.1"
+        nvidia-setup-kernel: "0.2.2"
 
     # Full setup after kernel is in place
     nvidia-setup-full:
-      image: ghcr.io/nvidia/skyhook-packages/nvidia-setup
-      version: "0.2.1"
+      image: ghcr.io/nvidia/nodewright-packages/nvidia-setup
+      version: "0.2.2"
       interrupt:
         type: reboot
       resources:
@@ -122,5 +122,5 @@ spec:
         - name: NVIDIA_SETUP_INSTALL_KERNEL
           value: "false"
       dependsOn:
-        nvidia-tuned: "0.2.3"
+        nvidia-tuned: "0.3.0"
 {{- end }}

--- a/recipes/overlays/gb200-eks-inference.yaml
+++ b/recipes/overlays/gb200-eks-inference.yaml
@@ -65,7 +65,7 @@ spec:
     - name: nodewright-customizations
       type: Helm
       manifestFiles:
-        - components/nodewright-customizations/manifests/no-op.yaml
+        - components/nodewright-customizations/manifests/tuning.yaml
       overrides:
         service: eks
         accelerator: gb200

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -71,7 +71,7 @@ spec:
     - name: nodewright-customizations
       type: Helm
       manifestFiles:
-        - components/nodewright-customizations/manifests/no-op.yaml
+        - components/nodewright-customizations/manifests/tuning.yaml
       overrides:
         service: eks
         accelerator: gb200


### PR DESCRIPTION
## Summary

Update nvidia-tuned and nvidia-setup for bug fixes related to gb200 on eks

Fixes: #656 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ X Other:  recipes/components/nodewright and eks-gb200

## Testing

Ran CUJ1 on 2 node eks gb200 cluster

< Evidence and final testing to come >

## Risk Assessment

- [X] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
