### PR TITLE
fix(ci): harden Fern docs CI and configure custom domain

### DIFF
--- a/.github/workflows/fern-docs-ci.yaml
+++ b/.github/workflows/fern-docs-ci.yaml
@@ -48,7 +48,7 @@ jobs:
         # Intentionally inline — a composite action would add indirection without benefit for a single grep.
         # Single-line grep is intentional — multiline <img> tags do not occur in practice in markdown docs.
         run: |
-          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
+          BAD=$(grep -rn '<img\b[^>]*[^/]>\|<img>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
           if [ -n "$BAD" ]; then
             echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
             echo "$BAD"

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -24,11 +24,6 @@ name: Publish Fern Docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'fern/**'
     tags:
       - 'docs/v*'
   workflow_dispatch: {}
@@ -60,9 +55,9 @@ jobs:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
         working-directory: ./fern
         run: |
-          OUTPUT=$(fern generate --docs 2>&1)
-          echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          set -o pipefail
+          fern generate --docs 2>&1 | tee /tmp/fern-output.log
+          URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
           if [ -n "$URL" ]; then
             echo "### Published: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,8 +14,12 @@
 
 instances:
   - url: https://aicr.docs.buildwithfern.com/aicr
+    custom-domain: docs.nvidia.com/aicr
 
 title: NVIDIA AI Cluster Runtime
+
+metadata:
+  canonical-host: "docs.nvidia.com/aicr"
 
 footer: ./components/CustomFooter.tsx
 


### PR DESCRIPTION
## Summary

Harden the Fern docs CI workflows and configure the production custom domain.

Fixes #756

## Motivation / Context

The bare `<img>` regex gap was found during nvcf-mono CI review (Greptile caught it). The `OUTPUT=$(...)` publish pattern swallows fern error output on failure. Publishing on every main merge is inconsistent with tag-based release workflow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Bare `<img>` tag (no attributes) escaped the `[^/]>` regex. Added `\|<img>` alternation.
- Switched publish from `OUTPUT=$(fern generate --docs 2>&1)` to `tee` pattern for error visibility.
- Restricted publish trigger to `docs/v*` tag push only. To publish: `git tag docs/v1.2.0 && git push origin docs/v1.2.0`
- Added `custom-domain: docs.nvidia.com/aicr` and `canonical-host` metadata.

## Testing

```bash
fern check  # 0 errors
```

## Risk Assessment

- [x] **Low** — CI-only changes plus Fern config additions

## Checklist

- [x] Commits are cryptographically signed
- [x] Changes follow existing patterns in the codebase