### PR TITLE
ci(uat-gcp): gate build/push/cleanup steps on skip_tests

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -71,6 +71,7 @@ jobs:
             vendor/modules.txt
 
       - name: Build aicr binary
+        if: inputs.skip_tests != true
         env:
           GOFLAGS: -mod=vendor
         run: |
@@ -81,6 +82,7 @@ jobs:
         uses: ./.github/actions/ghcr-login
 
       - name: Build and push validator images
+        if: inputs.skip_tests != true
         run: |
           GO_VERSION="$(cat .go-version)"
           for phase in deployment performance conformance; do
@@ -189,7 +191,7 @@ jobs:
 
       # Cleanup
       - name: Cleanup validator image
-        if: always()
+        if: always() && inputs.skip_tests != true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Lychee link checker configuration.
 # exclude_path patterns are matched against full file paths (including absolute paths in CI).
 # Use (^|/) prefix to match directory names anywhere in the path.


### PR DESCRIPTION
## Summary

Gates three UAT-only steps in `uat-gcp.yaml` on `inputs.skip_tests \!= true`, and adds the Apache-2.0 license header to `.lychee.toml`.

## Motivation / Context

`skip_tests=true` was added in #909 to support smoke-running the cluster bringup/teardown without exercising chainsaw, but the build and cleanup steps that exist *only* to support the test run still execute. That wastes ~minutes per dispatch and pushes validator image tags that then get deleted on the same run.

Steps now gated:
- Build aicr binary
- Build and push validator images
- Cleanup validator image (still wrapped in `always()` so it runs after a test failure when tests *did* run)

`Upload Test Artifacts` was already correctly guarded by `steps.tests.outcome \!= 'skipped'`, so no change there.

`.lychee.toml` license header is an unrelated drift the addlicense check flagged — bundling here to keep main clean.

Fixes: N/A
Related: #909

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/uat-gcp.yaml`, `.lychee.toml`

## Implementation Notes

Cleanup step keeps `always()` to ensure GHCR cleanup runs even when chainsaw fails. The added `&& inputs.skip_tests \!= true` short-circuits the cleanup only when nothing was pushed.

## Testing

Static change to workflow control flow only. Will validate on next dispatch with `skip_tests=true` that the three guarded steps report `skipped` and the job still completes the bringup/teardown.

## Risk Assessment

- [x] **Low** — Conditional `if:` additions on three steps; default path (scheduled run / manual run without `skip_tests`) is unchanged.

**Rollout notes:** N/A

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)