### PR TITLE
chore(docs): document make tools-update and unpin version from Tech Stack line

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
  state         config         vs actual     manifests
 ```
 
-**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.11.3, Ko for images
+**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint, Ko for images (pinned versions in `.settings.yaml`)
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
  state         config         vs actual     manifests
 ```
 
-**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint v2.11.3, Ko for images
+**Tech Stack:** Go 1.26, Kubernetes 1.33+, golangci-lint, Ko for images (pinned versions in `.settings.yaml`)
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,9 @@ These principles guide all design decisions in AICR. When faced with trade-offs,
 
 The same tools, same versions, and same validation run locally and in CI.
 
-**What:** Tool versions are centralized in `.settings.yaml`. Both `make tools-setup` (local) and GitHub Actions use this single source of truth. `make qualify` runs the exact same checks as CI.
+**What:** Tool versions are centralized in `.settings.yaml`. `make tools-setup` (first-time install), `make tools-update` (upgrade to current pins), `make tools-check` (verify), and GitHub Actions all use this single source of truth. `make qualify` runs the exact same checks as CI.
 
-**Why:** "Works on my machine" is not acceptable. If a contributor can run `make qualify` locally and it passes, CI will pass. This eliminates surprise failures and reduces feedback loops.
+**Why:** "Works on my machine" is not acceptable. If a contributor can run `make qualify` locally and it passes, CI will pass. This eliminates surprise failures and reduces feedback loops. Note that this only holds when your local toolchain matches `.settings.yaml` — run `make tools-update` after a `git pull` that touches `.settings.yaml`, or whenever `make tools-check` shows a `⚠` for a lint-sensitive tool. A behind-CI `golangci-lint` will silently miss lint findings that CI catches.
 
 ### Adoption Comes from Idiomatic Experience
 
@@ -329,7 +329,7 @@ By making a contribution to this project, I certify that:
 
 1. Start with issues labeled `good first issue`
 2. Read existing code in the package you're modifying before writing
-3. Run `make tools-check` to verify your environment
+3. Run `make tools-check` to verify your environment; run `make tools-update` if any tool is behind
 4. Study the [Design Principles](#design-principles) section
 
 **Good first contributions:**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,8 @@ alias aicrup='curl -sfL https://raw.githubusercontent.com/NVIDIA/aicr/main/insta
 ```bash
 # 1. Clone and setup
 git clone https://github.com/NVIDIA/aicr.git && cd aicr
-make tools-setup    # Install all required tools
+make tools-setup    # Install all required tools (first-time)
+make tools-update   # Upgrade existing tools to versions in .settings.yaml
 make tools-check    # Verify versions match .settings.yaml
 
 # 2. Develop
@@ -90,15 +91,25 @@ sudo chmod +x /usr/local/bin/yq
 The project uses `.settings.yaml` as a single source of truth for tool versions. This ensures consistency between local development and CI.
 
 ```bash
-# Install all required tools (interactive mode)
+# Install all required tools (first-time, interactive mode)
 make tools-setup
 
 # Or skip prompts for CI/scripts
 AUTO_MODE=true make tools-setup
 
+# Upgrade existing tools to the pinned versions in .settings.yaml
+# (run periodically — see "Keeping the toolchain in sync" below)
+make tools-update
+
 # Verify installation
 make tools-check
 ```
+
+#### Keeping the toolchain in sync
+
+CI uses the versions pinned in `.settings.yaml`. When Renovate bumps a pinned version (e.g. `golangci-lint`), your local install drifts behind CI until you run `make tools-update`. The most painful symptom is **silent false-negative lint runs locally**: a newer `golangci-lint` may default-enable a check (e.g. tighter `goconst` thresholds) that your older local version doesn't flag, so `make qualify` passes locally and fails in CI on the same code.
+
+Run `make tools-update` after a `git pull` that touches `.settings.yaml`, or whenever `make tools-check` shows a `⚠` for a lint-sensitive tool.
 
 Example `make tools-check` output:
 
@@ -124,7 +135,8 @@ Legend: ✓ = installed, ⚠ = version mismatch, ✗ = missing
 ### Version Management
 
 All tool versions are centrally managed in `.settings.yaml`, the single source of truth used by:
-- `make tools-setup` - Local development setup
+- `make tools-setup` - Local development setup (first-time install)
+- `make tools-update` - Upgrade existing tools to the pinned versions
 - `make tools-check` - Version verification
 - GitHub Actions CI - Ensures CI uses identical versions
 
@@ -605,7 +617,8 @@ Verify a bundle with `aicr verify <dir>`. Update the trusted root cache with
 | Target | Description |
 |--------|-------------|
 | `make tools-check` | Check tools and compare versions |
-| `make tools-setup` | Install all development tools |
+| `make tools-setup` | Install all development tools (first-time) |
+| `make tools-update` | Upgrade existing tools to versions pinned in `.settings.yaml` |
 
 ### Utilities
 
@@ -625,7 +638,8 @@ Verify a bundle with `aicr verify <dir>`. Update the trusted root cache with
 
 | Issue | Solution |
 |-------|----------|
-| `make tools-check` shows version mismatch | Run `make tools-setup` to update tools |
+| `make tools-check` shows version mismatch | Run `make tools-update` to upgrade tools to versions pinned in `.settings.yaml` |
+| `make qualify` passes locally but lint fails in CI | Local toolchain has drifted behind CI; run `make tools-update` and re-run `make qualify` |
 | Tests fail with race conditions | Ensure `context.Done()` is checked in loops |
 | Linter errors about `errors.Is()` | Use `errors.Is()` instead of `==` for error comparison |
 | Build failures | Run `make tidy` to update dependencies |


### PR DESCRIPTION
## Summary

Three small contributor-doc fixes, all triggered by a real lint miss on PR #924 where local `golangci-lint` v2.10.1 silently passed a `goconst` finding that CI's v2.12.2 caught.

## Motivation / Context

While addressing CodeRabbit review on #924, CI flagged a `goconst` issue that my local `make qualify` had cleared. Root cause: my local `golangci-lint` was v2.10.1 while CI runs v2.12.2 (pinned in `.settings.yaml`). The `goconst` check tightened its default occurrence threshold between those versions, so the local lint silently produced a false negative.

Investigation surfaced three small doc gaps that contributed:

1. **`.claude/CLAUDE.md` and `AGENTS.md` hard-code `golangci-lint v2.11.3`** in the Tech Stack line. Renovate auto-bumps `.settings.yaml` via the `# renovate:` annotation on each pinned line, but the bare prose mention in CLAUDE.md/AGENTS.md never moves — so the doc drifts on every minor bump. Today `.settings.yaml` says `v2.12.2`; the docs still say `v2.11.3`.
2. **`make tools-update` is undocumented** in CONTRIBUTING.md, DEVELOPMENT.md, and the contributor docs. The target exists in `Makefile` and is the only way to *upgrade* an existing local install to match `.settings.yaml`. The existing docs only describe `tools-setup` (first-time install) and `tools-check` (verify). The DEVELOPMENT.md troubleshooting row even pointed contributors at the wrong target (`tools-setup` for an upgrade scenario).
3. **No callout that local lint can silently miss issues if the toolchain is behind CI.** The existing docs imply that `make qualify` passing locally guarantees CI passes — which is only true when `.settings.yaml` and the local toolchain agree.

Fixes: N/A (no issue filed; surfaced from PR #924 review)
Related: #924

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: contributor docs (`CONTRIBUTING.md`, `DEVELOPMENT.md`), agent docs (`.claude/CLAUDE.md`, `AGENTS.md`)

## Implementation Notes

- **Self-healing version pointer.** Replaced \`golangci-lint v2.11.3\` in CLAUDE.md/AGENTS.md with \`golangci-lint, Ko for images (pinned versions in \`.settings.yaml\`)\`. Eliminates the recurring Renovate drift problem for this line. Same change mirrored in AGENTS.md to keep \`check-agents-sync\` green.
- **DEVELOPMENT.md.** Added \`make tools-update\` to: the quickstart command block, the central \"Version Management\" bullet list, the make-targets reference table under \"Tools\", and the troubleshooting row that used to misroute users to \`tools-setup\`. Also added a second troubleshooting row covering the specific PR #924 failure mode (\"qualify passes locally but lint fails in CI\").
- **DEVELOPMENT.md new subsection \"Keeping the toolchain in sync\"** explains the drift trap explicitly: when Renovate bumps `.settings.yaml`, local installs lag behind CI until you run `make tools-update`. Calls out the silent false-negative lint scenario as the main pitfall.
- **CONTRIBUTING.md.** Updated the \"What/Why\" callout on `.settings.yaml` to mention `tools-update` alongside `tools-setup`, and added a sentence noting that the `make qualify` ≡ CI guarantee only holds when the local toolchain matches `.settings.yaml`. Tightened the recommended starting-points bullet to mention `tools-update` next to `tools-check`.
- **Example output snapshot in DEVELOPMENT.md left untouched** — it still shows \`v2.11.3\` and friends, but it's clearly an illustrative snapshot rather than a current claim, and rewriting it would expand PR scope into version-table maintenance. A maintainer can refresh it later or convert to generic placeholders if desired.

## Testing

Doc-only PR (4 markdown files: \`.claude/CLAUDE.md\`, \`AGENTS.md\`, \`CONTRIBUTING.md\`, \`DEVELOPMENT.md\`). Per `CLAUDE.local.md`'s doc-only verification rule, ran the cheap doc-scoped checks instead of full \`make qualify\`:

\`\`\`bash
make check-agents-sync       # OK: AGENTS.md is in sync with .claude/CLAUDE.md
make check-docs-mdx          # OK: all doc files are MDX-safe
make check-docs-filenames    # OK: all doc filenames follow kebab-case convention
\`\`\`

Full \`make qualify\` skipped because:
- No \`.go\` files changed → Go tests / vet / golangci-lint / coverage can't regress.
- No \`.yaml\` files changed → yamllint and chainsaw e2e can't regress.
- No \`docs/\` files changed → lychee anchor-link checker and Fern docs preview have no relevant input.
- Docs sidebar untouched.

## Risk Assessment

- [x] **Low** — doc-only, no behavior change, easy to revert.

**Rollout notes:** None. Contributors who already know \`make tools-update\` are unaffected; new contributors and anyone diagnosing the \"qualify passes locally but fails in CI\" failure mode get correct guidance.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, doc-only
- [x] Linter passes (`make lint`) — N/A, doc-only; scoped doc checks ran
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, doc-only
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)