### PR TITLE
fix: prefer active job pods when selecting by label

### DIFF
--- a/pkg/k8s/pod/consts.go
+++ b/pkg/k8s/pod/consts.go
@@ -18,6 +18,7 @@ package pod
 const (
 	keyNamespace = "namespace"
 	keyName      = "name"
+	keyJob       = "job"
 	keyReason    = "reason"
 	keyMessage   = "message"
 	keyURI       = "uri"

--- a/pkg/k8s/pod/find.go
+++ b/pkg/k8s/pod/find.go
@@ -27,7 +27,7 @@ import (
 // Job (batch/v1) starting in 1.27. It supersedes the legacy job-name label.
 const jobNameLabel = "batch.kubernetes.io/job-name"
 
-// GetPodForJob returns the first pod owned by the named Job, located via the
+// GetPodForJob returns the best pod owned by the named Job, located via the
 // standard `batch.kubernetes.io/job-name=<jobName>` label selector.
 //
 // Returns an ErrCodeNotFound StructuredError when the listing succeeds but
@@ -39,13 +39,49 @@ func GetPodForJob(ctx context.Context, client kubernetes.Interface, namespace, j
 	})
 	if err != nil {
 		return nil, errors.WrapWithContext(errors.ErrCodeInternal, "failed to list pods for Job", err,
-			map[string]any{keyNamespace: namespace, "job": jobName})
+			map[string]any{keyNamespace: namespace, keyJob: jobName})
 	}
 
 	if len(pods.Items) == 0 {
 		return nil, errors.NewWithContext(errors.ErrCodeNotFound, "pod for job not found",
-			map[string]any{keyNamespace: namespace, "job": jobName})
+			map[string]any{keyNamespace: namespace, keyJob: jobName})
 	}
 
-	return &pods.Items[0], nil
+	selected := selectPodForJob(pods.Items)
+	if selected == nil {
+		return nil, errors.NewWithContext(errors.ErrCodeNotFound, "pod for job not found",
+			map[string]any{keyNamespace: namespace, keyJob: jobName})
+	}
+
+	return selected, nil
+}
+
+func selectPodForJob(pods []corev1.Pod) *corev1.Pod {
+	var newestNonFailed *corev1.Pod
+	var newestFailed *corev1.Pod
+
+	for i := range pods {
+		p := &pods[i]
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		if p.Status.Phase == corev1.PodFailed {
+			if isNewerPod(p, newestFailed) {
+				newestFailed = p
+			}
+			continue
+		}
+		if isNewerPod(p, newestNonFailed) {
+			newestNonFailed = p
+		}
+	}
+
+	if newestNonFailed != nil {
+		return newestNonFailed
+	}
+	return newestFailed
+}
+
+func isNewerPod(candidate, current *corev1.Pod) bool {
+	return current == nil || candidate.CreationTimestamp.After(current.CreationTimestamp.Time)
 }

--- a/pkg/k8s/pod/find_test.go
+++ b/pkg/k8s/pod/find_test.go
@@ -73,6 +73,45 @@ func TestGetPodForJob(t *testing.T) {
 			wantErr:   true,
 			wantCode:  errors.ErrCodeInternal,
 		},
+		{
+			name: "prefers youngest active pod over stale failed pod",
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "validator-job-aaa-stale",
+						Namespace:         ns,
+						Labels:            map[string]string{"batch.kubernetes.io/job-name": jobName},
+						CreationTimestamp: metav1.Unix(10, 0),
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "validator-job-zzz-current",
+						Namespace:         ns,
+						Labels:            map[string]string{"batch.kubernetes.io/job-name": jobName},
+						CreationTimestamp: metav1.Unix(20, 0),
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			wantName: "validator-job-zzz-current",
+		},
+		{
+			name: "falls back to failed pod when no active pod exists",
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "validator-job-failed",
+						Namespace:         ns,
+						Labels:            map[string]string{"batch.kubernetes.io/job-name": jobName},
+						CreationTimestamp: metav1.Unix(30, 0),
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				},
+			},
+			wantName: "validator-job-failed",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Pick the best pod for a Job instead of whatever pod happens to be first in the list. Tiny fix, but it avoids a stale failed pod winning the race.

## Motivation / Context

Kubernetes can have multiple pods with the same `batch.kubernetes.io/job-name` label while Jobs replace pods or old pods are still around. Returning `pods.Items[0]` is a footgun: a failed/old pod can beat the current one, bruh.

Repro before the fix:

```bash
go test ./pkg/k8s/pod -run TestGetPodForJob/prefers -count=1
```

Fixes: N/A
Related: #881

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

`GetPodForJob` now skips terminating pods, prefers the newest non-failed pod, and falls back to the newest failed pod. That keeps failed-job result extraction working, no drama.

## Testing

```bash
go test ./pkg/k8s/pod -run TestGetPodForJob -count=1
go test ./pkg/k8s/pod -count=1
go test -race ./pkg/k8s/pod -count=1
go test -cover ./pkg/k8s/pod
GOFLAGS="-mod=vendor" golangci-lint -c .golangci.yaml run --timeout=10m ./pkg/k8s/pod
make test
make lint
make e2e
make scan
make license-check
```

Also tried `make qualify`; it currently stops at repo-wide coverage `74.6%` vs threshold `75%`. The affected package is `79.3%`, and the remaining qualify targets pass when run directly.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
