### PR TITLE
feat(tools): add install-rc helper for latest RC binary

### DIFF
--- a/tools/install-rc
+++ b/tools/install-rc
@@ -36,8 +36,8 @@ the current OS/architecture from github.com/${REPO}.
 
 Options:
   -t, --tag <tag>     Install a specific tag (e.g., v0.13.0-rc3).
-                      Defaults to the most recent prerelease that matches
-                      'v*-rc*' or any prerelease if no rc tag exists.
+                      Defaults to the most recent prerelease tag matching
+                      'v*-rc[0-9]+'.
   -d, --dir <path>    Install directory (default: ${DEFAULT_DIR}).
                       Tilde and \$HOME expansion are honored.
       --keep-tmp      Keep the temporary download directory for debugging.
@@ -90,7 +90,7 @@ case "$INSTALL_DIR" in
 esac
 
 # Required tools
-has_tools curl tar uname shasum
+has_tools curl tar uname shasum jq
 
 # Detect OS
 case "$(uname -s)" in
@@ -120,13 +120,18 @@ resolve_latest_rc() {
       echo "$picked"; return 0
     fi
   fi
-  # Fallback: GitHub REST API (unauthenticated, low rate limit)
+  # Fallback: GitHub REST API (unauthenticated, low rate limit).
+  # Apply the same draft/prerelease filtering as the gh path.
   local api="https://api.github.com/repos/${REPO}/releases?per_page=50"
   curl -fsSL "$api" 2>/dev/null \
-    | grep -E '"tag_name"' \
-    | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
-    | grep -E -- '-rc[0-9]+$' \
-    | head -1
+    | jq -r '
+        [ .[]
+          | select(.draft == false)
+          | select(.prerelease == true)
+          | .tag_name
+          | select(test("-rc[0-9]+$"))
+        ][0] // empty
+      '
 }
 
 if [[ -z "$TAG" ]]; then
@@ -135,8 +140,12 @@ if [[ -z "$TAG" ]]; then
   [[ -n "$TAG" ]] || err "Could not resolve a latest RC tag. Pass one with --tag."
 fi
 
-# Validate tag format: v<semver>-rc<n> OR allow any v<semver>... for explicit overrides
-if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+# Validate tag format strictly with a safe charset before deriving paths/URLs.
+# Accepts vMAJOR.MINOR.PATCH with optional dot/hyphen-separated alnum segments
+# (e.g., v1.2.3, v1.2.3-rc1, v1.2.3-beta.1). Rejects slashes, dots, underscores,
+# or any character that could enable path traversal when concatenated into URLs
+# or filesystem paths.
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
   err "Tag '$TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH[-rcN])."
 fi
 

--- a/tools/install-rc
+++ b/tools/install-rc
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Dir setup
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${DIR}/common"
+
+# Defaults
+REPO="NVIDIA/aicr"
+BINARY="aicr"
+DEFAULT_DIR="/usr/local/bin"
+TAG=""
+INSTALL_DIR=""
+KEEP_TMP=false
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Downloads and installs the latest aicr release candidate (RC) binary for
+the current OS/architecture from github.com/${REPO}.
+
+Options:
+  -t, --tag <tag>     Install a specific tag (e.g., v0.13.0-rc3).
+                      Defaults to the most recent prerelease that matches
+                      'v*-rc*' or any prerelease if no rc tag exists.
+  -d, --dir <path>    Install directory (default: ${DEFAULT_DIR}).
+                      Tilde and \$HOME expansion are honored.
+      --keep-tmp      Keep the temporary download directory for debugging.
+  -h, --help          Show this help and exit.
+
+Behavior:
+  - Detects OS (darwin/linux) and arch (amd64/arm64).
+  - Downloads aicr_<version>_<os>_<arch>.tar.gz and aicr_checksums.txt.
+  - Verifies the SHA-256 checksum before installing.
+  - On macOS, removes the com.apple.quarantine attribute if Gatekeeper set it.
+  - Uses sudo automatically when the install directory is not user-writable.
+
+Examples:
+  $0                                # Latest RC into ${DEFAULT_DIR}
+  $0 --dir ~/bin                    # Latest RC into ~/bin
+  $0 --tag v0.13.0-rc3              # Pin to a specific RC
+  $0 -t v0.13.0-rc3 -d /tmp         # Specific tag into a custom dir
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--tag)
+      [[ $# -ge 2 ]] || err "--tag requires a value"
+      TAG="$2"; shift 2 ;;
+    -d|--dir)
+      [[ $# -ge 2 ]] || err "--dir requires a value"
+      INSTALL_DIR="$2"; shift 2 ;;
+    --keep-tmp)
+      KEEP_TMP=true; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    -*)
+      err "Unknown flag: $1 (try --help)" ;;
+    *)
+      # Allow a single positional argument as the install dir
+      if [[ -z "$INSTALL_DIR" ]]; then
+        INSTALL_DIR="$1"; shift
+      else
+        err "Unexpected argument: $1 (try --help)"
+      fi ;;
+  esac
+done
+
+INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_DIR}"
+# Expand leading ~ in install dir (literal tilde from the user, not shell-expanded)
+# shellcheck disable=SC2088
+case "$INSTALL_DIR" in
+  "~"|"~/"*) INSTALL_DIR="${HOME}${INSTALL_DIR:1}" ;;
+esac
+
+# Required tools
+has_tools curl tar uname shasum
+
+# Detect OS
+case "$(uname -s)" in
+  Darwin) OS="darwin" ;;
+  Linux)  OS="linux" ;;
+  *) err "Unsupported OS: $(uname -s) (only darwin/linux are released)" ;;
+esac
+
+# Detect arch
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) err "Unsupported architecture: $(uname -m) (only amd64/arm64 are released)" ;;
+esac
+
+# Resolve tag
+resolve_latest_rc() {
+  # Prefer gh CLI when available (authenticated, higher rate limits)
+  if command -v gh >/dev/null 2>&1; then
+    local picked
+    picked=$(gh release list --repo "$REPO" --limit 50 \
+               --json tagName,isPrerelease,isDraft \
+               --jq '[.[] | select(.isDraft|not) | select(.isPrerelease) | .tagName]
+                     | map(select(test("-rc[0-9]+$")))
+                     | .[0] // empty' 2>/dev/null || true)
+    if [[ -n "$picked" ]]; then
+      echo "$picked"; return 0
+    fi
+  fi
+  # Fallback: GitHub REST API (unauthenticated, low rate limit)
+  local api="https://api.github.com/repos/${REPO}/releases?per_page=50"
+  curl -fsSL "$api" 2>/dev/null \
+    | grep -E '"tag_name"' \
+    | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
+    | grep -E -- '-rc[0-9]+$' \
+    | head -1
+}
+
+if [[ -z "$TAG" ]]; then
+  log_info "Resolving latest RC tag from ${REPO}…"
+  TAG=$(resolve_latest_rc || true)
+  [[ -n "$TAG" ]] || err "Could not resolve a latest RC tag. Pass one with --tag."
+fi
+
+# Validate tag format: v<semver>-rc<n> OR allow any v<semver>... for explicit overrides
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+  err "Tag '$TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH[-rcN])."
+fi
+
+VERSION="${TAG#v}"
+ASSET="${BINARY}_${VERSION}_${OS}_${ARCH}.tar.gz"
+CHECKSUMS="${BINARY}_checksums.txt"
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+
+log_info "Tag:        ${TAG}"
+log_info "Platform:   ${OS}/${ARCH}"
+log_info "Asset:      ${ASSET}"
+log_info "Install to: ${INSTALL_DIR}/${BINARY}"
+
+# Temp workspace
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/aicr-install.XXXXXX")
+if [[ "$KEEP_TMP" == "true" ]]; then
+  log_warning "Keeping temp dir: ${TMP_DIR}"
+else
+  trap 'rm -rf "$TMP_DIR"' EXIT
+fi
+
+# Download
+download() {
+  local url=$1 dest=$2
+  if ! curl -fSL --retry 3 --retry-delay 2 --connect-timeout 10 \
+       --progress-bar -o "$dest" "$url"; then
+    err "Failed to download: $url"
+  fi
+}
+
+log_info "Downloading archive…"
+download "${BASE_URL}/${ASSET}" "${TMP_DIR}/${ASSET}"
+log_info "Downloading checksums…"
+download "${BASE_URL}/${CHECKSUMS}" "${TMP_DIR}/${CHECKSUMS}"
+
+# Verify checksum
+log_info "Verifying SHA-256 checksum…"
+EXPECTED=$(awk -v f="${ASSET}" '$2==f {print $1}' "${TMP_DIR}/${CHECKSUMS}")
+[[ -n "$EXPECTED" ]] || err "Checksum for ${ASSET} not found in ${CHECKSUMS}"
+ACTUAL=$(shasum -a 256 "${TMP_DIR}/${ASSET}" | awk '{print $1}')
+if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+  err "Checksum mismatch for ${ASSET} (expected ${EXPECTED}, got ${ACTUAL})"
+fi
+log_success "Checksum OK"
+
+# Extract
+log_info "Extracting…"
+tar -xzf "${TMP_DIR}/${ASSET}" -C "${TMP_DIR}"
+BIN_SRC="${TMP_DIR}/${BINARY}"
+[[ -f "$BIN_SRC" ]] || err "Expected binary '${BINARY}' not found in archive"
+chmod 0755 "$BIN_SRC"
+
+# Determine sudo
+SUDO=""
+if [[ ! -d "$INSTALL_DIR" ]]; then
+  if mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+    :
+  else
+    command -v sudo >/dev/null 2>&1 || err "Install dir '${INSTALL_DIR}' does not exist and sudo is unavailable"
+    SUDO="sudo"
+    log_warning "Creating ${INSTALL_DIR} with sudo (you may be prompted)"
+    $SUDO mkdir -p "$INSTALL_DIR"
+  fi
+fi
+if [[ ! -w "$INSTALL_DIR" ]]; then
+  command -v sudo >/dev/null 2>&1 || err "Install dir '${INSTALL_DIR}' is not writable and sudo is unavailable"
+  SUDO="sudo"
+  log_warning "${INSTALL_DIR} is not writable; using sudo (you may be prompted)"
+fi
+
+# Install
+TARGET="${INSTALL_DIR}/${BINARY}"
+log_info "Installing to ${TARGET}…"
+$SUDO install -m 0755 "$BIN_SRC" "$TARGET"
+
+# macOS: strip Gatekeeper quarantine if present
+if [[ "$OS" == "darwin" ]] && command -v xattr >/dev/null 2>&1; then
+  if xattr -p com.apple.quarantine "$TARGET" >/dev/null 2>&1; then
+    log_info "Removing com.apple.quarantine attribute…"
+    $SUDO xattr -d com.apple.quarantine "$TARGET" || \
+      log_warning "Failed to remove quarantine attribute (binary may prompt Gatekeeper)"
+  fi
+fi
+
+log_success "Installed ${BINARY} ${TAG} to ${TARGET}"
+
+# Post-install: warn if not on PATH, otherwise print version
+if ! command -v "$BINARY" >/dev/null 2>&1; then
+  log_warning "${INSTALL_DIR} is not on your PATH. Add it with:"
+  echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+elif [[ "$(command -v "$BINARY")" != "$TARGET" ]]; then
+  log_warning "$(command -v "$BINARY") is shadowing ${TARGET} on your PATH."
+else
+  "$TARGET" --version 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary

Add `tools/install-rc`, a shell helper that downloads and installs the latest aicr release-candidate binary for the current OS/architecture into `/usr/local/bin` (or a user-supplied directory).

## Motivation / Context

Testing RCs ahead of a stable cut currently means visiting the releases page, picking the right asset for your platform, copy/pasting checksums, and (on macOS) manually stripping Gatekeeper's quarantine attribute. A scripted path makes RC validation a one-liner and removes the failure modes around mismatched architectures or skipped checksum verification.

Fixes: N/A
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `tools/` (developer/maintainer tooling — no runtime impact)

## Implementation Notes

- **RC resolution:** prefers `gh release list` (authenticated, higher rate limits) and falls back to the public GitHub REST API. Picks the newest release whose tag matches `v*-rc[0-9]+`.
- **Checksum verification:** downloads `aicr_checksums.txt` alongside the archive and verifies SHA-256 before installation. Fails closed on mismatch.
- **OS / arch detection:** maps `uname -s` / `uname -m` to the `darwin|linux` × `amd64|arm64` matrix that goreleaser actually publishes; rejects anything else with a clear error.
- **macOS Gatekeeper:** strips `com.apple.quarantine` only when the attribute is present (`xattr -p ...` probe), so it's a no-op on Linux and on already-clean macOS binaries.
- **Permissions:** uses `sudo` only when the target directory is not user-writable (or needs to be created). Custom dirs like `~/bin` install without a prompt.
- **Footguns surfaced, not hidden:** warns if the install location is shadowed by another `aicr` earlier on `PATH`, or if the install location isn't on `PATH` at all.
- Sourced `tools/common` for the standard logging/`has_tools` helpers, matching the conventions of `tools/bump`, `tools/changelog`, etc.

## Testing

```bash
# Latest RC resolution + checksum-verified install into a temp dir
TEST_DIR=$(mktemp -d) && ./tools/install-rc --dir "$TEST_DIR"

# Explicit tag pinning
./tools/install-rc --tag v0.13.0-rc3 --dir /tmp/aicr-test

# Lint
shellcheck tools/install-rc   # only SC1091 (info) on `. common`, same as siblings
```

Both runs resolved the tag, downloaded the archive + checksum file, verified SHA-256, extracted, and installed a working binary. End-to-end output excerpt:

```
ℹ️  Tag:        v0.13.0-rc3
ℹ️  Platform:   darwin/arm64
ℹ️  Asset:      aicr_0.13.0-rc3_darwin_arm64.tar.gz
✅ Checksum OK
✅ Installed aicr v0.13.0-rc3 to /tmp/.../aicr
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No runtime impact on aicr itself; this is a developer helper sitting next to existing `tools/*` scripts. Removable with a single-file revert.

## Checklist

- [x] Tests pass locally (manual end-to-end run; no Go code changed)
- [x] Linter passes (`shellcheck` clean modulo the standard SC1091 info on sourced `common`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (shell helper; covered by manual e2e)
- [ ] I updated docs if user-facing behavior changed — N/A (internal tooling; `--help` is self-documenting)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)