### PR TITLE
Warn on missing PVC storageClassName in bundles

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1190,6 +1190,8 @@ aicr bundle --recipe recipe.yaml \
 
 When `--storage-class` is not set, any `storageClassName` values already defined in the recipe overlays are preserved as defaults. When it is set, `--set <component>:<path>=<value>` on the same path still wins — `--storage-class` only fills in paths that were not explicitly overridden.
 
+If a rendered component creates a PVC at a registry-declared `storageClassPaths` entry and no usable `storageClassName` is set after overlay, `--storage-class`, and `--set` precedence is resolved, `aicr bundle` emits a non-blocking warning. The bundle still relies on the target cluster's default StorageClass in that case.
+
 #### Deployment Methods
 
 The `--deployer` flag controls how deployment artifacts are generated:

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -284,6 +284,10 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 			"failed to extract component values", err)
 	}
 
+	if warningErr := b.warnMissingStorageClassForPVCs(ctx, recipeResult, componentValues); warningErr != nil {
+		return nil, warningErr
+	}
+
 	// Run component-specific validations
 	if validationErr := b.runComponentValidations(ctx, recipeResult); validationErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
@@ -804,6 +808,100 @@ func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, valu
 	}
 }
 
+// warnMissingStorageClassForPVCs emits a bundle note when a rendered component creates
+// a PVC but leaves storageClassName unset, causing Kubernetes to rely on the
+// target cluster's default StorageClass.
+func (b *DefaultBundler) warnMissingStorageClassForPVCs(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any) error {
+	if b.Config == nil {
+		return nil
+	}
+
+	registry, err := recipe.GetComponentRegistry()
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to load component registry for storage class warnings", err)
+	}
+
+	for _, ref := range recipeResult.ComponentRefs {
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(errors.ErrCodeTimeout,
+				"context cancelled during storage class warning evaluation", err)
+		}
+
+		comp := registry.Get(ref.Name)
+		if comp == nil {
+			continue
+		}
+
+		values := componentValues[ref.Name]
+		if values == nil {
+			continue
+		}
+
+		for _, path := range comp.GetStorageClassPaths() {
+			if !storageClassPathHasPVCSpec(values, path) || hasConfiguredStorageClass(values, path) {
+				continue
+			}
+
+			msg := fmt.Sprintf(
+				"%s renders a PVC without storageClassName at %s; set --storage-class <name> or --set %s:%s=<name> to avoid relying on the cluster default StorageClass",
+				ref.Name,
+				path,
+				ref.Name,
+				path,
+			)
+			b.appendWarning(msg)
+			slog.Warn("component PVC storageClassName is unset",
+				"component", ref.Name,
+				"path", path,
+			)
+		}
+	}
+
+	return nil
+}
+
+func storageClassPathHasPVCSpec(values map[string]any, path string) bool {
+	parentPath, ok := storageClassPathParent(path)
+	if !ok {
+		return false
+	}
+
+	parent, ok := component.GetValueByPath(values, parentPath)
+	if !ok || parent == nil {
+		return false
+	}
+	_, ok = parent.(map[string]any)
+	return ok
+}
+
+func storageClassPathParent(path string) (string, bool) {
+	idx := strings.LastIndex(path, ".")
+	if idx <= 0 {
+		return "", false
+	}
+	return path[:idx], true
+}
+
+func hasConfiguredStorageClass(values map[string]any, path string) bool {
+	value, ok := component.GetValueByPath(values, path)
+	if !ok || value == nil {
+		return false
+	}
+
+	if s, ok := value.(string); ok {
+		return strings.TrimSpace(s) != ""
+	}
+	return true
+}
+
+func (b *DefaultBundler) appendWarning(warning string) {
+	if !strings.HasPrefix(warning, "Warning: ") {
+		warning = "Warning: " + warning
+	}
+	b.warnings = append(b.warnings, warning)
+}
+
 // runComponentValidations executes all component-specific validations registered in the registry.
 // Collects warnings and errors based on validation severity.
 func (b *DefaultBundler) runComponentValidations(ctx context.Context, recipeResult *recipe.RecipeResult) error {
@@ -849,11 +947,7 @@ func (b *DefaultBundler) runComponentValidations(ctx context.Context, recipeResu
 
 		// Collect warnings (prepend "Warning: " if not already present)
 		for _, warning := range warnings {
-			msg := warning
-			if !strings.HasPrefix(warning, "Warning: ") {
-				msg = "Warning: " + warning
-			}
-			b.warnings = append(b.warnings, msg)
+			b.appendWarning(warning)
 		}
 
 		// Return first error (errors are blocking)

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -1071,6 +1071,104 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 	}
 }
 
+func TestWarnMissingStorageClassForPVCs(t *testing.T) {
+	const scPath = "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName"
+	const pvcSizePath = "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
+
+	recipeResult := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{{Name: "kube-prometheus-stack"}},
+	}
+
+	tests := []struct {
+		name        string
+		cfgOpts     []config.Option
+		setupValues func(map[string]any)
+		wantWarning bool
+	}{
+		{
+			name: "warns when rendered PVC omits storageClassName",
+			setupValues: func(values map[string]any) {
+				component.SetValueByPath(values, pvcSizePath, "50Gi")
+			},
+			wantWarning: true,
+		},
+		{
+			name: "warns when rendered PVC has blank storageClassName",
+			setupValues: func(values map[string]any) {
+				component.SetValueByPath(values, pvcSizePath, "50Gi")
+				component.SetValueByPath(values, scPath, " ")
+			},
+			wantWarning: true,
+		},
+		{
+			name: "does not warn when rendered PVC has storageClassName",
+			setupValues: func(values map[string]any) {
+				component.SetValueByPath(values, scPath, "gp3")
+			},
+		},
+		{
+			name: "does not warn for emptyDir storage",
+			setupValues: func(values map[string]any) {
+				component.SetValueByPath(values, "prometheus.prometheusSpec.storageSpec.emptyDir.sizeLimit", "10Gi")
+			},
+		},
+		{
+			name:    "warns when explicit blank override wins over global storageClass",
+			cfgOpts: []config.Option{config.WithStorageClass("gp3")},
+			setupValues: func(values map[string]any) {
+				component.SetValueByPath(values, pvcSizePath, "50Gi")
+				component.SetValueByPath(values, scPath, " ")
+			},
+			wantWarning: true,
+		},
+		{
+			name:    "does not warn when global storageClass was injected",
+			cfgOpts: []config.Option{config.WithStorageClass("gp3")},
+			setupValues: func(values map[string]any) {
+				component.SetValueByPath(values, pvcSizePath, "50Gi")
+				component.SetValueByPath(values, scPath, "gp3")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := New(WithConfig(config.NewConfig(tt.cfgOpts...)))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			values := map[string]any{}
+			tt.setupValues(values)
+
+			err = b.warnMissingStorageClassForPVCs(context.Background(), recipeResult, map[string]map[string]any{
+				"kube-prometheus-stack": values,
+			})
+			if err != nil {
+				t.Fatalf("warnMissingStorageClassForPVCs() error = %v", err)
+			}
+
+			if gotWarning := len(b.warnings) > 0; gotWarning != tt.wantWarning {
+				t.Fatalf("warning present = %v, want %v; warnings = %v", gotWarning, tt.wantWarning, b.warnings)
+			}
+
+			if tt.wantWarning {
+				warning := b.warnings[0]
+				for _, want := range []string{
+					"Warning: kube-prometheus-stack renders a PVC without storageClassName",
+					scPath,
+					"--storage-class <name>",
+					"--set kube-prometheus-stack:" + scPath + "=<name>",
+				} {
+					if !strings.Contains(warning, want) {
+						t.Errorf("warning = %q, want substring %q", warning, want)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCollectComponentManifests(t *testing.T) {
 	bundler, err := New()
 	if err != nil {


### PR DESCRIPTION
## Summary

Emit a non-blocking bundle warning when rendered component values create a PVC without a usable `storageClassName`.

Document the behavior and add regression coverage for PVC, `emptyDir`, global `--storage-class`, and explicit blank `--set` precedence cases.

## Motivation / Context

Cloud overlays can render `kube-prometheus-stack` with a `volumeClaimTemplate` but no `storageClassName`. On clusters without a default StorageClass, deployment can hang on a Pending PVC. This warns users at bundle time without making storage class selection a hard requirement.

Fixes: #898
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

The warning runs after component values are resolved, so it respects overlay, `--storage-class`, and explicit per-component `--set` precedence. It only warns when the PVC spec parent exists, avoiding false positives for `emptyDir` storage configurations.

## Testing

```bash
go test ./pkg/bundler -run 'TestApplyNodeSchedulingOverrides_StorageClass|TestWarnMissingStorageClassForPVCs' -count=1
env -u GITLAB_TOKEN make qualify
env GOFLAGS=-mod=vendor go build -o /tmp/aicr/issue-898-aicr2/aicr-reviewed ./cmd/aicr
/tmp/aicr/issue-898-aicr2/aicr-reviewed bundle --recipe /tmp/aicr/issue-898-aicr2/recipe.yaml --storage-class gp2 --set 'kube-prometheus-stack:prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName= ' --output /tmp/aicr/issue-898-aicr2/bundle-blank-set
```

`make qualify` completed successfully. The `aicr2` EKS smoke test confirmed the warning still fires when a blank per-component `--set` wins over global `--storage-class`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A. This only adds a warning note and does not change generated values.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
