### PR TITLE
fix(recipes): drop hook-succeeded from torch-distributed runtime

### DIFF
--- a/recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
+++ b/recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   mlPolicy:
     numNodes: 1


### PR DESCRIPTION
## Summary

Remove `hook-succeeded` from the `torch-distributed` ClusterTrainingRuntime's Helm hook delete policy so the resource persists after install instead of being deleted, unblocking any TrainJob that references it (e.g. the `pytorch-mnist` demo in `demos/cuj1-eks.md`).

## Motivation / Context

`recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml` declared its delete policy as:

```yaml
"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
```

Helm interprets `hook-succeeded` literally — after the post-install hook runs successfully, the resource is deleted. So every install creates the CTR and immediately deletes it.

Symptom (reproduced on a fresh `eks/h100/training/ubuntu/kubeflow` deploy):

```
admission webhook "validator.trainjob.trainer.kubeflow.org" denied the request:
ClusterTrainingRuntime.trainer.kubeflow.org "torch-distributed" not found:
specified clusterTrainingRuntime must be created before the TrainJob is created
```

Bug origin: the manifest was introduced in #94 (Feb 2026) with this delete policy already present; the move-in #114 preserved the file content unchanged. Confirmed via `git log -p` on both paths.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

Drop only `,hook-succeeded` from the delete policy. The other hook annotations are retained:

- `helm.sh/hook: post-install,post-upgrade` — required by `pkg/recipe.TestManifestHelmHooksRequired`, which enforces every CR-typed manifest in `recipes/components/*/manifests/` carry a `helm.sh/hook` annotation (or an explicit `aicr/skip-hook-validation: "true"` opt-out).
- `helm.sh/hook-weight: "5"` — unchanged.
- `helm.sh/hook-delete-policy: before-hook-creation` — keeps re-install idempotent (Helm deletes the previous CTR before re-applying on `helm upgrade`).

Without `hook-succeeded`, the CTR persists between installs.

## Testing

YAML manifest change with no Go code touched, but it interacts with `pkg/recipe.TestManifestHelmHooksRequired`, so I ran `pkg/recipe` tests in addition to lint:

```bash
yamllint -c .yamllint.yaml \
  recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
# OK

go test ./pkg/recipe/
# ok  github.com/NVIDIA/aicr/pkg/recipe  1.110s
```

End-to-end on a real EKS H100 cluster (aicr1):

1. Deployed full `eks/h100/training/ubuntu/kubeflow` bundle.
2. Stripped `hook-succeeded` from the rendered CTR manifest, applied via `kubectl apply` (proxy for the fix).
3. `kubectl get clustertrainingruntime` returns `torch-distributed` (previously: `No resources found`).
4. Submitted the `pytorch-mnist` TrainJob from `demos/cuj1-eks.md` — admission accepts, runtime resolves, worker pod schedules and runs to completion (1-epoch MNIST, accuracy 0.74).

## Risk Assessment

- [x] **Low** — One-character pair removed from a Helm hook annotation; isolated to a single manifest.

**Rollout notes:** On clusters that previously deployed with the broken hook, the CTR is currently absent (deleted by `hook-succeeded`). On the next `helm upgrade`, Helm will create the CTR fresh as a hook resource — there is no broken state to adopt. No migration steps required.

## Checklist

- [x] Tests pass locally (`go test ./pkg/recipe/`, yamllint)
- [x] Linter passes (`yamllint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — `TestManifestHelmHooksRequired` exists and now passes)
- [x] I updated docs if user-facing behavior changed (N/A — silent runtime fix; the demo it unblocks is documented in `demos/cuj1-eks.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)