### PR TITLE
feat(oci): expose URIScheme constant and Ensure/TrimScheme helpers

### DIFF
--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -36,8 +36,15 @@ const uriScheme = URIScheme
 
 // EnsureScheme returns ref with the oci:// prefix added when missing.
 // Used by callers that accept user input in either form.
+//
+// Refs that already carry a different URI scheme (e.g., "https://...")
+// are returned unchanged so callers don't accidentally build
+// "oci://https://..." when handed a non-oci URL by mistake.
 func EnsureScheme(ref string) string {
 	if strings.HasPrefix(ref, URIScheme) {
+		return ref
+	}
+	if strings.Contains(ref, "://") {
 		return ref
 	}
 	return URIScheme + ref

--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -26,8 +26,29 @@ import (
 	apperrors "github.com/NVIDIA/aicr/pkg/errors"
 )
 
-// uriScheme is the URI scheme for OCI registry output (e.g., "oci://ghcr.io/org/repo:tag").
-const uriScheme = "oci://"
+// URIScheme is the URI scheme for OCI registry references
+// (e.g., "oci://ghcr.io/org/repo:tag"). Exported so other packages can
+// build references without re-declaring the literal.
+const URIScheme = "oci://"
+
+// uriScheme is the unexported alias retained for legacy in-package use.
+const uriScheme = URIScheme
+
+// EnsureScheme returns ref with the oci:// prefix added when missing.
+// Used by callers that accept user input in either form.
+func EnsureScheme(ref string) string {
+	if strings.HasPrefix(ref, URIScheme) {
+		return ref
+	}
+	return URIScheme + ref
+}
+
+// TrimScheme returns ref with any oci:// prefix removed. Useful when
+// emitting a registry/repo:tag form for cosign or for human-readable
+// pointers that don't carry the URI scheme.
+func TrimScheme(ref string) string {
+	return strings.TrimPrefix(ref, URIScheme)
+}
 
 // Reference represents a parsed output target, which can be either an OCI registry
 // reference or a local directory path.

--- a/pkg/oci/reference_test.go
+++ b/pkg/oci/reference_test.go
@@ -241,3 +241,100 @@ func TestReference_WithTag(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureScheme(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"already prefixed", "oci://ghcr.io/x/y", "oci://ghcr.io/x/y"},
+		{"already prefixed with tag", "oci://ghcr.io/x/y:v1", "oci://ghcr.io/x/y:v1"},
+		{"unprefixed registry/repo", "ghcr.io/x/y", "oci://ghcr.io/x/y"},
+		{"unprefixed with tag", "ghcr.io/x/y:v1", "oci://ghcr.io/x/y:v1"},
+		{"unprefixed with port", "localhost:5000/x/y", "oci://localhost:5000/x/y"},
+		{"empty string gets prefix", "", "oci://"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := EnsureScheme(tt.in); got != tt.want {
+				t.Errorf("EnsureScheme(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureScheme_Idempotent(t *testing.T) {
+	t.Parallel()
+	a := EnsureScheme("ghcr.io/x/y")
+	b := EnsureScheme(a)
+	if a != b {
+		t.Errorf("EnsureScheme not idempotent: first=%q second=%q", a, b)
+	}
+}
+
+func TestTrimScheme(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"strip prefix", "oci://ghcr.io/x/y", "ghcr.io/x/y"},
+		{"strip prefix with tag", "oci://ghcr.io/x/y:v1", "ghcr.io/x/y:v1"},
+		{"already trimmed passthrough", "ghcr.io/x/y", "ghcr.io/x/y"},
+		{"already trimmed with tag", "ghcr.io/x/y:v1", "ghcr.io/x/y:v1"},
+		{"empty string", "", ""},
+		{"only scheme", "oci://", ""},
+		// TrimPrefix is exact-match: a non-oci scheme is left intact (caller's intent unclear).
+		{"different scheme left alone", "https://ghcr.io/x/y", "https://ghcr.io/x/y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := TrimScheme(tt.in); got != tt.want {
+				t.Errorf("TrimScheme(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimScheme_Idempotent(t *testing.T) {
+	t.Parallel()
+	a := TrimScheme("oci://ghcr.io/x/y")
+	b := TrimScheme(a)
+	if a != b {
+		t.Errorf("TrimScheme not idempotent: first=%q second=%q", a, b)
+	}
+}
+
+func TestEnsureTrimRoundTrip(t *testing.T) {
+	t.Parallel()
+	originals := []string{
+		"ghcr.io/x/y",
+		"ghcr.io/x/y:v1",
+		"localhost:5000/foo/bar:tag",
+	}
+	for _, ref := range originals {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+			if got := TrimScheme(EnsureScheme(ref)); got != ref {
+				t.Errorf("round-trip mismatch: TrimScheme(EnsureScheme(%q)) = %q", ref, got)
+			}
+		})
+	}
+}
+
+func TestURIScheme_Constant(t *testing.T) {
+	t.Parallel()
+	if URIScheme != "oci://" {
+		t.Errorf("URIScheme = %q, want %q", URIScheme, "oci://")
+	}
+	if uriScheme != URIScheme {
+		t.Errorf("legacy uriScheme alias drifted from URIScheme: %q vs %q", uriScheme, URIScheme)
+	}
+}

--- a/pkg/oci/reference_test.go
+++ b/pkg/oci/reference_test.go
@@ -256,6 +256,8 @@ func TestEnsureScheme(t *testing.T) {
 		{"unprefixed with tag", "ghcr.io/x/y:v1", "oci://ghcr.io/x/y:v1"},
 		{"unprefixed with port", "localhost:5000/x/y", "oci://localhost:5000/x/y"},
 		{"empty string gets prefix", "", "oci://"},
+		{"https url left alone", "https://ghcr.io/v2/x/y", "https://ghcr.io/v2/x/y"},
+		{"http url left alone", "http://localhost:5000/x/y", "http://localhost:5000/x/y"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Promotes `pkg/oci`'s in-package `uriScheme = "oci://"` literal to an exported `URIScheme` constant and adds two convenience helpers — `EnsureScheme` and `TrimScheme` — so other packages can build and normalize `oci://` references without redeclaring the prefix.

## Motivation / Context

The upcoming recipe-test attestation bundle (#754) needs to construct OCI references from user-supplied strings that may or may not carry the `oci://` prefix, and emit clean `registry/repo:tag` form (no scheme) into a pointer file. Today the prefix literal lives only inside `pkg/oci` as an unexported constant; without exposing it, every consumer would have to redeclare the same `strings.HasPrefix("oci://")` / `strings.TrimPrefix("oci://")` logic.

Fixes: N/A
Related: #754, ADR-007 (`docs/design/007-recipe-evidence.md`)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Core libraries (`pkg/oci`)

## Implementation Notes

- `URIScheme = "oci://"` becomes the public constant; the unexported `uriScheme` is preserved as a same-value alias so existing in-package callers compile without churn.
- `EnsureScheme(ref)` adds the prefix when missing; `TrimScheme(ref)` strips it. Both are idempotent and pass through inputs that don't apply.
- Tests cover happy paths, already-prefixed inputs, idempotency, round-trip (`TrimScheme(EnsureScheme(ref)) == ref`), foreign-scheme passthrough, and a drift check pinning `uriScheme == URIScheme`.

## Testing

```bash
make qualify
```

- `pkg/oci` builds and tests clean; new helpers fully covered.
- Existing callers of `ParseOutputTarget` and the unexported `uriScheme` continue to compile unchanged.

## Risk Assessment

- [x] **Low** — Purely additive to `pkg/oci`'s public surface; existing call sites unchanged.

**Rollout notes:** Additive change. No migration required for existing consumers.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (internal API addition)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)