### PR TITLE
fix(validator): per-run RBAC names to prevent concurrent-run races

### DIFF
--- a/docs/design/002-validatorv2-adr.md
+++ b/docs/design/002-validatorv2-adr.md
@@ -115,11 +115,20 @@ Job naming: `aicr-{validatorName}-{hash}`
 
 Three resources, using a purpose-built ClusterRole with minimum required permissions:
 
-1. **ServiceAccount** `aicr-validator` in validation namespace
+1. **ServiceAccount** `aicr-validator-<runID>` in validation namespace
 2. **ClusterRole** `aicr-validator` with scoped read/write rules per resource type
-3. **ClusterRoleBinding** `aicr-validator` binding the SA to the ClusterRole
+3. **ClusterRoleBinding** `aicr-validator-<runID>` binding the SA to the ClusterRole
 
 Created once per run via Server-Side Apply, cleaned up at end.
+
+> **Implementation note (2026-05-14):** The ServiceAccount and ClusterRoleBinding
+> names are suffixed with the per-run `runID` to prevent concurrent `aicr
+> validate` invocations from clobbering each other's RBAC during end-of-run
+> cleanup. The original design used fixed names (`aicr-validator`); operators
+> ran into a race where run A's cleanup deleted the SA while run B was still
+> deploying validator Jobs, causing `FailedCreate: serviceaccount … not found`.
+> Resource discovery in tests and tooling should match by the stable
+> `app.kubernetes.io/name=aicr-validator` label rather than the literal name.
 
 ### Timeout and Termination
 

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -724,7 +724,8 @@ Run validation without failing on check errors (informational mode):
 			if shared.noCleanup {
 				slog.Warn("--no-cleanup: cluster-admin ClusterRoleBinding will remain active after validation",
 					"namespace", shared.namespace,
-					"binding", "aicr-validator")
+					"bindingSelector", "app.kubernetes.io/name=aicr-validator",
+					"cleanupHint", "kubectl delete clusterrolebinding -l app.kubernetes.io/name=aicr-validator")
 			}
 
 			evidenceCfg := buildRecipeEvidenceConfig(cmd, resolved)

--- a/pkg/validator/job/deployer.go
+++ b/pkg/validator/job/deployer.go
@@ -323,7 +323,7 @@ func (d *Deployer) buildPodSpecApply() *applycorev1.PodSpecApplyConfiguration {
 	// available CPU node. User-provided tolerations (--toleration flag) are forwarded
 	// to inner workloads via AICR_TOLERATIONS and do not affect orchestrator scheduling.
 	return applycorev1.PodSpec().
-		WithServiceAccountName(ServiceAccountName).
+		WithServiceAccountName(ServiceAccountName(d.runID)).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithTerminationGracePeriodSeconds(int64(defaults.ValidatorTerminationGracePeriod.Seconds())).
 		WithImagePullSecrets(d.buildImagePullSecretsApply()...).

--- a/pkg/validator/job/deployer_test.go
+++ b/pkg/validator/job/deployer_test.go
@@ -534,8 +534,9 @@ func TestDeployJobPodSpec(t *testing.T) {
 	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil))
 
 	podSpec := job.Spec.Template.Spec
-	if podSpec.ServiceAccountName != ServiceAccountName {
-		t.Errorf("ServiceAccountName = %q, want %q", podSpec.ServiceAccountName, ServiceAccountName)
+	wantSA := ServiceAccountName("run1")
+	if podSpec.ServiceAccountName != wantSA {
+		t.Errorf("ServiceAccountName = %q, want %q", podSpec.ServiceAccountName, wantSA)
 	}
 	if podSpec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("RestartPolicy = %q, want %q", podSpec.RestartPolicy, corev1.RestartPolicyNever)

--- a/pkg/validator/job/rbac.go
+++ b/pkg/validator/job/rbac.go
@@ -28,14 +28,29 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// rbacNamePrefix is the shared prefix for the validator ServiceAccount and
+// ClusterRoleBinding. ServiceAccountName and ClusterRoleBindingName suffix
+// this with the runID so concurrent validation runs against the same cluster
+// (or, for the ClusterRoleBinding, against any cluster they share at all) do
+// not delete each other's RBAC during end-of-run cleanup.
+const rbacNamePrefix = "aicr-validator"
+
+// ServiceAccountName returns the per-run ServiceAccount name used by the
+// validator Jobs deployed for runID. Each `aicr validate` invocation generates
+// a unique runID, so the SA created at run start is the same one deleted at
+// run end — overlapping runs cannot clobber each other.
+func ServiceAccountName(runID string) string {
+	return rbacNamePrefix + "-" + runID
+}
+
+// ClusterRoleBindingName returns the per-run ClusterRoleBinding name. The CRB
+// is cluster-scoped, so name uniqueness across concurrent runs (even on
+// different namespaces) is what prevents cross-run cleanup races.
+func ClusterRoleBindingName(runID string) string {
+	return rbacNamePrefix + "-" + runID
+}
+
 const (
-	// ServiceAccountName is the name of the ServiceAccount used by all validator Jobs.
-	ServiceAccountName = "aicr-validator"
-
-	// ClusterRoleBindingName is the name of the ClusterRoleBinding that grants
-	// cluster-admin to the validator ServiceAccount.
-	ClusterRoleBindingName = "aicr-validator"
-
 	// clusterAdminRole is the built-in Kubernetes ClusterRole bound to validators.
 	//
 	// Why cluster-admin is safe here:
@@ -73,40 +88,47 @@ const (
 
 // EnsureRBAC applies the ServiceAccount and ClusterRoleBinding for validator
 // Jobs using server-side apply. Call once per validation run before deploying
-// any Jobs.
-func EnsureRBAC(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
-	if err := applyServiceAccount(ctx, clientset, namespace); err != nil {
+// any Jobs. The runID scopes the resource names so overlapping runs do not
+// clobber each other.
+func EnsureRBAC(ctx context.Context, clientset kubernetes.Interface, namespace, runID string) error {
+	saName := ServiceAccountName(runID)
+	crbName := ClusterRoleBindingName(runID)
+
+	if err := applyServiceAccount(ctx, clientset, namespace, saName); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to ensure ServiceAccount", err)
 	}
 
-	if err := applyClusterRoleBinding(ctx, clientset, namespace); err != nil {
+	if err := applyClusterRoleBinding(ctx, clientset, namespace, saName, crbName); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to ensure ClusterRoleBinding", err)
 	}
 
 	slog.Debug("RBAC resources applied",
-		"serviceAccount", ServiceAccountName,
+		"serviceAccount", saName,
 		"namespace", namespace,
 		"clusterRole", clusterAdminRole)
 
 	return nil
 }
 
-// CleanupRBAC removes the ServiceAccount and ClusterRoleBinding.
+// CleanupRBAC removes the per-run ServiceAccount and ClusterRoleBinding.
 // Ignores NotFound errors (idempotent). Call once at end of validation run.
 //
 // When both deletes fail, the returned StructuredError wraps the joined
 // underlying errors via stderrors.Join so callers can inspect individual
 // failures with errors.Is / errors.As.
-func CleanupRBAC(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
+func CleanupRBAC(ctx context.Context, clientset kubernetes.Interface, namespace, runID string) error {
+	saName := ServiceAccountName(runID)
+	crbName := ClusterRoleBindingName(runID)
+
 	var errs []error
 
-	if err := clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, ServiceAccountName, metav1.DeleteOptions{}); err != nil {
+	if err := clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, saName, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrap(errors.ErrCodeInternal, "failed to delete ServiceAccount", err))
 		}
 	}
 
-	if err := clientset.RbacV1().ClusterRoleBindings().Delete(ctx, ClusterRoleBindingName, metav1.DeleteOptions{}); err != nil {
+	if err := clientset.RbacV1().ClusterRoleBindings().Delete(ctx, crbName, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrap(errors.ErrCodeInternal, "failed to delete ClusterRoleBinding", err))
 		}
@@ -117,20 +139,20 @@ func CleanupRBAC(ctx context.Context, clientset kubernetes.Interface, namespace 
 			stderrors.Join(errs...),
 			map[string]any{
 				"namespace":          namespace,
-				"serviceAccount":     ServiceAccountName,
-				"clusterRoleBinding": ClusterRoleBindingName,
+				"serviceAccount":     saName,
+				"clusterRoleBinding": crbName,
 			})
 	}
 
 	slog.Debug("RBAC resources cleaned up",
-		"serviceAccount", ServiceAccountName,
+		"serviceAccount", saName,
 		"namespace", namespace)
 
 	return nil
 }
 
-func applyServiceAccount(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
-	sa := applycorev1.ServiceAccount(ServiceAccountName, namespace).
+func applyServiceAccount(ctx context.Context, clientset kubernetes.Interface, namespace, saName string) error {
+	sa := applycorev1.ServiceAccount(saName, namespace).
 		WithLabels(map[string]string{
 			labels.Name:      labels.ValueValidator,
 			labels.ManagedBy: labels.ValueAICR,
@@ -145,8 +167,8 @@ func applyServiceAccount(ctx context.Context, clientset kubernetes.Interface, na
 	return nil
 }
 
-func applyClusterRoleBinding(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
-	crb := applyrbacv1.ClusterRoleBinding(ClusterRoleBindingName).
+func applyClusterRoleBinding(ctx context.Context, clientset kubernetes.Interface, namespace, saName, crbName string) error {
+	crb := applyrbacv1.ClusterRoleBinding(crbName).
 		WithLabels(map[string]string{
 			labels.Name:      labels.ValueValidator,
 			labels.ManagedBy: labels.ValueAICR,
@@ -154,7 +176,7 @@ func applyClusterRoleBinding(ctx context.Context, clientset kubernetes.Interface
 		WithSubjects(
 			applyrbacv1.Subject().
 				WithKind("ServiceAccount").
-				WithName(ServiceAccountName).
+				WithName(saName).
 				WithNamespace(namespace),
 		).
 		WithRoleRef(

--- a/pkg/validator/job/rbac_test.go
+++ b/pkg/validator/job/rbac_test.go
@@ -23,14 +23,17 @@ import (
 
 func TestEnsureRBAC(t *testing.T) {
 	ns := createUniqueNamespace(t)
+	runID := "test-ensure-rbac"
+	saName := ServiceAccountName(runID)
+	crbName := ClusterRoleBindingName(runID)
 	ctx := context.Background()
 
-	if err := EnsureRBAC(ctx, testClientset, ns); err != nil {
+	if err := EnsureRBAC(ctx, testClientset, ns, runID); err != nil {
 		t.Fatalf("EnsureRBAC() failed: %v", err)
 	}
 
 	// Verify ServiceAccount was created
-	sa, err := testClientset.CoreV1().ServiceAccounts(ns).Get(ctx, ServiceAccountName, metav1.GetOptions{})
+	sa, err := testClientset.CoreV1().ServiceAccounts(ns).Get(ctx, saName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("ServiceAccount not found: %v", err)
 	}
@@ -39,7 +42,7 @@ func TestEnsureRBAC(t *testing.T) {
 	}
 
 	// Verify ClusterRoleBinding was created
-	crb, err := testClientset.RbacV1().ClusterRoleBindings().Get(ctx, ClusterRoleBindingName, metav1.GetOptions{})
+	crb, err := testClientset.RbacV1().ClusterRoleBindings().Get(ctx, crbName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("ClusterRoleBinding not found: %v", err)
 	}
@@ -49,8 +52,8 @@ func TestEnsureRBAC(t *testing.T) {
 	if len(crb.Subjects) != 1 {
 		t.Fatalf("ClusterRoleBinding subjects length = %d, want 1", len(crb.Subjects))
 	}
-	if crb.Subjects[0].Name != ServiceAccountName {
-		t.Errorf("ClusterRoleBinding subject name = %q, want %q", crb.Subjects[0].Name, ServiceAccountName)
+	if crb.Subjects[0].Name != saName {
+		t.Errorf("ClusterRoleBinding subject name = %q, want %q", crb.Subjects[0].Name, saName)
 	}
 	if crb.Subjects[0].Namespace != ns {
 		t.Errorf("ClusterRoleBinding subject namespace = %q, want %q", crb.Subjects[0].Namespace, ns)
@@ -58,64 +61,100 @@ func TestEnsureRBAC(t *testing.T) {
 
 	// Cleanup cluster-scoped resource
 	t.Cleanup(func() {
-		_ = CleanupRBAC(context.Background(), testClientset, ns)
+		_ = CleanupRBAC(context.Background(), testClientset, ns, runID)
 	})
 }
 
 func TestEnsureRBACIdempotent(t *testing.T) {
 	ns := createUniqueNamespace(t)
+	runID := "test-rbac-idempotent"
+	saName := ServiceAccountName(runID)
 	ctx := context.Background()
 
 	// Call twice — second call should not error
-	if err := EnsureRBAC(ctx, testClientset, ns); err != nil {
+	if err := EnsureRBAC(ctx, testClientset, ns, runID); err != nil {
 		t.Fatalf("first EnsureRBAC() failed: %v", err)
 	}
-	if err := EnsureRBAC(ctx, testClientset, ns); err != nil {
+	if err := EnsureRBAC(ctx, testClientset, ns, runID); err != nil {
 		t.Fatalf("second EnsureRBAC() failed: %v", err)
 	}
 
-	// Verify only one ServiceAccount exists
+	// Verify only one ServiceAccount exists for this runID
 	saList, err := testClientset.CoreV1().ServiceAccounts(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("failed to list ServiceAccounts: %v", err)
 	}
 	count := 0
 	for _, sa := range saList.Items {
-		if sa.Name == ServiceAccountName {
+		if sa.Name == saName {
 			count++
 		}
 	}
 	if count != 1 {
-		t.Errorf("expected 1 ServiceAccount named %q, found %d", ServiceAccountName, count)
+		t.Errorf("expected 1 ServiceAccount named %q, found %d", saName, count)
 	}
 
 	t.Cleanup(func() {
-		_ = CleanupRBAC(context.Background(), testClientset, ns)
+		_ = CleanupRBAC(context.Background(), testClientset, ns, runID)
+	})
+}
+
+// TestEnsureRBACConcurrentRunsIndependent guards the fix: two overlapping runs
+// against the same namespace must each get their own ServiceAccount and
+// ClusterRoleBinding, and one run's cleanup must not touch the other's.
+func TestEnsureRBACConcurrentRunsIndependent(t *testing.T) {
+	ns := createUniqueNamespace(t)
+	runA := "test-concurrent-a"
+	runB := "test-concurrent-b"
+	ctx := context.Background()
+
+	if err := EnsureRBAC(ctx, testClientset, ns, runA); err != nil {
+		t.Fatalf("EnsureRBAC(runA) failed: %v", err)
+	}
+	if err := EnsureRBAC(ctx, testClientset, ns, runB); err != nil {
+		t.Fatalf("EnsureRBAC(runB) failed: %v", err)
+	}
+
+	// Run A cleans up; run B's resources must still exist.
+	if err := CleanupRBAC(ctx, testClientset, ns, runA); err != nil {
+		t.Fatalf("CleanupRBAC(runA) failed: %v", err)
+	}
+
+	if _, err := testClientset.CoreV1().ServiceAccounts(ns).Get(ctx, ServiceAccountName(runB), metav1.GetOptions{}); err != nil {
+		t.Errorf("run B's ServiceAccount was deleted by run A's cleanup: %v", err)
+	}
+	if _, err := testClientset.RbacV1().ClusterRoleBindings().Get(ctx, ClusterRoleBindingName(runB), metav1.GetOptions{}); err != nil {
+		t.Errorf("run B's ClusterRoleBinding was deleted by run A's cleanup: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = CleanupRBAC(context.Background(), testClientset, ns, runB)
 	})
 }
 
 func TestCleanupRBAC(t *testing.T) {
 	ns := createUniqueNamespace(t)
+	runID := "test-cleanup-rbac"
 	ctx := context.Background()
 
 	// Create RBAC first
-	if err := EnsureRBAC(ctx, testClientset, ns); err != nil {
+	if err := EnsureRBAC(ctx, testClientset, ns, runID); err != nil {
 		t.Fatalf("EnsureRBAC() failed: %v", err)
 	}
 
 	// Cleanup
-	if err := CleanupRBAC(ctx, testClientset, ns); err != nil {
+	if err := CleanupRBAC(ctx, testClientset, ns, runID); err != nil {
 		t.Fatalf("CleanupRBAC() failed: %v", err)
 	}
 
 	// Verify ServiceAccount is gone
-	_, err := testClientset.CoreV1().ServiceAccounts(ns).Get(ctx, ServiceAccountName, metav1.GetOptions{})
+	_, err := testClientset.CoreV1().ServiceAccounts(ns).Get(ctx, ServiceAccountName(runID), metav1.GetOptions{})
 	if err == nil {
 		t.Error("ServiceAccount should be deleted")
 	}
 
 	// Verify ClusterRoleBinding is gone
-	_, err = testClientset.RbacV1().ClusterRoleBindings().Get(ctx, ClusterRoleBindingName, metav1.GetOptions{})
+	_, err = testClientset.RbacV1().ClusterRoleBindings().Get(ctx, ClusterRoleBindingName(runID), metav1.GetOptions{})
 	if err == nil {
 		t.Error("ClusterRoleBinding should be deleted")
 	}
@@ -125,7 +164,7 @@ func TestCleanupRBACNotFound(t *testing.T) {
 	ns := createUniqueNamespace(t)
 
 	// Cleanup without creating — should not error
-	if err := CleanupRBAC(context.Background(), testClientset, ns); err != nil {
+	if err := CleanupRBAC(context.Background(), testClientset, ns, "test-cleanup-notfound"); err != nil {
 		t.Fatalf("CleanupRBAC() on nonexistent resources should not error, got: %v", err)
 	}
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -108,7 +108,7 @@ func (v *Validator) prepareCluster(
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to ensure validation namespace", nsErr)
 	}
 
-	if rbacErr := job.EnsureRBAC(ctx, clientset, v.Namespace); rbacErr != nil {
+	if rbacErr := job.EnsureRBAC(ctx, clientset, v.Namespace, v.RunID); rbacErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to ensure RBAC", rbacErr)
 	}
 
@@ -135,7 +135,7 @@ func (v *Validator) deferClusterCleanup(clientset kubernetes.Interface) {
 		//nolint:contextcheck // Fresh context: parent may be canceled during cleanup
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 		defer cancel()
-		if cleanupErr := job.CleanupRBAC(cleanupCtx, clientset, v.Namespace); cleanupErr != nil {
+		if cleanupErr := job.CleanupRBAC(cleanupCtx, clientset, v.Namespace, v.RunID); cleanupErr != nil {
 			slog.Warn("failed to cleanup RBAC", "error", cleanupErr)
 		}
 		//nolint:contextcheck // Fresh context: parent may be canceled during cleanup

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1277,18 +1277,25 @@ RECIPE
     --output "$validation_result" \
     --no-cleanup 2>&1 || validation_exit=$?
 
-  # Check if RBAC resources were created
-  if kubectl get sa aicr-validator -n aicr-validation &>/dev/null; then
-    detail "ServiceAccount created: aicr-validator"
+  # Check if RBAC resources were created. The SA and CRB names are
+  # suffixed with the per-run runID, so look up by the stable
+  # `app.kubernetes.io/name=aicr-validator` label rather than the literal name.
+  local rbac_label_selector="app.kubernetes.io/name=aicr-validator"
+  local sa_name
+  sa_name=$(kubectl get sa -n aicr-validation -l "${rbac_label_selector}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "${sa_name}" ]; then
+    detail "ServiceAccount created: ${sa_name}"
     pass "validate/job-rbac-serviceaccount"
   else
     fail "validate/job-rbac-serviceaccount" "ServiceAccount not found after --no-cleanup"
   fi
 
-  if kubectl get clusterrolebinding aicr-validator &>/dev/null; then
+  local crb_name
+  crb_name=$(kubectl get clusterrolebinding -l "${rbac_label_selector}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "${crb_name}" ]; then
     local role_ref
-    role_ref=$(kubectl get clusterrolebinding aicr-validator -o jsonpath='{.roleRef.name}')
-    detail "ClusterRoleBinding created: aicr-validator → ${role_ref}"
+    role_ref=$(kubectl get clusterrolebinding "${crb_name}" -o jsonpath='{.roleRef.name}')
+    detail "ClusterRoleBinding created: ${crb_name} → ${role_ref}"
     pass "validate/job-rbac-role"
   else
     fail "validate/job-rbac-role" "ClusterRoleBinding not found after --no-cleanup"
@@ -1358,9 +1365,12 @@ RECIPE
     --output "$validation_custom" \
     2>&1 || true  # Keep || true here as this is just testing namespace config
 
-  # Check if RBAC was created in custom namespace
-  if kubectl get sa aicr-validator -n custom-validation &>/dev/null; then
-    detail "ServiceAccount created in custom-validation namespace"
+  # Check if RBAC was created in custom namespace. Match by label since the
+  # SA name carries the per-run runID suffix.
+  local custom_sa_name
+  custom_sa_name=$(kubectl get sa -n custom-validation -l "app.kubernetes.io/name=aicr-validator" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "${custom_sa_name}" ]; then
+    detail "ServiceAccount created in custom-validation namespace: ${custom_sa_name}"
     pass "validate/job-custom-namespace"
   else
     warn "ServiceAccount not found in custom namespace (may be expected if no checks defined)"
@@ -1413,9 +1423,14 @@ RECIPE
     pass "validate/job-result-format"
   fi
 
-  # Cleanup test namespaces
+  # Cleanup test namespaces, then any per-run validator ClusterRoleBindings.
+  # CRBs are cluster-scoped and survive namespace deletion, and the `--no-cleanup`
+  # run earlier in this test intentionally leaves its CRB behind. Label-based
+  # bulk delete also cleans up any stale CRBs from prior failed runs so they
+  # cannot be picked up by the label selector in the next invocation.
   kubectl delete namespace aicr-validation 2>&1 || true
   kubectl delete namespace custom-validation 2>&1 || true
+  kubectl delete clusterrolebinding -l app.kubernetes.io/name=aicr-validator 2>&1 || true
   cleanup_fake_gpu_operator_fixture
 }
 


### PR DESCRIPTION
## Summary

Suffix the validator `ServiceAccount` and `ClusterRoleBinding` names with the per-run `runID` so two concurrent `aicr validate` invocations against the same cluster do not delete each other's RBAC during end-of-run cleanup.

## Motivation / Context

When two `aicr validate` runs overlap on the same namespace, the second run's later validators trip `FailedCreate: serviceaccount "aicr-validator" not found` for ~10 minutes until each per-check `AICR_CHECK_TIMEOUT` fires. Root cause: both runs share the fixed `aicr-validator` SA + CRB. When run A finishes and runs `CleanupRBAC`, run B is mid-flight and loses its SA — every subsequent inner-Job pod-create fails.

The data ConfigMaps already encode the runID (`aicr-snapshot-<runID>`, `aicr-validation-<runID>`) to avoid exactly this class of race. RBAC was the singleton hole.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

`ServiceAccountName` and `ClusterRoleBindingName` change from exported package-level constants (`"aicr-validator"`) to functions of `runID` returning `"aicr-validator-<runID>"`. `EnsureRBAC` and `CleanupRBAC` take a `runID` parameter; `Validator.RunID` is plumbed through `prepareCluster` / `deferClusterCleanup`, and `Deployer.buildPodSpecApply` uses `ServiceAccountName(d.runID)` so per-validator Jobs mount the right SA.

- **Public API:** the two exported `ServiceAccountName` / `ClusterRoleBindingName` constants become functions. No external consumers in the codebase.
- **Labels:** `app.kubernetes.io/name=aicr-validator` is unchanged, so label-based discovery still works.
- **ADR-002** (`docs/design/002-validatorv2-adr.md`) gains an inline `Implementation note (2026-05-14)` block — the original design described fixed names, and readers should know why the names now carry a suffix.
- **`tests/e2e/run.sh`** (used by `make e2e-tilt`, not `make qualify`) is updated to discover the SA/CRB by label rather than by literal name.

## Testing

`make qualify` — green (test + lint + e2e + scan).

New regression test:
- `TestEnsureRBACConcurrentRunsIndependent` — runs `EnsureRBAC` twice with two different runIDs against the same namespace, then `CleanupRBAC` only run A, and asserts run B's SA and CRB are still present.

Existing RBAC tests updated to thread a `runID` through `EnsureRBAC` / `CleanupRBAC`.

**Coverage (affected packages):** no decrease — new function paths exercised by the same existing tests plus the new regression test.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No CLI flags or APIs change. On-cluster resource names change (`aicr-validator` → `aicr-validator-<runID>`), so any external automation that looks up the SA/CRB by literal name (rather than by `app.kubernetes.io/name=aicr-validator` label) needs an update. None known in-tree besides `tests/e2e/run.sh`, fixed here.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] `make qualify` passes
- [x] Docs updated (ADR-002 implementation note)
- [x] Cryptographically signed (`-S`)