### PR TITLE
fix(recipes): handle kubeflow-trainer v2.2.0 API changes

### DIFF
--- a/demos/cuj1-eks.md
+++ b/demos/cuj1-eks.md
@@ -97,30 +97,10 @@ spec:
         nvidia.com/gpu: 1
       limits:
         nvidia.com/gpu: 1
-  # Inject AICR-standard GPU node scheduling. kubeflow-trainer v2.2.0 replaced
-  # podTemplateOverrides with the runtimePatches API (PR kubeflow/trainer#3309).
-  runtimePatches:
-    - manager: aicr.nvidia.com/demo
-      trainingRuntimeSpec:
-        template:
-          spec:
-            replicatedJobs:
-              - name: node
-                template:
-                  spec:
-                    template:
-                      spec:
-                        nodeSelector:
-                          nodeGroup: gpu-worker
-                        tolerations:
-                          - key: dedicated
-                            operator: Equal
-                            value: worker-workload
-                            effect: NoSchedule
-                          - key: dedicated
-                            operator: Equal
-                            value: worker-workload
-                            effect: NoExecute
+  # No podTemplateOverrides / runtimePatches needed — the torch-distributed
+  # ClusterTrainingRuntime carries the cluster-aware nodeSelector and
+  # tolerations baked in at bundle time from --accelerated-node-selector /
+  # --accelerated-node-toleration flags.
   runtimeRef:
     name: torch-distributed
     apiGroup: trainer.kubeflow.org

--- a/demos/cuj1-gke.md
+++ b/demos/cuj1-gke.md
@@ -99,32 +99,10 @@ spec:
         nvidia.com/gpu: 1
       limits:
         nvidia.com/gpu: 1
-  # Inject GKE GPU node scheduling. Matches the snapshot/bundle/validate
-  # tolerations above (`dedicated=gpu-workload:NoSchedule` plus the GKE-managed
-  # `nvidia.com/gpu=present:NoSchedule` taint). kubeflow-trainer v2.2.0 replaced
-  # podTemplateOverrides with the runtimePatches API (PR kubeflow/trainer#3309).
-  runtimePatches:
-    - manager: aicr.nvidia.com/demo
-      trainingRuntimeSpec:
-        template:
-          spec:
-            replicatedJobs:
-              - name: node
-                template:
-                  spec:
-                    template:
-                      spec:
-                        nodeSelector:
-                          nodeGroup: gpu-worker
-                        tolerations:
-                          - key: dedicated
-                            operator: Equal
-                            value: gpu-workload
-                            effect: NoSchedule
-                          - key: nvidia.com/gpu
-                            operator: Equal
-                            value: present
-                            effect: NoSchedule
+  # No podTemplateOverrides / runtimePatches needed — the torch-distributed
+  # ClusterTrainingRuntime carries the cluster-aware nodeSelector and
+  # tolerations baked in at bundle time from --accelerated-node-selector /
+  # --accelerated-node-toleration flags.
   runtimeRef:
     name: torch-distributed
     apiGroup: trainer.kubeflow.org

--- a/recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
+++ b/recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
@@ -41,6 +41,22 @@ spec:
             spec:
               template:
                 spec:
+                  # nodeSelector and tolerations are injected by the AICR bundler
+                  # from --accelerated-node-selector / --accelerated-node-toleration
+                  # flags via the registry's nodeScheduling.accelerated paths
+                  # (see recipes/registry.yaml). This lets users submit a bare
+                  # TrainJob with no podTemplateOverrides / runtimePatches — the
+                  # runtime carries the per-cluster scheduling vocabulary baked
+                  # in at bundle time.
+                  {{- $kft := index .Values "kubeflow-trainer" }}
+                  {{- with $kft.acceleratedNodeSelector }}
+                  nodeSelector:
+                    {{- toYaml . | nindent 20 }}
+                  {{- end }}
+                  {{- with $kft.acceleratedTolerations }}
+                  tolerations:
+                    {{- toYaml . | nindent 20 }}
+                  {{- end }}
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -495,3 +495,13 @@ components:
         tolerationPaths:
           - manager.tolerations
           - jobset.controller.tolerations
+      # accelerated paths target top-level keys; consumed by the
+      # torch-distributed ClusterTrainingRuntime template in
+      # components/kubeflow-trainer/manifests/. Lets users submit a bare
+      # TrainJob with no podTemplateOverrides / runtimePatches — the
+      # runtime carries the per-cluster scheduling baked in at bundle time.
+      accelerated:
+        nodeSelectorPaths:
+          - acceleratedNodeSelector
+        tolerationPaths:
+          - acceleratedTolerations


### PR DESCRIPTION
## Summary

Bake the cluster-aware `nodeSelector` + `tolerations` into the `torch-distributed` ClusterTrainingRuntime, using AICR's existing `nodeScheduling.accelerated` bundler injection. Demos go back to bare-bones TrainJobs (no `podTemplateOverrides`, no `runtimePatches`).

## Motivation / Context

The pytorch demo TrainJobs in `demos/cuj1-{eks,gke}.md` currently carry per-cluster scheduling boilerplate so the resulting pods land on AICR's tainted GPU nodes. Each TrainJob author has to repeat it; each demo has to be edited per-cluster vocabulary; and the override mechanism keeps changing upstream (`PodTemplateOverrides` deprecated in v2.1 → replaced by `RuntimePatches` in v2.2; see [kubeflow/trainer#3309](https://github.com/kubeflow/trainer/pull/3309)).

This PR moves the per-cluster scheduling into the *runtime* itself. The bundler already supports this via `nodeScheduling.accelerated` paths declared in `recipes/registry.yaml` — already used by `gpu-operator`, `nfd`, `nodewright-customizations`, and `kgateway`. `kubeflow-trainer` was the only manifestFiles-using component without an `accelerated:` block. This PR adds it.

End state for users: same `--accelerated-node-selector` / `--accelerated-node-toleration` CLI flags at bundle time. Different cluster, different vocabulary, same demo TrainJob YAML.

**API-version-agnostic.** Works on kubeflow-trainer v2.1 (`PodTemplateOverrides` era) and v2.2+ (`RuntimePatches` era) identically, because the TrainJob no longer overrides anything — the runtime carries the scheduling.

Fixes: N/A
Related: kubeflow/trainer#3309

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (\`pkg/recipe\`)

## Implementation Notes

Three coordinated changes (4 files, +34/-12 net):

1. **\`recipes/registry.yaml\`** — add \`nodeScheduling.accelerated\` block to the \`kubeflow-trainer\` component entry. \`nodeSelectorPaths: [acceleratedNodeSelector]\` and \`tolerationPaths: [acceleratedTolerations]\` (top-level keys). Identical pattern to \`gpu-operator\` (\`daemonsets.nodeSelector\` / \`daemonsets.tolerations\`); just chose top-level for readability.

2. **\`recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml\`** — replace the static pod-spec scheduling region with Helm template directives:

\`\`\`yaml
{{- $kft := index .Values "kubeflow-trainer" }}
{{- with $kft.acceleratedNodeSelector }}
nodeSelector:
  {{- toYaml . | nindent 20 }}
{{- end }}
{{- with $kft.acceleratedTolerations }}
tolerations:
  {{- toYaml . | nindent 20 }}
{{- end }}
\`\`\`

\`index .Values "kubeflow-trainer"\` matches the bundler's \`manifest.RenderInput.Values\` shape (values nested under ComponentName). Same access pattern as \`nodewright-customizations/manifests/tuning.yaml\`.

The bundler renders this template at *bundle time*, so the \`bundle/<NNN>-kubeflow-trainer-post/templates/\` artifact is plain YAML with concrete values substituted — Helm at install time just applies it as-is.

3. **\`demos/cuj1-eks.md\` and \`demos/cuj1-gke.md\`** — drop the entire \`podTemplateOverrides\` block. Demo TrainJob is just \`trainer:\` + \`runtimeRef:\`.

What stays the same:
- \`helm.sh/hook\` annotations (still required by \`pkg/recipe.TestManifestHelmHooksRequired\`).
- Bundler CLI flags (\`--accelerated-node-selector\`, \`--accelerated-node-toleration\`).
- No bundler Go changes; no new patterns; no precedent broken.

## Testing

\`\`\`bash
yamllint -c .yamllint.yaml \
  recipes/registry.yaml \
  recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
# OK

go test ./pkg/recipe/
# ok  github.com/NVIDIA/aicr/pkg/recipe  0.845s
\`\`\`

End-to-end on a real EKS H100 cluster (kubeflow-trainer v2.2.0):

1. \`helm upgrade kubeflow-trainer-post\` from this branch's bundle -> CTR live with baked tolerations + nodeSelector.
2. Apply the bare-bones TrainJob from \`demos/cuj1-eks.md\` literally (no \`podTemplateOverrides\`, no \`runtimePatches\`). Admission accepts; pod scheduled to GPU node with \`dedicated=worker-workload:NoSchedule|NoExecute\` tolerations and \`nodeGroup=gpu-worker\` nodeSelector inherited from the runtime; \`pytorch-mnist\` runs to completion in 21s with \`accuracy=0.7424\`.

## Risk Assessment

- [x] **Low** — Isolated change, validated end-to-end, easy to revert.

**Rollout notes:** Existing clusters re-bundling get the new templated CTR on the next \`helm upgrade kubeflow-trainer-post\`. Backwards-compatible: TrainJobs that still use \`podTemplateOverrides\` (v2.1) or \`runtimePatches\` (v2.2) continue to work — those override mechanisms are additive, this PR just removes the *need* for them in the AICR-standard demo flow.

## Checklist

- [x] Tests pass locally (\`go test ./pkg/recipe/\`, \`yamllint\`)
- [x] Linter passes (\`yamllint\`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — uses existing \`nodeScheduling.accelerated\` injection paths covered by existing bundler tests)
- [x] I updated docs if user-facing behavior changed (\`demos/cuj1-{eks,gke}.md\` updated)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (\`git commit -S\`)