### PR TITLE
test(recipes): enforce sha256 specifically in digest-pin gate (CodeRabbit follow-up to #778)

### DIFF
--- a/recipes/manifest_images_test.go
+++ b/recipes/manifest_images_test.go
@@ -138,7 +138,11 @@ func TestComponentManifestImagesAreDigestPinned(t *testing.T) {
 		for _, img := range images {
 			checked++
 			ref := bom.ParseImageRef(img)
+			if strings.HasPrefix(ref.Digest, "sha256:") {
+				continue
+			}
 			if ref.Digest != "" {
+				t.Errorf("%s: image %q uses non-sha256 digest %q; ADR-006 requires @sha256:<digest>", p, img, ref.Digest)
 				continue
 			}
 			if reason, ok := imageDigestExemptions[img]; ok {


### PR DESCRIPTION
## Summary

Patches a CodeRabbit review comment from PR #778 that didn't make it into the squash-merge — my reply commit landed on the branch but the PR was already merged by then.

The digest-pin gate added in #778 accepts any non-empty digest algorithm; [ADR-006](docs/design/006-image-pinning-policy.md) specifically requires `sha256`. A non-sha256 ref would silently pass CI.

Now: `sha256:` prefix is the pass condition; any other digest algorithm emits a distinct error message naming the unexpected algorithm so the contributor knows what to fix.

Original CodeRabbit thread: https://github.com/NVIDIA/aicr/pull/778#discussion_r3196236956

Refs #739, #749.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Tests (`recipes/manifest_images_test.go`)

## Implementation Notes

Three-line change to the loop body in `TestComponentManifestImagesAreDigestPinned`:

```diff
-if ref.Digest != "" {
+if strings.HasPrefix(ref.Digest, "sha256:") {
     continue
 }
+if ref.Digest != "" {
+    t.Errorf("%s: image %q uses non-sha256 digest %q; ADR-006 requires @sha256:<digest>", p, img, ref.Digest)
+    continue
+}
```

The new branch surfaces a distinct error message for the "wrong-algorithm" case so a contributor seeing the failure knows to fix the algorithm rather than thinking the digest is missing.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed
```

## Risk Assessment

- [x] **Low** — Tightens an existing test. All current refs use `sha256:` (verified: 4 in-tree pins all sha256, the 7 CRD-triplet exemptions are bypassed before the digest check). No production behavior change. Easy to revert.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (n/a — internal test gate)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)