### PR TITLE
fix(evidence): fix a regression in cncf ai conformance evidence collection

### DIFF
--- a/pkg/evidence/cncf/collector.go
+++ b/pkg/evidence/cncf/collector.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -308,20 +309,24 @@ func (c *Collector) Run(ctx context.Context) error {
 }
 
 // resolveFeatures returns the list of canonical features to collect,
-// expanding aliases and collapsing to {"all"} when "all" is present or
-// no features were requested.
+// expanding aliases and the "all" wildcard (or an empty input) to the
+// full ValidFeatures list. Expanding "all" Go-side — rather than passing
+// it through to the bash script — ensures every feature runs as its own
+// runSection invocation and therefore gets its own EvidenceSectionTimeout
+// budget. The pre-expansion behavior shipped one shell-out for nine
+// features under a single 5-minute timeout, which reliably SIGKILL'd
+// before completion on real clusters.
 func (c *Collector) resolveFeatures() []string {
+	if len(c.features) == 0 {
+		return slices.Clone(ValidFeatures)
+	}
 	features := make([]string, 0, len(c.features))
 	for _, f := range c.features {
-		features = append(features, ResolveFeature(f))
-	}
-	if len(features) == 0 {
-		return []string{featureAll}
-	}
-	for _, f := range features {
-		if f == featureAll {
-			return []string{featureAll}
+		canonical := ResolveFeature(f)
+		if canonical == featureAll {
+			return slices.Clone(ValidFeatures)
 		}
+		features = append(features, canonical)
 	}
 	return features
 }

--- a/pkg/evidence/cncf/collector_test.go
+++ b/pkg/evidence/cncf/collector_test.go
@@ -430,3 +430,60 @@ func pathHasBinaries(t *testing.T) bool {
 	}
 	return true
 }
+
+// TestResolveFeaturesExpandsAll guards a regression: the "all" wildcard and
+// the empty-input default must both expand to the full ValidFeatures list
+// so each feature runs as its own runSection invocation under its own
+// EvidenceSectionTimeout. Collapsing back to a single {"all"} section would
+// reintroduce the 5-minute SIGKILL bug where one shell-out tries to run
+// every feature inside a single section budget.
+func TestResolveFeaturesExpandsAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		features []string
+		want     []string
+	}{
+		{"empty defaults to all features", nil, ValidFeatures},
+		{"empty slice defaults to all features", []string{}, ValidFeatures},
+		{"literal all expands", []string{featureAll}, ValidFeatures},
+		{"all with other entries still expands", []string{featureDRASupport, featureAll, featureGangScheduling}, ValidFeatures},
+		{"alias passthrough preserved", []string{"dra", "gang"}, []string{featureDRASupport, featureGangScheduling}},
+		{"explicit subset is not expanded", []string{featureDRASupport, featurePodAutoscaling}, []string{featureDRASupport, featurePodAutoscaling}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCollector("/tmp", WithFeatures(tt.features))
+			got := c.resolveFeatures()
+			if len(got) != len(tt.want) {
+				t.Fatalf("resolveFeatures() = %v (len %d), want %v (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i, f := range tt.want {
+				if got[i] != f {
+					t.Errorf("resolveFeatures()[%d] = %q, want %q", i, got[i], f)
+				}
+			}
+			for _, f := range got {
+				if f == featureAll {
+					t.Errorf("resolveFeatures() returned literal %q; expected expansion to individual feature names", featureAll)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveFeaturesReturnsIndependentSlice ensures callers cannot mutate
+// the package-level ValidFeatures slice via the returned value, which would
+// corrupt future resolutions.
+func TestResolveFeaturesReturnsIndependentSlice(t *testing.T) {
+	c := NewCollector("/tmp")
+	got := c.resolveFeatures()
+	if len(got) == 0 {
+		t.Fatal("resolveFeatures() returned empty slice for default input")
+	}
+	original := ValidFeatures[0]
+	got[0] = "tampered"
+	if ValidFeatures[0] != original {
+		t.Errorf("ValidFeatures[0] = %q after mutating resolveFeatures() output; want %q — slice must be cloned", ValidFeatures[0], original)
+	}
+}


### PR DESCRIPTION
## Summary

Fix a regression introduced by PR #721. `aicr validate --cncf-submission` (with empty `--feature` or explicit `--feature all`) was SIGKILL'd after 5 minutes. Expand the `all` wildcard Go-side into the full `ValidFeatures` list so each feature gets its own `EvidenceSectionTimeout` budget.

## Motivation / Context

Reproduced on a live EKS cluster: `--cncf-submission` with no `--feature` flag (documented as "default: all") hangs and is SIGKILL'd after ~5 minutes with `signal: killed exitCode=5`. Five of the nine markdown evidence files are written before the kill; the remaining four are lost. The same happens with explicit `--feature all`.

**Why now:** PR #721 ("fix: address top-7 code-review findings across packages", merged 2026-04-30) added `EvidenceSectionTimeout = 5 * time.Minute` and wrapped each `runSection` call with `context.WithTimeout(ctx, ...)`. The intent — bound runaway shell processes — is sound. But `pkg/evidence/cncf/collector.go::resolveFeatures()` predates that change and collapses both empty input and the `all` wildcard to a single `["all"]` section, so the Go loop fires exactly one shell-out (`bash collect-evidence.sh all`) bound by that 5-minute ceiling. The bash script's internal `case all)` block then has to run all nine features inside that window — far too short on real clusters (the per-feature budget at the script level used to be the 20-minute `CNCFSubmissionTimeout`).

Fixes: N/A
Related: regression introduced by #721

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — specifically `pkg/evidence/cncf`

## Implementation Notes

`resolveFeatures()` now expands `[]` and the `all` token into a clone of `ValidFeatures`. The Go loop in `Collector.Run()` then iterates nine times, calling `runSection(<feature>)` once per feature, with each invocation under its own `EvidenceSectionTimeout` (5 min). Total wall time remains bounded by the outer `CNCFSubmissionTimeout` (20 min).

- The bash script's `case all)` block is **preserved** for direct invocation (`bash collect-evidence.sh all`). Only the Go path stops routing through it.
- Defensive copy: `slices.Clone(ValidFeatures)` so callers can't mutate the package-level slice via the returned value.
- The `featureAll` constant stays — still needed as the input-recognition token for `--feature all`.

## Testing

`make qualify` — green.

Manual reproduction (before): on cluster `aicr2`, `aicr validate --phase conformance --cncf-submission --evidence-dir ...` exits non-zero with `evidence collection command failed: signal: killed exitCode=5` at ~5 min, 5/9 evidence files written. With explicit per-feature flags as a workaround: completes in ~10 min, 9/9 files written.

New regression coverage:
- `TestResolveFeaturesExpandsAll` — nil, `[]`, `["all"]`, and `["dra","all","gang"]` all expand to `ValidFeatures`; explicit subsets pass through unchanged; aliases resolve.
- `TestResolveFeaturesReturnsIndependentSlice` — guards the defensive `slices.Clone` so mutating the returned slice can't corrupt the package-level `ValidFeatures`.

Existing `pkg/evidence/cncf` tests still pass; no per-package coverage decrease.

## Risk Assessment

- [x] **Low** — Single-function change, well-covered, easy to revert. No effect on the Go validator-orchestrator path (PR #888) — `--cncf-submission` is a separate code path that returns before `runValidation`.

**Rollout notes:** No CLI flags change. Users who were working around this bug by enumerating `--feature` flags by hand can drop those flags after this lands.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] `make qualify` passes
- [x] No `Co-Authored-By` lines
- [x] Cryptographically signed (`-S`)