### PR TITLE
ci: add Jont828 to copy-pr-bot trustees

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -19,6 +19,7 @@ additional_trustees:
   - coffeepac
   - cullenmcdermott
   - dims
+  - Jont828
   - Kevin-Hawkins
   - lockwobr
   - mchmarny


### PR DESCRIPTION
## Summary
- Add `Jont828` to the `additional_trustees` list in `.github/copy-pr-bot.yaml`

## Test plan
- [x] Verify username is in alphabetical order in the trustees list