### PR TITLE
fix(ci): centralize GPU CI runtime pins

### DIFF
--- a/.github/actions/aicr-build/action.yml
+++ b/.github/actions/aicr-build/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Comma-separated validator phases to build (e.g., "conformance,deployment"), or "none" to skip all. Takes precedence over build_validators.'
     required: false
     default: ''
+  snapshot_agent_cuda_image:
+    description: 'CUDA base image for the snapshot agent image; defaults to .settings.yaml via load-versions'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -50,9 +54,16 @@ runs:
         GOFLAGS: -mod=vendor
       run: bash "${{ github.action_path }}/build-cli.sh"
 
+    - name: Load snapshot agent image version
+      if: inputs.build_snapshot_agent == 'true' && inputs.snapshot_agent_cuda_image == ''
+      id: snapshot-versions
+      uses: ./.github/actions/load-versions
+
     - name: Build snapshot agent image and load into kind
       if: inputs.build_snapshot_agent == 'true'
       shell: bash
+      env:
+        SNAPSHOT_AGENT_CUDA_IMAGE: ${{ inputs.snapshot_agent_cuda_image || steps.snapshot-versions.outputs.snapshot_agent_cuda_image }}
       run: bash "${{ github.action_path }}/build-snapshot-agent.sh"
 
     - name: Build validator images and load into kind

--- a/.github/actions/aicr-build/build-snapshot-agent.sh
+++ b/.github/actions/aicr-build/build-snapshot-agent.sh
@@ -15,14 +15,8 @@
 
 set -euo pipefail
 
-if ! command -v yq >/dev/null 2>&1; then
-  echo "::error::yq is required to read testing.snapshot_agent_cuda_image from .settings.yaml"
-  exit 1
-fi
-
-SNAPSHOT_AGENT_CUDA_IMAGE="$(yq eval '.testing.snapshot_agent_cuda_image // ""' .settings.yaml)"
-if [[ -z "${SNAPSHOT_AGENT_CUDA_IMAGE}" || "${SNAPSHOT_AGENT_CUDA_IMAGE}" == "null" ]]; then
-  echo "::error::testing.snapshot_agent_cuda_image must be set in .settings.yaml"
+if [[ -z "${SNAPSHOT_AGENT_CUDA_IMAGE:-}" || "${SNAPSHOT_AGENT_CUDA_IMAGE}" == "null" ]]; then
+  echo "::error::SNAPSHOT_AGENT_CUDA_IMAGE must be provided by the aicr-build action"
   exit 1
 fi
 

--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -97,6 +97,12 @@ outputs:
   h100_kind_node_image:
     description: 'Kind node image for H100 GPU tests'
     value: ${{ steps.versions.outputs.h100_kind_node_image }}
+  gpu_operator_chart_version:
+    description: 'GPU Operator Helm chart version for GPU smoke tests'
+    value: ${{ steps.versions.outputs.gpu_operator_chart_version }}
+  snapshot_agent_cuda_image:
+    description: 'CUDA base image for the snapshot agent image'
+    value: ${{ steps.versions.outputs.snapshot_agent_cuda_image }}
 
 runs:
   using: 'composite'
@@ -149,6 +155,8 @@ runs:
         # Testing configuration
         echo "kind_node_image=$(yq eval '.testing.kind_node_image' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "h100_kind_node_image=$(yq eval '.testing.h100_kind_node_image' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "gpu_operator_chart_version=$(yq eval '.testing.gpu_operator_chart_version' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "snapshot_agent_cuda_image=$(yq eval '.testing.snapshot_agent_cuda_image' .settings.yaml)" >> $GITHUB_OUTPUT
 
     - name: Display loaded versions
       shell: bash
@@ -182,3 +190,5 @@ runs:
         echo "  test_timeout: ${{ steps.versions.outputs.test_timeout }}"
         echo "  kind_node_image: ${{ steps.versions.outputs.kind_node_image }}"
         echo "  h100_kind_node_image: ${{ steps.versions.outputs.h100_kind_node_image }}"
+        echo "  gpu_operator_chart_version: ${{ steps.versions.outputs.gpu_operator_chart_version }}"
+        echo "  snapshot_agent_cuda_image: ${{ steps.versions.outputs.snapshot_agent_cuda_image }}"

--- a/.github/actions/runtime-install/action.yml
+++ b/.github/actions/runtime-install/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Continue deploying remaining bundle components after a component failure'
     required: false
     default: 'true'
+  gpu_operator_chart_version:
+    description: 'GPU Operator Helm chart version for helm mode; defaults to .settings.yaml via load-versions'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -58,9 +62,15 @@ runs:
 
     # --- Helm mode: standalone GPU operator chart ---
 
+    - name: Load GPU Operator chart version
+      if: inputs.method == 'helm' && inputs.gpu_operator_chart_version == ''
+      id: helm-versions
+      uses: ./.github/actions/load-versions
     - name: Install GPU Operator (helm)
       if: inputs.method == 'helm'
       shell: bash
+      env:
+        GPU_OPERATOR_CHART_VERSION: ${{ inputs.gpu_operator_chart_version || steps.helm-versions.outputs.gpu_operator_chart_version }}
       run: bash "${{ github.action_path }}/install-gpu-operator-helm.sh"
     - name: Wait for GPU operands (helm)
       if: inputs.method == 'helm'

--- a/.github/actions/runtime-install/install-gpu-operator-helm.sh
+++ b/.github/actions/runtime-install/install-gpu-operator-helm.sh
@@ -15,14 +15,8 @@
 
 set -euo pipefail
 
-if ! command -v yq >/dev/null 2>&1; then
-  echo "::error::yq is required to read testing.gpu_operator_chart_version from .settings.yaml"
-  exit 1
-fi
-
-GPU_OPERATOR_CHART_VERSION="$(yq eval '.testing.gpu_operator_chart_version // ""' .settings.yaml)"
-if [[ -z "${GPU_OPERATOR_CHART_VERSION}" || "${GPU_OPERATOR_CHART_VERSION}" == "null" ]]; then
-  echo "::error::testing.gpu_operator_chart_version must be set in .settings.yaml"
+if [[ -z "${GPU_OPERATOR_CHART_VERSION:-}" || "${GPU_OPERATOR_CHART_VERSION}" == "null" ]]; then
+  echo "::error::GPU_OPERATOR_CHART_VERSION must be provided by the runtime-install action"
   exit 1
 fi
 

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -73,6 +73,8 @@ docs_tools:
 testing:
   kind_node_image: 'kindest/node:v1.32.0'
   h100_kind_node_image: 'kindest/node:v1.35.0'
+
+  # GPU CI runtime pins consumed through .github/actions/load-versions.
   gpu_operator_chart_version: 'v25.10.1'
   snapshot_agent_cuda_image: 'nvcr.io/nvidia/cuda:13.1.0-base-ubuntu24.04'
 


### PR DESCRIPTION
## Summary

Centralizes the GPU CI runtime pins added in #694 behind the shared `load-versions` action. The GPU Operator chart version and snapshot-agent CUDA image remain in `.settings.yaml`, and the consuming scripts now receive those values from composite-action inputs/env instead of reading `.settings.yaml` directly.

## Motivation / Context

This is a small follow-up to merged PR #694. In review, we moved the GPU Operator chart version and snapshot-agent CUDA image into `.settings.yaml`; this PR finishes that cleanup by making those pins follow the same `load-versions` path as other CI tool/image pins.

This keeps `.settings.yaml` as the source and `.github/actions/load-versions` as the shared read path.

Fixes: N/A
Related: #694

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: GPU CI composite actions and `.settings.yaml`

## Implementation Notes

- Adds `gpu_operator_chart_version` and `snapshot_agent_cuda_image` outputs to `.github/actions/load-versions`.
- Updates `runtime-install` to load the GPU Operator chart version through `load-versions` for Helm-mode installs and pass it to `install-gpu-operator-helm.sh` via `GPU_OPERATOR_CHART_VERSION`.
- Updates `aicr-build` to load the snapshot-agent CUDA image through `load-versions` when `build_snapshot_agent=true` and pass it to `build-snapshot-agent.sh` via `SNAPSHOT_AGENT_CUDA_IMAGE`.
- Keeps optional action inputs for both values so future callers can override them explicitly if needed.
- Leaves the actual pinned values unchanged.

## Testing

```bash
bash -n .github/actions/runtime-install/install-gpu-operator-helm.sh .github/actions/aicr-build/build-snapshot-agent.sh
yamllint .settings.yaml .github/actions/load-versions/action.yml .github/actions/runtime-install/action.yml .github/actions/aicr-build/action.yml
actionlint .github/workflows/gpu-smoke-test.yaml .github/workflows/gpu-h100-kind-runtime-test.yaml .github/workflows/gpu-h100-training-test.yaml .github/workflows/gpu-h100-inference-test.yaml
git diff --check
```

Scoped CI checks passed locally. Full `make qualify` was not run because this is a CI-only composite-action wiring change with no Go, recipe, or user-facing behavior changes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Existing GPU CI callers keep using the same pinned values. The scripts now fail clearly if their parent action does not provide the required env value.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
