### PR TITLE
feat(recipes): pin chart versions for NVIDIA-owned components (#748 Phase B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ generate: ## Runs go generate for code generation
 	@echo "Code generation completed"
 
 .PHONY: lint
-lint: lint-go lint-yaml license check-agents-sync check-docs-sidebar ## Lints the entire project (Go, YAML, and license headers)
+lint: lint-go lint-yaml license check-agents-sync check-docs-sidebar bom-pinning-check ## Lints the entire project (Go, YAML, license headers, and chart-version pins)
 	@echo "Completed Go and YAML lints and ensured license headers"
 
 # Standalone target — NOT part of `make lint` because it requires Docker
@@ -291,6 +291,19 @@ bom-check: ## Verifies $(BOM_DOC_PATH) is up to date with the live registry (CI 
 	   exit 1; \
 	fi; \
 	echo "$(BOM_DOC_PATH) is up to date"
+
+.PHONY: bom-pinning-check
+bom-pinning-check: ## Verifies every Helm component in the registry has a pinned chart version (per ADR-006)
+	@set -e; \
+	echo "Verifying chart-version pins (ADR-006)..."; \
+	TMP="$$(mktemp -d)"; \
+	trap 'rm -rf "$$TMP"' EXIT; \
+	GOFLAGS="-mod=vendor" go run ./tools/bom \
+	  -repo-root "$(CURDIR)" \
+	  -out-dir "$$TMP" \
+	  -aicr-version "qualify" \
+	  -strict \
+	  -skip-helm
 
 .PHONY: server
 server: ## Starts a local development server with debug logging

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,53 @@ AICR (AICR) provides supply chain security artifacts for all container images:
 - **SBOM Attestation**: Complete inventory of packages, libraries, and components in SPDX format
 - **SLSA Build Provenance**: Verifiable build information (how and where images were created)
 
+### Deployed Image Inventory and Pinning Policy
+
+Beyond AICR's own runtime images, every cluster deployed by AICR pulls a set
+of upstream container images selected by the recipe and the Helm charts it
+references. The complete list — chart-by-chart and image-by-image — is
+published as a versioned doc artifact and refreshed weekly as upstream
+charts evolve:
+
+- [`docs/user/container-images.md`](docs/user/container-images.md) — human
+  readable summary of every component, chart, and image AICR can deploy.
+- A machine-readable [CycloneDX 1.6][cyclonedx] BOM is produced by `make
+  bom` and published as a release asset. Tooling that consumes SBOMs
+  (Trivy, Grype, Cosign attestation, in-toto) should prefer the JSON; the
+  Markdown is its companion.
+
+**Pinning policy** ([ADR-006][adr-006]) defines AICR's three-layer
+contract:
+
+1. **Chart versions** are pinned for every Helm component, with no
+   exceptions. `recipes/registry.yaml` MUST declare `defaultVersion`;
+   `make bom BOM_STRICT=1` enforces this in CI.
+2. **Explicit image overrides** that AICR pins in-tree (in
+   `recipes/components/<name>/values.yaml` or embedded manifests) carry
+   `@sha256:` digests in addition to tags. Renovate handles digest
+   rotation as upstream rebuilds the same tag.
+3. **Chart-default sub-images** (the ones the upstream chart pulls
+   without AICR overriding) ship at whatever the chart resolves at the
+   pinned chart version. Reproducibility for these images is delivered by
+   admission-time digest verification rather than per-sub-image overrides
+   (see the [supply-chain epic][epic-739] for the roadmap).
+
+**Upstream attestation coverage.** AICR's own runtime images and the
+[NVSentinel][nvsentinel] images deployed by AICR ship with full
+keyless cosign signatures, SLSA build provenance, and SBOM attestations
+verifiable from the public Sigstore Rekor transparency log. Other
+NVIDIA-owned images that AICR deploys today (gpu-operator,
+network-operator, k8s-dra-driver-gpu, nodewright/skyhook) ship legacy
+key-based cosign signatures but do not yet ship keyless signatures,
+SLSA provenance, or SBOM attestations. Issues requesting parity have
+been filed with each upstream and are tracked under the
+[supply-chain epic][epic-739] (Stage 3).
+
+[cyclonedx]: https://cyclonedx.org/specification/overview/
+[adr-006]: docs/design/006-image-pinning-policy.md
+[epic-739]: https://github.com/NVIDIA/aicr/issues/739
+[nvsentinel]: https://github.com/NVIDIA/nvsentinel
+
 ### Container Image Attestations
 
 All container images published from tagged releases include **multiple layers of attestations**, providing comprehensive supply chain security:

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -34,7 +34,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.kgateway.dev`, `
 | cert-manager | helm | jetstack/cert-manager | v1.20.2 | 4 |
 | dynamo-platform | helm | dynamo-platform | 1.0.2 | 1 |
 | gke-nccl-tcpxo | manifest | — | — | 4 |
-| gpu-operator | helm | nvidia/gpu-operator | — | 14 |
+| gpu-operator | helm | nvidia/gpu-operator | v26.3.1 | 14 |
 | grove | helm | grove-charts | v0.1.0-alpha.6 | 1 |
 | k8s-ephemeral-storage-metrics | helm | k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics | 1.19.2 | 1 |
 | k8s-nim-operator | helm | k8s-nim-operator | 3.1.0 | 1 |
@@ -44,11 +44,11 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.kgateway.dev`, `
 | kube-prometheus-stack | helm | prometheus-community/kube-prometheus-stack | 84.4.0 | 8 |
 | kubeflow-trainer | helm | kubeflow-trainer | 2.2.0 | 3 |
 | kueue | helm | kueue | 0.17.1 | 1 |
-| network-operator | helm | nvidia/network-operator | — | 5 |
+| network-operator | helm | nvidia/network-operator | 26.1.1 | 5 |
 | nfd | helm | node-feature-discovery | 0.18.3 | 1 |
 | nodewright-customizations | manifest | — | — | 4 |
-| nodewright-operator | helm | skyhook-operator | — | 3 |
-| nvidia-dra-driver-gpu | helm | nvidia/nvidia-dra-driver-gpu | — | 1 |
+| nodewright-operator | helm | skyhook-operator | v0.15.1 | 3 |
+| nvidia-dra-driver-gpu | helm | nvidia/nvidia-dra-driver-gpu | 25.12.0 | 1 |
 | nvsentinel | helm | nvsentinel | v1.3.0 | 6 |
 | prometheus-adapter | helm | prometheus-community/prometheus-adapter | 5.3.0 | 1 |
 

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -84,6 +84,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/gpu-operator
+      defaultVersion: v26.3.1
       defaultNamespace: gpu-operator
     nodeScheduling:
       system:
@@ -113,6 +114,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/network-operator
+      defaultVersion: "26.1.1"
       defaultNamespace: nvidia-network-operator
     nodeScheduling:
       system:
@@ -183,6 +185,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia/skyhook
       defaultChart: skyhook-operator
+      defaultVersion: v0.15.1
       defaultNamespace: skyhook
     nodeScheduling:
       nodeCountPaths:
@@ -259,6 +262,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/nvidia-dra-driver-gpu
+      defaultVersion: "25.12.0"
       defaultNamespace: nvidia-dra-driver
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary

Closes #748. Implements ADR-006 Phase B: pins chart versions for the four NVIDIA-owned helm components that previously rendered upstream-latest non-deterministically. Adds a CI gate that prevents future components from landing without a chart-version pin. Updates `SECURITY.md` to document the new policy. Files four upstream signing requests (linked below) and references them from #739 Stage 3.

Refs #739, #740, #748. Filed alongside as upstream signing requests:
- NVIDIA/gpu-operator#2432
- Mellanox/network-operator#2555
- kubernetes-sigs/dra-driver-nvidia-gpu#1105
- NVIDIA/nodewright#224

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe data (`recipes/registry.yaml`)
- [x] Build/tooling (`Makefile` — new `bom-pinning-check` lint target)
- [x] Docs (`SECURITY.md`, `docs/user/container-images.md`)

## Implementation Notes

**Pinned chart versions.** All four are the current upstream stable; verified our existing `values.yaml` shapes render against them.

| Component | Chart version |
|---|---|
| gpu-operator | `v26.3.1` |
| network-operator | `26.1.1` |
| nvidia-dra-driver-gpu | `25.12.0` |
| nodewright-operator (skyhook chart) | `v0.15.1` |

The deployed image set is byte-identical to today's upstream-latest output — the BOM doc auto-regeneration only updates the four version columns from `—` to their pinned values; image counts and image refs are unchanged.

**`bom-pinning-check` CI gate.** New `make` target invokes the BOM tool with `-strict -skip-helm` (no network) to fail CI when any helm component is missing `defaultVersion`. Wired into `make lint` alongside `check-agents-sync` and `check-docs-sidebar`. Future PRs adding a new helm component without `defaultVersion` will fail qualify automatically.

**SECURITY.md.** New "Deployed Image Inventory and Pinning Policy" subsection under Supply Chain Security: points at the published BOM, summarizes the three-layer ADR-006 contract, and acknowledges the upstream-signing gap with a forward reference to the supply-chain epic.

**Upstream signing requests.** Filed against the four NVIDIA-owned upstream repos asking for keyless cosign signatures, SLSA Build L3 provenance, and SBOM attestations. Verified beforehand that all four images today carry only legacy key-based `.sig` attachments without Fulcio cert / Rekor entry / SLSA predicate / SBOM. Notes:
- `NVIDIA/k8s-dra-driver-gpu` redirects to `kubernetes-sigs/dra-driver-nvidia-gpu` (project moved to kubernetes-sigs); issue filed at the canonical maintenance location.
- `NVIDIA/skyhook` redirects to `NVIDIA/nodewright` (rename); issue filed at the new home.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed (now includes bom-pinning-check)

make bom BOM_STRICT=1
# bom: wrote ... (22 components, 69 image refs)
```

`docs/user/container-images.md` regenerated; only the four version columns flipped from `—` to the pinned values, no image-set delta.

## Risk Assessment

- [x] **Low** — Pins to current upstream stable, which is what `helm template` resolves today. Image set byte-identical. New CI gate only enforces the policy ADR-006 codifies; no functional change to bundles already produced. Easy to revert.

**Rollout notes:** Existing bundles produced before this PR continue to deploy whatever upstream-latest resolved at their build time; bundles built after this PR deterministically deploy the pinned versions. Renovate will open chart-version bump PRs going forward (already wired under PR #737).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`) — including the new `bom-pinning-check`
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (the new lint gate covers the CI side; the BOM tool's strict mode already had unit-test coverage)
- [x] I updated docs if user-facing behavior changed (`SECURITY.md`, `docs/user/container-images.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)