### PR TITLE
feat(recipes): digest-pin explicit image references (#749)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,6 +107,19 @@
     },
   ],
 
+  // Kubernetes manager: scan AICR's component manifests for Pod-spec
+  // image references. The manager's default fileMatch is empty (YAML is
+  // ambiguous), so we explicitly point it at recipes/components/*/manifests/
+  // where AICR ships digest-pinned image refs that should be rotated as
+  // upstream rebuilds the same tag. ADR-006 is the policy basis (#749).
+  // helm-values manager is already active for recipes/components/*/values.yaml
+  // via its default fileMatch.
+  kubernetes: {
+    managerFilePatterns: [
+      "/^recipes/components/[^/]+/manifests/[^/]+\\.ya?ml$/",
+    ],
+  },
+
   packageRules: [
     // ---- Auto-merge: workflow digests, Go module patches, npm site deps ----
     // Low-blast-radius managers where patch / digest bumps almost never break.

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -83,7 +83,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.kgateway.dev`, `
 - `gcr.io/gke-release/nri-device-injector@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c`
 - `gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830`
 - `ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b`
-- `us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15`
+- `us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3f39455a2ea35e844e0fc92564ca5629f6b03250fde40e8160719dae4`
 
 ### gpu-operator
 
@@ -141,7 +141,7 @@ _No images extracted._
 ### kubeflow-trainer
 
 - `ghcr.io/kubeflow/trainer/trainer-controller-manager:v2.2.0`
-- `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime`
+- `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime@sha256:7b324d212a4450795b49edba9949b7cdc72429148a64e974334bfe5774d51385`
 - `registry.k8s.io/jobset/jobset:v0.11.0`
 
 ### kueue
@@ -150,7 +150,7 @@ _No images extracted._
 
 ### network-operator
 
-- `busybox:1.36`
+- `busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662`
 - `nvcr.io/nvidia/cloud-native/network-operator:v26.1.1`
 - `nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host`
 - `nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2`

--- a/recipes/components/gke-nccl-tcpxo/manifests/nccl-tcpxo-installer.yaml
+++ b/recipes/components/gke-nccl-tcpxo/manifests/nccl-tcpxo-installer.yaml
@@ -98,7 +98,7 @@ spec:
                   chmod a+rw /dev/aperture_devices/*/resource*
               fi
         - name: nccl-tcpxo-installer
-          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3f39455a2ea35e844e0fc92564ca5629f6b03250fde40e8160719dae4
           resources:
             requests:
               cpu: 150m

--- a/recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
+++ b/recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml
@@ -59,4 +59,4 @@ spec:
                   {{- end }}
                   containers:
                     - name: node
-                      image: pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
+                      image: pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime@sha256:7b324d212a4450795b49edba9949b7cdc72429148a64e974334bfe5774d51385

--- a/recipes/components/network-operator/manifests/ib-node-config-aks.yaml
+++ b/recipes/components/network-operator/manifests/ib-node-config-aks.yaml
@@ -76,7 +76,7 @@ spec:
           name: ib-node-config-settings
       initContainers:
       - name: ib-setup
-        image: busybox:1.36
+        image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
         securityContext:
           privileged: true
         volumeMounts:
@@ -149,7 +149,7 @@ spec:
           echo "=== Setup Complete ==="
       containers:
       - name: keepalive
-        image: busybox:1.36
+        image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
         command:
         - sh
         - -c

--- a/recipes/manifest_images_test.go
+++ b/recipes/manifest_images_test.go
@@ -74,3 +74,85 @@ func TestComponentManifestImagesAreFullyQualified(t *testing.T) {
 	}
 	t.Logf("verified %d image refs across components/*/manifests/", checked)
 }
+
+// imageDigestExemptions enumerates manifest-level image references that
+// AICR knowingly ships without an `@sha256:` digest. Each entry carries
+// the reason and the upstream tracking issue. New refs MUST either
+// include a digest or be added here with a reason; ADR-006 and #749
+// formalize this contract.
+//
+// The dominant exemption pattern: CRD-style schemas (NicClusterPolicy,
+// Skyhook Package) where `image:` and `version:` are sibling fields and
+// the schema does not accept an `@sha256:` digest. Reproducibility for
+// these refs is delivered by admission-time digest or signature
+// verification at deploy time (#745) plus the upstream signing requests
+// filed under the supply-chain epic (#739).
+var imageDigestExemptions = map[string]string{
+	// NicClusterPolicy (network-operator AKS): repository/image/version
+	// triplet schema; no digest field.
+	"nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2":               "NicClusterPolicy CRD does not accept image digests; tracked via #745 and Mellanox/network-operator#2555",
+	"nvcr.io/nvidia/mellanox/k8s-rdma-shared-dev-plugin:network-operator-v26.1.0": "NicClusterPolicy CRD does not accept image digests; tracked via #745 and Mellanox/network-operator#2555",
+	"nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host":                    "NicClusterPolicy CRD does not accept image digests; tracked via #745 and Mellanox/network-operator#2555",
+
+	// Skyhook Package (nodewright-customizations): image/version sibling
+	// schema; no digest field.
+	"ghcr.io/nvidia/skyhook-packages/shellscript:1.1.1":       "Skyhook Package CRD does not accept image digests; tracked via #745 and NVIDIA/nodewright#224",
+	"ghcr.io/nvidia/skyhook-packages/nvidia-tuning-gke:0.1.1": "Skyhook Package CRD does not accept image digests; tracked via #745 and NVIDIA/nodewright#224",
+	"ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.2.2":   "Skyhook Package CRD does not accept image digests; tracked via #745 and NVIDIA/nodewright#224",
+	"ghcr.io/nvidia/nodewright-packages/nvidia-tuned:0.3.0":   "Skyhook Package CRD does not accept image digests; tracked via #745 and NVIDIA/nodewright#224",
+}
+
+// TestComponentManifestImagesAreDigestPinned asserts that every image
+// reference under components/*/manifests/*.yaml carries an `@sha256:`
+// digest, except for the explicitly enumerated exemptions in
+// `imageDigestExemptions` above. This is the in-tree enforcement of
+// ADR-006 layer 2 (digest-pin every image AICR overrides explicitly).
+//
+// A bare-tag reference outside the exemption set fails the test. To add
+// a new tag-only manifest reference, add it to the exemption map with a
+// reason and a tracking issue; otherwise pin to a digest.
+func TestComponentManifestImagesAreDigestPinned(t *testing.T) {
+	var checked int
+	err := fs.WalkDir(FS, "components", func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.Contains(p, "/manifests/") {
+			return nil
+		}
+		if ext := path.Ext(p); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		data, rerr := fs.ReadFile(FS, p)
+		if rerr != nil {
+			return rerr
+		}
+		images, perr := bom.ExtractImagesFromYAML(data)
+		if perr != nil {
+			t.Errorf("%s: parse: %v", p, perr)
+			return nil
+		}
+		for _, img := range images {
+			checked++
+			ref := bom.ParseImageRef(img)
+			if ref.Digest != "" {
+				continue
+			}
+			if reason, ok := imageDigestExemptions[img]; ok {
+				t.Logf("exempted: %s — %s", img, reason)
+				continue
+			}
+			t.Errorf("%s: image %q is not digest-pinned and not in the documented exemption set (recipes/manifest_images_test.go::imageDigestExemptions); per ADR-006 layer 2, append an @sha256:<digest> or add an exemption with a reason", p, img)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk components: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("no images were checked; embedded FS may be empty")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #749. Implements ADR-006 Layer 2: digest-pins every Pod-spec image reference under `recipes/components/*/manifests/` that AICR overrides explicitly. Adds a CI gate enforcing the policy with an explicit, documented exemption list for CRD-triplet refs whose schemas don't accept digests. Configures Renovate to auto-rotate digests as upstream rebuilds the same tag.

Refs #739, #740 (ADR-006).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe data (3 manifests)
- [x] Tests (`recipes/manifest_images_test.go`)
- [x] Build/CI tooling (`.github/renovate.json5`)
- [x] Docs (`docs/user/container-images.md` — auto-regenerated)

## Implementation Notes

**Three refs digest-pinned:**

| File | Image |
|------|-------|
| `recipes/components/gke-nccl-tcpxo/manifests/nccl-tcpxo-installer.yaml` | `us-docker.pkg.dev/.../nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3…` |
| `recipes/components/network-operator/manifests/ib-node-config-aks.yaml` (×2) | `busybox:1.36@sha256:73aaf090…` |
| `recipes/components/kubeflow-trainer/manifests/torch-distributed-cluster-training-runtime.yaml` | `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime@sha256:7b324d21…` |

Digests resolved via `crane digest`.

**Out of scope (documented):**

- **`aws-efa/values.yaml`** — regional ECR (`602401143452.dkr.ecr.us-west-2.amazonaws.com`) requires AWS authentication to fetch a digest; no public ECR alternative exists. The same constraint affects every consumer outside AWS. The regional override pattern from PR #774 (#764) is the right answer here; digest-pinning would not produce a more reproducible deployment for users in other regions.
- **`aws-ebs-csi-driver/values.yaml`** — only `image.repository` is set; the chart's appVersion supplies the tag. Per ADR-006 this is a chart-default sub-image surface (Layer 3), not an explicit override (Layer 2).
- **CRD-style triplet manifests** (NicClusterPolicy `doca-driver`, `k8s-rdma-shared-dev-plugin`, `doca_telemetry`; Skyhook Package `shellscript`, `nvidia-tuning-gke`, `nvidia-setup`, `nvidia-tuned`). The schemas separate `image:` from `version:` and do not accept `@sha256:` digests. Reproducibility for these refs is delivered by admission-time verification (#745) plus the upstream signing requests filed under #739 Stage 3 (NVIDIA/gpu-operator#2432, Mellanox/network-operator#2555, kubernetes-sigs/dra-driver-nvidia-gpu#1105, NVIDIA/nodewright#224).

**CI gate.** New `TestComponentManifestImagesAreDigestPinned` in `recipes/manifest_images_test.go` walks every `components/*/manifests/*.yaml` and asserts every extracted image ref carries an `@sha256:` digest. The seven CRD-triplet exemptions are listed explicitly in `imageDigestExemptions` with reasons and upstream tracking issues. A future PR adding a tag-only manifest ref will fail the test unless either pinned to a digest or added to the exemption set with a reason. Self-documenting policy enforcement.

**Renovate config.** Pointed Renovate's kubernetes manager at `recipes/components/*/manifests/` so digest rotations land as auto-PRs as upstream rebuilds the same tag. The helm-values manager is already active for values.yaml via its default fileMatch.

**BOM doc.** Auto-regenerated; image set unchanged byte-wise. The three newly-pinned refs now show their `@sha256:` in the per-component listing.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed
```

```
$ go test -v -run TestComponentManifestImagesAreDigestPinned ./recipes/...
=== RUN   TestComponentManifestImagesAreDigestPinned
    manifest_images_test.go:145: exempted: nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host — NicClusterPolicy CRD does not accept image digests; tracked via #745 and Mellanox/network-operator#2555
    manifest_images_test.go:145: exempted: nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2 — ...
    [... 5 more exemptions logged ...]
--- PASS: TestComponentManifestImagesAreDigestPinned
```

## Risk Assessment

- [x] **Low** — Digest-pinning to a specific image content. Same image bytes deploy as before (digest of the existing tag), just made explicit. CI gate only enforces what ADR-006 already codifies. Renovate config changes how upstream digest bumps land but doesn't affect runtime. Easy to revert.

**Rollout notes:** Renovate will start opening digest-rotation PRs as upstream rebuilds the same tag. Patch-flow stays the same; the diff lands as a normal CI'd PR.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (the new `TestComponentManifestImagesAreDigestPinned`)
- [x] I updated docs if user-facing behavior changed (`docs/user/container-images.md` auto-regenerated)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)