### PR TITLE
fix(bundler): suppress kubectl auth prompt in undeploy.sh post-flight

### DIFF
--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -1729,6 +1729,118 @@ esac
 	}
 }
 
+// TestUndeployScript_PostflightTerminatingCheckSuppressesKubectlPrompt
+// proves the post-flight terminating-namespaces check does not surface
+// kubectl's interactive "Please enter Username:" auth prompt in its WARNING
+// when kubeconfig auth is broken. kubectl writes that prompt to *stdout*
+// before detecting non-TTY stdin, so `2>/dev/null` does not suppress it;
+// the fix routes the check through capture_kubectl_json, which closes
+// kubectl's stdin and discards stdout on non-zero exit. See issue #684.
+func TestUndeployScript_PostflightTerminatingCheckSuppressesKubectlPrompt(t *testing.T) {
+	skipIfMissingBins(t, "bash", "sed", "jq")
+
+	ctx := context.Background()
+	outputDir := t.TempDir()
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version: "v1.0.0",
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	undeployPath := filepath.Join(outputDir, "undeploy.sh")
+
+	// Stub kubectl mimics broken-kubeconfig behavior: writes the interactive
+	// auth prompt to stdout, then exits non-zero on stdin EOF. capture_kubectl_json
+	// must close kubectl's stdin (via </dev/null) so kubectl gets EOF immediately
+	// and the function fails closed without propagating the stdout prompt.
+	stubDir := t.TempDir()
+	writeStub(t, stubDir, "kubectl", `#!/bin/sh
+case "$*" in
+  "get namespaces -o json")
+    printf 'Please enter Username: '
+    echo "error: EOF" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`)
+
+	bashSnippet := `
+        snippet=$(sed -n "/^capture_kubectl_json()/,/^}/p" "$UNDEPLOY")
+        if [[ -z "${snippet}" ]]; then
+          echo "TEST_SETUP_ERROR: capture_kubectl_json helper not found in $UNDEPLOY" >&2
+          exit 1
+        fi
+        eval "$snippet"
+        snippet=$(sed -n '/^TERMINATING=""$/,/^kubectl get mutatingwebhookconfigurations/p' "$UNDEPLOY" | sed '$d')
+        if [[ -z "${snippet}" ]]; then
+          echo "TEST_SETUP_ERROR: post-flight terminating-check block not found in $UNDEPLOY; the fix from #684 may have been reverted to the bare 'TERMINATING=\$(kubectl ...)' form" >&2
+          exit 1
+        fi
+        postflight_issues=false
+        eval "$snippet"
+        # ${var+set} only expands when var is *set* (even to empty),
+        # distinguishing "initialized to empty" from "never assigned".
+        echo "FINAL_TERMINATING_SET=[${TERMINATING+set}]"
+        echo "FINAL_TERMINATING_VALUE=[${TERMINATING-unset}]"
+        echo "FINAL_POSTFLIGHT_ISSUES=[${postflight_issues}]"
+    `
+
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "bash", "-c", "set -uo pipefail\n"+bashSnippet)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"UNDEPLOY="+undeployPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("snippet exited non-zero.\nerr: %v\nstdout: %s\nstderr: %s",
+			err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	errOut := stderr.String()
+
+	// Regression: the kubectl prompt must NEVER appear in stdout.
+	if strings.Contains(out, "Please enter Username") {
+		t.Errorf("regression: kubectl prompt leaked into post-flight stdout.\nstdout=%q stderr=%q",
+			out, errOut)
+	}
+	// TERMINATING must be initialized but empty (no stray captured string).
+	if !strings.Contains(out, "FINAL_TERMINATING_SET=[set]") {
+		t.Errorf("expected TERMINATING to be initialized; stdout=%q stderr=%q",
+			out, errOut)
+	}
+	if !strings.Contains(out, "FINAL_TERMINATING_VALUE=[]") {
+		t.Errorf("expected TERMINATING value to be empty after failure; stdout=%q stderr=%q",
+			out, errOut)
+	}
+	// WARNING line about terminating namespaces must not appear (it would
+	// have rendered the leaked prompt as the namespace list).
+	if strings.Contains(out, "WARNING: namespaces still terminating:") {
+		t.Errorf("regression: terminating WARNING fired despite kubectl failure.\nstdout=%q",
+			out)
+	}
+	// The failure should be surfaced to stderr as a sensible warning.
+	if !strings.Contains(errOut, "failed to list namespaces") {
+		t.Errorf("expected stderr to contain failure warning; stderr=%q", errOut)
+	}
+	// postflight_issues should be flipped to true so the caller sees the failure.
+	if !strings.Contains(out, "FINAL_POSTFLIGHT_ISSUES=[true]") {
+		t.Errorf("expected postflight_issues=true after kubectl failure; stdout=%q", out)
+	}
+}
+
 // TestUndeployScript_DynamoPlatformOwnsExplicitGroveCRDs verifies the
 // dynamo-platform release owns the Grove CRDs via extra_crds_for_release.
 func TestUndeployScript_DynamoPlatformOwnsExplicitGroveCRDs(t *testing.T) {

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -1755,14 +1755,22 @@ func TestUndeployScript_PostflightTerminatingCheckSuppressesKubectlPrompt(t *tes
 	undeployPath := filepath.Join(outputDir, "undeploy.sh")
 
 	// Stub kubectl mimics broken-kubeconfig behavior: writes the interactive
-	// auth prompt to stdout, then exits non-zero on stdin EOF. capture_kubectl_json
-	// must close kubectl's stdin (via </dev/null) so kubectl gets EOF immediately
-	// and the function fails closed without propagating the stdout prompt.
+	// auth prompt to stdout, then probes stdin to verify capture_kubectl_json
+	// closed it via </dev/null. The test wires an open pipe pre-loaded with a
+	// sentinel to bash's stdin; if </dev/null is NOT applied, kubectl inherits
+	// the pipe and reads the sentinel — at which point the stub exits 99 to
+	// flag the regression. With </dev/null applied, kubectl reads /dev/null
+	// and gets immediate EOF, exits 1, and capture_kubectl_json discards the
+	// stdout-leaked prompt via its exit-code check.
 	stubDir := t.TempDir()
 	writeStub(t, stubDir, "kubectl", `#!/bin/sh
 case "$*" in
   "get namespaces -o json")
     printf 'Please enter Username: '
+    if IFS= read -r leaked_stdin; then
+      echo "STDIN_LEAK: capture_kubectl_json did not close kubectl stdin; read='${leaked_stdin}'" >&2
+      exit 99
+    fi
     echo "error: EOF" >&2
     exit 1
     ;;
@@ -1771,6 +1779,22 @@ case "$*" in
     ;;
 esac
 `)
+
+	// Pre-load an open pipe with a sentinel. With </dev/null wired in
+	// capture_kubectl_json, kubectl never sees this byte stream. Without it,
+	// kubectl inherits bash's stdin and reads the sentinel, triggering the
+	// STDIN_LEAK branch in the stub.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	if _, err := stdinW.WriteString("SENTINEL_USERNAME_VALUE\n"); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	if err := stdinW.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	defer func() { _ = stdinR.Close() }()
 
 	bashSnippet := `
         snippet=$(sed -n "/^capture_kubectl_json()/,/^}/p" "$UNDEPLOY")
@@ -1800,6 +1824,7 @@ esac
 		"PATH="+stubDir+":"+os.Getenv("PATH"),
 		"UNDEPLOY="+undeployPath,
 	)
+	cmd.Stdin = stdinR
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -1811,6 +1836,13 @@ esac
 	out := stdout.String()
 	errOut := stderr.String()
 
+	// Regression: capture_kubectl_json must close kubectl's stdin via </dev/null.
+	// If this fires, removing </dev/null from the helper would let kubectl
+	// inherit the caller's TTY and prompt indefinitely (or read bogus data).
+	if strings.Contains(errOut, "STDIN_LEAK") {
+		t.Errorf("regression: </dev/null missing from capture_kubectl_json — kubectl inherited test stdin.\nstderr=%q",
+			errOut)
+	}
 	// Regression: the kubectl prompt must NEVER appear in stdout.
 	if strings.Contains(out, "Please enter Username") {
 		t.Errorf("regression: kubectl prompt leaked into post-flight stdout.\nstdout=%q stderr=%q",

--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -254,6 +254,10 @@ skip_preflight_for_release() {
 }
 
 # Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# Closes kubectl's stdin so a broken kubeconfig (missing user / expired creds)
+# cannot leak its "Please enter Username:" prompt — kubectl writes the prompt
+# to *stdout* before detecting non-TTY stdin, which would otherwise land in
+# the captured value and resurface in WARNING messages (see issue #684).
 capture_kubectl_json() {
   local out_var="$1"
   shift
@@ -264,7 +268,7 @@ capture_kubectl_json() {
     return 1
   fi
 
-  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+  if ! output=$(kubectl "$@" 2>"${stderr_file}" </dev/null); then
     kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
     rm -f "${stderr_file}"
     printf -v "${out_var}" '%s' "${kubectl_err}"
@@ -599,7 +603,17 @@ delete_orphaned_webhooks_for_ns "{{ . }}"
 
 postflight_issues=false
 
-TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+TERMINATING=""
+postflight_ns_json=""
+if capture_kubectl_json postflight_ns_json get namespaces -o json; then
+  TERMINATING=$(echo "${postflight_ns_json}" \
+    | jq -r '.items[] | select(.status.phase=="Terminating") | .metadata.name' 2>/dev/null \
+    | tr '\n' ' ')
+  TERMINATING="${TERMINATING% }"
+else
+  echo "Warning: failed to list namespaces for post-flight terminating check; kubectl output: ${postflight_ns_json}" >&2
+  postflight_issues=true
+fi
 if [[ -n "${TERMINATING}" ]]; then
   echo "WARNING: namespaces still terminating: ${TERMINATING}"
   echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."

--- a/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/undeploy.sh
@@ -254,6 +254,10 @@ skip_preflight_for_release() {
 }
 
 # Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# Closes kubectl's stdin so a broken kubeconfig (missing user / expired creds)
+# cannot leak its "Please enter Username:" prompt — kubectl writes the prompt
+# to *stdout* before detecting non-TTY stdin, which would otherwise land in
+# the captured value and resurface in WARNING messages (see issue #684).
 capture_kubectl_json() {
   local out_var="$1"
   shift
@@ -264,7 +268,7 @@ capture_kubectl_json() {
     return 1
   fi
 
-  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+  if ! output=$(kubectl "$@" 2>"${stderr_file}" </dev/null); then
     kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
     rm -f "${stderr_file}"
     printf -v "${out_var}" '%s' "${kubectl_err}"
@@ -563,7 +567,17 @@ delete_orphaned_webhooks_for_ns "kai-scheduler"
 
 postflight_issues=false
 
-TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+TERMINATING=""
+postflight_ns_json=""
+if capture_kubectl_json postflight_ns_json get namespaces -o json; then
+  TERMINATING=$(echo "${postflight_ns_json}" \
+    | jq -r '.items[] | select(.status.phase=="Terminating") | .metadata.name' 2>/dev/null \
+    | tr '\n' ' ')
+  TERMINATING="${TERMINATING% }"
+else
+  echo "Warning: failed to list namespaces for post-flight terminating check; kubectl output: ${postflight_ns_json}" >&2
+  postflight_issues=true
+fi
 if [[ -n "${TERMINATING}" ]]; then
   echo "WARNING: namespaces still terminating: ${TERMINATING}"
   echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."

--- a/pkg/bundler/deployer/helm/testdata/manifest_only/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/manifest_only/undeploy.sh
@@ -254,6 +254,10 @@ skip_preflight_for_release() {
 }
 
 # Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# Closes kubectl's stdin so a broken kubeconfig (missing user / expired creds)
+# cannot leak its "Please enter Username:" prompt — kubectl writes the prompt
+# to *stdout* before detecting non-TTY stdin, which would otherwise land in
+# the captured value and resurface in WARNING messages (see issue #684).
 capture_kubectl_json() {
   local out_var="$1"
   shift
@@ -264,7 +268,7 @@ capture_kubectl_json() {
     return 1
   fi
 
-  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+  if ! output=$(kubectl "$@" 2>"${stderr_file}" </dev/null); then
     kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
     rm -f "${stderr_file}"
     printf -v "${out_var}" '%s' "${kubectl_err}"
@@ -562,7 +566,17 @@ delete_orphaned_webhooks_for_ns "skyhook"
 
 postflight_issues=false
 
-TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+TERMINATING=""
+postflight_ns_json=""
+if capture_kubectl_json postflight_ns_json get namespaces -o json; then
+  TERMINATING=$(echo "${postflight_ns_json}" \
+    | jq -r '.items[] | select(.status.phase=="Terminating") | .metadata.name' 2>/dev/null \
+    | tr '\n' ' ')
+  TERMINATING="${TERMINATING% }"
+else
+  echo "Warning: failed to list namespaces for post-flight terminating check; kubectl output: ${postflight_ns_json}" >&2
+  postflight_issues=true
+fi
 if [[ -n "${TERMINATING}" ]]; then
   echo "WARNING: namespaces still terminating: ${TERMINATING}"
   echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/undeploy.sh
@@ -254,6 +254,10 @@ skip_preflight_for_release() {
 }
 
 # Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# Closes kubectl's stdin so a broken kubeconfig (missing user / expired creds)
+# cannot leak its "Please enter Username:" prompt — kubectl writes the prompt
+# to *stdout* before detecting non-TTY stdin, which would otherwise land in
+# the captured value and resurface in WARNING messages (see issue #684).
 capture_kubectl_json() {
   local out_var="$1"
   shift
@@ -264,7 +268,7 @@ capture_kubectl_json() {
     return 1
   fi
 
-  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+  if ! output=$(kubectl "$@" 2>"${stderr_file}" </dev/null); then
     kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
     rm -f "${stderr_file}"
     printf -v "${out_var}" '%s' "${kubectl_err}"
@@ -562,7 +566,17 @@ delete_orphaned_webhooks_for_ns "gpu-operator"
 
 postflight_issues=false
 
-TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+TERMINATING=""
+postflight_ns_json=""
+if capture_kubectl_json postflight_ns_json get namespaces -o json; then
+  TERMINATING=$(echo "${postflight_ns_json}" \
+    | jq -r '.items[] | select(.status.phase=="Terminating") | .metadata.name' 2>/dev/null \
+    | tr '\n' ' ')
+  TERMINATING="${TERMINATING% }"
+else
+  echo "Warning: failed to list namespaces for post-flight terminating check; kubectl output: ${postflight_ns_json}" >&2
+  postflight_issues=true
+fi
 if [[ -n "${TERMINATING}" ]]; then
   echo "WARNING: namespaces still terminating: ${TERMINATING}"
   echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."

--- a/pkg/bundler/deployer/helm/testdata/nodewright_present/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/nodewright_present/undeploy.sh
@@ -254,6 +254,10 @@ skip_preflight_for_release() {
 }
 
 # Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# Closes kubectl's stdin so a broken kubeconfig (missing user / expired creds)
+# cannot leak its "Please enter Username:" prompt — kubectl writes the prompt
+# to *stdout* before detecting non-TTY stdin, which would otherwise land in
+# the captured value and resurface in WARNING messages (see issue #684).
 capture_kubectl_json() {
   local out_var="$1"
   shift
@@ -264,7 +268,7 @@ capture_kubectl_json() {
     return 1
   fi
 
-  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+  if ! output=$(kubectl "$@" 2>"${stderr_file}" </dev/null); then
     kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
     rm -f "${stderr_file}"
     printf -v "${out_var}" '%s' "${kubectl_err}"
@@ -581,7 +585,17 @@ delete_orphaned_webhooks_for_ns "skyhook"
 
 postflight_issues=false
 
-TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+TERMINATING=""
+postflight_ns_json=""
+if capture_kubectl_json postflight_ns_json get namespaces -o json; then
+  TERMINATING=$(echo "${postflight_ns_json}" \
+    | jq -r '.items[] | select(.status.phase=="Terminating") | .metadata.name' 2>/dev/null \
+    | tr '\n' ' ')
+  TERMINATING="${TERMINATING% }"
+else
+  echo "Warning: failed to list namespaces for post-flight terminating check; kubectl output: ${postflight_ns_json}" >&2
+  postflight_issues=true
+fi
 if [[ -n "${TERMINATING}" ]]; then
   echo "WARNING: namespaces still terminating: ${TERMINATING}"
   echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."

--- a/pkg/bundler/deployer/helm/testdata/upstream_helm_only/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/upstream_helm_only/undeploy.sh
@@ -254,6 +254,10 @@ skip_preflight_for_release() {
 }
 
 # Run `kubectl ... -o json` while keeping stdout parseable for jq.
+# Closes kubectl's stdin so a broken kubeconfig (missing user / expired creds)
+# cannot leak its "Please enter Username:" prompt — kubectl writes the prompt
+# to *stdout* before detecting non-TTY stdin, which would otherwise land in
+# the captured value and resurface in WARNING messages (see issue #684).
 capture_kubectl_json() {
   local out_var="$1"
   shift
@@ -264,7 +268,7 @@ capture_kubectl_json() {
     return 1
   fi
 
-  if ! output=$(kubectl "$@" 2>"${stderr_file}"); then
+  if ! output=$(kubectl "$@" 2>"${stderr_file}" </dev/null); then
     kubectl_err=$(cat "${stderr_file}" 2>/dev/null || true)
     rm -f "${stderr_file}"
     printf -v "${out_var}" '%s' "${kubectl_err}"
@@ -562,7 +566,17 @@ delete_orphaned_webhooks_for_ns "cert-manager"
 
 postflight_issues=false
 
-TERMINATING=$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+TERMINATING=""
+postflight_ns_json=""
+if capture_kubectl_json postflight_ns_json get namespaces -o json; then
+  TERMINATING=$(echo "${postflight_ns_json}" \
+    | jq -r '.items[] | select(.status.phase=="Terminating") | .metadata.name' 2>/dev/null \
+    | tr '\n' ' ')
+  TERMINATING="${TERMINATING% }"
+else
+  echo "Warning: failed to list namespaces for post-flight terminating check; kubectl output: ${postflight_ns_json}" >&2
+  postflight_issues=true
+fi
 if [[ -n "${TERMINATING}" ]]; then
   echo "WARNING: namespaces still terminating: ${TERMINATING}"
   echo "  A subsequent deploy.sh may fail. Wait or force-finalize these namespaces."


### PR DESCRIPTION
## Summary

Stop `undeploy.sh`'s post-flight terminating-namespaces check from leaking `kubectl`'s `Please enter Username:` credential prompt into a `WARNING` line when kubeconfig auth is broken.

> Temp bug fix until #671 lands

## Motivation / Context

`kubectl` writes its interactive `Please enter Username:` prompt to **stdout** *before* detecting that stdin is not a TTY, so the existing `2>/dev/null` on the post-flight check did not suppress it. The string was captured into `TERMINATING` and resurfaced as:

```
WARNING: namespaces still terminating: Please enter Username:
```

making a kubeconfig auth failure (expired creds, missing user, etc.) look like a script bug.

Fixes: #684
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Two-part defensive fix scoped to `pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl`:

1. **Harden the shared `capture_kubectl_json` helper** — add `</dev/null` to its `kubectl` invocation so a prompt-emitting `kubectl` gets EOF on stdin, exits non-zero, and the helper falls into its existing error branch (which discards stdout and propagates the stderr error message to the caller). All existing callers — pre-flight CRD discovery (`check_release_for_stuck_crds`, `check_crd_for_stuck_resources`), post-flight CRD enumeration — inherit the fix.

2. **Rewrite the post-flight terminating-namespaces check** to use the hardened helper plus `jq` instead of a bare `kubectl get namespaces ... 2>/dev/null`. On failure it now warns to stderr and sets `postflight_issues=true` instead of silently rendering the leaked prompt string.

Scope decision: minimal helper-level fix rather than a sweeping refactor of every other `kubectl ... 2>/dev/null` site. Other post-flight `kubectl get` pipelines (webhooks, apiservices) pipe through `jq` which silently swallows the leaked prompt — cosmetic, no user-visible bad string — so they're out of scope here. The hardened helper is the long-term insurance policy for future call sites.

Golden fixtures under `pkg/bundler/deployer/helm/testdata/*/undeploy.sh` regenerated with `go test -update`; diff is exactly the two intended template edits.

## Testing

```bash
make lint          # 0 issues
make test-coverage # 76.8% (threshold 75%) — passes
go test -race -count=1 ./pkg/bundler/deployer/helm/...  # ok (7.940s)
```

New regression test `TestUndeployScript_PostflightTerminatingCheckSuppressesKubectlPrompt` stubs a `kubectl` that mimics broken-kubeconfig behavior (writes `Please enter Username:` to stdout, exits non-zero on stdin EOF) and asserts:

- The prompt string never appears in stdout.
- `WARNING: namespaces still terminating:` never fires.
- `TERMINATING` is initialized but empty (no captured leak).
- Failure is surfaced to stderr (`Warning: failed to list namespaces ...`) and `postflight_issues=true`.

Test was verified to fail with a clear `TEST_SETUP_ERROR` if the template fix is reverted.

Per-package coverage: `pkg/bundler/deployer/helm` 87.9% (test-only addition, no source code changes — no delta concern).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Template-only change to a generated shell script. The hardened `capture_kubectl_json` adds `</dev/null` which is safe for all current callers (all are `get` operations that don't read stdin). The post-flight terminating check now reports auth failure as a stderr warning + `postflight_issues=true` instead of silently leaking the prompt — strictly more correct, no migration needed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — bug fix, no doc-level behavior contract changes)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)