### PR TITLE
docs(kwok): add prerequisites and fix copy-paste pitfalls

### DIFF
--- a/kwok/README.md
+++ b/kwok/README.md
@@ -2,13 +2,49 @@
 
 KWOK (Kubernetes WithOut Kubelet) tests AICR bundles against simulated GPU clusters without real hardware.
 
-## Quick Start
+## Prerequisites
+
+The following tools must be installed before using any `make kwok-*` target. Versions are pinned in `.settings.yaml`.
+
+**Docker Desktop must be running** — Kind uses it to create the local cluster.
 
 ```bash
-make build                              # Build aicr binary
-make kwok-test-all                      # Test all recipes (serial)
-make kwok-test-all-parallel             # Test all recipes (parallel, faster)
-make kwok-e2e RECIPE=h100-eks-ubuntu-training-kubeflow # Test single recipe
+# Kind and cluster lifecycle management
+brew install kind
+brew install tilt-dev/tap/ctlptl
+
+# Bundle deployment and YAML processing (used by KWOK scripts)
+brew install helm yq
+
+# Build the aicr binary (KWOK scripts look for it in dist/, not PATH)
+brew install goreleaser
+```
+
+> **Note:** The `kwok` and `kwokctl` binaries are not required — the KWOK controller is installed into the cluster automatically by `make kwok-cluster` via `kubectl apply`.
+
+> **Note:** If `GITLAB_TOKEN` is set in your environment, `make build` will fail. Always run `unset GITLAB_TOKEN` before building.
+
+Before running KWOK tests, use `aicr recipe`, `aicr query`, and `aicr bundle` to generate and inspect configuration without a cluster. See the [CLI reference](../docs/user/cli-reference.md) for details.
+
+## Quick Start
+
+All `make` commands must be run from the **repo root**. Run `cd /path/to/aicr` first, then:
+
+**Build** (one-time, or after code changes):
+```bash
+unset GITLAB_TOKEN
+make build
+```
+
+**Test a single recipe:**
+```bash
+make kwok-e2e RECIPE=h100-eks-ubuntu-training-kubeflow
+```
+
+**Test all recipes:**
+```bash
+make kwok-test-all
+make kwok-test-all-parallel
 ```
 
 ## Architecture
@@ -135,6 +171,7 @@ spec:
 Test it:
 
 ```bash
+unset GITLAB_TOKEN
 make build
 make kwok-e2e RECIPE=your-recipe-name
 ```


### PR DESCRIPTION
## Summary

Improve `kwok/README.md` to be self-contained and usable from a fresh setup — adding prerequisites, fixing copy-paste pitfalls, and linking out to the CLI reference instead of duplicating it.

## Motivation / Context

The existing README assumed tools were already installed and commands were run from the right directory. First-time users hit avoidable errors before getting to the actual KWOK workflow.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Changes

- Added **Prerequisites** section: `kind`, `ctlptl`, `helm`, `yq`, `goreleaser`, Docker Desktop
- Clarified that `kwok`/`kwokctl` binaries are not required (KWOK controller is applied via `kubectl`)
- Added `unset GITLAB_TOKEN` warning before `make build`
- Added repo root note so users don't run `make` from `kwok/`
- Split Quick Start into distinct operations to prevent unintended copy-paste execution
- Removed inline comments from code blocks (zsh interprets them unexpectedly when pasting blocks)
- Replaced a redundant local CLI section with a single link to `docs/user/cli-reference.md`

## Testing

Validated end-to-end on Apple Silicon Mac:
- `make build` — binary built into `dist/`
- `make kwok-e2e RECIPE=h100-eks-ubuntu-training-kubeflow` — 35 pods scheduled across 2 system nodes and 4 fake H100 GPU nodes, all passing

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — docs only, no functional changes.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)