### PR TITLE
ci(uat-gcp): add skip_delete and skip_tests workflow inputs

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -15,7 +15,16 @@
 name: UAT - GCP
 
 on:
-  workflow_dispatch: {}  # allow manual runs for testing
+  workflow_dispatch:
+    inputs:
+      skip_delete:
+        description: 'Skip cluster teardown (manual runs only; schedule always deletes)'
+        type: boolean
+        default: false
+      skip_tests:
+        description: 'Skip UAT test execution (manual runs only; schedule always tests)'
+        type: boolean
+        default: false
   schedule:
     - cron: '0 4 * * *' # daily at midnight PST, runs on default branch only
 
@@ -40,9 +49,6 @@ jobs:
       GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:latest"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
-
-      # Debug
-      SKIP_DELETE: "false"  # skip cluster deletion
 
     steps:
       # Checkout
@@ -148,7 +154,7 @@ jobs:
       # Test (capped to guarantee teardown headroom within the 90m job timeout)
       - name: Run UAT Tests
         id: tests
-        if: steps.client.outcome == 'success'
+        if: steps.client.outcome == 'success' && inputs.skip_tests != true
         timeout-minutes: 30
         shell: bash
         env:
@@ -161,7 +167,7 @@ jobs:
 
       # Teardown (retry up to 3 times)
       - name: Destroy Cluster
-        if: always() && steps.infra.outcome != 'skipped' && env.SKIP_DELETE != 'true'
+        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
         shell: bash
         run: |
           set -euxo pipefail


### PR DESCRIPTION
## Summary

Promote `SKIP_DELETE` from a hardcoded env var to a `workflow_dispatch` input, and add a matching `skip_tests` input so manual runs can bypass the "Run UAT Tests" step the same way they bypass "Destroy Cluster". Schedule runs are unaffected — both inputs default to `false` and are `null` on cron, so the `\!= true` guards always fall through.

## Motivation / Context

Today `SKIP_DELETE` lives in `env:` and can only be flipped by editing the workflow file. There's no equivalent escape hatch for the test step. Making both first-class `workflow_dispatch` inputs lets a maintainer invoke:

```bash
gh workflow run uat-gcp.yaml -f skip_delete=true -f skip_tests=true
```

…to (for example) bring up a GKE cluster and leave it running for ad-hoc debugging without modifying tracked files.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/uat-gcp.yaml`

## Implementation Notes

- `inputs.*` is `null` on `schedule` events, so `inputs.skip_delete \!= true` evaluates true on cron — defaults preserve the existing schedule behavior (always delete, always test) without an explicit branch.
- Preferred `if:`-gating over `continue-on-error: true` so the Test Summary table (`steps.tests.outcome`) honestly reports "skipped" instead of mislabeling a skipped run as success.
- Removed the now-dead `SKIP_DELETE` env var entirely — no external consumers grep for it.

## Testing

```bash
make lint        # golangci-lint: 0 issues; yamllint clean
actionlint .github/workflows/uat-gcp.yaml  # no errors on the modified expressions
make check-agents-sync  # OK
```

Pre-existing shellcheck info findings on lines 128/172/220 are unrelated to this change.

## Risk Assessment

- [x] **Low** — Isolated workflow change, schedule path defaults are identity-preserving, easy to revert.

**Rollout notes:** None. Next scheduled run will pick up the inputs with default values matching prior behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — N/A (internal CI workflow)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)