### PR TITLE
fix(bundler): preserve inner error codes instead of double-wrapping

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -16,6 +16,7 @@ package bundler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -241,6 +242,10 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	// Extract values for each component from the recipe
 	componentValues, err := b.extractComponentValues(ctx, recipeResult)
 	if err != nil {
+		var se *errors.StructuredError
+		if stderrors.As(err, &se) {
+			return nil, err
+		}
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to extract component values", err)
 	}
@@ -256,6 +261,10 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	// attestation. This is a no-op when --data is not set.
 	dataFiles, err := b.copyDataFiles(dir)
 	if err != nil {
+		var se *errors.StructuredError
+		if stderrors.As(err, &se) {
+			return nil, err
+		}
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to copy external data files", err)
 	}
@@ -313,6 +322,10 @@ func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe
 	case config.DeployerHelm:
 		componentManifests, manifestErr := b.collectComponentManifests(ctx, recipeResult)
 		if manifestErr != nil {
+			var se *errors.StructuredError
+			if stderrors.As(manifestErr, &se) {
+				return nil, manifestErr
+			}
 			return nil, errors.Wrap(errors.ErrCodeInternal,
 				"failed to collect component manifests", manifestErr)
 		}
@@ -337,6 +350,10 @@ func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe
 func (b *DefaultBundler) runDeployer(ctx context.Context, d deployer.Deployer, recipeResult *recipe.RecipeResult, dir string, dataFiles []string, start time.Time) (*result.Output, error) {
 	output, err := d.Generate(ctx, dir)
 	if err != nil {
+		var se *errors.StructuredError
+		if stderrors.As(err, &se) {
+			return nil, err
+		}
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate bundle", err)
 	}
 

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -16,6 +16,7 @@ package bundler
 
 import (
 	"context"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
@@ -1251,4 +1253,74 @@ func computeTestChecksum(content []byte) string {
 		hash[i%32] ^= b
 	}
 	return string(hash)
+}
+
+func TestMake_PreservesInnerErrorCode(t *testing.T) {
+	bundler, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	// "../evil" triggers deployer.IsSafePathComponent → ErrCodeInvalidRequest
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "../evil", Version: "v1.0.0", Type: "helm", Source: "https://example.com"},
+		},
+		DeploymentOrder: []string{"../evil"},
+	}
+
+	_, err = bundler.Make(ctx, recipeResult, tmpDir)
+	if err == nil {
+		t.Fatal("expected error for path-traversal component name, got nil")
+	}
+
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("expected *errors.StructuredError, got %T: %v", err, err)
+	}
+
+	if se.Code != errors.ErrCodeInvalidRequest {
+		t.Errorf("expected error code %s, got %s (error: %v)",
+			errors.ErrCodeInvalidRequest, se.Code, err)
+	}
+}
+
+func TestMake_PreservesTimeoutFromExtractValues(t *testing.T) {
+	bundler, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately — extractComponentValues checks ctx.Err()
+
+	tmpDir := t.TempDir()
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia"},
+		},
+		DeploymentOrder: []string{"gpu-operator"},
+	}
+
+	_, err = bundler.Make(ctx, recipeResult, tmpDir)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("expected *errors.StructuredError, got %T: %v", err, err)
+	}
+
+	if se.Code != errors.ErrCodeTimeout {
+		t.Errorf("expected error code %s, got %s (error: %v)",
+			errors.ErrCodeTimeout, se.Code, err)
+	}
 }

--- a/pkg/bundler/handler_test.go
+++ b/pkg/bundler/handler_test.go
@@ -675,3 +675,43 @@ func TestZipCanBeExtracted(t *testing.T) {
 		}
 	}
 }
+
+func TestBundleEndpointPathTraversalReturns400(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	body := `{
+		"apiVersion": "aicr.nvidia.com/v1alpha1",
+		"kind": "Recipe",
+		"componentRefs": [
+			{"name": "../evil", "version": "v1.0.0", "type": "helm", "source": "https://example.com"}
+		],
+		"deploymentOrder": ["../evil"]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/bundle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	b.HandleBundles(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d. Body: %s",
+			http.StatusBadRequest, w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if code, ok := resp["code"].(string); !ok || code != "INVALID_REQUEST" {
+		t.Errorf("expected code INVALID_REQUEST, got %q", resp["code"])
+	}
+
+	if retryable, ok := resp["retryable"].(bool); !ok || retryable {
+		t.Errorf("expected retryable=false, got %v", resp["retryable"])
+	}
+}


### PR DESCRIPTION
## Summary

Stop `bundler.Make()` from clobbering inner structured error codes (e.g., `INVALID_REQUEST`, `TIMEOUT`) with `ErrCodeInternal`, so the API returns correct HTTP status codes and `retryable` values.

## Motivation / Context

`POST /v1/bundle` returns HTTP 500 / `INTERNAL` / `retryable: true` for request-validation failures raised inside deployers. The inner error already carries `ErrCodeInvalidRequest`, but the outer wrap in `runDeployer` overwrites it with `ErrCodeInternal`. Clients that retry on 5xx hammer the server for errors that will never succeed.

Fixes: #679
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

At 4 call sites in `pkg/bundler/bundler.go` (`runDeployer`, `extractComponentValues`, `copyDataFiles`, `collectComponentManifests`), replaced unconditional `errors.Wrap(ErrCodeInternal, ...)` with a conditional pattern: if the inner error is already a `*errors.StructuredError`, return it as-is to preserve its code; otherwise wrap with `ErrCodeInternal` as before.

This follows the existing CLAUDE.md rule: "Don't double-wrap errors that already have proper codes."

## Testing

```bash
make qualify   # all tests pass (pre-existing sandbox failures unrelated)
golangci-lint run -c .golangci.yaml ./pkg/bundler/...  # 0 issues
```

Added 3 new tests:
- `TestMake_PreservesInnerErrorCode` — path-traversal component returns `ErrCodeInvalidRequest`
- `TestMake_PreservesTimeoutFromExtractValues` — cancelled context returns `ErrCodeTimeout`
- `TestBundleEndpointPathTraversalReturns400` — HTTP integration: verifies 400 + `INVALID_REQUEST` + `retryable: false`

pkg/bundler coverage: 61.3% (no decrease)

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** API clients that previously retried on these 500s will now see 400s. This is the correct behavior per the API contract — no migration needed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)