### PR TITLE
fix(validator): accept pre-release tags as release versions

### DIFF
--- a/demos/cuj1-gke-config.md
+++ b/demos/cuj1-gke-config.md
@@ -195,14 +195,8 @@ cd ..
 
 ## Validate Cluster + Emit Evidence
 
-`AICR_VALIDATOR_IMAGE_TAG=edge` works around tagged-release binaries asking for
-a `:sha-<commit>` validator image the release workflow never publishes (it
-publishes `:v<version>` instead). Drop the env var once running a binary built
-from a `main` push (whose `:sha-<commit>` images exist).
-See https://github.com/NVIDIA/aicr/issues/916.
-
 ```shell
-AICR_VALIDATOR_IMAGE_TAG=edge aicr validate --config aicr-config.yaml \
+aicr validate --config aicr-config.yaml \
     --phase conformance \
     --output report.json
 ```

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -46,8 +46,10 @@ type (
 // by name, and new validators are appended.
 //
 // Image tag resolution (applied in order):
-//  1. If a catalog entry uses :latest and version is a release (vX.Y.Z),
-//     the tag is replaced with the CLI version for reproducibility.
+//  1. If a catalog entry uses :latest and version looks like a release tag
+//     published by on-tag.yaml (vX.Y.Z or vX.Y.Z-<prerelease>, but not the
+//     goreleaser snapshot suffix -next), the tag is replaced with the CLI
+//     version for reproducibility.
 //  2. If version is a non-release dev build and commit is a valid short SHA,
 //     the tag is replaced with :sha-<commit> to match on-push.yaml image tags.
 //  3. If AICR_VALIDATOR_IMAGE_TAG is set, the resolved tag is overridden.
@@ -81,7 +83,10 @@ func Load(version, commit string) (*ValidatorCatalog, error) {
 // catalog (for example the inner AIPerf benchmark image referenced by the
 // inference-perf validator). Applies, in order:
 //
-//  1. :latest tag replacement with version if version is a release (vX.Y.Z).
+//  1. :latest tag replacement with version if version looks like a release
+//     tag published by on-tag.yaml — strict (vX.Y.Z) or a pre-release
+//     suffix (vX.Y.Z-rc1, vX.Y.Z-beta, vX.Y.Z-alpha.1). Goreleaser snapshot
+//     strings (suffix -next) are NOT releases and fall through to step 2.
 //  2. If non-release and commit is a valid SHA, :latest → :sha-<commit>.
 //  3. Tag override if AICR_VALIDATOR_IMAGE_TAG is set (overrides steps 1-2
 //     AND explicit catalog tags). Intended for feature-branch dev builds
@@ -149,15 +154,39 @@ func ImagePullPolicy(image string) corev1.PullPolicy {
 	return corev1.PullIfNotPresent
 }
 
-// releaseVersionPattern matches strict semantic versions: vX.Y.Z or X.Y.Z
-// with no pre-release suffix. This ensures snapshot strings like
-// v0.0.0-12-gabc1234 or pre-release tags like v1.0.0-rc1 are not treated
-// as releases.
-var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+// releaseVersionPattern matches the version strings on-tag.yaml turns into
+// validator image tags: strict semver (vX.Y.Z) or a single pre-release
+// suffix (vX.Y.Z-rc1, vX.Y.Z-beta, vX.Y.Z-alpha.1). The suffix is one
+// segment of alphanumerics and dots — multi-segment forms like the git
+// describe snapshot v0.0.0-12-gabc1234 contain an internal dash and do
+// not match.
+//
+// Mirrors the on-tag.yaml trigger filter `v[0-9]+.[0-9]+.[0-9]+*`: any
+// reference that filter accepts produces an image manifest tagged
+// `:<github.ref_name>`, and the binary's version string is the same
+// `.Tag` value goreleaser stamps in, so the two move in lockstep.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[A-Za-z0-9.]+)?$`)
 
-// isReleaseVersion returns true for strict semantic version strings (vX.Y.Z),
-// false for dev builds, pre-release suffixes, snapshots, and empty strings.
+// snapshotSuffixPattern matches goreleaser's snapshot.version_template
+// (`{{ .Tag }}-next` in .goreleaser.yaml). Snapshot builds produced by
+// on-push.yaml stamp the binary with versions like `v0.13.0-next` —
+// shape-equivalent to a pre-release tag but with NO corresponding image
+// in ghcr. Excluding them keeps the main-development flow on the
+// :sha-<commit> path (which on-push.yaml does publish).
+//
+// Do NOT remove this guard without also moving the main-push CI to
+// publish `v<version>-next` image tags — the two coordinated changes
+// must land together or :validate goes back to ImagePullBackOff on main.
+var snapshotSuffixPattern = regexp.MustCompile(`-next$`)
+
+// isReleaseVersion returns true when the version string matches a tag
+// on-tag.yaml would publish (strict semver or pre-release) AND is not a
+// goreleaser snapshot string. Dev builds, empty strings, and snapshots
+// fall through to the :sha-<commit> resolution path.
 func isReleaseVersion(version string) bool {
+	if snapshotSuffixPattern.MatchString(version) {
+		return false
+	}
 	return releaseVersionPattern.MatchString(version)
 }
 

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -519,7 +519,13 @@ func TestResolveImage(t *testing.T) {
 			want:    imgLatest,
 		},
 		{
-			name:    "-next version — no tag rewrite",
+			// Goreleaser snapshot template `{{ .Tag }}-next` is not a
+			// published image tag — must fall through to :sha-<commit>
+			// (the path on-push.yaml does publish). Regression guard for
+			// issue #916: silently dropping the -next exclusion would
+			// route every main-development build to an unpublished
+			// :v0.X.Y-next tag.
+			name:    "-next snapshot version — no tag rewrite",
 			image:   imgLatest,
 			version: "v0.11.1-next",
 			want:    imgLatest,
@@ -531,10 +537,55 @@ func TestResolveImage(t *testing.T) {
 			want:    imgLatest,
 		},
 		{
-			name:    "pre-release rc suffix is not a release",
+			// on-tag.yaml publishes `:v1.0.0-rc1` for pre-release tags;
+			// the binary's version is the same `.Tag` string goreleaser
+			// stamps in, so they must resolve to the same image tag.
+			// Regression guard for issue #916.
+			name:    "pre-release rc tag rewrites :latest to :vX.Y.Z-rc1",
 			image:   imgLatest,
 			version: "v1.0.0-rc1",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:v1.0.0-rc1",
+		},
+		{
+			name:    "pre-release beta tag rewrites :latest to :vX.Y.Z-beta",
+			image:   imgLatest,
+			version: "v1.0.0-beta",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:v1.0.0-beta",
+		},
+		{
+			name:    "pre-release alpha.1 (dotted) tag rewrites :latest",
+			image:   imgLatest,
+			version: "v1.0.0-alpha.1",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:v1.0.0-alpha.1",
+		},
+		{
+			// Snapshot of a pre-release checkout: goreleaser snapshot
+			// produces `v1.0.0-rc1-next`. The internal dash takes the
+			// suffix out of the single-segment shape AND the trailing
+			// -next is excluded — either guard alone is sufficient,
+			// both are present for defense-in-depth.
+			name:    "snapshot of a pre-release tag falls through",
+			image:   imgLatest,
+			version: "v1.0.0-rc1-next",
 			want:    imgLatest,
+		},
+		{
+			// Snapshot of stable release falls through to :sha-<commit>.
+			name:    "snapshot of stable release with commit → sha tag",
+			image:   imgLatest,
+			version: "v1.0.0-next",
+			commit:  "abc1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:sha-abc1234",
+		},
+		{
+			// Pre-release version takes precedence over commit (same
+			// as stable releases — the release workflow published the
+			// tagged image, no need to chase :sha-<commit>).
+			name:    "pre-release tag ignores commit (release wins)",
+			image:   imgLatest,
+			version: "v1.0.0-rc1",
+			commit:  "abc1234",
+			want:    "ghcr.io/nvidia/aicr-validators/aiperf-bench:v1.0.0-rc1",
 		},
 		{
 			name:    "snapshot with valid commit resolves to sha tag",


### PR DESCRIPTION
## Summary

`aicr validate` failed with `ImagePullBackOff` on every tagged-release binary because the catalog rewrote `:latest` to `:sha-<commit>`, but the release workflow (`on-tag.yaml`) publishes validator images at `:v<version>` — including pre-release tags like `v0.13.0-rc3`. Widens `releaseVersionPattern` to accept a single pre-release suffix segment and adds an explicit `-next$` exclusion so goreleaser snapshot builds keep falling through to `:sha-<commit>`.

## Motivation / Context

Reported in #916. The tag-rewrite logic was written when the only published image stream was `on-push.yaml`'s `:sha-<commit>` aliases, so `releaseVersionPattern` was deliberately strict (`^v?\d+\.\d+\.\d+$`). Once `on-tag.yaml` started publishing `:<github.ref_name>` for pre-release tags too (`v[0-9]+.[0-9]+.[0-9]+*` trigger), every install from a released binary like `v0.13.0-rc3` started chasing a `:sha-<commit>` image that release CI never pushed.

Fixes: #916
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update (demo workaround removed)

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New regex: `^v?\d+\.\d+\.\d+(-[A-Za-z0-9.]+)?$`. The pre-release suffix is a *single* alphanumeric-plus-dots segment — multi-segment forms like the git-describe snapshot `v0.0.0-12-gabc1234` contain an internal dash and are still rejected.
- New `snapshotSuffixPattern = -next$` excludes goreleaser's snapshot template (`.goreleaser.yaml`: `snapshot.version_template: "{{ .Tag }}-next"`). This is the critical guard that keeps main-development builds on the `:sha-<commit>` path (which `on-push.yaml` publishes). The exclusion is documented in code so a future change does not silently re-break dev flow.
- Build-path coverage with the new logic:

  | Build path | Binary version | Image expected | Match published? |
  |---|---|---|---|
  | `main` push (on-push.yaml snapshot) | `v0.X.Y-next` | `:sha-<commit>` (falls through via `-next$`) | ✅ |
  | Tagged release `v0.13.0-rc3` | `v0.13.0-rc3` | `:v0.13.0-rc3` | ✅ (new) |
  | Tagged release `v0.13.0` (stable) | `v0.13.0` | `:v0.13.0` | ✅ (unchanged) |
  | Local `make build` on main HEAD | `v0.X.Y-next` | `:sha-<commit>` | ✅ if HEAD on main; else env-var (unchanged) |
  | Feature branch / fork | `v0.X.Y-next` | `:sha-<commit>` | ❌ — env-var workaround required (unchanged) |

- `demos/cuj1-gke-config.md`: drops the `AICR_VALIDATOR_IMAGE_TAG=edge` workaround now that the binary asks for the right tag by default.

## Testing

```bash
make qualify
```

New test cases in `TestResolveImage`:
- `pre-release rc tag rewrites :latest to :vX.Y.Z-rc1` (flipped from prior "is not a release")
- `pre-release beta tag rewrites :latest to :vX.Y.Z-beta`
- `pre-release alpha.1 (dotted) tag rewrites :latest`
- `snapshot of a pre-release tag falls through` (`v1.0.0-rc1-next`)
- `snapshot of stable release with commit → sha tag` (`v1.0.0-next` + commit)
- `pre-release tag ignores commit (release wins)`

Existing cases preserved (regressions covered):
- `-next snapshot version — no tag rewrite` — pinned with explanatory comment as the regression guard.
- `git-describe snapshot is not a release` — still falls through.

Coverage on `pkg/validator/catalog`: 97.6%.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert.

**Rollout notes:** Backwards-compatible at runtime. The only behavioral change is for binaries whose version string matches the new shape — previously broken with `ImagePullBackOff`, now resolves correctly. The `-next$` exclusion ensures main-development builds keep using `:sha-<commit>`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)