### PR TITLE
refactor(config): unified Resolve() per spec type for wire→domain conversion

### DIFF
--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -35,7 +35,6 @@ import (
 	"github.com/NVIDIA/aicr/pkg/oci"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
-	"github.com/NVIDIA/aicr/pkg/snapshotter"
 	"github.com/urfave/cli/v3"
 )
 
@@ -82,24 +81,31 @@ type bundleCmdOptions struct {
 	imageRefsPath string // Path to write published image references (like ko --image-refs)
 }
 
-// parseBundleCmdOptions parses and validates command options. When cfg is
-// non-nil, spec.bundle fields supply defaults; CLI flags always override.
+// parseBundleCmdOptions parses and validates command options. The wire
+// config is converted to a typed *config.BundleResolved up-front via
+// (*config.BundleSpec).Resolve so this function only layers CLI flag
+// overrides onto already-typed values. All string→typed conversion of
+// config-supplied fields happens at the conversion boundary in Resolve;
+// errors from that boundary carry "spec.bundle.<path>" attribution.
 //
 //nolint:gocyclo // option resolution is inherently long but linear
 func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmdOptions, error) {
-	bs := cfg.Bundle()
+	resolved, err := cfg.Bundle().Resolve()
+	if err != nil {
+		return nil, err
+	}
 
 	opts := &bundleCmdOptions{
-		recipeFilePath:            stringFlagOrConfig(cmd, "recipe", bs.RecipeInput()),
+		recipeFilePath:            stringFlagOrConfig(cmd, "recipe", resolved.RecipeInput),
 		kubeconfig:                cmd.String("kubeconfig"),
-		repoURL:                   stringFlagOrConfig(cmd, "repo", bs.DeploymentRepo()),
-		attest:                    boolFlagOrConfig(cmd, "attest", bs.AttestEnabled()),
-		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", bs.CertIDRegexp()),
+		repoURL:                   stringFlagOrConfig(cmd, "repo", resolved.Repo),
+		attest:                    boolFlagOrConfig(cmd, "attest", resolved.Attest),
+		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", resolved.CertIDRegexp),
 		identityToken:             cmd.String("identity-token"),
-		oidcDeviceFlow:            boolFlagOrConfig(cmd, "oidc-device-flow", bs.OIDCDeviceFlow()),
-		insecureTLS:               boolFlagOrConfig(cmd, "insecure-tls", bs.RegistryInsecureTLS()),
-		plainHTTP:                 boolFlagOrConfig(cmd, "plain-http", bs.RegistryPlainHTTP()),
-		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", bs.OutputImageRefs()),
+		oidcDeviceFlow:            boolFlagOrConfig(cmd, "oidc-device-flow", resolved.OIDCDeviceFlow),
+		insecureTLS:               boolFlagOrConfig(cmd, "insecure-tls", resolved.InsecureTLS),
+		plainHTTP:                 boolFlagOrConfig(cmd, "plain-http", resolved.PlainHTTP),
+		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", resolved.ImageRefs),
 	}
 
 	if opts.recipeFilePath == "" {
@@ -115,39 +121,26 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		!strings.HasPrefix(opts.recipeFilePath, "https://") &&
 		!strings.HasPrefix(opts.recipeFilePath, serializer.ConfigMapURIScheme) {
 
-		absPath, err := filepath.Abs(opts.recipeFilePath)
-		if err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to resolve recipe path", err)
+		absPath, absErr := filepath.Abs(opts.recipeFilePath)
+		if absErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to resolve recipe path", absErr)
 		}
-		if _, err := os.Stat(absPath); err != nil {
-			if os.IsNotExist(err) {
+		if _, statErr := os.Stat(absPath); statErr != nil {
+			if os.IsNotExist(statErr) {
 				return nil, errors.New(errors.ErrCodeNotFound, "recipe file not found: "+absPath)
 			}
-			return nil, errors.Wrap(errors.ErrCodeInternal, "cannot access recipe file: "+absPath, err)
+			return nil, errors.Wrap(errors.ErrCodeInternal, "cannot access recipe file: "+absPath, statErr)
 		}
 		opts.recipeFilePath = absPath
 	}
 
-	// Parse and validate deployer flag using strongly-typed parser
-	deployerStr := stringFlagOrConfig(cmd, "deployer", bs.DeploymentDeployer())
-	if deployerStr == "" {
-		opts.deployer = config.DeployerHelm
-	} else {
-		deployer, err := config.ParseDeployerType(deployerStr)
-		if err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --deployer value", err)
-		}
-		opts.deployer = deployer
+	if opts.deployer, err = resolveDeployer(cmd, resolved.Deployer); err != nil {
+		return nil, err
 	}
 
-	// Parse output target (detects oci:// URI or local directory)
-	outputTarget := stringFlagOrConfig(cmd, "output", bs.OutputTarget())
-	if outputTarget == "" {
-		outputTarget = "."
-	}
-	ref, err := oci.ParseOutputTarget(outputTarget)
+	ref, err := resolveOutputTarget(cmd, resolved)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --output value", err)
+		return nil, err
 	}
 
 	if ref.IsOCI {
@@ -180,47 +173,37 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		opts.targetRevision = opts.ociRef.Tag
 	}
 
-	// Parse value overrides from --set / spec.bundle.deployment.set
-	opts.valueOverrides, err = config.ParseValueOverrides(stringSliceFlagOrConfig(cmd, "set", bs.DeploymentSet()))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "set", "spec.bundle.deployment.set"), err)
+	if opts.valueOverrides, err = resolveComponentPaths(cmd, "set", resolved.ValueOverrides, config.ParseValueOverrides); err != nil {
+		return nil, err
+	}
+	if opts.dynamicValues, err = resolveComponentPaths(cmd, "dynamic", resolved.DynamicValues, config.ParseDynamicValues); err != nil {
+		return nil, err
 	}
 
-	opts.dynamicValues, err = config.ParseDynamicValues(stringSliceFlagOrConfig(cmd, "dynamic", bs.DeploymentDynamic()))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "dynamic", "spec.bundle.deployment.dynamic"), err)
+	if opts.systemNodeSelector, err = resolveNodeSelector(cmd, "system-node-selector", resolved.SystemNodeSelector); err != nil {
+		return nil, err
+	}
+	if opts.acceleratedNodeSelector, err = resolveNodeSelector(cmd, "accelerated-node-selector", resolved.AcceleratedNodeSelector); err != nil {
+		return nil, err
 	}
 
-	if opts.systemNodeSelector, err = resolveNodeSelector(cmd, "system-node-selector", bs.SystemNodeSelector()); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-			"invalid "+sourceLabel(cmd, "system-node-selector", "spec.bundle.scheduling.systemNodeSelector"), err)
+	if opts.systemNodeTolerations, err = resolveTolerations(cmd, "system-node-toleration", resolved.SystemNodeTolerations); err != nil {
+		return nil, err
 	}
-	if opts.acceleratedNodeSelector, err = resolveNodeSelector(cmd, "accelerated-node-selector", bs.AcceleratedNodeSelector()); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-			"invalid "+sourceLabel(cmd, "accelerated-node-selector", "spec.bundle.scheduling.acceleratedNodeSelector"), err)
+	if opts.acceleratedNodeTolerations, err = resolveTolerations(cmd, "accelerated-node-toleration", resolved.AcceleratedNodeTolerations); err != nil {
+		return nil, err
 	}
 
-	if opts.systemNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "system-node-toleration", bs.SystemNodeTolerations())); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "system-node-toleration", "spec.bundle.scheduling.systemNodeTolerations"), err)
-	}
-	if opts.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(stringSliceFlagOrConfig(cmd, "accelerated-node-toleration", bs.AcceleratedNodeTolerations())); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "accelerated-node-toleration", "spec.bundle.scheduling.acceleratedNodeTolerations"), err)
+	if opts.workloadGateTaint, err = resolveTaint(cmd, "workload-gate", resolved.WorkloadGate); err != nil {
+		return nil, err
 	}
 
-	if workloadGateStr := stringFlagOrConfig(cmd, "workload-gate", bs.WorkloadGate()); workloadGateStr != "" {
-		opts.workloadGateTaint, err = snapshotter.ParseTaint(workloadGateStr)
-		if err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid "+sourceLabel(cmd, "workload-gate", "spec.bundle.scheduling.workloadGate"), err)
-		}
-	}
-
-	if opts.workloadSelector, err = resolveNodeSelector(cmd, "workload-selector", bs.WorkloadSelector()); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-			"invalid "+sourceLabel(cmd, "workload-selector", "spec.bundle.scheduling.workloadSelector"), err)
+	if opts.workloadSelector, err = resolveNodeSelector(cmd, "workload-selector", resolved.WorkloadSelector); err != nil {
+		return nil, err
 	}
 
 	// Estimated node count for bundle; 0 = unset.
-	n := intFlagOrConfig(cmd, "nodes", bs.SchedulingNodes())
+	n := intFlagOrConfig(cmd, "nodes", resolved.Nodes)
 	if n < 0 {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "--nodes must be >= 0")
 	}
@@ -232,21 +215,44 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 			return nil, errors.New(errors.ErrCodeInvalidRequest, "--storage-class cannot be blank when specified")
 		}
 		opts.storageClass = sc
-	} else if v := bs.SchedulingStorageClass(); v != "" {
-		opts.storageClass = v
+	} else if resolved.StorageClass != "" {
+		opts.storageClass = resolved.StorageClass
 	}
 
 	return opts, nil
 }
 
-// sourceLabel returns the user-facing label of whichever input contributed
-// the value being parsed: the CLI flag if it was explicitly set, otherwise
-// the config-spec path. Used to keep parse errors pointed at the right place.
-func sourceLabel(cmd *cli.Command, flagName, configPath string) string {
+// resolveOutputTarget returns the parsed *oci.Reference for --output,
+// preferring CLI input over the typed fallback in resolved. When the
+// CLI flag is set to an empty string OR neither source supplies a
+// value, defaults to the current directory ("."). The empty-CLI case
+// matches pre-refactor behavior where stringFlagOrConfig surfaced ""
+// and the caller substituted "." before parsing.
+func resolveOutputTarget(cmd *cli.Command, resolved *appcfg.BundleResolved) (*oci.Reference, error) {
+	const flagName = "output"
 	if cmd.IsSet(flagName) {
-		return "--" + flagName
+		target := cmd.String(flagName)
+		if target == "" {
+			target = "."
+		}
+		if resolved.OutputTargetRaw != "" && resolved.OutputTargetRaw != target {
+			slog.Info("CLI flag overriding config value", "flag", flagName,
+				"config", resolved.OutputTargetRaw, "override", target)
+		}
+		ref, err := oci.ParseOutputTarget(target)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --"+flagName+" value", err)
+		}
+		return ref, nil
 	}
-	return configPath
+	if resolved.OutputTarget != nil {
+		return resolved.OutputTarget, nil
+	}
+	ref, err := oci.ParseOutputTarget(".")
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to resolve default output target", err)
+	}
+	return ref, nil
 }
 
 //nolint:funlen // bundle command is inherently large (flags + description + action)

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -20,8 +20,11 @@ import (
 	"maps"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/urfave/cli/v3"
 
+	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
@@ -78,4 +81,111 @@ func resolveNodeSelector(cmd *cli.Command, flagName string, fallback map[string]
 		return parsed, nil
 	}
 	return maps.Clone(fallback), nil
+}
+
+// resolveTolerations returns the final tolerations slice for a flag,
+// preferring CLI input over the typed fallback (already parsed from
+// config). When neither source supplies a value, returns
+// snapshotter.DefaultTolerations() — matching the parser's
+// nil-input → DefaultTolerations behavior so callers never see a nil
+// toleration slice from this entry point.
+func resolveTolerations(cmd *cli.Command, flagName string, fallback []corev1.Toleration) ([]corev1.Toleration, error) {
+	if cmd.IsSet(flagName) {
+		raw := cmd.StringSlice(flagName)
+		if len(fallback) > 0 {
+			slog.Info("CLI flag replacing config value", "flag", flagName,
+				"configCount", len(fallback), "overrideCount", len(raw))
+		}
+		parsed, err := snapshotter.ParseTolerations(raw)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid --%s", flagName), err)
+		}
+		return parsed, nil
+	}
+	if fallback == nil {
+		return snapshotter.DefaultTolerations(), nil
+	}
+	return fallback, nil
+}
+
+// resolveComponentPaths returns the final component-path slice for a
+// flag, preferring CLI input (parsed via parser) over the typed
+// fallback (already parsed from config in BundleSpec.Resolve).
+func resolveComponentPaths(cmd *cli.Command, flagName string,
+	fallback []bundlercfg.ComponentPath,
+	parser func([]string) ([]bundlercfg.ComponentPath, error),
+) ([]bundlercfg.ComponentPath, error) {
+
+	if cmd.IsSet(flagName) {
+		raw := cmd.StringSlice(flagName)
+		if len(fallback) > 0 {
+			slog.Info("CLI flag replacing config value", "flag", flagName,
+				"configCount", len(fallback), "overrideCount", len(raw))
+		}
+		parsed, err := parser(raw)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid --%s", flagName), err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
+// resolveTaint returns the final taint pointer for a flag, preferring
+// CLI input (parsed via snapshotter.ParseTaint) over the typed fallback
+// (already parsed from config in BundleSpec.Resolve). An explicitly
+// empty CLI value masks the fallback and yields nil — matching the
+// pre-refactor behavior where stringFlagOrConfig would surface "" to
+// the caller, the caller would skip parsing, and the taint would
+// remain unset.
+func resolveTaint(cmd *cli.Command, flagName string, fallback *corev1.Taint) (*corev1.Taint, error) {
+	if cmd.IsSet(flagName) {
+		raw := cmd.String(flagName)
+		if raw == "" {
+			//nolint:nilnil // a nil taint is the documented "no gate" state.
+			return nil, nil
+		}
+		t, err := snapshotter.ParseTaint(raw)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid --%s", flagName), err)
+		}
+		if fallback != nil {
+			slog.Info("CLI flag overriding config value", "flag", flagName)
+		}
+		return t, nil
+	}
+	return fallback, nil
+}
+
+// resolveDeployer returns the final deployer for the --deployer flag,
+// preferring CLI input over the typed fallback. When the CLI flag is
+// set to an empty string OR neither source supplies a value, returns
+// bundlercfg.DeployerHelm — matching the pre-refactor behavior where
+// the empty deployer string fell through to the Helm default rather
+// than being passed to ParseDeployerType (which rejects "").
+func resolveDeployer(cmd *cli.Command, fallback bundlercfg.DeployerType) (bundlercfg.DeployerType, error) {
+	const flagName = "deployer"
+	if cmd.IsSet(flagName) {
+		raw := cmd.String(flagName)
+		if raw == "" {
+			return bundlercfg.DeployerHelm, nil
+		}
+		if fallback != "" && string(fallback) != raw {
+			slog.Info("CLI flag overriding config value", "flag", flagName,
+				"config", string(fallback), "override", raw)
+		}
+		d, err := bundlercfg.ParseDeployerType(raw)
+		if err != nil {
+			return "", errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid --%s value", flagName), err)
+		}
+		return d, nil
+	}
+	if fallback != "" {
+		return fallback, nil
+	}
+	return bundlercfg.DeployerHelm, nil
 }

--- a/pkg/cli/bundle_resolve_helpers_test.go
+++ b/pkg/cli/bundle_resolve_helpers_test.go
@@ -1,0 +1,440 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/urfave/cli/v3"
+
+	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
+	appcfg "github.com/NVIDIA/aicr/pkg/config"
+)
+
+// === resolveDeployer ===
+
+func TestResolveDeployer_FlagSetWinsOverConfig(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "deployer"}}
+	runWith(t, flags, []string{"--deployer", "argocd"}, func(c *cli.Command) {
+		got, err := resolveDeployer(c, bundlercfg.DeployerHelm)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != bundlercfg.DeployerArgoCD {
+			t.Errorf("got %q, want argocd", got)
+		}
+	})
+}
+
+func TestResolveDeployer_NoFlagUsesConfigFallback(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "deployer"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveDeployer(c, bundlercfg.DeployerArgoCD)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != bundlercfg.DeployerArgoCD {
+			t.Errorf("got %q, want argocd from config", got)
+		}
+	})
+}
+
+func TestResolveDeployer_NoFlagNoConfigDefaultsToHelm(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "deployer"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveDeployer(c, bundlercfg.DeployerType(""))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != bundlercfg.DeployerHelm {
+			t.Errorf("got %q, want helm default", got)
+		}
+	})
+}
+
+func TestResolveDeployer_InvalidFlagReturnsError(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "deployer"}}
+	runWith(t, flags, []string{"--deployer", "fluxcd"}, func(c *cli.Command) {
+		_, err := resolveDeployer(c, bundlercfg.DeployerType(""))
+		if err == nil {
+			t.Fatal("expected error for invalid deployer")
+		}
+		if !strings.Contains(err.Error(), "invalid --deployer") {
+			t.Errorf("error %q must mention --deployer", err.Error())
+		}
+	})
+}
+
+func TestResolveDeployer_FlagSetEmptyDefaultsToHelm(t *testing.T) {
+	// `--deployer ""` matches pre-refactor behavior: empty CLI string
+	// masks config and falls through to the Helm default rather than
+	// being passed to ParseDeployerType (which rejects "").
+	flags := []cli.Flag{&cli.StringFlag{Name: "deployer"}}
+	runWith(t, flags, []string{"--deployer", ""}, func(c *cli.Command) {
+		got, err := resolveDeployer(c, bundlercfg.DeployerArgoCD)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != bundlercfg.DeployerHelm {
+			t.Errorf("got %q, want helm default", got)
+		}
+	})
+}
+
+// === resolveComponentPaths ===
+
+func TestResolveComponentPaths_FlagSetParsesCLI(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "set"}}
+	runWith(t, flags, []string{"--set", "gpuoperator:driver.version=570.0.0"},
+		func(c *cli.Command) {
+			got, err := resolveComponentPaths(c, "set", nil, bundlercfg.ParseValueOverrides)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Errorf("got %d entries, want 1", len(got))
+			}
+		})
+}
+
+func TestResolveComponentPaths_NoFlagReturnsFallback(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "set"}}
+	fallback := []bundlercfg.ComponentPath{{Component: "x"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveComponentPaths(c, "set", fallback, bundlercfg.ParseValueOverrides)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].Component != "x" {
+			t.Errorf("expected fallback returned, got %v", got)
+		}
+	})
+}
+
+func TestResolveComponentPaths_NoFlagNilFallbackReturnsNil(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "set"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveComponentPaths(c, "set", nil, bundlercfg.ParseValueOverrides)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+}
+
+func TestResolveComponentPaths_InvalidFlagReturnsError(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "set"}}
+	runWith(t, flags, []string{"--set", "no-equals-sign"}, func(c *cli.Command) {
+		_, err := resolveComponentPaths(c, "set", nil, bundlercfg.ParseValueOverrides)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "invalid --set") {
+			t.Errorf("error %q must mention --set", err.Error())
+		}
+	})
+}
+
+func TestResolveComponentPaths_FlagOverridesNonEmptyConfig(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "set"}}
+	fallback := []bundlercfg.ComponentPath{{Component: "old"}}
+	runWith(t, flags, []string{"--set", "gpuoperator:driver.version=570.0.0"},
+		func(c *cli.Command) {
+			got, err := resolveComponentPaths(c, "set", fallback, bundlercfg.ParseValueOverrides)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 || got[0].Component == "old" {
+				t.Errorf("expected CLI to replace fallback, got %v", got)
+			}
+		})
+}
+
+// === resolveTolerations ===
+
+func TestResolveTolerations_FlagSetParsesCLI(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "tol"}}
+	runWith(t, flags, []string{"--tol", "k=v:NoSchedule"}, func(c *cli.Command) {
+		got, err := resolveTolerations(c, "tol", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].Key != "k" {
+			t.Errorf("got %v", got)
+		}
+	})
+}
+
+func TestResolveTolerations_NoFlagNilFallbackUsesDefault(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "tol"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveTolerations(c, "tol", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// DefaultTolerations is a single Toleration{Op: Exists}.
+		if len(got) != 1 || got[0].Operator != corev1.TolerationOpExists {
+			t.Errorf("expected DefaultTolerations, got %v", got)
+		}
+	})
+}
+
+func TestResolveTolerations_NoFlagNonNilFallbackReturnsFallback(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "tol"}}
+	fallback := []corev1.Toleration{{Key: "from-config"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveTolerations(c, "tol", fallback)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].Key != "from-config" {
+			t.Errorf("expected fallback, got %v", got)
+		}
+	})
+}
+
+func TestResolveTolerations_NoFlagEmptyNonNilFallbackReturnsFallback(t *testing.T) {
+	// Explicitly empty (non-nil) fallback round-trips as an empty
+	// (non-nil) slice — the parser is not invoked when the flag is unset.
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "tol"}}
+	fallback := []corev1.Toleration{}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveTolerations(c, "tol", fallback)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected non-nil empty, got nil")
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %v", got)
+		}
+	})
+}
+
+func TestResolveTolerations_InvalidFlagReturnsError(t *testing.T) {
+	flags := []cli.Flag{&cli.StringSliceFlag{Name: "tol"}}
+	runWith(t, flags, []string{"--tol", "malformed"}, func(c *cli.Command) {
+		_, err := resolveTolerations(c, "tol", nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "invalid --tol") {
+			t.Errorf("error %q must mention --tol", err.Error())
+		}
+	})
+}
+
+// === resolveTaint ===
+
+func TestResolveTaint_FlagSetParsesCLI(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "gate"}}
+	runWith(t, flags, []string{"--gate", "k=v:NoSchedule"}, func(c *cli.Command) {
+		got, err := resolveTaint(c, "gate", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || got.Key != "k" {
+			t.Errorf("got %+v", got)
+		}
+	})
+}
+
+func TestResolveTaint_FlagSetEmptyMasksFallback(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "gate"}}
+	fallback := &corev1.Taint{Key: "from-config"}
+	// Explicit empty CLI value masks the config fallback and yields nil.
+	// This preserves pre-refactor behavior where stringFlagOrConfig
+	// surfaced "" and the caller skipped parsing entirely.
+	runWith(t, flags, []string{"--gate", ""}, func(c *cli.Command) {
+		got, err := resolveTaint(c, "gate", fallback)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil (CLI empty masks fallback), got %+v", got)
+		}
+	})
+}
+
+func TestResolveTaint_NoFlagReturnsFallback(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "gate"}}
+	fallback := &corev1.Taint{Key: "from-config"}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveTaint(c, "gate", fallback)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || got.Key != "from-config" {
+			t.Errorf("expected fallback, got %+v", got)
+		}
+	})
+}
+
+func TestResolveTaint_NoFlagNilFallbackReturnsNil(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "gate"}}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		got, err := resolveTaint(c, "gate", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+}
+
+func TestResolveTaint_FlagOverridesFallbackLogsOverride(t *testing.T) {
+	// Just exercise the override branch; we don't assert the log.
+	flags := []cli.Flag{&cli.StringFlag{Name: "gate"}}
+	fallback := &corev1.Taint{Key: "old"}
+	runWith(t, flags, []string{"--gate", "new=v:NoSchedule"}, func(c *cli.Command) {
+		got, err := resolveTaint(c, "gate", fallback)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || got.Key != "new" {
+			t.Errorf("expected new taint, got %+v", got)
+		}
+	})
+}
+
+func TestResolveTaint_InvalidFlagReturnsError(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "gate"}}
+	runWith(t, flags, []string{"--gate", "no-effect"}, func(c *cli.Command) {
+		_, err := resolveTaint(c, "gate", nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "invalid --gate") {
+			t.Errorf("error %q must mention --gate", err.Error())
+		}
+	})
+}
+
+// === resolveOutputTarget ===
+
+func TestResolveOutputTarget_FlagSetParsesCLI(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "output"}}
+	resolved := &appcfg.BundleResolved{}
+	runWith(t, flags, []string{"--output", "./mybundle"}, func(c *cli.Command) {
+		ref, err := resolveOutputTarget(c, resolved)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref == nil || ref.IsOCI {
+			t.Errorf("expected local ref, got %+v", ref)
+		}
+	})
+}
+
+func TestResolveOutputTarget_NoFlagUsesResolvedTarget(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "output"}}
+	b := &appcfg.BundleSpec{Output: &appcfg.BundleOutputSpec{Target: "./from-config"}}
+	resolved, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		ref, err := resolveOutputTarget(c, resolved)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref == nil {
+			t.Fatal("expected ref, got nil")
+		}
+		if ref.LocalPath == "" {
+			t.Errorf("expected LocalPath populated, got %+v", ref)
+		}
+	})
+}
+
+func TestResolveOutputTarget_NoFlagNoResolvedDefaultsToCurrentDir(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "output"}}
+	resolved := &appcfg.BundleResolved{}
+	runWith(t, flags, []string{}, func(c *cli.Command) {
+		ref, err := resolveOutputTarget(c, resolved)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref == nil || ref.IsOCI {
+			t.Errorf("expected local ref defaulting to '.', got %+v", ref)
+		}
+	})
+}
+
+func TestResolveOutputTarget_InvalidFlagReturnsError(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "output"}}
+	resolved := &appcfg.BundleResolved{}
+	runWith(t, flags, []string{"--output", "oci://"}, func(c *cli.Command) {
+		_, err := resolveOutputTarget(c, resolved)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "invalid --output") {
+			t.Errorf("error %q must mention --output", err.Error())
+		}
+	})
+}
+
+func TestResolveOutputTarget_FlagSetEmptyDefaultsToCurrentDir(t *testing.T) {
+	// `--output ""` matches pre-refactor behavior where the empty
+	// string was substituted with "." before parsing rather than
+	// passed through (which would have produced LocalPath: "").
+	flags := []cli.Flag{&cli.StringFlag{Name: "output"}}
+	b := &appcfg.BundleSpec{Output: &appcfg.BundleOutputSpec{Target: "./from-config"}}
+	resolved, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	runWith(t, flags, []string{"--output", ""}, func(c *cli.Command) {
+		ref, err := resolveOutputTarget(c, resolved)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref == nil || ref.IsOCI {
+			t.Errorf("expected local ref defaulting to '.', got %+v", ref)
+		}
+		if ref.LocalPath != "." {
+			t.Errorf("expected LocalPath '.', got %q", ref.LocalPath)
+		}
+	})
+}
+
+func TestResolveOutputTarget_FlagOverridesNonEmptyConfigLogs(t *testing.T) {
+	flags := []cli.Flag{&cli.StringFlag{Name: "output"}}
+	b := &appcfg.BundleSpec{Output: &appcfg.BundleOutputSpec{Target: "./old"}}
+	resolved, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	runWith(t, flags, []string{"--output", "./new"}, func(c *cli.Command) {
+		ref, err := resolveOutputTarget(c, resolved)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref == nil {
+			t.Fatal("expected ref")
+		}
+		if !strings.HasSuffix(ref.LocalPath, "new") {
+			t.Errorf("expected ./new override, got %+v", ref)
+		}
+	})
+}

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -210,59 +210,41 @@ func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializ
 // populates it. CLI flags subsequently override both via applyCriteriaOverrides,
 // yielding precedence: CLI > config > snapshot.
 //
+// Conversion (string→typed enum) happens in (*config.RecipeSpec).ResolveCriteria
+// — this function only handles the merge-and-log concern.
+//
 // Override events are logged at INFO so the resolved value is auditable.
 func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig) error {
-	c := cfg.Recipe().CriteriaFields()
-	if c == nil {
-		return nil
+	resolved, err := cfg.Recipe().ResolveCriteria()
+	if err != nil {
+		return err
 	}
-
-	if c.Service != "" {
-		parsed, err := recipe.ParseCriteriaServiceType(c.Service)
-		if err != nil {
-			return err
-		}
-		logCriteriaOverride("service", string(criteria.Service), string(parsed))
-		criteria.Service = parsed
+	if resolved.Service != "" {
+		logCriteriaOverride("service", string(criteria.Service), string(resolved.Service))
+		criteria.Service = resolved.Service
 	}
-	if c.Accelerator != "" {
-		parsed, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator)
-		if err != nil {
-			return err
-		}
-		logCriteriaOverride("accelerator", string(criteria.Accelerator), string(parsed))
-		criteria.Accelerator = parsed
+	if resolved.Accelerator != "" {
+		logCriteriaOverride("accelerator", string(criteria.Accelerator), string(resolved.Accelerator))
+		criteria.Accelerator = resolved.Accelerator
 	}
-	if c.Intent != "" {
-		parsed, err := recipe.ParseCriteriaIntentType(c.Intent)
-		if err != nil {
-			return err
-		}
-		logCriteriaOverride("intent", string(criteria.Intent), string(parsed))
-		criteria.Intent = parsed
+	if resolved.Intent != "" {
+		logCriteriaOverride("intent", string(criteria.Intent), string(resolved.Intent))
+		criteria.Intent = resolved.Intent
 	}
-	if c.OS != "" {
-		parsed, err := recipe.ParseCriteriaOSType(c.OS)
-		if err != nil {
-			return err
-		}
-		logCriteriaOverride("os", string(criteria.OS), string(parsed))
-		criteria.OS = parsed
+	if resolved.OS != "" {
+		logCriteriaOverride("os", string(criteria.OS), string(resolved.OS))
+		criteria.OS = resolved.OS
 	}
-	if c.Platform != "" {
-		parsed, err := recipe.ParseCriteriaPlatformType(c.Platform)
-		if err != nil {
-			return err
-		}
-		logCriteriaOverride("platform", string(criteria.Platform), string(parsed))
-		criteria.Platform = parsed
+	if resolved.Platform != "" {
+		logCriteriaOverride("platform", string(criteria.Platform), string(resolved.Platform))
+		criteria.Platform = resolved.Platform
 	}
-	if c.Nodes > 0 {
-		if criteria.Nodes > 0 && criteria.Nodes != c.Nodes {
+	if resolved.Nodes > 0 {
+		if criteria.Nodes > 0 && criteria.Nodes != resolved.Nodes {
 			slog.Info("config overriding snapshot-detected value",
-				"field", "nodes", "snapshot", criteria.Nodes, "config", c.Nodes)
+				"field", "nodes", "snapshot", criteria.Nodes, "config", resolved.Nodes)
 		}
-		criteria.Nodes = c.Nodes
+		criteria.Nodes = resolved.Nodes
 	}
 	return nil
 }

--- a/pkg/config/accessors.go
+++ b/pkg/config/accessors.go
@@ -14,20 +14,14 @@
 
 package config
 
-import (
-	"maps"
-	"slices"
-)
-
 // Accessors here are nil-receiver tolerant so callers can write
-// `cfg.RecipeCriteria()` without nil-checking every intermediate pointer.
-// Slice and map returns are defensive copies (slices.Clone / maps.Clone)
-// so callers cannot mutate the loaded config; nil inputs preserve nil
-// outputs while explicitly-empty collections (e.g. `set: []` in YAML)
-// round-trip as non-nil empty values, preserving the user's intent to
-// clear an inherited default.
-
-// === Top-level ===
+// `cfg.Recipe().OutputPath()` without nil-checking every intermediate pointer.
+//
+// Bundle-section accessors that previously returned untyped strings are
+// gone — callers now consume (*BundleSpec).Resolve which performs the
+// wire→domain conversion exactly once. The recipe-section accessors
+// here remain because their fields are simple strings with no enum
+// parsing beyond Output.Format (handled inline at the call site).
 
 // Recipe returns the recipe section, or nil if cfg or the section is unset.
 func (c *AICRConfig) Recipe() *RecipeSpec {
@@ -43,16 +37,6 @@ func (c *AICRConfig) Bundle() *BundleSpec {
 		return nil
 	}
 	return c.Spec.Bundle
-}
-
-// === RecipeSpec accessors ===
-
-// CriteriaFields returns the criteria spec or nil.
-func (r *RecipeSpec) CriteriaFields() *CriteriaSpec {
-	if r == nil {
-		return nil
-	}
-	return r.Criteria
 }
 
 // SnapshotPath returns spec.recipe.input.snapshot, or "" when unset.
@@ -85,166 +69,4 @@ func (r *RecipeSpec) DataDir() string {
 		return ""
 	}
 	return r.Data
-}
-
-// === BundleSpec accessors ===
-
-// RecipeInput returns spec.bundle.input.recipe, or "" when unset.
-func (b *BundleSpec) RecipeInput() string {
-	if b == nil || b.Input == nil {
-		return ""
-	}
-	return b.Input.Recipe
-}
-
-// OutputTarget returns spec.bundle.output.target, or "" when unset.
-func (b *BundleSpec) OutputTarget() string {
-	if b == nil || b.Output == nil {
-		return ""
-	}
-	return b.Output.Target
-}
-
-// OutputImageRefs returns spec.bundle.output.imageRefs, or "" when unset.
-func (b *BundleSpec) OutputImageRefs() string {
-	if b == nil || b.Output == nil {
-		return ""
-	}
-	return b.Output.ImageRefs
-}
-
-// DeploymentDeployer returns spec.bundle.deployment.deployer, or "" when unset.
-func (b *BundleSpec) DeploymentDeployer() string {
-	if b == nil || b.Deployment == nil {
-		return ""
-	}
-	return b.Deployment.Deployer
-}
-
-// DeploymentRepo returns spec.bundle.deployment.repo, or "" when unset.
-func (b *BundleSpec) DeploymentRepo() string {
-	if b == nil || b.Deployment == nil {
-		return ""
-	}
-	return b.Deployment.Repo
-}
-
-// DeploymentSet returns a defensive copy of spec.bundle.deployment.set.
-func (b *BundleSpec) DeploymentSet() []string {
-	if b == nil || b.Deployment == nil {
-		return nil
-	}
-	return slices.Clone(b.Deployment.Set)
-}
-
-// DeploymentDynamic returns a defensive copy of spec.bundle.deployment.dynamic.
-func (b *BundleSpec) DeploymentDynamic() []string {
-	if b == nil || b.Deployment == nil {
-		return nil
-	}
-	return slices.Clone(b.Deployment.Dynamic)
-}
-
-// SystemNodeSelector returns a defensive copy of the system selector.
-func (b *BundleSpec) SystemNodeSelector() map[string]string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return maps.Clone(b.Scheduling.SystemNodeSelector)
-}
-
-// SystemNodeTolerations returns a defensive copy of the system tolerations.
-func (b *BundleSpec) SystemNodeTolerations() []string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return slices.Clone(b.Scheduling.SystemNodeTolerations)
-}
-
-// AcceleratedNodeSelector returns a defensive copy of the accelerated selector.
-func (b *BundleSpec) AcceleratedNodeSelector() map[string]string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return maps.Clone(b.Scheduling.AcceleratedNodeSelector)
-}
-
-// AcceleratedNodeTolerations returns a defensive copy of accelerated tolerations.
-func (b *BundleSpec) AcceleratedNodeTolerations() []string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return slices.Clone(b.Scheduling.AcceleratedNodeTolerations)
-}
-
-// WorkloadGate returns spec.bundle.scheduling.workloadGate, or "" when unset.
-func (b *BundleSpec) WorkloadGate() string {
-	if b == nil || b.Scheduling == nil {
-		return ""
-	}
-	return b.Scheduling.WorkloadGate
-}
-
-// WorkloadSelector returns a defensive copy of the workload selector.
-func (b *BundleSpec) WorkloadSelector() map[string]string {
-	if b == nil || b.Scheduling == nil {
-		return nil
-	}
-	return maps.Clone(b.Scheduling.WorkloadSelector)
-}
-
-// SchedulingNodes returns spec.bundle.scheduling.nodes, or 0 when unset.
-func (b *BundleSpec) SchedulingNodes() int {
-	if b == nil || b.Scheduling == nil {
-		return 0
-	}
-	return b.Scheduling.Nodes
-}
-
-// SchedulingStorageClass returns spec.bundle.scheduling.storageClass, or "" when unset.
-func (b *BundleSpec) SchedulingStorageClass() string {
-	if b == nil || b.Scheduling == nil {
-		return ""
-	}
-	return b.Scheduling.StorageClass
-}
-
-// AttestEnabled returns spec.bundle.attestation.enabled, or false when unset.
-func (b *BundleSpec) AttestEnabled() bool {
-	if b == nil || b.Attestation == nil {
-		return false
-	}
-	return b.Attestation.Enabled
-}
-
-// CertIDRegexp returns the certificateIdentityRegexp, or "" when unset.
-func (b *BundleSpec) CertIDRegexp() string {
-	if b == nil || b.Attestation == nil {
-		return ""
-	}
-	return b.Attestation.CertificateIdentityRegexp
-}
-
-// OIDCDeviceFlow returns spec.bundle.attestation.oidcDeviceFlow.
-func (b *BundleSpec) OIDCDeviceFlow() bool {
-	if b == nil || b.Attestation == nil {
-		return false
-	}
-	return b.Attestation.OIDCDeviceFlow
-}
-
-// RegistryInsecureTLS returns spec.bundle.registry.insecureTLS.
-func (b *BundleSpec) RegistryInsecureTLS() bool {
-	if b == nil || b.Registry == nil {
-		return false
-	}
-	return b.Registry.InsecureTLS
-}
-
-// RegistryPlainHTTP returns spec.bundle.registry.plainHTTP.
-func (b *BundleSpec) RegistryPlainHTTP() bool {
-	if b == nil || b.Registry == nil {
-		return false
-	}
-	return b.Registry.PlainHTTP
 }

--- a/pkg/config/accessors_test.go
+++ b/pkg/config/accessors_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/config"
+)
+
+func TestAccessors_NilTolerant(t *testing.T) {
+	var nilCfg *config.AICRConfig
+	if got := nilCfg.Recipe(); got != nil {
+		t.Errorf("nil cfg Recipe() = %v, want nil", got)
+	}
+	if got := nilCfg.Bundle(); got != nil {
+		t.Errorf("nil cfg Bundle() = %v, want nil", got)
+	}
+
+	var nilRecipe *config.RecipeSpec
+	if got := nilRecipe.SnapshotPath(); got != "" {
+		t.Errorf("nil RecipeSpec SnapshotPath = %q, want empty", got)
+	}
+	if got := nilRecipe.OutputPath(); got != "" {
+		t.Errorf("nil RecipeSpec OutputPath = %q, want empty", got)
+	}
+	if got := nilRecipe.OutputFormat(); got != "" {
+		t.Errorf("nil RecipeSpec OutputFormat = %q, want empty", got)
+	}
+	if got := nilRecipe.DataDir(); got != "" {
+		t.Errorf("nil RecipeSpec DataDir = %q, want empty", got)
+	}
+}
+
+func TestAccessors_EmptyReturnsEmpty(t *testing.T) {
+	r := &config.RecipeSpec{}
+	if got := r.SnapshotPath(); got != "" {
+		t.Errorf("empty RecipeSpec SnapshotPath = %q", got)
+	}
+	if got := r.OutputPath(); got != "" {
+		t.Errorf("empty RecipeSpec OutputPath = %q", got)
+	}
+	if got := r.OutputFormat(); got != "" {
+		t.Errorf("empty RecipeSpec OutputFormat = %q", got)
+	}
+	if got := r.DataDir(); got != "" {
+		t.Errorf("empty RecipeSpec DataDir = %q", got)
+	}
+}
+
+func TestAccessors_PopulatedReturnsValues(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Spec: config.Spec{
+			Recipe: &config.RecipeSpec{
+				Input:  &config.RecipeInputSpec{Snapshot: "snap.yaml"},
+				Output: &config.RecipeOutputSpec{Path: "out.yaml", Format: "json"},
+				Data:   "/data",
+			},
+			Bundle: &config.BundleSpec{},
+		},
+	}
+	r := cfg.Recipe()
+	if r == nil {
+		t.Fatal("Recipe() = nil")
+	}
+	if got := r.SnapshotPath(); got != "snap.yaml" {
+		t.Errorf("SnapshotPath = %q", got)
+	}
+	if got := r.OutputPath(); got != "out.yaml" {
+		t.Errorf("OutputPath = %q", got)
+	}
+	if got := r.OutputFormat(); got != "json" {
+		t.Errorf("OutputFormat = %q", got)
+	}
+	if got := r.DataDir(); got != "/data" {
+		t.Errorf("DataDir = %q", got)
+	}
+	if cfg.Bundle() == nil {
+		t.Fatal("Bundle() = nil")
+	}
+}

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+
+	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/oci"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+)
+
+// BundleResolved is the typed-domain projection of BundleSpec produced by
+// (*BundleSpec).Resolve. Every field is converted from its wire form
+// exactly once at the conversion boundary; CLI and API consumers layer
+// flag overrides on top of these values rather than re-parsing strings.
+//
+// Zero values mean "config did not set this field." Maps and slices
+// preserve the nil-vs-explicitly-empty distinction from the wire spec —
+// callers can therefore detect whether a user wrote `selector: {}` to
+// clear an inherited default vs. omitted the key entirely.
+type BundleResolved struct {
+	// RecipeInput is spec.bundle.input.recipe.
+	RecipeInput string
+
+	// OutputTarget is the parsed spec.bundle.output.target. Nil when
+	// config did not set a target. OutputTargetRaw preserves the original
+	// string for log/error messages.
+	OutputTarget    *oci.Reference
+	OutputTargetRaw string
+
+	// ImageRefs is spec.bundle.output.imageRefs.
+	ImageRefs string
+
+	// Deployer is the parsed spec.bundle.deployment.deployer. Empty
+	// (zero) when config did not set a deployer.
+	Deployer bundlercfg.DeployerType
+
+	// Repo is spec.bundle.deployment.repo.
+	Repo string
+
+	// ValueOverrides is spec.bundle.deployment.set, parsed.
+	// Nil if config did not set the field; non-nil (possibly empty) if
+	// config provided an explicit list (including `set: []`).
+	ValueOverrides []bundlercfg.ComponentPath
+
+	// DynamicValues is spec.bundle.deployment.dynamic, parsed.
+	// Same nil-vs-empty semantics as ValueOverrides.
+	DynamicValues []bundlercfg.ComponentPath
+
+	// SystemNodeSelector is spec.bundle.scheduling.systemNodeSelector.
+	// Nil if config did not set it; non-nil empty if `{}` was explicit.
+	SystemNodeSelector map[string]string
+
+	// SystemNodeTolerations is spec.bundle.scheduling.systemNodeTolerations,
+	// parsed. Nil if config did not set the field.
+	SystemNodeTolerations []corev1.Toleration
+
+	// AcceleratedNodeSelector is spec.bundle.scheduling.acceleratedNodeSelector.
+	AcceleratedNodeSelector map[string]string
+
+	// AcceleratedNodeTolerations is the parsed slice.
+	AcceleratedNodeTolerations []corev1.Toleration
+
+	// WorkloadGate is the parsed spec.bundle.scheduling.workloadGate taint.
+	// Nil when config did not set it.
+	WorkloadGate *corev1.Taint
+
+	// WorkloadSelector is spec.bundle.scheduling.workloadSelector.
+	WorkloadSelector map[string]string
+
+	// Nodes is spec.bundle.scheduling.nodes; 0 when unset.
+	Nodes int
+
+	// StorageClass is spec.bundle.scheduling.storageClass.
+	StorageClass string
+
+	// Attest is spec.bundle.attestation.enabled.
+	Attest bool
+
+	// CertIDRegexp is spec.bundle.attestation.certificateIdentityRegexp.
+	CertIDRegexp string
+
+	// OIDCDeviceFlow is spec.bundle.attestation.oidcDeviceFlow.
+	OIDCDeviceFlow bool
+
+	// InsecureTLS is spec.bundle.registry.insecureTLS.
+	InsecureTLS bool
+
+	// PlainHTTP is spec.bundle.registry.plainHTTP.
+	PlainHTTP bool
+}
+
+// Resolve converts a BundleSpec from the wire-string form to a typed
+// BundleResolved. It is nil-receiver tolerant and never returns a nil
+// pointer — callers reach into fields, so nil would just relocate the
+// nil-pointer dereference.
+//
+// Errors are attributed to their source spec path (for example,
+// "spec.bundle.deployment.set") so callers can surface the location of
+// invalid input without reconstructing the path themselves.
+func (b *BundleSpec) Resolve() (*BundleResolved, error) {
+	out := &BundleResolved{}
+	if b == nil {
+		return out, nil
+	}
+
+	if b.Input != nil {
+		out.RecipeInput = b.Input.Recipe
+	}
+
+	if b.Output != nil {
+		out.OutputTargetRaw = b.Output.Target
+		out.ImageRefs = b.Output.ImageRefs
+		if b.Output.Target != "" {
+			ref, err := oci.ParseOutputTarget(b.Output.Target)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.output.target", err)
+			}
+			out.OutputTarget = ref
+		}
+	}
+
+	if b.Deployment != nil {
+		out.Repo = b.Deployment.Repo
+		if b.Deployment.Deployer != "" {
+			d, err := bundlercfg.ParseDeployerType(b.Deployment.Deployer)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.deployment.deployer", err)
+			}
+			out.Deployer = d
+		}
+		if b.Deployment.Set != nil {
+			paths, err := bundlercfg.ParseValueOverrides(b.Deployment.Set)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.deployment.set", err)
+			}
+			out.ValueOverrides = paths
+		}
+		if b.Deployment.Dynamic != nil {
+			paths, err := bundlercfg.ParseDynamicValues(b.Deployment.Dynamic)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.deployment.dynamic", err)
+			}
+			out.DynamicValues = paths
+		}
+	}
+
+	if b.Scheduling != nil {
+		if b.Scheduling.Nodes < 0 {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("spec.bundle.scheduling.nodes must be >= 0, got %d", b.Scheduling.Nodes))
+		}
+		out.Nodes = b.Scheduling.Nodes
+		out.StorageClass = b.Scheduling.StorageClass
+
+		// maps.Clone preserves nil-vs-explicitly-empty: clone(nil) is nil,
+		// clone({}) is non-nil empty.
+		out.SystemNodeSelector = maps.Clone(b.Scheduling.SystemNodeSelector)
+		out.AcceleratedNodeSelector = maps.Clone(b.Scheduling.AcceleratedNodeSelector)
+		out.WorkloadSelector = maps.Clone(b.Scheduling.WorkloadSelector)
+
+		if b.Scheduling.SystemNodeTolerations != nil {
+			tols, err := snapshotter.ParseTolerations(b.Scheduling.SystemNodeTolerations)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.scheduling.systemNodeTolerations", err)
+			}
+			out.SystemNodeTolerations = tols
+		}
+		if b.Scheduling.AcceleratedNodeTolerations != nil {
+			tols, err := snapshotter.ParseTolerations(b.Scheduling.AcceleratedNodeTolerations)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.scheduling.acceleratedNodeTolerations", err)
+			}
+			out.AcceleratedNodeTolerations = tols
+		}
+		if b.Scheduling.WorkloadGate != "" {
+			t, err := snapshotter.ParseTaint(b.Scheduling.WorkloadGate)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.bundle.scheduling.workloadGate", err)
+			}
+			out.WorkloadGate = t
+		}
+	}
+
+	if b.Attestation != nil {
+		out.Attest = b.Attestation.Enabled
+		out.CertIDRegexp = b.Attestation.CertificateIdentityRegexp
+		out.OIDCDeviceFlow = b.Attestation.OIDCDeviceFlow
+	}
+
+	if b.Registry != nil {
+		out.InsecureTLS = b.Registry.InsecureTLS
+		out.PlainHTTP = b.Registry.PlainHTTP
+	}
+
+	return out, nil
+}
+
+// ResolveCriteria converts the recipe criteria spec from wire-string form
+// to a typed *recipe.Criteria. Nil-receiver tolerant; never returns a nil
+// pointer.
+//
+// Unlike recipe.NewCriteria, the returned Criteria does NOT default
+// unset fields to "any": empty enum fields signal "config did not set
+// this slot" so callers can detect what to copy onto a target Criteria.
+// Nodes < 0 is rejected; Nodes == 0 means unset.
+func (r *RecipeSpec) ResolveCriteria() (*recipe.Criteria, error) {
+	out := &recipe.Criteria{}
+	if r == nil || r.Criteria == nil {
+		return out, nil
+	}
+	c := r.Criteria
+	if c.Service != "" {
+		v, err := recipe.ParseCriteriaServiceType(c.Service)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.recipe.criteria.service", err)
+		}
+		out.Service = v
+	}
+	if c.Accelerator != "" {
+		v, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.recipe.criteria.accelerator", err)
+		}
+		out.Accelerator = v
+	}
+	if c.Intent != "" {
+		v, err := recipe.ParseCriteriaIntentType(c.Intent)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.recipe.criteria.intent", err)
+		}
+		out.Intent = v
+	}
+	if c.OS != "" {
+		v, err := recipe.ParseCriteriaOSType(c.OS)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.recipe.criteria.os", err)
+		}
+		out.OS = v
+	}
+	if c.Platform != "" {
+		v, err := recipe.ParseCriteriaPlatformType(c.Platform)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.recipe.criteria.platform", err)
+		}
+		out.Platform = v
+	}
+	if c.Nodes < 0 {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("spec.recipe.criteria.nodes must be >= 0, got %d", c.Nodes))
+	}
+	out.Nodes = c.Nodes
+	return out, nil
+}

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -1,0 +1,547 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// === RecipeSpec.ResolveCriteria ===
+
+func TestResolveCriteria_NilReceiver(t *testing.T) {
+	var r *config.RecipeSpec
+	got, err := r.ResolveCriteria()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result for nil receiver")
+	}
+	want := &recipe.Criteria{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected zero-valued Criteria, got %+v", got)
+	}
+}
+
+func TestResolveCriteria_NilCriteria(t *testing.T) {
+	r := &config.RecipeSpec{}
+	got, err := r.ResolveCriteria()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.Service != "" || got.Nodes != 0 {
+		t.Errorf("expected zero-valued, got %+v", got)
+	}
+}
+
+func TestResolveCriteria_AllFieldsPopulated(t *testing.T) {
+	r := &config.RecipeSpec{
+		Criteria: &config.CriteriaSpec{
+			Service:     "eks",
+			Accelerator: "h100",
+			Intent:      "training",
+			OS:          "ubuntu",
+			Platform:    "kubeflow",
+			Nodes:       4,
+		},
+	}
+	got, err := r.ResolveCriteria()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Service != recipe.CriteriaServiceEKS {
+		t.Errorf("Service: got %q, want eks", got.Service)
+	}
+	if got.Accelerator != recipe.CriteriaAcceleratorH100 {
+		t.Errorf("Accelerator: got %q", got.Accelerator)
+	}
+	if got.Intent != recipe.CriteriaIntentTraining {
+		t.Errorf("Intent: got %q", got.Intent)
+	}
+	if got.OS != recipe.CriteriaOSUbuntu {
+		t.Errorf("OS: got %q", got.OS)
+	}
+	if got.Platform != recipe.CriteriaPlatformKubeflow {
+		t.Errorf("Platform: got %q", got.Platform)
+	}
+	if got.Nodes != 4 {
+		t.Errorf("Nodes: got %d, want 4", got.Nodes)
+	}
+}
+
+func TestResolveCriteria_PartialFields_UnsetStayZero(t *testing.T) {
+	r := &config.RecipeSpec{
+		Criteria: &config.CriteriaSpec{Service: "gke"},
+	}
+	got, err := r.ResolveCriteria()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Service != recipe.CriteriaServiceGKE {
+		t.Errorf("Service: got %q, want gke", got.Service)
+	}
+	if got.Accelerator != "" {
+		t.Errorf("Accelerator: expected empty (unset), got %q", got.Accelerator)
+	}
+	if got.Intent != "" || got.OS != "" || got.Platform != "" {
+		t.Errorf("expected unset enum fields to remain zero, got %+v", got)
+	}
+}
+
+func TestResolveCriteria_InvalidEnums(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*config.CriteriaSpec)
+		wantSub string
+	}{
+		{
+			name:    "service",
+			mutate:  func(c *config.CriteriaSpec) { c.Service = "bogus" },
+			wantSub: "spec.recipe.criteria.service",
+		},
+		{
+			name:    "accelerator",
+			mutate:  func(c *config.CriteriaSpec) { c.Accelerator = "h99999" },
+			wantSub: "spec.recipe.criteria.accelerator",
+		},
+		{
+			name:    "intent",
+			mutate:  func(c *config.CriteriaSpec) { c.Intent = "mining" },
+			wantSub: "spec.recipe.criteria.intent",
+		},
+		{
+			name:    "os",
+			mutate:  func(c *config.CriteriaSpec) { c.OS = "windows" },
+			wantSub: "spec.recipe.criteria.os",
+		},
+		{
+			name:    "platform",
+			mutate:  func(c *config.CriteriaSpec) { c.Platform = "spark" },
+			wantSub: "spec.recipe.criteria.platform",
+		},
+		{
+			name:    "negative nodes",
+			mutate:  func(c *config.CriteriaSpec) { c.Nodes = -1 },
+			wantSub: "spec.recipe.criteria.nodes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &config.RecipeSpec{Criteria: &config.CriteriaSpec{}}
+			tt.mutate(r.Criteria)
+			_, err := r.ResolveCriteria()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q must contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+// === BundleSpec.Resolve ===
+
+func TestBundleResolve_NilReceiver(t *testing.T) {
+	var b *config.BundleSpec
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result for nil receiver")
+	}
+	want := &config.BundleResolved{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected zero BundleResolved, got %+v", got)
+	}
+}
+
+func TestBundleResolve_EmptySpec(t *testing.T) {
+	b := &config.BundleSpec{}
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil")
+	}
+	if got.Deployer != "" || got.RecipeInput != "" {
+		t.Errorf("expected zero, got %+v", got)
+	}
+}
+
+func TestBundleResolve_AllFieldsPopulated(t *testing.T) {
+	b := &config.BundleSpec{
+		Input:  &config.BundleInputSpec{Recipe: "recipe.yaml"},
+		Output: &config.BundleOutputSpec{Target: "./out", ImageRefs: "refs.txt"},
+		Deployment: &config.DeploymentSpec{
+			Deployer: "argocd",
+			Repo:     "https://repo.example",
+			Set:      []string{"gpuoperator:driver.version=570.0.0"},
+			Dynamic:  []string{"gpuoperator:storage.class"},
+		},
+		Scheduling: &config.SchedulingSpec{
+			SystemNodeSelector:         map[string]string{"sys": "true"},
+			SystemNodeTolerations:      []string{"sys-only=yes:NoSchedule"},
+			AcceleratedNodeSelector:    map[string]string{"gpu": "true"},
+			AcceleratedNodeTolerations: []string{"gpu-only=yes:NoSchedule"},
+			WorkloadGate:               "k=v:NoSchedule",
+			WorkloadSelector:           map[string]string{"workload": "true"},
+			Nodes:                      8,
+			StorageClass:               "fast-ssd",
+		},
+		Attestation: &config.AttestationSpec{
+			Enabled:                   true,
+			CertificateIdentityRegexp: ".+",
+			OIDCDeviceFlow:            true,
+		},
+		Registry: &config.RegistrySpec{InsecureTLS: true, PlainHTTP: true},
+	}
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RecipeInput != "recipe.yaml" {
+		t.Errorf("RecipeInput: got %q", got.RecipeInput)
+	}
+	if got.OutputTargetRaw != "./out" {
+		t.Errorf("OutputTargetRaw: got %q", got.OutputTargetRaw)
+	}
+	if got.OutputTarget == nil {
+		t.Errorf("OutputTarget should be non-nil for non-empty target")
+	}
+	if got.ImageRefs != "refs.txt" {
+		t.Errorf("ImageRefs: got %q", got.ImageRefs)
+	}
+	if got.Deployer != bundlercfg.DeployerArgoCD {
+		t.Errorf("Deployer: got %q", got.Deployer)
+	}
+	if got.Repo != "https://repo.example" {
+		t.Errorf("Repo: got %q", got.Repo)
+	}
+	if len(got.ValueOverrides) != 1 {
+		t.Errorf("ValueOverrides count: got %d, want 1", len(got.ValueOverrides))
+	}
+	if len(got.DynamicValues) != 1 {
+		t.Errorf("DynamicValues count: got %d, want 1", len(got.DynamicValues))
+	}
+	if got.SystemNodeSelector["sys"] != "true" {
+		t.Errorf("SystemNodeSelector: got %v", got.SystemNodeSelector)
+	}
+	if len(got.SystemNodeTolerations) != 1 {
+		t.Errorf("SystemNodeTolerations count: got %d, want 1", len(got.SystemNodeTolerations))
+	}
+	if len(got.AcceleratedNodeTolerations) != 1 {
+		t.Errorf("AcceleratedNodeTolerations count: got %d", len(got.AcceleratedNodeTolerations))
+	}
+	if got.WorkloadGate == nil || got.WorkloadGate.Key != "k" {
+		t.Errorf("WorkloadGate: got %+v", got.WorkloadGate)
+	}
+	if got.WorkloadSelector["workload"] != "true" {
+		t.Errorf("WorkloadSelector: got %v", got.WorkloadSelector)
+	}
+	if got.Nodes != 8 {
+		t.Errorf("Nodes: got %d", got.Nodes)
+	}
+	if got.StorageClass != "fast-ssd" {
+		t.Errorf("StorageClass: got %q", got.StorageClass)
+	}
+	if !got.Attest || got.CertIDRegexp != ".+" || !got.OIDCDeviceFlow {
+		t.Errorf("Attestation fields: got attest=%v cert=%q oidc=%v",
+			got.Attest, got.CertIDRegexp, got.OIDCDeviceFlow)
+	}
+	if !got.InsecureTLS || !got.PlainHTTP {
+		t.Errorf("Registry: got insecure=%v plain=%v", got.InsecureTLS, got.PlainHTTP)
+	}
+}
+
+func TestBundleResolve_NilVsExplicitlyEmptyMaps(t *testing.T) {
+	tests := []struct {
+		name           string
+		scheduling     *config.SchedulingSpec
+		wantSysSel     map[string]string
+		wantSysSelNil  bool
+		wantSysSelLen0 bool
+	}{
+		{
+			name:          "nil scheduling: selector nil",
+			scheduling:    nil,
+			wantSysSelNil: true,
+		},
+		{
+			name:          "scheduling present, selector nil: stays nil",
+			scheduling:    &config.SchedulingSpec{},
+			wantSysSelNil: true,
+		},
+		{
+			name:           "scheduling present, selector explicitly empty: non-nil empty",
+			scheduling:     &config.SchedulingSpec{SystemNodeSelector: map[string]string{}},
+			wantSysSelLen0: true,
+		},
+		{
+			name:       "scheduling present, selector populated",
+			scheduling: &config.SchedulingSpec{SystemNodeSelector: map[string]string{"k": "v"}},
+			wantSysSel: map[string]string{"k": "v"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &config.BundleSpec{Scheduling: tt.scheduling}
+			got, err := b.Resolve()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantSysSelNil {
+				if got.SystemNodeSelector != nil {
+					t.Errorf("expected nil, got %v", got.SystemNodeSelector)
+				}
+				return
+			}
+			if tt.wantSysSelLen0 {
+				if got.SystemNodeSelector == nil {
+					t.Errorf("expected non-nil empty map")
+				}
+				if len(got.SystemNodeSelector) != 0 {
+					t.Errorf("expected empty, got %v", got.SystemNodeSelector)
+				}
+				return
+			}
+			if got.SystemNodeSelector["k"] != "v" {
+				t.Errorf("got %v, want %v", got.SystemNodeSelector, tt.wantSysSel)
+			}
+		})
+	}
+}
+
+func TestBundleResolve_NilVsExplicitlyEmptySlices(t *testing.T) {
+	tests := []struct {
+		name           string
+		deployment     *config.DeploymentSpec
+		wantOverNil    bool
+		wantOverLen0   bool
+		wantDynamicNil bool
+	}{
+		{
+			name:           "nil deployment: both nil",
+			deployment:     nil,
+			wantOverNil:    true,
+			wantDynamicNil: true,
+		},
+		{
+			name:           "deployment present, set nil: nil",
+			deployment:     &config.DeploymentSpec{},
+			wantOverNil:    true,
+			wantDynamicNil: true,
+		},
+		{
+			name:         "deployment present, set explicitly empty: non-nil empty",
+			deployment:   &config.DeploymentSpec{Set: []string{}, Dynamic: []string{}},
+			wantOverLen0: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &config.BundleSpec{Deployment: tt.deployment}
+			got, err := b.Resolve()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOverNil {
+				if got.ValueOverrides != nil {
+					t.Errorf("ValueOverrides: expected nil, got %v", got.ValueOverrides)
+				}
+			} else if tt.wantOverLen0 {
+				if got.ValueOverrides == nil {
+					t.Errorf("ValueOverrides: expected non-nil empty, got nil")
+				}
+				if len(got.ValueOverrides) != 0 {
+					t.Errorf("ValueOverrides: expected len 0, got %d", len(got.ValueOverrides))
+				}
+				if got.DynamicValues == nil {
+					t.Errorf("DynamicValues: expected non-nil empty, got nil")
+				}
+			}
+			if tt.wantDynamicNil && got.DynamicValues != nil {
+				t.Errorf("DynamicValues: expected nil, got %v", got.DynamicValues)
+			}
+		})
+	}
+}
+
+func TestBundleResolve_NilVsExplicitlyEmptyTolerations(t *testing.T) {
+	// nil tolerations: resolved field stays nil so CLI can apply DefaultTolerations.
+	b1 := &config.BundleSpec{Scheduling: &config.SchedulingSpec{}}
+	r1, err := b1.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r1.SystemNodeTolerations != nil {
+		t.Errorf("nil input → expected nil output, got %v", r1.SystemNodeTolerations)
+	}
+
+	// Explicitly empty tolerations: parser conflates nil/empty and returns
+	// DefaultTolerations — Resolve preserves that parser semantics.
+	b2 := &config.BundleSpec{Scheduling: &config.SchedulingSpec{SystemNodeTolerations: []string{}}}
+	r2, err := b2.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r2.SystemNodeTolerations) == 0 {
+		t.Errorf("explicit empty input → expected DefaultTolerations, got empty")
+	}
+}
+
+func TestBundleResolve_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.BundleSpec
+		wantSub string
+	}{
+		{
+			name: "invalid deployer",
+			spec: &config.BundleSpec{
+				Deployment: &config.DeploymentSpec{Deployer: "fluxcd"},
+			},
+			wantSub: "spec.bundle.deployment.deployer",
+		},
+		{
+			name: "invalid set value override",
+			spec: &config.BundleSpec{
+				Deployment: &config.DeploymentSpec{Set: []string{"no-equals-sign"}},
+			},
+			wantSub: "spec.bundle.deployment.set",
+		},
+		{
+			name: "invalid dynamic declaration",
+			spec: &config.BundleSpec{
+				Deployment: &config.DeploymentSpec{Dynamic: []string{"with=equals"}},
+			},
+			wantSub: "spec.bundle.deployment.dynamic",
+		},
+		{
+			name: "invalid system tolerations",
+			spec: &config.BundleSpec{
+				Scheduling: &config.SchedulingSpec{
+					SystemNodeTolerations: []string{"malformed"},
+				},
+			},
+			wantSub: "spec.bundle.scheduling.systemNodeTolerations",
+		},
+		{
+			name: "invalid accelerated tolerations",
+			spec: &config.BundleSpec{
+				Scheduling: &config.SchedulingSpec{
+					AcceleratedNodeTolerations: []string{"bad:taint:format"},
+				},
+			},
+			wantSub: "spec.bundle.scheduling.acceleratedNodeTolerations",
+		},
+		{
+			name: "invalid workload gate",
+			spec: &config.BundleSpec{
+				Scheduling: &config.SchedulingSpec{WorkloadGate: "no-effect"},
+			},
+			wantSub: "spec.bundle.scheduling.workloadGate",
+		},
+		{
+			name: "invalid output target",
+			spec: &config.BundleSpec{
+				Output: &config.BundleOutputSpec{Target: "oci://"},
+			},
+			wantSub: "spec.bundle.output.target",
+		},
+		{
+			name: "negative nodes",
+			spec: &config.BundleSpec{
+				Scheduling: &config.SchedulingSpec{Nodes: -3},
+			},
+			wantSub: "spec.bundle.scheduling.nodes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.spec.Resolve()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q must contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestBundleResolve_OutputTargetEmptyStringStaysNil(t *testing.T) {
+	b := &config.BundleSpec{Output: &config.BundleOutputSpec{}}
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.OutputTarget != nil {
+		t.Errorf("expected nil OutputTarget for empty raw, got %+v", got.OutputTarget)
+	}
+	if got.OutputTargetRaw != "" {
+		t.Errorf("expected empty OutputTargetRaw, got %q", got.OutputTargetRaw)
+	}
+}
+
+func TestBundleResolve_DeployerEmptyStaysZero(t *testing.T) {
+	// Empty config-deployer means "config did not set" — Resolve does NOT
+	// fabricate a default. The CLI is responsible for defaulting to Helm.
+	b := &config.BundleSpec{Deployment: &config.DeploymentSpec{}}
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Deployer != "" {
+		t.Errorf("expected zero deployer, got %q", got.Deployer)
+	}
+}
+
+func TestBundleResolve_WorkloadGateEmptyStaysNil(t *testing.T) {
+	b := &config.BundleSpec{Scheduling: &config.SchedulingSpec{WorkloadGate: ""}}
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.WorkloadGate != nil {
+		t.Errorf("expected nil WorkloadGate, got %+v", got.WorkloadGate)
+	}
+}
+
+func TestBundleResolve_DefensiveCloneOfMaps(t *testing.T) {
+	// Ensures Resolve clones map fields so callers cannot mutate the
+	// loaded config's backing map by mutating the resolved value.
+	src := map[string]string{"k": "v"}
+	b := &config.BundleSpec{Scheduling: &config.SchedulingSpec{SystemNodeSelector: src}}
+	got, err := b.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got.SystemNodeSelector["k"] = "mutated"
+	if src["k"] != "v" {
+		t.Errorf("Resolve must defensively clone maps; source was mutated to %q", src["k"])
+	}
+}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -18,9 +18,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
@@ -84,6 +82,11 @@ func (s Spec) validateRecipeBundleHandoff() error {
 	return nil
 }
 
+// Wire-type validation delegates to the same Resolve methods callers use
+// to consume the values. There is no parallel parser to maintain — if a
+// field parses cleanly here, it will parse cleanly when consumed, and
+// vice versa.
+
 func (r *RecipeSpec) validate() error {
 	if r == nil {
 		return nil
@@ -92,7 +95,7 @@ func (r *RecipeSpec) validate() error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			"spec.recipe.criteria and spec.recipe.input.snapshot are mutually exclusive")
 	}
-	if err := r.Criteria.validate(); err != nil {
+	if _, err := r.ResolveCriteria(); err != nil {
 		return err
 	}
 	if r.Output != nil && r.Output.Format != "" {
@@ -104,55 +107,12 @@ func (r *RecipeSpec) validate() error {
 	return nil
 }
 
-func (c *CriteriaSpec) validate() error {
-	if c == nil {
-		return nil
-	}
-	if c.Service != "" {
-		if _, err := recipe.ParseCriteriaServiceType(c.Service); err != nil {
-			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.service", err)
-		}
-	}
-	if c.Accelerator != "" {
-		if _, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator); err != nil {
-			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.accelerator", err)
-		}
-	}
-	if c.Intent != "" {
-		if _, err := recipe.ParseCriteriaIntentType(c.Intent); err != nil {
-			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.intent", err)
-		}
-	}
-	if c.OS != "" {
-		if _, err := recipe.ParseCriteriaOSType(c.OS); err != nil {
-			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.os", err)
-		}
-	}
-	if c.Platform != "" {
-		if _, err := recipe.ParseCriteriaPlatformType(c.Platform); err != nil {
-			return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.recipe.criteria.platform", err)
-		}
-	}
-	if c.Nodes < 0 {
-		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("spec.recipe.criteria.nodes must be >= 0, got %d", c.Nodes))
-	}
-	return nil
-}
-
 func (b *BundleSpec) validate() error {
 	if b == nil {
 		return nil
 	}
-	if b.Deployment != nil && b.Deployment.Deployer != "" {
-		if _, err := bundlercfg.ParseDeployerType(b.Deployment.Deployer); err != nil {
-			return errors.Wrap(errors.ErrCodeInvalidRequest,
-				"invalid spec.bundle.deployment.deployer", err)
-		}
-	}
-	if b.Scheduling != nil && b.Scheduling.Nodes < 0 {
-		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("spec.bundle.scheduling.nodes must be >= 0, got %d", b.Scheduling.Nodes))
+	if _, err := b.Resolve(); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Consolidates string→typed conversion of wire-spec fields into a single boundary: `(*BundleSpec).Resolve()` and `(*RecipeSpec).ResolveCriteria()`. Removes the three-way parallel parsing across `validate.go`, `applyCriteriaFromConfig`, and `parseBundleCmdOptions`.

## Motivation / Context

Follow-up to #782 (review feedback from @lockwobr). Wire types in `pkg/config` are intentionally string-typed; conversion to domain types was happening in three places with subtly different code paths and error attribution. This refactor makes the conversion happen once at the type boundary.

Fixes: #783
Related: #782

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Other: `pkg/config`

## Implementation Notes

- `BundleResolved` is the typed projection of `BundleSpec`. `(*BundleSpec).Resolve()` performs all string→domain conversion (`bundlercfg.DeployerType`, `*oci.Reference`, `[]bundlercfg.ComponentPath`, `[]corev1.Toleration`, `*corev1.Taint`, etc.) and attributes parse errors to their `spec.bundle.<path>` source.
- `(*RecipeSpec).ResolveCriteria()` returns `*recipe.Criteria` with parsed enums; unset fields stay zero so callers can detect what to copy onto a target.
- Both methods are nil-receiver tolerant, never return a nil pointer, and preserve the nil-vs-explicitly-empty distinction for maps and slices via `maps.Clone` / conditional parsing.
- `validate()` delegates to `Resolve*()` and discards the result — there's no parallel parser to keep in sync.
- `applyCriteriaFromConfig` simplifies to "call ResolveCriteria, copy non-zero fields, log overrides."
- `parseBundleCmdOptions` consumes `*BundleResolved` directly. New small CLI helpers in `pkg/cli/bundle_config.go` (`resolveDeployer`, `resolveTolerations`, `resolveComponentPaths`, `resolveTaint`) and `bundle.go::resolveOutputTarget` layer CLI flag overrides onto typed values.
- The dead per-field bundle accessors on `BundleSpec` are removed since `BundleResolved` is now the single consumption point. Recipe accessors stay because their fields have no enum parsing.

**Behavior preservation for empty CLI strings**: `--deployer ""`, `--workload-gate ""`, and `--output ""` previously masked config and fell through to documented defaults (Helm / nil / "."). The new helpers preserve this — verified with dedicated tests.

## Testing

```bash
unset GITLAB_TOKEN && make test    # ok pkg/config (95.1%) + pkg/cli (62.6%)
golangci-lint run -c .golangci.yaml ./pkg/config/... ./pkg/cli/...    # 0 issues
```

Coverage on changed packages (vs `origin/main`):

| Package | Baseline | Branch | Delta |
|---|---|---|---|
| `pkg/config` | 75.8% | 95.1% | **+19.3pp** |
| `pkg/cli` | 60.7% | 62.6% | **+1.9pp** |

New exported methods at 100% coverage. New CLI helpers at 90–100%. New tests:

- `pkg/config/resolve_test.go` — table-driven, including nil-receiver, all-empty, all-populated, every invalid-enum case, nil-vs-explicitly-empty for selectors / tolerations / value-overrides, defensive map cloning.
- `pkg/config/accessors_test.go` — nil-tolerance and population for the remaining recipe-side accessors.
- `pkg/cli/bundle_resolve_helpers_test.go` — every branch of every new helper, including the empty-CLI behavior-preservation cases (`TestResolveDeployer_FlagSetEmptyDefaultsToHelm`, `TestResolveTaint_FlagSetEmptyMasksFallback`, `TestResolveOutputTarget_FlagSetEmptyDefaultsToCurrentDir`).

All existing integration/E2E tests in `pkg/cli/config_*_test.go` continue to pass unchanged.

## Risk Assessment

- [x] **Low** — Pure refactor, no schema changes, behavior verified by existing + new tests.

**Rollout notes:** No user-visible behavior change; wire format unchanged. One internal API change: `*BundleSpec` no longer carries per-field accessors (`RecipeInput`, `OutputTarget`, `DeploymentDeployer`, etc.); callers should use `(*BundleSpec).Resolve()` instead. No external consumers of those accessors found in the codebase.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (no user-facing changes)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)