### PR TITLE
fix(verifier): add trust level reason to verify output

### DIFF
--- a/pkg/bundler/verifier/integration_test.go
+++ b/pkg/bundler/verifier/integration_test.go
@@ -39,6 +39,9 @@ func TestIntegration_VerifyChecksumOnly(t *testing.T) {
 	if result.TrustLevel != TrustUnverified {
 		t.Errorf("TrustLevel = %s, want unverified", result.TrustLevel)
 	}
+	if result.TrustReason == "" {
+		t.Error("TrustReason should be set")
+	}
 	if result.BundleAttested {
 		t.Error("BundleAttested should be false")
 	}
@@ -69,6 +72,9 @@ func TestIntegration_VerifyTamperedBundle(t *testing.T) {
 	}
 	if result.TrustLevel != TrustUnknown {
 		t.Errorf("TrustLevel = %s, want unknown (tampered)", result.TrustLevel)
+	}
+	if result.TrustReason == "" {
+		t.Error("TrustReason should be set")
 	}
 	if len(result.Errors) == 0 {
 		t.Error("expected errors describing tampered file")
@@ -112,6 +118,9 @@ func TestIntegration_VerifyWithDataDir(t *testing.T) {
 	// The data/ check only applies when full chain is verified
 	if result.TrustLevel != TrustUnverified {
 		t.Errorf("TrustLevel = %s, want unverified (no attestation)", result.TrustLevel)
+	}
+	if result.TrustReason == "" {
+		t.Error("TrustReason should be set")
 	}
 }
 

--- a/pkg/bundler/verifier/trust.go
+++ b/pkg/bundler/verifier/trust.go
@@ -116,8 +116,17 @@ type VerifyResult struct {
 	// HasExternalData indicates the bundle contains external data files (data/ directory).
 	HasExternalData bool `json:"hasExternalData"`
 
+	// TrustReason explains why the trust level was set to its current value.
+	TrustReason string `json:"trustReason,omitempty"`
+
 	// Errors contains verification failure messages.
 	Errors []string `json:"errors,omitempty"`
+}
+
+// setTrust sets the trust level and the human-readable reason together.
+func (r *VerifyResult) setTrust(level TrustLevel, reason string) {
+	r.TrustLevel = level
+	r.TrustReason = reason
 }
 
 // Policy defines verification requirements to enforce after verification.

--- a/pkg/bundler/verifier/verifier.go
+++ b/pkg/bundler/verifier/verifier.go
@@ -117,7 +117,7 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 	}
 	if _, statErr := os.Stat(bundleAttestPath); os.IsNotExist(statErr) {
 		// No attestation — checksums valid but unverified
-		result.TrustLevel = TrustUnverified
+		result.setTrust(TrustUnverified, "checksums valid but no attestation files found (bundle created without --attest)")
 		return result, nil
 	}
 
@@ -133,7 +133,7 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 	bundleCreator, err := verifySigstoreBundle(ctx, bundleAttestPath, checksumDigest)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("bundle attestation verification failed: %v", err))
-		result.TrustLevel = TrustUnknown
+		result.setTrust(TrustUnknown, "bundle attestation verification failed")
 		return result, nil
 	}
 	result.BundleAttested = true
@@ -149,7 +149,7 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 	}
 	if _, statErr := os.Stat(binaryAttestPath); os.IsNotExist(statErr) {
 		// Bundle attested but no binary attestation — chain incomplete
-		result.TrustLevel = TrustAttested
+		result.setTrust(TrustAttested, "bundle attested but binary attestation not found (incomplete chain)")
 		return result, nil
 	}
 
@@ -160,14 +160,14 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 	binaryDigest, err := extractBinaryDigest(bundleAttestPath)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("could not extract binary digest from bundle attestation: %v", err))
-		result.TrustLevel = TrustAttested
+		result.setTrust(TrustAttested, "could not extract binary digest from bundle attestation")
 		return result, nil
 	}
 
 	binaryBuilder, err := VerifyBinaryAttestation(ctx, binaryAttestPath, identityPattern, binaryDigest)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("binary attestation verification failed: %v", err))
-		result.TrustLevel = TrustAttested
+		result.setTrust(TrustAttested, "binary attestation verification failed")
 		return result, nil
 	}
 	result.BinaryAttested = true
@@ -183,11 +183,11 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 	}
 	if _, dataDirErr := os.Stat(dataDir); dataDirErr == nil {
 		result.HasExternalData = true
-		result.TrustLevel = TrustAttested
+		result.setTrust(TrustAttested, "external --data files included; verified requires only embedded recipe data")
 		return result, nil
 	}
 
-	result.TrustLevel = TrustVerified
+	result.setTrust(TrustVerified, "full chain verified: checksums, bundle attestation, binary attestation with NVIDIA CI identity")
 	return result, nil
 }
 
@@ -197,18 +197,18 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 func verifyChecksumStep(bundleDir string, result *VerifyResult) ([]byte, bool) {
 	checksumPath, joinErr := deployer.SafeJoin(bundleDir, checksum.ChecksumFileName)
 	if joinErr != nil {
-		result.TrustLevel = TrustUnknown
+		result.setTrust(TrustUnknown, "unsafe checksum path")
 		result.Errors = append(result.Errors, fmt.Sprintf("unsafe checksum path: %v", joinErr))
 		return nil, true
 	}
 	checksumData, err := os.ReadFile(checksumPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			result.TrustLevel = TrustUnknown
+			result.setTrust(TrustUnknown, "checksums.txt not found")
 			result.Errors = append(result.Errors, "checksums.txt not found")
 			return nil, true
 		}
-		result.TrustLevel = TrustUnknown
+		result.setTrust(TrustUnknown, "failed to read checksums.txt")
 		result.Errors = append(result.Errors, fmt.Sprintf("failed to read checksums.txt: %v", err))
 		return nil, true
 	}
@@ -216,7 +216,7 @@ func verifyChecksumStep(bundleDir string, result *VerifyResult) ([]byte, bool) {
 	checksumErrors := checksum.VerifyChecksumsFromData(bundleDir, checksumData)
 	if len(checksumErrors) > 0 {
 		result.Errors = append(result.Errors, checksumErrors...)
-		result.TrustLevel = TrustUnknown
+		result.setTrust(TrustUnknown, "checksum verification failed")
 		return nil, true
 	}
 	result.ChecksumsPassed = true

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -179,6 +179,9 @@ func outputText(w io.Writer, r *verifier.VerifyResult, policyFailure string) {
 	}
 
 	fmt.Fprintf(w, "  Trust level: %s\n", r.TrustLevel)
+	if r.TrustReason != "" {
+		fmt.Fprintf(w, "    ↳ %s\n", r.TrustReason)
+	}
 
 	if len(r.Errors) > 0 {
 		fmt.Fprintf(w, "\nDetails:\n")

--- a/pkg/cli/bundle_verify_test.go
+++ b/pkg/cli/bundle_verify_test.go
@@ -115,6 +115,19 @@ func TestOutputText_Verdict(t *testing.T) {
 			wantAbsent:   "FAILED",
 		},
 		{
+			name: "trust reason displayed when set",
+			result: &verifier.VerifyResult{
+				ChecksumsPassed: true,
+				ChecksumFiles:   5,
+				BundleAttested:  true,
+				HasExternalData: true,
+				TrustLevel:      verifier.TrustAttested,
+				TrustReason:     "external --data files included; verified requires only embedded recipe data",
+			},
+			wantContains: "external --data files included",
+			wantAbsent:   "FAILED",
+		},
+		{
 			name: "attestation verification error shows FAILED",
 			result: &verifier.VerifyResult{
 				ChecksumsPassed: true,


### PR DESCRIPTION
## Summary

Add `TrustReason` field to `VerifyResult` so every trust-level decision carries a human-readable rationale. Displayed in `aicr verify` text output as an indented line below the trust level, and included in JSON output via the struct tag.

Example output after fix:
```
  Trust level: attested
    ↳ external --data files included; verified requires only embedded recipe data
```

## Motivation / Context

`aicr verify` reports different trust levels for `--attest` vs `--attest --data` bundles but gives no explanation for the difference. The tier delta is intentional (external data provenance is unknown) but the lack of signal is confusing.

Fixes: #683
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] CLI (`cmd/aicr`, `pkg/cli`)

## Implementation Notes

- Added `TrustReason string` field to `VerifyResult` in `pkg/bundler/verifier/trust.go`
- Added `setTrust()` helper method to set level + reason atomically (also keeps `Verify()` under the `funlen` lint limit)
- Set reason at every trust-level assignment in `Verify()` and `verifyChecksumStep()` (10 return paths total)
- CLI text output renders reason as `    ↳ <reason>` below the trust level line
- JSON output includes `trustReason` field automatically via struct tag
- No changes to trust-level semantics — only adds explanatory context

## Testing

```bash
make qualify
```

- `pkg/bundler/verifier`: ALL PASS — added `TrustReason` assertions to 3 integration tests
- `pkg/cli`: ALL PASS — added test case verifying reason display in text output
- `golangci-lint`: 0 issues on changed packages
- Pre-existing sandbox failure in `pkg/trust` (Sigstore TUF) is unrelated

## Risk Assessment

- [x] **Low** — Additive field, no behavioral changes to trust-level calculation

**Rollout notes:** N/A — purely additive UX improvement. Existing JSON consumers ignore unknown fields.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)