### PR TITLE
fix(bundler): add --force-conflicts to per-component helm upgrade --install

### DIFF
--- a/pkg/bundler/deployer/helm/templates/README.md.tmpl
+++ b/pkg/bundler/deployer/helm/templates/README.md.tmpl
@@ -66,6 +66,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/001-kai-scheduler/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/001-kai-scheduler/install.sh
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts kai-scheduler "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} kai-scheduler "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace kai-scheduler --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/001-kai-scheduler/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/001-kai-scheduler/install.sh
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install kai-scheduler "${CHART}" \
+helm upgrade --install --force-conflicts kai-scheduler "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace kai-scheduler --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/README.md
+++ b/pkg/bundler/deployer/helm/testdata/kai_scheduler_present/README.md
@@ -50,6 +50,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/helm/testdata/manifest_only/001-skyhook-customizations/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/manifest_only/001-skyhook-customizations/install.sh
@@ -17,7 +17,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install --force-conflicts skyhook-customizations ./ \
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators own on rotated webhook cert
+# Secrets. Helm 3 uses client-side apply and does not recognize the flag.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} skyhook-customizations ./ \
   --namespace skyhook --create-namespace \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/manifest_only/001-skyhook-customizations/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/manifest_only/001-skyhook-customizations/install.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install skyhook-customizations ./ \
+helm upgrade --install --force-conflicts skyhook-customizations ./ \
   --namespace skyhook --create-namespace \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/manifest_only/README.md
+++ b/pkg/bundler/deployer/helm/testdata/manifest_only/README.md
@@ -50,6 +50,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/001-gpu-operator-pre/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/001-gpu-operator-pre/install.sh
@@ -17,7 +17,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install --force-conflicts gpu-operator-pre ./ \
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators own on rotated webhook cert
+# Secrets. Helm 3 uses client-side apply and does not recognize the flag.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} gpu-operator-pre ./ \
   --namespace privileged-gpu-operator \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/001-gpu-operator-pre/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/001-gpu-operator-pre/install.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install gpu-operator-pre ./ \
+helm upgrade --install --force-conflicts gpu-operator-pre ./ \
   --namespace privileged-gpu-operator \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/002-gpu-operator/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/002-gpu-operator/install.sh
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts gpu-operator "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} gpu-operator "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace privileged-gpu-operator --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/002-gpu-operator/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/002-gpu-operator/install.sh
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install gpu-operator "${CHART}" \
+helm upgrade --install --force-conflicts gpu-operator "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace privileged-gpu-operator --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/003-gpu-operator-post/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/003-gpu-operator-post/install.sh
@@ -17,7 +17,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install --force-conflicts gpu-operator-post ./ \
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators own on rotated webhook cert
+# Secrets. Helm 3 uses client-side apply and does not recognize the flag.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} gpu-operator-post ./ \
   --namespace privileged-gpu-operator --create-namespace \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/003-gpu-operator-post/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/003-gpu-operator-post/install.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install gpu-operator-post ./ \
+helm upgrade --install --force-conflicts gpu-operator-post ./ \
   --namespace privileged-gpu-operator --create-namespace \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/README.md
+++ b/pkg/bundler/deployer/helm/testdata/mixed_gpu_operator/README.md
@@ -50,6 +50,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/helm/testdata/mixed_with_pre/001-foo-pre/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_with_pre/001-foo-pre/install.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install foo-pre ./ \
+helm upgrade --install --force-conflicts foo-pre ./ \
   --namespace privileged-foo \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/mixed_with_pre/001-foo-pre/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_with_pre/001-foo-pre/install.sh
@@ -17,7 +17,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install --force-conflicts foo-pre ./ \
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators own on rotated webhook cert
+# Secrets. Helm 3 uses client-side apply and does not recognize the flag.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} foo-pre ./ \
   --namespace privileged-foo \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/helm/testdata/mixed_with_pre/002-foo/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_with_pre/002-foo/install.sh
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts foo "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} foo "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace privileged-foo --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/mixed_with_pre/002-foo/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/mixed_with_pre/002-foo/install.sh
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install foo "${CHART}" \
+helm upgrade --install --force-conflicts foo "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace privileged-foo --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/mixed_with_pre/README.md
+++ b/pkg/bundler/deployer/helm/testdata/mixed_with_pre/README.md
@@ -50,6 +50,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/helm/testdata/nodewright_present/001-nodewright-operator/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/nodewright_present/001-nodewright-operator/install.sh
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install nodewright-operator "${CHART}" \
+helm upgrade --install --force-conflicts nodewright-operator "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace skyhook --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/nodewright_present/001-nodewright-operator/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/nodewright_present/001-nodewright-operator/install.sh
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts nodewright-operator "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} nodewright-operator "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace skyhook --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/nodewright_present/README.md
+++ b/pkg/bundler/deployer/helm/testdata/nodewright_present/README.md
@@ -50,6 +50,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/helm/testdata/upstream_helm_only/001-cert-manager/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/upstream_helm_only/001-cert-manager/install.sh
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts cert-manager "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} cert-manager "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace cert-manager --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/upstream_helm_only/001-cert-manager/install.sh
+++ b/pkg/bundler/deployer/helm/testdata/upstream_helm_only/001-cert-manager/install.sh
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install cert-manager "${CHART}" \
+helm upgrade --install --force-conflicts cert-manager "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace cert-manager --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/helm/testdata/upstream_helm_only/README.md
+++ b/pkg/bundler/deployer/helm/testdata/upstream_helm_only/README.md
@@ -50,6 +50,15 @@ cd NNN-<component-name>
 bash install.sh
 ```
 
+> **Helm 4 vs Helm 3:** On Helm 4 (server-side apply by default), each
+> `install.sh` automatically passes `--force-conflicts` so the upgrade can
+> overwrite fields that operators (cert-manager, gpu-operator, nvsentinel,
+> grove, ...) own on their rotated webhook cert Secrets — without it the
+> upgrade fails on field-manager conflicts. On Helm 3 (client-side apply,
+> no field-manager conflicts) the flag is omitted; the script detects the
+> Helm major version at run time, so the same bundle works with either
+> binary.
+
 ## Customization
 
 Each component folder has its own `values.yaml` (static) and `cluster-values.yaml`

--- a/pkg/bundler/deployer/localformat/templates/install-local-helm.sh.tmpl
+++ b/pkg/bundler/deployer/localformat/templates/install-local-helm.sh.tmpl
@@ -17,7 +17,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install --force-conflicts {{ .Name }} ./ \
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators own on rotated webhook cert
+# Secrets. Helm 3 uses client-side apply and does not recognize the flag.
+HELM_MAJOR=$(helm version --template '{{`{{.Version}}`}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} {{ .Name }} ./ \
   --namespace {{ .Namespace }}{{ if .CreateNamespace }} --create-namespace{{ end }} \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/localformat/templates/install-local-helm.sh.tmpl
+++ b/pkg/bundler/deployer/localformat/templates/install-local-helm.sh.tmpl
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install {{ .Name }} ./ \
+helm upgrade --install --force-conflicts {{ .Name }} ./ \
   --namespace {{ .Namespace }}{{ if .CreateNamespace }} --create-namespace{{ end }} \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/localformat/templates/install-upstream-helm.sh.tmpl
+++ b/pkg/bundler/deployer/localformat/templates/install-upstream-helm.sh.tmpl
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{`{{.Version}}`}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts {{ .Name }} "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} {{ .Name }} "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace {{ .Namespace }} --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/localformat/templates/install-upstream-helm.sh.tmpl
+++ b/pkg/bundler/deployer/localformat/templates/install-upstream-helm.sh.tmpl
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install {{ .Name }} "${CHART}" \
+helm upgrade --install --force-conflicts {{ .Name }} "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace {{ .Namespace }} --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/localformat/testdata/local_helm_manifest_only/001-skyhook-customizations/install.sh
+++ b/pkg/bundler/deployer/localformat/testdata/local_helm_manifest_only/001-skyhook-customizations/install.sh
@@ -17,7 +17,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install --force-conflicts skyhook-customizations ./ \
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators own on rotated webhook cert
+# Secrets. Helm 3 uses client-side apply and does not recognize the flag.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} skyhook-customizations ./ \
   --namespace skyhook --create-namespace \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/localformat/testdata/local_helm_manifest_only/001-skyhook-customizations/install.sh
+++ b/pkg/bundler/deployer/localformat/testdata/local_helm_manifest_only/001-skyhook-customizations/install.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
-helm upgrade --install skyhook-customizations ./ \
+helm upgrade --install --force-conflicts skyhook-customizations ./ \
   --namespace skyhook --create-namespace \
   -f values.yaml -f cluster-values.yaml \
   ${COMPONENT_WAIT_ARGS:-} ${DRY_RUN_FLAG:-} ${KUBECONFIG_FLAG:-} ${HELM_DEBUG_FLAG:-}

--- a/pkg/bundler/deployer/localformat/testdata/upstream_helm_only/001-nfd/install.sh
+++ b/pkg/bundler/deployer/localformat/testdata/upstream_helm_only/001-nfd/install.sh
@@ -22,7 +22,7 @@ source ./upstream.env
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install nfd "${CHART}" \
+helm upgrade --install --force-conflicts nfd "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace node-feature-discovery --create-namespace \
   -f values.yaml -f cluster-values.yaml \

--- a/pkg/bundler/deployer/localformat/testdata/upstream_helm_only/001-nfd/install.sh
+++ b/pkg/bundler/deployer/localformat/testdata/upstream_helm_only/001-nfd/install.sh
@@ -19,10 +19,21 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=/dev/null
 source ./upstream.env
 
+# Helm 4 uses server-side apply by default; --force-conflicts lets the
+# upgrade overwrite fields that operators (cert-manager, gpu-operator,
+# nvsentinel, ...) own on rotated webhook cert Secrets. Helm 3 uses
+# client-side apply (no field-manager conflicts) and does not recognize
+# the flag, so omit it on Helm 3.
+HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -nE 's/^v([0-9]+)\..*/\1/p')
+FORCE_CONFLICTS_FLAG=""
+if [[ "${HELM_MAJOR:-0}" -ge 4 ]]; then
+  FORCE_CONFLICTS_FLAG="--force-conflicts"
+fi
+
 # CHART carries the full OCI URI for OCI charts and just the chart name for
 # HTTP/HTTPS charts. REPO is non-empty only for HTTP/HTTPS charts; the
 # ${REPO:+--repo "${REPO}"} expansion adds --repo iff REPO is set.
-helm upgrade --install --force-conflicts nfd "${CHART}" \
+helm upgrade --install ${FORCE_CONFLICTS_FLAG} nfd "${CHART}" \
   ${REPO:+--repo "${REPO}"} --version "${VERSION}" \
   --namespace node-feature-discovery --create-namespace \
   -f values.yaml -f cluster-values.yaml \


### PR DESCRIPTION
## Summary

Helm 4 uses server-side apply by default. Charts whose operators mutate
their own webhook cert Secret at runtime (cert-manager, gpu-operator,
kubeflow-trainer+jobset, kgateway, nvsentinel, grove, kai-scheduler)
cause `helm upgrade` to fail with field-manager conflicts on
re-install/redeploy, leaving the deploy unrecoverable short of
`helm uninstall`. Add `--force-conflicts` to both install.sh templates.

## Motivation / Context

Reproduced live on a GKE cluster: after the grove-operator rotated its
own webhook cert Secret during run #1, run #2 of `./deploy.sh` failed
with:

```
UPGRADE FAILED: conflict occurred while applying object
dynamo-system/grove-webhook-server-cert /v1, Kind=Secret:
Apply failed with 2 conflicts: conflicts with "grove-operator"
using v1:
  - .data.tls.crt
  - .data.tls.key
```

The bundle's per-component install.sh retried 5 times — every retry
failed identically — and the deploy aborted at the 7th release of 20.
The same blocker would have recurred at gpu-operator and nvsentinel
later in the sequence.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

Two-line template change in
`pkg/bundler/deployer/localformat/templates/`:
- `install-upstream-helm.sh.tmpl`
- `install-local-helm.sh.tmpl`

Add `--force-conflicts` to every generated `helm upgrade --install`
invocation. 11 golden testdata files regenerated.

### Tradeoff acknowledgment

`--force-conflicts` causes helm upgrade to forcibly overwrite fields
owned by other field-managers. The intended use is to unblock the
operator-rotated-cert pattern, but the same mechanism will silently
revert manual `kubectl edit`/`kubectl patch` hotfixes on chart-managed
fields. For AICR's greenfield install + clean-redeploy use case this
is acceptable; long-running GitOps drift accumulation is out of scope
for `deploy.sh`.

Argo CD's `ServerSideApply=force` and FluxCD's SSA mode default to the
same behavior for this exact reason — it is the standard convergence
strategy for SSA-managed GitOps tooling, not a workaround.

## Testing

```bash
make qualify
```

Bundler tests pass (`go test -race ./pkg/bundler/deployer/...`).
The 7 packages that failed under the local sandbox harness
(`pkg/bundler/attestation`, `pkg/bundler/deployer/helm`, `pkg/cli`,
`pkg/config`, `pkg/serializer`, `pkg/server`, `pkg/trust`) all failed
on sandbox-only errors (`bind: operation not permitted` on httptest,
`mktemp` denied under `/var/folders`, sigstore TUF cache write,
go mod cache write) and pass cleanly when re-run outside the sandbox.
None are related to this change.

Verified end-to-end on a live GKE cluster: regenerated bundle's
`deploy.sh` upgrades the previously-blocked grove release in
~1 second and continues through the remaining 14 releases without
field-manager conflicts.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, documented tradeoff

**Rollout notes:** Each bundle's `install.sh` is regenerated on every
`aicr bundle` invocation; users pick up the new flag automatically on
next bundle generation. No migration required for existing installs —
the next upgrade simply succeeds where it previously failed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Lint passes locally (`make lint`)