### PR TITLE
fix(tests): update stale "15 components" comments to 16

### DIFF
--- a/tests/chainsaw/ai-conformance/offline/chainsaw-test.yaml
+++ b/tests/chainsaw/ai-conformance/offline/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
   description: |
     AI-Conformance Inference Stack — Offline Validation.
     Generates the h100-eks-ubuntu-inference-dynamo recipe and bundle,
-    then asserts the recipe has correct criteria, constraints, all 15
+    then asserts the recipe has correct criteria, constraints, all 16
     components, and expected deployment order.
     No cluster needed. Run with:
       AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/ai-conformance/offline
@@ -81,7 +81,7 @@ spec:
               test -f "${WORK}/bundle/deploy.sh"
               test -x "${WORK}/bundle/deploy.sh"
               test -f "${WORK}/bundle/recipe.yaml"
-              # Verify all 15 component directories exist (aws-ebs-csi-driver excluded: disabled by default in EKS overlay)
+              # Verify all 16 component directories exist (aws-ebs-csi-driver excluded: disabled by default in EKS overlay)
               # Helm deployer now produces NNN-<component>/ numbered folders
               # (#662). Mixed components (helm + raw manifests) emit two
               # adjacent folders — the primary plus an injected "-post"


### PR DESCRIPTION
## Summary

Updates two stale descriptive comments in the offline chainsaw test from "15 components" to "16" to match the assertion logic, which already enumerates 16 components.

## Motivation / Context

PR #926 added `prometheus-operator-crds` to the offline component set, bumping the count from 15 to 16. The assertion loop and the line 50 description were updated; two other inline comments (lines 24 and 84) were missed.

Fixes: #931
Related: #926

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: tests (`tests/chainsaw/ai-conformance/offline`)

## Implementation Notes

Comment-only change. Assertion logic was already correct.

## Testing

```bash
yamllint tests/chainsaw/ai-conformance/offline/chainsaw-test.yaml  # clean
```

Comment-only YAML change — no test/build behavior affected.

## Risk Assessment

- [x] **Low** — Isolated comment-only change, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)