### PR TITLE
fix(recipes): correct nvsentinel registry default to OCI source

### DIFF
--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -231,8 +231,8 @@ components:
     healthCheck:
       assertFile: checks/nvsentinel/health-check.yaml
     helm:
-      defaultRepository: https://helm.ngc.nvidia.com/nvidia
-      defaultChart: nvidia/nvsentinel
+      defaultRepository: oci://ghcr.io/nvidia
+      defaultChart: nvsentinel
       defaultVersion: v1.3.0
       defaultNamespace: nvsentinel
     nodeScheduling:


### PR DESCRIPTION
## Summary

The `nvsentinel` entry in `recipes/registry.yaml` declares a `defaultRepository` (`https://helm.ngc.nvidia.com/nvidia`) and `defaultChart` (`nvidia/nvsentinel`) that don't actually serve the chart — the HTTPS NGC index doesn't carry nvsentinel; only `oci://ghcr.io/nvidia/nvsentinel` does. This PR aligns the registry defaults with the canonical OCI source that every overlay already uses.

## Motivation / Context

Surfaced during the #715 cross-review and tracked as Phase-1 follow-up item #2 on #698. The mismatch is silent / dead-code today because every `nvsentinel`-using overlay (`base.yaml`, etc.) explicitly sets `source: oci://ghcr.io/nvidia` + chart `nvsentinel` — the registry default never resolves. But anyone relying on the registry defaults (e.g. an `aicr bundle` invocation that doesn't override the source) would hit the dead path.

The fix mirrors the same pattern the `kai-scheduler` entry uses post-#720: OCI registry path in `defaultRepository`, bare chart name in `defaultChart`.

```diff
   - name: nvsentinel
     ...
     helm:
-      defaultRepository: https://helm.ngc.nvidia.com/nvidia
-      defaultChart: nvidia/nvsentinel
+      defaultRepository: oci://ghcr.io/nvidia
+      defaultChart: nvsentinel
       defaultVersion: v1.3.0
       defaultNamespace: nvsentinel
```

### Note on other NGC HTTPS entries

`gpu-operator`, `network-operator`, `nodewright-operator`, and `nvidia-dra-driver-gpu` also use `defaultRepository: https://helm.ngc.nvidia.com/...` — those are intentionally unchanged. The HTTPS NGC index genuinely serves those charts. `nvsentinel` is the only NVIDIA-published component that ships exclusively via OCI, which is why its registry default was broken.

Fixes: nvsentinel registry-default dead path
Related: #698 (Phase-1 follow-up item #2), #715 (Phase 1), #720 (Phase 2)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — registry data only

## Implementation Notes

- 2-line registry data fix. No code, no overlays, no values.
- Matches the kai-scheduler post-#720 pattern (OCI registry + bare chart name).
- Verified the OCI URL pulls cleanly: `helm pull oci://ghcr.io/nvidia/nvsentinel --version v1.3.0` succeeds.
- End-to-end bundle generation now produces `CHART='oci://ghcr.io/nvidia/nvsentinel'` with empty `REPO` in the per-component `upstream.env` (correct OCI form).

## Testing

```bash
make lint                                      # 0 issues
go test -count=1 ./pkg/recipe/...              # ok
helm pull oci://ghcr.io/nvidia/nvsentinel \
         --version v1.3.0                      # pulls cleanly

# End-to-end bundle generation
$ aicr recipe --service eks --accelerator h100 --intent training --os ubuntu -o recipe.yaml
$ aicr bundle -r recipe.yaml -o /tmp/bundle
$ cat /tmp/bundle/*-nvsentinel/upstream.env
CHART='oci://ghcr.io/nvidia/nvsentinel'
REPO=''
VERSION='v1.3.0'
```

## Risk Assessment

- [x] **Low** — Single-file, 2-line registry data correction. The new defaults match what every overlay already uses, so re-bundled artifacts are byte-identical to today's. No code, no overlays, no values surfaces touched.

**Rollout notes:** No migration steps. The broken default is dead code today (overlays override it), so the fix has no behavior impact on existing bundles. Fresh bundles where the user doesn't override the source via overlay will now resolve correctly instead of failing.

## Checklist

- [x] Tests pass locally
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — registry data fix matching existing overlay convention)
- [x] I updated docs if user-facing behavior changed (N/A — internal data fix)
- [x] Changes follow existing patterns in the codebase (matches kai-scheduler post-#720)
- [x] Commits are cryptographically signed (`git commit -S`)