### PR TITLE
fix(bundler): demote nodewright selector warnings to info severity

### DIFF
--- a/pkg/bundler/validations/registry.go
+++ b/pkg/bundler/validations/registry.go
@@ -136,6 +136,8 @@ func RunValidations(ctx context.Context, componentName string, validations []rec
 			for _, err := range checkErrors {
 				slog.Info("validation check reported error",
 					"component", componentName,
+					"function", validation.Function,
+					"message", validation.Message,
 					"error", err,
 				)
 			}

--- a/pkg/bundler/validations/registry.go
+++ b/pkg/bundler/validations/registry.go
@@ -101,11 +101,13 @@ func RunValidations(ctx context.Context, componentName string, validations []rec
 		// Execute validation function
 		checkWarnings, checkErrors := fn(ctx, componentName, recipeResult, bundlerConfig, validation.Conditions)
 
-		// Process results based on severity
-		// If severity is "error", convert warnings to errors
-		// If severity is "warning", keep as warnings
+		// Process results based on severity:
+		//   "error"   — convert all check results to blocking errors
+		//   "info"    — log only (visible with --debug), not surfaced in deployment notes
+		//   "warning" — (default) non-blocking deployment notes
 		severity := strings.ToLower(validation.Severity)
-		if severity == "error" {
+		switch severity {
+		case "error":
 			// Convert all check results to errors
 			for _, warning := range checkWarnings {
 				msg := warning
@@ -121,7 +123,23 @@ func RunValidations(ctx context.Context, componentName string, validations []rec
 					errors = append(errors, err)
 				}
 			}
-		} else {
+		case "info":
+			// Log as informational only — not surfaced in deployment notes.
+			// Visible when debug logging is enabled (--debug).
+			for _, warning := range checkWarnings {
+				msg := warning
+				if validation.Message != "" {
+					msg = warning + ". " + validation.Message
+				}
+				slog.Info(msg, "component", componentName)
+			}
+			for _, err := range checkErrors {
+				slog.Info("validation check reported error",
+					"component", componentName,
+					"error", err,
+				)
+			}
+		default:
 			// Default to warning severity
 			for _, warning := range checkWarnings {
 				if validation.Message != "" {

--- a/pkg/bundler/validations/registry_test.go
+++ b/pkg/bundler/validations/registry_test.go
@@ -194,6 +194,52 @@ func TestRunValidations(t *testing.T) {
 			wantMsgInWarn: false,
 			wantMsg:       "This is an error",
 		},
+		{
+			name:          "info severity suppresses warnings",
+			componentName: "nodewright-customizations",
+			validations: []recipe.ComponentValidationConfig{
+				{
+					Function:   "CheckWorkloadSelectorMissing",
+					Severity:   "info",
+					Conditions: map[string][]string{"intent": {"training"}},
+					Message:    "Consider setting --workload-selector",
+				},
+			},
+			recipeResult: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{Name: "nodewright-customizations"},
+				},
+				Criteria: &recipe.Criteria{
+					Intent: recipe.CriteriaIntentTraining,
+				},
+			},
+			bundlerConfig: config.NewConfig(),
+			wantWarnings:  0,
+			wantErrors:    0,
+		},
+		{
+			name:          "info severity suppresses errors from checks",
+			componentName: "nodewright-customizations",
+			validations: []recipe.ComponentValidationConfig{
+				{
+					Function:   "CheckAcceleratedSelectorMissing",
+					Severity:   "info",
+					Conditions: map[string][]string{"intent": {"training", "inference"}},
+					Message:    "Consider setting --accelerated-node-selector",
+				},
+			},
+			recipeResult: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{Name: "nodewright-customizations"},
+				},
+				Criteria: &recipe.Criteria{
+					Intent: recipe.CriteriaIntentTraining,
+				},
+			},
+			bundlerConfig: config.NewConfig(),
+			wantWarnings:  0,
+			wantErrors:    0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/recipe/components_test.go
+++ b/pkg/recipe/components_test.go
@@ -288,8 +288,8 @@ func TestComponentRegistry_Validations(t *testing.T) {
 	for _, v := range validations {
 		if v.Function == "CheckWorkloadSelectorMissing" {
 			foundWorkloadSelector = true
-			if v.Severity != "warning" {
-				t.Errorf("CheckWorkloadSelectorMissing should have severity 'warning', got %q", v.Severity)
+			if v.Severity != "info" {
+				t.Errorf("CheckWorkloadSelectorMissing should have severity 'info', got %q", v.Severity)
 			}
 			if v.Conditions == nil {
 				t.Error("CheckWorkloadSelectorMissing should have conditions")
@@ -305,8 +305,8 @@ func TestComponentRegistry_Validations(t *testing.T) {
 		}
 		if v.Function == "CheckAcceleratedSelectorMissing" {
 			foundAcceleratedSelector = true
-			if v.Severity != "warning" {
-				t.Errorf("CheckAcceleratedSelectorMissing should have severity 'warning', got %q", v.Severity)
+			if v.Severity != "info" {
+				t.Errorf("CheckAcceleratedSelectorMissing should have severity 'info', got %q", v.Severity)
 			}
 			if v.Conditions == nil {
 				t.Error("CheckAcceleratedSelectorMissing should have conditions")

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -204,13 +204,13 @@ components:
           - workloadSelector
     validations:
       - function: CheckWorkloadSelectorMissing
-        severity: warning
+        severity: info
         conditions:
           intent:
             - training
         message: "This may cause nodewright to evict running training jobs. Consider setting --workload-selector to prevent eviction."
       - function: CheckAcceleratedSelectorMissing
-        severity: warning
+        severity: info
         conditions:
           intent:
             - training


### PR DESCRIPTION
## Summary

Add `info` severity tier to the bundler validation framework and demote both nodewright-customizations selector warnings from `warning` to `info`. Info-level messages are logged via `slog.Info` (visible with `--debug`) but no longer surfaced as deployment warnings.

## Motivation / Context

Every `aicr bundle --intent training` emits two nodewright warnings about missing `--workload-selector` and `--accelerated-node-selector` regardless of context. This universal-fire noise dilutes real warnings.

Fixes: #686
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

- Added `"info"` case to the severity switch in `RunValidations()` (`pkg/bundler/validations/registry.go`). Info-severity check results are logged via `slog.Info` but not appended to returned warnings/errors.
- Changed both nodewright-customizations validations in `recipes/registry.yaml` from `severity: warning` to `severity: info`.
- Updated `TestComponentRegistry_Validations` in `pkg/recipe/components_test.go` to expect the new severity.
- No changes to check functions, bundler, CLI, or config — severity routing is handled entirely in `RunValidations()`.

## Testing

```bash
make qualify
```

- `pkg/bundler/validations`: ALL PASS (including 2 new info-severity test cases)
- `pkg/recipe`: ALL PASS
- `golangci-lint`: 0 issues on changed packages
- Pre-existing sandbox failures in `pkg/trust` (Sigstore TUF) and `pkg/bundler/deployer/helm` (mktemp) are unrelated

Coverage: `pkg/bundler/validations` maintains existing coverage with 2 additional test cases.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — advisory messages move from deployment notes to debug log; no behavioral change for bundle generation.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)