### PR TITLE
feat(recipes): pin nfd and k8s-ephemeral-storage-metrics chart versions

### DIFF
--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -50,6 +50,7 @@ components:
     helm:
       defaultRepository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
       defaultChart: node-feature-discovery
+      defaultVersion: "0.18.3"
       defaultNamespace: node-feature-discovery
     nodeScheduling:
       system:
@@ -356,6 +357,7 @@ components:
     helm:
       defaultRepository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
       defaultChart: k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics
+      defaultVersion: "1.19.2"
       defaultNamespace: monitoring
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary

First pass of #749 (Phase A). Pins chart versions for the two external helm components, where no policy decision under #742 is needed.

## Motivation / Context

Today these two charts have no `defaultVersion` in `recipes/registry.yaml`, so renders track upstream-latest non-deterministically — same recipe rendered today vs. next month can produce different image sets. Pinning closes that gap for the unblocked subset.

NVIDIA-owned charts (`gpu-operator`, `network-operator`, `nvidia-dra-driver-gpu`, `nodewright-operator`) remain unpinned pending the policy decision in #742 and will land in a follow-up Phase B.

Fixes: (none) — partial progress on #749
Related: #739, #742

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`recipes/registry.yaml`)

## Implementation Notes

Versions chosen are the current upstream stable releases (`helm search repo --versions`):

- `node-feature-discovery`: **0.18.3**
- `k8s-ephemeral-storage-metrics`: **1.19.2**

Verified that our existing `values.yaml` shapes still render cleanly against the pinned versions (no value-key drift). The resulting image sets are unchanged — 1 image per component, matching pre-pin output.

`make bom` after the change:
```
| k8s-ephemeral-storage-metrics | helm | k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics | 1.19.2 | 1 |
| nfd | helm | node-feature-discovery | 0.18.3 | 1 |
```

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed
```

`make bom` produces the same 71-image inventory across 22 components — pinning these two doesn't change the deployed image set, just locks in determinism.

## Risk Assessment

- [x] **Low** — Two-line change to `recipes/registry.yaml`. Both versions verified to render against existing values. No image-set delta. Easy to revert if a downstream regression surfaces.

**Rollout notes:** none.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (no new code paths; behavior verified via `make bom`)
- [x] I updated docs if user-facing behavior changed (n/a)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)