### PR TITLE
fix(recipes): document aws-efa regional ECR override pattern

### DIFF
--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -488,6 +488,44 @@ aicr --debug recipe --service eks --data ./my-data --dry-run
 aicr recipe --service eks --data ./my-data --output /dev/stdout
 ```
 
+### Regional registry overrides
+
+A handful of components ship images from regional, account-scoped container registries rather than a single public URI. The clearest example today is the AWS EFA device plugin, whose canonical home is `<account>.dkr.ecr.<region>.amazonaws.com/eks/aws-efa-k8s-device-plugin` — a per-region private ECR that every EKS node is auto-authorized to pull from. AWS publishes these add-ons regionally for three reasons: pulls go over the AWS internal backbone (no NAT egress), no Docker Hub / public-registry rate limits, and the image stays available even when the public internet or another region is degraded.
+
+AICR ships a sensible default for each such image (e.g., us-west-2 for `aws-efa`), but customers deploying in a different region need to override the registry's region segment. Two override paths cover the common cases:
+
+**Bundle-time override (single region per bundle).** Use `--set` to bake a specific region into the bundle:
+
+```bash
+aicr bundle --recipe recipe.yaml \
+  --set awsefa:image.repository=602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/aws-efa-k8s-device-plugin \
+  -o ./bundle
+```
+
+**Install-time override (one bundle, many regions).** Use `--dynamic` to declare the path as install-time-fillable, then provide the value via `helm install --set` (or your GitOps tool):
+
+```bash
+aicr bundle --recipe recipe.yaml \
+  --dynamic awsefa:image.repository \
+  --deployer helm \
+  -o ./bundle
+
+# Per-cluster install
+helm install ... --set image.repository=602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/aws-efa-k8s-device-plugin
+```
+
+`--dynamic` is supported with `helm` and `argocd-helm` deployers; `argocd` does not support it (use `argocd-helm` instead). See [Dynamic Install-Time Values](../user/cli-reference.md#dynamic-install-time-values) for the broader pattern.
+
+**Partition-aware variants.** Standard AWS uses account ID `602401143452`. GovCloud and China use different accounts and URI suffixes:
+
+| Partition | Account ID | URI shape |
+|-----------|------------|-----------|
+| `aws` (standard) | `602401143452` | `<account>.dkr.ecr.<region>.amazonaws.com` |
+| `aws-us-gov` (GovCloud) | `013241004608` | `<account>.dkr.ecr.<region>.amazonaws.com` |
+| `aws-cn` (China) | `961992271922` | `<account>.dkr.ecr.<region>.amazonaws.com.cn` |
+
+Substitute the appropriate account and suffix in the `--set` / install-time value.
+
 ## Troubleshooting
 
 **Debug overlay matching:**

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -210,7 +210,7 @@ AICR pulls from a deliberately diverse set of registries:
 - **`quay.io`** — cert-manager and Prometheus components.
 - **`registry.k8s.io`** — Kubernetes SIG components (NFD, prometheus-adapter, kueue, csi-sidecars).
 - **`public.ecr.aws`** — AWS public artifacts (aws-ebs-csi-driver).
-- **Regional ECR** (`*.dkr.ecr.<region>.amazonaws.com`) — EKS-internal add-ons (aws-efa).
+- **Regional ECR** (`<account>.dkr.ecr.<region>.amazonaws.com`) — EKS-internal add-ons. The `aws-efa` entry below shows `us-west-2` because that is the in-tree default; deployments in other regions override `awsefa:image.repository` at bundle or install time. See [Regional registry overrides](../integrator/recipe-development.md#regional-registry-overrides) for the pattern.
 - **`gcr.io`, `gke.gcr.io`, `us-docker.pkg.dev`** — GCP/GKE add-ons (gke-nccl-tcpxo).
 - **`cr.kgateway.dev`** — kgateway.
 - **`docker.io`** — assorted upstream images (`busybox`, `pytorch`, etc.).

--- a/recipes/components/aws-efa/values.yaml
+++ b/recipes/components/aws-efa/values.yaml
@@ -14,6 +14,28 @@
 
 # AWS EFA Device Plugin Helm values
 # Base configuration for EFA-enabled EKS clusters
+#
+# Regional ECR. AWS publishes EKS add-ons (EFA plugin, VPC CNI, kube-proxy)
+# to per-region private ECR repositories that EKS nodes are auto-authorized
+# to pull from. The default below points at us-west-2; deploying in any other
+# region requires overriding the registry's region segment.
+#
+# Account ID 602401143452 is stable across all standard AWS partitions.
+# GovCloud and China use different account IDs and URI suffixes:
+#   aws-us-gov: 013241004608.dkr.ecr.<region>.amazonaws.com
+#   aws-cn:     961992271922.dkr.ecr.<region>.amazonaws.com.cn
+#
+# Override the registry at bundle time:
+#   aicr bundle ... \
+#     --set awsefa:image.repository=602401143452.dkr.ecr.<region>.amazonaws.com/eks/aws-efa-k8s-device-plugin
+#
+# Or defer the choice to install time so a single bundle deploys to multiple
+# regions:
+#   aicr bundle ... --dynamic awsefa:image.repository
+#   helm install ... --set image.repository=...
+#
+# See docs/integrator/recipe-development.md (Regional registry overrides) for
+# the full pattern and partition-aware variants. Tracked under #764 / #739.
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin


### PR DESCRIPTION
## Summary

Closes #764. Non-breaking: `us-west-2` stays as the in-tree default; this PR adds the documentation and override paths needed for non-us-west-2 deployments via AICR's existing `--set` / `--dynamic` mechanisms.

## Motivation / Context

`recipes/components/aws-efa/values.yaml` pins the EFA device plugin image to `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin`. AWS publishes EKS add-ons regionally — every EKS cluster pulls from its own region's private ECR over the AWS internal backbone. Customers in any region other than us-west-2 today either pay cross-region NAT egress to pull from us-west-2 or fail entirely if cross-region access is blocked.

Fixes #764. Refs #739.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe data (`recipes/components/aws-efa/values.yaml` — comment only)
- [x] Docs (`docs/integrator/recipe-development.md`, `docs/user/container-images.md`)

## Implementation Notes

**Why documentation rather than templating.** AICR's bundler doesn't process Go templates on base values files today — the override mechanisms are `--set` (bake-in at bundle time) and `--dynamic` (placeholder for install-time fill). The original issue's draft fix proposed `{{ .region }}` syntax in `values.yaml`; verifying the bundler showed that wouldn't actually work. Adding template processing on base values is a feature change with broader scope. The pragmatic fix uses the existing mechanisms.

**Comment block in values.yaml** explains the regional pattern and shows both override paths plus partition-aware account IDs (standard / GovCloud / China).

**Recipe-development doc** gets a new *Regional registry overrides* section under Advanced Topics with worked examples for both `--set` (single-region bundle) and `--dynamic` (one bundle, many regions) plus the partition table.

**BOM doc prose** flags the regional caveat in the *Registries spanned* section so a reader can immediately tell the `us-west-2` host shown in the auto-generated table is overridable.

**Auto-generated BOM table is byte-identical** because in-tree defaults didn't change. Verified via md5 round-trip on `make bom-docs`.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed

md5sum docs/user/container-images.md
# d600e5b7a16444b0b9866eb5a1a0f9c0  docs/user/container-images.md

make bom-docs
# Updated docs/user/container-images.md (prose preserved, auto-generated section refreshed)

md5sum docs/user/container-images.md
# d600e5b7a16444b0b9866eb5a1a0f9c0  docs/user/container-images.md
```

## Risk Assessment

- [x] **Low** — Pure docs / comment change. No code paths touched. Default image URI unchanged. Easy to revert.

**Rollout notes:** Existing bundles produced without an override behave identically. New deployments outside us-west-2 should follow the new doc section.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (n/a — docs/comment-only)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)