### PR TITLE
ci: retry grype install on transient github 502s

### DIFF
--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -491,7 +491,22 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
                 GRYPE_TMP=$(mktemp -d)
                 curl -fsSL "$GRYPE_SCRIPT_URL" -o "$GRYPE_TMP/install.sh"
                 verify_sha256 "$GRYPE_TMP/install.sh" "${GRYPE_INSTALL_SHA256:-SKIP}"
-                sh "$GRYPE_TMP/install.sh" -b "$GRYPE_TMP" "${GRYPE_VERSION}"
+                # The anchore install.sh queries github.com for release metadata,
+                # which intermittently 502s. Retry with quadratic backoff so a brief
+                # CDN blip does not fail the whole CI step.
+                grype_attempt=0
+                grype_max_attempts=3
+                until sh "$GRYPE_TMP/install.sh" -b "$GRYPE_TMP" "${GRYPE_VERSION}"; do
+                    grype_attempt=$((grype_attempt + 1))
+                    if [[ ${grype_attempt} -ge ${grype_max_attempts} ]]; then
+                        log_error "grype install failed after ${grype_max_attempts} attempts"
+                        rm -rf "$GRYPE_TMP"
+                        exit 1
+                    fi
+                    grype_delay=$((grype_attempt * grype_attempt * 5))
+                    log_warning "grype install attempt ${grype_attempt} failed (likely transient github.com 502); retrying in ${grype_delay}s"
+                    sleep "${grype_delay}"
+                done
                 sudo mv "$GRYPE_TMP/grype" /usr/local/bin/grype
                 sudo chmod +x /usr/local/bin/grype
                 rm -rf "$GRYPE_TMP"


### PR DESCRIPTION
## Summary

Wrap `tools/setup-tools` grype install in a quadratic-backoff retry loop so transient `github.com` 502s during release-metadata lookups do not fail the merge-gate E2E job.

## Motivation / Context

Recent merge-gate runs have failed spuriously with:

```
[error] received HTTP status=502 for url='https://github.com/anchore/grype/releases/v0.107.0'
##[error]Process completed with exit code 1.
```

Example: https://github.com/NVIDIA/aicr/actions/runs/25031579265/job/73314217949

The first download (raw.githubusercontent.com `install.sh`) succeeds; the script's subsequent `github.com` release-metadata query is what 502s. With `set -e` the step dies immediately on the first failure.

This change retries the anchore `install.sh` up to 3 times with 5s/20s backoff, mirroring the pattern already used in `kwok/scripts/run-all-recipes.sh` and `pkg/bundler/deployer/helm/templates/deploy.sh.tmpl`.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: setup-tools / dev-environment installer

## Implementation Notes

- Three attempts with quadratic backoff (5s, 20s); third failure aborts the step.
- Cleans up `GRYPE_TMP` before exiting on terminal failure.
- Uses the existing `log_warning` / `log_error` functions from `tools/common`.

## Testing

- `bash -n tools/setup-tools` — syntax OK.
- `actionlint`/`yamllint` not applicable (shell-only change).
- Full `make qualify` was not run because this is a tooling-script-only change with no Go, YAML, docs-sidebar, or recipe impact.

## Risk Assessment

Blast radius is limited to the linux grype install path of `tools/setup-tools`. macOS install (`brew install grype`) is unchanged. Happy path (no 502) is identical — no extra latency in the success case. Worst-case added latency on persistent 502: ~25s before failing the same way it does today.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `make qualify` and all checks pass