### PR TITLE
fix: AKS H100 RDMA sets network operator as dependency and fix chart values/metrics

### DIFF
--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -580,9 +580,18 @@ func mergeComponentRef(base, overlay ComponentRef) ComponentRef {
 		result.Patches = overlay.Patches
 	}
 
-	// DependencyRefs: overlay replaces if set
+	// DependencyRefs: additive merge (base + overlay, deduplicated)
 	if len(overlay.DependencyRefs) > 0 {
-		result.DependencyRefs = overlay.DependencyRefs
+		seen := make(map[string]bool)
+		for _, d := range result.DependencyRefs {
+			seen[d] = true
+		}
+		for _, d := range overlay.DependencyRefs {
+			if !seen[d] {
+				result.DependencyRefs = append(result.DependencyRefs, d)
+				seen[d] = true
+			}
+		}
 	}
 
 	// ManifestFiles: additive merge (base + overlay, deduplicated)

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -603,6 +603,7 @@ func mergeComponentRef(base, overlay ComponentRef) ComponentRef {
 		for _, f := range overlay.ManifestFiles {
 			if !seen[f] {
 				result.ManifestFiles = append(result.ManifestFiles, f)
+				seen[f] = true
 			}
 		}
 	}

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -497,6 +497,22 @@ func TestMergeComponentRef_AdvancedFields(t *testing.T) {
 		}
 	})
 
+	t.Run("manifestFiles dedup within overlay", func(t *testing.T) {
+		base := ComponentRef{
+			Name:          "test",
+			ManifestFiles: []string{"a.yaml"},
+		}
+		overlay := ComponentRef{
+			Name:          "test",
+			ManifestFiles: []string{"b.yaml", "b.yaml"},
+		}
+		result := mergeComponentRef(base, overlay)
+		want := []string{"a.yaml", "b.yaml"}
+		if !reflect.DeepEqual(result.ManifestFiles, want) {
+			t.Errorf("manifestFiles = %v, want %v", result.ManifestFiles, want)
+		}
+	})
+
 	t.Run("tag from overlay", func(t *testing.T) {
 		base := ComponentRef{Name: "test", Tag: "v1.0"}
 		overlay := ComponentRef{Name: "test", Tag: "v2.0"}

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -35,6 +35,7 @@ package recipe
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -433,7 +434,7 @@ func TestMergeComponentRef_AdvancedFields(t *testing.T) {
 		}
 	})
 
-	t.Run("dependencyRefs replaced by overlay", func(t *testing.T) {
+	t.Run("dependencyRefs additive dedup merge", func(t *testing.T) {
 		base := ComponentRef{
 			Name:           "test",
 			DependencyRefs: []string{"dep-a"},
@@ -443,8 +444,41 @@ func TestMergeComponentRef_AdvancedFields(t *testing.T) {
 			DependencyRefs: []string{"dep-b", "dep-c"},
 		}
 		result := mergeComponentRef(base, overlay)
-		if len(result.DependencyRefs) != 2 {
-			t.Errorf("dependencyRefs len = %d, want 2", len(result.DependencyRefs))
+		want := []string{"dep-a", "dep-b", "dep-c"}
+		if !reflect.DeepEqual(result.DependencyRefs, want) {
+			t.Errorf("dependencyRefs = %v, want %v", result.DependencyRefs, want)
+		}
+	})
+
+	t.Run("dependencyRefs dedup on merge", func(t *testing.T) {
+		base := ComponentRef{
+			Name:           "test",
+			DependencyRefs: []string{"dep-a", "dep-b"},
+		}
+		overlay := ComponentRef{
+			Name:           "test",
+			DependencyRefs: []string{"dep-b", "dep-c"},
+		}
+		result := mergeComponentRef(base, overlay)
+		want := []string{"dep-a", "dep-b", "dep-c"}
+		if !reflect.DeepEqual(result.DependencyRefs, want) {
+			t.Errorf("dependencyRefs = %v, want %v", result.DependencyRefs, want)
+		}
+	})
+
+	t.Run("dependencyRefs dedup within overlay", func(t *testing.T) {
+		base := ComponentRef{
+			Name:           "test",
+			DependencyRefs: []string{"dep-a"},
+		}
+		overlay := ComponentRef{
+			Name:           "test",
+			DependencyRefs: []string{"dep-b", "dep-b"},
+		}
+		result := mergeComponentRef(base, overlay)
+		want := []string{"dep-a", "dep-b"}
+		if !reflect.DeepEqual(result.DependencyRefs, want) {
+			t.Errorf("dependencyRefs = %v, want %v", result.DependencyRefs, want)
 		}
 	})
 

--- a/recipes/components/gpu-operator/manifests/dcgm-exporter.yaml
+++ b/recipes/components/gpu-operator/manifests/dcgm-exporter.yaml
@@ -83,7 +83,6 @@ data:
     DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
 
     # BCP Additional metrics
-    DCGM_FI_DEV_CLOCK_THROTTLE_REASONS, gauge, Current clock throttle reasons (bitmask of DCGM_CLOCKS_THROTTLE_REASON_*)
     DCGM_FI_DEV_GPU_NVLINK_ERRORS,      gauge, Identifies a GPU NVLink error type returned by DCGM_FI_DEV_GPU_NVLINK_ERRORS.
 
     # Added RunAI Additional metrics https://docs.run.ai/latest/developer/metrics/metrics-api/#advanced-metrics

--- a/recipes/components/gpu-operator/values-aks.yaml
+++ b/recipes/components/gpu-operator/values-aks.yaml
@@ -15,29 +15,12 @@
 # GPU Operator Helm values
 # AKS base configuration overrides
 #
-# AKS pre-installs NVIDIA container toolkit on GPU VMs.
-# Disable toolkit installation to avoid conflicts.
-#
 # By default, GPU Operator manages the NVIDIA driver. Create nodepools
 # with `--gpu-driver none` to prevent AKS from also installing drivers.
 # To use the AKS-managed driver instead, set driver.enabled to false.
 # See https://learn.microsoft.com/en-us/azure/aks/nvidia-gpu-operator
 #
 # Reference: https://github.com/Azure/aks-rdma-infiniband/blob/main/configs/values/gpu-operator/values.yaml
-# TODO: Evaluate full alignment with aks-rdma-infiniband setup scripts
-#       (tests/setup-infra/deploy-aks.sh) and fold remaining automation into recipe.
-
-# AKS pre-installs NVIDIA container toolkit; disable to avoid conflicts.
-toolkit:
-  enabled: false
-
-driver:
-  rdma:
-    # Use MOFED installed by network-operator instead of building nvidia-peermem
-    # from source. Required for GPUDirect RDMA on AKS ND-series.
-    # Set to false when disabling network-operator (no host MOFED present):
-    #   --set gpuoperator:driver.rdma.useHostMofed=false
-    useHostMofed: true
 
 # NFD is deployed as a standalone shared component from the base recipe.
 # Both network-operator and gpu-operator disable their sub-chart copies


### PR DESCRIPTION
## Summary

Three fixes for AKS H100 RDMA recipe deployment discovered while testing the changes from #700 on a fresh ND-H100 cluster.

### 1. dependencyRefs overlay merge loses ancestor dependencies

mergeComponentRef() used full-replace semantics for dependencyRefs — if an overlay set them, the base's deps were dropped entirely. This was boilerplate copied from the scalar fields in the same function
(Version, Repository, Chart, etc.) where "overlay replaces if set" is correct. But dependencyRefs is accumulative by nature: each layer in the overlay chain adds deployment-ordering constraints, it doesn't
redefine them from scratch. The bug was never caught because until #700 no overlay chain had two layers setting dependencyRefs on the same component.

With #700, the overlay chain base → aks → h100-aks-inference triggers the bug:
- aks.yaml sets gpu-operator's dependencyRefs: [network-operator]
- h100-aks-inference.yaml sets dependencyRefs: [nfd, cert-manager, kube-prometheus-stack]
- The leaf overlay's deps replace the parent's, dropping network-operator

Without network-operator as a dependency, TopologicalSort places gpu-operator and network-operator in the same tier, and alphabetically gpu-operator installs first. But gpu-operator has rdma.enabled: true
in base values, so its driver-manager init container polls "Waiting for MOFED to be installed" — and MOFED comes from network-operator, which hasn't been installed yet. Deadlock.

Changed to additive-dedup merge so ancestor deps are preserved. This matches the semantics already used for manifestFiles in the same function.

### 2. AKS gpu-operator values misaligned with upstream

Removed `toolkit.enabled: false` and `driver.rdma.useHostMofed: true` from `values-aks.yaml`. The [upstream aks-rdma-infiniband reference](https://github.com/Azure/aks-rdma-infiniband/blob/main/configs/values/gpu-operator/values.yaml) does not set either:

- `toolkit.enabled: false` broke the gpu-operator validation chain — all pods wait for `/run/nvidia/validations/toolkit-ready` which only the toolkit daemonset creates
- `useHostMofed: true` is unnecessary — `rdma.enabled: true` (set in base values) is sufficient for peermem to build against MOFED

### 3. dcgm-exporter crash on DCGM 4.x+

Removed `DCGM_FI_DEV_CLOCK_THROTTLE_REASONS` from the metrics ConfigMap. This field was renamed to `DCGM_FI_DEV_CLOCKS_EVENT_REASONS` in DCGM 4.0.0 ([v3.3.9 definition](https://github.com/NVIDIA/DCGM/blob/v3.3.9/dcgmlib/dcgm_fields.h) vs [v4.0.0 definition](https://github.com/NVIDIA/DCGM/blob/v4.0.0/dcgmlib/dcgm_fields.h)). The old name only survives as a [deprecated C preprocessor alias](https://github.com/NVIDIA/DCGM/blob/v4.0.0/dcgmlib/dcgm_fields.h) (`#define DCGM_FI_DEV_CLOCK_THROTTLE_REASONS DCGM_FI_DEV_CLOCKS_EVENT_REASONS`), but dcgm-exporter resolves CSV field names at runtime through the DCGM API string lookup — not through C macros — so the old name is unrecognized and causes a CrashLoopBackOff.

GPU Operator v25.10.1 ships DCGM 4.5.x, making this crash reproducible on every recipe deployed to real GPU hardware. The upstream [default-counters.csv](https://github.com/NVIDIA/dcgm-exporter/blob/main/etc/default-counters.csv) does not include either name, which is why deployments using the chart's built-in config are unaffected.

## Motivation / Context

PR #700 added AKS H100 Dynamo recipes, but deploying them on a fresh cluster revealed three bugs that deadlock or crash the install.

Fixes: N/A
Related: #700

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `recipes/components/gpu-operator/`

## Implementation Notes

## Testing

```bash
make test
make lint
```

Verified end-to-end on a fresh AKS ND-H100 cluster (h100-san):
- All 83 pods Running/Completed
- 8 IB links ACTIVE/LINK_UP
- nvidia-peermem module loaded
- dcgm-exporter serving metrics
- gpu-operator validation chain passing

Also verified the dependency fix is required even without `useHostMofed` — reverting the merge fix on a clean cluster deadlocks gpu-operator at "Waiting for MOFED to be installed" while network-operator is unreachable at a later deploy step.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — fixes existing broken behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)