### PR TITLE
fix(examples): remove stale nvsentinel manifest reference in aks-training

### DIFF
--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -124,8 +124,6 @@ componentRefs:
     dependencyRefs:
       - cert-manager
       - gpu-operator
-    manifestFiles:
-      - components/nvsentinel/manifests/allow-intra-namespace.yaml
   - name: prometheus-adapter
     namespace: monitoring
     chart: prometheus-adapter


### PR DESCRIPTION
## Summary

Remove an orphaned `manifestFiles:` reference in `examples/recipes/aks-training.yaml` that points to a non-existent file (`components/nvsentinel/manifests/allow-intra-namespace.yaml`). The reference has been broken since the AKS example was added.

## Motivation / Context

`aicr bundle examples/recipes/aks-training.yaml` currently fails:

```
failed to load manifest components/nvsentinel/manifests/allow-intra-namespace.yaml
for component nvsentinel: open ...: file does not exist
```

### Bug history

- **#68** — `fix: add NetworkPolicy workaround for nvsentinel metrics-access restriction` — introduced the manifest as a workaround for nvsentinel **< v0.7.0**, which shipped a `metrics-access` NetworkPolicy with `podSelector: {}` that isolated all pods in the namespace and blocked:
  - intra-namespace pod-to-pod traffic (e.g. DCGM port `5555`)
  - API-server → webhook traffic (e.g. cert-manager webhook port `443`)
- **#309** — `feat: move to latest NVSentinel` — bumped nvsentinel past **v0.7.0** (the upstream NVSentinel/PR#789 fix landed) and **removed the workaround source file**. References in existing examples were cleaned up at that time.
- **#415** — `feat: Add AKS (Azure Kubernetes Service) H100 recipe overlays` — added the new AKS example by copying the template structure from another example, but **kept the now-orphaned `manifestFiles:` block**. The reference has been broken since this PR merged.

The nvsentinel pin in this example is `v0.10.0`, well past the `v0.7.0` cutoff, so the workaround is irrelevant. Removing the two orphaned lines lets the example bundle cleanly.

Surfaced during phase 1 of the recipe version-bump campaign (#698 / #715), where Codex's verification flagged this as a pre-existing bundling failure on `main` not introduced by the bump PR. Filing as a standalone fix per scoping discussion.

Fixes: bundling failure on `aicr bundle examples/recipes/aks-training.yaml`
Related: #698, #715

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — example only

## Implementation Notes

Two-line deletion. No values or version changes. Other example recipes (`kind.yaml`, `eks-training.yaml`, `eks-gb200-ubuntu-training-with-validation.yaml`) bundle cleanly and don't reference the missing manifest.

## Testing

```bash
$ aicr bundle -r examples/recipes/aks-training.yaml -o /tmp/aicr/bundle-aks-test
... succeeds, no missing-manifest error

$ make lint    # 0 issues
$ yamllint examples/recipes/aks-training.yaml   # clean
```

## Risk Assessment

- [x] **Low** — Example-only change, two-line deletion, restores broken bundling. No production code touched.

**Rollout notes:** None. Example file only.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — orphaned reference cleanup)
- [x] I updated docs if user-facing behavior changed (N/A — example fix)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)