### PR TITLE
feat(cli): add --config support to snapshot command

### DIFF
--- a/demos/cuj1-gke-config.md
+++ b/demos/cuj1-gke-config.md
@@ -6,11 +6,6 @@ file via `--config` for `recipe`, `bundle`, and `validate`, and finished with
 for the standalone evidence walkthrough). Reproducible inputs in, signed
 recipe-evidence bundle out.
 
-> Note: This demo duplicates a lot of the validation demo from demos/evidence.md. 
->       The will be to generalize the cluster validation and evidence collection 
->       into standalone demo that will work across all services, although whether 
->       that's possible remains to be seen. 
-
 ## Assumptions
 
 * Target cluster is the UAT GKE cluster provisioned by
@@ -54,6 +49,17 @@ apiVersion: aicr.nvidia.com/v1alpha1
 metadata:
   name: gke-h100-training
 spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - dedicated=gpu-workload:NoSchedule
+        - nvidia.com/gpu=present:NoSchedule
+
   recipe:
     criteria:
       service: gke
@@ -106,16 +112,13 @@ EOF
 
 ## Snapshot
 
-`snapshot` does not read `--config` yet. Capture it manually:
-
 ```shell
-aicr snapshot \
-    --namespace aicr-validation \
-    --node-selector nodeGroup=gpu-worker \
-    --toleration dedicated=gpu-workload:NoSchedule \
-    --toleration nvidia.com/gpu=present:NoSchedule \
-    --output snapshot.yaml
+aicr snapshot --config aicr-config.yaml
 ```
+
+Reads `spec.snapshot.*` from the config — agent namespace, GPU-node
+selector, GPU-taint tolerations, and the `snapshot.yaml` output path are
+all pinned there.
 
 ## Gen Recipe
 

--- a/demos/cuj1-gke-config.md
+++ b/demos/cuj1-gke-config.md
@@ -18,14 +18,6 @@ recipe-evidence bundle out.
 
   > Make sure to cleanup after yourself
 
-  Then connect locally:
-
-  ```shell
-  gcloud container clusters get-credentials "aicr-<run-id>" \
-    --region us-central1 --project eidosx
-  kubectl get nodes
-  ```
-
   The cluster has 2× `a3-megagpu-8g` (H100, 8 GPUs/node) GPU nodes labeled
   `nodeGroup=gpu-worker` with taint `dedicated=gpu-workload:NoSchedule`, and
   system nodes labeled `nodeGroup=system-worker` (no custom taints — GKE

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -76,6 +76,7 @@ aicr snapshot [flags]
 |------|-------|------|---------|-------------|
 | `--output` | `-o` | string | stdout | Output destination: file path, ConfigMap URI (cm://namespace/name), or stdout |
 | `--format` | | string | yaml | Output format: json, yaml, table |
+| `--config` | | string | | Path or HTTP/HTTPS URL to an AICRConfig file (YAML/JSON) that populates `spec.snapshot.*`. CLI flags below always win over the corresponding config field. |
 | `--kubeconfig` | `-k` | string | ~/.kube/config | Path to kubeconfig file (overrides KUBECONFIG env) |
 | `--namespace` | `-n` | string | default | Kubernetes namespace for agent deployment |
 | `--image` | | string | ghcr.io/nvidia/aicr:latest | Container image for agent Job |
@@ -163,6 +164,54 @@ aicr snapshot \
   --namespace gpu-operator \
   --template examples/templates/snapshot-template.md.tmpl \
   --output cluster-report.yaml
+```
+
+#### Snapshot Config File Mode
+
+Drive `aicr snapshot` from an `AICRConfig` document so the snapshot inputs version-control alongside the recipe, bundle, and validate steps in an end-to-end workflow.
+
+```yaml
+kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gke-h100-training
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml          # written to disk; same shape as -o
+      format: yaml                 # yaml | json | table
+      template: ""                 # optional Go template path
+    agent:
+      namespace: aicr-validation
+      image: ""                    # default: ghcr.io/nvidia/aicr:latest
+      imagePullSecrets: []
+      jobName: aicr
+      serviceAccountName: aicr
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - dedicated=gpu-workload:NoSchedule
+        - nvidia.com/gpu=present:NoSchedule
+      requireGpu: false
+      runtimeClassName: ""         # mutually exclusive with requireGpu
+      os: ""                       # ubuntu | rhel | cos | amazonlinux | talos
+      requests: ""                 # "cpu=500m,memory=1Gi"
+      limits: ""                   # "cpu=1,memory=2Gi"
+    execution:
+      timeout: 5m
+      noCleanup: false
+      privileged: true             # set false for PSS-restricted namespaces
+      maxNodesPerEntry: 0          # 0 = unlimited topology entries
+```
+
+Precedence: a CLI flag always wins over the matching config field. Selectors and tolerations omitted entirely inherit the snapshotter's compiled-in defaults (`tolerations` defaults to *tolerate all taints*); an explicit empty list (`tolerations: []`) clears the tolerate-all default — the same nil-vs-empty semantics used by `spec.validate.agent`.
+
+```shell
+# Run snapshot driven entirely by config
+aicr snapshot --config aicr-config.yaml
+
+# Reuse the same config but write to a one-off path
+aicr snapshot --config aicr-config.yaml -o /tmp/snapshot.yaml
 ```
 
 #### Custom Templates

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -18,16 +18,215 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/urfave/cli/v3"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/NVIDIA/aicr/pkg/collector"
+	"github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
+
+// resolveSnapshotNodeSelector resolves the snapshot node selector with
+// CLI-overrides-config precedence. The CLI flag is a repeated string in
+// key=value form; the config value is already a typed map. Either source
+// can be empty; the result preserves the same nil-vs-empty semantics.
+func resolveSnapshotNodeSelector(cmd *cli.Command, resolved *config.SnapshotResolved) (map[string]string, error) {
+	if cmd.IsSet("node-selector") {
+		ns, err := snapshotter.ParseNodeSelectors(cmd.StringSlice("node-selector"))
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid node-selector", err)
+		}
+		if resolved.NodeSelector != nil {
+			slog.Info("CLI flag overriding config value", "flag", "node-selector",
+				"config", resolved.NodeSelector, "override", ns)
+		}
+		return ns, nil
+	}
+	return resolved.NodeSelector, nil
+}
+
+// resolveSnapshotTolerations resolves the snapshot toleration list with
+// CLI-overrides-config precedence.
+//
+// Behavior preserves the pre-config semantics of `aicr snapshot`:
+//   - CLI flag set: parse the CLI value (empty input → DefaultTolerations).
+//   - CLI unset, config set: use the config value (a non-nil empty slice
+//     in config means "operator opted out of the tolerate-all default").
+//   - CLI unset, config unset: fall through to DefaultTolerations()
+//     (the legacy snapshot behavior — without it, an aicr snapshot
+//     invocation that does not pass --toleration would suddenly stop
+//     tolerating tainted nodes).
+func resolveSnapshotTolerations(cmd *cli.Command, resolved *config.SnapshotResolved) ([]corev1.Toleration, error) {
+	if cmd.IsSet("toleration") {
+		tols, err := snapshotter.ParseTolerations(cmd.StringSlice("toleration"))
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid toleration", err)
+		}
+		if resolved.Tolerations != nil {
+			slog.Info("CLI flag overriding config value", "flag", "toleration",
+				"config", resolved.Tolerations, "override", tols)
+		}
+		return tols, nil
+	}
+	if resolved.Tolerations != nil {
+		return resolved.Tolerations, nil
+	}
+	return snapshotter.DefaultTolerations(), nil
+}
+
+// snapshotCmdOptions holds every option resolved by parseSnapshotCmdOptions,
+// in the form used by both the Action's deploy path and tests that want to
+// assert on the merged CLI-overrides-config result. Resource lists and
+// tolerations are typed so callers do not re-parse them.
+type snapshotCmdOptions struct {
+	kubeconfig         string
+	namespace          string
+	image              string
+	imagePullSecrets   []string
+	jobName            string
+	serviceAccountName string
+	nodeSelector       map[string]string
+	tolerations        []corev1.Toleration
+	timeout            time.Duration
+	cleanup            bool
+	debug              bool
+	privileged         bool
+	requireGPU         bool
+	runtimeClass       string
+	os                 string
+	maxNodesPerEntry   int
+	requests           corev1.ResourceList
+	limits             corev1.ResourceList
+	tmplOpts           *snapshotTemplateOptions
+}
+
+// toAgentConfig converts the resolved options into the snapshotter.AgentConfig
+// the snapshotter deploy path expects.
+func (o *snapshotCmdOptions) toAgentConfig() *snapshotter.AgentConfig {
+	return &snapshotter.AgentConfig{
+		Kubeconfig:         o.kubeconfig,
+		Namespace:          o.namespace,
+		Image:              o.image,
+		ImagePullSecrets:   o.imagePullSecrets,
+		JobName:            o.jobName,
+		ServiceAccountName: o.serviceAccountName,
+		NodeSelector:       o.nodeSelector,
+		Tolerations:        o.tolerations,
+		Timeout:            o.timeout,
+		Cleanup:            o.cleanup,
+		Output:             o.tmplOpts.outputPath,
+		Debug:              o.debug,
+		Privileged:         o.privileged,
+		RequireGPU:         o.requireGPU,
+		RuntimeClassName:   o.runtimeClass,
+		TemplatePath:       o.tmplOpts.templatePath,
+		MaxNodesPerEntry:   o.maxNodesPerEntry,
+		OS:                 o.os,
+		Requests:           o.requests,
+		Limits:             o.limits,
+	}
+}
+
+// parseSnapshotCmdOptions resolves snapshot command inputs by merging CLI
+// flags with the optional --config (AICRConfig) source. CLI flags always win
+// over config values. Returns a fully-typed snapshotCmdOptions that callers
+// can pass to the snapshotter without further parsing.
+func parseSnapshotCmdOptions(cmd *cli.Command, cfg *config.AICRConfig) (*snapshotCmdOptions, error) {
+	if err := validateSingleValueFlags(cmd, "namespace", "image", "job-name", "service-account-name", "timeout", "template", "max-nodes-per-entry", "runtime-class", "output", "format", "config", "os", "requests", "limits"); err != nil {
+		return nil, err
+	}
+
+	resolved, err := cfg.Snapshot().Resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	// Normalize/validate the --os value via the recipe parser so that
+	// only documented OS criteria values reach the agent and the
+	// in-pod collector factory.
+	osVal := stringFlagOrConfig(cmd, "os", resolved.OS)
+	if osVal != "" {
+		parsedOS, parseErr := recipe.ParseCriteriaOSType(osVal)
+		if parseErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --os value", parseErr)
+		}
+		osVal = string(parsedOS)
+	}
+
+	requireGPU := boolFlagOrConfig(cmd, "require-gpu", resolved.RequireGPU)
+	runtimeClass := stringFlagOrConfig(cmd, "runtime-class", resolved.RuntimeClassName)
+
+	// Mutual exclusion: --require-gpu and --runtime-class cannot be used together
+	if requireGPU && runtimeClass != "" {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"--require-gpu and --runtime-class are mutually exclusive; "+
+				"prefer --runtime-class, which provides nvidia-smi access via the container runtime without consuming a GPU allocation")
+	}
+
+	// Parse output format. The config-provided format only kicks in
+	// when the CLI flag is not explicitly set; otherwise the CLI
+	// value wins. Validation of unknown formats happens here.
+	if !cmd.IsSet("format") && resolved.OutputFormat != "" {
+		if setErr := cmd.Set("format", resolved.OutputFormat); setErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid spec.snapshot.output.format", setErr)
+		}
+	}
+	outFormat, err := parseOutputFormat(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	tmplOpts, err := parseSnapshotTemplateOptions(cmd, outFormat, resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeSelector, err := resolveSnapshotNodeSelector(cmd, resolved)
+	if err != nil {
+		return nil, err
+	}
+	tolerations, err := resolveSnapshotTolerations(cmd, resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceRequests, err := snapshotter.ParseResourceList(stringFlagOrConfig(cmd, "requests", resolved.Requests))
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "invalid --requests")
+	}
+	resourceLimits, err := snapshotter.ParseResourceList(stringFlagOrConfig(cmd, "limits", resolved.Limits))
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "invalid --limits")
+	}
+
+	return &snapshotCmdOptions{
+		kubeconfig:         cmd.String("kubeconfig"),
+		namespace:          stringFlagOrConfig(cmd, "namespace", resolved.Namespace),
+		image:              stringFlagOrConfig(cmd, "image", resolved.Image),
+		imagePullSecrets:   stringSliceFlagOrConfig(cmd, "image-pull-secret", resolved.ImagePullSecrets),
+		jobName:            stringFlagOrConfig(cmd, "job-name", resolved.JobName),
+		serviceAccountName: stringFlagOrConfig(cmd, "service-account-name", resolved.ServiceAccountName),
+		nodeSelector:       nodeSelector,
+		tolerations:        tolerations,
+		timeout:            durationFlagOrConfig(cmd, "timeout", resolved.Timeout),
+		cleanup:            !boolFlagOrConfig(cmd, "no-cleanup", resolved.NoCleanup),
+		debug:              cmd.Bool("debug"),
+		privileged:         boolFlagOrConfig(cmd, "privileged", derefBoolOr(resolved.Privileged, true)),
+		requireGPU:         requireGPU,
+		runtimeClass:       runtimeClass,
+		os:                 osVal,
+		maxNodesPerEntry:   intFlagOrConfig(cmd, "max-nodes-per-entry", resolved.MaxNodesPerEntry),
+		requests:           resourceRequests,
+		limits:             resourceLimits,
+		tmplOpts:           tmplOpts,
+	}, nil
+}
 
 // snapshotTemplateOptions holds parsed template options for the snapshot command.
 type snapshotTemplateOptions struct {
@@ -36,9 +235,9 @@ type snapshotTemplateOptions struct {
 	format       serializer.Format
 }
 
-func parseSnapshotTemplateOptions(cmd *cli.Command, outFormat serializer.Format) (*snapshotTemplateOptions, error) {
-	templatePath := cmd.String("template")
-	outputPath := cmd.String("output")
+func parseSnapshotTemplateOptions(cmd *cli.Command, outFormat serializer.Format, resolved *config.SnapshotResolved) (*snapshotTemplateOptions, error) {
+	templatePath := stringFlagOrConfig(cmd, "template", resolved.OutputTemplate)
+	outputPath := stringFlagOrConfig(cmd, "output", resolved.OutputPath)
 
 	if templatePath != "" {
 		// Validate format is YAML when using template
@@ -175,6 +374,7 @@ func snapshotCmdFlags() []cli.Flag {
 		},
 		outputFlag(),
 		formatFlag(),
+		configFlag(),
 		kubeconfigFlag(),
 	}
 }
@@ -250,50 +450,23 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 `,
 		Flags: snapshotCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			// Validate single-value flags are not duplicated
-			if err := validateSingleValueFlags(cmd, "namespace", "image", "job-name", "service-account-name", "timeout", "template", "max-nodes-per-entry", "runtime-class", "output", "format", "os", "requests", "limits"); err != nil {
-				return err
-			}
-
-			// Normalize/validate the --os value via the recipe parser so that
-			// only documented OS criteria values reach the agent and the
-			// in-pod collector factory.
-			osVal := cmd.String("os")
-			if osVal != "" {
-				parsedOS, err := recipe.ParseCriteriaOSType(osVal)
-				if err != nil {
-					return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid --os value", err)
-				}
-				osVal = string(parsedOS)
-			}
-
-			// Mutual exclusion: --require-gpu and --runtime-class cannot be used together
-			if cmd.Bool("require-gpu") && cmd.String("runtime-class") != "" {
-				return errors.New(errors.ErrCodeInvalidRequest,
-					"--require-gpu and --runtime-class are mutually exclusive; "+
-						"prefer --runtime-class, which provides nvidia-smi access via the container runtime without consuming a GPU allocation")
-			}
-
-			// Parse output format
-			outFormat, err := parseOutputFormat(cmd)
+			cfg, err := loadCmdConfig(ctx, cmd)
 			if err != nil {
 				return err
 			}
-
-			// Parse and validate template options
-			tmplOpts, err := parseSnapshotTemplateOptions(cmd, outFormat)
+			opts, err := parseSnapshotCmdOptions(cmd, cfg)
 			if err != nil {
 				return err
 			}
 
 			// Create factory
 			factory := collector.NewDefaultFactory(
-				collector.WithMaxNodesPerEntry(cmd.Int("max-nodes-per-entry")),
-				collector.WithOS(osVal),
+				collector.WithMaxNodesPerEntry(opts.maxNodesPerEntry),
+				collector.WithOS(opts.os),
 			)
 
 			// Create output serializer
-			ser, err := createSnapshotSerializer(tmplOpts)
+			ser, err := createSnapshotSerializer(opts.tmplOpts)
 			if err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to create output serializer", err)
 			}
@@ -310,30 +483,7 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				Version:    version,
 				Factory:    factory,
 				Serializer: ser,
-				RequireGPU: cmd.Bool("require-gpu"),
-			}
-
-			// Parse node selectors
-			nodeSelector, err := snapshotter.ParseNodeSelectors(cmd.StringSlice("node-selector"))
-			if err != nil {
-				return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid node-selector", err)
-			}
-
-			// Parse tolerations
-			tolerations, err := snapshotter.ParseTolerations(cmd.StringSlice("toleration"))
-			if err != nil {
-				return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid toleration", err)
-			}
-
-			// Parse resource overrides (CLI takes the same comma-separated
-			// 'name=quantity' shape as kubectl run --requests / --limits).
-			resourceRequests, err := snapshotter.ParseResourceList(cmd.String("requests"))
-			if err != nil {
-				return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "invalid --requests")
-			}
-			resourceLimits, err := snapshotter.ParseResourceList(cmd.String("limits"))
-			if err != nil {
-				return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "invalid --limits")
+				RequireGPU: opts.requireGPU,
 			}
 
 			// When running inside an agent Job, collect locally instead of
@@ -345,30 +495,7 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				return ns.Measure(ctx)
 			}
 
-			// Configure agent deployment
-			ns.AgentConfig = &snapshotter.AgentConfig{
-				Kubeconfig:         cmd.String("kubeconfig"),
-				Namespace:          cmd.String("namespace"),
-				Image:              cmd.String("image"),
-				ImagePullSecrets:   cmd.StringSlice("image-pull-secret"),
-				JobName:            cmd.String("job-name"),
-				ServiceAccountName: cmd.String("service-account-name"),
-				NodeSelector:       nodeSelector,
-				Tolerations:        tolerations,
-				Timeout:            cmd.Duration("timeout"),
-				Cleanup:            !cmd.Bool("no-cleanup"),
-				Output:             tmplOpts.outputPath,
-				Debug:              cmd.Bool("debug"),
-				Privileged:         cmd.Bool("privileged"),
-				RequireGPU:         cmd.Bool("require-gpu"),
-				RuntimeClassName:   cmd.String("runtime-class"),
-				TemplatePath:       tmplOpts.templatePath,
-				MaxNodesPerEntry:   cmd.Int("max-nodes-per-entry"),
-				OS:                 osVal,
-				Requests:           resourceRequests,
-				Limits:             resourceLimits,
-			}
-
+			ns.AgentConfig = opts.toAgentConfig()
 			return ns.Measure(ctx)
 		},
 	}

--- a/pkg/cli/snapshot_config_test.go
+++ b/pkg/cli/snapshot_config_test.go
@@ -1,0 +1,643 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/urfave/cli/v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// === Regression: --config wiring on snapshot command ===
+
+// TestSnapshotCmd_HasConfigFlag asserts --config is wired on the snapshot
+// command. Regression guard for issue NVIDIA/aicr#913.
+func TestSnapshotCmd_HasConfigFlag(t *testing.T) {
+	cmd := snapshotCmd()
+	found := false
+	for _, f := range cmd.Flags {
+		for _, name := range f.Names() {
+			if name == "config" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("snapshot command must define --config flag")
+	}
+}
+
+// captureSnapshotOpts runs parseSnapshotCmdOptions through the snapshot CLI
+// command and returns the resolved options, so tests can assert on every
+// merged value without invoking the snapshotter deploy path.
+func captureSnapshotOpts(t *testing.T, args []string) *snapshotCmdOptions {
+	t.Helper()
+	var captured *snapshotCmdOptions
+	cmd := snapshotCmd()
+	cmd.Action = func(ctx context.Context, c *cli.Command) error {
+		cfg, err := loadCmdConfig(ctx, c)
+		if err != nil {
+			return err
+		}
+		opts, err := parseSnapshotCmdOptions(c, cfg)
+		if err != nil {
+			return err
+		}
+		captured = opts
+		return nil
+	}
+	if err := cmd.Run(context.Background(), append([]string{"snapshot"}, args...)); err != nil {
+		t.Fatalf("snapshot run: %v", err)
+	}
+	return captured
+}
+
+// runSnapshotCmdExpectErr runs the snapshot command and returns the error
+// produced by parseSnapshotCmdOptions. Used for negative-path tests.
+func runSnapshotCmdExpectErr(t *testing.T, args []string) error {
+	t.Helper()
+	cmd := snapshotCmd()
+	cmd.Action = func(ctx context.Context, c *cli.Command) error {
+		cfg, err := loadCmdConfig(ctx, c)
+		if err != nil {
+			return err
+		}
+		_, err = parseSnapshotCmdOptions(c, cfg)
+		return err
+	}
+	return cmd.Run(context.Background(), append([]string{"snapshot"}, args...))
+}
+
+// === Behavior preservation: flags-only path still works ===
+
+// TestSnapshotCmd_FlagsAloneStillWork ensures the pre-config flag pathway
+// continues to work after the --config refactor.
+func TestSnapshotCmd_FlagsAloneStillWork(t *testing.T) {
+	opts := captureSnapshotOpts(t, []string{
+		"--namespace", "aicr-validation",
+		"--node-selector", "nodeGroup=gpu-worker",
+		"--toleration", "dedicated=gpu-workload:NoSchedule",
+		"--timeout", "5m",
+		"--no-cleanup",
+		"-o", "snapshot.yaml",
+	})
+
+	if opts.namespace != "aicr-validation" {
+		t.Errorf("namespace = %q, want aicr-validation", opts.namespace)
+	}
+	if opts.nodeSelector["nodeGroup"] != "gpu-worker" {
+		t.Errorf("nodeSelector = %v, want nodeGroup=gpu-worker", opts.nodeSelector)
+	}
+	if len(opts.tolerations) != 1 || opts.tolerations[0].Key != "dedicated" {
+		t.Errorf("tolerations = %+v, want one entry keyed by dedicated", opts.tolerations)
+	}
+	if opts.timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want 5m", opts.timeout)
+	}
+	if opts.cleanup {
+		t.Errorf("cleanup = true, want false (--no-cleanup)")
+	}
+	if opts.tmplOpts.outputPath != "snapshot.yaml" {
+		t.Errorf("outputPath = %q, want snapshot.yaml", opts.tmplOpts.outputPath)
+	}
+}
+
+// TestSnapshotCmd_FlagsAloneDefaultsTolerateAll preserves the legacy
+// behavior of `aicr snapshot` (no --toleration, no --config) tolerating
+// every taint. A regression here would silently break snapshot capture
+// on every tainted-node cluster.
+func TestSnapshotCmd_FlagsAloneDefaultsTolerateAll(t *testing.T) {
+	opts := captureSnapshotOpts(t, []string{"-o", "-"})
+	if len(opts.tolerations) == 0 {
+		t.Fatal("expected default tolerate-all tolerations when neither CLI nor config set them")
+	}
+	// DefaultTolerations() is a single bare Exists entry. Don't pin to that
+	// exact shape — just verify it tolerates all taints.
+	if opts.tolerations[0].Operator != corev1.TolerationOpExists {
+		t.Errorf("default toleration operator = %v, want Exists", opts.tolerations[0].Operator)
+	}
+}
+
+// === Config-driven: every section resolves into options ===
+
+// TestSnapshotCmd_AllConfigSectionsResolve drives parseSnapshotCmdOptions
+// with a config exercising every section, then asserts each option lands
+// on the resolved snapshotCmdOptions. Regression backstop for schema drift.
+func TestSnapshotCmd_AllConfigSectionsResolve(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+      format: yaml
+    agent:
+      namespace: aicr-validation
+      image: ghcr.io/example/aicr:test
+      imagePullSecrets:
+        - secret-a
+        - secret-b
+      jobName: snap-job
+      serviceAccountName: snap-sa
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - dedicated=gpu-workload:NoSchedule
+        - nvidia.com/gpu=present:NoSchedule
+      requireGpu: true
+      os: ubuntu
+      requests: "cpu=500m,memory=1Gi"
+      limits: "cpu=1,memory=2Gi"
+    execution:
+      timeout: 7m
+      noCleanup: true
+      maxNodesPerEntry: 4
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	opts := captureSnapshotOpts(t, []string{"--config", cfgPath})
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"namespace", opts.namespace, "aicr-validation"},
+		{"image", opts.image, "ghcr.io/example/aicr:test"},
+		{"jobName", opts.jobName, "snap-job"},
+		{"serviceAccountName", opts.serviceAccountName, "snap-sa"},
+		{"requireGPU", opts.requireGPU, true},
+		{"os", opts.os, "ubuntu"},
+		{"timeout", opts.timeout, 7 * time.Minute},
+		{"cleanup", opts.cleanup, false},
+		{"maxNodesPerEntry", opts.maxNodesPerEntry, 4},
+		{"outputPath", opts.tmplOpts.outputPath, "snapshot.yaml"},
+		{"nodeSelector size", len(opts.nodeSelector), 1},
+		{"nodeSelector value", opts.nodeSelector["nodeGroup"], "gpu-worker"},
+		{"tolerations size", len(opts.tolerations), 2},
+		{"imagePullSecrets size", len(opts.imagePullSecrets), 2},
+	}
+	for _, c := range checks {
+		if !reflect.DeepEqual(c.got, c.want) {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+	if opts.requests == nil || opts.requests.Cpu().String() != "500m" {
+		t.Errorf("requests cpu = %v, want 500m", opts.requests)
+	}
+	if opts.limits == nil || opts.limits.Memory().String() != "2Gi" {
+		t.Errorf("limits memory = %v, want 2Gi", opts.limits)
+	}
+}
+
+// TestSnapshotCmd_ConfigOnly_NoCLIFlags mirrors the demo workflow:
+// `aicr snapshot --config aicr-config.yaml` with no other flags. Success
+// criterion from issue #913.
+func TestSnapshotCmd_ConfigOnly_NoCLIFlags(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - dedicated=gpu-workload:NoSchedule
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	opts := captureSnapshotOpts(t, []string{"--config", cfgPath})
+
+	if opts.namespace != "aicr-validation" {
+		t.Errorf("namespace = %q, want aicr-validation", opts.namespace)
+	}
+	if opts.nodeSelector["nodeGroup"] != "gpu-worker" {
+		t.Errorf("nodeSelector nodeGroup = %q, want gpu-worker", opts.nodeSelector["nodeGroup"])
+	}
+	if len(opts.tolerations) != 1 || opts.tolerations[0].Key != "dedicated" {
+		t.Errorf("tolerations = %+v, want one entry for dedicated", opts.tolerations)
+	}
+	if opts.tmplOpts.outputPath != "snapshot.yaml" {
+		t.Errorf("outputPath = %q, want snapshot.yaml", opts.tmplOpts.outputPath)
+	}
+}
+
+// === CLI overrides config in every dimension ===
+
+// TestSnapshotCmd_FlagOverridesEverySection verifies CLI flags win over
+// the corresponding config fields. This is the documented precedence
+// rule for AICRConfig consumers.
+func TestSnapshotCmd_FlagOverridesEverySection(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: config-snapshot.yaml
+    agent:
+      namespace: config-ns
+      image: config:image
+      jobName: config-job
+      serviceAccountName: config-sa
+      nodeSelector:
+        nodeGroup: config-group
+      tolerations:
+        - cfg=val:NoSchedule
+      requireGpu: false
+      os: ubuntu
+    execution:
+      timeout: 1m
+      noCleanup: false
+      maxNodesPerEntry: 2
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	opts := captureSnapshotOpts(t, []string{
+		"--config", cfgPath,
+		"--namespace", "flag-ns",
+		"--image", "flag:image",
+		"--job-name", "flag-job",
+		"--service-account-name", "flag-sa",
+		"--node-selector", "nodeGroup=flag-group",
+		"--toleration", "flag=val:NoSchedule",
+		"--timeout", "9m",
+		"--no-cleanup",
+		"--max-nodes-per-entry", "10",
+		"--os", "rhel",
+		"--require-gpu",
+		"-o", "flag-snapshot.yaml",
+	})
+
+	wants := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"namespace", opts.namespace, "flag-ns"},
+		{"image", opts.image, "flag:image"},
+		{"jobName", opts.jobName, "flag-job"},
+		{"serviceAccountName", opts.serviceAccountName, "flag-sa"},
+		{"nodeSelector", opts.nodeSelector["nodeGroup"], "flag-group"},
+		{"tolerations[0].Key", opts.tolerations[0].Key, "flag"},
+		{"timeout", opts.timeout, 9 * time.Minute},
+		{"cleanup", opts.cleanup, false},
+		{"maxNodesPerEntry", opts.maxNodesPerEntry, 10},
+		{"os", opts.os, "rhel"},
+		{"requireGPU", opts.requireGPU, true},
+		{"outputPath", opts.tmplOpts.outputPath, "flag-snapshot.yaml"},
+	}
+	for _, w := range wants {
+		if !reflect.DeepEqual(w.got, w.want) {
+			t.Errorf("%s: got %v, want %v", w.name, w.got, w.want)
+		}
+	}
+}
+
+// === Config: tolerations nil-vs-empty semantics ===
+
+// TestSnapshotCmd_ConfigEmptyTolerationsOptOut verifies that
+// `tolerations: []` in config drops the implicit tolerate-all default —
+// the explicit opt-out path documented on ValidateAgentSpec, which
+// SnapshotAgentSpec mirrors.
+func TestSnapshotCmd_ConfigEmptyTolerationsOptOut(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      tolerations: []
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	opts := captureSnapshotOpts(t, []string{"--config", cfgPath})
+	if opts.tolerations == nil {
+		t.Fatal("expected non-nil empty tolerations from explicit []")
+	}
+	if len(opts.tolerations) != 0 {
+		t.Errorf("expected zero tolerations, got %+v", opts.tolerations)
+	}
+}
+
+// === Negative cases ===
+
+// TestSnapshotCmd_InvalidConfig_BadTimeout verifies that a malformed
+// timeout in config surfaces as ErrCodeInvalidRequest via Resolve, not
+// silently fall through.
+func TestSnapshotCmd_InvalidConfig_BadTimeout(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    execution:
+      timeout: not-a-duration
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	err := runSnapshotCmdExpectErr(t, []string{"--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected error for malformed timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.snapshot.execution.timeout") {
+		t.Errorf("error %q must reference spec.snapshot.execution.timeout", err.Error())
+	}
+}
+
+// TestSnapshotCmd_InvalidConfig_BadFormat verifies the format enum is
+// validated at config-load time.
+func TestSnapshotCmd_InvalidConfig_BadFormat(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+      format: xml
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	err := runSnapshotCmdExpectErr(t, []string{"--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected error for invalid format, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.snapshot.output.format") {
+		t.Errorf("error %q must reference spec.snapshot.output.format", err.Error())
+	}
+}
+
+// TestSnapshotCmd_InvalidConfig_UnknownField confirms the strict-decode
+// path catches typos in spec.snapshot. This guards the "additive only"
+// promise from the issue.
+func TestSnapshotCmd_InvalidConfig_UnknownField(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    bogusKey: oops
+    output:
+      path: snapshot.yaml
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	err := runSnapshotCmdExpectErr(t, []string{"--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogusKey") {
+		t.Errorf("error %q must reference the unknown field", err.Error())
+	}
+}
+
+// TestSnapshotCmd_RequireGPURuntimeClass_StillMutuallyExclusive verifies
+// the existing mutual-exclusion check survives the config-merge layer.
+// The conflict should be detected regardless of whether the values come
+// from CLI flags or config.
+func TestSnapshotCmd_RequireGPURuntimeClass_StillMutuallyExclusive(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      requireGpu: true
+      runtimeClassName: nvidia
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	err := runSnapshotCmdExpectErr(t, []string{"--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected mutual-exclusion error from config-only conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error %q must reference mutual exclusion", err.Error())
+	}
+}
+
+// TestSnapshotCmd_ConfigBadResourcesRejected verifies bad `requests` /
+// `limits` content from config is rejected with the same error code as
+// CLI-supplied bad input. The config field uses the kubectl
+// name=quantity comma-separated form.
+func TestSnapshotCmd_ConfigBadResourcesRejected(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      requests: "cpu="
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	err := runSnapshotCmdExpectErr(t, []string{"--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected error for malformed requests, got nil")
+	}
+	// PropagateOrWrap preserves the inner error's ErrCodeInvalidRequest
+	// without re-prefixing, so assert on the parser's diagnostic message
+	// (the offending entry) rather than the wrap label.
+	if !strings.Contains(err.Error(), "cpu=") {
+		t.Errorf("error %q must reference the offending entry cpu=", err.Error())
+	}
+}
+
+// === toAgentConfig conversion sanity check ===
+
+// TestSnapshotCmdOptions_ToAgentConfig pins the field-by-field
+// translation from snapshotCmdOptions to snapshotter.AgentConfig.
+// Regression guard: silent drops would manifest as default empty values
+// reaching the deployer.
+func TestSnapshotCmdOptions_ToAgentConfig(t *testing.T) {
+	opts := &snapshotCmdOptions{
+		kubeconfig:         "/kube/config",
+		namespace:          "ns",
+		image:              "img",
+		imagePullSecrets:   []string{"secret"},
+		jobName:            "job",
+		serviceAccountName: "sa",
+		nodeSelector:       map[string]string{"k": "v"},
+		tolerations:        []corev1.Toleration{{Key: "t"}},
+		timeout:            3 * time.Minute,
+		cleanup:            true,
+		debug:              true,
+		privileged:         false,
+		requireGPU:         true,
+		runtimeClass:       "nvidia",
+		os:                 "ubuntu",
+		maxNodesPerEntry:   5,
+		requests:           corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		limits:             corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
+		tmplOpts: &snapshotTemplateOptions{
+			outputPath:   "snapshot.yaml",
+			templatePath: "tpl.tmpl",
+		},
+	}
+	ac := opts.toAgentConfig()
+	if ac == nil {
+		t.Fatal("nil AgentConfig")
+	}
+	wants := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"Kubeconfig", ac.Kubeconfig, "/kube/config"},
+		{"Namespace", ac.Namespace, "ns"},
+		{"Image", ac.Image, "img"},
+		{"JobName", ac.JobName, "job"},
+		{"ServiceAccountName", ac.ServiceAccountName, "sa"},
+		{"Timeout", ac.Timeout, 3 * time.Minute},
+		{"Cleanup", ac.Cleanup, true},
+		{"Debug", ac.Debug, true},
+		{"Privileged", ac.Privileged, false},
+		{"RequireGPU", ac.RequireGPU, true},
+		{"RuntimeClassName", ac.RuntimeClassName, "nvidia"},
+		{"OS", ac.OS, "ubuntu"},
+		{"MaxNodesPerEntry", ac.MaxNodesPerEntry, 5},
+		{"Output", ac.Output, "snapshot.yaml"},
+		{"TemplatePath", ac.TemplatePath, "tpl.tmpl"},
+		{"NodeSelector[k]", ac.NodeSelector["k"], "v"},
+	}
+	for _, w := range wants {
+		if !reflect.DeepEqual(w.got, w.want) {
+			t.Errorf("%s: got %v, want %v", w.name, w.got, w.want)
+		}
+	}
+	if len(ac.Tolerations) != 1 || ac.Tolerations[0].Key != "t" {
+		t.Errorf("Tolerations = %+v", ac.Tolerations)
+	}
+	if ac.Requests.Cpu().String() != "1" {
+		t.Errorf("Requests CPU = %v, want 1", ac.Requests.Cpu())
+	}
+	if ac.Limits.Memory().String() != "2Gi" {
+		t.Errorf("Limits Memory = %v, want 2Gi", ac.Limits.Memory())
+	}
+}
+
+// === Privileged pointer semantics ===
+
+// TestSnapshotCmd_ConfigPrivilegedFalseHonored verifies an explicit
+// privileged=false in config flows through to the agent unless the CLI
+// flag overrides it. The CLI default for --privileged is true; without
+// the pointer-vs-bool distinction in SnapshotExecutionSpec, an opt-out
+// from PSS-restricted namespaces would silently fail.
+func TestSnapshotCmd_ConfigPrivilegedFalseHonored(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    execution:
+      privileged: false
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	opts := captureSnapshotOpts(t, []string{"--config", cfgPath})
+	if opts.privileged {
+		t.Error("expected privileged=false from config to override CLI default=true")
+	}
+}
+
+// TestSnapshotCmd_NoConfigPrivilegedDefaultsTrue preserves the legacy
+// default. Without --privileged and without --config, the agent runs
+// privileged so the system collectors keep working.
+func TestSnapshotCmd_NoConfigPrivilegedDefaultsTrue(t *testing.T) {
+	opts := captureSnapshotOpts(t, []string{"-o", "-"})
+	if !opts.privileged {
+		t.Error("expected privileged=true by default (CLI flag default)")
+	}
+}
+
+// === HTTP source: snapshot section round-trips through config.Load ===
+
+// testSnapshotConfig is a canned config used by the HTTP source test;
+// declared at package scope so other tests can reuse it if needed.
+var testSnapshotConfig = `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+`
+
+func TestSnapshotCmd_ConfigFromInlineFile(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(testSnapshotConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	opts := captureSnapshotOpts(t, []string{"--config", cfgPath})
+	if opts.namespace != "aicr-validation" {
+		t.Errorf("namespace = %q, want aicr-validation", opts.namespace)
+	}
+	if opts.nodeSelector["nodeGroup"] != "gpu-worker" {
+		t.Errorf("nodeSelector nodeGroup = %q, want gpu-worker", opts.nodeSelector["nodeGroup"])
+	}
+}

--- a/pkg/config/accessors.go
+++ b/pkg/config/accessors.go
@@ -49,6 +49,14 @@ func (c *AICRConfig) Validation() *ValidateSpec {
 	return c.Spec.Validate
 }
 
+// Snapshot returns the snapshot section, or nil if cfg or the section is unset.
+func (c *AICRConfig) Snapshot() *SnapshotSpec {
+	if c == nil {
+		return nil
+	}
+	return c.Spec.Snapshot
+}
+
 // SnapshotPath returns spec.recipe.input.snapshot, or "" when unset.
 func (r *RecipeSpec) SnapshotPath() string {
 	if r == nil || r.Input == nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,7 @@ const Kind = "AICRConfig"
 const APIVersion = "aicr.nvidia.com/v1alpha1"
 
 // AICRConfig is the top-level schema for the --config file accepted by
-// the aicr CLI's recipe, bundle, and validate commands.
+// the aicr CLI's snapshot, recipe, bundle, and validate commands.
 type AICRConfig struct {
 	Kind       string   `yaml:"kind" json:"kind"`
 	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`
@@ -40,9 +40,60 @@ type Metadata struct {
 // populate just Recipe; one used only with `aicr bundle` may populate just
 // Bundle. A single file may populate any combination for end-to-end workflows.
 type Spec struct {
+	Snapshot *SnapshotSpec `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
 	Recipe   *RecipeSpec   `yaml:"recipe,omitempty" json:"recipe,omitempty"`
 	Bundle   *BundleSpec   `yaml:"bundle,omitempty" json:"bundle,omitempty"`
 	Validate *ValidateSpec `yaml:"validate,omitempty" json:"validate,omitempty"`
+}
+
+// SnapshotSpec captures the inputs to `aicr snapshot`.
+//
+// Snapshot does not declare an input section: it produces the snapshot
+// from a live cluster. Agent shape mirrors ValidateAgentSpec so a single
+// config file can pin matching agent placement across snapshot and
+// validate runs.
+type SnapshotSpec struct {
+	Output    *SnapshotOutputSpec    `yaml:"output,omitempty" json:"output,omitempty"`
+	Agent     *SnapshotAgentSpec     `yaml:"agent,omitempty" json:"agent,omitempty"`
+	Execution *SnapshotExecutionSpec `yaml:"execution,omitempty" json:"execution,omitempty"`
+}
+
+// SnapshotOutputSpec describes how the snapshot is emitted.
+type SnapshotOutputSpec struct {
+	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
+	Format   string `yaml:"format,omitempty" json:"format,omitempty"`
+	Template string `yaml:"template,omitempty" json:"template,omitempty"`
+}
+
+// SnapshotAgentSpec configures the in-cluster snapshot-capture Job pod.
+// Empty fields use the snapshotter's compiled-in defaults; selectors and
+// tolerations omitted entirely (nil) inherit the defaults, while an
+// explicit empty map/list (`{}` / `[]`) clears them.
+type SnapshotAgentSpec struct {
+	Namespace          string            `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Image              string            `yaml:"image,omitempty" json:"image,omitempty"`
+	ImagePullSecrets   []string          `yaml:"imagePullSecrets,omitempty" json:"imagePullSecrets,omitempty"`
+	JobName            string            `yaml:"jobName,omitempty" json:"jobName,omitempty"`
+	ServiceAccountName string            `yaml:"serviceAccountName,omitempty" json:"serviceAccountName,omitempty"`
+	NodeSelector       map[string]string `yaml:"nodeSelector,omitempty" json:"nodeSelector,omitempty"`
+	Tolerations        []string          `yaml:"tolerations,omitempty" json:"tolerations,omitempty"`
+	RequireGPU         bool              `yaml:"requireGpu,omitempty" json:"requireGpu,omitempty"`
+	RuntimeClassName   string            `yaml:"runtimeClassName,omitempty" json:"runtimeClassName,omitempty"`
+	OS                 string            `yaml:"os,omitempty" json:"os,omitempty"`
+	Requests           string            `yaml:"requests,omitempty" json:"requests,omitempty"`
+	Limits             string            `yaml:"limits,omitempty" json:"limits,omitempty"`
+}
+
+// SnapshotExecutionSpec controls snapshot behavior independent of where
+// the agent runs.
+//
+// Timeout is the wire-string form (e.g. "5m"); Resolve parses it to a
+// time.Duration with errors attributed to spec.snapshot.execution.timeout.
+type SnapshotExecutionSpec struct {
+	Timeout          string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	NoCleanup        bool   `yaml:"noCleanup,omitempty" json:"noCleanup,omitempty"`
+	Privileged       *bool  `yaml:"privileged,omitempty" json:"privileged,omitempty"`
+	MaxNodesPerEntry int    `yaml:"maxNodesPerEntry,omitempty" json:"maxNodesPerEntry,omitempty"`
 }
 
 // RecipeSpec captures the inputs to `aicr recipe`.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -232,94 +232,77 @@ func TestValidate_Errors(t *testing.T) {
 	}
 }
 
-func TestValidate_SnapshotOnly(t *testing.T) {
-	cfg := &config.AICRConfig{
-		Kind:       config.Kind,
-		APIVersion: config.APIVersion,
-		Spec: config.Spec{
-			Snapshot: &config.SnapshotSpec{
+// TestValidate_Snapshot exercises Validate on the spec.snapshot section.
+// Cases share the same shape (build a config with snapshot only → call
+// Validate → assert error substring or nil) so they consolidate cleanly.
+func TestValidate_Snapshot(t *testing.T) {
+	tests := []struct {
+		name    string
+		snap    *config.SnapshotSpec
+		wantSub string // "" = expect no error
+	}{
+		{
+			name: "happy path snapshot only",
+			snap: &config.SnapshotSpec{
 				Output: &config.SnapshotOutputSpec{Path: "./snapshot.yaml"},
 				Agent: &config.SnapshotAgentSpec{
-					Namespace: "aicr-validation",
-					NodeSelector: map[string]string{
-						"nodeGroup": "gpu-worker",
-					},
-					Tolerations: []string{
-						"dedicated=gpu-workload:NoSchedule",
-					},
+					Namespace:    "aicr-validation",
+					NodeSelector: map[string]string{"nodeGroup": "gpu-worker"},
+					Tolerations:  []string{"dedicated=gpu-workload:NoSchedule"},
 				},
-				Execution: &config.SnapshotExecutionSpec{
-					Timeout: "5m",
-				},
+				Execution: &config.SnapshotExecutionSpec{Timeout: "5m"},
 			},
 		},
-	}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-}
-
-func TestValidate_InvalidSnapshotTimeout(t *testing.T) {
-	cfg := &config.AICRConfig{
-		Kind:       config.Kind,
-		APIVersion: config.APIVersion,
-		Spec: config.Spec{
-			Snapshot: &config.SnapshotSpec{
+		{
+			name: "invalid timeout",
+			snap: &config.SnapshotSpec{
 				Execution: &config.SnapshotExecutionSpec{Timeout: "abc"},
 			},
+			wantSub: "spec.snapshot.execution.timeout",
 		},
-	}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.timeout") {
-		t.Fatalf("expected timeout error, got %v", err)
-	}
-}
-
-func TestValidate_InvalidSnapshotFormat(t *testing.T) {
-	cfg := &config.AICRConfig{
-		Kind:       config.Kind,
-		APIVersion: config.APIVersion,
-		Spec: config.Spec{
-			Snapshot: &config.SnapshotSpec{
+		{
+			name: "invalid format",
+			snap: &config.SnapshotSpec{
 				Output: &config.SnapshotOutputSpec{Format: "xml"},
 			},
+			wantSub: "spec.snapshot.output.format",
 		},
-	}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.output.format") {
-		t.Fatalf("expected format error, got %v", err)
-	}
-}
-
-func TestValidate_InvalidSnapshotTolerations(t *testing.T) {
-	cfg := &config.AICRConfig{
-		Kind:       config.Kind,
-		APIVersion: config.APIVersion,
-		Spec: config.Spec{
-			Snapshot: &config.SnapshotSpec{
+		{
+			name: "invalid tolerations",
+			snap: &config.SnapshotSpec{
 				Agent: &config.SnapshotAgentSpec{Tolerations: []string{"::"}},
 			},
+			wantSub: "spec.snapshot.agent.tolerations",
 		},
-	}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.agent.tolerations") {
-		t.Fatalf("expected tolerations error, got %v", err)
-	}
-}
-
-func TestValidate_NegativeSnapshotMaxNodesPerEntry(t *testing.T) {
-	cfg := &config.AICRConfig{
-		Kind:       config.Kind,
-		APIVersion: config.APIVersion,
-		Spec: config.Spec{
-			Snapshot: &config.SnapshotSpec{
+		{
+			name: "negative maxNodesPerEntry",
+			snap: &config.SnapshotSpec{
 				Execution: &config.SnapshotExecutionSpec{MaxNodesPerEntry: -1},
 			},
+			wantSub: "spec.snapshot.execution.maxNodesPerEntry",
 		},
 	}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.maxNodesPerEntry") {
-		t.Fatalf("expected maxNodesPerEntry error, got %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.AICRConfig{
+				Kind:       config.Kind,
+				APIVersion: config.APIVersion,
+				Spec:       config.Spec{Snapshot: tt.snap},
+			}
+			err := cfg.Validate()
+			if tt.wantSub == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSub)
+			}
+		})
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -132,13 +132,14 @@ func TestValidate_Errors(t *testing.T) {
 			wantSub: "invalid apiVersion",
 		},
 		{
-			name: "no recipe, no bundle, and no validate",
+			name: "no snapshot, no recipe, no bundle, and no validate",
 			mutate: func(c *config.AICRConfig) {
+				c.Spec.Snapshot = nil
 				c.Spec.Recipe = nil
 				c.Spec.Bundle = nil
 				c.Spec.Validate = nil
 			},
-			wantSub: "none of spec.recipe, spec.bundle, spec.validate",
+			wantSub: "none of spec.snapshot, spec.recipe, spec.bundle, spec.validate",
 		},
 		{
 			name: "criteria and snapshot mutually exclusive",
@@ -228,6 +229,97 @@ func TestValidate_Errors(t *testing.T) {
 				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSub)
 			}
 		})
+	}
+}
+
+func TestValidate_SnapshotOnly(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Snapshot: &config.SnapshotSpec{
+				Output: &config.SnapshotOutputSpec{Path: "./snapshot.yaml"},
+				Agent: &config.SnapshotAgentSpec{
+					Namespace: "aicr-validation",
+					NodeSelector: map[string]string{
+						"nodeGroup": "gpu-worker",
+					},
+					Tolerations: []string{
+						"dedicated=gpu-workload:NoSchedule",
+					},
+				},
+				Execution: &config.SnapshotExecutionSpec{
+					Timeout: "5m",
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidate_InvalidSnapshotTimeout(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Snapshot: &config.SnapshotSpec{
+				Execution: &config.SnapshotExecutionSpec{Timeout: "abc"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.timeout") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestValidate_InvalidSnapshotFormat(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Snapshot: &config.SnapshotSpec{
+				Output: &config.SnapshotOutputSpec{Format: "xml"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.output.format") {
+		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+func TestValidate_InvalidSnapshotTolerations(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Snapshot: &config.SnapshotSpec{
+				Agent: &config.SnapshotAgentSpec{Tolerations: []string{"::"}},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.agent.tolerations") {
+		t.Fatalf("expected tolerations error, got %v", err)
+	}
+}
+
+func TestValidate_NegativeSnapshotMaxNodesPerEntry(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Snapshot: &config.SnapshotSpec{
+				Execution: &config.SnapshotExecutionSpec{MaxNodesPerEntry: -1},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.maxNodesPerEntry") {
+		t.Fatalf("expected maxNodesPerEntry error, got %v", err)
 	}
 }
 

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -213,6 +213,29 @@ func TestLoad_RejectsUnknownJSONField(t *testing.T) {
 	}
 }
 
+// TestLoad_RejectsUnknownSnapshotField guards spec.snapshot against typos.
+// Schema parity with the other sections: unknown keys must surface a
+// decode error rather than silently dropping the field.
+func TestLoad_RejectsUnknownSnapshotField(t *testing.T) {
+	bad := `kind: AICRConfig
+apiVersion: aicr.nvidia.com/v1alpha1
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespacE: aicr-validation   # typo on purpose
+`
+	path := writeTempFile(t, "config.yaml", bad)
+	_, err := config.Load(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected error for unknown snapshot agent field, got nil")
+	}
+	if !strings.Contains(err.Error(), "namespacE") {
+		t.Errorf("error should reference unknown field, got %q", err.Error())
+	}
+}
+
 // TestLoad_HTTPBodyLimit verifies the HTTP fetch path bounds response size
 // against defaults.HTTPResponseBodyLimit.
 func TestLoad_HTTPBodyLimit(t *testing.T) {

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -435,6 +435,159 @@ func (v *ValidateSpec) Resolve() (*ValidateResolved, error) {
 	return out, nil
 }
 
+// SnapshotResolved is the typed-domain projection of SnapshotSpec produced
+// by (*SnapshotSpec).Resolve. Conversion from the wire form happens
+// exactly once at this boundary; CLI consumers layer flag overrides on
+// top of these values rather than re-parsing the spec strings.
+//
+// Zero values mean "config did not set this field." Maps and slices
+// preserve the nil-vs-explicitly-empty distinction from the wire spec —
+// callers can detect whether a user wrote `nodeSelector: {}` to clear an
+// inherited default vs. omitted the field entirely.
+type SnapshotResolved struct {
+	// OutputPath is spec.snapshot.output.path.
+	OutputPath string
+
+	// OutputFormat is spec.snapshot.output.format (validated against the
+	// serializer's known formats but left as a string; the CLI parses
+	// the flag form anyway).
+	OutputFormat string
+
+	// OutputTemplate is spec.snapshot.output.template.
+	OutputTemplate string
+
+	// Namespace is spec.snapshot.agent.namespace.
+	Namespace string
+
+	// Image is spec.snapshot.agent.image.
+	Image string
+
+	// ImagePullSecrets is spec.snapshot.agent.imagePullSecrets. Nil if
+	// config did not set the field.
+	ImagePullSecrets []string
+
+	// JobName is spec.snapshot.agent.jobName.
+	JobName string
+
+	// ServiceAccountName is spec.snapshot.agent.serviceAccountName.
+	ServiceAccountName string
+
+	// NodeSelector is spec.snapshot.agent.nodeSelector. Nil if unset;
+	// non-nil empty if `{}` was explicit.
+	NodeSelector map[string]string
+
+	// Tolerations is the parsed spec.snapshot.agent.tolerations slice.
+	// Nil if config did not set the field.
+	Tolerations []corev1.Toleration
+
+	// RequireGPU is spec.snapshot.agent.requireGpu.
+	RequireGPU bool
+
+	// RuntimeClassName is spec.snapshot.agent.runtimeClassName.
+	RuntimeClassName string
+
+	// OS is spec.snapshot.agent.os.
+	OS string
+
+	// Requests is spec.snapshot.agent.requests (raw "name=quantity,..." form).
+	Requests string
+
+	// Limits is spec.snapshot.agent.limits (raw "name=quantity,..." form).
+	Limits string
+
+	// Timeout is the parsed spec.snapshot.execution.timeout. Nil pointer
+	// signals "config did not set the field" so callers can fall through
+	// to the CLI flag's default duration.
+	Timeout *time.Duration
+
+	// NoCleanup is spec.snapshot.execution.noCleanup.
+	NoCleanup bool
+
+	// Privileged is spec.snapshot.execution.privileged. Nil pointer
+	// signals "config did not set the field" so the CLI flag's default
+	// (true) flows through; *false preserves an explicit opt-out.
+	Privileged *bool
+
+	// MaxNodesPerEntry is spec.snapshot.execution.maxNodesPerEntry.
+	MaxNodesPerEntry int
+}
+
+// Resolve converts a SnapshotSpec from the wire-string form to a typed
+// SnapshotResolved. It is nil-receiver tolerant and never returns a nil
+// pointer — callers reach into fields, so nil would just relocate the
+// nil-pointer dereference.
+//
+// Errors are attributed to their source spec path (for example,
+// "spec.snapshot.agent.tolerations") so callers can surface the location
+// of invalid input without reconstructing the path themselves.
+func (s *SnapshotSpec) Resolve() (*SnapshotResolved, error) {
+	out := &SnapshotResolved{}
+	if s == nil {
+		return out, nil
+	}
+
+	if s.Output != nil {
+		out.OutputPath = s.Output.Path
+		out.OutputFormat = s.Output.Format
+		out.OutputTemplate = s.Output.Template
+	}
+
+	if s.Agent != nil {
+		out.Namespace = s.Agent.Namespace
+		out.Image = s.Agent.Image
+		out.JobName = s.Agent.JobName
+		out.ServiceAccountName = s.Agent.ServiceAccountName
+		out.RequireGPU = s.Agent.RequireGPU
+		out.RuntimeClassName = s.Agent.RuntimeClassName
+		out.OS = s.Agent.OS
+		out.Requests = s.Agent.Requests
+		out.Limits = s.Agent.Limits
+		out.ImagePullSecrets = slices.Clone(s.Agent.ImagePullSecrets)
+		out.NodeSelector = maps.Clone(s.Agent.NodeSelector)
+		if s.Agent.Tolerations != nil {
+			if len(s.Agent.Tolerations) == 0 {
+				// Preserve the explicit-clear intent: `tolerations: []`
+				// means "drop the default tolerate-all," not "use it."
+				out.Tolerations = []corev1.Toleration{}
+			} else {
+				tols, err := snapshotter.ParseTolerations(s.Agent.Tolerations)
+				if err != nil {
+					return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+						"invalid spec.snapshot.agent.tolerations", err)
+				}
+				out.Tolerations = tols
+			}
+		}
+	}
+
+	if s.Execution != nil {
+		out.NoCleanup = s.Execution.NoCleanup
+		if s.Execution.MaxNodesPerEntry < 0 {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("spec.snapshot.execution.maxNodesPerEntry must be >= 0, got %d", s.Execution.MaxNodesPerEntry))
+		}
+		out.MaxNodesPerEntry = s.Execution.MaxNodesPerEntry
+		if s.Execution.Privileged != nil {
+			b := *s.Execution.Privileged
+			out.Privileged = &b
+		}
+		if s.Execution.Timeout != "" {
+			d, err := time.ParseDuration(s.Execution.Timeout)
+			if err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.snapshot.execution.timeout", err)
+			}
+			if d < 0 {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("spec.snapshot.execution.timeout must be >= 0, got %s", d))
+			}
+			out.Timeout = &d
+		}
+	}
+
+	return out, nil
+}
+
 // ResolveCriteria converts the recipe criteria spec from wire-string form
 // to a typed *recipe.Criteria. Nil-receiver tolerant; never returns a nil
 // pointer.

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -736,3 +736,228 @@ func TestValidateResolve_NilVsExplicitlyEmpty(t *testing.T) {
 		t.Errorf("explicit [] source → expected len 0, got %v", got2.Tolerations)
 	}
 }
+
+// === SnapshotSpec.Resolve ===
+
+func TestSnapshotResolve_NilReceiver(t *testing.T) {
+	var s *config.SnapshotSpec
+	got, err := s.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("nil SnapshotResolved")
+	}
+}
+
+func TestSnapshotResolve_EmptySpec(t *testing.T) {
+	got, err := (&config.SnapshotSpec{}).Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.OutputPath != "" || got.OutputFormat != "" || got.OutputTemplate != "" ||
+		got.Namespace != "" || got.Image != "" || got.JobName != "" ||
+		got.ServiceAccountName != "" || got.RequireGPU || got.RuntimeClassName != "" ||
+		got.OS != "" || got.Requests != "" || got.Limits != "" || got.NoCleanup ||
+		got.MaxNodesPerEntry != 0 || got.Timeout != nil || got.Privileged != nil ||
+		got.NodeSelector != nil || got.Tolerations != nil || got.ImagePullSecrets != nil {
+
+		t.Errorf("expected all zero, got %+v", got)
+	}
+}
+
+func TestSnapshotResolve_AllFieldsPopulated(t *testing.T) {
+	fals := false
+	s := &config.SnapshotSpec{
+		Output: &config.SnapshotOutputSpec{
+			Path:     "snapshot.yaml",
+			Format:   "yaml",
+			Template: "tpl.tmpl",
+		},
+		Agent: &config.SnapshotAgentSpec{
+			Namespace:          "aicr-validation",
+			Image:              "img:1",
+			ImagePullSecrets:   []string{"secret-a", "secret-b"},
+			JobName:            "snap-job",
+			ServiceAccountName: "snap-sa",
+			NodeSelector:       map[string]string{"nodeGroup": "gpu-worker"},
+			Tolerations: []string{
+				"dedicated=gpu-workload:NoSchedule",
+				"nvidia.com/gpu=present:NoSchedule",
+			},
+			RequireGPU:       true,
+			RuntimeClassName: "nvidia",
+			OS:               "ubuntu",
+			Requests:         "cpu=500m,memory=1Gi",
+			Limits:           "cpu=1,memory=2Gi",
+		},
+		Execution: &config.SnapshotExecutionSpec{
+			Timeout:          "7m",
+			NoCleanup:        true,
+			Privileged:       &fals,
+			MaxNodesPerEntry: 4,
+		},
+	}
+	got, err := s.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.OutputPath != "snapshot.yaml" || got.OutputFormat != "yaml" || got.OutputTemplate != "tpl.tmpl" {
+		t.Errorf("output mismatch: %+v", got)
+	}
+	if got.Namespace != "aicr-validation" || got.Image != "img:1" || got.JobName != "snap-job" ||
+		got.ServiceAccountName != "snap-sa" || !got.RequireGPU ||
+		got.RuntimeClassName != "nvidia" || got.OS != "ubuntu" ||
+		got.Requests != "cpu=500m,memory=1Gi" || got.Limits != "cpu=1,memory=2Gi" {
+
+		t.Errorf("agent mismatch: %+v", got)
+	}
+	if !reflect.DeepEqual(got.ImagePullSecrets, []string{"secret-a", "secret-b"}) {
+		t.Errorf("ImagePullSecrets = %v", got.ImagePullSecrets)
+	}
+	if !reflect.DeepEqual(got.NodeSelector, map[string]string{"nodeGroup": "gpu-worker"}) {
+		t.Errorf("NodeSelector = %v", got.NodeSelector)
+	}
+	if len(got.Tolerations) != 2 || got.Tolerations[0].Key != "dedicated" || got.Tolerations[1].Key != "nvidia.com/gpu" {
+		t.Errorf("Tolerations = %+v", got.Tolerations)
+	}
+	if !got.NoCleanup || got.MaxNodesPerEntry != 4 {
+		t.Errorf("execution flags = %+v", got)
+	}
+	if got.Privileged == nil || *got.Privileged {
+		t.Errorf("Privileged = %v (want &false)", got.Privileged)
+	}
+	if got.Timeout == nil || got.Timeout.String() != "7m0s" {
+		t.Errorf("Timeout = %v", got.Timeout)
+	}
+}
+
+func TestSnapshotResolve_ZeroTimeoutPreserved(t *testing.T) {
+	// A config-supplied "0s" must surface as a non-nil zero, distinct from
+	// "field unset" (nil), so callers like durationFlagOrConfig can honor
+	// an intentional disable-timeout setting.
+	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "0s"}}
+	got, err := s.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Timeout == nil {
+		t.Fatal("expected non-nil Timeout for explicit 0s; got nil")
+	}
+	if *got.Timeout != 0 {
+		t.Errorf("expected *Timeout = 0, got %v", *got.Timeout)
+	}
+}
+
+func TestSnapshotResolve_InvalidTimeout(t *testing.T) {
+	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "not-a-duration"}}
+	_, err := s.Resolve()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.timeout") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestSnapshotResolve_NegativeTimeout(t *testing.T) {
+	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "-5s"}}
+	_, err := s.Resolve()
+	if err == nil || !strings.Contains(err.Error(), ">= 0") {
+		t.Fatalf("expected negative-timeout error, got %v", err)
+	}
+}
+
+func TestSnapshotResolve_NegativeMaxNodesPerEntry(t *testing.T) {
+	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{MaxNodesPerEntry: -1}}
+	_, err := s.Resolve()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.maxNodesPerEntry") {
+		t.Fatalf("expected maxNodesPerEntry error, got %v", err)
+	}
+}
+
+func TestSnapshotResolve_InvalidToleration(t *testing.T) {
+	s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{Tolerations: []string{"::"}}}
+	_, err := s.Resolve()
+	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.agent.tolerations") {
+		t.Fatalf("expected tolerations error, got %v", err)
+	}
+}
+
+func TestSnapshotResolve_DefensiveCloneOfNodeSelector(t *testing.T) {
+	src := map[string]string{"nodeGroup": "gpu-worker"}
+	s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{NodeSelector: src}}
+	got, err := s.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got.NodeSelector["nodeGroup"] = "mutated"
+	if src["nodeGroup"] != "gpu-worker" {
+		t.Errorf("Resolve must defensively clone NodeSelector; source mutated to %q", src["nodeGroup"])
+	}
+}
+
+func TestSnapshotResolve_DefensiveCloneOfImagePullSecrets(t *testing.T) {
+	src := []string{"secret-a"}
+	s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{ImagePullSecrets: src}}
+	got, err := s.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got.ImagePullSecrets[0] = "mutated"
+	if src[0] != "secret-a" {
+		t.Errorf("Resolve must defensively clone ImagePullSecrets; source mutated to %q", src[0])
+	}
+}
+
+func TestSnapshotResolve_NilVsExplicitlyEmpty(t *testing.T) {
+	// Tolerations nil → resolved nil. Downstream uses nil as the "no
+	// override" sentinel so the snapshotter's default (tolerate-all) applies.
+	s1 := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{}}
+	got1, err := s1.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got1.Tolerations != nil {
+		t.Errorf("nil source → expected nil Tolerations, got %v", got1.Tolerations)
+	}
+	// Tolerations [] → resolved non-nil empty slice (explicit opt-out).
+	s2 := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{Tolerations: []string{}}}
+	got2, err := s2.Resolve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got2.Tolerations == nil {
+		t.Error("explicit [] source → expected non-nil empty Tolerations, got nil")
+	}
+	if len(got2.Tolerations) != 0 {
+		t.Errorf("explicit [] source → expected len 0, got %v", got2.Tolerations)
+	}
+}
+
+func TestSnapshotResolve_PrivilegedPointer(t *testing.T) {
+	tr := true
+	fals := false
+	tests := []struct {
+		name string
+		in   *bool
+		want *bool
+	}{
+		{"unset stays nil", nil, nil},
+		{"explicit true", &tr, &tr},
+		{"explicit false", &fals, &fals},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Privileged: tt.in}}
+			got, err := s.Resolve()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if (got.Privileged == nil) != (tt.want == nil) {
+				t.Fatalf("Privileged nil-mismatch: got=%v want=%v", got.Privileged, tt.want)
+			}
+			if got.Privileged != nil && *got.Privileged != *tt.want {
+				t.Errorf("Privileged = %v, want %v", *got.Privileged, *tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -739,30 +739,36 @@ func TestValidateResolve_NilVsExplicitlyEmpty(t *testing.T) {
 
 // === SnapshotSpec.Resolve ===
 
-func TestSnapshotResolve_NilReceiver(t *testing.T) {
-	var s *config.SnapshotSpec
-	got, err := s.Resolve()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestSnapshotResolve_ShapeEdges covers the nil-receiver and empty-spec
+// cases together: both must return a non-nil, all-zero SnapshotResolved
+// so callers can read fields without nil-checking the result.
+func TestSnapshotResolve_ShapeEdges(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *config.SnapshotSpec
+	}{
+		{"nil receiver", nil},
+		{"empty spec", &config.SnapshotSpec{}},
 	}
-	if got == nil {
-		t.Fatal("nil SnapshotResolved")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.in.Resolve()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("nil SnapshotResolved")
+			}
+			if got.OutputPath != "" || got.OutputFormat != "" || got.OutputTemplate != "" ||
+				got.Namespace != "" || got.Image != "" || got.JobName != "" ||
+				got.ServiceAccountName != "" || got.RequireGPU || got.RuntimeClassName != "" ||
+				got.OS != "" || got.Requests != "" || got.Limits != "" || got.NoCleanup ||
+				got.MaxNodesPerEntry != 0 || got.Timeout != nil || got.Privileged != nil ||
+				got.NodeSelector != nil || got.Tolerations != nil || got.ImagePullSecrets != nil {
 
-func TestSnapshotResolve_EmptySpec(t *testing.T) {
-	got, err := (&config.SnapshotSpec{}).Resolve()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.OutputPath != "" || got.OutputFormat != "" || got.OutputTemplate != "" ||
-		got.Namespace != "" || got.Image != "" || got.JobName != "" ||
-		got.ServiceAccountName != "" || got.RequireGPU || got.RuntimeClassName != "" ||
-		got.OS != "" || got.Requests != "" || got.Limits != "" || got.NoCleanup ||
-		got.MaxNodesPerEntry != 0 || got.Timeout != nil || got.Privileged != nil ||
-		got.NodeSelector != nil || got.Tolerations != nil || got.ImagePullSecrets != nil {
-
-		t.Errorf("expected all zero, got %+v", got)
+				t.Errorf("expected all zero, got %+v", got)
+			}
+		})
 	}
 }
 
@@ -833,10 +839,54 @@ func TestSnapshotResolve_AllFieldsPopulated(t *testing.T) {
 	}
 }
 
+// TestSnapshotResolve_InvalidInput consolidates the wire-form parser
+// failure modes: every case is "bad input → expected error substring."
+func TestSnapshotResolve_InvalidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      *config.SnapshotSpec
+		wantSub string
+	}{
+		{
+			name:    "invalid timeout",
+			in:      &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "not-a-duration"}},
+			wantSub: "spec.snapshot.execution.timeout",
+		},
+		{
+			name:    "negative timeout",
+			in:      &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "-5s"}},
+			wantSub: ">= 0",
+		},
+		{
+			name:    "negative maxNodesPerEntry",
+			in:      &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{MaxNodesPerEntry: -1}},
+			wantSub: "spec.snapshot.execution.maxNodesPerEntry",
+		},
+		{
+			name:    "invalid toleration",
+			in:      &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{Tolerations: []string{"::"}}},
+			wantSub: "spec.snapshot.agent.tolerations",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.in.Resolve()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+// TestSnapshotResolve_ZeroTimeoutPreserved verifies that a config-supplied
+// "0s" surfaces as a non-nil zero, distinct from "field unset" (nil), so
+// callers like durationFlagOrConfig can honor an intentional
+// disable-timeout setting. Kept separate from the error-table because
+// the assertion shape (non-nil + dereferenced value) differs.
 func TestSnapshotResolve_ZeroTimeoutPreserved(t *testing.T) {
-	// A config-supplied "0s" must surface as a non-nil zero, distinct from
-	// "field unset" (nil), so callers like durationFlagOrConfig can honor
-	// an intentional disable-timeout setting.
 	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "0s"}}
 	got, err := s.Resolve()
 	if err != nil {
@@ -850,86 +900,94 @@ func TestSnapshotResolve_ZeroTimeoutPreserved(t *testing.T) {
 	}
 }
 
-func TestSnapshotResolve_InvalidTimeout(t *testing.T) {
-	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "not-a-duration"}}
-	_, err := s.Resolve()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.timeout") {
-		t.Fatalf("expected timeout error, got %v", err)
+// TestSnapshotResolve_DefensiveCloneOfCollections verifies Resolve does
+// not alias map/slice memory with the source spec, so callers mutating
+// the resolved value cannot leak into a shared config.
+func TestSnapshotResolve_DefensiveCloneOfCollections(t *testing.T) {
+	tests := []struct {
+		name   string
+		assert func(t *testing.T, srcSpec *config.SnapshotSpec, got *config.SnapshotResolved)
+	}{
+		{
+			name: "node selector",
+			assert: func(t *testing.T, srcSpec *config.SnapshotSpec, got *config.SnapshotResolved) {
+				got.NodeSelector["nodeGroup"] = "mutated"
+				if srcSpec.Agent.NodeSelector["nodeGroup"] != "gpu-worker" {
+					t.Errorf("Resolve must defensively clone NodeSelector; source mutated to %q",
+						srcSpec.Agent.NodeSelector["nodeGroup"])
+				}
+			},
+		},
+		{
+			name: "image pull secrets",
+			assert: func(t *testing.T, srcSpec *config.SnapshotSpec, got *config.SnapshotResolved) {
+				got.ImagePullSecrets[0] = "mutated"
+				if srcSpec.Agent.ImagePullSecrets[0] != "secret-a" {
+					t.Errorf("Resolve must defensively clone ImagePullSecrets; source mutated to %q",
+						srcSpec.Agent.ImagePullSecrets[0])
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{
+				NodeSelector:     map[string]string{"nodeGroup": "gpu-worker"},
+				ImagePullSecrets: []string{"secret-a"},
+			}}
+			got, err := src.Resolve()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.assert(t, src, got)
+		})
 	}
 }
 
-func TestSnapshotResolve_NegativeTimeout(t *testing.T) {
-	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{Timeout: "-5s"}}
-	_, err := s.Resolve()
-	if err == nil || !strings.Contains(err.Error(), ">= 0") {
-		t.Fatalf("expected negative-timeout error, got %v", err)
+// TestSnapshotResolve_TolerationsNilVsExplicitlyEmpty pins the
+// distinguish-the-two-sentinels contract. Both cases share shape: build
+// a spec, call Resolve, assert on the resolved Tolerations slice.
+func TestSnapshotResolve_TolerationsNilVsExplicitlyEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		// nil = no Tolerations field on the input spec.
+		// non-nil with len 0 = explicit `tolerations: []`.
+		in       []string
+		wantNil  bool
+		wantLen0 bool
+	}{
+		{
+			// Downstream uses nil as the "no override" sentinel so
+			// the snapshotter's default (tolerate-all) applies.
+			name: "nil source → resolved nil",
+			in:   nil, wantNil: true,
+		},
+		{
+			// Explicit empty list opts out of tolerate-all; resolved
+			// must preserve the non-nil-but-empty shape.
+			name: "explicit [] source → resolved non-nil empty",
+			in:   []string{}, wantLen0: true,
+		},
 	}
-}
-
-func TestSnapshotResolve_NegativeMaxNodesPerEntry(t *testing.T) {
-	s := &config.SnapshotSpec{Execution: &config.SnapshotExecutionSpec{MaxNodesPerEntry: -1}}
-	_, err := s.Resolve()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.execution.maxNodesPerEntry") {
-		t.Fatalf("expected maxNodesPerEntry error, got %v", err)
-	}
-}
-
-func TestSnapshotResolve_InvalidToleration(t *testing.T) {
-	s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{Tolerations: []string{"::"}}}
-	_, err := s.Resolve()
-	if err == nil || !strings.Contains(err.Error(), "spec.snapshot.agent.tolerations") {
-		t.Fatalf("expected tolerations error, got %v", err)
-	}
-}
-
-func TestSnapshotResolve_DefensiveCloneOfNodeSelector(t *testing.T) {
-	src := map[string]string{"nodeGroup": "gpu-worker"}
-	s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{NodeSelector: src}}
-	got, err := s.Resolve()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got.NodeSelector["nodeGroup"] = "mutated"
-	if src["nodeGroup"] != "gpu-worker" {
-		t.Errorf("Resolve must defensively clone NodeSelector; source mutated to %q", src["nodeGroup"])
-	}
-}
-
-func TestSnapshotResolve_DefensiveCloneOfImagePullSecrets(t *testing.T) {
-	src := []string{"secret-a"}
-	s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{ImagePullSecrets: src}}
-	got, err := s.Resolve()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got.ImagePullSecrets[0] = "mutated"
-	if src[0] != "secret-a" {
-		t.Errorf("Resolve must defensively clone ImagePullSecrets; source mutated to %q", src[0])
-	}
-}
-
-func TestSnapshotResolve_NilVsExplicitlyEmpty(t *testing.T) {
-	// Tolerations nil → resolved nil. Downstream uses nil as the "no
-	// override" sentinel so the snapshotter's default (tolerate-all) applies.
-	s1 := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{}}
-	got1, err := s1.Resolve()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got1.Tolerations != nil {
-		t.Errorf("nil source → expected nil Tolerations, got %v", got1.Tolerations)
-	}
-	// Tolerations [] → resolved non-nil empty slice (explicit opt-out).
-	s2 := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{Tolerations: []string{}}}
-	got2, err := s2.Resolve()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got2.Tolerations == nil {
-		t.Error("explicit [] source → expected non-nil empty Tolerations, got nil")
-	}
-	if len(got2.Tolerations) != 0 {
-		t.Errorf("explicit [] source → expected len 0, got %v", got2.Tolerations)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &config.SnapshotSpec{Agent: &config.SnapshotAgentSpec{Tolerations: tt.in}}
+			got, err := s.Resolve()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil && got.Tolerations != nil {
+				t.Errorf("expected nil Tolerations, got %v", got.Tolerations)
+			}
+			if tt.wantLen0 {
+				if got.Tolerations == nil {
+					t.Error("expected non-nil empty Tolerations, got nil")
+				}
+				if len(got.Tolerations) != 0 {
+					t.Errorf("expected len 0, got %v", got.Tolerations)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -40,9 +40,12 @@ func (c *AICRConfig) Validate() error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid apiVersion %q: expected %q", c.APIVersion, APIVersion))
 	}
-	if c.Spec.Recipe == nil && c.Spec.Bundle == nil && c.Spec.Validate == nil {
+	if c.Spec.Snapshot == nil && c.Spec.Recipe == nil && c.Spec.Bundle == nil && c.Spec.Validate == nil {
 		return errors.New(errors.ErrCodeInvalidRequest,
-			"config has none of spec.recipe, spec.bundle, spec.validate; at least one is required")
+			"config has none of spec.snapshot, spec.recipe, spec.bundle, spec.validate; at least one is required")
+	}
+	if err := c.Spec.Snapshot.validate(); err != nil {
+		return err
 	}
 	if err := c.Spec.Recipe.validate(); err != nil {
 		return err
@@ -126,6 +129,22 @@ func (v *ValidateSpec) validate() error {
 	}
 	if _, err := v.Resolve(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (s *SnapshotSpec) validate() error {
+	if s == nil {
+		return nil
+	}
+	if _, err := s.Resolve(); err != nil {
+		return err
+	}
+	if s.Output != nil && s.Output.Format != "" {
+		if serializer.Format(s.Output.Format).IsUnknown() {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid spec.snapshot.output.format %q (valid: yaml, json, table)", s.Output.Format))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Extends `AICRConfig` with `spec.snapshot.*` so `aicr snapshot --config aicr-config.yaml` works without bare CLI flags, mirroring the existing config support on `recipe`, `bundle`, and `validate`.

## Motivation / Context

`pkg/cli/snapshot.go` did not read `--config`, so config-driven CUJ demos (e.g. `demos/cuj1-gke-config.md`) still had to pass `--namespace`, `--node-selector`, and `--toleration` as bare CLI flags for the snapshot step while the rest of the pipeline was config-driven. This broke the "one file drives the whole flow" property.

Fixes: #913
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/config`
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New `SnapshotSpec` in `pkg/config/config.go` with `output`, `agent`, `execution` sub-sections, mirroring the shape of `ValidateSpec`. The agent block reuses the same nil-vs-explicitly-empty semantics for `nodeSelector` and `tolerations` (omit → inherit; `[]` → clear the tolerate-all default).
- `(*SnapshotSpec).Resolve()` converts wire-string form to a typed `SnapshotResolved` once at the boundary; CLI overrides layer on top via the existing `stringFlagOrConfig` / `boolFlagOrConfig` / `stringSliceFlagOrConfig` / `durationFlagOrConfig` / `intFlagOrConfig` helpers — same pattern as `recipe`, `bundle`, and `validate`.
- Snapshot CLI action refactored to extract `parseSnapshotCmdOptions(cmd, cfg)` (mirroring `parseBundleCmdOptions`) so tests can capture the merged result without touching the deploy path.
- Behavior preserved: when neither CLI nor config sets `tolerations`, the resolver falls back to `snapshotter.DefaultTolerations()` (tolerate all) — matching the legacy `aicr snapshot` default. This is verified by `TestSnapshotCmd_FlagsAloneDefaultsTolerateAll`.
- `Privileged` is a `*bool` in `SnapshotExecutionSpec` so an operator running in PSS-restricted namespaces can set `privileged: false` without the CLI flag's default-true silently re-enabling it.
- Demo `demos/cuj1-gke-config.md` updated to use `aicr snapshot --config aicr-config.yaml` (no more bare flags); removed the implicit issue-tracking note.

## Testing

```bash
make qualify
```

Coverage delta on affected packages:
- `pkg/cli`: 63.7% → 66.5% (+2.8%)
- `pkg/config`: 93.7% → 93.8% (+0.1%)

New tests:
- `pkg/config/resolve_test.go` — `SnapshotResolve_*`: nil receiver, empty spec, all fields, zero/invalid/negative timeout, invalid tolerations, defensive map/slice clone, nil-vs-explicitly-empty, `Privileged` pointer semantics, negative `maxNodesPerEntry`.
- `pkg/config/config_test.go` — `Validate_SnapshotOnly`, `Validate_InvalidSnapshot{Timeout,Format,Tolerations}`, `Validate_NegativeSnapshotMaxNodesPerEntry`, plus the updated `none of` test now covers `spec.snapshot`.
- `pkg/config/loader_test.go` — `TestLoad_RejectsUnknownSnapshotField` guards the strict-decode path.
- `pkg/cli/snapshot_config_test.go` (new) — `--config` flag wiring, `FlagsAloneStillWork`, `FlagsAloneDefaultsTolerateAll`, `AllConfigSectionsResolve`, `ConfigOnly_NoCLIFlags`, `FlagOverridesEverySection`, `ConfigEmptyTolerationsOptOut`, `InvalidConfig_*` (bad timeout/format/unknown field/bad resources), `RequireGPURuntimeClass_StillMutuallyExclusive`, `ConfigPrivilegedFalseHonored`, `NoConfigPrivilegedDefaultsTrue`, `ToAgentConfig` translation pin.

## Risk Assessment

- [x] **Low** — Additive: new optional `spec.snapshot` section. No existing CLI flags removed or renamed. Strict-decode rejection unaffected since the new fields are added to the schema in the same change.

**Rollout notes:** Backwards-compatible. Existing `aicr snapshot` invocations without `--config` continue to work unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)