### PR TITLE
fix(validator): surface skip reason in CTRF, treat missing constraint as skip

### DIFF
--- a/validators/deployment/gpu_operator_version.go
+++ b/validators/deployment/gpu_operator_version.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/constraints"
@@ -40,8 +39,7 @@ func checkGPUOperatorVersion(ctx *validators.Context) error {
 	// Find the version constraint in the recipe
 	constraintExpr, found := findDeploymentConstraint(ctx, "Deployment.gpu-operator.version")
 	if !found {
-		slog.Info("no version constraint in recipe, reporting detected version only")
-		return nil
+		return validators.Skip(fmt.Sprintf("no Deployment.gpu-operator.version constraint in recipe; detected %s", version))
 	}
 
 	// Evaluate constraint

--- a/validators/runner.go
+++ b/validators/runner.go
@@ -26,8 +26,9 @@ import (
 )
 
 // terminationLogPath is the standard K8s termination message path.
-// Kept as a constant (not configurable) since it matches the Job spec.
-const terminationLogPath = "/dev/termination-log"
+// Declared as a var (not const) only so unit tests can redirect writes
+// to a temp file; production code must not reassign it.
+var terminationLogPath = "/dev/termination-log"
 
 // exitCodeSkip is the exit code for a skipped check (not applicable).
 const exitCodeSkip = 2
@@ -89,24 +90,44 @@ func runCheck(checkFn CheckFunc) int {
 		return 1
 	}
 	defer ctx.Cancel()
+	return handleCheckResult(checkFn(ctx))
+}
 
-	if err := checkFn(ctx); err != nil {
-		if errors.Is(err, errSkip) {
-			slog.Info("SKIP", "reason", err.Error())
-			return exitCodeSkip
-		}
-		writeTerminationLog("%v", err)
-		return 1
+// handleCheckResult maps a CheckFunc return value to an exit code and
+// surfaces the reason (skip or failure) via slog and the termination log.
+// Writing the skip reason to the termination log is required for the
+// orchestrator's ValidatorResult.TerminationMsg to flow into the CTRF
+// report's TestResult.Message; without it skipped checks appear with a
+// null message in the signed evidence bundle.
+func handleCheckResult(err error) int {
+	if err == nil {
+		return 0
 	}
+	if errors.Is(err, errSkip) {
+		slog.Info("SKIP", "reason", err.Error())
+		writeTerminationFile(err.Error())
+		return exitCodeSkip
+	}
+	writeTerminationLog("%v", err)
+	return 1
+}
 
-	return 0
+// writeTerminationFile writes msg to the termination log path, truncated
+// to TerminationLogMaxSize. Does not emit any slog entry for the message
+// itself; callers log separately so the slog level can reflect skip vs.
+// failure. A failed write is logged at WARN — silent loss here is the
+// exact class of bug this code path exists to prevent.
+func writeTerminationFile(msg string) {
+	if len(msg) > defaults.TerminationLogMaxSize {
+		msg = msg[:defaults.TerminationLogMaxSize]
+	}
+	if err := os.WriteFile(filepath.Clean(terminationLogPath), []byte(msg), 0o600); err != nil { //nolint:gosec // Fixed path, not user-controlled
+		slog.Warn("failed to write termination log", "path", terminationLogPath, "error", err)
+	}
 }
 
 func writeTerminationLog(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	slog.Error("FAIL", "message", msg)
-	if len(msg) > defaults.TerminationLogMaxSize {
-		msg = msg[:defaults.TerminationLogMaxSize]
-	}
-	_ = os.WriteFile(filepath.Clean(terminationLogPath), []byte(msg), 0o600) //nolint:gosec // Fixed path, not user-controlled
+	writeTerminationFile(msg)
 }

--- a/validators/runner_test.go
+++ b/validators/runner_test.go
@@ -16,8 +16,12 @@ package validators
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
 )
 
 func TestSkip(t *testing.T) {
@@ -67,5 +71,145 @@ func TestSkipIsNotGenericError(t *testing.T) {
 	plain := errors.New("some other error")
 	if errors.Is(plain, errSkip) {
 		t.Error("plain error should not match errSkip")
+	}
+}
+
+// withTempTerminationLog redirects terminationLogPath to a temp file for
+// the duration of a test and returns the path. Restores the original on
+// test cleanup.
+//
+// NOTE: this helper mutates a package-level var; tests using it must not
+// call t.Parallel().
+func withTempTerminationLog(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "termination-log")
+	orig := terminationLogPath
+	terminationLogPath = tmp
+	t.Cleanup(func() { terminationLogPath = orig })
+	return tmp
+}
+
+func TestHandleCheckResult(t *testing.T) {
+	longReason := strings.Repeat("y", defaults.TerminationLogMaxSize+200)
+
+	tests := []struct {
+		name         string
+		err          error
+		wantExitCode int
+		wantFile     bool
+		wantContains string
+		wantMaxLen   int // 0 = no length assertion
+	}{
+		{
+			name:         "nil error returns 0 and writes no termination log",
+			err:          nil,
+			wantExitCode: 0,
+			wantFile:     false,
+		},
+		{
+			name:         "skip writes reason to termination log",
+			err:          Skip("because constraint missing"),
+			wantExitCode: exitCodeSkip,
+			wantFile:     true,
+			wantContains: "because constraint missing",
+		},
+		{
+			name:         "skip with empty reason still writes file",
+			err:          Skip(""),
+			wantExitCode: exitCodeSkip,
+			wantFile:     true,
+			// Skip("") wraps errSkip and still produces a non-empty message
+			// (the wrapper string), so we only assert the file exists.
+		},
+		{
+			name:         "skip truncates oversize reason",
+			err:          Skip(longReason),
+			wantExitCode: exitCodeSkip,
+			wantFile:     true,
+			wantMaxLen:   defaults.TerminationLogMaxSize,
+		},
+		{
+			name:         "failure writes error to termination log",
+			err:          errors.New("boom"),
+			wantExitCode: 1,
+			wantFile:     true,
+			wantContains: "boom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := withTempTerminationLog(t)
+
+			got := handleCheckResult(tt.err)
+			if got != tt.wantExitCode {
+				t.Errorf("handleCheckResult exit code = %d, want %d", got, tt.wantExitCode)
+			}
+
+			data, err := os.ReadFile(filepath.Clean(path))
+			switch {
+			case tt.wantFile && errors.Is(err, os.ErrNotExist):
+				t.Fatalf("expected termination log at %s, got none", path)
+			case !tt.wantFile && err == nil:
+				t.Fatalf("expected no termination log, got %q", string(data))
+			case tt.wantFile && err != nil && !errors.Is(err, os.ErrNotExist):
+				t.Fatalf("reading termination log: %v", err)
+			}
+
+			if tt.wantContains != "" && !strings.Contains(string(data), tt.wantContains) {
+				t.Errorf("termination log = %q, want substring %q", string(data), tt.wantContains)
+			}
+			if tt.wantMaxLen > 0 && len(data) != tt.wantMaxLen {
+				t.Errorf("termination log length = %d, want %d", len(data), tt.wantMaxLen)
+			}
+		})
+	}
+}
+
+// TestHandleCheckResultOverwrites verifies that a second skip overwrites
+// the first — terminationLogPath is treated as a single-shot message
+// surface, not an append log. Catches regressions that would switch to
+// O_APPEND.
+func TestHandleCheckResultOverwrites(t *testing.T) {
+	path := withTempTerminationLog(t)
+
+	if got := handleCheckResult(Skip("first")); got != exitCodeSkip {
+		t.Fatalf("first call exit code = %d, want %d", got, exitCodeSkip)
+	}
+	if got := handleCheckResult(Skip("second")); got != exitCodeSkip {
+		t.Fatalf("second call exit code = %d, want %d", got, exitCodeSkip)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("reading termination log: %v", err)
+	}
+	if strings.Contains(string(data), "first") {
+		t.Errorf("termination log = %q, want only the second message", string(data))
+	}
+	if !strings.Contains(string(data), "second") {
+		t.Errorf("termination log = %q, want substring %q", string(data), "second")
+	}
+}
+
+func TestWriteTerminationFileTruncatesKeepsPrefix(t *testing.T) {
+	path := withTempTerminationLog(t)
+
+	// Distinguishable prefix so we can confirm truncation kept the front,
+	// not the tail. The prefix is short enough to survive truncation.
+	prefix := "HEAD-MARKER:"
+	msg := prefix + strings.Repeat("x", defaults.TerminationLogMaxSize+100)
+
+	writeTerminationFile(msg)
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("reading termination log: %v", err)
+	}
+	if got := len(data); got != defaults.TerminationLogMaxSize {
+		t.Errorf("termination log length = %d, want %d", got, defaults.TerminationLogMaxSize)
+	}
+	if !strings.HasPrefix(string(data), prefix) {
+		t.Errorf("termination log did not keep prefix; first 32 bytes = %q", string(data[:32]))
 	}
 }


### PR DESCRIPTION
## Summary

Two related defects in the validator-runtime skip path. Together they erased the difference between "constraint satisfied" and "constraint missing" in the signed evidence bundle. Skip reasons now write to `/dev/termination-log` (so they appear as `TestResult.Message` in CTRF reports), and `gpu-operator-version` reports a skip — not a pass — when no version constraint is set.

## Motivation / Context

Without these fixes, every skipped validator records `"message": null` in the signed CTRF predicate, and `gpu-operator-version` masquerades skips as passes — weakening the trust property the bundle is meant to carry. Diagnosing why anything skipped required `--no-cleanup` and hand-tailing pod logs.

Fixes: #875
Related: #874 (originally surfaced this)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `validators/` runtime (in-container CheckFunc runner)

## Implementation Notes

**Runner (`validators/runner.go`)**
- Extracted `handleCheckResult(err) int` so the skip-vs-fail decision is unit-testable without `LoadContext` (which needs a real K8s client).
- Extracted `writeTerminationFile(msg)` as the shared file-write seam; `writeTerminationLog` (the FAIL helper) now delegates to it.
- Skip branch now writes the reason to the termination log *after* the existing `slog.Info("SKIP", ...)`.
- `writeTerminationFile` logs `slog.Warn` on `os.WriteFile` failure — silent loss here is the exact class of bug being fixed.
- `terminationLogPath` is now a `var` (with a guard-rail comment) only so unit tests can redirect to a temp file; the test helper documents the non-parallel constraint.

**gpu-operator-version (`validators/deployment/gpu_operator_version.go`)**
- `return nil` (= pass) replaced with `return validators.Skip(fmt.Sprintf("no Deployment.gpu-operator.version constraint in recipe; detected %s", version))`. The detected version is intentionally embedded in the skip message — it's diagnostic information that belongs in the report consumer's view. Pattern matches sibling validators (`inference_perf.go`, `nccl_all_reduce_bw.go`) but adds the detected value.

## Testing

```bash
make qualify                                                # green: tests + lint + e2e + scan + license headers
golangci-lint run -c .golangci.yaml ./validators/...        # 0 issues
go test -race -count=1 ./validators/...                     # all 6 sub-packages green
```

**New tests (validators/runner_test.go):**
- `TestHandleCheckResult` — 5 subtests: nil/skip/empty-skip/oversize-skip-truncates/fail. The oversize-skip case proves end-to-end truncation through the skip branch.
- `TestHandleCheckResultOverwrites` — two sequential skips; second overwrites first (guards against O_APPEND regressions).
- `TestWriteTerminationFileTruncatesKeepsPrefix` — distinguishable prefix asserts truncation keeps the head, not the tail.

**Coverage (changed packages, vs origin/main):**
- `validators/`: 29.9% → 44.0% (+14.1%)
- `validators/deployment/`: 43.8% → 43.9% (+0.1%)

**Note on `make test-coverage`:** the project-wide gate currently fails at 74.5% / 75% threshold. This is a **pre-existing failure on `origin/main`** (verified by running the same command against the unmodified baseline) — not introduced by this PR. This PR moves the needle in the right direction on the changed packages. Separate ticket may be warranted to investigate which package(s) dropped recently.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Behavior change is observable but is the intended outcome of the fix:
1. CTRF reports for previously-skipped validators will now have a non-null `message` field (was `null`). Downstream consumers parsing CTRF that asserted `message == null` for skipped tests will need to update.
2. `gpu-operator-version` results will now show `status: "skipped"` (was `"passed"`) when the recipe has no version constraint. Pass/fail are unchanged when a constraint is present.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (no validator-name level docs reference `gpu-operator-version`; CTRF message field already existed)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)