### PR TITLE
chore(settings): drop unused docs_tools (hugo, node)

### DIFF
--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -85,12 +85,6 @@ outputs:
   yq:
     description: 'yq version'
     value: ${{ steps.versions.outputs.yq }}
-  hugo:
-    description: 'Hugo version'
-    value: ${{ steps.versions.outputs.hugo }}
-  node:
-    description: 'Node.js major version'
-    value: ${{ steps.versions.outputs.node }}
   coverage_threshold:
     description: 'Minimum test coverage percentage'
     value: ${{ steps.versions.outputs.coverage_threshold }}
@@ -155,10 +149,6 @@ runs:
         echo "chainsaw_sha256_linux_arm64=$(yq eval '.testing_tools.chainsaw_checksums.linux_arm64' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "yq=$(yq eval '.testing_tools.yq' .settings.yaml)" >> $GITHUB_OUTPUT
 
-        # Documentation tools
-        echo "hugo=$(yq eval '.docs_tools.hugo' .settings.yaml)" >> $GITHUB_OUTPUT
-        echo "node=$(yq eval '.docs_tools.node' .settings.yaml)" >> $GITHUB_OUTPUT
-
         # Quality thresholds
         echo "coverage_threshold=$(yq eval '.quality.coverage_threshold' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "lint_timeout=$(yq eval '.quality.lint_timeout' .settings.yaml)" >> $GITHUB_OUTPUT
@@ -198,8 +188,6 @@ runs:
         echo "  chainsaw_sha256_linux_amd64: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}"
         echo "  chainsaw_sha256_linux_arm64: ${{ steps.versions.outputs.chainsaw_sha256_linux_arm64 }}"
         echo "  yq: ${{ steps.versions.outputs.yq }}"
-        echo "  hugo: ${{ steps.versions.outputs.hugo }}"
-        echo "  node: ${{ steps.versions.outputs.node }}"
         echo "  coverage_threshold: ${{ steps.versions.outputs.coverage_threshold }}"
         echo "  lint_timeout: ${{ steps.versions.outputs.lint_timeout }}"
         echo "  test_timeout: ${{ steps.versions.outputs.test_timeout }}"

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -96,13 +96,6 @@ quality:
 build:
   image_registry: 'ghcr.io/nvidia'
 
-# Documentation Tools
-docs_tools:
-  # renovate: datasource=github-releases depName=gohugoio/hugo depType=docs_tools
-  hugo: '0.155.3'
-  # renovate: datasource=node-version depName=node depType=docs_tools
-  node: '22'
-
 # Testing Configuration
 testing:
   # renovate: datasource=docker depName=kindest/node depType=testing


### PR DESCRIPTION
## Summary

Removes the unused `docs_tools.hugo` and `docs_tools.node` pins from `.settings.yaml` and their plumbing in `.github/actions/load-versions/action.yml`.

## Motivation / Context

Renovate keeps opening PRs to bump these pins (#907 Hugo, #908 Node 24), but both settings are dead:

- **Node:** `outputs.node` is exposed by `load-versions` but no workflow consumes it. The three Fern docs workflows (`fern-docs-ci.yaml`, `publish-fern-docs.yml`, `fern-docs-preview-comment.yml`) hardcode `node-version: '20'` directly.
- **Hugo:** No `hugo.toml`/`config.toml`, no Makefile target, no workflow consumes `outputs.hugo`. Docs are pure markdown rendered by Fern.

Closing the renovate PRs without removing the pins will just regenerate them.

Fixes: N/A
Related: #907, #908

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.settings.yaml`, `.github/actions/load-versions`

## Implementation Notes

Left the Fern workflows' inline `node-version: '20'` pins as-is — they already work and are independent of `.settings.yaml`.

## Testing

No functional code paths exercise these settings (verified via `grep -rn "outputs\.hugo\|outputs\.node"` across `.github/`). `make qualify` is not meaningful for this change: `.settings.yaml` is only read by `load-versions/action.yml` (also edited here), and CI workflow YAML is not executed by qualify.

## Risk Assessment

- [x] **Low** — Removes only unused outputs; no workflow references `outputs.hugo` or `outputs.node`. Easy to revert.

**Rollout notes:** N/A — no behavior change. After merge, close renovate PRs #907 and #908.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)