### PR TITLE
fix(bundler): layer-neutral dynamic declaration errors

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -298,7 +298,7 @@ func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe
 	case config.DeployerArgoCD:
 		if b.Config.HasDynamicValues() {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
-				"--dynamic is not supported with --deployer argocd; use --deployer argocd-helm instead")
+				"dynamic declarations are not supported with deployer \"argocd\"; use deployer \"argocd-helm\" instead")
 		}
 		return &argocd.Generator{
 			RecipeResult:     recipeResult,
@@ -942,7 +942,7 @@ func (b *DefaultBundler) buildDynamicValuesMap() (map[string][]string, error) {
 
 	registry, err := recipe.GetComponentRegistry()
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load component registry for --dynamic resolution", err)
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load component registry for dynamic resolution", err)
 	}
 
 	raw := b.Config.DynamicValues()
@@ -951,7 +951,7 @@ func (b *DefaultBundler) buildDynamicValuesMap() (map[string][]string, error) {
 		comp := registry.GetByOverrideKey(key)
 		if comp == nil {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("unknown component %q in --dynamic flag: not found in component registry", key))
+				fmt.Sprintf("unknown component %q in dynamic declaration: not found in component registry", key))
 		}
 		result[comp.Name] = append(result[comp.Name], paths...)
 	}

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -1098,7 +1098,7 @@ func TestMake_DynamicValuesUnknownComponent(t *testing.T) {
 
 	_, err = bundler.Make(context.Background(), recipeResult, t.TempDir())
 	if err == nil {
-		t.Fatal("expected error for unknown component in --dynamic, got nil")
+		t.Fatal("expected error for unknown component in dynamic declaration, got nil")
 	}
 	if !strings.Contains(err.Error(), "nonexistent-component") {
 		t.Errorf("error should mention the unknown component, got: %v", err)
@@ -1133,7 +1133,7 @@ func TestMake_DynamicValuesValidComponent(t *testing.T) {
 
 	out, err := bundler.Make(context.Background(), recipeResult, t.TempDir())
 	if err != nil {
-		t.Fatalf("expected success for valid --dynamic component, got: %v", err)
+		t.Fatalf("expected success for valid dynamic component, got: %v", err)
 	}
 	if out == nil {
 		t.Fatal("expected non-nil output")
@@ -1213,8 +1213,8 @@ func TestMake_DisabledComponentWithDynamic(t *testing.T) {
 	}
 }
 
-// TestMake_ArgoCDRejectsDynamic verifies that --deployer argocd with --dynamic
-// returns a clear error directing users to --deployer argocd-helm.
+// TestMake_ArgoCDRejectsDynamic verifies that deployer argocd with dynamic declarations
+// returns a clear error directing users to deployer argocd-helm.
 func TestMake_ArgoCDRejectsDynamic(t *testing.T) {
 	cfg := config.NewConfig(
 		config.WithDeployer(config.DeployerArgoCD),
@@ -1237,7 +1237,7 @@ func TestMake_ArgoCDRejectsDynamic(t *testing.T) {
 
 	_, err = bundler.Make(context.Background(), recipeResult, t.TempDir())
 	if err == nil {
-		t.Fatal("expected error for --deployer argocd with --dynamic")
+		t.Fatal("expected error for deployer argocd with dynamic declarations")
 	}
 	if !strings.Contains(err.Error(), "argocd-helm") {
 		t.Errorf("error should suggest argocd-helm, got: %v", err)

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -522,7 +522,7 @@ func ParseDynamicValues(inputs []string) ([]ComponentPath, error) {
 		}
 		if cp.Value != nil {
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("invalid format %q: --dynamic does not accept '=value'", input))
+				fmt.Sprintf("invalid format %q: dynamic declaration does not accept '=value'", input))
 		}
 		result = append(result, cp)
 	}


### PR DESCRIPTION
## Summary

Reword four CLI-centric error messages in the bundler core to layer-neutral phrasing so both CLI and API consumers see the same non-CLI-centric text.

## Motivation / Context

When `POST /v1/bundle?dynamic=nonexistent:foo` names an unknown component, the API returns `"in --dynamic flag"` — confusing for API consumers who never use the CLI. The bundler is shared by both CLI and API, so its error text should be surface-agnostic.

Fixes: #680
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Four string-only changes (no logic changes):

| File | Old phrasing | New phrasing |
|------|-------------|--------------|
| `bundler.go:954` | `in --dynamic flag` | `in dynamic declaration` |
| `bundler.go:945` | `for --dynamic resolution` | `for dynamic resolution` |
| `bundler.go:301` | `--dynamic is not supported with --deployer argocd; use --deployer argocd-helm instead` | `dynamic declarations are not supported with deployer "argocd"; use deployer "argocd-helm" instead` |
| `config/config.go:525` | `--dynamic does not accept '=value'` | `dynamic declaration does not accept '=value'` |

Test comments updated to match. No assertions changed — existing assertions check for component names and `argocd-helm`, not for the CLI-specific phrasing.

## Testing

```bash
make qualify
```

All bundler and config tests pass. Lint clean. Two pre-existing sandbox failures (pkg/trust TUF write, deployer/helm mktemp) unrelated to this change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — error message text only, no API contract change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)