### PR TITLE
fix(validator): write ValidationInput wire shape to ConfigMap

### DIFF
--- a/pkg/api/validator/v1/conversion_test.go
+++ b/pkg/api/validator/v1/conversion_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"gopkg.in/yaml.v3"
 )
 
 func TestToValidationInput(t *testing.T) {
@@ -93,4 +94,88 @@ func TestToValidationInputNil(t *testing.T) {
 	if validation != nil {
 		t.Errorf("ToValidationInput(nil) = %v, want nil", validation)
 	}
+}
+
+// TestToValidationInputYAMLRoundTrip is the regression guard for the
+// orchestrator/validator wire-shape mismatch that silently dropped phase
+// constraints (issue #874). The validator runtime deserializes the
+// ConfigMap payload into *ValidationInput and looks up phase constraints
+// under ctx.ValidationInput.Config.Performance / Config.Deployment.
+//
+// This test exercises the exact path: recipe.RecipeResult →
+// ToValidationInput → yaml.Marshal → yaml.Unmarshal → constraint lookup,
+// and asserts both a performance and a deployment constraint survive the
+// round trip. A regression to marshaling recipe.Validation directly (which
+// inlines ValidationConfig) would land the phase fields at the YAML root
+// and fail this test.
+func TestToValidationInputYAMLRoundTrip(t *testing.T) {
+	rec := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1",
+		Kind:       "RecipeResult",
+		Constraints: []recipe.Constraint{
+			{Name: "K8s.server.version", Value: ">= 1.32.4"},
+		},
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator"},
+		},
+		Validation: &recipe.ValidationConfig{
+			Deployment: &recipe.ValidationPhase{
+				Constraints: []recipe.Constraint{
+					{Name: "Deployment.gpu-operator.version", Value: "580.126.20"},
+				},
+				Checks: []string{"gpu-operator-version"},
+			},
+			Performance: &recipe.ValidationPhase{
+				Constraints: []recipe.Constraint{
+					{Name: "nccl-all-reduce-bw-net", Value: ">= 300"},
+					{Name: "nccl-all-reduce-bw-nvls", Value: ">= 800"},
+				},
+				Checks: []string{"nccl-all-reduce-bw-net", "nccl-all-reduce-bw-nvls"},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(ToValidationInput(rec))
+	if err != nil {
+		t.Fatalf("yaml.Marshal() failed: %v", err)
+	}
+
+	var got ValidationInput
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("yaml.Unmarshal() failed: %v\npayload:\n%s", err, data)
+	}
+
+	// Deployment constraint must survive the round trip — the bug surfaced
+	// here as gpu-operator-version silently passing.
+	deploy := findConstraint(got.Config.Deployment, "Deployment.gpu-operator.version")
+	if deploy == nil {
+		t.Errorf("Deployment.gpu-operator.version constraint lost after YAML round trip\npayload:\n%s", data)
+	} else if deploy.Value != "580.126.20" {
+		t.Errorf("Deployment constraint value = %q, want %q", deploy.Value, "580.126.20")
+	}
+
+	// Performance constraints must survive — the bug surfaced here as
+	// nccl-all-reduce-bw-{net,nvls} silently skipping with "no
+	// <name> constraint in recipe".
+	for _, name := range []string{"nccl-all-reduce-bw-net", "nccl-all-reduce-bw-nvls"} {
+		c := findConstraint(got.Config.Performance, name)
+		if c == nil {
+			t.Errorf("%s constraint lost after YAML round trip\npayload:\n%s", name, data)
+		}
+	}
+}
+
+// findConstraint mirrors how validator runtime helpers look up phase
+// constraints — see validators/performance/nccl_all_reduce_bw.go and
+// validators/deployment/gpu_operator_version.go.
+func findConstraint(phase *ValidationPhase, name string) *recipe.Constraint {
+	if phase == nil {
+		return nil
+	}
+	for i := range phase.Constraints {
+		if phase.Constraints[i].Name == name {
+			return &phase.Constraints[i]
+		}
+	}
+	return nil
 }

--- a/pkg/api/validator/v1/validation_input.go
+++ b/pkg/api/validator/v1/validation_input.go
@@ -149,7 +149,7 @@ func ToValidationInput(r *recipe.RecipeResult) *ValidationInput {
 	validation := NewValidationInput()
 
 	// Populate optional resource fields for standalone usage
-	validation.APIVersion = "validator.nvidia.com/v1alpha1"
+	validation.APIVersion = CatalogAPIVersion
 	validation.Kind = KindValidationInput
 	if r.Metadata.Version != "" {
 		validation.Metadata = &ValidationMetadata{

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -320,10 +320,7 @@ func runValidation(
 		validator.WithNodeSelector(cfg.nodeSelector),
 	)
 
-	// Convert recipe to validation for validators
-	validation := recipe.ToValidation(rec)
-
-	results, err := v.ValidatePhases(ctx, cfg.phases, validation, snap)
+	results, err := v.ValidatePhases(ctx, cfg.phases, rec, snap)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "validation failed", err)
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
+	v1 "github.com/NVIDIA/aicr/pkg/api/validator/v1"
 	"github.com/NVIDIA/aicr/pkg/constraints"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -95,7 +96,7 @@ type clusterState struct {
 // The caller must close stopCh and handle cleanup deferrals.
 func (v *Validator) prepareCluster(
 	ctx context.Context,
-	validation *recipe.Validation,
+	rec *recipe.RecipeResult,
 	snap *snapshotter.Snapshot,
 ) (*clusterState, error) {
 
@@ -112,7 +113,7 @@ func (v *Validator) prepareCluster(
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to ensure RBAC", rbacErr)
 	}
 
-	if cmErr := v.ensureDataConfigMaps(ctx, clientset, snap, validation); cmErr != nil {
+	if cmErr := v.ensureDataConfigMaps(ctx, clientset, snap, rec); cmErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create data ConfigMaps", cmErr)
 	}
 
@@ -151,7 +152,7 @@ func (v *Validator) deferClusterCleanup(clientset kubernetes.Interface) {
 func (v *Validator) ValidatePhases(
 	ctx context.Context,
 	phases []Phase,
-	validation *recipe.Validation,
+	rec *recipe.RecipeResult,
 	snap *snapshotter.Snapshot,
 ) ([]*PhaseResult, error) {
 
@@ -160,6 +161,8 @@ func (v *Validator) ValidatePhases(
 	}
 
 	slog.Info("running validation phases", "runID", v.RunID, "phases", phases)
+
+	validation := recipe.ToValidation(rec)
 
 	// Pre-flight: evaluate top-level validation constraints against snapshot.
 	// Fails fast before deploying any Jobs if prerequisites aren't met.
@@ -177,7 +180,7 @@ func (v *Validator) ValidatePhases(
 		return v.phasesSkipped(cat, phases, "skipped - no-cluster mode"), nil
 	}
 
-	cs, err := v.prepareCluster(ctx, validation, snap)
+	cs, err := v.prepareCluster(ctx, rec, snap)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +224,7 @@ func (v *Validator) ValidatePhases(
 func (v *Validator) ValidatePhase(
 	ctx context.Context,
 	phase Phase,
-	validation *recipe.Validation,
+	rec *recipe.RecipeResult,
 	snap *snapshotter.Snapshot,
 ) (*PhaseResult, error) {
 
@@ -234,14 +237,14 @@ func (v *Validator) ValidatePhase(
 		return v.phaseSkipped(cat, phase, "skipped - no-cluster mode"), nil
 	}
 
-	cs, err := v.prepareCluster(ctx, validation, snap)
+	cs, err := v.prepareCluster(ctx, rec, snap)
 	if err != nil {
 		return nil, err
 	}
 	defer close(cs.stopCh)
 	defer v.deferClusterCleanup(cs.clientset) //nolint:contextcheck // cleanup uses fresh context
 
-	return v.runPhase(ctx, cs.clientset, cs.factory, cat, phase, validation)
+	return v.runPhase(ctx, cs.clientset, cs.factory, cat, phase, recipe.ToValidation(rec))
 }
 
 // filterEntriesByValidation returns only catalog entries that the validation declares
@@ -469,11 +472,16 @@ func (v *Validator) phaseSkipped(cat *catalog.ValidatorCatalog, phase Phase, rea
 }
 
 // ensureDataConfigMaps creates snapshot and validation ConfigMaps for this run.
+// The validation payload is written in the v1.ValidationInput wire shape that
+// validator containers consume — converting from RecipeResult here, rather
+// than marshaling recipe.Validation directly, ensures the inlined phase
+// configs (deployment/performance/etc.) land under the nested `config:` field
+// the validators read.
 func (v *Validator) ensureDataConfigMaps(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	snap *snapshotter.Snapshot,
-	validation *recipe.Validation,
+	rec *recipe.RecipeResult,
 ) error {
 
 	snapshotYAML, err := yaml.Marshal(snap)
@@ -481,7 +489,7 @@ func (v *Validator) ensureDataConfigMaps(
 		return errors.Wrap(errors.ErrCodeInternal, "failed to serialize snapshot", err)
 	}
 
-	validationYAML, err := yaml.Marshal(validation)
+	validationYAML, err := yaml.Marshal(v1.ToValidationInput(rec))
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to serialize validation", err)
 	}


### PR DESCRIPTION
## Summary

The validator orchestrator was marshaling `recipe.Validation` directly into the validator ConfigMap, but validator containers deserialize that payload into `*v1.ValidationInput` and look up phase constraints under `ctx.ValidationInput.Config.{Performance,Deployment}`. The shapes disagree, so phase constraints silently dropped from the lookup and the affected validators reported "no constraint in recipe" instead of evaluating.

## Motivation / Context

`recipe.Validation` inlines `ValidationConfig` at the struct root, while `v1.ValidationInput` nests it under a `Config` field. When the orchestrator marshaled the raw recipe shape into the ConfigMap, performance and deployment constraints landed at the YAML root and were invisible to the runtime helpers that look under `Config.Performance` / `Config.Deployment`. On a fresh GB200/EKS deploy this surfaced as `nccl-all-reduce-bw-{net,nvls}` and `gpu-operator-version` skipping silently — green report with no constraints evaluated.

Fixes: #874
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: `pkg/api/validator/v1`

## Implementation Notes

- Propagate `*recipe.RecipeResult` through `ValidatePhases` / `ValidatePhase` / `prepareCluster` rather than the pre-converted `*recipe.Validation`. The conversion to `recipe.Validation` still happens, just at the call site that actually needs it (`runPhase`, `checkReadiness`).
- `ensureDataConfigMaps` now marshals `v1.ToValidationInput(rec)` so the ConfigMap matches the wire shape validator containers already expect — no container rebuild required, `:edge` / pinned tags continue to work.
- Switched the hardcoded API version literal in `ToValidationInput` to the existing `CatalogAPIVersion` constant so the wire string can't drift again.
- Added `TestToValidationInputYAMLRoundTrip` that mirrors the validator runtime constraint lookup (`Config.Performance` / `Config.Deployment`) against a marshal/unmarshal round trip — would have caught this regression at unit-test time.

## Testing

```bash
make qualify  # passed (test + lint + e2e + scan + license headers)
```

End-to-end verified against a live EKS GB200 cluster with `AICR_VALIDATOR_IMAGE_TAG=edge` — all phases run and pass with constraints actually evaluated:

```
performance: 2/2 passed (nccl-all-reduce-bw-net, nccl-all-reduce-bw-nvls)
conformance: 8/8 passed
```

Per-package coverage delta vs. `upstream/main`:

- `pkg/validator`: 38.5% → 39.3% (+0.8%)
- `pkg/api/validator/v1`: 76.9% → 76.9% (flat; new test exercises an existing covered path)

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Host-side fix only. Validator container images do not need to be rebuilt — the ConfigMap payload now matches the shape containers were already deserializing. No migration required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)