### PR TITLE
fix(ci): use yq instead of sed for version stamp in publish workflow

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -183,12 +183,13 @@ jobs:
           cp fern/docs.yml /tmp/docs.yml.preStamp
           VERSION=$(curl -sf https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name || true)
           if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            sed -i 's/display-name: "Latest"/display-name: "Latest · '"${VERSION}"'"/' fern/docs.yml
+            export VERSION
+            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
           else
             echo "::warning::Could not resolve latest GitHub release tag; continuing without stamping"
           fi
           echo "--- docs.yml versions after stamp ---"
-          grep "display-name:" fern/docs.yml
+          yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary

Replace fragile `sed` pattern with structural `yq` selector for the "Latest · vX.Y.Z" version stamp in the publish workflow.

## Motivation / Context

Fixes: #942
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: .github/workflows/publish-fern-docs.yml

## Implementation Notes

The stamp step uses `sed 's/display-name: "Latest"/display-name: "Latest · vX.Y.Z"/'` but after `yq` rewrites `docs.yml` in earlier steps, the YAML quoting style changes and the `sed` pattern no longer matches. The stamp silently fails.

Replaced with the same `yq` approach used by topograph and NVSentinel:

```yaml
yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
```

Also updated the diagnostic output from `grep` to `yq` for consistency.

## Testing

Full publish pipeline replicated locally:
1. Extracted frozen content for v0.12.0, v0.12.1, v0.13.0
2. Stamped with yq — dropdown shows "Latest · v0.13.0"
3. Published to preview — verified at nvidia-preview-debug-full-gha.docs.buildwithfern.com/aicr

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Requires a workflow_dispatch after merge to take effect on the live site.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)