### PR TITLE
fix(api): sync OpenAPI platform enum with Go criteria type

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -152,7 +152,7 @@ paths:
           description: Platform/framework type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [kubeflow, any]
+            enum: [dynamo, kubeflow, nim, any]
             default: any
         - name: nodes
           in: query
@@ -519,7 +519,7 @@ paths:
           description: Platform/framework type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [kubeflow, any]
+            enum: [dynamo, kubeflow, nim, any]
             default: any
         - name: nodes
           in: query
@@ -1238,6 +1238,11 @@ components:
           description: Operating system family
           enum: [ubuntu, rhel, cos, amazonlinux, talos, any]
           example: ubuntu
+        platform:
+          type: string
+          description: Platform/framework type
+          enum: [dynamo, kubeflow, nim, any]
+          example: kubeflow
         nodes:
           type: integer
           description: Number of GPU nodes (0 = any)

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -64,13 +64,15 @@
 // # Query Parameters (GET /v1/recipe)
 //
 // The /v1/recipe endpoint accepts these query parameters for GET requests:
-//   - os: Operating system (ubuntu, cos, rhel, any)
+//   - os: Operating system (ubuntu, rhel, cos, amazonlinux, talos, any)
 //   - osv: OS version (e.g., 24.04)
 //   - kernel: Kernel version (supports vendor suffixes)
 //   - service: Kubernetes service (eks, gke, aks, oke, kind, lke, any)
 //   - k8s: Kubernetes version (supports vendor suffixes)
-//   - gpu: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000, any)
+//   - accelerator: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000, any)
+//   - gpu: Alias for accelerator (back-compat)
 //   - intent: Workload intent (training, inference, any)
+//   - platform: Platform/framework (dynamo, kubeflow, nim, any)
 //   - context: Include context metadata (true/false)
 //
 // # Request Body (POST /v1/recipe)

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -64,16 +64,13 @@
 // # Query Parameters (GET /v1/recipe)
 //
 // The /v1/recipe endpoint accepts these query parameters for GET requests:
-//   - os: Operating system (ubuntu, rhel, cos, amazonlinux, talos, any)
-//   - osv: OS version (e.g., 24.04)
-//   - kernel: Kernel version (supports vendor suffixes)
 //   - service: Kubernetes service (eks, gke, aks, oke, kind, lke, any)
-//   - k8s: Kubernetes version (supports vendor suffixes)
 //   - accelerator: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000, any)
 //   - gpu: Alias for accelerator (back-compat)
 //   - intent: Workload intent (training, inference, any)
+//   - os: Operating system (ubuntu, rhel, cos, amazonlinux, talos, any)
 //   - platform: Platform/framework (dynamo, kubeflow, nim, any)
-//   - context: Include context metadata (true/false)
+//   - nodes: Number of GPU nodes (0 = any/unspecified)
 //
 // # Request Body (POST /v1/recipe)
 //

--- a/pkg/api/openapi_sync_test.go
+++ b/pkg/api/openapi_sync_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"gopkg.in/yaml.v3"
+)
+
+// TestOpenAPIEnumsMatchGoTypes asserts that every criteria-field enum in
+// api/aicr/v1/server.yaml matches the canonical list returned by the
+// corresponding pkg/recipe.GetCriteria*Types function.
+//
+// Drift here is a contract bug: clients that conform to the OpenAPI spec
+// will reject inputs the server actually accepts (or generate types that
+// reject server outputs). Adding a new value to a Go criteria type must
+// be reflected in the spec — and vice versa — and this test enforces it.
+//
+// Sites checked:
+//   - Query parameters (- name: <field>) under any operation
+//   - Schema properties (Criteria.properties.<field>) under components.schemas
+//
+// "any" is allowed to appear in the spec as a wildcard but is NOT part of
+// the Go type list, so it is stripped before comparison.
+func TestOpenAPIEnumsMatchGoTypes(t *testing.T) {
+	specPath := filepath.Join("..", "..", "api", "aicr", "v1", "server.yaml")
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read spec %q: %v", specPath, err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+
+	// Canonical Go enums, keyed by criteria field name as it appears in the spec.
+	// "gpu" is a back-compat alias for "accelerator" and shares its enum.
+	canonical := map[string][]string{
+		"service":     recipe.GetCriteriaServiceTypes(),
+		"accelerator": recipe.GetCriteriaAcceleratorTypes(),
+		"gpu":         recipe.GetCriteriaAcceleratorTypes(),
+		"intent":      recipe.GetCriteriaIntentTypes(),
+		"os":          recipe.GetCriteriaOSTypes(),
+		"platform":    recipe.GetCriteriaPlatformTypes(),
+	}
+
+	sites := collectCriteriaEnumSites(&root, canonical)
+
+	for field, want := range canonical {
+		observed, ok := sites[field]
+		if !ok {
+			t.Errorf("server.yaml: no enum sites found for criteria field %q", field)
+			continue
+		}
+		sortedWant := append([]string(nil), want...)
+		sort.Strings(sortedWant)
+		for i, enum := range observed {
+			got := stripAny(enum)
+			sort.Strings(got)
+			if !equalStrings(got, sortedWant) {
+				t.Errorf("criteria field %q, enum site %d: got %v (sans \"any\"), want %v",
+					field, i, got, sortedWant)
+			}
+		}
+	}
+}
+
+// collectCriteriaEnumSites walks the YAML tree and returns every enum array
+// that belongs to a known criteria field, keyed by field name.
+//
+// Two patterns are recognized:
+//
+//  1. OpenAPI parameter:
+//     - name: <field>
+//     in: query
+//     schema:
+//     enum: [...]
+//
+//  2. OpenAPI schema property:
+//     <field>:
+//     type: string
+//     enum: [...]
+func collectCriteriaEnumSites(root *yaml.Node, names map[string][]string) map[string][][]string {
+	out := map[string][][]string{}
+
+	var walk func(*yaml.Node)
+	walk = func(n *yaml.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Kind {
+		case yaml.ScalarNode, yaml.AliasNode:
+			// Leaves — nothing to recurse into.
+		case yaml.DocumentNode, yaml.SequenceNode:
+			for _, c := range n.Content {
+				walk(c)
+			}
+		case yaml.MappingNode:
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				key, val := n.Content[i], n.Content[i+1]
+
+				// Pattern 1: parameter object — current mapping has "name: <field>"
+				if key.Value == "name" {
+					if _, want := names[val.Value]; want {
+						if enum := findEnumInSchemaSibling(n); enum != nil {
+							out[val.Value] = append(out[val.Value], enum)
+						}
+					}
+				}
+
+				// Pattern 2: schema property — key is a known field name and value
+				// is a mapping with an "enum" child. Avoid matching the parameter
+				// "name: <field>" form (where val is a scalar string).
+				if _, want := names[key.Value]; want && val.Kind == yaml.MappingNode {
+					if enum := findDirectEnum(val); enum != nil {
+						out[key.Value] = append(out[key.Value], enum)
+					}
+				}
+
+				walk(val)
+			}
+		}
+	}
+	walk(root)
+	return out
+}
+
+// findEnumInSchemaSibling searches a parameter mapping for a "schema" child
+// and returns its "enum" array, if present.
+func findEnumInSchemaSibling(paramObj *yaml.Node) []string {
+	for i := 0; i+1 < len(paramObj.Content); i += 2 {
+		if paramObj.Content[i].Value == "schema" {
+			return findDirectEnum(paramObj.Content[i+1])
+		}
+	}
+	return nil
+}
+
+// findDirectEnum returns the "enum" array of a schema mapping, or nil.
+func findDirectEnum(schema *yaml.Node) []string {
+	if schema == nil || schema.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(schema.Content); i += 2 {
+		if schema.Content[i].Value != "enum" {
+			continue
+		}
+		seq := schema.Content[i+1]
+		if seq.Kind != yaml.SequenceNode {
+			return nil
+		}
+		out := make([]string, 0, len(seq.Content))
+		for _, c := range seq.Content {
+			out = append(out, c.Value)
+		}
+		return out
+	}
+	return nil
+}
+
+func stripAny(s []string) []string {
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if v == "any" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -529,7 +529,7 @@ func BuildCriteria(opts ...CriteriaOption) (*Criteria, error) {
 
 // ParseCriteriaFromRequest parses recipe criteria from HTTP query parameters.
 // All parameters are optional and default to "any" if not specified.
-// Supported parameters: service, accelerator (alias: gpu), intent, os, nodes.
+// Supported parameters: service, accelerator (alias: gpu), intent, os, platform, nodes.
 func ParseCriteriaFromRequest(r *http.Request) (*Criteria, error) {
 	if r == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "request cannot be nil")
@@ -541,7 +541,7 @@ func ParseCriteriaFromRequest(r *http.Request) (*Criteria, error) {
 
 // ParseCriteriaFromValues parses recipe criteria from URL values.
 // All parameters are optional and default to "any" if not specified.
-// Supported parameters: service, accelerator (alias: gpu), intent, os, nodes.
+// Supported parameters: service, accelerator (alias: gpu), intent, os, platform, nodes.
 func ParseCriteriaFromValues(values url.Values) (*Criteria, error) {
 	c := NewCriteria()
 


### PR DESCRIPTION
## Summary

The `platform` enum in `api/aicr/v1/server.yaml` listed only `[kubeflow, any]` while `pkg/recipe/criteria.go`'s `GetCriteriaPlatformTypes()` accepts `[dynamo, kubeflow, nim]`. Clients conforming to the OpenAPI spec rejected valid inputs the server actually accepts, and code generators driven from the spec produced incorrect types.

## Motivation / Context

Surfaced during the doc review in #797 / #796 and tracked as a standalone bug in #798. The server has accepted `dynamo` and `nim` for some time (e.g., `recipes/registry.yaml` has real entries for both); only the published contract was wrong.

Fixes: #798
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)

## Implementation Notes

**Spec fixes**
- Extend `platform` enum to `[dynamo, kubeflow, nim, any]` at both query-parameter sites (`POST /v1/recipe`, `GET /v1/recipe/yaml`).
- Add `platform` property to the `Criteria` schema under `components.schemas` (it was missing entirely — the schema only had service, accelerator, intent, os, nodes).

**Doc fix**
- `pkg/api/doc.go` listed stale enums (`os: ubuntu, cos, rhel, any`; `gpu` only). Updated to current `os: ubuntu, rhel, cos, amazonlinux, talos, any`, added `accelerator` (canonical), kept `gpu` as documented back-compat alias, added `platform`.

**Drift prevention**
- New test `pkg/api/openapi_sync_test.go::TestOpenAPIEnumsMatchGoTypes` walks the OpenAPI YAML, finds every enum site for `service`, `accelerator`, `gpu`, `intent`, `os`, `platform`, and asserts each (with `any` stripped) matches the corresponding `recipe.GetCriteria*Types()` output. Future drift in either direction fails CI.

The walker recognizes both patterns the spec uses today:
1. OpenAPI parameter — `- name: <field>` with sibling `schema.enum`
2. OpenAPI schema property — `<field>: { type: string, enum: [...] }`

**Verified test catches drift**

Temporarily reverting the platform fix makes the test report:

```
criteria field "platform", enum site 0: got [kubeflow] (sans "any"), want [dynamo kubeflow nim]
criteria field "platform", enum site 1: got [kubeflow] (sans "any"), want [dynamo kubeflow nim]
criteria field "platform", enum site 2: got [kubeflow] (sans "any"), want [dynamo kubeflow nim]
```

Restoring passes again.

## Testing

```bash
make qualify
```

Passes locally, including the new sync test.

Per-package coverage delta (`pkg/api`): test was added with no implementation change; coverage % does not regress (no new exported symbols in pkg/api).

## Risk Assessment

- [x] **Low** — Spec change is additive (added enum values + new optional property). No existing client that sent `kubeflow` is affected. The new property is optional with no default, so existing payloads remain valid.

**Rollout notes:** N/A — additive change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (sync test)
- [x] I updated docs if user-facing behavior changed (`pkg/api/doc.go`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)