### PR TITLE
docs(roadmap): restructure around v1 objectives

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ Recipe portfolio is the defining, perpetual theme of the project — expanding t
 matrix of optimized GPU-accelerated Kubernetes configurations. Coverage is judged
 along four axes plus the validation that keeps it honest.
 
-**Service axis.** Validate end-to-end AICR on managed Kubernetes services CSP, NCP, and vanilla Kubernetes.
+**Service axis.** Validate end-to-end AICR on managed Kubernetes services — both Cloud Service Provider (CSP) and partner-cloud offerings — alongside vanilla Kubernetes.
 
 **Accelerator axis.** H100 is mature; v1 needs L40 and B200 in addition to the
 GB200 work already in flight, with GB300 framed as a near-horizon target.
@@ -33,9 +33,11 @@ that cell is in scope.
 through NFD-based discovery so recipes are derivable from real cluster state, not
 hand-authored criteria.
 
-**Sustained validation.** KWOK-tiered tests already gate every recipe in CI;
-v1 adds a nightly UAT cadence on the live CSPs so coverage cannot silently rot
-between releases.
+**Sustained validation.** KWOK-tiered tests exercise the recipe matrix today —
+advisory on PRs (Tier 1 generic plus diff-aware Tier 2) with the full matrix
+running on merges to `main` and nightly. v1 closes the gap by adding a nightly
+UAT cadence on live managed Kubernetes services and tightening these signals
+into the merge path so coverage cannot silently rot between releases.
 
 **CNCF AI Conformance.** Certify AICR-on-EKS as conformant once the WG finalizes
 requirements. Treat conformance evidence as a first-class output of the validator.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,9 +17,9 @@ v1 will be the first release we declare stable and production-ready. The bar:
 
 ### 1. Coverage
 
-Recipe portfolio is the defining, perpetual theme of the project — expanding the
-matrix of optimized GPU-accelerated Kubernetes configurations. Coverage is judged
-along four axes plus the validation that keeps it honest.
+Recipe portfolio is the ongoing focus of the project: expanding the matrix of
+optimized GPU-accelerated Kubernetes configurations. Coverage is judged along
+four axes plus the validation that backs it.
 
 **Service axis.** Validate end-to-end AICR on managed Kubernetes services — both Cloud Service Provider (CSP) and partner-cloud offerings — alongside vanilla Kubernetes.
 
@@ -37,7 +37,7 @@ hand-authored criteria.
 advisory on PRs (Tier 1 generic plus diff-aware Tier 2) with the full matrix
 running on merges to `main` and nightly. v1 closes the gap by adding a nightly
 UAT cadence on live managed Kubernetes services and tightening these signals
-into the merge path so coverage cannot silently rot between releases.
+into the merge path so coverage stays validated between releases.
 
 **CNCF AI Conformance.** Certify AICR-on-EKS as conformant once the WG finalizes
 requirements. Treat conformance evidence as a first-class output of the validator.
@@ -97,8 +97,9 @@ GPU clusters are high-value targets. A fully configured GPU training environment
 can carry hundreds of configuration values across many components; verifiable
 provenance is foundational for production trust.
 
-**Build-time provenance** — SLSA build attestation, cosign signatures, trust-level
-evaluation, and bundle attestation for `argocd-helm` are all in place.
+**Build-time provenance.** SLSA build attestation, cosign signing, trust-level
+evaluation in `aicr bundle verify`, and bundle attestation for the `argocd-helm`
+output are shipped.
 
 **Enterprise signing modes.** v1 closes the gap for production users who can't
 rely on the public Sigstore: air-gapped signing flows, private Sigstore deployment,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,196 +1,126 @@
 # AICR Roadmap
 
-This roadmap tracks remaining work for the AICR launch and future enhancements.
+This roadmap tracks remaining work toward AICR v1 (GA) and post-v1 enhancements.
 
-## Structure
+## Objectives
 
-| Section | Description |
-|---------|-------------|
-| **Remaining MVP Work** | Tasks blocking launch |
-| **Backlog** | Post-launch enhancements by priority |
-| **Completed** | Delivered capabilities (reference only) |
+v1 will be the first release we declare stable and production-ready. The bar:
 
----
+| Objective | Definition |
+|-----------|------------|
+| **Sufficient Coverage** | Enough recipe coverage to establish gravity across the key axes (service / accelerator / platform), backed by sustained validation |
+| **API/CLI Stability** | Both surfaces — including bundler output — stable enough to GA; subsequent breaking changes require a major version bump |
+| **Easy to Contribute** | No-code recipe contribution path validated end-to-end; new recipes don't require deep AICR internals knowledge, and the review pipeline keeps up with community flow |
+| **Closed Supply Chain** | Every bundle has verifiable provenance from build through deploy, including air-gapped and enterprise-controlled signing modes |
 
-## Remaining MVP Work
+## Scope
 
-### MVP Recipe Matrix Completion
+### 1. Coverage
 
-**Status:** In progress (6 leaf recipes complete)
+Recipe portfolio is the defining, perpetual theme of the project — expanding the
+matrix of optimized GPU-accelerated Kubernetes configurations. Coverage is judged
+along four axes plus the validation that keeps it honest.
 
-Expand recipe coverage for MVP platforms and accelerators.
+**Service axis.** Validate end-to-end AICR on managed Kubernetes services CSP, NCP, and vanilla Kubernetes.
 
-**Current:**
-- EKS + H100 + Training (+ Ubuntu, + Kubeflow)
-- EKS + H100 + Inference (+ Ubuntu, + Dynamo)
+**Accelerator axis.** H100 is mature; v1 needs L40 and B200 in addition to the
+GB200 work already in flight, with GB300 framed as a near-horizon target.
 
-**Needed:**
+**Intent axis.** Both training and inference per (service × accelerator) cell once
+that cell is in scope.
 
-| Platform | Accelerator | Intent | Status |
-|----------|-------------|--------|--------|
-| EKS | GB200 | Training | Partial (kernel-module-params only) |
-| EKS | A100 | Training | Not started |
-| GKE | H100 | Training | Not started |
-| GKE | H100 | Inference | Not started |
-| GKE | GB200 | Training | Not started |
-| AKS | H100 | Training | Not started |
-| AKS | H100 | Inference | Not started |
-| OKE | H100 | Training | Not started |
-| OKE | H100 | Inference | Not started |
-| OKE | GB200 | Training | Not started |
+**Automated snapshot intake.** Continue closing the loop from `--from-snapshot`
+through NFD-based discovery so recipes are derivable from real cluster state, not
+hand-authored criteria.
 
-**Acceptance:** each validates and generates bundles.
+**Sustained validation.** KWOK-tiered tests already gate every recipe in CI;
+v1 adds a nightly UAT cadence on the live CSPs so coverage cannot silently rot
+between releases.
 
----
+**CNCF AI Conformance.** Certify AICR-on-EKS as conformant once the WG finalizes
+requirements. Treat conformance evidence as a first-class output of the validator.
 
-### Validator Enhancements
+**Acceptance:** every (service × accelerator × intent) cell in the v1 matrix
+validates against a snapshot, generates a bundle, deploys via UAT, and is exercised
+by nightly automation.
 
-**Status:** Core complete, advanced features pending
+### 2. Stability
 
-**Implemented:**
-- Constraint evaluation against snapshots
-- Component health checks
-- Validation result reporting
-- Four-phase validation framework (readiness, deployment, performance, conformance)
+Lock every product surface — CLI, REST API, and bundle output — before declaring
+v1, so breaking changes after GA require a major version bump.
 
-**Needed:**
+**CLI and REST API freeze.** Audit every flag, subcommand, endpoint, and schema
+field in `api/aicr/v1/server.yaml`; remove deprecated paths; tag a baseline that
+CI can diff against to catch unintended breakage. Establish a deprecation channel
+so future changes can warn before they break.
 
-| Feature | Description | Priority |
-|---------|-------------|----------|
-| NCCL fabric validation | Deploy test job, verify GPU-to-GPU communication | P0 |
-| CNCF AI conformance | Generate conformance report | P1 |
-| Remediation guidance | Actionable fixes for common failures | P1 |
+**Bundle output as a stable surface.** The bundle is what downstream consumers
+integrate against; v1 hardens it as a first-class contract. This includes a generic
+Helm bundle format that is deployer-neutral, undeploy pre/post-flight checks for
+safe teardown, and decoupling environment specifics (e.g., StorageClass) from
+recipe content so bundles are portable.
 
-**Acceptance:** `aicr validate --deployment` and `aicr validate --conformance ai` produce valid output.
+**Versioning policy.** Document the major-bump policy for each surface in
+`RELEASING.md` and wire compatibility tests into CI.
 
----
+**Acceptance:** `v1.0.0` ships with a frozen, documented contract for the CLI,
+REST API, and bundle layout; any subsequent breaking change is detected in CI and
+gated behind a major-version bump.
 
-### E2E Deployment Validation
+### 3. UX
 
-**Status:** Partial
+Friction in the contribution path is the primary bottleneck to community growth.
+Two sub-themes:
 
-Validate bundler output deploys successfully on target platforms.
+**Authoring path.** Validate the no-code recipe contribution path end-to-end:
+static recipe validation (syntax, cross-reference, semantic) usable pre-PR via CLI,
+pre-commit, and CI; an `aicr recipe validate` verb; a scaffolding generator that
+produces a working overlay skeleton from `(service, accelerator, intent)`; a
+reusable overlay template; KWOK e2e auto-generation for new leaves; and a public
+walkthrough in `docs/contributor/`. Recipe quality discipline — mixin-based
+composition with no duplication across overlays — is part of this theme so new
+contributors aren't copy-pasting drift into the tree.
 
-| Platform | Script Deploy | Argo CD Deploy |
-|----------|---------------|---------------|
-| EKS | Not validated | Not validated |
-| GKE | Not validated | Not validated |
-| AKS | Not validated | Not validated |
+**Review pipeline.** A merge queue and a unified merge-gating CI definition keep
+the review pipeline fast and predictable; a local registry for nvkind keeps the
+inner-loop tight for contributors without cloud access.
 
-**Acceptance:** At least one successful deployment per platform with both deployers.
+**Acceptance:** an external contributor adds a new validated leaf recipe using
+only public docs and the CLI, and the review pipeline merges community PRs at the
+cadence the inbound flow demands.
 
----
+### 4. Security
 
-## Backlog
+GPU clusters are high-value targets. A fully configured GPU training environment
+can carry hundreds of configuration values across many components; verifiable
+provenance is foundational for production trust.
 
-Post-launch enhancements organized by priority.
+**Build-time provenance** — SLSA build attestation, cosign signatures, trust-level
+evaluation, and bundle attestation for `argocd-helm` are all in place.
 
-### P1 — High Value
+**Enterprise signing modes.** v1 closes the gap for production users who can't
+rely on the public Sigstore: air-gapped signing flows, private Sigstore deployment,
+and KMS-backed key custody.
 
-#### Expand Recipe Coverage
+**Verify-on-deploy.** Document and test the path that gates deploys on signature
+and provenance verification, so the chain isn't broken at the last hop.
 
-Extend beyond MVP platforms and accelerators.
+**Recipe data provenance.** Sign and verify the embedded validator catalog and
+component registry — the recipe data layer must carry the same trust guarantees
+as the binaries that read it.
 
-- Self-managed Kubernetes support
-- Additional cloud providers (Oracle OCI, Alibaba Cloud)
-- Additional accelerators (L40S, future architectures)
-- Prioritized recipe backlog with components
+**End-user verification.** A top-level guide that walks a consumer from a
+downloaded bundle to a fully-verified deploy, covering all signing modes above.
 
-#### New Bundlers
-
-Additional component bundlers.
-
-| Bundler | Description |
-|---------|-------------|
-| NIM Operator | NVIDIA Inference Microservices deployment |
-| KServe | Inference serving configurations |
-| Nsight Operator | Cluster-wide profiling and observability |
-| Storage | GPU workload storage configurations |
-
-#### Recipe Creation Tooling
-
-Simplify recipe development and contribution to accelerate MVP recipe matrix completion.
-
-**Recipe Validation Framework** — Static validation tool to catch errors before PR submission
-
-Three validation levels:
-- **Syntax validation** — YAML parsing, required fields present, valid apiVersion/kind
-- **Cross-reference validation** — Component refs exist in registry, valueOverrideKeys match, no orphaned components
-- **Semantic validation** — Helm/Kustomize sources reachable, constraint expressions parsable, dependency cycles detected
-
-Implementation options:
-- `aicr recipe validate` CLI command
-- Pre-commit git hook (automatic gating)
-- CI/CD integration (GitHub Actions validation step)
-
-**Recipe Scaffolding Generator** — Template-based recipe creation
-
-- Generate overlay YAML from platform/accelerator/intent parameters
-- Pre-populate common components for recipe type
-- Inline documentation and validation
-- Usage: `aicr recipe scaffold --platform gke --accelerator a100 --intent training`
-
-**Component Reference Checker** — Static analysis for recipe integrity
-
-- Validate all overlay components exist in registry
-- Check valueOverrideKeys consistency
-- Verify required fields (helm.chart OR kustomize.source)
-- Validate node scheduling paths for component type
-
-**Development Workflow Integration**
-
-- Recipe template file (`recipes/overlays/_TEMPLATE.yaml`)
-- Validation script integrated into `make qualify`
-- KWOK test generator (auto-generate `tools/kwok/e2e_<recipe>.sh`)
-- Recipe documentation generator (auto-generate `docs/recipes/*.md`)
-- Contribution guide (`docs/RECIPE_CONTRIBUTION.md`)
-
----
-
-### P2 — Medium Value
-
-#### Configuration Drift Detection
-
-Detect when clusters diverge from recipe-defined state.
-
-- `aicr diff` command for snapshot comparison
-- Scheduled drift detection via CronJob
-- Alerting integration for drift events
-
-#### Enhanced Nodewright Integration
-
-Deeper OS-level node optimization. Ubuntu done; RHEL and Amazon Linux remain.
-
-- OS-specific overlays for RHEL and Amazon Linux
-- Automated node configuration validation
-
----
-
-### P3 — Future
-
-#### Additional API Interfaces
-
-Programmatic integration options.
-
-- gRPC API for high-performance access
-- GraphQL API for flexible querying
-- Multi-tenancy support
-
-## Completed
-
-Delivered capabilities (reference only).
-
-- **EKS + H100 recipes** — Training (+ Ubuntu, + Kubeflow) and Inference (+ Ubuntu, + Dynamo) overlays
-- **Snapshot-to-recipe transformation** — `ExtractCriteriaFromSnapshot` in `pkg/recipe/snapshot.go`
-- **Monitoring components** — kube-prometheus-stack, prometheus-adapter, nvsentinel, ephemeral-storage-metrics in registry; monitoring-hpa overlay
-- **Nodewright Ubuntu integration** — nodewright-operator + nodewright-customizations with H100 tuning manifest
-- **Argo CD deployer** — `pkg/bundler/deployer/argocd/` alongside Helm deployer
-- **Validation framework** — Four-phase validation (readiness, deployment, performance, conformance)
+**Acceptance:** every artifact (binary, image, recipe data, bundle) has retrievable
+provenance and a documented verification path that works in air-gapped, private,
+and public-trust deployments.
 
 ## Revision History
 
 | Date | Change |
 |------|--------|
+| 2026-04-28 | Restructured around v1 objectives |
 | 2026-02-17 | Expanded Recipe Creation Tooling with validation framework details, scaffolding, and workflow integration |
 | 2026-02-14 | Moved implemented items to Completed: EKS H100 recipes, snapshot-to-recipe, monitoring, Nodewright Ubuntu |
 | 2026-01-26 | Reorganized: removed completed items, streamlined structure |


### PR DESCRIPTION
## Summary

Restructures `ROADMAP.md` around the four v1 objectives (coverage, stability, UX, security), prunes shipped items, and removes individual issue references and internal program terminology to keep the document high-level and externally consumable.

## Motivation / Context

The previous roadmap mixed shipped MVP work, in-flight tasks, and post-launch backlog in a flat task-list format that had drifted out of date. With AICR converging on v1, the document needs to communicate the GA bar at a theme level rather than serve as a per-issue tracker (the project board handles that).

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`) — `ROADMAP.md` only

## Implementation Notes

- Reframed the document as ``Objectives`` + ``Scope`` (Coverage / Stability / UX / Security) instead of a task list.
- Each scope section ends with an explicit ``Acceptance`` definition.
- Removed shipped items already reflected in the codebase (recipe families, validation framework, mixin composition, NIM bundler, Argo CD attestation, etc.).
- Removed issue numbers and references to internal programs / boards so the document reads cleanly as an external roadmap.

## Testing

Documentation-only change (no code or build files touched). Rendered locally to verify formatting.

## Risk Assessment

- [x] **Low** — Isolated documentation change, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (N/A — docs only)
- [x] Linter passes (N/A — docs only)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A)
- [x] I updated docs if user-facing behavior changed (this PR is the doc update)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)