### PR TITLE
fix(bundler): strip literal quotes from awk-extracted CRD names in undeploy preflight

### DIFF
--- a/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then

--- a/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/undeploy.sh
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then

--- a/pkg/bundler/deployer/helm/testdata/manifest_only/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/manifest_only/undeploy.sh
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/undeploy.sh
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then

--- a/pkg/bundler/deployer/helm/testdata/mixed_with_pre/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_with_pre/undeploy.sh
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then

--- a/pkg/bundler/deployer/helm/testdata/nodewright_present/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/nodewright_present/undeploy.sh
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then

--- a/pkg/bundler/deployer/helm/testdata/upstream_helm_only/undeploy.sh
+++ b/pkg/bundler/deployer/helm/testdata/upstream_helm_only/undeploy.sh
@@ -348,7 +348,7 @@ check_release_for_stuck_crds() {
   local all_crds_json kubectl_err crd_name
   manifest=$(helm get manifest "${release}" -n "${ns}" 2>/dev/null || true)
   manifest_crds=$(echo "${manifest}" \
-    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{print $2; kind=""}')
+    | awk '/^kind:/{kind=$2} /^  name:/ && kind=="CustomResourceDefinition"{name=$2; gsub(/"/,"",name); print name; kind=""}')
 
   all_crds_json="${PREFLIGHT_ALL_CRDS_JSON:-}"
   if [[ -z "${all_crds_json}" ]]; then


### PR DESCRIPTION
## Summary

undeploy.sh's preflight extracted CRD names with literal double quotes from
chart-rendered manifests, causing `kubectl get crd '"name"'` to return
NotFound and the script to fail closed before touching any release.

## Motivation / Context

cert-manager's chart renders CRD names quoted in YAML:

    metadata:
      name: "certificaterequests.cert-manager.io"

The awk extractor in `manifest_crds` printed `$2` verbatim, so the
preflight check then called `kubectl get crd` with the quoted name
literally — which always returns NotFound. The preflight is designed
to fail closed on inspection errors, so the entire undeploy aborted
at the cert-manager step before any helm release was touched.

Reproduced on a live GKE cluster; the failure was a hard block.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

One-line fix in `pkg/bundler/deployer/helm/templates/undeploy.sh.tmpl`:
strip surrounding double quotes inside the awk one-liner via
`gsub(/"/,"",name)`. Kubernetes resource names cannot contain double
quotes, so this is safe. Six golden testdata files regenerated.

## Testing

```bash
make qualify
```

Bundler package tests pass (`go test -race ./pkg/bundler/deployer/helm/...`).
Verified end-to-end on a live cluster: the regenerated `undeploy.sh`
clears cert-manager preflight and now surfaces a different (legitimate)
stuck-CR blocker that the preflight is designed to catch.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — the bundle's `undeploy.sh` is regenerated on
every `aicr bundle` invocation; users will pick up the fix as soon as
they regenerate their bundle. No migration required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Lint passes locally (`make lint`)