### PR TITLE
fix(recipes): track nri-device-injector by tag, ignore tcpxo image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -322,14 +322,27 @@
     },
   ],
 
-  // The AWS EFA device-plugin image lives in AWS's authenticated public ECR
-  // (602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/...) — that is the
-  // canonical distribution path AWS publishes for EKS add-ons. Renovate
-  // can't query it without AWS credentials and there is no public.ecr.aws
-  // mirror, so suppress the lookup-failure warning. Bumping this image is
-  // gated on AWS releasing a new EKS add-on version anyway.
+  // Vendor-curated GPU networking images that Renovate cannot crawl without
+  // cloud-provider credentials we don't ship to the runner. Each one returns
+  // 401/403 from the registry's tag-list endpoint and produces a recurring
+  // "Failed to look up docker package" warning. Suppressing the warning is
+  // honest about the gap; bumps for these images are coordinated with
+  // vendor-side stack releases (EKS add-on cadence, GKE TCPXO stack
+  // version-coupling) and should remain a deliberate, human-driven change
+  // rather than a Renovate-auto PR.
+  //
+  // - aws-efa-k8s-device-plugin: AWS authenticated public ECR
+  //   (602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/...). No
+  //   public.ecr.aws mirror; bumping is tied to EKS add-on releases.
+  // - nccl-plugin-gpudirecttcpx-dev: Google's auth-gated GAR
+  //   (us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/...) for the GKE
+  //   GPUDirect-TCPXO stack. The TCPXO installer (this image) and the
+  //   workload-side daemon (tcpgpudmarxd-dev) must move together; an
+  //   independent Renovate bump on this image alone would create
+  //   stack version skew. See docs/integrator/gke-tcpxo-networking.md.
   ignoreDeps: [
     "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin",
+    "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev",
   ],
 
   // Paths Renovate should not scan.

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -80,7 +80,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.kgateway.dev`, `
 
 ### gke-nccl-tcpxo
 
-- `gcr.io/gke-release/nri-device-injector@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c`
+- `gcr.io/gke-release/nri-device-injector:1.0.25-gke.6@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c`
 - `gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830`
 - `ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b`
 - `us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3f39455a2ea35e844e0fc92564ca5629f6b03250fde40e8160719dae4`

--- a/recipes/components/gke-nccl-tcpxo/manifests/nri-device-injector.yaml
+++ b/recipes/components/gke-nccl-tcpxo/manifests/nri-device-injector.yaml
@@ -64,7 +64,7 @@ spec:
       # root mount restrictions. If NRI is not enabled on your cluster,
       # configure it via node pool settings or manually patch containerd config.
       containers:
-        - image: "gcr.io/gke-release/nri-device-injector@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c"
+        - image: "gcr.io/gke-release/nri-device-injector:1.0.25-gke.6@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c"
           name: device-injector
           resources:
             requests:


### PR DESCRIPTION
## Summary

Fix two Renovate package-lookup failures on the `gke-nccl-tcpxo` component manifests with the right tool for each: tag the `nri-device-injector` reference so Renovate can actually track it, and add the GAR-hosted `nccl-plugin-gpudirecttcpx-dev` to `ignoreDeps` because it's auth-walled and stack-coupled.

## Motivation / Context

Each Renovate run logs:

```
Failed to look up docker package us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev: no-result
Could not determine new digest for update (docker package gcr.io/gke-release/nri-device-injector)
```

Both failures touch the same component (`recipes/components/gke-nccl-tcpxo/manifests/`), but the underlying causes are different and warrant different fixes.

**`gcr.io/gke-release/nri-device-injector` — manifest authoring gap.** The image was pinned by digest only (`@sha256:7704e2bd…`) with no tag. Renovate's docker manager needs a tag to compute upgrade paths, so it had nothing to track. Querying `gcr.io/v2/gke-release/nri-device-injector/tags/list` resolves the deployed digest to tag `1.0.25-gke.6` (published 2024-02-15), so adding the tag is purely informational — same digest, no behavior change. The kubernetes manager block introduced in #778 (ADR-006 digest-pinning policy) now applies cleanly to this image.

Side observation surfaced by this investigation: the deployed digest is ~21 months old. GCR shows a newer tag `1.34.10-gke.0` (published 2025-11-25), which is a major version family change with a multi-arch manifest list — not a mechanical bump. After this PR lands, Renovate will surface that as a regular PR for human review; it should not be auto-merged (`gpu-operator`-class change, needs GKE-recipe-owner sign-off). Tracking outside this PR.

**`us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev` — auth wall + stack coupling.** This is Google's curated GAR repo for the GPUDirect-TCPXO stack. The Docker v2 endpoint returns 401 UNAUTHORIZED and the public `artifactregistry.googleapis.com` REST API returns 403 PERMISSION_DENIED without GCP IAM credentials, which we don't ship to the renovate runner. Beyond the auth wall, `docs/integrator/gke-tcpxo-networking.md` explicitly says the installer image (this one) and the workload-side `tcpgpudmarxd-dev` daemon must move together — currently `v1.0.15` installer vs `v1.0.20` daemon in the docs example, which itself suggests stack drift worth a closer look separately. An independent Renovate-driven bump on the installer alone would cause skew. Same shape as the existing `aws-efa-k8s-device-plugin` entry (also auth-walled, also vendor-coordinated), so extend the existing `ignoreDeps` block and rewrite the comment to cover the shared rationale.

Fixes: N/A
Related: #749 (ADR-006 digest-pinning policy), #778 (kubernetes manager block introduction)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — manifest under `recipes/components/gke-nccl-tcpxo/`
- [x] Docs/examples (`docs/`, `examples/`) — `docs/user/container-images.md` regenerated
- [x] Other: `.github/renovate.json5`

## Implementation Notes

- **Tag-and-digest, not tag-only.** The manifest goes from `image@sha256:…` to `image:1.0.25-gke.6@sha256:…`. The digest stays as the source of truth for what actually runs; the tag is added so Renovate knows what stream to track. This is the form ADR-006 expects.
- **No version delta.** The deployed digest is unchanged, so the running image and any cached layers are untouched. This is metadata-only as far as cluster state is concerned.
- **`docs/user/container-images.md` is auto-generated.** Regenerated via `make bom-docs` per the contributor expectation called out at the top of that file. Diff is one line, mirroring the manifest change.
- **`ignoreDeps` comment rewritten, not just appended.** The existing aws-efa entry had a single-paragraph comment specific to AWS ECR. With a second auth-walled vendor image joining, the comment now leads with the shared rationale (vendor-curated, auth-gated, stack-coordinated) and lists each entry's specifics underneath. Future readers should be able to evaluate "should this new vendor image join the list?" against a stated principle, not by analogy alone.
- **Two commits intentionally separate.** The manifest fix is valuable on its own (truthful provenance, ADR-006 compliance) regardless of the Renovate-noise goal; the `ignoreDeps` is a CI-config tweak that doesn't depend on the manifest fix. Keeps each independently revertable.

## Testing

```bash
# Verified the new tag matches the deployed digest:
curl -s "https://gcr.io/v2/gke-release/nri-device-injector/tags/list" \
  | jq '.manifest["sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c"].tag'
# → ["1.0.25-gke.6"]

# Regenerated the BOM doc:
unset GITLAB_TOKEN && make bom-docs
# → "Updated docs/user/container-images.md (prose preserved, auto-generated section refreshed)"
```

No Go code changes — `make qualify` test/lint/coverage gates are not applicable (manifest YAML and JSON5 config only).

Validation plan post-merge: trigger Renovate via `workflow_dispatch` and confirm the run log no longer contains either of the two `Package lookup failures` lines for this component.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Both commits revert cleanly via `git revert`. The manifest change is digest-preserving, so deployed state is unchanged whether the change is in or out. The `ignoreDeps` change is purely CI-side and has no runtime effect.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go code touched
- [x] Linter passes (`make lint`) — N/A, no Go code; YAML manifest is digest-preserving
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — `docs/user/container-images.md` regenerated via `make bom-docs`
- [x] Changes follow existing patterns in the codebase — mirrors the `aws-efa-k8s-device-plugin` `ignoreDeps` entry; tag-and-digest manifest form matches every other digest-pinned image in `recipes/components/*/manifests/`
- [x] Commits are cryptographically signed (`git commit -S`)
