### PR TITLE
chore: bump tool versions and raise coverage threshold to 75

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
  state         config         vs actual     manifests
 ```
 
-**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.10.1, Ko for images
+**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.11.3, Ko for images
 
 ## Commands
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,7 +91,7 @@ NVIDIA AICR provides validated GPU-accelerated Kubernetes configurations through
 - **Bundlers**: Plugin-based artifact generators — one per component in `recipes/registry.yaml`
 - **Deployers**: GitOps integration providers (helm, argocd) with deployment ordering
 
-**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.10.1, Container images via Ko
+**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.11.3, Container images via Ko
 
 **Package Architecture (Critical Principle):**
 - **User Interaction Packages** (`pkg/cli`, `pkg/api`): Focus solely on capturing user intent, validating input, and formatting output. No business logic.

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -19,18 +19,18 @@
 # Build Tools
 build_tools:
   # renovate: datasource=github-releases depName=goreleaser/goreleaser depType=build_tools
-  goreleaser: 'v2.15.3'
+  goreleaser: 'v2.15.4'
   # renovate: datasource=github-releases depName=ko-build/ko depType=build_tools
-  ko: 'v0.18.0'
+  ko: 'v0.18.1'
   # renovate: datasource=github-releases depName=google/go-containerregistry depType=build_tools
-  crane: 'v0.21.0'
+  crane: 'v0.21.5'
   # renovate: datasource=github-releases depName=orhun/git-cliff depType=build_tools
-  git_cliff: '2.12.0'
+  git_cliff: '2.13.1'
 
 # Linting
 linting:
   # renovate: datasource=github-releases depName=golangci/golangci-lint depType=linting
-  golangci_lint: 'v2.10.1'
+  golangci_lint: 'v2.11.3'
   # renovate: datasource=pypi depName=yamllint depType=linting
   yamllint: '1.38.0'
   # renovate: datasource=github-releases depName=google/addlicense depType=linting
@@ -45,7 +45,7 @@ security_tools:
   # renovate: datasource=github-releases depName=sigstore/cosign depType=security_tools
   cosign: 'v3.0.4'
   # renovate: datasource=github-releases depName=anchore/syft depType=security_tools
-  syft: 'v1.42.2'
+  syft: 'v1.44.0'
 
 # E2E Testing Tools
 testing_tools:
@@ -58,7 +58,7 @@ testing_tools:
   # renovate: datasource=github-releases depName=tilt-dev/ctlptl depType=testing_tools
   ctlptl: '0.9.0'
   # renovate: datasource=github-releases depName=tilt-dev/tilt depType=testing_tools
-  tilt: '0.37.0'
+  tilt: '0.37.3'
   # renovate: datasource=github-releases depName=helm/helm depType=testing_tools
   helm: 'v4.1.1'
   # renovate: datasource=github-releases depName=kubernetes-sigs/kwok depType=testing_tools
@@ -79,7 +79,7 @@ testing_tools:
 
 # Quality Thresholds
 quality:
-  coverage_threshold: '70'
+  coverage_threshold: '75'
   lint_timeout: '10m'
   test_timeout: '10m'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
  state         config         vs actual     manifests
 ```
 
-**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.10.1, Ko for images
+**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.11.3, Ko for images
 
 ## Commands
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -108,7 +108,7 @@ Example `make tools-check` output:
 Tool                 Expected        Installed       Status
 ----                 --------        ---------       ------
 go                   1.26            1.26            ✓
-golangci-lint        v2.10.1         2.10.1          ✓
+golangci-lint        v2.11.3         2.11.3          ✓
 grype                v0.107.0        0.107.0         ✓
 ko                   v0.18.0         0.18.0          ✓
 goreleaser           v2              2.13.3          ✓

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ test: ## Runs unit tests with race detector and coverage (use -short to skip int
 	go tool cover -func=coverage.out | tail -1
 
 .PHONY: test-coverage
-test-coverage: test ## Runs tests and enforces coverage threshold (COVERAGE_THRESHOLD=70)
+test-coverage: test ## Runs tests and enforces coverage threshold (from .settings.yaml quality.coverage_threshold)
 	@coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//'); \
 	echo "Coverage: $$coverage% (threshold: $(COVERAGE_THRESHOLD)%)"; \
 	if [ $$(echo "$$coverage < $(COVERAGE_THRESHOLD)" | bc) -eq 1 ]; then \

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1200,7 +1200,7 @@ jobs:
       - uses: ./.github/actions/go-ci
         with:
           go_version: '1.26'
-          golangci_lint_version: 'v2.10.1'
+          golangci_lint_version: 'v2.11.3'
 ```
 
 ### Adding New Tests

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -1111,7 +1111,7 @@ flowchart TD
 ```
 
 **Components**:
-- **go-ci** composite action: Go setup (1.26), tests with race detector, golangci-lint (v2.10.1), GitHub-native coverage
+- **go-ci** composite action: Go setup (1.26), tests with race detector, golangci-lint (v2.11.3), GitHub-native coverage
 - **integration** composite action: CLI integration tests via tools/e2e
 - **e2e** composite action: Full E2E tests with Kind cluster and fake GPU environment
 - **security-scan** composite action: Anchore/Grype vulnerability scanning (MEDIUM+), SARIF upload to Security tab


### PR DESCRIPTION
## Summary

- Bump build, lint, security, and testing tool versions in `.settings.yaml`.
- Raise `quality.coverage_threshold` from 70 to 75 (we ain't going back)
- Refresh stale `golangci-lint v2.10.1` references across docs and the `Makefile` help text.

## Motivation / Context

Routine version refresh ahead of incoming Renovate PRs, batched into one change. Coverage floor raised to align with current project-wide coverage and to catch regressions earlier.

## Type of Change

- chore

## Components Affected

- CI / build (`.settings.yaml`, `Makefile`)
- Docs (`AGENTS.md`, `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `DEVELOPMENT.md`, `docs/contributor/data.md`, `docs/contributor/index.md`)

## Implementation Notes

- `.settings.yaml` bumps:
  - `goreleaser` v2.15.3 → v2.15.4
  - `ko` v0.18.0 → v0.18.1
  - `crane` v0.21.0 → v0.21.5
  - `git_cliff` 2.12.0 → 2.13.1
  - `golangci_lint` v2.10.1 → v2.11.3
  - `syft` v1.42.2 → v1.44.0
  - `tilt` 0.37.0 → 0.37.3
- `quality.coverage_threshold` 70 → 75 — consumed by `Makefile:test-coverage` (via `yq`) and `.github/actions/load-versions`.
- Doc references to `golangci-lint v2.10.1` updated to `v2.11.3` where the value was authoritative. Historical `CHANGELOG.md` entries left unchanged.
- `Makefile` `test-coverage` help text now points to `.settings.yaml quality.coverage_threshold` instead of a hardcoded value, eliminating drift.

## Testing

- [x] `make qualify` locally
- [x] CI green
- [x] `golangci-lint run -c .golangci.yaml ./...` clean under v2.11.3
- [x] Module-wide coverage clears the new 75% floor

## Risk Assessment

Low. Patch/minor version bumps with no consumer removals — every key in `.settings.yaml` is still actively consumed by `tools/setup-tools`, `tools/check-tools`, `Makefile`, or `.github/actions/load-versions`. The coverage threshold bump is the primary risk surface and is gated by CI.

## Checklist

- [x] Self-reviewed the diff
- [x] Updated stale documentation references
- [ ] CI passes