### PR TITLE
fix(performance): add GKE inference performance validation + cold-start readiness probe

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -315,10 +315,14 @@ const (
 // Inference performance validation timeouts.
 const (
 	// InferenceHealthTimeout is the maximum time to wait for the inference
-	// endpoint to become healthy before running the benchmark.
+	// endpoint to start serving real requests before running the benchmark.
+	// Readiness is determined by a real /v1/chat/completions probe — a /health
+	// 200 is insufficient because the frontend serves /health before backend
+	// workers register.
 	InferenceHealthTimeout = 5 * time.Minute
 
-	// InferenceHealthPollInterval is the polling interval for health checks.
+	// InferenceHealthPollInterval is the polling interval for the readiness
+	// probe described on InferenceHealthTimeout.
 	InferenceHealthPollInterval = 10 * time.Second
 
 	// InferencePerfJobTimeout is the maximum time for the AIPerf benchmark Job
@@ -390,6 +394,14 @@ const (
 	// MaxErrorBodySize is the maximum size in bytes for HTTP error response bodies.
 	// Bounds io.ReadAll on error paths to prevent unbounded memory allocation.
 	MaxErrorBodySize = 4096
+
+	// InferenceProbeBodyLimit caps the response read by the inference-perf
+	// readiness probe (POST /v1/chat/completions before launching AIPerf).
+	// A successful probe with max_tokens=4 is well under 1 KiB; the cap is
+	// generous enough for any reasonable OpenAI-compatible frontend yet small
+	// enough that a runaway/streaming frontend can't blow memory before the
+	// probe gives up.
+	InferenceProbeBodyLimit = 8 * 1024 // 8 KiB
 )
 
 // Job configuration constants.

--- a/pkg/defaults/timeouts_test.go
+++ b/pkg/defaults/timeouts_test.go
@@ -148,7 +148,7 @@ func TestCheckExecutionTimeoutRelationships(t *testing.T) {
 	//
 	//   InferenceNamespaceTerminationWait (5m)  — prior run's ns drain
 	//   + InferenceWorkloadReadyTimeout   (10m) — DynamoGraphDeployment ready
-	//   + InferenceHealthTimeout          (5m)  — frontend /health probe
+	//   + InferenceHealthTimeout          (5m)  — /v1/chat/completions readiness probe
 	//   + InferencePerfPodTimeout         (5m)  — AIPerf pod scheduling
 	//   + InferencePerfJobTimeout         (15m) — AIPerf benchmark runtime
 	//

--- a/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
+++ b/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
@@ -68,6 +68,19 @@ spec:
       constraints:
         - name: Deployment.gpu-operator.version
           value: ">= v24.6.0"
+    performance:
+      checks:
+        - inference-perf
+      # Placeholder thresholds — pending empirical tuning on H100 with
+      # Qwen/Qwen3-0.6B at concurrency=16/GPU. Current values are loose
+      # smoke-test floors; tighten once reference runs are published. Each
+      # constraint name corresponds to one metric the inference-perf check
+      # produces (throughput in tok/s; time-to-first-token p99 in ms).
+      constraints:
+        - name: inference-throughput
+          value: ">= 5000"
+        - name: inference-ttft-p99
+          value: "<= 200"
     conformance:
       checks:
         - platform-health

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -248,11 +249,11 @@ func validateInferencePerf(ctx *validators.Context) (*inferenceResult, error) {
 
 	slog.Info("Using inference endpoint", "endpoint", endpoint, "concurrency", config.concurrency)
 
-	// Wait for the endpoint to be healthy. Callee returns ErrCodeTimeout on
-	// deadline exhaustion, ErrCodeInternal on request-construction errors;
-	// both classifications are lost if we rewrap here.
-	if healthErr := waitForEndpointHealth(ctx.Ctx, endpoint); healthErr != nil {
-		return nil, healthErr
+	// Wait for the endpoint to be ready to serve requests. Callee returns
+	// ErrCodeTimeout on deadline exhaustion, ErrCodeInternal on
+	// request-construction errors; both classifications are lost if we rewrap.
+	if readyErr := waitForEndpointReady(ctx.Ctx, endpoint, inferenceModel); readyErr != nil {
+		return nil, readyErr
 	}
 
 	// Run AIPerf benchmark. On failure, surface the captured pod logs so the
@@ -1012,38 +1013,76 @@ func inferServicePort(svc v1.Service) int32 {
 	return 8000
 }
 
-// waitForEndpointHealth polls the inference endpoint health check until it returns 200.
-func waitForEndpointHealth(ctx context.Context, endpoint string) error {
-	healthURL := endpoint + "/health"
-	slog.Info("Waiting for inference endpoint health", "url", healthURL)
+// waitForEndpointReady polls the inference endpoint with a real chat-completion
+// request until it produces a non-empty completion. This is stricter than a
+// /health probe: Dynamo's frontend returns 200 from /health as soon as the HTTP
+// server is up — before backend workers have registered or the model has
+// finished loading. Hitting that window with AIPerf produces an "all requests
+// completed, zero tokens" result that masquerades as a benchmark failure. A
+// real inference probe is the only signal that's both necessary and sufficient
+// for the endpoint to serve a benchmark workload.
+func waitForEndpointReady(ctx context.Context, endpoint, model string) error {
+	return waitForEndpointReadyWithInterval(ctx, endpoint, model, defaults.InferenceHealthPollInterval)
+}
+
+// waitForEndpointReadyWithInterval is the testable seam: production callers go
+// through waitForEndpointReady (10 s poll); tests pass a tighter interval so
+// the success / timeout paths run in milliseconds.
+func waitForEndpointReadyWithInterval(ctx context.Context, endpoint, model string, pollInterval time.Duration) error {
+	chatURL := endpoint + "/v1/chat/completions"
+	slog.Info("Waiting for inference endpoint to serve requests", "url", chatURL, "model", model)
 
 	client := &http.Client{Timeout: defaults.HTTPClientTimeout}
 
 	pollCtx, cancel := context.WithTimeout(ctx, defaults.InferenceHealthTimeout)
 	defer cancel()
 
-	for {
-		req, err := http.NewRequestWithContext(pollCtx, http.MethodGet, healthURL, nil)
-		if err != nil {
-			return errors.Wrap(errors.ErrCodeInternal, "failed to create health request", err)
-		}
+	bodyTmpl := `{"model":%q,"messages":[{"role":"user","content":"hi"}],"max_tokens":4}`
+	body := fmt.Sprintf(bodyTmpl, model)
 
-		resp, err := client.Do(req) //nolint:gosec // G704 -- URL constructed from in-cluster K8s service discovery
+	for {
+		req, err := http.NewRequestWithContext(pollCtx, http.MethodPost, chatURL, strings.NewReader(body))
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to create inference probe request", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req) //nolint:gosec // G107 -- URL constructed from in-cluster K8s service discovery
 		if err == nil {
+			respBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, defaults.InferenceProbeBodyLimit+1))
 			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				slog.Info("Inference endpoint is healthy")
-				return nil
+			switch {
+			case readErr != nil:
+				slog.Debug("Inference probe read failed", "error", readErr)
+			case int64(len(respBytes)) > defaults.InferenceProbeBodyLimit:
+				slog.Debug("Inference probe response exceeded limit", "limit", defaults.InferenceProbeBodyLimit)
+			case resp.StatusCode != http.StatusOK:
+				slog.Debug("Inference probe non-200", "status", resp.StatusCode)
+			default:
+				var probe struct {
+					Choices []struct {
+						Message struct {
+							Content string `json:"content"`
+						} `json:"message"`
+					} `json:"choices"`
+				}
+				ok := json.Unmarshal(respBytes, &probe) == nil &&
+					len(probe.Choices) > 0 &&
+					probe.Choices[0].Message.Content != ""
+				if ok {
+					slog.Info("Inference endpoint is serving requests")
+					return nil
+				}
+				slog.Debug("Inference probe response missing completion content")
 			}
-			slog.Debug("Health check returned non-200", "status", resp.StatusCode)
 		} else {
-			slog.Debug("Health check failed", "error", err)
+			slog.Debug("Inference probe request failed", "error", err)
 		}
 
 		select {
 		case <-pollCtx.Done():
-			return errors.Wrap(errors.ErrCodeTimeout, "timed out waiting for inference endpoint health", pollCtx.Err())
-		case <-time.After(defaults.InferenceHealthPollInterval):
+			return errors.Wrap(errors.ErrCodeTimeout, "timed out waiting for inference endpoint to serve requests", pollCtx.Err())
+		case <-time.After(pollInterval):
 		}
 	}
 }

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -17,11 +17,17 @@ package main
 import (
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	validatorv1 "github.com/NVIDIA/aicr/pkg/api/validator/v1"
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/validators"
 	v1 "k8s.io/api/core/v1"
@@ -937,5 +943,79 @@ func TestRequireComparatorPrefix(t *testing.T) {
 					tt.value, tt.want, err, tt.wantError)
 			}
 		})
+	}
+}
+
+// TestWaitForEndpointReady_AcceptsOnFirstRealCompletion covers the warmup race
+// the function exists to handle: Dynamo's frontend responds 200 to /health
+// before backend workers register, so a /health-only probe lets AIPerf launch
+// against an endpoint that completes requests with zero tokens. The probe must
+// only accept once /v1/chat/completions returns a non-empty completion — every
+// other shape (404, 503, 200-empty-content, 200-but-no-choices) must be
+// retried, not treated as ready.
+func TestWaitForEndpointReady_AcceptsOnFirstRealCompletion(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if r.Method != http.MethodPost {
+			t.Errorf("probe method = %q, want %q", r.Method, http.MethodPost)
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("probe hit %q, expected /v1/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1: // backend not registered yet
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case 2: // accepted but no completion produced (the failure mode we're guarding against)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":""}}]}`))
+		case 3: // worker connected, real completion
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hi"}}]}`))
+		default:
+			t.Errorf("unexpected extra probe call %d after success", n)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hi"}}]}`))
+		}
+	}))
+	defer srv.Close()
+
+	// Bound the success-path probe so a regression that breaks the accept
+	// condition fails the test in milliseconds rather than blocking up to
+	// InferenceHealthTimeout (5 m). 250 ms is comfortable headroom over the
+	// 3-call/1 ms expected critical path while still tight enough to surface
+	// a stuck loop.
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	if err := waitForEndpointReadyWithInterval(ctx, srv.URL, "test-model", time.Millisecond); err != nil {
+		t.Fatalf("waitForEndpointReady returned error: %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("probe call count = %d, want 3 (503 → empty 200 → real 200)", got)
+	}
+}
+
+// TestWaitForEndpointReady_TimesOutWhenAlwaysEmpty ensures the probe doesn't
+// silently treat persistent "200 with empty completion" as ready — that's the
+// exact failure mode (frontend up, workers absent) the function exists to
+// detect. Use a tiny ctx deadline so the test stays fast.
+func TestWaitForEndpointReady_TimesOutWhenAlwaysEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := waitForEndpointReadyWithInterval(ctx, srv.URL, "test-model", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+		t.Errorf("error code = %v, want ErrCodeTimeout (err=%v)", err, err)
 	}
 }


### PR DESCRIPTION
## Summary

Two related fixes that together unblock `aicr validate --phase
performance` against the GKE H100 COS Dynamo recipe:

1. **Wire the GKE Dynamo overlay to the `inference-perf` validator.**
   Without this, the phase is a no-op (`validators=0, status=skipped`)
   — the validator and EKS sibling overlay already exist; the GKE
   overlay was never extended.
2. **Replace the `inference-perf` validator's `GET /health` probe with
   a real `POST /v1/chat/completions` probe.** Dynamo's frontend
   returns 200 from `/health` as soon as the HTTP server is up — well
   before backend workers register or the model finishes loading.
   Hitting that window with AIPerf produced an "all requests completed,
   zero tokens" benchmark result that masqueraded as a regression. The
   chat-completion probe only accepts the endpoint once the response
   carries a non-empty completion — the only signal both necessary and
   sufficient to know AIPerf will produce real numbers. Affects both
   EKS and GKE Dynamo overlays (single shared codepath).

## Motivation / Context

`aicr validate --phase performance` against the GKE Dynamo recipe was
silently a no-op:

```
[cli] phase requested but no checks defined in recipe;
      phase will be empty: phase=performance
[cli] phase completed: phase=performance status=skipped
```

Wiring the overlay to the `inference-perf` validator exposed a
pre-existing cold-start flake in the validator itself — first runs
against a fresh workload reported `throughput=0 tok/s`, while a third
run several minutes later reported `33,982 tok/s`. Root-caused to the
`/health` probe accepting an endpoint that's not actually serving yet
(Dynamo's frontend reports `instances: []` until backend workers
register, even though `/health` already returns 200). The fix replaces
the probe with a real chat-completion request that demands a non-empty
response before AIPerf launches.

Fixes: #937
Related: #641

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`pkg/validator`, `validators/performance`)
- [x] Core libraries (`pkg/defaults`)

## Implementation Notes

- `recipes/overlays/h100-gke-cos-inference-dynamo.yaml`: mirrors the
  EKS overlay's `validation.performance` block one-for-one
  (`inference-perf` check + placeholder `>= 5000 tok/s` /
  `<= 200 ms p99` thresholds, both empirically validated below).
- `validators/performance/inference_perf_constraint.go`:
  - Replaces `waitForEndpointHealth` (a `GET /health` poll) with
    `waitForEndpointReady` (a `POST /v1/chat/completions` poll that
    requires a non-empty `choices[0].message.content`).
  - Bounds the probe response body with `io.LimitReader` against a
    new `inferenceProbeBodyLimit` const (per the repo's "no unbounded
    `io.ReadAll`" rule).
  - Splits an internal `waitForEndpointReadyWithInterval(...,
    pollInterval)` seam so unit tests can drive the loop in
    milliseconds without changing the production 10 s poll.
- `pkg/defaults/timeouts.go`: refreshes the `InferenceHealthTimeout`
  godoc to reflect the new probe shape; the 5 min / 10 s budget is
  unchanged.
- `validators/performance/inference_perf_test.go`: two new
  `httptest`-backed tests cover the "503 → 200-empty → 200-real"
  accept path and the persistent-empty timeout path.

## Testing

```bash
make qualify
```

- `make lint` (yamllint + golangci-lint + license headers + agents sync + BOM): clean
- `make test-coverage`: pass (project-wide floor maintained at 76.7%)
- `make e2e` (chainsaw): 21/21 pass
- `make scan` (Grype): no vulnerabilities

End-to-end run against a real GKE H100-mega-80gb COS Dynamo cluster
with the fix in place:

```
[cli] validator completed: name=inference-perf status=passed
[cli] Inference throughput: 33982.54 tokens/sec
[cli] Inference TTFT p99: 119.79 ms
[cli] phase completed: phase=performance status=passed validators=1 passed=1 failed=0
```

`33,982 tok/s` is comfortably above the `>= 5000` placeholder; `119.79 ms`
sits under the `<= 200` placeholder. Per-platform threshold tuning is
not required at this time — the placeholders carried over from the EKS
overlay turn out to fit GKE H100-mega-80gb fine.

New unit tests:
```
=== RUN   TestWaitForEndpointReady_AcceptsOnFirstRealCompletion
--- PASS: TestWaitForEndpointReady_AcceptsOnFirstRealCompletion (0.01s)
=== RUN   TestWaitForEndpointReady_TimesOutWhenAlwaysEmpty
--- PASS: TestWaitForEndpointReady_TimesOutWhenAlwaysEmpty (0.05s)
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** The validator-side change replaces one readiness
probe with another stricter one; existing EKS Dynamo runs that relied
on the `/health` probe will now wait for a real chat completion before
launching AIPerf — the same behavior every EKS run *should* already
have had, so this is a tightening, not a behavior break. No
migrations, feature flags, or backwards-compat shims required. Reverts
cleanly.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (two `httptest`-backed cases for the new probe)
- [x] I updated docs if user-facing behavior changed (N/A — no user-facing surface added)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)