### PR TITLE
docs(bom): wrap auto-generated image inventory with hand-written prose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,19 +255,31 @@ bom: ## Generates container image BOM (CycloneDX 1.6 + Markdown) at $(BOM_OUT_DI
 BOM_DOC_PATH := docs/user/container-images.md
 
 .PHONY: bom-docs
-bom-docs: ## Regenerates $(BOM_DOC_PATH) from the live registry (renders all helm charts; needs network)
+bom-docs: ## Regenerates the auto-generated section of $(BOM_DOC_PATH) from the live registry
 	@set -e; \
+	if [ ! -f $(BOM_DOC_PATH) ]; then \
+	   echo "ERROR: $(BOM_DOC_PATH) does not exist; cannot splice." >&2; exit 1; \
+	fi; \
+	if ! grep -q '<!-- BEGIN AICR-BOM -->' $(BOM_DOC_PATH) || \
+	   ! grep -q '<!-- END AICR-BOM -->' $(BOM_DOC_PATH); then \
+	   echo "ERROR: $(BOM_DOC_PATH) is missing AICR-BOM markers." >&2; exit 1; \
+	fi; \
 	TMP="$$(mktemp -d)"; \
 	trap 'rm -rf "$$TMP"' EXIT; \
-	echo "Regenerating $(BOM_DOC_PATH) (helm rendering, this can take ~30s)..."; \
+	echo "Regenerating auto-generated section of $(BOM_DOC_PATH) (helm rendering, ~30s)..."; \
 	GOFLAGS="-mod=vendor" go run ./tools/bom \
 	  -repo-root "$(CURDIR)" \
 	  -out-dir "$$TMP" \
 	  -aicr-version "main" \
-	  -deterministic; \
-	mkdir -p "$$(dirname $(BOM_DOC_PATH))"; \
-	mv "$$TMP/bom.md" $(BOM_DOC_PATH); \
-	echo "Wrote $(BOM_DOC_PATH)"
+	  -deterministic \
+	  -no-title; \
+	awk -v body="$$TMP/bom.md" ' \
+	  /<!-- BEGIN AICR-BOM -->/ { print; while ((getline line < body) > 0) print line; close(body); skip = 1; next } \
+	  /<!-- END AICR-BOM -->/   { skip = 0 } \
+	  !skip                     { print } \
+	' $(BOM_DOC_PATH) > "$$TMP/merged.md"; \
+	mv "$$TMP/merged.md" $(BOM_DOC_PATH); \
+	echo "Updated $(BOM_DOC_PATH) (prose preserved, auto-generated section refreshed)"
 
 .PHONY: bom-check
 bom-check: ## Verifies $(BOM_DOC_PATH) is up to date with the live registry (CI gate, opt-in locally)

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -1,5 +1,22 @@
-# NVIDIA AI Cluster Runtime — Container Image Inventory
+<!--
+Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Container Image Inventory
+
+This page lists every container image AICR can deploy across all registered components. It is the canonical reference for security review, air-gap planning, and any other workflow that needs to know "what does AICR pull onto my cluster."
+
+The image set below is regenerated from the live Helm chart catalog and the embedded manifests under `recipes/components/*/manifests/`. The auto-generated section is refreshed weekly by the [`bom-refresh`](https://github.com/NVIDIA/aicr/actions/workflows/bom-refresh.yaml) GitHub Action, which opens a chore PR whenever upstream chart rerenders cause drift. Contributors changing recipes are expected to regenerate locally with `make bom-docs` and commit the result alongside their change.
+
+A machine-readable **CycloneDX 1.6 JSON** companion to this page is produced by `make bom` and published as a release asset. Tooling that consumes SBOMs (Trivy, Grype, Cosign attestation, in-toto) should prefer the JSON; this Markdown is the human-readable view.
+
+<!-- BEGIN AICR-BOM -->
 ## Summary
 
 - Components: **22**
@@ -174,3 +191,55 @@ _No images extracted._
 
 - `registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0`
 
+<!-- END AICR-BOM -->
+
+## How to read this list
+
+### Explicit vs. implicit images
+
+AICR pins some images directly in this repository — in `recipes/components/<name>/values.yaml` or in embedded Kubernetes manifests under `recipes/components/<name>/manifests/`. Those are the **explicit** images. Everything else comes from upstream Helm charts that AICR consumes without overriding their image references; those are the **implicit** images. The per-component image counts in the table above reflect the union of both.
+
+The trade-off is intentional. Pinning an image gives reproducibility; deferring to the upstream chart lets security patches flow without an AICR release. The split is policy, not oversight — see the [supply chain epic](https://github.com/NVIDIA/aicr/issues/739) for how each component's policy is being made explicit.
+
+### Registries spanned
+
+AICR pulls from a deliberately diverse set of registries:
+
+- **`nvcr.io`** — NVIDIA's primary container registry; GPU Operator, Network Operator, DRA driver, NIM Operator, Dynamo Platform.
+- **`ghcr.io`** — GitHub Container Registry; nvsentinel, nodewright, kai-scheduler, grove, kubeflow-trainer, k8s-ephemeral-storage-metrics.
+- **`quay.io`** — cert-manager and Prometheus components.
+- **`registry.k8s.io`** — Kubernetes SIG components (NFD, prometheus-adapter, kueue, csi-sidecars).
+- **`public.ecr.aws`** — AWS public artifacts (aws-ebs-csi-driver).
+- **Regional ECR** (`*.dkr.ecr.<region>.amazonaws.com`) — EKS-internal add-ons (aws-efa).
+- **`gcr.io`, `gke.gcr.io`, `us-docker.pkg.dev`** — GCP/GKE add-ons (gke-nccl-tcpxo).
+- **`cr.kgateway.dev`** — kgateway.
+- **`docker.io`** — assorted upstream images (`busybox`, `pytorch`, etc.).
+
+Customers running in air-gapped or private-registry environments need to mirror every registry above. A dedicated mirroring guide is tracked under [#743](https://github.com/NVIDIA/aicr/issues/743).
+
+### Reproducibility
+
+Two recipes rendered at the same chart version against the same registry should produce the same image set. Where charts are not yet pinned to a specific version, the upstream default determines the deployed images and the set can drift between renders — that's the drift the weekly refresh action surfaces. Tracking fully-deterministic deployments (chart-version pins, then digest pins for explicit refs) is the second stage of the [supply chain epic](https://github.com/NVIDIA/aicr/issues/739); progress is tracked under issues [#740](https://github.com/NVIDIA/aicr/issues/740), [#748](https://github.com/NVIDIA/aicr/issues/748), and [#749](https://github.com/NVIDIA/aicr/issues/749).
+
+For chart-default sub-images that AICR cannot pin in-tree (e.g., the GPU Operator's ~15 sub-images, where the chart does not expose digest fields), the right answer is admission-time digest verification rather than per-image overrides — see [#745](https://github.com/NVIDIA/aicr/issues/745).
+
+## Regenerating locally
+
+```bash
+# Full BOM (CycloneDX JSON + Markdown) into dist/bom/
+make bom
+
+# Just regenerate this doc page from the live registry
+make bom-docs
+
+# Verify the committed page is in sync with the live registry
+make bom-check
+```
+
+Both targets shell out to `helm template` for every chart, so an internet connection is required.
+
+## Related
+
+- [Component Catalog](component-catalog.md) — what each component does and its scheduling characteristics.
+- [Supply chain epic](https://github.com/NVIDIA/aicr/issues/739) — visibility, reproducibility, and provenance roadmap.
+- [Air-gap mirroring guide](https://github.com/NVIDIA/aicr/issues/743) — planned follow-up.

--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -44,6 +44,12 @@ type Metadata struct {
 	// <version>_" line is omitted). Use for committed doc artifacts and
 	// any other bit-for-bit reproducible output path.
 	Deterministic bool
+
+	// NoTitle suppresses the H1 title line in WriteMarkdown so the body
+	// can be embedded as a section of a larger document (e.g., the
+	// auto-generated middle of docs/user/container-images.md, where the
+	// title and surrounding prose are hand-edited).
+	NoTitle bool
 }
 
 // ComponentResult is the per-component image survey input to BuildBOM.

--- a/pkg/bom/bom_test.go
+++ b/pkg/bom/bom_test.go
@@ -153,6 +153,25 @@ func TestWriteMarkdown(t *testing.T) {
 	}
 }
 
+func TestWriteMarkdown_NoTitleSuppressesH1(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteMarkdown(&buf, Metadata{
+		Name:    "aicr",
+		Version: "v0.13.0",
+		NoTitle: true,
+	}, sampleResults())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if strings.HasPrefix(out, "# ") {
+		t.Errorf("NoTitle output should not start with H1, got:\n%s", out[:80])
+	}
+	if !strings.Contains(out, "## Summary") {
+		t.Errorf("NoTitle output should still contain the body sections")
+	}
+}
+
 func TestWriteMarkdown_DeterministicSuppressesGenerationLine(t *testing.T) {
 	var buf bytes.Buffer
 	err := WriteMarkdown(&buf, Metadata{

--- a/pkg/bom/markdown.go
+++ b/pkg/bom/markdown.go
@@ -47,8 +47,10 @@ func WriteMarkdown(w io.Writer, meta Metadata, results []ComponentResult) error 
 		}
 	}
 
-	if _, err := fmt.Fprintf(w, "# %s — Container Image Inventory\n\n", titleFor(meta)); err != nil {
-		return err
+	if !meta.NoTitle {
+		if _, err := fmt.Fprintf(w, "# %s — Container Image Inventory\n\n", titleFor(meta)); err != nil {
+			return err
+		}
 	}
 	if !meta.Deterministic {
 		if _, err := fmt.Fprintf(w, "_Generated %s for %s %s._\n\n",

--- a/tools/bom/main.go
+++ b/tools/bom/main.go
@@ -52,6 +52,7 @@ func main() {
 		skipHelm      bool
 		strict        bool
 		deterministic bool
+		noTitle       bool
 	)
 	flag.StringVar(&repoRoot, "repo-root", ".", "path to the AICR repository root")
 	flag.StringVar(&outDir, "out-dir", "dist/bom", "directory to write bom.cdx.json and bom.md")
@@ -59,15 +60,16 @@ func main() {
 	flag.BoolVar(&skipHelm, "skip-helm", false, "skip helm template rendering (only walk embedded manifests)")
 	flag.BoolVar(&strict, "strict", false, "fail if any component fails to render or is missing a pinned chart version")
 	flag.BoolVar(&deterministic, "deterministic", false, "suppress per-run metadata (timestamps, version churn) in the Markdown output for committable artifacts")
+	flag.BoolVar(&noTitle, "no-title", false, "omit the H1 title in the Markdown output so the body can be embedded as a section of a larger document")
 	flag.Parse()
 
-	if err := run(repoRoot, outDir, aicrVersion, skipHelm, strict, deterministic); err != nil {
+	if err := run(repoRoot, outDir, aicrVersion, skipHelm, strict, deterministic, noTitle); err != nil {
 		fmt.Fprintln(os.Stderr, "bom:", err)
 		os.Exit(1)
 	}
 }
 
-func run(repoRoot, outDir, aicrVersion string, skipHelm, strict, deterministic bool) error {
+func run(repoRoot, outDir, aicrVersion string, skipHelm, strict, deterministic, noTitle bool) error {
 	registryPath := filepath.Join(repoRoot, "recipes", "registry.yaml")
 	reg, err := loadRegistry(registryPath)
 	if err != nil {
@@ -137,6 +139,7 @@ func run(repoRoot, outDir, aicrVersion string, skipHelm, strict, deterministic b
 		Version:       aicrVersion,
 		Description:   "NVIDIA AI Cluster Runtime",
 		Deterministic: deterministic,
+		NoTitle:       noTitle,
 	}, results)
 	closeErr = mf.Close()
 	if mdErr != nil {


### PR DESCRIPTION
## Summary

Closes the second half of #741 (1b — content/prose). The first half landed via #763 (tooling, deterministic output, scheduled refresh); this PR adds the explanation around the auto-generated table that customers need to interpret it.

Refs #739, #741. Filed alongside as a follow-up: #765 (gpu-operator BOM extracts a bare `vgpu-manager` ref — surfaced by publishing the doc, scoped out of this PR).

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs (`docs/user/container-images.md`)
- [x] Build/tooling (`Makefile` — `bom-docs` splice logic)
- [x] Core libraries (`pkg/bom` — `NoTitle` flag)

## Implementation Notes

**Doc structure.** `docs/user/container-images.md` is now wrapped:

```
[hand-written intro: page purpose, refresh cadence, JSON companion]

<!-- BEGIN AICR-BOM -->
[auto-generated body: summary, components table, per-component image lists]
<!-- END AICR-BOM -->

[hand-written outro: explicit-vs-implicit, registry rationale,
 reproducibility caveat, regeneration instructions, related links]
```

**`make bom-docs` splices instead of overwriting.** The target now:

1. Requires the doc and its markers to exist (errors clearly otherwise).
2. Runs the BOM tool with `-no-title` to a temp dir.
3. Uses `awk` to replace content between `<!-- BEGIN AICR-BOM -->` and `<!-- END AICR-BOM -->` with the fresh body, preserving everything outside.

Verified idempotent: two consecutive `make bom-docs` runs produce identical md5.

**`pkg/bom` API addition.** `Metadata.NoTitle bool` opt-in flag (off by default) that suppresses the H1 line so the body can be embedded as a section of a larger document. The same pattern will be useful for the planned per-bundle SBOM in `pkg/bundler` (#750).

**Numbering note.** I'd drifted from the actual issue numbering in earlier work; cross-references in this PR's commit message, the doc itself, and the freshly-corrected #739 epic body now consistently use:

| # | Title |
|---|-------|
| 739 | Supply chain epic |
| 740 | Pinning policy decision |
| 741 | Document image inventory (this PR closes 1b) |
| 742 | BOM tool (delivered via #747) |
| 743 | Air-gap mirroring guide |
| 744 | Untagged refs (delivered via #761) |
| 745 | Provenance audit |
| 748 | Pin chart versions (Phase A delivered via #758) |
| 749 | Digest-pin explicit refs |

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed
```

Idempotency check:

```bash
$ md5sum docs/user/container-images.md
c937c78eb0966f884b8f127a6287c826  docs/user/container-images.md

$ make bom-docs
Updated docs/user/container-images.md (prose preserved, auto-generated section refreshed)

$ md5sum docs/user/container-images.md
c937c78eb0966f884b8f127a6287c826  docs/user/container-images.md
```

`pkg/bom` coverage held with new `TestWriteMarkdown_NoTitleSuppressesH1`.

## Risk Assessment

- [x] **Low** — Doc-only change for the prose; new `NoTitle` flag is opt-in and defaults off (no behavior change for existing callers); `make bom-docs` is now safer (errors on missing markers instead of clobbering prose). Easy to revert.

**Rollout notes:** Future contributors who edit recipes need to run `make bom-docs` to refresh the auto-generated section; the splice preserves their prose untouched. The weekly refresh action keeps the same behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (the doc page itself is what's changing)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)