### PR TITLE
ci(chainsaw): make .settings.yaml the single source of truth

### DIFF
--- a/.github/actions/chainsaw/action.yml
+++ b/.github/actions/chainsaw/action.yml
@@ -20,12 +20,11 @@ inputs:
     description: 'Go version to install (e.g., 1.25)'
     required: true
   chainsaw_version:
-    description: 'Chainsaw version to install (e.g., v0.2.14)'
+    description: 'Chainsaw version (from .settings.yaml via load-versions)'
     required: true
   chainsaw_sha256:
-    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml)'
-    required: false
-    default: 'f2f4a3f9a541d65db12f5c910950758f7d56fae20ad5b1272cdc271c9568443e'
+    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml via load-versions)'
+    required: true
 
 runs:
   using: 'composite'

--- a/.github/actions/cli-e2e/action.yml
+++ b/.github/actions/cli-e2e/action.yml
@@ -23,12 +23,11 @@ inputs:
     description: 'GoReleaser version (e.g., v2.15.3)'
     required: true
   chainsaw_version:
-    description: 'Chainsaw version (e.g., v0.2.14)'
+    description: 'Chainsaw version (from .settings.yaml via load-versions)'
     required: true
   chainsaw_sha256:
-    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml)'
-    required: false
-    default: 'f2f4a3f9a541d65db12f5c910950758f7d56fae20ad5b1272cdc271c9568443e'
+    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml via load-versions)'
+    required: true
   helmfile_version:
     description: 'Helmfile version (e.g., v1.5.1) — required by tests/chainsaw/cli/bundle-helmfile'
     required: true

--- a/.github/actions/integration/action.yml
+++ b/.github/actions/integration/action.yml
@@ -27,13 +27,11 @@ inputs:
     required: false
     default: 'v4.1.1'
   chainsaw_version:
-    description: 'Chainsaw version to install (e.g., v0.2.14)'
-    required: false
-    default: 'v0.2.14'
+    description: 'Chainsaw version (from .settings.yaml via load-versions)'
+    required: true
   chainsaw_sha256:
-    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml)'
-    required: false
-    default: 'f2f4a3f9a541d65db12f5c910950758f7d56fae20ad5b1272cdc271c9568443e'
+    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml via load-versions)'
+    required: true
 
 runs:
   using: 'composite'

--- a/.github/actions/setup-build-tools/action.yml
+++ b/.github/actions/setup-build-tools/action.yml
@@ -49,13 +49,13 @@ inputs:
     required: false
     default: 'false'
   chainsaw_version:
-    description: 'Chainsaw version (e.g. v0.2.14)'
+    description: 'Chainsaw version (from .settings.yaml via load-versions; required when install_chainsaw=true)'
     required: false
-    default: 'v0.2.14'
+    default: ''
   chainsaw_sha256:
-    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml)'
+    description: 'Chainsaw SHA256 checksum for linux/amd64 (from .settings.yaml via load-versions; required when install_chainsaw=true)'
     required: false
-    default: 'f2f4a3f9a541d65db12f5c910950758f7d56fae20ad5b1272cdc271c9568443e'
+    default: ''
   install_helm:
     description: 'Install helm (true/false)'
     required: false
@@ -186,10 +186,14 @@ runs:
         set -euo pipefail
         if [[ -x /usr/local/bin/chainsaw ]]; then echo "chainsaw already installed"; chainsaw version; exit 0; fi
         VERSION="${{ inputs.chainsaw_version }}"
+        EXPECTED="${{ inputs.chainsaw_sha256 }}"
+        if [[ -z "${VERSION}" || -z "${EXPECTED}" ]]; then
+          echo "::error::install_chainsaw=true requires chainsaw_version and chainsaw_sha256 (pass from load-versions outputs to keep .settings.yaml as the single source of truth)"
+          exit 1
+        fi
         VERSION="${VERSION#v}"
         TAR="chainsaw_linux_amd64.tar.gz"
         URL="https://github.com/kyverno/chainsaw/releases/download/v${VERSION}/${TAR}"
-        EXPECTED="${{ inputs.chainsaw_sha256 }}"
         TMP="$(mktemp -d)"
         curl -fsSL -o "${TMP}/${TAR}" "${URL}"
         ACTUAL=$(sha256sum "${TMP}/${TAR}" | awk '{print $1}')

--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -125,6 +125,7 @@ jobs:
           yq_version: '${{ steps.versions.outputs.yq }}'
           install_chainsaw: 'true'
           chainsaw_version: '${{ steps.versions.outputs.chainsaw }}'
+          chainsaw_sha256: '${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}'
 
       # Config
       - name: Update Config

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -115,6 +115,7 @@ jobs:
           yq_version: '${{ steps.versions.outputs.yq }}'
           install_chainsaw: 'true'
           chainsaw_version: '${{ steps.versions.outputs.chainsaw }}'
+          chainsaw_sha256: '${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}'
 
       # Config
       - name: Update Config


### PR DESCRIPTION
## Summary

Removes stale hardcoded `chainsaw_version` and `chainsaw_sha256` defaults from 4 composite actions, makes them required, and updates the 2 workflow callers that relied on the drifted default.

## Motivation / Context

UAT-GCP run [25909694038](https://github.com/NVIDIA/aicr/actions/runs/25909694038/job/76151400131) failed with:

```
chainsaw checksum mismatch:
  expected f2f4a3f9a541d65db12f5c910950758f7d56fae20ad5b1272cdc271c9568443e
  got      295d226c89f126c0a97775d364be149f47a810c8a3f9829ee410583d0c1abe3c
```

Root cause:

- `.settings.yaml` correctly pins chainsaw `v0.2.15` with sha `295d226c...` (matches the artifact GitHub serves today).
- Composite actions `setup-build-tools`, `chainsaw`, `cli-e2e`, and `integration` each shipped a hardcoded default `chainsaw_sha256: f2f4a3f9...` (and `chainsaw_version: v0.2.14`) — frozen at some prior version.
- `qualification.yaml` and `gpu-h100-kind-runtime-test.yaml` correctly pass `chainsaw_sha256` from `load-versions` outputs, so they stayed in sync.
- `uat-aws.yaml` and `uat-gcp.yaml` install chainsaw without passing `chainsaw_sha256`, so they silently fell back to the stale default — and started failing once the upstream artifact diverged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: composite actions (`setup-build-tools`, `chainsaw`, `cli-e2e`, `integration`), workflows (`uat-aws`, `uat-gcp`)

## Implementation Notes

- `setup-build-tools`: `chainsaw_version` and `chainsaw_sha256` defaults set to empty; install step fails fast with a pointer back to `load-versions` if either is missing when `install_chainsaw=true`. Kept `required: false` because these inputs are only meaningful when `install_chainsaw=true`, and most callers of `setup-build-tools` don't install chainsaw.
- `chainsaw`, `cli-e2e`, `integration`: both inputs marked `required: true` and the stale defaults removed. These actions always install chainsaw, so the contract is simpler.
- `uat-aws.yaml` and `uat-gcp.yaml`: now pass `chainsaw_sha256: '${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}'`, matching the pattern in `qualification.yaml:111` and `gpu-h100-kind-runtime-test.yaml:124`.

**Out of scope (follow-up candidates):** `setup-build-tools` still ships stale defaults for `kubectl_version`, `yq_version`, `helm_version`, `helmfile_version`, `kind_version`, `ko_version`, `crane_version`, `goreleaser_version`. Same drift risk; not biting today because every caller passes from `load-versions`. Worth a separate sweep.

## Testing

Static workflow change. Verified:
- `yamllint` clean on all 6 edited files.
- No remaining references to the stale `f2f4a3f9...` hash or `v0.2.14` default anywhere under `.github/`.
- Fail-fast check in `setup-build-tools` triggers only on `install_chainsaw=true` with missing inputs — preserves existing behavior for callers that don't install chainsaw.

The fix will be validated on the next UAT-GCP / UAT-AWS dispatch.

## Risk Assessment

- [x] **Low** — Tightens an existing contract that every chainsaw-installing caller in-repo already honored except the two now updated.

**Rollout notes:** N/A. Any external workflow that called these composite actions and relied on the hardcoded chainsaw default (unlikely — repo-internal use only) would now fail fast with a clear pointer to the fix.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase (`cli-e2e.helmfile_sha256` already used `required: true`)
- [x] Commits are cryptographically signed (`git commit -S`)