### PR TITLE
chore(recipes): bump gpu-operator chart to v26.3.1 and driver to 580.126.20

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -107,7 +107,7 @@ _No images extracted._
 - `nvcr.io/nvidia/cloud-native/nvidia-fs:2.27.3`
 - `nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin:v0.0.3`
 - `nvcr.io/nvidia/cloud-native/vgpu-device-manager:v0.4.2`
-- `nvcr.io/nvidia/driver:580.105.08`
+- `nvcr.io/nvidia/driver:580.126.20`
 - `nvcr.io/nvidia/gpu-operator:v26.3.1`
 - `nvcr.io/nvidia/k8s-device-plugin:v0.19.0`
 - `nvcr.io/nvidia/k8s/container-toolkit:v1.19.0`

--- a/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
+++ b/pkg/bundler/deployer/helm/templates/deploy.sh.tmpl
@@ -346,6 +346,46 @@ for dir in "${SCRIPT_DIR}"/[0-9][0-9][0-9]-*/; do
   {{- range .Components }}
   {{- if eq .Name "nvidia-dra-driver-gpu" }}
   if [[ "${name}" == "nvidia-dra-driver-gpu" ]]; then
+    # gpu-operator's k8s-driver-manager reloads NVIDIA kernel modules
+    # asynchronously per-node after `helm upgrade gpu-operator` returns.
+    # If the DRA kubelet plugin pod re-rolls (via the chart's
+    # podAnnotations or the post-install restart below) before those
+    # reloads finish on every managed GPU node, the freshly-started
+    # plugin can pin its NVML handle to the now-stale driver state on
+    # a not-yet-migrated node. CDI spec generation then fails with
+    # "invalid CDI Spec: empty device edits" and DRA-allocated pods
+    # stay in ContainerCreating until the plugin is restarted again.
+    # Wait for the migration to settle on every managed node before
+    # touching the plugin. See issue #973.
+    #
+    # Two gates skip this wait safely:
+    #   1. The gpu-operator nvidia-driver-daemonset is absent — host-
+    #      managed-driver recipes (GKE COS, OKE, Kind, etc.) run
+    #      gpu-operator with driver.enabled=false, so the DaemonSet is
+    #      never created. Look it up by name across all namespaces so
+    #      we discover it whichever namespace the operator runs in
+    #      (e.g. os-talos moves it to "privileged-gpu-operator").
+    #   2. No nodes carry nvidia.com/gpu.deploy.driver=true — the
+    #      operator's reconciler sets that label only on nodes its
+    #      driver DaemonSet selects (this respects
+    #      --accelerated-node-selector). Waiting on every
+    #      gpu.present=true node would block until the 15-min timeout
+    #      for any GPU node the operator deliberately excludes.
+    DRIVER_DS_NS=$(kubectl get daemonset -A -o jsonpath='{.items[?(@.metadata.name=="nvidia-driver-daemonset")].metadata.namespace}' 2>/dev/null | awk '{print $1}')
+    if [[ -z "${DRIVER_DS_NS}" ]]; then
+      echo "  gpu-operator nvidia-driver-daemonset not present (host-managed driver); skipping migration wait"
+    else
+      MANAGED_NODES=$(kubectl get nodes -l nvidia.com/gpu.deploy.driver=true -o name 2>/dev/null | wc -l | tr -d ' ')
+      if [[ "${MANAGED_NODES}" -gt 0 ]]; then
+        echo "  Waiting for gpu-operator driver migration on ${MANAGED_NODES} managed GPU node(s) to reach upgrade-done (ns=${DRIVER_DS_NS})..."
+        if ! kubectl wait --for=jsonpath='{.metadata.labels.nvidia\.com/gpu-driver-upgrade-state}=upgrade-done' \
+             nodes -l nvidia.com/gpu.deploy.driver=true --timeout=15m; then
+          echo "  WARNING: not all managed GPU nodes reached upgrade-done within 15m; proceeding with restart anyway"
+        fi
+      else
+        echo "  No nodes labeled nvidia.com/gpu.deploy.driver=true yet; skipping migration wait"
+      fi
+    fi
     # Best-effort mitigation for kubelet DRA plugin registration drift.
     # After uninstall/reinstall, kubelet's fsnotify watcher may not detect new
     # registration sockets. Restarting the plugin DS forces fresh socket creation.

--- a/recipes/components/gpu-operator/values-aks-training.yaml
+++ b/recipes/components/gpu-operator/values-aks-training.yaml
@@ -23,6 +23,15 @@ cdi:
 toolkit:
   enabled: false
 
+# Re-enable GPUDirect RDMA. AKS ships MOFED via network-operator on
+# ND-series InfiniBand nodes; useHostMofed: true binds nvidia_peermem
+# against the host's MOFED kernel modules (see values-aks.yaml for the
+# full rationale).
+driver:
+  rdma:
+    enabled: true
+    useHostMofed: true
+
 validator:
   plugin:
     env:

--- a/recipes/components/gpu-operator/values-aks.yaml
+++ b/recipes/components/gpu-operator/values-aks.yaml
@@ -28,6 +28,19 @@
 nfd:
   enabled: false
 
+# Re-enable GPUDirect RDMA. The AKS overlay deploys network-operator,
+# which installs MOFED kernel modules on the host (ND-series InfiniBand
+# nodes). useHostMofed: true tells gpu-operator's driver container to
+# bind nvidia_peermem against the host's MOFED symbols instead of
+# building its own bundled MOFED — required for the network-operator
+# integration to actually work end-to-end. The global default in
+# components/gpu-operator/values.yaml is off because EFA / non-MOFED
+# fabrics trip v26.3.1's driver-validation gate.
+driver:
+  rdma:
+    enabled: true
+    useHostMofed: true
+
 # The following flags are set in the aks-rdma-infiniband reference configuration
 # but are not required for RDMA functionality. They suppress DaemonSets that
 # serve no purpose on AKS ND-H100 nodes. Uncomment if your deployment needs them.

--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -137,12 +137,19 @@ gfd:
   enabled: true
 
 driver:
-  version: 580.105.08
+  # NVIDIA's recommended driver for the v26.3.1 chart; matches the
+  # GB200+EFA floor so a single global pin covers H100/B200/GB200 EKS.
+  version: 580.126.20
   enabled: true
   useOpenKernelModules: true
   maxParallelUpgrades: 5
   rdma:
-    enabled: true
+    # Default off: nvidia_peermem only loads against Mellanox MOFED
+    # symbols. AWS EFA (EKS p4d/p5/p5e) and Linode have no MOFED, so
+    # peermem fails to load and v26.3.1's stricter driver-validation
+    # init container blocks the rest of the GPU stack. Overlays that
+    # ship MOFED (AKS via network-operator) explicitly re-enable this.
+    enabled: false
 
 devicePlugin:
   env:
@@ -165,4 +172,9 @@ validator:
 
 # NFD deployed as standalone shared component — disable sub-chart
 nfd:
+  enabled: false
+
+# Confidential Compute Manager defaults to enabled in chart v26.3.x; keep
+# it off until AICR has explicit CC-capable hardware support.
+ccManager:
   enabled: false

--- a/recipes/components/nvidia-dra-driver-gpu/values.yaml
+++ b/recipes/components/nvidia-dra-driver-gpu/values.yaml
@@ -56,7 +56,25 @@ resources:
   gpus:
     enabled: true
 
+# gpu-operator-chart-version annotation forces a DaemonSet re-roll when
+# the gpu-operator chart (and its managed driver) bumps. The DRA
+# kubelet plugin loads libnvidia-ml.so at pod start and pins to the
+# driver version running at that moment; gpu-operator's k8s-driver-manager
+# reloads the host kernel modules during a driver bump but does NOT
+# restart the sibling DRA DaemonSet (its chart template hasn't changed),
+# leaving the kubelet plugin's NVML handle stale. CDI spec generation
+# then fails with "Driver/library version mismatch" and DRA-allocated
+# pods stay in ContainerCreating.
+#
+# Bumping this annotation value on every gpu-operator chart bump (here:
+# v26.3.1) changes the rendered pod template and forces helm upgrade to
+# roll the DaemonSet, picking up a fresh NVML handle against the
+# now-running driver. Track follow-up to automate this in #973.
 controller:
   priorityClassName: ""
+  podAnnotations:
+    aicr.nvidia.com/gpu-operator-chart-version: v26.3.1
 kubeletPlugin:
   priorityClassName: ""
+  podAnnotations:
+    aicr.nvidia.com/gpu-operator-chart-version: v26.3.1

--- a/recipes/overlays/aks.yaml
+++ b/recipes/overlays/aks.yaml
@@ -42,7 +42,7 @@ spec:
     # AKS pre-installs NVIDIA container toolkit; disable toolkit installation
     - name: gpu-operator
       type: Helm
-      version: "v26.3.0"
+      version: "v26.3.1"
       valuesFile: components/gpu-operator/values-aks.yaml
       dependencyRefs:
         - network-operator

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -40,7 +40,7 @@ spec:
     - name: gpu-operator
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia
-      version: v25.10.1
+      version: v26.3.1
       valuesFile: components/gpu-operator/values.yaml
       dependencyRefs:
         - nfd

--- a/recipes/overlays/gb200-eks-inference.yaml
+++ b/recipes/overlays/gb200-eks-inference.yaml
@@ -56,7 +56,6 @@ spec:
         gdrcopy:
           enabled: true
         driver:
-          version: 580.126.20
           kernelModuleConfig:
             name: nvidia-kernel-module-params
 

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -61,10 +61,6 @@ spec:
         gdrcopy:
           enabled: true
         driver:
-          # 580.126.20 is NVIDIA's recommended floor for GB200+EFA; the global
-          # default (580.105.08 in components/gpu-operator/values.yaml) stays
-          # unchanged for H100/B200 and non-EKS GB200 recipes.
-          version: 580.126.20
           kernelModuleConfig:
             name: nvidia-kernel-module-params
 

--- a/recipes/overlays/oke.yaml
+++ b/recipes/overlays/oke.yaml
@@ -40,7 +40,7 @@ spec:
     # (BM.GPU.B200, BM.GPU.H100, etc.). Disable both to avoid conflicts.
     - name: gpu-operator
       type: Helm
-      version: v26.3.0
+      version: v26.3.1
       valuesFile: components/gpu-operator/values-oke.yaml
 
     # Prometheus persistent storage (provide --storage-class at bundle time, e.g. oci-bv)

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
@@ -37,11 +37,15 @@ daemonsets:
       value: present
       effect: NoSchedule
 
-# ── Driver: RDMA required for multi-node training ────────────────────
+# ── Driver: nvidia_peermem off on EKS (AWS EFA path uses aws-ofi-nccl)
+# nvidia_peermem only loads against Mellanox MOFED symbols; on AWS EFA
+# (p4d/p5/p5e) it fails to load and v26.3.1's strict driver-validation
+# init container blocks the rest of the GPU stack. NCCL multi-node on
+# EFA uses libfabric via aws-ofi-nccl, not nvidia_peermem.
 driver:
   enabled: true
   rdma:
-    enabled: true
+    enabled: false
   useOpenKernelModules: true
 
 # ── GDRCopy: GPU-direct memory for high-performance training ─────────


### PR DESCRIPTION
## Summary

Lift every leaf recipe to the current upstream stable gpu-operator chart (v26.3.1, published 2026-04-18), align the driver pin with NVIDIA's qualified version (580.126.20), and mitigate three v26.3.1-introduced regressions: stricter `driver-validation` init container (peermem gate), stale DRA NVML handles after a kernel-module reload, and the timing race between gpu-operator's async per-node driver migration and the DRA kubelet plugin's post-install restart.

## Motivation / Context

The registry already defaulted to `v26.3.1`, but `base.yaml` shadowed it with `v25.10.1` and the AKS/OKE overlays held `v26.3.0`. As a result, **leaves actually shipped `v25.10.1` / `v26.3.0` images even though `docs/user/container-images.md` advertised `v26.3.1`** — BOM-vs-leaf drift introduced by chart-pin duplication between the registry and `base.yaml`. This PR resolves that drift by single-sourcing the version pin in `base.yaml` at the upstream-stable level. The broader resolver/BOM cleanup is tracked separately in #966.

Coupled value updates so the bump matches NVIDIA's qualified stack and avoids v26.3.1 regressions:

- **`driver.version`** advances from `580.105.08` to **`580.126.20`** — the v26.3.1 chart default and the GB200+EFA floor. The per-overlay GB200 driver pin (previously `580.126.20`) becomes redundant and is dropped; `kernelModuleConfig` stays.
- **`ccManager.enabled: false`** pinned in global values. Upstream v26.3.x flipped defaults from `{enabled: false, defaultMode: "off"}` to `{enabled: true, defaultMode: "on"}`. AICR keeps it off until we have explicit CC-capable hardware support.
- **`driver.rdma.enabled` global default flipped `true → false`.** v26.3.1's `driver-validation` init container now hard-gates on `lsmod | grep nvidia_peermem`. That module only loads against **Mellanox MOFED** symbols. On AWS EFA (EKS p4d/p5/p5e) and Linode there is no MOFED, so peermem fails to load (`modprobe ... Invalid argument`) and the rest of the GPU stack stays stuck in `Init` forever. NCCL on EFA uses `aws-ofi-nccl`/libfabric, which does not consume `nvidia_peermem`, so there is no functional path lost.
- **`driver.rdma.useHostMofed: true`** explicitly set on AKS (`values-aks.yaml`, `values-aks-training.yaml`) alongside `enabled: true`. AKS overlays deploy `network-operator`, which installs MOFED kernel modules on the host via a privileged DaemonSet. With `useHostMofed: true`, peermem binds against host symbols.
- **DRA pod-template annotation** added to `recipes/components/nvidia-dra-driver-gpu/values.yaml` on both `controller.podAnnotations` and `kubeletPlugin.podAnnotations` — `aicr.nvidia.com/gpu-operator-chart-version: v26.3.1`. Bumping the annotation value on every gpu-operator chart change forces a DaemonSet re-roll across **every** deployer (Helm, helmfile, Flux, Argo CD), refreshing NVML against the now-running driver. Manual coupling of the annotation value to the chart version is a known maintenance gap — tracked in #973 with a bundler-derived annotation as the durable fix.
- **Wait for per-node driver migration before the DRA post-install rollout-restart** (`pkg/bundler/deployer/helm/templates/deploy.sh.tmpl`). gpu-operator's `k8s-driver-manager` runs its per-node module reload asynchronously after `helm upgrade gpu-operator` returns. On a multi-GPU-node cluster, the previously-existing DRA rollout-restart in `deploy.sh` (and the annotation re-roll above) could fire before some nodes had finished migration — leaving the freshly-rolled DRA kubelet plugin pinned to a now-stale NVML handle. Reproduced live on a GB200 EKS cluster during this PR's validation: the chart-version annotation re-rolled the DRA pods, then the second GB200 node's driver migration ran *after* the re-roll, leaving its kubelet-plugin pod with stale NVML and triggering the same "invalid CDI Spec: empty device edits" failure mode the annotation was meant to prevent. The fix is ~10 lines in the deploy.sh template: `kubectl wait --for=jsonpath` until every `nvidia.com/gpu.present=true` node carries `nvidia.com/gpu-driver-upgrade-state=upgrade-done` (15-min timeout, best-effort fall-through), *then* run the existing rollout-restart. Helm-deployer only; #973 will deliver a Helm post-install hook on `gpu-operator-post` to extend the protection to GitOps deployers.

Effective resolved values per leaf, post-PR (verified via `aicr bundle` + values inspection):

| Service | `driver.enabled` | `driver.rdma.enabled` | `useHostMofed` |
|---|---|---|---|
| EKS h100 / gb200 (training, inference, dynamo) | `true` | **`false`** | n/a |
| AKS h100 (training, inference-dynamo) | `true` | **`true`** *(explicit override)* | **`true`** *(explicit override; binds peermem to host MOFED from network-operator)* |
| GKE COS h100 (training, inference) | `false` *(host driver)* | n/a | n/a |
| OKE gb200 (training, inference) | `false` *(host driver)* | n/a | n/a |
| Kind | `false` *(host driver)* | `false` | n/a |
| LKE rtx-pro-6000 (training, inference) | `true` | **`false`** | n/a |

Chart version on every supported leaf resolves to **v26.3.1** (verified via `aicr query ... --selector components.gpu-operator.version`).

Fixes: #894
Related: #698, #966, #973

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue — v26.3.1 validator trap on EKS / LKE + stale DRA NVML after driver migration)
- [x] Build/CI/tooling (component version maintenance)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler/...` — deploy.sh template)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Constraint floor `Deployment.gpu-operator.version >= v24.6.0` (8 overlays) is still satisfied.
- `kubeVersion` in Chart.yaml is unchanged (`>= 1.16.0-0`); AICR's `>= 1.32.4` floor in `base.yaml` remains binding.
- Bundle render verified for `h100-eks-training`, `gb200-eks-training`, and AKS leaves: rendered `gpu-operator/values.yaml` shows `version: 580.126.20`, `ccManager.enabled: false`, the correct per-cloud `rdma.enabled` + `useHostMofed`, and (for gb200) `kernelModuleConfig.name: nvidia-kernel-module-params`.
- DRA values render with both `controller.podAnnotations.aicr.nvidia.com/gpu-operator-chart-version` and `kubeletPlugin.podAnnotations.aicr.nvidia.com/gpu-operator-chart-version` set to `v26.3.1`. Confirmed on aicr2 and the yljtrxpmzu GB200 cluster that `helm upgrade` on the new bundle force-rolls both DRA pods.
- The new `kubectl wait` block in `deploy.sh.tmpl` uses a 15-min timeout and `WARNING; proceeding anyway` semantics rather than a hard fail, so a misconfigured cluster (e.g. nodes never reach `upgrade-done`) still gets the rollout-restart attempt. The guard around `GPU_NODE_COUNT > 0` avoids `kubectl wait`'s "no matching resources" error on clusters with no GPU nodes yet (initial install ordering).
- BOM diff is narrow: only `nvcr.io/nvidia/driver:580.105.08` → `:580.126.20` moves, because the registry-driven BOM was already rendering against v26.3.1 (the BOM-vs-leaf drift this PR also resolves at the leaf layer; the BOM tool itself is rewritten in #966).
- `tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml` updated to match the new EKS expectation (`rdma.enabled: false`), with a comment explaining the EFA / `aws-ofi-nccl` rationale.
- Off-overlay implication: anyone running AICR on bare-metal MOFED hosts *without* using the AKS overlay (which ships network-operator) would need to opt in via `--set gpuoperator:driver.rdma.enabled=true` and `--set gpuoperator:driver.rdma.useHostMofed=true`. Documented inline in `recipes/components/gpu-operator/values.yaml`.

## Testing

```bash
make qualify   # PASS — tests + lint + e2e + scan + repo-specific checks
make bom-docs  # regenerated docs/user/container-images.md
```

Live cluster validation:

**aicr2** (EKS H100 `p5.48xlarge`, ad-hoc dev cluster):
- Pre-upgrade driver: `580.105.08`. Post-upgrade: **`580.126.20`**. All GPU pods Running, `nvidia-cuda-validator` Completed.
- Full `aicr validate`: deployment **passed** (4/4, 28.8s), performance **passed** (`inference-perf`: 39,776.81 tok/s, TTFT p99 122.74 ms, 3m 15.7s), conformance **passed** (1m 49.5s).

**yljtrxpmzu** (EKS GB200 `p6e-gb200.36xlarge` × 2, DGX Cloud dev cluster):
- Validated the upgrade-time timing race that motivated the new `kubectl wait` block: the chart-version annotation re-rolled DRA pods correctly, but a subsequent driver-module reload on the second GB200 node left the kubelet-plugin pod with stale NVML, producing `invalid CDI Spec: empty device edits` on the next `aicr validate --phase performance` run. Adding the wait closes that gap.
- After the new wait block: deployment **passed** (4/4, 26.5s), performance **passed** (16,705.82 tok/s, TTFT p99 233.31 ms, 2m 21.8s — against the placeholder thresholds added in #977).

GPU CI follow-up: H100 nvkind run is required per #894 DoD; will trigger via CI label after maintainer review.

## Risk Assessment

- [x] **Medium** — Single coherent chart bump touching every leaf, plus a localized deploy.sh template change that only fires for clusters that have any `nvidia.com/gpu.present=true` nodes. Drivers move 580.105.08 → 580.126.20 (node-side change; cordon/reboot on upgrade). `ccManager` and `driver.rdma.enabled` explicitly disabled to preserve behavior or to mitigate v26.3.1 regressions. AKS preserves the prior `rdma.enabled: true` behavior via explicit per-cloud overrides plus the `useHostMofed: true` correctness fix. DRA annotation closes the cross-deployer GPU-allocation regression introduced by the driver bump; the new `kubectl wait` closes the residual same-deployer timing race.

**Rollout notes:**
- Existing deployments using the prior chart should follow the standard gpu-operator upgrade path (the chart's `k8s-driver-manager` handles driver replacement with `maxParallelUpgrades = 5`). No CRD migrations are introduced.
- For any user running AICR on bare-metal MOFED hosts off-overlay, the global `rdma.enabled` flip from `true → false` is a behavior change. They can opt back in with `--set gpuoperator:driver.rdma.enabled=true` (and add `useHostMofed=true` if MOFED is on the host). Documented in `recipes/components/gpu-operator/values.yaml`.
- The new `kubectl wait` adds at most 15 min to `deploy.sh` on clusters whose nodes never reach `upgrade-done` (best-effort; logs WARNING then proceeds). On a healthy cluster the wait is sub-second once migration completes.

## Known follow-ups

- **#966** — `tools/bom` and recipe resolver both read `helm.defaultVersion` today, so chart-pin drift between registry and overlays can happen silently. This PR fixes the immediate `gpu-operator` instance; #966 fixes the resolver and BOM layers so the class can't recur.
- **#973** — durable cross-deployer DRA-rollout trigger. The annotation + `kubectl wait` in this PR cover the default Helm-deployer flow. #973 tracks the durable fix that works for helmfile / Flux / Argo CD too — a Helm `post-install,post-upgrade` hook on `gpu-operator-post` that runs the same wait-and-restart logic from inside the cluster, so non-Helm-deployer pipelines get the same protection.

## Checklist

- [x] Tests pass locally (`make qualify`)
- [x] Linter passes (`make lint` — included in qualify)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed (`docs/user/container-images.md` regenerated; rationale comments in `values.yaml`, `values-aks*.yaml`, `nvidia-dra-driver-gpu/values.yaml`, and `deploy.sh.tmpl`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
