### PR TITLE
feat(cli): unified --config flag for recipe and bundle

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -269,43 +269,54 @@ aicr recipe [flags]
 
 **Modes:**
 
-#### Criteria File Mode (Recommended)
+#### Config File Mode (Recommended)
 
-Generate recipes using a Kubernetes-style criteria file:
+Generate recipes using an `AICRConfig` document. The same file format also drives the `bundle` command, so a single file can describe an end-to-end recipe-to-bundle workflow.
 
 **Flags:**
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
-| `--criteria` | `-c` | string | Path to criteria file (YAML/JSON), alternative to individual flags |
+| `--config` | | string | Path or HTTPS URL to an AICRConfig file (YAML/JSON) |
 | `--output` | `-o` | string | Output file (default: stdout) |
 | `--format` | `-f` | string | Format: json, yaml (default: yaml) |
 | `--data` | | string | External data directory to overlay on embedded data (see [External Data](#external-data-directory)) |
 
-The criteria file uses a Kubernetes-style format:
+The config file uses a Kubernetes-style envelope:
 ```yaml
-kind: RecipeCriteria
+kind: AICRConfig
 apiVersion: aicr.nvidia.com/v1alpha1
 metadata:
   name: gb200-eks-ubuntu-training
 spec:
-  service: eks
-  os: ubuntu
-  accelerator: gb200
-  intent: training
-  nodes: 8
+  recipe:
+    criteria:
+      service: eks
+      os: ubuntu
+      accelerator: gb200
+      intent: training
+      nodes: 8
+    output:
+      path: recipe.yaml
+      format: yaml
 ```
 
-Individual CLI flags can override criteria file values:
+Individual CLI flags always override config file values. For slice/map flags, presence on the CLI replaces the file's value (no append).
+
 ```shell
-# Load criteria from file
-aicr recipe --criteria criteria.yaml
+# Load criteria from config file
+aicr recipe --config config.yaml
 
 # Override service from file
-aicr recipe --criteria criteria.yaml --service gke
+aicr recipe --config config.yaml --service gke
 
 # Save output to file
-aicr recipe -c criteria.yaml -o recipe.yaml
+aicr recipe --config config.yaml -o recipe.yaml
+
+# Load config from a URL (e.g. CI shared template)
+aicr recipe --config https://team.example.com/configs/eks-h100-training.yaml
 ```
+
+`--config` accepts a local file path or an HTTP/HTTPS URL. ConfigMap (`cm://`) sources are not supported; export the data with `kubectl get cm <name> -o yaml` and pass the resulting file.
 
 #### Query Mode
 
@@ -833,7 +844,8 @@ aicr bundle [flags]
 **Flags:**
 | Flag | Short | Type | Description |
 |---------------------------------|-------|------|-------------|
-| `--recipe` | `-r` | string | Path to recipe file (required) |
+| `--recipe` | `-r` | string | Path to recipe file (required, or via `spec.bundle.input.recipe` in `--config`) |
+| `--config` | | string | Path or HTTPS URL to an AICRConfig file (YAML/JSON). CLI flags override values from this file. See [Config File Mode](#config-file-mode-1). |
 | `--output` | `-o` | string | Output directory (default: current dir) |
 | `--deployer` | `-d` | string | Deployment method: `helm` (default), `argocd`, or `argocd-helm` |
 | `--repo` | | string | Git repository URL for Argo CD applications (used with `--deployer argocd` and `--deployer argocd-helm`) |
@@ -856,6 +868,50 @@ aicr bundle [flags]
 | `--certificate-identity-regexp` | | string | Override the certificate identity pattern for binary attestation verification. Must contain `"NVIDIA/aicr"`. For testing only. |
 | `--identity-token` | | string | Pre-fetched OIDC identity token for `--attest` keyless signing. Skips ambient/browser/device-code flows. Prefer `COSIGN_IDENTITY_TOKEN` on shared hosts — flag values are visible in `ps` and `/proc/<pid>/cmdline`. |
 | `--oidc-device-flow` | | bool | Use the OAuth 2.0 device authorization grant for `--attest` instead of opening a browser callback. Useful on headless hosts that can still reach Sigstore (`--identity-token` and CI ambient OIDC are alternatives). Also reads `AICR_OIDC_DEVICE_FLOW`. |
+
+#### Config File Mode
+
+The bundle command accepts the same `AICRConfig` format used by `aicr recipe`. A single file can populate both `spec.recipe` and `spec.bundle`, capturing an end-to-end workflow that can be committed to git, fetched from CI, or shared across environments.
+
+```yaml
+kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  bundle:
+    input:
+      recipe: ./recipe.yaml
+    output:
+      target: oci://ghcr.io/example/bundle:v1.0.0
+    deployment:
+      deployer: argocd
+      repo: https://example.git/charts
+      set:
+        - gpuoperator:driver.version=570.86.16
+    scheduling:
+      systemNodeSelector:
+        role: system
+      acceleratedNodeTolerations:
+        - "nvidia.com/gpu=present:NoSchedule"
+      nodes: 8
+      storageClass: gp3
+    attestation:
+      enabled: false
+    registry:
+      insecureTLS: false
+      plainHTTP: false
+```
+
+```shell
+# Drive the bundle entirely from a config file
+aicr bundle --config bundle.yaml
+
+# Override the deployer for a one-off run
+aicr bundle --config bundle.yaml --deployer helm
+```
+
+CLI flags always override values loaded from `--config`. For slice/map flags (`--set`, `--dynamic`, `--system-node-selector`, etc.), CLI presence replaces the config's value rather than appending. Override events are logged at INFO so users can see which input won.
+
+**Secrets:** the cosign identity token is never read from a config file; supply it via `--identity-token` or `COSIGN_IDENTITY_TOKEN`.
 
 #### Node Scheduling
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -274,14 +274,16 @@ aicr recipe [flags]
 Generate recipes using an `AICRConfig` document. The same file format also drives the `bundle` command, so a single file can describe an end-to-end recipe-to-bundle workflow.
 
 **Flags:**
+
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
-| `--config` | | string | Path or HTTPS URL to an AICRConfig file (YAML/JSON) |
+| `--config` | | string | Path or HTTP/HTTPS URL to an AICRConfig file (YAML/JSON) |
 | `--output` | `-o` | string | Output file (default: stdout) |
 | `--format` | `-f` | string | Format: json, yaml (default: yaml) |
 | `--data` | | string | External data directory to overlay on embedded data (see [External Data](#external-data-directory)) |
 
 The config file uses a Kubernetes-style envelope:
+
 ```yaml
 kind: AICRConfig
 apiVersion: aicr.nvidia.com/v1alpha1
@@ -845,7 +847,7 @@ aicr bundle [flags]
 | Flag | Short | Type | Description |
 |---------------------------------|-------|------|-------------|
 | `--recipe` | `-r` | string | Path to recipe file (required, or via `spec.bundle.input.recipe` in `--config`) |
-| `--config` | | string | Path or HTTPS URL to an AICRConfig file (YAML/JSON). CLI flags override values from this file. See [Config File Mode](#config-file-mode-1). |
+| `--config` | | string | Path or HTTP/HTTPS URL to an AICRConfig file (YAML/JSON). CLI flags override values from this file. See [Bundle Config File Mode](#bundle-config-file-mode). |
 | `--output` | `-o` | string | Output directory (default: current dir) |
 | `--deployer` | `-d` | string | Deployment method: `helm` (default), `argocd`, or `argocd-helm` |
 | `--repo` | | string | Git repository URL for Argo CD applications (used with `--deployer argocd` and `--deployer argocd-helm`) |
@@ -869,9 +871,11 @@ aicr bundle [flags]
 | `--identity-token` | | string | Pre-fetched OIDC identity token for `--attest` keyless signing. Skips ambient/browser/device-code flows. Prefer `COSIGN_IDENTITY_TOKEN` on shared hosts — flag values are visible in `ps` and `/proc/<pid>/cmdline`. |
 | `--oidc-device-flow` | | bool | Use the OAuth 2.0 device authorization grant for `--attest` instead of opening a browser callback. Useful on headless hosts that can still reach Sigstore (`--identity-token` and CI ambient OIDC are alternatives). Also reads `AICR_OIDC_DEVICE_FLOW`. |
 
-#### Config File Mode
+#### Bundle Config File Mode
 
 The bundle command accepts the same `AICRConfig` format used by `aicr recipe`. A single file can populate both `spec.recipe` and `spec.bundle`, capturing an end-to-end workflow that can be committed to git, fetched from CI, or shared across environments.
+
+When both `spec.recipe.output.path` and `spec.bundle.input.recipe` are set, they must reference the same path; otherwise loading fails fast.
 
 ```yaml
 kind: AICRConfig

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -192,10 +192,12 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 	}
 
 	if opts.systemNodeSelector, err = resolveNodeSelector(cmd, "system-node-selector", bs.SystemNodeSelector()); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid system node selector", err)
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"invalid "+sourceLabel(cmd, "system-node-selector", "spec.bundle.scheduling.systemNodeSelector"), err)
 	}
 	if opts.acceleratedNodeSelector, err = resolveNodeSelector(cmd, "accelerated-node-selector", bs.AcceleratedNodeSelector()); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid accelerated node selector", err)
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"invalid "+sourceLabel(cmd, "accelerated-node-selector", "spec.bundle.scheduling.acceleratedNodeSelector"), err)
 	}
 
 	if opts.systemNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "system-node-toleration", bs.SystemNodeTolerations())); err != nil {
@@ -213,7 +215,8 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 	}
 
 	if opts.workloadSelector, err = resolveNodeSelector(cmd, "workload-selector", bs.WorkloadSelector()); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid workload selector", err)
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"invalid "+sourceLabel(cmd, "workload-selector", "spec.bundle.scheduling.workloadSelector"), err)
 	}
 
 	// Estimated node count for bundle; 0 = unset.

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -295,11 +295,11 @@ Package with explicit tag (overrides CLI version):
 			&cli.StringFlag{
 				Name:    "output",
 				Aliases: []string{"o"},
-				Value:   ".",
-				Usage: `Output target: local directory path or OCI registry URI.
+				Usage: `Output target: local directory path or OCI registry URI (default: current dir).
 	For local output: ./my-bundle or /tmp/bundle
 	For OCI registry: oci://ghcr.io/nvidia/bundle:v1.0.0
-	If no tag specified, CLI version is used (e.g., oci://ghcr.io/nvidia/bundle)`,
+	If no tag specified, CLI version is used (e.g., oci://ghcr.io/nvidia/bundle)
+	May also be supplied via spec.bundle.output.target in --config.`,
 				Category: "Output",
 			},
 			&cli.StringSliceFlag{
@@ -362,8 +362,7 @@ Package with explicit tag (overrides CLI version):
 			withCompletions(&cli.StringFlag{
 				Name:     "deployer",
 				Aliases:  []string{"d"},
-				Value:    string(config.DeployerHelm),
-				Usage:    fmt.Sprintf("Deployment method (e.g. %s)", strings.Join(config.GetDeployerTypes(), ", ")),
+				Usage:    fmt.Sprintf("Deployment method (default: helm; e.g. %s)", strings.Join(config.GetDeployerTypes(), ", ")),
 				Category: "Deployment",
 			}, config.GetDeployerTypes),
 			&cli.StringFlag{

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -87,19 +87,19 @@ type bundleCmdOptions struct {
 //
 //nolint:gocyclo // option resolution is inherently long but linear
 func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmdOptions, error) {
-	bs := bundleSpec(cfg)
+	bs := cfg.Bundle()
 
 	opts := &bundleCmdOptions{
-		recipeFilePath:            stringFlagOrConfig(cmd, "recipe", bundleRecipeInput(bs)),
+		recipeFilePath:            stringFlagOrConfig(cmd, "recipe", bs.RecipeInput()),
 		kubeconfig:                cmd.String("kubeconfig"),
-		repoURL:                   stringFlagOrConfig(cmd, "repo", bundleDeploymentRepo(bs)),
-		attest:                    boolFlagOrConfig(cmd, "attest", bundleAttestEnabled(bs)),
-		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", bundleCertIDRegexp(bs)),
+		repoURL:                   stringFlagOrConfig(cmd, "repo", bs.DeploymentRepo()),
+		attest:                    boolFlagOrConfig(cmd, "attest", bs.AttestEnabled()),
+		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", bs.CertIDRegexp()),
 		identityToken:             cmd.String("identity-token"),
-		oidcDeviceFlow:            boolFlagOrConfig(cmd, "oidc-device-flow", bundleOIDCDeviceFlow(bs)),
-		insecureTLS:               boolFlagOrConfig(cmd, "insecure-tls", bundleRegistryInsecureTLS(bs)),
-		plainHTTP:                 boolFlagOrConfig(cmd, "plain-http", bundleRegistryPlainHTTP(bs)),
-		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", bundleOutputImageRefs(bs)),
+		oidcDeviceFlow:            boolFlagOrConfig(cmd, "oidc-device-flow", bs.OIDCDeviceFlow()),
+		insecureTLS:               boolFlagOrConfig(cmd, "insecure-tls", bs.RegistryInsecureTLS()),
+		plainHTTP:                 boolFlagOrConfig(cmd, "plain-http", bs.RegistryPlainHTTP()),
+		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", bs.OutputImageRefs()),
 	}
 
 	if opts.recipeFilePath == "" {
@@ -129,7 +129,7 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 	}
 
 	// Parse and validate deployer flag using strongly-typed parser
-	deployerStr := stringFlagOrConfig(cmd, "deployer", bundleDeploymentDeployer(bs))
+	deployerStr := stringFlagOrConfig(cmd, "deployer", bs.DeploymentDeployer())
 	if deployerStr == "" {
 		opts.deployer = config.DeployerHelm
 	} else {
@@ -141,7 +141,7 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 	}
 
 	// Parse output target (detects oci:// URI or local directory)
-	outputTarget := stringFlagOrConfig(cmd, "output", bundleOutputTarget(bs))
+	outputTarget := stringFlagOrConfig(cmd, "output", bs.OutputTarget())
 	if outputTarget == "" {
 		outputTarget = "."
 	}
@@ -180,44 +180,44 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		opts.targetRevision = opts.ociRef.Tag
 	}
 
-	// Parse value overrides from --set flags (config replaced by CLI when set)
-	opts.valueOverrides, err = config.ParseValueOverrides(stringSliceFlagOrConfig(cmd, "set", bundleDeploymentSet(bs)))
+	// Parse value overrides from --set / spec.bundle.deployment.set
+	opts.valueOverrides, err = config.ParseValueOverrides(stringSliceFlagOrConfig(cmd, "set", bs.DeploymentSet()))
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --set flag", err)
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "set", "spec.bundle.deployment.set"), err)
 	}
 
-	opts.dynamicValues, err = config.ParseDynamicValues(stringSliceFlagOrConfig(cmd, "dynamic", bundleDeploymentDynamic(bs)))
+	opts.dynamicValues, err = config.ParseDynamicValues(stringSliceFlagOrConfig(cmd, "dynamic", bs.DeploymentDynamic()))
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --dynamic flag", err)
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "dynamic", "spec.bundle.deployment.dynamic"), err)
 	}
 
-	if opts.systemNodeSelector, err = resolveNodeSelector(cmd, "system-node-selector", bundleSystemNodeSelector(bs)); err != nil {
+	if opts.systemNodeSelector, err = resolveNodeSelector(cmd, "system-node-selector", bs.SystemNodeSelector()); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid system node selector", err)
 	}
-	if opts.acceleratedNodeSelector, err = resolveNodeSelector(cmd, "accelerated-node-selector", bundleAcceleratedNodeSelector(bs)); err != nil {
+	if opts.acceleratedNodeSelector, err = resolveNodeSelector(cmd, "accelerated-node-selector", bs.AcceleratedNodeSelector()); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid accelerated node selector", err)
 	}
 
-	if opts.systemNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "system-node-toleration", bundleSystemNodeTolerations(bs))); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --system-node-toleration", err)
+	if opts.systemNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "system-node-toleration", bs.SystemNodeTolerations())); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "system-node-toleration", "spec.bundle.scheduling.systemNodeTolerations"), err)
 	}
-	if opts.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "accelerated-node-toleration", bundleAcceleratedNodeTolerations(bs))); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --accelerated-node-toleration", err)
+	if opts.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "accelerated-node-toleration", bs.AcceleratedNodeTolerations())); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "accelerated-node-toleration", "spec.bundle.scheduling.acceleratedNodeTolerations"), err)
 	}
 
-	if workloadGateStr := stringFlagOrConfig(cmd, "workload-gate", bundleWorkloadGate(bs)); workloadGateStr != "" {
+	if workloadGateStr := stringFlagOrConfig(cmd, "workload-gate", bs.WorkloadGate()); workloadGateStr != "" {
 		opts.workloadGateTaint, err = snapshotter.ParseTaint(workloadGateStr)
 		if err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --workload-gate", err)
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "workload-gate", "spec.bundle.scheduling.workloadGate"), err)
 		}
 	}
 
-	if opts.workloadSelector, err = resolveNodeSelector(cmd, "workload-selector", bundleWorkloadSelector(bs)); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --workload-selector", err)
+	if opts.workloadSelector, err = resolveNodeSelector(cmd, "workload-selector", bs.WorkloadSelector()); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid workload selector", err)
 	}
 
 	// Estimated node count for bundle; 0 = unset.
-	n := intFlagOrConfig(cmd, "nodes", bundleSchedulingNodes(bs))
+	n := intFlagOrConfig(cmd, "nodes", bs.SchedulingNodes())
 	if n < 0 {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "--nodes must be >= 0")
 	}
@@ -229,11 +229,21 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 			return nil, errors.New(errors.ErrCodeInvalidRequest, "--storage-class cannot be blank when specified")
 		}
 		opts.storageClass = sc
-	} else if v := bundleSchedulingStorageClass(bs); v != "" {
+	} else if v := bs.SchedulingStorageClass(); v != "" {
 		opts.storageClass = v
 	}
 
 	return opts, nil
+}
+
+// sourceLabel returns the user-facing label of whichever input contributed
+// the value being parsed: the CLI flag if it was explicitly set, otherwise
+// the config-spec path. Used to keep parse errors pointed at the right place.
+func sourceLabel(cmd *cli.Command, flagName, configPath string) string {
+	if cmd.IsSet(flagName) {
+		return "--" + flagName
+	}
+	return configPath
 }
 
 //nolint:funlen // bundle command is inherently large (flags + description + action)

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -30,6 +30,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
 	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
+	appcfg "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/oci"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -81,19 +82,29 @@ type bundleCmdOptions struct {
 	imageRefsPath string // Path to write published image references (like ko --image-refs)
 }
 
-// parseBundleCmdOptions parses and validates command options.
-func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
+// parseBundleCmdOptions parses and validates command options. When cfg is
+// non-nil, spec.bundle fields supply defaults; CLI flags always override.
+//
+//nolint:gocyclo // option resolution is inherently long but linear
+func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmdOptions, error) {
+	bs := bundleSpec(cfg)
+
 	opts := &bundleCmdOptions{
-		recipeFilePath:            cmd.String("recipe"),
+		recipeFilePath:            stringFlagOrConfig(cmd, "recipe", bundleRecipeInput(bs)),
 		kubeconfig:                cmd.String("kubeconfig"),
-		repoURL:                   cmd.String("repo"),
-		attest:                    cmd.Bool("attest"),
-		certificateIdentityRegexp: cmd.String("certificate-identity-regexp"),
+		repoURL:                   stringFlagOrConfig(cmd, "repo", bundleDeploymentRepo(bs)),
+		attest:                    boolFlagOrConfig(cmd, "attest", bundleAttestEnabled(bs)),
+		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", bundleCertIDRegexp(bs)),
 		identityToken:             cmd.String("identity-token"),
-		oidcDeviceFlow:            cmd.Bool("oidc-device-flow"),
-		insecureTLS:               cmd.Bool("insecure-tls"),
-		plainHTTP:                 cmd.Bool("plain-http"),
-		imageRefsPath:             cmd.String("image-refs"),
+		oidcDeviceFlow:            boolFlagOrConfig(cmd, "oidc-device-flow", bundleOIDCDeviceFlow(bs)),
+		insecureTLS:               boolFlagOrConfig(cmd, "insecure-tls", bundleRegistryInsecureTLS(bs)),
+		plainHTTP:                 boolFlagOrConfig(cmd, "plain-http", bundleRegistryPlainHTTP(bs)),
+		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", bundleOutputImageRefs(bs)),
+	}
+
+	if opts.recipeFilePath == "" {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"--recipe is required (or set spec.bundle.input.recipe in --config)")
 	}
 
 	// Resolve recipe path to absolute and validate it exists early.
@@ -118,7 +129,7 @@ func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
 	}
 
 	// Parse and validate deployer flag using strongly-typed parser
-	deployerStr := cmd.String("deployer")
+	deployerStr := stringFlagOrConfig(cmd, "deployer", bundleDeploymentDeployer(bs))
 	if deployerStr == "" {
 		opts.deployer = config.DeployerHelm
 	} else {
@@ -130,7 +141,10 @@ func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
 	}
 
 	// Parse output target (detects oci:// URI or local directory)
-	outputTarget := cmd.String("output")
+	outputTarget := stringFlagOrConfig(cmd, "output", bundleOutputTarget(bs))
+	if outputTarget == "" {
+		outputTarget = "."
+	}
 	ref, err := oci.ParseOutputTarget(outputTarget)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --output value", err)
@@ -166,55 +180,44 @@ func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
 		opts.targetRevision = opts.ociRef.Tag
 	}
 
-	// Parse value overrides from --set flags
-	opts.valueOverrides, err = config.ParseValueOverrides(cmd.StringSlice("set"))
+	// Parse value overrides from --set flags (config replaced by CLI when set)
+	opts.valueOverrides, err = config.ParseValueOverrides(stringSliceFlagOrConfig(cmd, "set", bundleDeploymentSet(bs)))
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --set flag", err)
 	}
 
-	// Parse dynamic value declarations from --dynamic flags
-	opts.dynamicValues, err = config.ParseDynamicValues(cmd.StringSlice("dynamic"))
+	opts.dynamicValues, err = config.ParseDynamicValues(stringSliceFlagOrConfig(cmd, "dynamic", bundleDeploymentDynamic(bs)))
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --dynamic flag", err)
 	}
 
-	// Parse node selectors
-	opts.systemNodeSelector, err = snapshotter.ParseNodeSelectors(cmd.StringSlice("system-node-selector"))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --system-node-selector", err)
+	if opts.systemNodeSelector, err = resolveNodeSelector(cmd, "system-node-selector", bundleSystemNodeSelector(bs)); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid system node selector", err)
 	}
-	opts.acceleratedNodeSelector, err = snapshotter.ParseNodeSelectors(cmd.StringSlice("accelerated-node-selector"))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --accelerated-node-selector", err)
+	if opts.acceleratedNodeSelector, err = resolveNodeSelector(cmd, "accelerated-node-selector", bundleAcceleratedNodeSelector(bs)); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid accelerated node selector", err)
 	}
 
-	// Parse tolerations
-	opts.systemNodeTolerations, err = snapshotter.ParseTolerations(cmd.StringSlice("system-node-toleration"))
-	if err != nil {
+	if opts.systemNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "system-node-toleration", bundleSystemNodeTolerations(bs))); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --system-node-toleration", err)
 	}
-	opts.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(cmd.StringSlice("accelerated-node-toleration"))
-	if err != nil {
+	if opts.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "accelerated-node-toleration", bundleAcceleratedNodeTolerations(bs))); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --accelerated-node-toleration", err)
 	}
 
-	// Parse workload-gate taint
-	workloadGateStr := cmd.String("workload-gate")
-	if workloadGateStr != "" {
+	if workloadGateStr := stringFlagOrConfig(cmd, "workload-gate", bundleWorkloadGate(bs)); workloadGateStr != "" {
 		opts.workloadGateTaint, err = snapshotter.ParseTaint(workloadGateStr)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --workload-gate", err)
 		}
 	}
 
-	// Parse workload-selector
-	opts.workloadSelector, err = snapshotter.ParseNodeSelectors(cmd.StringSlice("workload-selector"))
-	if err != nil {
+	if opts.workloadSelector, err = resolveNodeSelector(cmd, "workload-selector", bundleWorkloadSelector(bs)); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --workload-selector", err)
 	}
 
-	// Parse --nodes (estimated node count for bundle; 0 = unset)
-	n := cmd.Int("nodes")
+	// Estimated node count for bundle; 0 = unset.
+	n := intFlagOrConfig(cmd, "nodes", bundleSchedulingNodes(bs))
 	if n < 0 {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "--nodes must be >= 0")
 	}
@@ -226,6 +229,8 @@ func parseBundleCmdOptions(cmd *cli.Command) (*bundleCmdOptions, error) {
 			return nil, errors.New(errors.ErrCodeInvalidRequest, "--storage-class cannot be blank when specified")
 		}
 		opts.storageClass = sc
+	} else if v := bundleSchedulingStorageClass(bs); v != "" {
+		opts.storageClass = v
 	}
 
 	return opts, nil
@@ -279,13 +284,14 @@ Package with explicit tag (overrides CLI version):
 `,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "recipe",
-				Aliases:  []string{"r"},
-				Required: true,
+				Name:    "recipe",
+				Aliases: []string{"r"},
 				Usage: `Path/URI to previously generated recipe from which to build the bundle.
-	Supports: file paths, HTTP/HTTPS URLs, or ConfigMap URIs (cm://namespace/name).`,
+	Supports: file paths, HTTP/HTTPS URLs, or ConfigMap URIs (cm://namespace/name).
+	May also be supplied via spec.bundle.input.recipe in --config.`,
 				Category: "Input",
 			},
+			configFlag(),
 			&cli.StringFlag{
 				Name:    "output",
 				Aliases: []string{"o"},
@@ -390,8 +396,8 @@ Package with explicit tag (overrides CLI version):
 				Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
 				Category: "Deployment",
 			},
-			kubeconfigFlag,
-			dataFlag,
+			kubeconfigFlag(),
+			dataFlag(),
 			// OCI registry connection flags (used when --output is oci://...)
 			&cli.BoolFlag{
 				Name:     "insecure-tls",
@@ -416,16 +422,21 @@ Package with explicit tag (overrides CLI version):
 // runBundleCmd is the Action handler for the bundle command.
 func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 	// Validate single-value flags are not duplicated
-	if err := validateSingleValueFlags(cmd, "recipe", "output", "deployer", "repo", "storage-class"); err != nil {
+	if err := validateSingleValueFlags(cmd, "recipe", "config", "output", "deployer", "repo", "storage-class"); err != nil {
+		return err
+	}
+
+	cfg, err := loadCmdConfig(ctx, cmd)
+	if err != nil {
 		return err
 	}
 
 	// Initialize external data provider if --data flag is set
-	if err := initDataProvider(cmd); err != nil {
+	if err = initDataProvider(cmd, cfg); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
 	}
 
-	opts, err := parseBundleCmdOptions(cmd)
+	opts, err := parseBundleCmdOptions(cmd, cfg)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid bundle command options", err)
 	}
@@ -461,7 +472,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Create bundler with config
-	cfg := config.NewConfig(
+	bcfg := config.NewConfig(
 		config.WithVersion(version),
 		config.WithDeployer(opts.deployer),
 		config.WithRepoURL(opts.repoURL),
@@ -487,7 +498,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	b, err := bundler.New(
-		bundler.WithConfig(cfg),
+		bundler.WithConfig(bcfg),
 		bundler.WithAttester(attester),
 	)
 	if err != nil {

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -437,7 +437,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 
 	opts, err := parseBundleCmdOptions(cmd, cfg)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid bundle command options", err)
+		return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "invalid bundle command options")
 	}
 
 	outputType := "Helm per-component bundle"

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -39,20 +39,26 @@ func boolFlagOrConfig(cmd *cli.Command, flagName string, fallback bool) bool {
 
 // stringSliceFlagOrConfig returns the CLI slice value when explicitly set,
 // otherwise the fallback slice. Per the agreed design, CLI replaces config
-// rather than appending.
+// rather than appending. Returns a defensive copy so callers cannot mutate
+// the loaded config's backing slice.
 func stringSliceFlagOrConfig(cmd *cli.Command, flagName string, fallback []string) []string {
 	if cmd.IsSet(flagName) {
 		v := cmd.StringSlice(flagName)
 		if len(fallback) > 0 {
 			slog.Info("CLI flag replacing config value", "flag", flagName, "configCount", len(fallback), "overrideCount", len(v))
 		}
-		return v
+		return append([]string(nil), v...)
 	}
-	return fallback
+	if len(fallback) == 0 {
+		return nil
+	}
+	return append([]string(nil), fallback...)
 }
 
 // resolveNodeSelector returns the parsed map for a CLI selector flag,
-// preferring CLI input over the supplied fallback map.
+// preferring CLI input over the supplied fallback map. Returns a defensive
+// copy in either path so callers cannot mutate the loaded config's map.
+// An empty fallback yields an empty (non-nil) map for caller convenience.
 func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]string) (map[string]string, error) {
 	if cmd.IsSet(flagName) {
 		parsed, err := snapshotter.ParseNodeSelectors(cmd.StringSlice(flagName))
@@ -64,10 +70,6 @@ func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]
 		}
 		return parsed, nil
 	}
-	if fallback == nil {
-		return map[string]string{}, nil
-	}
-	// Return a defensive copy so callers cannot mutate the cached config map.
 	out := make(map[string]string, len(fallback))
 	for k, v := range fallback {
 		out[k] = v

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -120,46 +120,68 @@ func bundleDeploymentRepo(b *appcfg.BundleSpec) string {
 	return b.Deployment.Repo
 }
 
+// copyStrings returns a defensive copy of s (or nil for empty input) so
+// callers cannot mutate the loaded config's backing slice.
+func copyStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return append([]string(nil), s...)
+}
+
+// copyStringMap returns a defensive copy of m (or nil for empty input) so
+// callers cannot mutate the loaded config's backing map.
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func bundleDeploymentSet(b *appcfg.BundleSpec) []string {
 	if b == nil || b.Deployment == nil {
 		return nil
 	}
-	return b.Deployment.Set
+	return copyStrings(b.Deployment.Set)
 }
 
 func bundleDeploymentDynamic(b *appcfg.BundleSpec) []string {
 	if b == nil || b.Deployment == nil {
 		return nil
 	}
-	return b.Deployment.Dynamic
+	return copyStrings(b.Deployment.Dynamic)
 }
 
 func bundleSystemNodeSelector(b *appcfg.BundleSpec) map[string]string {
 	if b == nil || b.Scheduling == nil {
 		return nil
 	}
-	return b.Scheduling.SystemNodeSelector
+	return copyStringMap(b.Scheduling.SystemNodeSelector)
 }
 
 func bundleSystemNodeTolerations(b *appcfg.BundleSpec) []string {
 	if b == nil || b.Scheduling == nil {
 		return nil
 	}
-	return b.Scheduling.SystemNodeTolerations
+	return copyStrings(b.Scheduling.SystemNodeTolerations)
 }
 
 func bundleAcceleratedNodeSelector(b *appcfg.BundleSpec) map[string]string {
 	if b == nil || b.Scheduling == nil {
 		return nil
 	}
-	return b.Scheduling.AcceleratedNodeSelector
+	return copyStringMap(b.Scheduling.AcceleratedNodeSelector)
 }
 
 func bundleAcceleratedNodeTolerations(b *appcfg.BundleSpec) []string {
 	if b == nil || b.Scheduling == nil {
 		return nil
 	}
-	return b.Scheduling.AcceleratedNodeTolerations
+	return copyStrings(b.Scheduling.AcceleratedNodeTolerations)
 }
 
 func bundleWorkloadGate(b *appcfg.BundleSpec) string {
@@ -173,7 +195,7 @@ func bundleWorkloadSelector(b *appcfg.BundleSpec) map[string]string {
 	if b == nil || b.Scheduling == nil {
 		return nil
 	}
-	return b.Scheduling.WorkloadSelector
+	return copyStringMap(b.Scheduling.WorkloadSelector)
 }
 
 func bundleSchedulingNodes(b *appcfg.BundleSpec) int {

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"log/slog"
+
+	"github.com/urfave/cli/v3"
+
+	appcfg "github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+)
+
+// boolFlagOrConfig returns the CLI flag value when explicitly set on the
+// command (or via env-var Source binding), otherwise the fallback. Logs an
+// INFO line when the CLI value differs from a non-default fallback.
+func boolFlagOrConfig(cmd *cli.Command, flagName string, fallback bool) bool {
+	if cmd.IsSet(flagName) {
+		v := cmd.Bool(flagName)
+		if v != fallback {
+			slog.Info("CLI flag overriding config value", "flag", flagName, "config", fallback, "override", v)
+		}
+		return v
+	}
+	return fallback
+}
+
+// stringSliceFlagOrConfig returns the CLI slice value when explicitly set,
+// otherwise the fallback slice. Per the agreed design, CLI replaces config
+// rather than appending.
+func stringSliceFlagOrConfig(cmd *cli.Command, flagName string, fallback []string) []string {
+	if cmd.IsSet(flagName) {
+		v := cmd.StringSlice(flagName)
+		if len(fallback) > 0 {
+			slog.Info("CLI flag replacing config value", "flag", flagName, "configCount", len(fallback), "overrideCount", len(v))
+		}
+		return v
+	}
+	return fallback
+}
+
+// resolveNodeSelector returns the parsed map for a CLI selector flag,
+// preferring CLI input over the supplied fallback map.
+func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]string) (map[string]string, error) {
+	if cmd.IsSet(flagName) {
+		parsed, err := snapshotter.ParseNodeSelectors(cmd.StringSlice(flagName))
+		if err != nil {
+			return nil, err
+		}
+		if len(fallback) > 0 {
+			slog.Info("CLI flag replacing config selector", "flag", flagName)
+		}
+		return parsed, nil
+	}
+	if fallback == nil {
+		return map[string]string{}, nil
+	}
+	// Return a defensive copy so callers cannot mutate the cached config map.
+	out := make(map[string]string, len(fallback))
+	for k, v := range fallback {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// bundleSpec returns cfg.Spec.Bundle if cfg is non-nil, else nil.
+func bundleSpec(cfg *appcfg.AICRConfig) *appcfg.BundleSpec {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Spec.Bundle
+}
+
+func bundleRecipeInput(b *appcfg.BundleSpec) string {
+	if b == nil || b.Input == nil {
+		return ""
+	}
+	return b.Input.Recipe
+}
+
+func bundleOutputTarget(b *appcfg.BundleSpec) string {
+	if b == nil || b.Output == nil {
+		return ""
+	}
+	return b.Output.Target
+}
+
+func bundleOutputImageRefs(b *appcfg.BundleSpec) string {
+	if b == nil || b.Output == nil {
+		return ""
+	}
+	return b.Output.ImageRefs
+}
+
+func bundleDeploymentDeployer(b *appcfg.BundleSpec) string {
+	if b == nil || b.Deployment == nil {
+		return ""
+	}
+	return b.Deployment.Deployer
+}
+
+func bundleDeploymentRepo(b *appcfg.BundleSpec) string {
+	if b == nil || b.Deployment == nil {
+		return ""
+	}
+	return b.Deployment.Repo
+}
+
+func bundleDeploymentSet(b *appcfg.BundleSpec) []string {
+	if b == nil || b.Deployment == nil {
+		return nil
+	}
+	return b.Deployment.Set
+}
+
+func bundleDeploymentDynamic(b *appcfg.BundleSpec) []string {
+	if b == nil || b.Deployment == nil {
+		return nil
+	}
+	return b.Deployment.Dynamic
+}
+
+func bundleSystemNodeSelector(b *appcfg.BundleSpec) map[string]string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return b.Scheduling.SystemNodeSelector
+}
+
+func bundleSystemNodeTolerations(b *appcfg.BundleSpec) []string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return b.Scheduling.SystemNodeTolerations
+}
+
+func bundleAcceleratedNodeSelector(b *appcfg.BundleSpec) map[string]string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return b.Scheduling.AcceleratedNodeSelector
+}
+
+func bundleAcceleratedNodeTolerations(b *appcfg.BundleSpec) []string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return b.Scheduling.AcceleratedNodeTolerations
+}
+
+func bundleWorkloadGate(b *appcfg.BundleSpec) string {
+	if b == nil || b.Scheduling == nil {
+		return ""
+	}
+	return b.Scheduling.WorkloadGate
+}
+
+func bundleWorkloadSelector(b *appcfg.BundleSpec) map[string]string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return b.Scheduling.WorkloadSelector
+}
+
+func bundleSchedulingNodes(b *appcfg.BundleSpec) int {
+	if b == nil || b.Scheduling == nil {
+		return 0
+	}
+	return b.Scheduling.Nodes
+}
+
+func bundleSchedulingStorageClass(b *appcfg.BundleSpec) string {
+	if b == nil || b.Scheduling == nil {
+		return ""
+	}
+	return b.Scheduling.StorageClass
+}
+
+func bundleAttestEnabled(b *appcfg.BundleSpec) bool {
+	if b == nil || b.Attestation == nil {
+		return false
+	}
+	return b.Attestation.Enabled
+}
+
+func bundleCertIDRegexp(b *appcfg.BundleSpec) string {
+	if b == nil || b.Attestation == nil {
+		return ""
+	}
+	return b.Attestation.CertificateIdentityRegexp
+}
+
+func bundleOIDCDeviceFlow(b *appcfg.BundleSpec) bool {
+	if b == nil || b.Attestation == nil {
+		return false
+	}
+	return b.Attestation.OIDCDeviceFlow
+}
+
+func bundleRegistryInsecureTLS(b *appcfg.BundleSpec) bool {
+	if b == nil || b.Registry == nil {
+		return false
+	}
+	return b.Registry.InsecureTLS
+}
+
+func bundleRegistryPlainHTTP(b *appcfg.BundleSpec) bool {
+	if b == nil || b.Registry == nil {
+		return false
+	}
+	return b.Registry.PlainHTTP
+}

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -15,11 +15,13 @@
 package cli
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/urfave/cli/v3"
 
 	appcfg "github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
@@ -41,40 +43,40 @@ func boolFlagOrConfig(cmd *cli.Command, flagName string, fallback bool) bool {
 // otherwise the fallback slice. Per the agreed design, CLI replaces config
 // rather than appending. Returns a defensive copy so callers cannot mutate
 // the loaded config's backing slice.
+//
+// nil input yields a nil result; an explicitly empty slice (e.g. `set: []`
+// in config) yields an empty (non-nil) slice — preserving the user's
+// intent to clear a list.
 func stringSliceFlagOrConfig(cmd *cli.Command, flagName string, fallback []string) []string {
 	if cmd.IsSet(flagName) {
 		v := cmd.StringSlice(flagName)
 		if len(fallback) > 0 {
 			slog.Info("CLI flag replacing config value", "flag", flagName, "configCount", len(fallback), "overrideCount", len(v))
 		}
-		return append([]string(nil), v...)
+		return copyStrings(v)
 	}
-	if len(fallback) == 0 {
-		return nil
-	}
-	return append([]string(nil), fallback...)
+	return copyStrings(fallback)
 }
 
 // resolveNodeSelector returns the parsed map for a CLI selector flag,
 // preferring CLI input over the supplied fallback map. Returns a defensive
 // copy in either path so callers cannot mutate the loaded config's map.
-// An empty fallback yields an empty (non-nil) map for caller convenience.
+//
+// nil fallback yields nil; an explicitly empty config map yields an empty
+// (non-nil) map — preserving the user's intent to clear a default selector.
 func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]string) (map[string]string, error) {
 	if cmd.IsSet(flagName) {
 		parsed, err := snapshotter.ParseNodeSelectors(cmd.StringSlice(flagName))
 		if err != nil {
-			return nil, err
+			return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid --%s", flagName))
 		}
 		if len(fallback) > 0 {
 			slog.Info("CLI flag replacing config selector", "flag", flagName)
 		}
 		return parsed, nil
 	}
-	out := make(map[string]string, len(fallback))
-	for k, v := range fallback {
-		out[k] = v
-	}
-	return out, nil
+	return copyStringMap(fallback), nil
 }
 
 // bundleSpec returns cfg.Spec.Bundle if cfg is non-nil, else nil.
@@ -120,19 +122,22 @@ func bundleDeploymentRepo(b *appcfg.BundleSpec) string {
 	return b.Deployment.Repo
 }
 
-// copyStrings returns a defensive copy of s (or nil for empty input) so
-// callers cannot mutate the loaded config's backing slice.
+// copyStrings returns a defensive copy of s. nil input yields nil; an
+// explicitly empty slice yields an empty (non-nil) slice — preserving the
+// caller's distinction between "unset" and "explicitly cleared".
 func copyStrings(s []string) []string {
-	if len(s) == 0 {
+	if s == nil {
 		return nil
 	}
-	return append([]string(nil), s...)
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
 }
 
-// copyStringMap returns a defensive copy of m (or nil for empty input) so
-// callers cannot mutate the loaded config's backing map.
+// copyStringMap returns a defensive copy of m. nil input yields nil; an
+// explicitly empty map yields an empty (non-nil) map.
 func copyStringMap(m map[string]string) map[string]string {
-	if len(m) == 0 {
+	if m == nil {
 		return nil
 	}
 	out := make(map[string]string, len(m))

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -17,10 +17,11 @@ package cli
 import (
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 
 	"github.com/urfave/cli/v3"
 
-	appcfg "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
@@ -44,26 +45,26 @@ func boolFlagOrConfig(cmd *cli.Command, flagName string, fallback bool) bool {
 // rather than appending. Returns a defensive copy so callers cannot mutate
 // the loaded config's backing slice.
 //
-// nil input yields a nil result; an explicitly empty slice (e.g. `set: []`
-// in config) yields an empty (non-nil) slice — preserving the user's
-// intent to clear a list.
+// nil input yields nil; an explicitly empty slice (e.g. `set: []` in
+// config) yields an empty (non-nil) slice — preserving the user's intent
+// to clear a list.
 func stringSliceFlagOrConfig(cmd *cli.Command, flagName string, fallback []string) []string {
 	if cmd.IsSet(flagName) {
 		v := cmd.StringSlice(flagName)
 		if len(fallback) > 0 {
 			slog.Info("CLI flag replacing config value", "flag", flagName, "configCount", len(fallback), "overrideCount", len(v))
 		}
-		return copyStrings(v)
+		return slices.Clone(v)
 	}
-	return copyStrings(fallback)
+	return slices.Clone(fallback)
 }
 
 // resolveNodeSelector returns the parsed map for a CLI selector flag,
-// preferring CLI input over the supplied fallback map. Returns a defensive
-// copy in either path so callers cannot mutate the loaded config's map.
-//
-// nil fallback yields nil; an explicitly empty config map yields an empty
-// (non-nil) map — preserving the user's intent to clear a default selector.
+// preferring CLI input over the supplied fallback map. Errors from
+// parsing carry ErrCodeInvalidRequest. The fallback is defensively
+// cloned even though spec accessors already clone — this is the
+// canonical entry point and should not require the caller to remember
+// who copies what.
 func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]string) (map[string]string, error) {
 	if cmd.IsSet(flagName) {
 		parsed, err := snapshotter.ParseNodeSelectors(cmd.StringSlice(flagName))
@@ -76,178 +77,5 @@ func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]
 		}
 		return parsed, nil
 	}
-	return copyStringMap(fallback), nil
-}
-
-// bundleSpec returns cfg.Spec.Bundle if cfg is non-nil, else nil.
-func bundleSpec(cfg *appcfg.AICRConfig) *appcfg.BundleSpec {
-	if cfg == nil {
-		return nil
-	}
-	return cfg.Spec.Bundle
-}
-
-func bundleRecipeInput(b *appcfg.BundleSpec) string {
-	if b == nil || b.Input == nil {
-		return ""
-	}
-	return b.Input.Recipe
-}
-
-func bundleOutputTarget(b *appcfg.BundleSpec) string {
-	if b == nil || b.Output == nil {
-		return ""
-	}
-	return b.Output.Target
-}
-
-func bundleOutputImageRefs(b *appcfg.BundleSpec) string {
-	if b == nil || b.Output == nil {
-		return ""
-	}
-	return b.Output.ImageRefs
-}
-
-func bundleDeploymentDeployer(b *appcfg.BundleSpec) string {
-	if b == nil || b.Deployment == nil {
-		return ""
-	}
-	return b.Deployment.Deployer
-}
-
-func bundleDeploymentRepo(b *appcfg.BundleSpec) string {
-	if b == nil || b.Deployment == nil {
-		return ""
-	}
-	return b.Deployment.Repo
-}
-
-// copyStrings returns a defensive copy of s. nil input yields nil; an
-// explicitly empty slice yields an empty (non-nil) slice — preserving the
-// caller's distinction between "unset" and "explicitly cleared".
-func copyStrings(s []string) []string {
-	if s == nil {
-		return nil
-	}
-	out := make([]string, len(s))
-	copy(out, s)
-	return out
-}
-
-// copyStringMap returns a defensive copy of m. nil input yields nil; an
-// explicitly empty map yields an empty (non-nil) map.
-func copyStringMap(m map[string]string) map[string]string {
-	if m == nil {
-		return nil
-	}
-	out := make(map[string]string, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
-}
-
-func bundleDeploymentSet(b *appcfg.BundleSpec) []string {
-	if b == nil || b.Deployment == nil {
-		return nil
-	}
-	return copyStrings(b.Deployment.Set)
-}
-
-func bundleDeploymentDynamic(b *appcfg.BundleSpec) []string {
-	if b == nil || b.Deployment == nil {
-		return nil
-	}
-	return copyStrings(b.Deployment.Dynamic)
-}
-
-func bundleSystemNodeSelector(b *appcfg.BundleSpec) map[string]string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return copyStringMap(b.Scheduling.SystemNodeSelector)
-}
-
-func bundleSystemNodeTolerations(b *appcfg.BundleSpec) []string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return copyStrings(b.Scheduling.SystemNodeTolerations)
-}
-
-func bundleAcceleratedNodeSelector(b *appcfg.BundleSpec) map[string]string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return copyStringMap(b.Scheduling.AcceleratedNodeSelector)
-}
-
-func bundleAcceleratedNodeTolerations(b *appcfg.BundleSpec) []string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return copyStrings(b.Scheduling.AcceleratedNodeTolerations)
-}
-
-func bundleWorkloadGate(b *appcfg.BundleSpec) string {
-	if b == nil || b.Scheduling == nil {
-		return ""
-	}
-	return b.Scheduling.WorkloadGate
-}
-
-func bundleWorkloadSelector(b *appcfg.BundleSpec) map[string]string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return copyStringMap(b.Scheduling.WorkloadSelector)
-}
-
-func bundleSchedulingNodes(b *appcfg.BundleSpec) int {
-	if b == nil || b.Scheduling == nil {
-		return 0
-	}
-	return b.Scheduling.Nodes
-}
-
-func bundleSchedulingStorageClass(b *appcfg.BundleSpec) string {
-	if b == nil || b.Scheduling == nil {
-		return ""
-	}
-	return b.Scheduling.StorageClass
-}
-
-func bundleAttestEnabled(b *appcfg.BundleSpec) bool {
-	if b == nil || b.Attestation == nil {
-		return false
-	}
-	return b.Attestation.Enabled
-}
-
-func bundleCertIDRegexp(b *appcfg.BundleSpec) string {
-	if b == nil || b.Attestation == nil {
-		return ""
-	}
-	return b.Attestation.CertificateIdentityRegexp
-}
-
-func bundleOIDCDeviceFlow(b *appcfg.BundleSpec) bool {
-	if b == nil || b.Attestation == nil {
-		return false
-	}
-	return b.Attestation.OIDCDeviceFlow
-}
-
-func bundleRegistryInsecureTLS(b *appcfg.BundleSpec) bool {
-	if b == nil || b.Registry == nil {
-		return false
-	}
-	return b.Registry.InsecureTLS
-}
-
-func bundleRegistryPlainHTTP(b *appcfg.BundleSpec) bool {
-	if b == nil || b.Registry == nil {
-		return false
-	}
-	return b.Registry.PlainHTTP
+	return maps.Clone(fallback), nil
 }

--- a/pkg/cli/config_e2e_test.go
+++ b/pkg/cli/config_e2e_test.go
@@ -1,0 +1,500 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+)
+
+// === Regression: --criteria removal ===
+
+// TestRecipeCmd_NoCriteriaFlag asserts the deprecated --criteria flag is no
+// longer accepted. Users must migrate to --config.
+func TestRecipeCmd_NoCriteriaFlag(t *testing.T) {
+	cmd := recipeCmd()
+	for _, f := range cmd.Flags {
+		for _, name := range f.Names() {
+			if name == "criteria" || name == "c" {
+				t.Errorf("flag %q should not be defined on recipe command (replaced by --config)", name)
+			}
+		}
+	}
+}
+
+// TestRecipeCmd_HasConfigFlag asserts --config is the canonical replacement.
+func TestRecipeCmd_HasConfigFlag(t *testing.T) {
+	cmd := recipeCmd()
+	found := false
+	for _, f := range cmd.Flags {
+		for _, name := range f.Names() {
+			if name == "config" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("recipe command must define --config flag")
+	}
+}
+
+// TestBundleCmd_HasConfigFlag asserts --config is wired on bundle.
+func TestBundleCmd_HasConfigFlag(t *testing.T) {
+	cmd := bundleCmd()
+	found := false
+	for _, f := range cmd.Flags {
+		for _, name := range f.Names() {
+			if name == "config" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("bundle command must define --config flag")
+	}
+}
+
+// TestRecipeCmd_CriteriaFlagRejected verifies that passing --criteria now
+// produces an "unknown flag" error rather than silently working.
+func TestRecipeCmd_CriteriaFlagRejected(t *testing.T) {
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{name, "recipe", "--criteria", "foo.yaml"})
+	if err == nil {
+		t.Fatal("expected error for removed --criteria flag")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "criteria") {
+		t.Logf("error: %v", err)
+	}
+}
+
+// === Regression: existing flags still work without --config ===
+
+// TestRecipeCmd_FlagsAloneStillWork ensures the criteria-from-flags pathway
+// (which has always worked) still works after the --config refactor.
+func TestRecipeCmd_FlagsAloneStillWork(t *testing.T) {
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{
+		name, "recipe",
+		"--service", "eks",
+		"--accelerator", "h100",
+		"--intent", "training",
+		"--os", "ubuntu",
+		"-o", "-",
+	})
+	if err != nil {
+		t.Fatalf("recipe with flag-only criteria failed: %v", err)
+	}
+}
+
+// TestBundleCmd_FlagsAloneStillWork ensures bundle works with only CLI flags
+// (no --config) just as before.
+func TestBundleCmd_FlagsAloneStillWork(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+
+	captured := captureBundleOpts(t, []string{
+		"--recipe", recipePath,
+		"--deployer", "argocd",
+		"--repo", "https://example.git",
+		"--system-node-selector", "role=system",
+		"--accelerated-node-toleration", "nvidia.com/gpu=present:NoSchedule",
+		"--nodes", "16",
+		"--storage-class", "gp3",
+		"-o", tmp,
+	})
+	if captured.recipeFilePath != recipePath {
+		t.Errorf("recipeFilePath = %q, want %q", captured.recipeFilePath, recipePath)
+	}
+	if captured.deployer.String() != "argocd" {
+		t.Errorf("deployer = %q, want argocd", captured.deployer)
+	}
+	if captured.estimatedNodeCount != 16 {
+		t.Errorf("estimatedNodeCount = %d, want 16", captured.estimatedNodeCount)
+	}
+	if captured.systemNodeSelector["role"] != "system" {
+		t.Errorf("missing role=system in systemNodeSelector: %v", captured.systemNodeSelector)
+	}
+	if len(captured.acceleratedNodeTolerations) == 0 {
+		t.Errorf("expected toleration, got none")
+	}
+	if captured.storageClass != "gp3" {
+		t.Errorf("storageClass = %q, want gp3", captured.storageClass)
+	}
+}
+
+// captureBundleOpts runs the bundle command's parsing flow and returns the
+// resolved options, so tests can assert on every option without invoking the
+// expensive bundler.Make() path.
+func captureBundleOpts(t *testing.T, args []string) *bundleCmdOptions {
+	t.Helper()
+	var captured *bundleCmdOptions
+	cmd := bundleCmd()
+	cmd.Action = func(ctx context.Context, c *cli.Command) error {
+		cfg, err := loadCmdConfig(ctx, c)
+		if err != nil {
+			return err
+		}
+		opts, err := parseBundleCmdOptions(c, cfg)
+		if err != nil {
+			return err
+		}
+		captured = opts
+		return nil
+	}
+	if err := cmd.Run(context.Background(), append([]string{"bundle"}, args...)); err != nil {
+		t.Fatalf("bundle run: %v", err)
+	}
+	return captured
+}
+
+// === All-bundle-options exhaustive coverage ===
+
+// TestBundleCmd_AllConfigSectionsResolve drives parseBundleCmdOptions with a
+// config exercising every section, then asserts each option lands on the
+// resolved bundleCmdOptions. This is the regression backstop for any future
+// schema change.
+func TestBundleCmd_AllConfigSectionsResolve(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := fmt.Sprintf(`kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  bundle:
+    input:
+      recipe: %s
+    output:
+      target: %s
+      imageRefs: %s/refs.txt
+    deployment:
+      deployer: argocd
+      repo: https://example.git/charts
+      set:
+        - gpuoperator:driver.version=570.86.16
+        - alloy:clusterName=base
+      dynamic:
+        - alloy:clusterName
+    scheduling:
+      systemNodeSelector:
+        role: system
+        tier: control
+      systemNodeTolerations:
+        - "node-role.kubernetes.io/control-plane:NoSchedule"
+      acceleratedNodeSelector:
+        nodeGroup: gpu-nodes
+      acceleratedNodeTolerations:
+        - "nvidia.com/gpu=present:NoSchedule"
+      workloadGate: "nvidia.com/training=true:NoSchedule"
+      workloadSelector:
+        workload: training
+      nodes: 12
+      storageClass: gp3
+    attestation:
+      enabled: true
+      certificateIdentityRegexp: ".*NVIDIA/aicr.*"
+      oidcDeviceFlow: true
+    registry:
+      insecureTLS: true
+      plainHTTP: true
+`, recipePath, tmp, tmp)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	opts := captureBundleOpts(t, []string{"--config", cfgPath})
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"recipeFilePath", opts.recipeFilePath, recipePath},
+		{"repoURL", opts.repoURL, "https://example.git/charts"},
+		{"deployer", opts.deployer, config.DeployerArgoCD},
+		{"valueOverrides count", len(opts.valueOverrides), 2},
+		{"dynamicValues count", len(opts.dynamicValues), 1},
+		{"systemNodeSelector role", opts.systemNodeSelector["role"], "system"},
+		{"systemNodeSelector tier", opts.systemNodeSelector["tier"], "control"},
+		{"acceleratedNodeSelector nodeGroup", opts.acceleratedNodeSelector["nodeGroup"], "gpu-nodes"},
+		{"systemNodeTolerations count", len(opts.systemNodeTolerations), 1},
+		{"acceleratedNodeTolerations count", len(opts.acceleratedNodeTolerations), 1},
+		{"workloadSelector", opts.workloadSelector["workload"], "training"},
+		{"estimatedNodeCount", opts.estimatedNodeCount, 12},
+		{"storageClass", opts.storageClass, "gp3"},
+		{"attest", opts.attest, true},
+		{"certificateIdentityRegexp", opts.certificateIdentityRegexp, ".*NVIDIA/aicr.*"},
+		{"oidcDeviceFlow", opts.oidcDeviceFlow, true},
+		{"insecureTLS", opts.insecureTLS, true},
+		{"plainHTTP", opts.plainHTTP, true},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+	if opts.workloadGateTaint == nil {
+		t.Errorf("workloadGateTaint should be parsed from workloadGate")
+	}
+}
+
+// TestBundleCmd_FlagOverridesEverySection verifies that for each major
+// section, a CLI flag wins over the same field in --config.
+func TestBundleCmd_FlagOverridesEverySection(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	altRecipe := filepath.Join(tmp, "recipe-alt.yaml")
+	if err := os.WriteFile(altRecipe, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe-alt: %v", err)
+	}
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := fmt.Sprintf(`kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  bundle:
+    input:
+      recipe: %s
+    deployment:
+      deployer: argocd
+      repo: https://config.example.git
+    scheduling:
+      nodes: 4
+      storageClass: standard
+    attestation:
+      enabled: false
+    registry:
+      insecureTLS: false
+      plainHTTP: false
+`, recipePath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	opts := captureBundleOpts(t, []string{
+		"--config", cfgPath,
+		"--recipe", altRecipe,
+		"--deployer", "helm",
+		"--repo", "https://flag.example.git",
+		"--nodes", "16",
+		"--storage-class", "premium",
+		"--insecure-tls",
+		"--plain-http",
+		"-o", tmp,
+	})
+
+	if opts.recipeFilePath != altRecipe {
+		t.Errorf("--recipe should override config: got %q, want %q", opts.recipeFilePath, altRecipe)
+	}
+	if opts.deployer != config.DeployerHelm {
+		t.Errorf("--deployer should override: got %q", opts.deployer)
+	}
+	if opts.repoURL != "https://flag.example.git" {
+		t.Errorf("--repo should override: got %q", opts.repoURL)
+	}
+	if opts.estimatedNodeCount != 16 {
+		t.Errorf("--nodes should override: got %d", opts.estimatedNodeCount)
+	}
+	if opts.storageClass != "premium" {
+		t.Errorf("--storage-class should override: got %q", opts.storageClass)
+	}
+	if !opts.insecureTLS {
+		t.Errorf("--insecure-tls should override config false")
+	}
+	if !opts.plainHTTP {
+		t.Errorf("--plain-http should override config false")
+	}
+}
+
+// === HTTP source for --config ===
+
+// TestRecipeCmd_ConfigFromHTTP verifies a --config URL is fetched and applied.
+func TestRecipeCmd_ConfigFromHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte(testRecipeConfig))
+	}))
+	t.Cleanup(srv.Close)
+
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{
+		name, "recipe", "--config", srv.URL + "/config.yaml", "-o", "-",
+	})
+	if err != nil {
+		t.Fatalf("recipe with HTTP --config failed: %v", err)
+	}
+}
+
+// === Snapshot + config interaction ===
+
+// TestRecipeCmd_ConfigFillsMissingCriteriaFromSnapshot covers the merge case
+// where a snapshot lacks one criteria field and --config fills it in. This is
+// the snapshot path of applyCriteriaFromConfig.
+func TestRecipeCmd_ConfigFillsMissingFromConfig(t *testing.T) {
+	// Pure config path (no snapshot): partial criteria in config, the rest
+	// supplied by CLI flags. Specificity should sum to all four fields.
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  recipe:
+    criteria:
+      service: eks
+      accelerator: h100
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{
+		name, "recipe", "--config", cfgPath,
+		"--intent", "training",
+		"--os", "ubuntu",
+		"-o", "-",
+	})
+	if err != nil {
+		t.Fatalf("recipe with partial config + flags failed: %v", err)
+	}
+}
+
+// === Validation surfaces ===
+
+// TestRecipeCmd_ConfigBadEnumRejected ensures invalid enum values in --config
+// are rejected with a useful error message at load time.
+func TestRecipeCmd_ConfigBadEnumRejected(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	bad := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  recipe:
+    criteria:
+      service: bogus-service
+`
+	if err := os.WriteFile(cfgPath, []byte(bad), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{name, "recipe", "--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected error for invalid service enum")
+	}
+	if !strings.Contains(err.Error(), "criteria.service") {
+		t.Errorf("error %q should reference criteria.service", err.Error())
+	}
+}
+
+// TestBundleCmd_ConfigBadDeployerRejected ensures an invalid deployer enum in
+// --config is rejected.
+func TestBundleCmd_ConfigBadDeployerRejected(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	bad := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  bundle:
+    deployment:
+      deployer: not-a-real-deployer
+`
+	if err := os.WriteFile(cfgPath, []byte(bad), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{name, "bundle", "--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected error for invalid deployer enum")
+	}
+	if !strings.Contains(err.Error(), "deployer") {
+		t.Errorf("error %q should reference deployer", err.Error())
+	}
+}
+
+// === Recipe → Bundle workflow with shared config ===
+
+// TestE2E_RecipeAndBundleShareConfig drives the full pipeline: a single
+// AICRConfig populates both spec.recipe and spec.bundle. The recipe step
+// writes a recipe to disk, the bundle step reads it back via the same config.
+func TestE2E_RecipeAndBundleShareConfig(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	bundleDir := filepath.Join(tmp, "bundle")
+	cfgPath := filepath.Join(tmp, "config.yaml")
+
+	cfg := fmt.Sprintf(`kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: e2e-shared
+spec:
+  recipe:
+    criteria:
+      service: eks
+      accelerator: h100
+      intent: training
+      os: ubuntu
+    output:
+      path: %s
+      format: yaml
+  bundle:
+    input:
+      recipe: %s
+    output:
+      target: %s
+    deployment:
+      deployer: helm
+`, recipePath, recipePath, bundleDir)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Step 1: recipe writes to spec.recipe.output.path.
+	root := newRootCmd()
+	if err := root.Run(context.Background(), []string{name, "recipe", "--config", cfgPath}); err != nil {
+		t.Fatalf("recipe failed: %v", err)
+	}
+	if _, err := os.Stat(recipePath); err != nil {
+		t.Fatalf("recipe output not written: %v", err)
+	}
+
+	// Step 2: parseBundleCmdOptions resolves the recipe path and other
+	// options from the same config file. We don't run the full bundle
+	// (which would need full Helm chart resolution) — option resolution is
+	// the contract under test.
+	opts := captureBundleOpts(t, []string{"--config", cfgPath})
+	if opts.recipeFilePath != recipePath {
+		t.Errorf("bundle did not pick up recipe path from config: got %q, want %q",
+			opts.recipeFilePath, recipePath)
+	}
+	if opts.deployer != config.DeployerHelm {
+		t.Errorf("bundle deployer = %q, want helm", opts.deployer)
+	}
+}

--- a/pkg/cli/config_e2e_test.go
+++ b/pkg/cli/config_e2e_test.go
@@ -387,6 +387,10 @@ spec:
 	}
 }
 
+// Precedence (CLI > config > snapshot) is locked in by the unit tests in
+// config_integration_test.go: TestApplyCriteriaFromConfig_OverridesSnapshot
+// and TestApplyCriteriaFromConfig_FillsEmptyCriteria.
+
 // === Validation surfaces ===
 
 // TestRecipeCmd_ConfigBadEnumRejected ensures invalid enum values in --config

--- a/pkg/cli/config_helpers_test.go
+++ b/pkg/cli/config_helpers_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+// runWith builds a Command with the given Flags and runs it with args, calling
+// the supplied capture function inside Action so tests can inspect the parsed
+// command (cmd.IsSet, cmd.String, etc.) the same way real handlers do.
+func runWith(t *testing.T, flags []cli.Flag, args []string, capture func(*cli.Command)) {
+	t.Helper()
+	cmd := &cli.Command{
+		Name:  "t",
+		Flags: flags,
+		Action: func(_ context.Context, c *cli.Command) error {
+			capture(c)
+			return nil
+		},
+	}
+	if err := cmd.Run(context.Background(), append([]string{"t"}, args...)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestStringFlagOrConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flagDef  cli.Flag
+		fallback string
+		want     string
+	}{
+		{
+			name:     "flag not set returns fallback",
+			args:     []string{},
+			flagDef:  &cli.StringFlag{Name: "x"},
+			fallback: "from-config",
+			want:     "from-config",
+		},
+		{
+			name:     "flag set wins over fallback",
+			args:     []string{"--x", "from-flag"},
+			flagDef:  &cli.StringFlag{Name: "x"},
+			fallback: "from-config",
+			want:     "from-flag",
+		},
+		{
+			name:     "default value does NOT count as set",
+			args:     []string{},
+			flagDef:  &cli.StringFlag{Name: "x", Value: "default"},
+			fallback: "from-config",
+			want:     "from-config", // critical: default-only must not mask config
+		},
+		{
+			name:     "explicit value matching default still counts as set",
+			args:     []string{"--x", "default"},
+			flagDef:  &cli.StringFlag{Name: "x", Value: "default"},
+			fallback: "from-config",
+			want:     "default",
+		},
+		{
+			name:     "no fallback no flag returns empty",
+			args:     []string{},
+			flagDef:  &cli.StringFlag{Name: "x"},
+			fallback: "",
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWith(t, []cli.Flag{tt.flagDef}, tt.args, func(c *cli.Command) {
+				if got := stringFlagOrConfig(c, "x", tt.fallback); got != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+			})
+		})
+	}
+}
+
+func TestIntFlagOrConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flagDef  cli.Flag
+		fallback int
+		want     int
+	}{
+		{"flag not set returns fallback", []string{}, &cli.IntFlag{Name: "n"}, 5, 5},
+		{"flag set overrides fallback", []string{"--n", "9"}, &cli.IntFlag{Name: "n"}, 5, 9},
+		{"default zero does not count as set", []string{}, &cli.IntFlag{Name: "n", Value: 0}, 5, 5},
+		{"explicit zero counts as set", []string{"--n", "0"}, &cli.IntFlag{Name: "n"}, 5, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWith(t, []cli.Flag{tt.flagDef}, tt.args, func(c *cli.Command) {
+				if got := intFlagOrConfig(c, "n", tt.fallback); got != tt.want {
+					t.Errorf("got %d, want %d", got, tt.want)
+				}
+			})
+		})
+	}
+}
+
+func TestBoolFlagOrConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		fallback bool
+		want     bool
+	}{
+		{"unset returns false fallback", []string{}, false, false},
+		{"unset returns true fallback", []string{}, true, true},
+		{"explicit true overrides false fallback", []string{"--b"}, false, true},
+		{"explicit true matches true fallback", []string{"--b"}, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWith(t, []cli.Flag{&cli.BoolFlag{Name: "b"}}, tt.args, func(c *cli.Command) {
+				if got := boolFlagOrConfig(c, "b", tt.fallback); got != tt.want {
+					t.Errorf("got %v, want %v", got, tt.want)
+				}
+			})
+		})
+	}
+}
+
+func TestStringSliceFlagOrConfig(t *testing.T) {
+	flag := &cli.StringSliceFlag{Name: "s"}
+
+	t.Run("unset returns fallback", func(t *testing.T) {
+		runWith(t, []cli.Flag{flag}, nil, func(c *cli.Command) {
+			got := stringSliceFlagOrConfig(c, "s", []string{"a", "b"})
+			if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+				t.Errorf("got %v, want [a b]", got)
+			}
+		})
+	})
+
+	t.Run("CLI replaces fallback", func(t *testing.T) {
+		runWith(t, []cli.Flag{flag}, []string{"--s", "x", "--s", "y"}, func(c *cli.Command) {
+			got := stringSliceFlagOrConfig(c, "s", []string{"a", "b"})
+			if len(got) != 2 || got[0] != "x" || got[1] != "y" {
+				t.Errorf("got %v, want [x y] (CLI replaces, not appends)", got)
+			}
+		})
+	})
+}
+
+func TestResolveNodeSelector(t *testing.T) {
+	flag := &cli.StringSliceFlag{Name: "sel"}
+
+	t.Run("unset returns copy of fallback", func(t *testing.T) {
+		fallback := map[string]string{"role": "system"}
+		runWith(t, []cli.Flag{flag}, nil, func(c *cli.Command) {
+			got, err := resolveNodeSelector(c, "sel", fallback)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got["role"] != "system" {
+				t.Errorf("got %v, want role=system", got)
+			}
+			// Mutating result must not mutate fallback (defensive copy).
+			got["role"] = "modified"
+			if fallback["role"] != "system" {
+				t.Errorf("fallback was mutated")
+			}
+		})
+	})
+
+	t.Run("unset with nil fallback returns empty map", func(t *testing.T) {
+		runWith(t, []cli.Flag{flag}, nil, func(c *cli.Command) {
+			got, err := resolveNodeSelector(c, "sel", nil)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got == nil {
+				t.Errorf("got nil, want empty map")
+			}
+		})
+	})
+
+	t.Run("CLI parses and replaces fallback", func(t *testing.T) {
+		runWith(t, []cli.Flag{flag}, []string{"--sel", "k=v"}, func(c *cli.Command) {
+			got, err := resolveNodeSelector(c, "sel", map[string]string{"role": "system"})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got["k"] != "v" {
+				t.Errorf("missing k=v in %v", got)
+			}
+			if _, ok := got["role"]; ok {
+				t.Errorf("CLI should replace, not merge: %v", got)
+			}
+		})
+	})
+
+	t.Run("malformed CLI selector returns error", func(t *testing.T) {
+		runWith(t, []cli.Flag{flag}, []string{"--sel", "no-equals-sign"}, func(c *cli.Command) {
+			_, err := resolveNodeSelector(c, "sel", nil)
+			if err == nil {
+				t.Errorf("expected error for malformed selector")
+			}
+		})
+	})
+}

--- a/pkg/cli/config_helpers_test.go
+++ b/pkg/cli/config_helpers_test.go
@@ -184,14 +184,29 @@ func TestResolveNodeSelector(t *testing.T) {
 		})
 	})
 
-	t.Run("unset with nil fallback returns empty map", func(t *testing.T) {
+	t.Run("unset with nil fallback returns nil (preserves unset)", func(t *testing.T) {
 		runWith(t, []cli.Flag{flag}, nil, func(c *cli.Command) {
 			got, err := resolveNodeSelector(c, "sel", nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
+			if got != nil {
+				t.Errorf("got %v, want nil (nil fallback must propagate)", got)
+			}
+		})
+	})
+
+	t.Run("unset with explicitly empty fallback returns non-nil empty map", func(t *testing.T) {
+		runWith(t, []cli.Flag{flag}, nil, func(c *cli.Command) {
+			got, err := resolveNodeSelector(c, "sel", map[string]string{})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
 			if got == nil {
-				t.Errorf("got nil, want empty map")
+				t.Errorf("got nil, want empty (non-nil) map (explicit-empty preserved)")
+			}
+			if len(got) != 0 {
+				t.Errorf("got %v, want empty map", got)
 			}
 		})
 	})

--- a/pkg/cli/config_integration_test.go
+++ b/pkg/cli/config_integration_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	"github.com/urfave/cli/v3"
+
+	appcfg "github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 // writeYAML writes content to a temp file in the test's temp dir and returns its path.
@@ -33,6 +36,67 @@ func writeYAML(t *testing.T, name, content string) string {
 		t.Fatalf("write temp file: %v", err)
 	}
 	return path
+}
+
+// TestApplyCriteriaFromConfig_OverridesSnapshot locks in the documented
+// precedence: when both a snapshot and a config supply the same criteria
+// field, the config wins. CLI flags subsequently override either.
+func TestApplyCriteriaFromConfig_OverridesSnapshot(t *testing.T) {
+	criteria := recipe.NewCriteria()
+	criteria.Service = recipe.CriteriaServiceType("eks")
+	criteria.Accelerator = recipe.CriteriaAcceleratorType("h100")
+	criteria.Intent = recipe.CriteriaIntentType("training")
+	criteria.OS = recipe.CriteriaOSType("ubuntu")
+
+	cfg := &appcfg.AICRConfig{
+		Spec: appcfg.Spec{
+			Recipe: &appcfg.RecipeSpec{
+				Criteria: &appcfg.CriteriaSpec{
+					Service: "gke",       // overrides snapshot eks
+					Intent:  "inference", // overrides snapshot training
+					// accelerator + os intentionally unset; snapshot values must persist
+				},
+			},
+		},
+	}
+
+	if err := applyCriteriaFromConfig(criteria, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if string(criteria.Service) != "gke" {
+		t.Errorf("service = %q, want gke (config overrides snapshot)", criteria.Service)
+	}
+	if string(criteria.Intent) != "inference" {
+		t.Errorf("intent = %q, want inference (config overrides snapshot)", criteria.Intent)
+	}
+	if string(criteria.Accelerator) != "h100" {
+		t.Errorf("accelerator = %q, want h100 (snapshot preserved when config silent)", criteria.Accelerator)
+	}
+	if string(criteria.OS) != "ubuntu" {
+		t.Errorf("os = %q, want ubuntu (snapshot preserved when config silent)", criteria.OS)
+	}
+}
+
+// TestApplyCriteriaFromConfig_FillsEmptyCriteria covers the no-snapshot path:
+// the criteria starts as NewCriteria (all "any") and config populates it.
+func TestApplyCriteriaFromConfig_FillsEmptyCriteria(t *testing.T) {
+	criteria := recipe.NewCriteria()
+	cfg := &appcfg.AICRConfig{
+		Spec: appcfg.Spec{
+			Recipe: &appcfg.RecipeSpec{
+				Criteria: &appcfg.CriteriaSpec{
+					Service: "eks",
+				},
+			},
+		},
+	}
+	if err := applyCriteriaFromConfig(criteria, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if string(criteria.Service) != "eks" {
+		t.Errorf("service = %q, want eks", criteria.Service)
+	}
 }
 
 const testRecipeConfig = `kind: AICRConfig

--- a/pkg/cli/config_integration_test.go
+++ b/pkg/cli/config_integration_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+// writeYAML writes content to a temp file in the test's temp dir and returns its path.
+func writeYAML(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+const testRecipeConfig = `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: cfg-test
+spec:
+  recipe:
+    criteria:
+      service: eks
+      accelerator: h100
+      intent: training
+      os: ubuntu
+`
+
+func TestRecipeCmd_ConfigFlag_AppliesCriteria(t *testing.T) {
+	cfgPath := writeYAML(t, "config.yaml", testRecipeConfig)
+	root := newRootCmd()
+
+	// Use --output - to write to stdout-substitute (cmd.Writer is captured).
+	err := root.Run(context.Background(), []string{
+		name, "recipe", "--config", cfgPath, "-o", "-",
+	})
+	if err != nil {
+		t.Fatalf("recipe with --config failed: %v", err)
+	}
+}
+
+func TestRecipeCmd_ConfigFlag_FlagOverride(t *testing.T) {
+	cfgPath := writeYAML(t, "config.yaml", testRecipeConfig)
+	root := newRootCmd()
+
+	err := root.Run(context.Background(), []string{
+		name, "recipe", "--config", cfgPath, "--service", "gke", "-o", "-",
+	})
+	if err != nil {
+		t.Fatalf("recipe with --config + flag override failed: %v", err)
+	}
+}
+
+func TestRecipeCmd_ConfigFlag_InvalidConfig(t *testing.T) {
+	cfgPath := writeYAML(t, "config.yaml", "kind: NotARealKind\napiVersion: v1\nspec: {recipe: {}}\n")
+	root := newRootCmd()
+
+	err := root.Run(context.Background(), []string{
+		name, "recipe", "--config", cfgPath,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid kind, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid kind") {
+		t.Errorf("error %q should mention 'invalid kind'", err.Error())
+	}
+}
+
+func TestRecipeCmd_ConfigFlag_MissingFile(t *testing.T) {
+	root := newRootCmd()
+	err := root.Run(context.Background(), []string{
+		name, "recipe", "--config", "/does/not/exist.yaml",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing config file, got nil")
+	}
+}
+
+const testBundleConfig = `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  bundle:
+    input:
+      recipe: %q
+    deployment:
+      deployer: argocd
+      repo: https://example.git/charts
+      set:
+        - gpuoperator:driver.version=570.86.16
+    scheduling:
+      systemNodeSelector:
+        role: system
+      acceleratedNodeTolerations:
+        - "nvidia.com/gpu=present:NoSchedule"
+      nodes: 4
+      storageClass: gp3
+    attestation:
+      enabled: false
+    registry:
+      insecureTLS: false
+      plainHTTP: false
+`
+
+// runBundleParse executes the bundle command's flag parser via a minimal
+// shim Action, returning the captured *bundleCmdOptions for assertion.
+func runBundleParse(t *testing.T, args []string) *bundleCmdOptions {
+	t.Helper()
+	var captured *bundleCmdOptions
+	cmd := bundleCmd()
+	cmd.Action = func(ctx context.Context, c *cli.Command) error {
+		cfg, err := loadCmdConfig(ctx, c)
+		if err != nil {
+			return err
+		}
+		opts, err := parseBundleCmdOptions(c, cfg)
+		if err != nil {
+			return err
+		}
+		captured = opts
+		return nil
+	}
+	if err := cmd.Run(context.Background(), append([]string{"bundle"}, args...)); err != nil {
+		t.Fatalf("bundle.Run: %v", err)
+	}
+	return captured
+}
+
+func TestBundleCmd_ConfigFlag_PopulatesAllSections(t *testing.T) {
+	// Write a fake recipe file so the existence check passes.
+	recipePath := writeYAML(t, "recipe.yaml", "kind: Recipe\n")
+	cfgPath := writeYAML(t, "config.yaml",
+		strings.ReplaceAll(testBundleConfig, "%q", recipePath))
+
+	opts := runBundleParse(t, []string{"--config", cfgPath, "-o", t.TempDir()})
+
+	if opts.recipeFilePath != recipePath {
+		t.Errorf("recipeFilePath = %q, want %q", opts.recipeFilePath, recipePath)
+	}
+	if got := opts.deployer.String(); got != "argocd" {
+		t.Errorf("deployer = %q, want argocd", got)
+	}
+	if opts.repoURL != "https://example.git/charts" {
+		t.Errorf("repoURL = %q", opts.repoURL)
+	}
+	if len(opts.valueOverrides) == 0 {
+		t.Errorf("expected valueOverrides to be populated, got empty")
+	}
+	if v := opts.systemNodeSelector["role"]; v != "system" {
+		t.Errorf("systemNodeSelector[role] = %q, want system", v)
+	}
+	if len(opts.acceleratedNodeTolerations) == 0 {
+		t.Errorf("expected acceleratedNodeTolerations to be populated")
+	}
+	if opts.estimatedNodeCount != 4 {
+		t.Errorf("estimatedNodeCount = %d, want 4", opts.estimatedNodeCount)
+	}
+	if opts.storageClass != "gp3" {
+		t.Errorf("storageClass = %q, want gp3", opts.storageClass)
+	}
+	if opts.attest {
+		t.Errorf("attest = true, want false")
+	}
+}
+
+func TestBundleCmd_ConfigFlag_FlagOverridesScalar(t *testing.T) {
+	recipePath := writeYAML(t, "recipe.yaml", "kind: Recipe\n")
+	cfgPath := writeYAML(t, "config.yaml",
+		strings.ReplaceAll(testBundleConfig, "%q", recipePath))
+
+	opts := runBundleParse(t, []string{
+		"--config", cfgPath,
+		"--deployer", "helm",
+		"--storage-class", "premium",
+		"-o", t.TempDir(),
+	})
+	if got := opts.deployer.String(); got != "helm" {
+		t.Errorf("deployer = %q, want helm (CLI override)", got)
+	}
+	if opts.storageClass != "premium" {
+		t.Errorf("storageClass = %q, want premium (CLI override)", opts.storageClass)
+	}
+}
+
+func TestBundleCmd_ConfigFlag_FlagReplacesSlice(t *testing.T) {
+	recipePath := writeYAML(t, "recipe.yaml", "kind: Recipe\n")
+	cfgPath := writeYAML(t, "config.yaml",
+		strings.ReplaceAll(testBundleConfig, "%q", recipePath))
+
+	opts := runBundleParse(t, []string{
+		"--config", cfgPath,
+		"--set", "alloy:clusterName=mine",
+		"-o", t.TempDir(),
+	})
+	// CLI replaces config: only the CLI-provided override is present.
+	if len(opts.valueOverrides) != 1 {
+		t.Errorf("valueOverrides count = %d, want 1 (CLI replaces config slice)", len(opts.valueOverrides))
+	}
+}
+
+func TestBundleCmd_ConfigFlag_RecipeFromConfig(t *testing.T) {
+	recipePath := writeYAML(t, "recipe.yaml", "kind: Recipe\n")
+	cfgPath := writeYAML(t, "config.yaml",
+		strings.ReplaceAll(testBundleConfig, "%q", recipePath))
+
+	// No --recipe on CLI; resolved from config.
+	opts := runBundleParse(t, []string{"--config", cfgPath, "-o", t.TempDir()})
+	if opts.recipeFilePath != recipePath {
+		t.Errorf("recipeFilePath = %q, want %q (from config)", opts.recipeFilePath, recipePath)
+	}
+}
+
+func TestBundleCmd_ConfigFlag_RecipeMissingFromConfigAndCLI(t *testing.T) {
+	cfgPath := writeYAML(t, "config.yaml", `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  bundle:
+    deployment:
+      deployer: helm
+`)
+	cmd := bundleCmd()
+	cmd.Action = func(ctx context.Context, c *cli.Command) error {
+		cfg, err := loadCmdConfig(ctx, c)
+		if err != nil {
+			return err
+		}
+		_, err = parseBundleCmdOptions(c, cfg)
+		return err
+	}
+	err := cmd.Run(context.Background(), []string{"bundle", "--config", cfgPath, "-o", t.TempDir()})
+	if err == nil {
+		t.Fatal("expected error when --recipe is missing from both CLI and config")
+	}
+	if !strings.Contains(err.Error(), "--recipe is required") {
+		t.Errorf("error %q should mention --recipe required", err.Error())
+	}
+}

--- a/pkg/cli/doc.go
+++ b/pkg/cli/doc.go
@@ -37,36 +37,38 @@
 //	aicr recipe --os ubuntu --osv 24.04 --service eks --gpu h100 --intent training
 //	aicr recipe --snapshot system.yaml --intent inference --output recipe.yaml
 //	aicr recipe -s cm://namespace/snapshot -o cm://namespace/recipe  # ConfigMap I/O
-//	aicr recipe --criteria criteria.yaml --output recipe.yaml  # Criteria file mode
+//	aicr recipe --config config.yaml --output recipe.yaml  # Config file mode
 //
 // Generates optimized configuration recipes based on either:
 //   - Specified environment parameters (OS, service, GPU, intent)
 //   - Existing system snapshot (analyzes snapshot to extract parameters)
-//   - Criteria file (Kubernetes-style YAML/JSON with kind: RecipeCriteria)
+//   - AICRConfig file (Kubernetes-style YAML/JSON with kind: AICRConfig)
 //
-// # Criteria File Mode
+// # Config File Mode
 //
-// The --criteria/-c flag allows defining criteria in a Kubernetes-style
-// resource file instead of individual CLI flags:
+// The --config flag accepts a single AICRConfig document carrying defaults
+// for the recipe and/or bundle commands:
 //
-//	aicr recipe --criteria /path/to/criteria.yaml
+//	aicr recipe --config /path/to/config.yaml
 //
-// Criteria file format (YAML or JSON):
+// Config file format (YAML or JSON):
 //
-//	kind: RecipeCriteria
+//	kind: AICRConfig
 //	apiVersion: aicr.nvidia.com/v1alpha1
 //	metadata:
-//	  name: my-deployment-criteria
+//	  name: my-deployment
 //	spec:
-//	  service: eks
-//	  accelerator: gb200
-//	  os: ubuntu
-//	  intent: training
-//	  nodes: 8
+//	  recipe:
+//	    criteria:
+//	      service: eks
+//	      accelerator: gb200
+//	      os: ubuntu
+//	      intent: training
+//	      nodes: 8
 //
-// Individual CLI flags override criteria file values:
+// Individual CLI flags override config file values:
 //
-//	aicr recipe --criteria criteria.yaml --service gke  # service=gke overrides file
+//	aicr recipe --config config.yaml --service gke  # service=gke overrides file
 //
 // validate - Validate recipe constraints (Step 3):
 //

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -24,6 +24,7 @@ import (
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
 
+	appcfg "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/constraints"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -95,20 +96,25 @@ Use in shell scripts:
     --selector components.gpu-operator.values.driver.version)`,
 		Flags: queryCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", "snapshot", "criteria", "format", "selector"); err != nil {
+			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", "snapshot", "config", "format", "selector"); err != nil {
 				return err
 			}
 
-			if err := initDataProvider(cmd); err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
-			}
-
-			outFormat, err := parseOutputFormat(cmd)
+			cfg, err := loadCmdConfig(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			result, err := buildRecipeFromCmd(ctx, cmd)
+			if err = initDataProvider(cmd, cfg); err != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+			}
+
+			outFormat, err := parseRecipeOutputFormat(cmd, cfg)
+			if err != nil {
+				return err
+			}
+
+			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg)
 			if err != nil {
 				return err
 			}
@@ -129,17 +135,22 @@ Use in shell scripts:
 	}
 }
 
-// buildRecipeFromCmd resolves a recipe from CLI criteria flags.
-// Shared logic extracted from the recipe command action.
-func buildRecipeFromCmd(ctx context.Context, cmd *cli.Command) (*recipe.RecipeResult, error) {
+// buildRecipeFromCmdWithConfig resolves a recipe from CLI flags layered on
+// top of an optional AICRConfig. Resolution order for each input is:
+//
+//  1. CLI flag (if explicitly set)
+//  2. spec.recipe.* field on cfg (if non-empty)
+//  3. zero value
+//
+// A snapshot path provided by either source takes precedence over the
+// criteria pathway, matching today's --snapshot behavior.
+func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig) (*recipe.RecipeResult, error) {
 	builder := recipe.NewBuilder(
 		recipe.WithVersion(version),
 	)
 
-	snapFilePath := cmd.String("snapshot")
-	criteriaFilePath := cmd.String("criteria")
+	snapFilePath := stringFlagOrConfig(cmd, "snapshot", configRecipeSnapshot(cfg))
 
-	//nolint:gocritic // if-else chain is appropriate for non-empty string conditions
 	if snapFilePath != "" {
 		slog.Info("loading snapshot from", "uri", snapFilePath)
 		snap, loadErr := serializer.FromFileWithKubeconfig[snapshotter.Snapshot](snapFilePath, cmd.String("kubeconfig"))
@@ -148,6 +159,9 @@ func buildRecipeFromCmd(ctx context.Context, cmd *cli.Command) (*recipe.RecipeRe
 		}
 
 		criteria := recipe.ExtractCriteriaFromSnapshot(snap)
+		if applyErr := applyCriteriaFromConfig(criteria, cfg); applyErr != nil {
+			return nil, applyErr
+		}
 		if applyErr := applyCriteriaOverrides(cmd, criteria); applyErr != nil {
 			return nil, applyErr
 		}
@@ -163,28 +177,16 @@ func buildRecipeFromCmd(ctx context.Context, cmd *cli.Command) (*recipe.RecipeRe
 
 		slog.Info("building recipe from snapshot", "criteria", criteria.String())
 		return builder.BuildFromCriteriaWithEvaluator(ctx, criteria, evaluator)
-	} else if criteriaFilePath != "" {
-		slog.Info("loading criteria from file", "path", criteriaFilePath)
-		criteria, loadErr := recipe.LoadCriteriaFromFileWithContext(ctx, criteriaFilePath)
-		if loadErr != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to load criteria from %q", criteriaFilePath), loadErr)
-		}
-
-		if applyErr := applyCriteriaOverrides(cmd, criteria); applyErr != nil {
-			return nil, applyErr
-		}
-
-		slog.Info("building recipe from criteria file", "criteria", criteria.String())
-		return builder.BuildFromCriteria(ctx, criteria)
 	}
 
-	criteria, buildErr := buildCriteriaFromCmd(cmd)
-	if buildErr != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "error parsing criteria", buildErr)
+	criteria, err := mergeCriteriaFromCmdAndConfig(cmd, cfg)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "error parsing criteria", err)
 	}
 
 	if criteria.Specificity() == 0 {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "no criteria provided: specify at least one of --service, --accelerator, --intent, --os, --platform, --nodes, --criteria, or use --snapshot to load from a snapshot file")
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"no criteria provided: specify at least one of --service, --accelerator, --intent, --os, --platform, --nodes, --config, or use --snapshot to load from a snapshot file")
 	}
 
 	slog.Info("building recipe from criteria", "criteria", criteria.String())

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -149,7 +149,7 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 		recipe.WithVersion(version),
 	)
 
-	snapFilePath := stringFlagOrConfig(cmd, "snapshot", configRecipeSnapshot(cfg))
+	snapFilePath := stringFlagOrConfig(cmd, "snapshot", cfg.Recipe().SnapshotPath())
 
 	if snapFilePath != "" {
 		slog.Info("loading snapshot from", "uri", snapFilePath)

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	appcfg "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
@@ -68,17 +69,11 @@ func recipeCmdFlags() []cli.Flag {
 	If provided, criteria are extracted from the snapshot.`,
 			Category: "Input",
 		},
-		&cli.StringFlag{
-			Name:    "criteria",
-			Aliases: []string{"c"},
-			Usage: `Path to criteria file (YAML/JSON), alternative to individual flags.
-	Criteria file fields can be overridden by individual flags.`,
-			Category: "Input",
-		},
-		dataFlag,
-		outputFlag,
+		configFlag(),
+		dataFlag(),
+		outputFlag(),
 		formatFlag(),
-		kubeconfigFlag,
+		kubeconfigFlag(),
 	}
 }
 
@@ -102,8 +97,8 @@ Examples:
 Generate recipe from explicit criteria:
   aicr recipe --service eks --accelerator h100 --os ubuntu --intent training
 
-Generate recipe from a criteria file:
-  aicr recipe --criteria criteria.yaml
+Generate recipe from a config file:
+  aicr recipe --config config.yaml
 
 Generate recipe from a snapshot file:
   aicr recipe --snapshot snapshot.yaml
@@ -114,27 +109,32 @@ Generate recipe from a ConfigMap snapshot:
 Save recipe to a file:
   aicr recipe --snapshot cm://gpu-operator/aicr-snapshot -o recipe.yaml
 
-Override criteria file values with flags:
-  aicr recipe --criteria criteria.yaml --service gke
+Override config file values with flags:
+  aicr recipe --config config.yaml --service gke
 
 Override snapshot-detected criteria:
   aicr recipe --snapshot cm://gpu-operator/aicr-snapshot --service gke`,
 		Flags: recipeCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", "snapshot", "criteria", "output", "format"); err != nil {
+			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", "snapshot", "config", "output", "format"); err != nil {
 				return err
 			}
 
-			if err := initDataProvider(cmd); err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
-			}
-
-			outFormat, err := parseOutputFormat(cmd)
+			cfg, err := loadCmdConfig(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			result, err := buildRecipeFromCmd(ctx, cmd)
+			if err = initDataProvider(cmd, cfg); err != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+			}
+
+			outFormat, err := parseRecipeOutputFormat(cmd, cfg)
+			if err != nil {
+				return err
+			}
+
+			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg)
 			if err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "error building recipe", err)
 			}
@@ -151,7 +151,7 @@ Override snapshot-detected criteria:
 				}
 			}
 
-			output := cmd.String("output")
+			output := recipeOutputPath(cmd, cfg)
 			ser, err := serializer.NewFileWriterOrStdout(outFormat, output)
 			if err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to create output writer", err)
@@ -176,6 +176,107 @@ Override snapshot-detected criteria:
 			return nil
 		},
 	}
+}
+
+// configRecipeSnapshot returns the snapshot path from spec.recipe.input.snapshot
+// (or empty string when cfg or any intermediate path is nil).
+func configRecipeSnapshot(cfg *appcfg.AICRConfig) string {
+	if cfg == nil || cfg.Spec.Recipe == nil || cfg.Spec.Recipe.Input == nil {
+		return ""
+	}
+	return cfg.Spec.Recipe.Input.Snapshot
+}
+
+// recipeOutputPath returns the recipe output destination, with the CLI flag
+// overriding spec.recipe.output.path.
+func recipeOutputPath(cmd *cli.Command, cfg *appcfg.AICRConfig) string {
+	fallback := ""
+	if cfg != nil && cfg.Spec.Recipe != nil && cfg.Spec.Recipe.Output != nil {
+		fallback = cfg.Spec.Recipe.Output.Path
+	}
+	return stringFlagOrConfig(cmd, "output", fallback)
+}
+
+// parseRecipeOutputFormat reads --format with a fallback to spec.recipe.output.format
+// and validates the result.
+func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializer.Format, error) {
+	raw := cmd.String("format")
+	if raw == "" && cfg != nil && cfg.Spec.Recipe != nil && cfg.Spec.Recipe.Output != nil {
+		raw = cfg.Spec.Recipe.Output.Format
+	}
+	if raw == "" {
+		raw = string(serializer.FormatYAML)
+	}
+	out := serializer.Format(raw)
+	if out.IsUnknown() {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unknown output format: %q, valid formats are: yaml, json, table", raw))
+	}
+	return out, nil
+}
+
+// applyCriteriaFromConfig merges spec.recipe.criteria values into an existing
+// Criteria. Non-empty config fields fill in fields that are unset (empty or
+// the "any" wildcard) on the criteria, without overwriting values already
+// populated from a snapshot.
+func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig) error {
+	if cfg == nil || cfg.Spec.Recipe == nil || cfg.Spec.Recipe.Criteria == nil {
+		return nil
+	}
+	c := cfg.Spec.Recipe.Criteria
+
+	if c.Service != "" && (criteria.Service == "" || criteria.Service == recipe.CriteriaServiceAny) {
+		parsed, err := recipe.ParseCriteriaServiceType(c.Service)
+		if err != nil {
+			return err
+		}
+		criteria.Service = parsed
+	}
+	if c.Accelerator != "" && (criteria.Accelerator == "" || criteria.Accelerator == recipe.CriteriaAcceleratorAny) {
+		parsed, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator)
+		if err != nil {
+			return err
+		}
+		criteria.Accelerator = parsed
+	}
+	if c.Intent != "" && (criteria.Intent == "" || criteria.Intent == recipe.CriteriaIntentAny) {
+		parsed, err := recipe.ParseCriteriaIntentType(c.Intent)
+		if err != nil {
+			return err
+		}
+		criteria.Intent = parsed
+	}
+	if c.OS != "" && (criteria.OS == "" || criteria.OS == recipe.CriteriaOSAny) {
+		parsed, err := recipe.ParseCriteriaOSType(c.OS)
+		if err != nil {
+			return err
+		}
+		criteria.OS = parsed
+	}
+	if c.Platform != "" && (criteria.Platform == "" || criteria.Platform == recipe.CriteriaPlatformAny) {
+		parsed, err := recipe.ParseCriteriaPlatformType(c.Platform)
+		if err != nil {
+			return err
+		}
+		criteria.Platform = parsed
+	}
+	if c.Nodes > 0 && criteria.Nodes == 0 {
+		criteria.Nodes = c.Nodes
+	}
+	return nil
+}
+
+// mergeCriteriaFromCmdAndConfig builds a Criteria starting from spec.recipe.criteria
+// (when cfg is non-nil) and overlays CLI flag values on top.
+func mergeCriteriaFromCmdAndConfig(cmd *cli.Command, cfg *appcfg.AICRConfig) (*recipe.Criteria, error) {
+	criteria := recipe.NewCriteria()
+	if err := applyCriteriaFromConfig(criteria, cfg); err != nil {
+		return nil, err
+	}
+	if err := applyCriteriaOverrides(cmd, criteria); err != nil {
+		return nil, err
+	}
+	return criteria, nil
 }
 
 // buildCriteriaFromCmd constructs a recipe.Criteria from CLI command flags.

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -136,7 +136,7 @@ Override snapshot-detected criteria:
 
 			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg)
 			if err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "error building recipe", err)
+				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "error building recipe")
 			}
 
 			// Log constraint warnings for visibility
@@ -199,11 +199,17 @@ func recipeOutputPath(cmd *cli.Command, cfg *appcfg.AICRConfig) string {
 
 // parseRecipeOutputFormat reads --format with a fallback to spec.recipe.output.format
 // and validates the result.
+//
+// The flag has a "yaml" Value default; cmd.String("format") returns it even
+// when the user did not pass --format, which would otherwise mask any
+// config-supplied value. stringFlagOrConfig uses cmd.IsSet so a missing
+// flag still falls through to the config fallback.
 func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializer.Format, error) {
-	raw := cmd.String("format")
-	if raw == "" && cfg != nil && cfg.Spec.Recipe != nil && cfg.Spec.Recipe.Output != nil {
-		raw = cfg.Spec.Recipe.Output.Format
+	fallback := ""
+	if cfg != nil && cfg.Spec.Recipe != nil && cfg.Spec.Recipe.Output != nil {
+		fallback = cfg.Spec.Recipe.Output.Format
 	}
+	raw := stringFlagOrConfig(cmd, "format", fallback)
 	if raw == "" {
 		raw = string(serializer.FormatYAML)
 	}

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -216,54 +216,77 @@ func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializ
 }
 
 // applyCriteriaFromConfig merges spec.recipe.criteria values into an existing
-// Criteria. Non-empty config fields fill in fields that are unset (empty or
-// the "any" wildcard) on the criteria, without overwriting values already
-// populated from a snapshot.
+// Criteria. Config values override snapshot-extracted values when both are
+// present and differ; when criteria is empty (no snapshot), config simply
+// populates it. CLI flags subsequently override both via applyCriteriaOverrides,
+// yielding precedence: CLI > config > snapshot.
+//
+// Override events are logged at INFO so the resolved value is auditable.
 func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig) error {
 	if cfg == nil || cfg.Spec.Recipe == nil || cfg.Spec.Recipe.Criteria == nil {
 		return nil
 	}
 	c := cfg.Spec.Recipe.Criteria
 
-	if c.Service != "" && (criteria.Service == "" || criteria.Service == recipe.CriteriaServiceAny) {
+	if c.Service != "" {
 		parsed, err := recipe.ParseCriteriaServiceType(c.Service)
 		if err != nil {
 			return err
 		}
+		logCriteriaOverride("service", string(criteria.Service), string(parsed))
 		criteria.Service = parsed
 	}
-	if c.Accelerator != "" && (criteria.Accelerator == "" || criteria.Accelerator == recipe.CriteriaAcceleratorAny) {
+	if c.Accelerator != "" {
 		parsed, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator)
 		if err != nil {
 			return err
 		}
+		logCriteriaOverride("accelerator", string(criteria.Accelerator), string(parsed))
 		criteria.Accelerator = parsed
 	}
-	if c.Intent != "" && (criteria.Intent == "" || criteria.Intent == recipe.CriteriaIntentAny) {
+	if c.Intent != "" {
 		parsed, err := recipe.ParseCriteriaIntentType(c.Intent)
 		if err != nil {
 			return err
 		}
+		logCriteriaOverride("intent", string(criteria.Intent), string(parsed))
 		criteria.Intent = parsed
 	}
-	if c.OS != "" && (criteria.OS == "" || criteria.OS == recipe.CriteriaOSAny) {
+	if c.OS != "" {
 		parsed, err := recipe.ParseCriteriaOSType(c.OS)
 		if err != nil {
 			return err
 		}
+		logCriteriaOverride("os", string(criteria.OS), string(parsed))
 		criteria.OS = parsed
 	}
-	if c.Platform != "" && (criteria.Platform == "" || criteria.Platform == recipe.CriteriaPlatformAny) {
+	if c.Platform != "" {
 		parsed, err := recipe.ParseCriteriaPlatformType(c.Platform)
 		if err != nil {
 			return err
 		}
+		logCriteriaOverride("platform", string(criteria.Platform), string(parsed))
 		criteria.Platform = parsed
 	}
-	if c.Nodes > 0 && criteria.Nodes == 0 {
+	if c.Nodes > 0 {
+		if criteria.Nodes > 0 && criteria.Nodes != c.Nodes {
+			slog.Info("config overriding snapshot-detected value",
+				"field", "nodes", "snapshot", criteria.Nodes, "config", c.Nodes)
+		}
 		criteria.Nodes = c.Nodes
 	}
 	return nil
+}
+
+// logCriteriaOverride logs an INFO line when config replaces a non-default
+// snapshot-extracted value with a different one. Empty/wildcard prior values
+// are not interesting (the field was effectively unset).
+func logCriteriaOverride(field, prior, override string) {
+	if prior == "" || prior == "any" || prior == override {
+		return
+	}
+	slog.Info("config overriding snapshot-detected value",
+		"field", field, "snapshot", prior, "config", override)
 }
 
 // mergeCriteriaFromCmdAndConfig builds a Criteria starting from spec.recipe.criteria

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -212,10 +212,10 @@ func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializ
 //
 // Override events are logged at INFO so the resolved value is auditable.
 func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig) error {
-	if cfg == nil || cfg.Spec.Recipe == nil || cfg.Spec.Recipe.Criteria == nil {
+	c := cfg.Recipe().CriteriaFields()
+	if c == nil {
 		return nil
 	}
-	c := cfg.Spec.Recipe.Criteria
 
 	if c.Service != "" {
 		parsed, err := recipe.ParseCriteriaServiceType(c.Service)

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -178,23 +178,10 @@ Override snapshot-detected criteria:
 	}
 }
 
-// configRecipeSnapshot returns the snapshot path from spec.recipe.input.snapshot
-// (or empty string when cfg or any intermediate path is nil).
-func configRecipeSnapshot(cfg *appcfg.AICRConfig) string {
-	if cfg == nil || cfg.Spec.Recipe == nil || cfg.Spec.Recipe.Input == nil {
-		return ""
-	}
-	return cfg.Spec.Recipe.Input.Snapshot
-}
-
 // recipeOutputPath returns the recipe output destination, with the CLI flag
 // overriding spec.recipe.output.path.
 func recipeOutputPath(cmd *cli.Command, cfg *appcfg.AICRConfig) string {
-	fallback := ""
-	if cfg != nil && cfg.Spec.Recipe != nil && cfg.Spec.Recipe.Output != nil {
-		fallback = cfg.Spec.Recipe.Output.Path
-	}
-	return stringFlagOrConfig(cmd, "output", fallback)
+	return stringFlagOrConfig(cmd, "output", cfg.Recipe().OutputPath())
 }
 
 // parseRecipeOutputFormat reads --format with a fallback to spec.recipe.output.format
@@ -205,11 +192,7 @@ func recipeOutputPath(cmd *cli.Command, cfg *appcfg.AICRConfig) string {
 // config-supplied value. stringFlagOrConfig uses cmd.IsSet so a missing
 // flag still falls through to the config fallback.
 func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializer.Format, error) {
-	fallback := ""
-	if cfg != nil && cfg.Spec.Recipe != nil && cfg.Spec.Recipe.Output != nil {
-		fallback = cfg.Spec.Recipe.Output.Format
-	}
-	raw := stringFlagOrConfig(cmd, "format", fallback)
+	raw := stringFlagOrConfig(cmd, "format", cfg.Recipe().OutputFormat())
 	if raw == "" {
 		raw = string(serializer.FormatYAML)
 	}

--- a/pkg/cli/recipe_test.go
+++ b/pkg/cli/recipe_test.go
@@ -686,7 +686,7 @@ func TestInitDataProvider_EmptyPath(t *testing.T) {
 			&cli.StringFlag{Name: "data"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return initDataProvider(cmd)
+			return initDataProvider(cmd, nil)
 		},
 	}
 
@@ -704,7 +704,7 @@ func TestInitDataProvider_InvalidPath(t *testing.T) {
 			&cli.StringFlag{Name: "data"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return initDataProvider(cmd)
+			return initDataProvider(cmd, nil)
 		},
 	}
 
@@ -725,7 +725,7 @@ func TestInitDataProvider_MissingRegistry(t *testing.T) {
 			&cli.StringFlag{Name: "data"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return initDataProvider(cmd)
+			return initDataProvider(cmd, nil)
 		},
 	}
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/logging"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -58,15 +59,21 @@ var (
 	commit  = "unknown"
 	date    = "unknown"
 
-	outputFlag = &cli.StringFlag{
-		Name:     "output",
-		Aliases:  []string{"o"},
-		Usage:    fmt.Sprintf("output destination: file path, ConfigMap URI (%snamespace/name), or stdout (default)", serializer.ConfigMapURIScheme),
-		Category: "Output",
+	// Shared flags are functions (not vars) so each Command gets its own
+	// instance. urfave/cli mutates parsed-state on the Flag value, so a
+	// shared instance leaks Count and parsed values across successive Run
+	// invocations — particularly visible in tests that build multiple
+	// command trees.
+
+	outputFlag = func() cli.Flag {
+		return &cli.StringFlag{
+			Name:     "output",
+			Aliases:  []string{"o"},
+			Usage:    fmt.Sprintf("output destination: file path, ConfigMap URI (%snamespace/name), or stdout (default)", serializer.ConfigMapURIScheme),
+			Category: "Output",
+		}
 	}
 
-	// formatFlag is a function to avoid sharing a single flag instance across
-	// commands, which causes urfave/cli internal state conflicts in parallel tests.
 	formatFlag = func() cli.Flag {
 		return withCompletions(&cli.StringFlag{
 			Name:     "format",
@@ -77,21 +84,39 @@ var (
 		}, serializer.SupportedFormats)
 	}
 
-	kubeconfigFlag = &cli.StringFlag{
-		Name:     "kubeconfig",
-		Aliases:  []string{"k"},
-		Usage:    "Path to kubeconfig file (overrides KUBECONFIG env and default ~/.kube/config)",
-		Category: "Input",
+	kubeconfigFlag = func() cli.Flag {
+		return &cli.StringFlag{
+			Name:     "kubeconfig",
+			Aliases:  []string{"k"},
+			Usage:    "Path to kubeconfig file (overrides KUBECONFIG env and default ~/.kube/config)",
+			Category: "Input",
+		}
 	}
 
-	dataFlag = &cli.StringFlag{
-		Name: "data",
-		Usage: `Path to external data directory to overlay on embedded recipe data.
+	dataFlag = func() cli.Flag {
+		return &cli.StringFlag{
+			Name: "data",
+			Usage: `Path to external data directory to overlay on embedded recipe data.
 	The directory must contain registry.yaml (required). Registry components and
 	validator catalog entries are merged with embedded (external takes precedence
 	by name). All other files (base.yaml, overlays, component values) fully
 	replace embedded files or add new ones.`,
-		Category: "Input",
+			Category: "Input",
+		}
+	}
+
+	// configFlag is a function (not a var) to avoid sharing a single flag
+	// instance across commands and successive test runs, which causes
+	// urfave/cli internal state (Count, parsed value) to leak between Runs.
+	// Mirrors the pattern used by formatFlag.
+	configFlag = func() cli.Flag {
+		return &cli.StringFlag{
+			Name: "config",
+			Usage: `Path or HTTPS URL to an AICRConfig file (YAML or JSON) populating defaults
+	for this command. Individual CLI flags always override config file values.
+	See docs/user/cli-reference.md for the file schema.`,
+			Category: "Input",
+		}
 	}
 )
 
@@ -333,12 +358,15 @@ func sanitizeCompletionArgs(args []string) []string {
 	return out
 }
 
-// initDataProvider initializes the data provider from the --data flag.
-// If the flag is not set, returns nil (uses embedded data).
-// If the flag is set, creates a layered provider that overlays the external
-// directory on top of embedded data.
-func initDataProvider(cmd *cli.Command) error {
+// initDataProvider initializes the data provider from the --data flag,
+// falling back to spec.recipe.data on the supplied AICRConfig when the flag
+// is not set. cfg may be nil; if so, only the flag is consulted. When neither
+// is set the embedded data is used (no provider override).
+func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
 	dataDir := cmd.String("data")
+	if dataDir == "" && cfg != nil && cfg.Spec.Recipe != nil {
+		dataDir = cfg.Spec.Recipe.Data
+	}
 	if dataDir == "" {
 		return nil
 	}
@@ -362,4 +390,53 @@ func initDataProvider(cmd *cli.Command) error {
 
 	slog.Info("external data provider initialized successfully", "directory", dataDir)
 	return nil
+}
+
+// loadCmdConfig reads --config from the command and returns a parsed
+// *AICRConfig (or nil when the flag is not set). The returned config is
+// fully validated; callers can rely on enum fields parsing without
+// re-checking.
+//
+// sentinel error would force every caller into a useless error-check branch.
+//
+//nolint:nilnil // (nil, nil) is the documented "flag not set" signal; a
+func loadCmdConfig(ctx context.Context, cmd *cli.Command) (*config.AICRConfig, error) {
+	src := cmd.String("config")
+	if src == "" {
+		return nil, nil
+	}
+	cfg, err := config.Load(ctx, src)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("failed to load --config %q", src), err)
+	}
+	return cfg, nil
+}
+
+// stringFlagOrConfig returns the CLI flag value when explicitly set on the
+// command line (or via env-var Source binding); otherwise the fallback.
+// Default flag values do NOT count as "set" and yield the fallback.
+// Logs an INFO line when the CLI value differs from a non-empty fallback.
+func stringFlagOrConfig(cmd *cli.Command, flagName, fallback string) string {
+	if !cmd.IsSet(flagName) {
+		return fallback
+	}
+	v := cmd.String(flagName)
+	if fallback != "" && fallback != v {
+		slog.Info("CLI flag overriding config value", "flag", flagName, "config", fallback, "override", v)
+	}
+	return v
+}
+
+// intFlagOrConfig returns the CLI flag value when explicitly set; otherwise
+// the fallback.
+func intFlagOrConfig(cmd *cli.Command, flagName string, fallback int) int {
+	if !cmd.IsSet(flagName) {
+		return fallback
+	}
+	v := cmd.Int(flagName)
+	if fallback > 0 && fallback != v {
+		slog.Info("CLI flag overriding config value", "flag", flagName, "config", fallback, "override", v)
+	}
+	return v
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -397,20 +397,21 @@ func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
 // fully validated; callers can rely on enum fields parsing without
 // re-checking.
 //
-// sentinel error would force every caller into a useless error-check branch.
+// Errors from config.Load are propagated unchanged so their pkg/errors
+// codes survive (ErrCodeNotFound for missing files, ErrCodeInvalidRequest
+// for malformed input or strict-decode rejections, ErrCodeUnavailable for
+// HTTP failures). Wrapping here would clobber those codes.
 //
-//nolint:nilnil // (nil, nil) is the documented "flag not set" signal; a
+// (nil, nil) is the deliberate "config flag not set" signal — a sentinel
+// error would force every caller into a useless error-check branch.
+//
+//nolint:nilnil
 func loadCmdConfig(ctx context.Context, cmd *cli.Command) (*config.AICRConfig, error) {
 	src := cmd.String("config")
 	if src == "" {
 		return nil, nil
 	}
-	cfg, err := config.Load(ctx, src)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("failed to load --config %q", src), err)
-	}
-	return cfg, nil
+	return config.Load(ctx, src)
 }
 
 // stringFlagOrConfig returns the CLI flag value when explicitly set on the

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -112,9 +112,9 @@ var (
 	configFlag = func() cli.Flag {
 		return &cli.StringFlag{
 			Name: "config",
-			Usage: `Path or HTTPS URL to an AICRConfig file (YAML or JSON) populating defaults
-	for this command. Individual CLI flags always override config file values.
-	See docs/user/cli-reference.md for the file schema.`,
+			Usage: `Path or HTTP(S) URL to an AICRConfig file (YAML or JSON) populating
+	defaults for this command. Individual CLI flags always override config file
+	values. See docs/user/cli-reference.md for the file schema.`,
 			Category: "Input",
 		}
 	}
@@ -360,23 +360,27 @@ func sanitizeCompletionArgs(args []string) []string {
 
 // initDataProvider initializes the data provider from the --data flag,
 // falling back to spec.recipe.data on the supplied AICRConfig when the flag
-// is not set. cfg may be nil; if so, only the flag is consulted. When neither
-// is set the embedded data is used (no provider override).
+// is not set. cfg may be nil; if so, only the flag is consulted.
+//
+// The data provider is a process-global. When neither input is set the
+// provider is reset to the embedded one so a long-lived process (or a
+// successive Run within tests) does not silently keep a layered provider
+// installed by a previous invocation.
 func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
+	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
+
 	dataDir := cmd.String("data")
 	if dataDir == "" && cfg != nil && cfg.Spec.Recipe != nil {
 		dataDir = cfg.Spec.Recipe.Data
 	}
 	if dataDir == "" {
+		// Reset to embedded so prior --data state does not leak across runs.
+		recipe.SetDataProvider(embedded)
 		return nil
 	}
 
 	slog.Info("initializing external data provider", "directory", dataDir)
 
-	// Create embedded provider
-	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
-
-	// Create layered provider
 	layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
 		ExternalDir:   dataDir,
 		AllowSymlinks: false,
@@ -385,7 +389,6 @@ func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to initialize external data", err)
 	}
 
-	// Set as global data provider
 	recipe.SetDataProvider(layered)
 
 	slog.Info("external data provider initialized successfully", "directory", dataDir)

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -370,8 +370,8 @@ func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
 	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
 
 	dataDir := cmd.String("data")
-	if dataDir == "" && cfg != nil && cfg.Spec.Recipe != nil {
-		dataDir = cfg.Spec.Recipe.Data
+	if dataDir == "" {
+		dataDir = cfg.Recipe().DataDir()
 	}
 	if dataDir == "" {
 		// Reset to embedded so prior --data state does not leak across runs.
@@ -433,13 +433,16 @@ func stringFlagOrConfig(cmd *cli.Command, flagName, fallback string) string {
 }
 
 // intFlagOrConfig returns the CLI flag value when explicitly set; otherwise
-// the fallback.
+// the fallback. Logs an INFO line whenever the resolved value differs from
+// the fallback (matching stringFlagOrConfig's symmetric guard so a config
+// value of 0 — or any value the user explicitly set — is not silently
+// overridden).
 func intFlagOrConfig(cmd *cli.Command, flagName string, fallback int) int {
 	if !cmd.IsSet(flagName) {
 		return fallback
 	}
 	v := cmd.Int(flagName)
-	if fallback > 0 && fallback != v {
+	if fallback != v {
 		slog.Info("CLI flag overriding config value", "flag", flagName, "config", fallback, "override", v)
 	}
 	return v

--- a/pkg/cli/skill_claude_code.go
+++ b/pkg/cli/skill_claude_code.go
@@ -147,7 +147,7 @@ func writeFlagEntry(buf *bytes.Buffer, f flagMeta) {
 	}
 
 	// Flag Usage strings can carry embedded newlines/tabs (e.g. recipe's
-	// --snapshot/--criteria multi-line descriptions); collapse whitespace
+	// --snapshot/--config multi-line descriptions); collapse whitespace
 	// so the markdown bullet renders as a single line.
 	if usage := normalizeMarkdownText(f.Usage); usage != "" {
 		line += " — " + usage

--- a/pkg/cli/skill_test.go
+++ b/pkg/cli/skill_test.go
@@ -164,7 +164,7 @@ func assertNoFrameworkSubcommand(t *testing.T, c cmdMeta, path string) {
 }
 
 // TestWriteFlagEntryNormalizesUsage verifies that flag Usage strings carrying
-// embedded newlines or tabs (e.g. recipe's --snapshot/--criteria multi-line
+// embedded newlines or tabs (e.g. recipe's --snapshot/--config multi-line
 // descriptions) are collapsed onto a single markdown bullet so the generated
 // SKILL.md does not get its layout broken.
 func TestWriteFlagEntryNormalizesUsage(t *testing.T) {

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -162,9 +162,9 @@ func snapshotCmdFlags() []cli.Flag {
 			Sources:  cli.EnvVars("AICR_OS"),
 			Category: "Agent Deployment",
 		},
-		outputFlag,
+		outputFlag(),
 		formatFlag(),
-		kubeconfigFlag,
+		kubeconfigFlag(),
 	}
 }
 

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -437,9 +437,9 @@ func validateCmdFlags() []cli.Flag {
 				"Options: " + strings.Join(evidence.ValidFeatures, ", "),
 			Category: "Evidence",
 		},
-		dataFlag,
-		outputFlag,
-		kubeconfigFlag,
+		dataFlag(),
+		outputFlag(),
+		kubeconfigFlag(),
 	}
 }
 
@@ -482,7 +482,7 @@ Run validation without failing on check errors (informational mode):
 				return err
 			}
 
-			if err := initDataProvider(cmd); err != nil {
+			if err := initDataProvider(cmd, nil); err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
 			}
 

--- a/pkg/config/accessors.go
+++ b/pkg/config/accessors.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"maps"
+	"slices"
+)
+
+// Accessors here are nil-receiver tolerant so callers can write
+// `cfg.RecipeCriteria()` without nil-checking every intermediate pointer.
+// Slice and map returns are defensive copies (slices.Clone / maps.Clone)
+// so callers cannot mutate the loaded config; nil inputs preserve nil
+// outputs while explicitly-empty collections (e.g. `set: []` in YAML)
+// round-trip as non-nil empty values, preserving the user's intent to
+// clear an inherited default.
+
+// === Top-level ===
+
+// Recipe returns the recipe section, or nil if cfg or the section is unset.
+func (c *AICRConfig) Recipe() *RecipeSpec {
+	if c == nil {
+		return nil
+	}
+	return c.Spec.Recipe
+}
+
+// Bundle returns the bundle section, or nil if cfg or the section is unset.
+func (c *AICRConfig) Bundle() *BundleSpec {
+	if c == nil {
+		return nil
+	}
+	return c.Spec.Bundle
+}
+
+// === RecipeSpec accessors ===
+
+// CriteriaFields returns the criteria spec or nil.
+func (r *RecipeSpec) CriteriaFields() *CriteriaSpec {
+	if r == nil {
+		return nil
+	}
+	return r.Criteria
+}
+
+// SnapshotPath returns spec.recipe.input.snapshot, or "" when unset.
+func (r *RecipeSpec) SnapshotPath() string {
+	if r == nil || r.Input == nil {
+		return ""
+	}
+	return r.Input.Snapshot
+}
+
+// OutputPath returns spec.recipe.output.path, or "" when unset.
+func (r *RecipeSpec) OutputPath() string {
+	if r == nil || r.Output == nil {
+		return ""
+	}
+	return r.Output.Path
+}
+
+// OutputFormat returns spec.recipe.output.format, or "" when unset.
+func (r *RecipeSpec) OutputFormat() string {
+	if r == nil || r.Output == nil {
+		return ""
+	}
+	return r.Output.Format
+}
+
+// DataDir returns spec.recipe.data, or "" when unset.
+func (r *RecipeSpec) DataDir() string {
+	if r == nil {
+		return ""
+	}
+	return r.Data
+}
+
+// === BundleSpec accessors ===
+
+// RecipeInput returns spec.bundle.input.recipe, or "" when unset.
+func (b *BundleSpec) RecipeInput() string {
+	if b == nil || b.Input == nil {
+		return ""
+	}
+	return b.Input.Recipe
+}
+
+// OutputTarget returns spec.bundle.output.target, or "" when unset.
+func (b *BundleSpec) OutputTarget() string {
+	if b == nil || b.Output == nil {
+		return ""
+	}
+	return b.Output.Target
+}
+
+// OutputImageRefs returns spec.bundle.output.imageRefs, or "" when unset.
+func (b *BundleSpec) OutputImageRefs() string {
+	if b == nil || b.Output == nil {
+		return ""
+	}
+	return b.Output.ImageRefs
+}
+
+// DeploymentDeployer returns spec.bundle.deployment.deployer, or "" when unset.
+func (b *BundleSpec) DeploymentDeployer() string {
+	if b == nil || b.Deployment == nil {
+		return ""
+	}
+	return b.Deployment.Deployer
+}
+
+// DeploymentRepo returns spec.bundle.deployment.repo, or "" when unset.
+func (b *BundleSpec) DeploymentRepo() string {
+	if b == nil || b.Deployment == nil {
+		return ""
+	}
+	return b.Deployment.Repo
+}
+
+// DeploymentSet returns a defensive copy of spec.bundle.deployment.set.
+func (b *BundleSpec) DeploymentSet() []string {
+	if b == nil || b.Deployment == nil {
+		return nil
+	}
+	return slices.Clone(b.Deployment.Set)
+}
+
+// DeploymentDynamic returns a defensive copy of spec.bundle.deployment.dynamic.
+func (b *BundleSpec) DeploymentDynamic() []string {
+	if b == nil || b.Deployment == nil {
+		return nil
+	}
+	return slices.Clone(b.Deployment.Dynamic)
+}
+
+// SystemNodeSelector returns a defensive copy of the system selector.
+func (b *BundleSpec) SystemNodeSelector() map[string]string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return maps.Clone(b.Scheduling.SystemNodeSelector)
+}
+
+// SystemNodeTolerations returns a defensive copy of the system tolerations.
+func (b *BundleSpec) SystemNodeTolerations() []string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return slices.Clone(b.Scheduling.SystemNodeTolerations)
+}
+
+// AcceleratedNodeSelector returns a defensive copy of the accelerated selector.
+func (b *BundleSpec) AcceleratedNodeSelector() map[string]string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return maps.Clone(b.Scheduling.AcceleratedNodeSelector)
+}
+
+// AcceleratedNodeTolerations returns a defensive copy of accelerated tolerations.
+func (b *BundleSpec) AcceleratedNodeTolerations() []string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return slices.Clone(b.Scheduling.AcceleratedNodeTolerations)
+}
+
+// WorkloadGate returns spec.bundle.scheduling.workloadGate, or "" when unset.
+func (b *BundleSpec) WorkloadGate() string {
+	if b == nil || b.Scheduling == nil {
+		return ""
+	}
+	return b.Scheduling.WorkloadGate
+}
+
+// WorkloadSelector returns a defensive copy of the workload selector.
+func (b *BundleSpec) WorkloadSelector() map[string]string {
+	if b == nil || b.Scheduling == nil {
+		return nil
+	}
+	return maps.Clone(b.Scheduling.WorkloadSelector)
+}
+
+// SchedulingNodes returns spec.bundle.scheduling.nodes, or 0 when unset.
+func (b *BundleSpec) SchedulingNodes() int {
+	if b == nil || b.Scheduling == nil {
+		return 0
+	}
+	return b.Scheduling.Nodes
+}
+
+// SchedulingStorageClass returns spec.bundle.scheduling.storageClass, or "" when unset.
+func (b *BundleSpec) SchedulingStorageClass() string {
+	if b == nil || b.Scheduling == nil {
+		return ""
+	}
+	return b.Scheduling.StorageClass
+}
+
+// AttestEnabled returns spec.bundle.attestation.enabled, or false when unset.
+func (b *BundleSpec) AttestEnabled() bool {
+	if b == nil || b.Attestation == nil {
+		return false
+	}
+	return b.Attestation.Enabled
+}
+
+// CertIDRegexp returns the certificateIdentityRegexp, or "" when unset.
+func (b *BundleSpec) CertIDRegexp() string {
+	if b == nil || b.Attestation == nil {
+		return ""
+	}
+	return b.Attestation.CertificateIdentityRegexp
+}
+
+// OIDCDeviceFlow returns spec.bundle.attestation.oidcDeviceFlow.
+func (b *BundleSpec) OIDCDeviceFlow() bool {
+	if b == nil || b.Attestation == nil {
+		return false
+	}
+	return b.Attestation.OIDCDeviceFlow
+}
+
+// RegistryInsecureTLS returns spec.bundle.registry.insecureTLS.
+func (b *BundleSpec) RegistryInsecureTLS() bool {
+	if b == nil || b.Registry == nil {
+		return false
+	}
+	return b.Registry.InsecureTLS
+}
+
+// RegistryPlainHTTP returns spec.bundle.registry.plainHTTP.
+func (b *BundleSpec) RegistryPlainHTTP() bool {
+	if b == nil || b.Registry == nil {
+		return false
+	}
+	return b.Registry.PlainHTTP
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// Kind is the kind value for AICRConfig documents.
+const Kind = "AICRConfig"
+
+// APIVersion is the apiVersion for AICRConfig documents.
+const APIVersion = "aicr.nvidia.com/v1alpha1"
+
+// AICRConfig is the top-level schema for the --config file accepted by
+// the aicr CLI's recipe and bundle commands.
+type AICRConfig struct {
+	Kind       string   `yaml:"kind" json:"kind"`
+	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`
+	Metadata   Metadata `yaml:"metadata" json:"metadata"`
+	Spec       Spec     `yaml:"spec" json:"spec"`
+}
+
+// Metadata holds identifying information for an AICRConfig document.
+type Metadata struct {
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+// Spec contains the per-command sections.
+//
+// Each section is optional: a config file used only with `aicr recipe` may
+// populate just Recipe; one used only with `aicr bundle` may populate just
+// Bundle. A single file may populate both for end-to-end workflows.
+type Spec struct {
+	Recipe *RecipeSpec `yaml:"recipe,omitempty" json:"recipe,omitempty"`
+	Bundle *BundleSpec `yaml:"bundle,omitempty" json:"bundle,omitempty"`
+}
+
+// RecipeSpec captures the inputs to `aicr recipe`.
+type RecipeSpec struct {
+	Criteria *CriteriaSpec     `yaml:"criteria,omitempty" json:"criteria,omitempty"`
+	Input    *RecipeInputSpec  `yaml:"input,omitempty" json:"input,omitempty"`
+	Output   *RecipeOutputSpec `yaml:"output,omitempty" json:"output,omitempty"`
+	Data     string            `yaml:"data,omitempty" json:"data,omitempty"`
+}
+
+// CriteriaSpec mirrors the recipe query parameters. Field names and string
+// values match the corresponding CLI flags so a config file can be read
+// alongside an aicr recipe invocation without translation.
+//
+// Values are stored as strings (rather than typed enums) so the loader can
+// surface validation errors with the same messages as the CLI parsers.
+type CriteriaSpec struct {
+	Service     string `yaml:"service,omitempty" json:"service,omitempty"`
+	Accelerator string `yaml:"accelerator,omitempty" json:"accelerator,omitempty"`
+	Intent      string `yaml:"intent,omitempty" json:"intent,omitempty"`
+	OS          string `yaml:"os,omitempty" json:"os,omitempty"`
+	Platform    string `yaml:"platform,omitempty" json:"platform,omitempty"`
+	Nodes       int    `yaml:"nodes,omitempty" json:"nodes,omitempty"`
+}
+
+// RecipeInputSpec describes alternate inputs to recipe generation. Snapshot
+// is mutually exclusive with Criteria at the top of RecipeSpec.
+type RecipeInputSpec struct {
+	Snapshot string `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
+}
+
+// RecipeOutputSpec describes how the recipe is emitted.
+type RecipeOutputSpec struct {
+	Path   string `yaml:"path,omitempty" json:"path,omitempty"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty"`
+}
+
+// BundleSpec captures the inputs to `aicr bundle`.
+type BundleSpec struct {
+	Input       *BundleInputSpec  `yaml:"input,omitempty" json:"input,omitempty"`
+	Output      *BundleOutputSpec `yaml:"output,omitempty" json:"output,omitempty"`
+	Deployment  *DeploymentSpec   `yaml:"deployment,omitempty" json:"deployment,omitempty"`
+	Scheduling  *SchedulingSpec   `yaml:"scheduling,omitempty" json:"scheduling,omitempty"`
+	Attestation *AttestationSpec  `yaml:"attestation,omitempty" json:"attestation,omitempty"`
+	Registry    *RegistrySpec     `yaml:"registry,omitempty" json:"registry,omitempty"`
+}
+
+// BundleInputSpec captures input file paths for the bundle command.
+type BundleInputSpec struct {
+	Recipe string `yaml:"recipe,omitempty" json:"recipe,omitempty"`
+}
+
+// BundleOutputSpec describes the bundle output destination.
+type BundleOutputSpec struct {
+	// Target is a local directory path or an oci:// URI.
+	Target    string `yaml:"target,omitempty" json:"target,omitempty"`
+	ImageRefs string `yaml:"imageRefs,omitempty" json:"imageRefs,omitempty"`
+}
+
+// DeploymentSpec captures deployer choice and value-override inputs.
+type DeploymentSpec struct {
+	Deployer string   `yaml:"deployer,omitempty" json:"deployer,omitempty"`
+	Repo     string   `yaml:"repo,omitempty" json:"repo,omitempty"`
+	Set      []string `yaml:"set,omitempty" json:"set,omitempty"`
+	Dynamic  []string `yaml:"dynamic,omitempty" json:"dynamic,omitempty"`
+}
+
+// SchedulingSpec captures node-placement inputs for system and accelerated workloads.
+//
+// Selectors are YAML maps for readability; tolerations are strings in the
+// same `key=value:effect` format the CLI accepts so users can copy/paste
+// between command lines and config files.
+type SchedulingSpec struct {
+	SystemNodeSelector         map[string]string `yaml:"systemNodeSelector,omitempty" json:"systemNodeSelector,omitempty"`
+	SystemNodeTolerations      []string          `yaml:"systemNodeTolerations,omitempty" json:"systemNodeTolerations,omitempty"`
+	AcceleratedNodeSelector    map[string]string `yaml:"acceleratedNodeSelector,omitempty" json:"acceleratedNodeSelector,omitempty"`
+	AcceleratedNodeTolerations []string          `yaml:"acceleratedNodeTolerations,omitempty" json:"acceleratedNodeTolerations,omitempty"`
+	WorkloadGate               string            `yaml:"workloadGate,omitempty" json:"workloadGate,omitempty"`
+	WorkloadSelector           map[string]string `yaml:"workloadSelector,omitempty" json:"workloadSelector,omitempty"`
+	Nodes                      int               `yaml:"nodes,omitempty" json:"nodes,omitempty"`
+	StorageClass               string            `yaml:"storageClass,omitempty" json:"storageClass,omitempty"`
+}
+
+// AttestationSpec captures bundle attestation inputs.
+//
+// IdentityToken is intentionally absent: tokens are secrets and must be
+// supplied via the COSIGN_IDENTITY_TOKEN environment variable or the
+// --identity-token flag.
+type AttestationSpec struct {
+	Enabled                   bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	CertificateIdentityRegexp string `yaml:"certificateIdentityRegexp,omitempty" json:"certificateIdentityRegexp,omitempty"`
+	OIDCDeviceFlow            bool   `yaml:"oidcDeviceFlow,omitempty" json:"oidcDeviceFlow,omitempty"`
+}
+
+// RegistrySpec captures OCI-registry transport options for bundle push.
+type RegistrySpec struct {
+	InsecureTLS bool `yaml:"insecureTLS,omitempty" json:"insecureTLS,omitempty"`
+	PlainHTTP   bool `yaml:"plainHTTP,omitempty" json:"plainHTTP,omitempty"`
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/config"
+)
+
+func newValid() *config.AICRConfig {
+	return &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Metadata:   config.Metadata{Name: "test"},
+		Spec: config.Spec{
+			Recipe: &config.RecipeSpec{
+				Criteria: &config.CriteriaSpec{
+					Service:     "eks",
+					Accelerator: "h100",
+					Intent:      "training",
+					OS:          "ubuntu",
+					Platform:    "kubeflow",
+					Nodes:       8,
+				},
+			},
+		},
+	}
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	if err := newValid().Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidate_BothSpecsPopulated(t *testing.T) {
+	cfg := newValid()
+	cfg.Spec.Bundle = &config.BundleSpec{
+		Deployment: &config.DeploymentSpec{Deployer: "helm"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidate_BundleOnly(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Bundle: &config.BundleSpec{
+				Input:      &config.BundleInputSpec{Recipe: "./recipe.yaml"},
+				Deployment: &config.DeploymentSpec{Deployer: "argocd"},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidate_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*config.AICRConfig)
+		wantSub string
+	}{
+		{
+			name: "wrong kind",
+			mutate: func(c *config.AICRConfig) {
+				c.Kind = "Recipe"
+			},
+			wantSub: "invalid kind",
+		},
+		{
+			name: "wrong apiVersion",
+			mutate: func(c *config.AICRConfig) {
+				c.APIVersion = "v1"
+			},
+			wantSub: "invalid apiVersion",
+		},
+		{
+			name: "no recipe and no bundle",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe = nil
+				c.Spec.Bundle = nil
+			},
+			wantSub: "neither spec.recipe nor spec.bundle",
+		},
+		{
+			name: "criteria and snapshot mutually exclusive",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Input = &config.RecipeInputSpec{Snapshot: "s.yaml"}
+			},
+			wantSub: "mutually exclusive",
+		},
+		{
+			name: "invalid service",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Criteria.Service = "bogus"
+			},
+			wantSub: "criteria.service",
+		},
+		{
+			name: "invalid accelerator",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Criteria.Accelerator = "h99999"
+			},
+			wantSub: "criteria.accelerator",
+		},
+		{
+			name: "invalid intent",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Criteria.Intent = "mining"
+			},
+			wantSub: "criteria.intent",
+		},
+		{
+			name: "invalid os",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Criteria.OS = "windows"
+			},
+			wantSub: "criteria.os",
+		},
+		{
+			name: "invalid platform",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Criteria.Platform = "spark"
+			},
+			wantSub: "criteria.platform",
+		},
+		{
+			name: "negative nodes",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Criteria.Nodes = -1
+			},
+			wantSub: "must be >= 0",
+		},
+		{
+			name: "invalid format",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Output = &config.RecipeOutputSpec{Format: "xml"}
+			},
+			wantSub: "spec.recipe.output.format",
+		},
+		{
+			name: "invalid deployer",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Bundle = &config.BundleSpec{
+					Deployment: &config.DeploymentSpec{Deployer: "fluxcd"},
+				}
+			},
+			wantSub: "deployment.deployer",
+		},
+		{
+			name: "negative bundle nodes",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Bundle = &config.BundleSpec{
+					Scheduling: &config.SchedulingSpec{Nodes: -1},
+				}
+			},
+			wantSub: "scheduling.nodes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newValid()
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestValidate_NilReceiver(t *testing.T) {
+	var c *config.AICRConfig
+	if err := c.Validate(); err == nil {
+		t.Errorf("expected error from nil receiver, got nil")
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -198,3 +198,53 @@ func TestValidate_NilReceiver(t *testing.T) {
 		t.Errorf("expected error from nil receiver, got nil")
 	}
 }
+
+func TestValidate_RecipeBundleHandoff(t *testing.T) {
+	tests := []struct {
+		name        string
+		recipePath  string
+		bundleInput string
+		wantErrSub  string
+	}{
+		{"both empty is fine", "", "", ""},
+		{"only recipe.output set is fine", "out.yaml", "", ""},
+		{"only bundle.input set is fine", "", "in.yaml", ""},
+		{"matching paths is fine", "shared.yaml", "shared.yaml", ""},
+		{"mismatched paths rejected", "out.yaml", "different.yaml", "must match"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.AICRConfig{
+				Kind:       config.Kind,
+				APIVersion: config.APIVersion,
+				Spec: config.Spec{
+					Recipe: &config.RecipeSpec{
+						Criteria: &config.CriteriaSpec{Service: "eks"},
+					},
+					Bundle: &config.BundleSpec{
+						Deployment: &config.DeploymentSpec{Deployer: "helm"},
+					},
+				},
+			}
+			if tt.recipePath != "" {
+				cfg.Spec.Recipe.Output = &config.RecipeOutputSpec{Path: tt.recipePath}
+			}
+			if tt.bundleInput != "" {
+				cfg.Spec.Bundle.Input = &config.BundleInputSpec{Recipe: tt.bundleInput}
+			}
+			err := cfg.Validate()
+			if tt.wantErrSub == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErrSub)
+			}
+		})
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -210,7 +210,9 @@ func TestValidate_RecipeBundleHandoff(t *testing.T) {
 		{"only recipe.output set is fine", "out.yaml", "", ""},
 		{"only bundle.input set is fine", "", "in.yaml", ""},
 		{"matching paths is fine", "shared.yaml", "shared.yaml", ""},
-		{"mismatched paths rejected", "out.yaml", "different.yaml", "must match"},
+		{"mismatched paths rejected", "out.yaml", "different.yaml", "must reference the same file"},
+		{"equivalent relative forms accepted", "./recipe.yaml", "recipe.yaml", ""},
+		{"redundant separators accepted", "dir//file.yaml", "dir/file.yaml", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config defines the AICRConfig file schema accepted by the
+// aicr CLI's --config flag on the recipe and bundle commands.
+//
+// AICRConfig is a Kubernetes-style envelope (kind / apiVersion / metadata / spec)
+// that lets users capture flag values for both commands in a single YAML or
+// JSON document. CLI flags always override values loaded from a config file;
+// for slice/map flags, presence on the command line replaces the file's
+// value rather than appending.
+//
+// Sources are restricted to local file paths and HTTP/HTTPS URLs.
+// ConfigMap (cm://) URIs are intentionally rejected: extract the data with
+// kubectl and pass the resulting file instead.
+//
+// Secrets (notably the cosign identity token) are not part of the schema;
+// they must be supplied via environment variables or dedicated CLI flags.
+package config

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -153,7 +154,12 @@ func readHTTP(ctx context.Context, url string) ([]byte, error) {
 }
 
 // decodeStrict parses raw bytes into target using strict semantics: unknown
-// fields cause an error. Both YAML and JSON inputs are supported.
+// fields cause an error and only a single document is accepted. Both YAML
+// and JSON inputs are supported.
+//
+// The trailing-data check uses a second Decode + io.EOF rather than
+// json.Decoder.More() — More() returns false for some malformed trailing
+// tokens (e.g. a stray "]"), letting garbage through.
 func decodeStrict(data []byte, format sourceFormat, target any) error {
 	switch format {
 	case formatJSON:
@@ -162,9 +168,12 @@ func decodeStrict(data []byte, format sourceFormat, target any) error {
 		if err := dec.Decode(target); err != nil {
 			return err
 		}
-		// Reject trailing garbage after the document.
-		if dec.More() {
-			return errors.New(errors.ErrCodeInvalidRequest, "unexpected trailing data after JSON document")
+		var extra any
+		if err := dec.Decode(&extra); !stderrors.Is(err, io.EOF) {
+			if err == nil {
+				return errors.New(errors.ErrCodeInvalidRequest, "unexpected trailing data after JSON document")
+			}
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "trailing JSON data is not valid", err)
 		}
 		return nil
 	case formatYAML:
@@ -172,6 +181,13 @@ func decodeStrict(data []byte, format sourceFormat, target any) error {
 		dec.KnownFields(true)
 		if err := dec.Decode(target); err != nil {
 			return err
+		}
+		var extra any
+		if err := dec.Decode(&extra); !stderrors.Is(err, io.EOF) {
+			if err == nil {
+				return errors.New(errors.ErrCodeInvalidRequest, "unexpected trailing YAML document; AICRConfig accepts a single document")
+			}
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "trailing YAML data is not valid", err)
 		}
 		return nil
 	default:

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -15,12 +15,19 @@
 package config
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
-	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // configMapURIScheme matches the prefix used by the snapshot/recipe loaders
@@ -31,6 +38,10 @@ const configMapURIScheme = "cm://"
 
 // Load reads and parses an AICRConfig from a local file path or
 // HTTP(S) URL. ConfigMap (cm://) URIs are rejected.
+//
+// Decoding is strict: unknown fields cause an error, so typos like
+// `spec.bundel.deployment.deployer` fail at load time rather than silently
+// producing zero values.
 //
 // The returned AICRConfig is fully validated: kind/apiVersion match the
 // expected constants, criteria enums parse against pkg/recipe parsers,
@@ -45,17 +56,124 @@ func Load(ctx context.Context, source string) (*AICRConfig, error) {
 				"export the ConfigMap data with `kubectl get cm <name> -o yaml` and pass the resulting file")
 	}
 
-	if err := ctx.Err(); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeTimeout, "context canceled before config load", err)
+	data, format, err := readSource(ctx, source)
+	if err != nil {
+		return nil, err
 	}
 
-	cfg, err := serializer.FromFile[AICRConfig](source)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, fmt.Sprintf("failed to load config from %q", source), err)
+	cfg := &AICRConfig{}
+	if err := decodeStrict(data, format, cfg); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("failed to parse config from %q", source), err)
 	}
 
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+// sourceFormat is the on-the-wire format detected from the source path or URL.
+type sourceFormat int
+
+const (
+	formatYAML sourceFormat = iota
+	formatJSON
+)
+
+// readSource fetches the raw bytes from a file path or HTTP(S) URL and
+// returns them along with the detected format. HTTP responses are bounded
+// by defaults.HTTPResponseBodyLimit; oversized bodies are rejected.
+func readSource(ctx context.Context, source string) ([]byte, sourceFormat, error) {
+	format := detectFormat(source)
+	switch {
+	case strings.HasPrefix(source, "http://"), strings.HasPrefix(source, "https://"):
+		data, err := readHTTP(ctx, source)
+		return data, format, err
+	default:
+		data, err := readFile(ctx, source)
+		return data, format, err
+	}
+}
+
+func detectFormat(source string) sourceFormat {
+	lower := strings.ToLower(source)
+	// Strip query/fragment for URL extension matching.
+	if i := strings.IndexAny(lower, "?#"); i >= 0 {
+		lower = lower[:i]
+	}
+	if strings.HasSuffix(lower, ".json") {
+		return formatJSON
+	}
+	return formatYAML
+}
+
+func readFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "context canceled before file read", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is user-supplied --config target
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.Wrap(errors.ErrCodeNotFound, fmt.Sprintf("config file not found: %q", path), err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, fmt.Sprintf("failed to read config file %q", path), err)
+	}
+	return data, nil
+}
+
+func readHTTP(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid config URL %q", url), err)
+	}
+	client := &http.Client{Timeout: defaults.HTTPClientTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeUnavailable, fmt.Sprintf("failed to fetch config from %q", url), err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errors.New(errors.ErrCodeUnavailable,
+			fmt.Sprintf("config fetch %q returned HTTP %d", url, resp.StatusCode))
+	}
+
+	limited := io.LimitReader(resp.Body, defaults.HTTPResponseBodyLimit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to read config body from %q", url), err)
+	}
+	if int64(len(data)) > defaults.HTTPResponseBodyLimit {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("config body from %q exceeds %d-byte limit", url, defaults.HTTPResponseBodyLimit))
+	}
+	return data, nil
+}
+
+// decodeStrict parses raw bytes into target using strict semantics: unknown
+// fields cause an error. Both YAML and JSON inputs are supported.
+func decodeStrict(data []byte, format sourceFormat, target any) error {
+	switch format {
+	case formatJSON:
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(target); err != nil {
+			return err
+		}
+		// Reject trailing garbage after the document.
+		if dec.More() {
+			return fmt.Errorf("unexpected trailing data after JSON document")
+		}
+		return nil
+	case formatYAML:
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(target); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported config format")
+	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -164,7 +164,7 @@ func decodeStrict(data []byte, format sourceFormat, target any) error {
 		}
 		// Reject trailing garbage after the document.
 		if dec.More() {
-			return fmt.Errorf("unexpected trailing data after JSON document")
+			return errors.New(errors.ErrCodeInvalidRequest, "unexpected trailing data after JSON document")
 		}
 		return nil
 	case formatYAML:
@@ -175,6 +175,6 @@ func decodeStrict(data []byte, format sourceFormat, target any) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("unsupported config format")
+		return errors.New(errors.ErrCodeInternal, "unsupported config format")
 	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -128,7 +128,8 @@ func readHTTP(ctx context.Context, url string) ([]byte, error) {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid config URL %q", url), err)
 	}
 	client := &http.Client{Timeout: defaults.HTTPClientTimeout}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G107: --config URL is the user's explicit choice; scheme is gated to http(s) by readSource and body is bounded by HTTPResponseBodyLimit
+
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeUnavailable, fmt.Sprintf("failed to fetch config from %q", url), err)
 	}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+// configMapURIScheme matches the prefix used by the snapshot/recipe loaders
+// for ConfigMap-backed inputs. AICRConfig deliberately does not support
+// ConfigMap sources; this constant exists so we can reject those URIs with
+// a tailored error pointing users at `kubectl`.
+const configMapURIScheme = "cm://"
+
+// Load reads and parses an AICRConfig from a local file path or
+// HTTP(S) URL. ConfigMap (cm://) URIs are rejected.
+//
+// The returned AICRConfig is fully validated: kind/apiVersion match the
+// expected constants, criteria enums parse against pkg/recipe parsers,
+// and the deployer string parses against pkg/bundler/config.
+func Load(ctx context.Context, source string) (*AICRConfig, error) {
+	if source == "" {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "config source is empty")
+	}
+	if strings.HasPrefix(source, configMapURIScheme) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"ConfigMap (cm://) sources are not supported by --config; "+
+				"export the ConfigMap data with `kubectl get cm <name> -o yaml` and pass the resulting file")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "context canceled before config load", err)
+	}
+
+	cfg, err := serializer.FromFile[AICRConfig](source)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, fmt.Sprintf("failed to load config from %q", source), err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -37,6 +37,11 @@ import (
 // a tailored error pointing users at `kubectl`.
 const configMapURIScheme = "cm://"
 
+// fileURIScheme is rejected explicitly because os.ReadFile would otherwise
+// produce a confusing "file not found: 'file:///abs/path'" error. Users
+// should pass the bare path.
+const fileURIScheme = "file://"
+
 // Load reads and parses an AICRConfig from a local file path or
 // HTTP(S) URL. ConfigMap (cm://) URIs are rejected.
 //
@@ -55,6 +60,10 @@ func Load(ctx context.Context, source string) (*AICRConfig, error) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			"ConfigMap (cm://) sources are not supported by --config; "+
 				"export the ConfigMap data with `kubectl get cm <name> -o yaml` and pass the resulting file")
+	}
+	if strings.HasPrefix(source, fileURIScheme) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"file:// URIs are not supported by --config; pass the path directly (e.g. /etc/aicr/config.yaml)")
 	}
 
 	data, format, err := readSource(ctx, source)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -171,3 +171,84 @@ func TestLoad_CanceledContext(t *testing.T) {
 		t.Fatal("expected error for canceled context, got nil")
 	}
 }
+
+func TestLoad_RejectsUnknownYAMLField(t *testing.T) {
+	bad := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  recipe:
+    criteria:
+      service: eks
+      bogusFieldThatDoesNotExist: oops
+`
+	path := writeTempFile(t, "config.yaml", bad)
+	_, err := config.Load(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected error for unknown YAML field, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogusFieldThatDoesNotExist") {
+		t.Errorf("error should reference unknown field, got %q", err.Error())
+	}
+}
+
+func TestLoad_RejectsUnknownJSONField(t *testing.T) {
+	bad := `{"kind":"AICRConfig","apiVersion":"aicr.nvidia.com/v1alpha1","spec":{"recipe":{"criteria":{"service":"eks","bogusFieldThatDoesNotExist":"oops"}}}}`
+	path := writeTempFile(t, "config.json", bad)
+	_, err := config.Load(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected error for unknown JSON field, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogusFieldThatDoesNotExist") {
+		t.Errorf("error should reference unknown field, got %q", err.Error())
+	}
+}
+
+// TestLoad_HTTPBodyLimit verifies the HTTP fetch path bounds response size
+// against defaults.HTTPResponseBodyLimit.
+func TestLoad_HTTPBodyLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Write more than the body limit (1 MiB by default; emit 2 MiB).
+		w.Header().Set("Content-Type", "application/yaml")
+		// Valid prefix then padding so YAML parsing isn't the failure mode.
+		_, _ = w.Write([]byte(validYAML))
+		pad := make([]byte, 2*1024*1024)
+		_, _ = w.Write(pad)
+	}))
+	t.Cleanup(srv.Close)
+	_, err := config.Load(context.Background(), srv.URL+"/big.yaml")
+	if err == nil {
+		t.Fatal("expected error for oversized response, got nil")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Errorf("error should mention size limit, got %q", err.Error())
+	}
+}
+
+func TestLoad_HTTPNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	_, err := config.Load(context.Background(), srv.URL+"/missing.yaml")
+	if err == nil {
+		t.Fatal("expected error for HTTP 404, got nil")
+	}
+}
+
+// TestLoad_HTTPCanceledMidFetch verifies context cancellation propagates
+// through the HTTP fetch (regression for the earlier ctx-not-threaded bug).
+func TestLoad_HTTPCanceledMidFetch(t *testing.T) {
+	// Server that hangs forever (until client disconnects).
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the request never completes.
+	cancel()
+	_, err := config.Load(ctx, srv.URL+"/hangs.yaml")
+	if err == nil {
+		t.Fatal("expected error for canceled HTTP fetch, got nil")
+	}
+}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -128,6 +128,16 @@ func TestLoad_RejectsConfigMapURI(t *testing.T) {
 	}
 }
 
+func TestLoad_RejectsFileURI(t *testing.T) {
+	_, err := config.Load(context.Background(), "file:///etc/aicr/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for file:// URI, got nil")
+	}
+	if !strings.Contains(err.Error(), "file://") {
+		t.Errorf("error %q should mention file://", err.Error())
+	}
+}
+
 func TestLoad_EmptySource(t *testing.T) {
 	_, err := config.Load(context.Background(), "")
 	if err == nil {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/config"
+)
+
+const validYAML = `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-training
+spec:
+  recipe:
+    criteria:
+      service: eks
+      accelerator: gb200
+      intent: training
+      os: ubuntu
+      platform: kubeflow
+      nodes: 8
+  bundle:
+    deployment:
+      deployer: argocd
+      repo: https://example.git/charts
+      set:
+        - gpuoperator:driver.version=570.86.16
+    scheduling:
+      systemNodeSelector:
+        role: system
+      acceleratedNodeTolerations:
+        - "nvidia.com/gpu=present:NoSchedule"
+      nodes: 8
+`
+
+const validJSON = `{
+  "kind": "AICRConfig",
+  "apiVersion": "aicr.nvidia.com/v1alpha1",
+  "metadata": {"name": "test"},
+  "spec": {
+    "recipe": {
+      "criteria": {"service": "eks", "accelerator": "h100", "intent": "training"}
+    }
+  }
+}`
+
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+func TestLoad_File_YAML(t *testing.T) {
+	path := writeTempFile(t, "config.yaml", validYAML)
+	cfg, err := config.Load(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Spec.Recipe == nil || cfg.Spec.Recipe.Criteria.Accelerator != "gb200" {
+		t.Errorf("unexpected criteria: %+v", cfg.Spec.Recipe)
+	}
+	if cfg.Spec.Bundle == nil || cfg.Spec.Bundle.Deployment.Deployer != "argocd" {
+		t.Errorf("unexpected bundle: %+v", cfg.Spec.Bundle)
+	}
+	if got := cfg.Spec.Bundle.Scheduling.SystemNodeSelector["role"]; got != "system" {
+		t.Errorf("systemNodeSelector role = %q, want system", got)
+	}
+}
+
+func TestLoad_File_JSON(t *testing.T) {
+	path := writeTempFile(t, "config.json", validJSON)
+	cfg, err := config.Load(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Spec.Recipe.Criteria.Service != "eks" {
+		t.Errorf("expected service eks, got %q", cfg.Spec.Recipe.Criteria.Service)
+	}
+}
+
+func TestLoad_HTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte(validYAML))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg, err := config.Load(context.Background(), srv.URL+"/config.yaml")
+	if err != nil {
+		t.Fatalf("Load HTTP: %v", err)
+	}
+	if cfg.Spec.Recipe.Criteria.Accelerator != "gb200" {
+		t.Errorf("unexpected accelerator: %q", cfg.Spec.Recipe.Criteria.Accelerator)
+	}
+}
+
+func TestLoad_RejectsConfigMapURI(t *testing.T) {
+	_, err := config.Load(context.Background(), "cm://gpu-operator/aicr-config")
+	if err == nil {
+		t.Fatal("expected error for cm:// URI, got nil")
+	}
+	if !strings.Contains(err.Error(), "ConfigMap") {
+		t.Errorf("error %q does not mention ConfigMap", err.Error())
+	}
+}
+
+func TestLoad_EmptySource(t *testing.T) {
+	_, err := config.Load(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty source, got nil")
+	}
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := config.Load(context.Background(), "/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	path := writeTempFile(t, "config.yaml", "kind: AICRConfig\n  bad: indent")
+	_, err := config.Load(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+}
+
+func TestLoad_FailsValidation(t *testing.T) {
+	// Wrong kind should fail validation
+	bad := strings.ReplaceAll(validYAML, "kind: AICRConfig", "kind: SomethingElse")
+	path := writeTempFile(t, "config.yaml", bad)
+	_, err := config.Load(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid kind") {
+		t.Errorf("expected 'invalid kind' in error, got %q", err.Error())
+	}
+}
+
+func TestLoad_CanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := config.Load(ctx, writeTempFile(t, "config.yaml", validYAML))
+	if err == nil {
+		t.Fatal("expected error for canceled context, got nil")
+	}
+}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+// Validate checks that an AICRConfig is well-formed and that all enumerated
+// values are recognized by the corresponding recipe / bundler parsers.
+//
+// Validate does NOT check semantic interactions across the recipe and bundle
+// commands (for example, that a bundle.input.recipe path actually exists);
+// such checks belong to the caller that consumes the config.
+func (c *AICRConfig) Validate() error {
+	if c == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "config is nil")
+	}
+	if c.Kind != Kind {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid kind %q: expected %q", c.Kind, Kind))
+	}
+	if c.APIVersion != APIVersion {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid apiVersion %q: expected %q", c.APIVersion, APIVersion))
+	}
+	if c.Spec.Recipe == nil && c.Spec.Bundle == nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"config has neither spec.recipe nor spec.bundle; at least one is required")
+	}
+	if err := c.Spec.Recipe.validate(); err != nil {
+		return err
+	}
+	if err := c.Spec.Bundle.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RecipeSpec) validate() error {
+	if r == nil {
+		return nil
+	}
+	if r.Criteria != nil && r.Input != nil && r.Input.Snapshot != "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"spec.recipe.criteria and spec.recipe.input.snapshot are mutually exclusive")
+	}
+	if err := r.Criteria.validate(); err != nil {
+		return err
+	}
+	if r.Output != nil && r.Output.Format != "" {
+		if serializer.Format(r.Output.Format).IsUnknown() {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid spec.recipe.output.format %q (valid: yaml, json, table)", r.Output.Format))
+		}
+	}
+	return nil
+}
+
+func (c *CriteriaSpec) validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.Service != "" {
+		if _, err := recipe.ParseCriteriaServiceType(c.Service); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.service", err)
+		}
+	}
+	if c.Accelerator != "" {
+		if _, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.accelerator", err)
+		}
+	}
+	if c.Intent != "" {
+		if _, err := recipe.ParseCriteriaIntentType(c.Intent); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.intent", err)
+		}
+	}
+	if c.OS != "" {
+		if _, err := recipe.ParseCriteriaOSType(c.OS); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.os", err)
+		}
+	}
+	if c.Platform != "" {
+		if _, err := recipe.ParseCriteriaPlatformType(c.Platform); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.platform", err)
+		}
+	}
+	if c.Nodes < 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("spec.recipe.criteria.nodes must be >= 0, got %d", c.Nodes))
+	}
+	return nil
+}
+
+func (b *BundleSpec) validate() error {
+	if b == nil {
+		return nil
+	}
+	if b.Deployment != nil && b.Deployment.Deployer != "" {
+		if _, err := bundlercfg.ParseDeployerType(b.Deployment.Deployer); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.bundle.deployment.deployer", err)
+		}
+	}
+	if b.Scheduling != nil && b.Scheduling.Nodes < 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("spec.bundle.scheduling.nodes must be >= 0, got %d", b.Scheduling.Nodes))
+	}
+	return nil
+}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -51,6 +51,30 @@ func (c *AICRConfig) Validate() error {
 	if err := c.Spec.Bundle.validate(); err != nil {
 		return err
 	}
+	if err := c.Spec.validateRecipeBundleHandoff(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRecipeBundleHandoff catches a silent footgun in workflow files:
+// when both spec.recipe.output.path and spec.bundle.input.recipe are set,
+// they typically describe the same artifact (the recipe written by `aicr
+// recipe` and consumed by `aicr bundle`). Mismatched paths almost always
+// indicate a typo rather than a deliberate two-recipe workflow, so reject
+// them up-front. Setting only one side is fine.
+func (s Spec) validateRecipeBundleHandoff() error {
+	if s.Recipe == nil || s.Recipe.Output == nil || s.Recipe.Output.Path == "" {
+		return nil
+	}
+	if s.Bundle == nil || s.Bundle.Input == nil || s.Bundle.Input.Recipe == "" {
+		return nil
+	}
+	if s.Recipe.Output.Path != s.Bundle.Input.Recipe {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("spec.recipe.output.path (%q) and spec.bundle.input.recipe (%q) must match when both are set",
+				s.Recipe.Output.Path, s.Bundle.Input.Recipe))
+	}
 	return nil
 }
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 
 	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -63,6 +64,11 @@ func (c *AICRConfig) Validate() error {
 // recipe` and consumed by `aicr bundle`). Mismatched paths almost always
 // indicate a typo rather than a deliberate two-recipe workflow, so reject
 // them up-front. Setting only one side is fine.
+//
+// Comparison uses filepath.Clean on both sides so equivalent forms like
+// "./recipe.yaml" and "recipe.yaml", or "dir//file" and "dir/file", do not
+// trigger a false rejection. Mixing absolute and relative paths still
+// fails — they are not equivalent without a known base directory.
 func (s Spec) validateRecipeBundleHandoff() error {
 	if s.Recipe == nil || s.Recipe.Output == nil || s.Recipe.Output.Path == "" {
 		return nil
@@ -70,9 +76,9 @@ func (s Spec) validateRecipeBundleHandoff() error {
 	if s.Bundle == nil || s.Bundle.Input == nil || s.Bundle.Input.Recipe == "" {
 		return nil
 	}
-	if s.Recipe.Output.Path != s.Bundle.Input.Recipe {
+	if filepath.Clean(s.Recipe.Output.Path) != filepath.Clean(s.Bundle.Input.Recipe) {
 		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("spec.recipe.output.path (%q) and spec.bundle.input.recipe (%q) must match when both are set",
+			fmt.Sprintf("spec.recipe.output.path (%q) and spec.bundle.input.recipe (%q) must reference the same file when both are set",
 				s.Recipe.Output.Path, s.Bundle.Input.Recipe))
 	}
 	return nil

--- a/tests/chainsaw/README.md
+++ b/tests/chainsaw/README.md
@@ -58,7 +58,7 @@ No cluster needed. All tests receive `AICR_BIN` and `REPO_ROOT` from the environ
 | `cli/bundle-variants` | `run_bundle_tests()` in `tools/e2e` | All bundle flag combinations: node selectors, tolerations, value overrides, Argo CD deployer |
 | `cli/bundle-scheduling` | `test_cli_bundle()` scheduling in `tests/e2e/run.sh` | Scheduling injection at correct Helm value paths |
 | `cli/cuj1-training` | `test_cuj1()` in `tools/e2e` | Full CUJ1 journey: recipe with kubeflow, validate, bundle, multi-phase |
-| `cli/criteria-file` | `test_criteria_file_flag()` in `tools/e2e` | Valid YAML/JSON criteria, CLI overrides, invalid files, partial criteria |
+| `cli/config-file` | `test_criteria_file_flag()` in `tools/e2e` | Valid YAML/JSON AICRConfig, CLI overrides, invalid files, partial criteria |
 | `cli/validate-phases` | `test_validate_phases()` in `tools/e2e` | Individual phases, --phase all, invalid phase, multiple --phase flags |
 | `cli/duplicate-flags` | `test_duplicate_flag_validation()` in `tools/e2e` | Duplicate --recipe, --service flags rejected |
 | `cli/validate-agent-flags` | `test_validate_agent_flags()` in `tools/e2e` | Agent flags present in validate --help |
@@ -83,7 +83,7 @@ tests/chainsaw/
 ├── cli/
 │   ├── bundle-scheduling/                        # Scheduling injection at Helm paths
 │   ├── bundle-variants/                          # All bundle flag combinations
-│   ├── criteria-file/                            # --criteria flag validation
+│   ├── config-file/                              # --config flag validation
 │   ├── cuj1-training/                            # Full CUJ1 user journey
 │   ├── duplicate-flags/                          # Duplicate flag rejection
 │   ├── external-data/                            # --data flag for external registries

--- a/tests/chainsaw/cli/config-file/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/config-file/chainsaw-test.yaml
@@ -16,149 +16,158 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: cli-criteria-file
+  name: cli-config-file
 spec:
   description: |
-    Validates the --criteria flag for recipe generation.
-    Tests valid YAML/JSON criteria, CLI flag overrides, invalid files,
-    non-existent files, partial criteria, and bundle from criteria.
-    Replaces test_criteria_file_flag() in tools/e2e.
+    Validates the --config flag for recipe and bundle commands.
+    Tests valid YAML/JSON config, CLI flag overrides, invalid files,
+    non-existent files, partial criteria, and bundle from a config-derived recipe.
     No cluster needed.
   timeouts:
     exec: 30s
   steps:
     - name: setup-fixtures
-      description: Create criteria fixture files (valid YAML, JSON, invalid variants).
+      description: Create AICRConfig fixture files (valid YAML, JSON, invalid variants).
       try:
         - script:
             content: |
-              WORK="/tmp/chainsaw-criteria-file"
+              WORK="/tmp/chainsaw-config-file"
               rm -rf "${WORK}" && mkdir -p "${WORK}"
 
-              cat > "${WORK}/criteria.yaml" << 'EOF'
-              kind: RecipeCriteria
+              cat > "${WORK}/config.yaml" << 'EOF'
+              kind: AICRConfig
               apiVersion: aicr.nvidia.com/v1alpha1
               metadata:
-                name: test-criteria
+                name: test-config
               spec:
-                service: eks
-                accelerator: h100
-                os: ubuntu
-                intent: training
+                recipe:
+                  criteria:
+                    service: eks
+                    accelerator: h100
+                    os: ubuntu
+                    intent: training
               EOF
 
-              cat > "${WORK}/criteria.json" << 'EOF'
-              {"kind":"RecipeCriteria","apiVersion":"aicr.nvidia.com/v1alpha1","metadata":{"name":"test"},"spec":{"service":"gke","accelerator":"a100","os":"ubuntu","intent":"inference"}}
+              cat > "${WORK}/config.json" << 'EOF'
+              {"kind":"AICRConfig","apiVersion":"aicr.nvidia.com/v1alpha1","metadata":{"name":"test"},"spec":{"recipe":{"criteria":{"service":"gke","accelerator":"a100","os":"ubuntu","intent":"inference"}}}}
               EOF
 
               echo 'kind: wrongKind' > "${WORK}/invalid-kind.yaml"
 
               cat > "${WORK}/invalid-version.yaml" << 'EOF'
-              kind: RecipeCriteria
+              kind: AICRConfig
               apiVersion: wrong.version/v1
+              spec:
+                recipe:
+                  criteria:
+                    service: eks
               EOF
 
               cat > "${WORK}/invalid-enum.yaml" << 'EOF'
-              kind: RecipeCriteria
+              kind: AICRConfig
               apiVersion: aicr.nvidia.com/v1alpha1
               spec:
-                service: invalid-service
+                recipe:
+                  criteria:
+                    service: invalid-service
               EOF
 
               cat > "${WORK}/partial.yaml" << 'EOF'
-              kind: RecipeCriteria
+              kind: AICRConfig
               apiVersion: aicr.nvidia.com/v1alpha1
               spec:
-                accelerator: h100
+                recipe:
+                  criteria:
+                    accelerator: h100
               EOF
 
-    - name: valid-yaml-criteria
-      description: Recipe generation with valid YAML criteria file succeeds.
+    - name: valid-yaml-config
+      description: Recipe generation with valid YAML config file succeeds.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/criteria.yaml" -o "${WORK}/yaml-recipe.yaml"
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/config.yaml" -o "${WORK}/yaml-recipe.yaml"
               test -f "${WORK}/yaml-recipe.yaml"
             check:
               ($error == null): true
 
-    - name: valid-json-criteria
-      description: Recipe generation with valid JSON criteria file succeeds.
+    - name: valid-json-config
+      description: Recipe generation with valid JSON config file succeeds.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/criteria.json" -o "${WORK}/json-recipe.yaml"
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/config.json" -o "${WORK}/json-recipe.yaml"
               test -f "${WORK}/json-recipe.yaml"
             check:
               ($error == null): true
 
     - name: cli-flag-override
-      description: CLI --service flag overrides criteria file value.
+      description: CLI --service flag overrides config file value.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/criteria.yaml" --service gke \
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/config.yaml" --service gke \
                 -o "${WORK}/override.yaml"
               grep -q "gke" "${WORK}/override.yaml"
             check:
               ($error == null): true
 
     - name: invalid-kind
-      description: Criteria file with wrong kind must fail.
+      description: Config file with wrong kind must fail.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/invalid-kind.yaml" -o /dev/null 2>&1
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/invalid-kind.yaml" -o /dev/null 2>&1
             check:
               ($error != null): true
 
     - name: invalid-apiversion
-      description: Criteria file with wrong apiVersion must fail.
+      description: Config file with wrong apiVersion must fail.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/invalid-version.yaml" -o /dev/null 2>&1
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/invalid-version.yaml" -o /dev/null 2>&1
             check:
               ($error != null): true
 
     - name: invalid-enum
-      description: Criteria file with invalid enum value must fail.
+      description: Config file with invalid enum value must fail.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/invalid-enum.yaml" -o /dev/null 2>&1
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/invalid-enum.yaml" -o /dev/null 2>&1
             check:
               ($error != null): true
 
     - name: non-existent-file
-      description: Non-existent criteria file must fail.
+      description: Non-existent config file must fail.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              ${AICR_BIN} recipe --criteria "/non/existent/file.yaml" -o /dev/null 2>&1
+              ${AICR_BIN} recipe --config "/non/existent/file.yaml" -o /dev/null 2>&1
             check:
               ($error != null): true
 
-    - name: bundle-from-criteria
-      description: Bundle generation from criteria-derived recipe succeeds.
+    - name: bundle-from-config
+      description: Bundle generation from a config-derived recipe succeeds.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
+              WORK="/tmp/chainsaw-config-file"
               ${AICR_BIN} bundle -r "${WORK}/yaml-recipe.yaml" -o "${WORK}/bundle"
               test -f "${WORK}/bundle/deploy.sh"
               test -f "${WORK}/bundle/README.md"
@@ -167,17 +176,17 @@ spec:
               ($error == null): true
 
     - name: partial-criteria
-      description: Partial criteria file (only accelerator) succeeds.
+      description: Partial criteria in config file (only accelerator) succeeds.
       try:
         - script:
             content: |
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              WORK="/tmp/chainsaw-criteria-file"
-              ${AICR_BIN} recipe --criteria "${WORK}/partial.yaml" -o "${WORK}/partial-recipe.yaml"
+              WORK="/tmp/chainsaw-config-file"
+              ${AICR_BIN} recipe --config "${WORK}/partial.yaml" -o "${WORK}/partial-recipe.yaml"
               test -f "${WORK}/partial-recipe.yaml"
             check:
               ($error == null): true
       cleanup:
         - script:
             content: |
-              rm -rf /tmp/chainsaw-criteria-file
+              rm -rf /tmp/chainsaw-config-file


### PR DESCRIPTION
## Summary

Introduce `--config <path-or-URL>` on `aicr recipe` and `aicr bundle` accepting a single `AICRConfig` document that can drive either or both commands. Replaces (and removes) the recipe-only `--criteria` flag.

## Motivation / Context

Both `aicr recipe` and `aicr bundle` have accumulated many flags (~9 and ~22). Long invocations are tedious to type, hard to review, and don't fit well into CI pipelines, environment promotion, or shared "blessed" templates. The existing `--criteria` flag is a partial solution scoped to one command and one section of inputs. Design discussion captured in #781.

Fixes: #781

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (`--criteria` flag is removed; pre-1.0, no shim)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: new `pkg/config` package

## Implementation Notes

Schema: Kubernetes-style envelope (`kind: AICRConfig`, `apiVersion: aicr.nvidia.com/v1alpha1`) with `spec.recipe` and `spec.bundle` sections — each command reads only its own section, no implicit handoff.

Precedence: CLI flags always override config file values. For slice/map flags, CLI presence **replaces** the file's value (no append). Override events log at INFO so the winning input is visible.

Sources: file path or `http(s)://` URL. ConfigMap (`cm://`) sources are intentionally rejected with a tailored error pointing at `kubectl get cm -o yaml`. ConfigMap support drops a kubeconfig dependency from config loading.

Secrets: cosign identity token is **never** read from the config file; supplied via `COSIGN_IDENTITY_TOKEN` or `--identity-token` only.

Default-flag semantics: `cmd.IsSet()` (not "non-empty value") gates flag-overrides-config so default flag values like `--deployer helm` and `--output .` don't shadow user-provided config values.

Shared CLI flag instances (`output`, `format`, `kubeconfig`, `data`, `config`) are now functions rather than vars, mirroring the existing pattern for `formatFlag`. urfave/cli mutates parsed-state on the Flag value, so a shared instance leaks `Count` and parsed values across successive `Run` invocations — visible in tests that build multiple command trees.

Snapshot+config interaction: when a snapshot supplies criteria, config fields fill in only the slots the snapshot left wildcarded; CLI flags override on top. This preserves today's snapshot-override behavior while making config a clean middle layer.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
# Codebase qualification completed
```

Coverage on changed packages:

| Package | Baseline (origin/main) | Branch | Delta |
|---|---|---|---|
| `pkg/cli` | 52.2% | 63.1% | +10.9pp |
| `pkg/config` | (new) | 98.4% | — |

New tests:
- `pkg/config/{config,loader}_test.go` — schema validation, file/HTTP loading, kind/apiVersion checks, enum validation, mutually-exclusive snapshot+criteria, ConfigMap rejection, canceled context.
- `pkg/cli/config_helpers_test.go` — table-driven tests for `stringFlagOrConfig`, `intFlagOrConfig`, `boolFlagOrConfig`, `stringSliceFlagOrConfig`, `resolveNodeSelector` (incl. defensive-copy semantics and CLI-replaces-config rule).
- `pkg/cli/config_integration_test.go` — recipe/bundle CLI integration: applies criteria, flag overrides config, recipe-from-config, missing-recipe error, slice replace.
- `pkg/cli/config_e2e_test.go` — regression tests proving `--criteria` is rejected; full bundle option resolution from a config exercising every section; CLI override of every section; HTTP `--config` source; partial criteria + flag merge; bad-enum rejection per command; recipe→bundle E2E sharing the same config file.
- `tests/chainsaw/cli/config-file/` — chainsaw e2e (renamed from `criteria-file`) covering valid YAML/JSON, CLI override, invalid kind/apiVersion/enum, non-existent file, partial criteria, bundle-from-config-derived-recipe.

All 18 chainsaw tests pass; full unit suite green with `-race`.

## Risk Assessment

- [x] **Medium** — Touches multiple commands and changes user-facing behavior

**Rollout notes:** `--criteria` is removed in this PR (pre-1.0, no compatibility shim — see issue #781 discussion). Existing `criteria.yaml` files do not migrate automatically; users must wrap content in `spec.recipe.criteria:` and change `kind: RecipeCriteria` → `kind: AICRConfig`. The CLI's `--config` flag is the documented replacement; example file in `docs/user/cli-reference.md`. The API server's `RecipeCriteria` request body is unchanged (separate concern).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)