### PR TITLE
chore(recipes): fix stale kgateway-crds path in slinky-slurm-operator-crds comment

### DIFF
--- a/recipes/components/slinky-slurm-operator-crds/values.yaml
+++ b/recipes/components/slinky-slurm-operator-crds/values.yaml
@@ -20,7 +20,7 @@
 # This chart has no configurable values upstream — it only installs CRDs.
 # `enabled: true` below follows the AICR umbrella convention used by other
 # CRD-only components (see components/dynamo-crds/values.yaml,
-# components/kgateway-crds/values.yaml). It is consumed by the AICR
+# components/agentgateway-crds/values.yaml). It is consumed by the AICR
 # bundler to mark the component for inclusion; the upstream chart
 # itself ignores this value.
 enabled: true


### PR DESCRIPTION
## Summary

One-line comment fix. `recipes/components/slinky-slurm-operator-crds/values.yaml:23` references `components/kgateway-crds/values.yaml` as an example of the "AICR umbrella convention for CRD-only components." That path no longer exists — the kgateway component was renamed to **agentgateway** in #871, and the file is now at `components/agentgateway-crds/values.yaml`.

## Motivation / Context

Surfaced during a post-#871 audit for residual kgateway references in active code paths. The conformance validator, chainsaw assertions, and evidence collection script were all fully updated in #871; this stale cross-reference comment was the only actionable residual that would mislead future maintainers (the other surviving kgateway references are intentional historical context — frozen conformance snapshots, the changelog, etc.).

Related: #871 (kgateway → agentgateway migration), #866 (slinky-slurm-operator component addition)

## Type of Change

- [x] Documentation update (comment-only)

## Component(s) Affected

- [x] Recipe engine / data (`recipes/components/slinky-slurm-operator-crds/values.yaml` — comment only)

## Implementation Notes

```diff
- # components/kgateway-crds/values.yaml). It is consumed by the AICR
+ # components/agentgateway-crds/values.yaml). It is consumed by the AICR
```

No behavior change, no Helm value semantics affected.

## Testing

```bash
make lint   # passes (yamllint, license headers, agents-sync, chart-pin verification)
```

Comment-only YAML change; full `make qualify` not necessary.

## Risk Assessment

- [x] **Low** — Pure comment fix. No code, no chart pins, no values semantics affected.

**Rollout notes:** None — comment-only.

## Checklist

- [x] Tests pass locally (`make lint`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (n/a — comment-only)
- [x] I updated docs if user-facing behavior changed (n/a — internal comment)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)