### PR TITLE
docs: walk new contributors through emitting recipe evidence

### DIFF
--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -527,14 +527,154 @@ aicr recipe --service eks --accelerator gb200 --format yaml  # Test generation
 ## Submitting Your Recipe
 
 Recipes that target hardware AICR maintainers cannot independently
-re-run require an evidence bundle so reviewers can verify the recipe
-without owning the hardware. The end-to-end contribution flow — local
-validation, OCI push, pointer commit, PR template — is documented
-alongside the recipe-evidence CI gate; for now, the maintainer-side
-view of how those bundles are reviewed lives in
-[Maintaining Recipe Contributions](../contributor/maintaining.md).
-ADR-007 ([Recipe Evidence](https://github.com/NVIDIA/aicr/blob/main/docs/design/007-recipe-evidence.md))
-is the source of truth for the bundle format and verifier semantics.
+re-run require an **evidence bundle** so a reviewer can verify the
+recipe without owning the hardware. The bundle is a signed,
+OCI-distributed artifact that captures the resolved recipe, the
+cluster snapshot, the validator phase results, a CycloneDX BOM, and
+a manifest of per-file hashes. It is produced by adding two flags to
+the same `aicr validate` invocation you already use to check the
+recipe — no separate build step.
+
+### When You Need Evidence
+
+You need an evidence bundle when your PR adds or changes a recipe
+whose `criteria` reach hardware or a service that AICR maintainers
+cannot independently re-run — most non-H100 GPUs, non-EKS services,
+and specialty fabrics fall into this bucket. The recipe-evidence CI
+gate posts a sticky Markdown comment on every PR touching
+`recipes/**` and fails closed when a touched recipe has no matching
+`recipes/evidence/<recipe>.yaml` pointer.
+
+Non-material edits (comments, formatting, `displayName`,
+`description`, key-order) produce the same material-slice digest and
+do not require a fresh bundle — the existing pointer stays valid.
+The CI gate's canonicalizer collapses these to the same digest, so
+the gate passes without re-attestation. See
+[ADR-007 § Material-slice canonicalization](https://github.com/NVIDIA/aicr/blob/main/docs/design/007-recipe-evidence.md#material-slice-canonicalization-proposed)
+for the slice definition.
+
+### Producing the Bundle
+
+Run `aicr validate` against the cluster that exercises your recipe
+and add `--emit-attestation` (writes the bundle to disk) and
+`--push` (signs and uploads the OCI artifact):
+
+```bash
+# 1. Capture snapshot and resolve the recipe you're contributing.
+aicr snapshot --output snapshot.yaml
+aicr recipe --service eks --accelerator gb200 --os ubuntu \
+            --intent training --output recipe.yaml
+
+# 2. Validate with attestation emission. Replace the OCI ref with a
+#    registry you control (GHCR, GitLab Container Registry, Harbor,
+#    AWS ECR, Google Artifact Registry, Azure Container Registry,
+#    or JFrog Artifactory — any OCI 1.1 registry with Referrers API
+#    support).
+aicr validate \
+  --recipe recipe.yaml \
+  --snapshot snapshot.yaml \
+  --emit-attestation ./out \
+  --push ghcr.io/<owner>/aicr-evidence
+
+# 3. Commit the pointer. The bundle bytes live in OCI; the repo
+#    only stores the locator.
+mkdir -p recipes/evidence
+cp ./out/pointer.yaml recipes/evidence/<recipe-name>.yaml
+git add recipes/evidence/<recipe-name>.yaml
+```
+
+`--push` triggers cosign keyless signing through Sigstore's
+public-good infrastructure. The CLI resolves an OIDC token through
+the precedence chain documented under
+[`--identity-token`](../user/cli-reference.md#aicr-validate); if no
+pre-fetched token, ambient GitHub Actions OIDC, or
+`--oidc-device-flow` is available, it opens a browser. The signed
+`attestation.intoto.jsonl` is attached to the OCI artifact as a
+Sigstore Bundle referrer.
+
+For the full bundle layout, flag reference, and registry
+compatibility notes, see
+[Emitting recipe evidence for a PR](../user/validation.md#emitting-recipe-evidence-for-a-pr).
+For the producer-and-consumer walkthrough end-to-end, see
+[Recipe Evidence Demo](https://github.com/NVIDIA/aicr/blob/main/demos/evidence.md).
+
+### Self-Verifying Before You Open the PR
+
+Run the verifier locally — it is the same code the CI gate runs
+against the committed pointer, so failures here will block merge:
+
+```bash
+aicr evidence verify recipes/evidence/<recipe-name>.yaml
+```
+
+Exit 0 means signature, schema, inventory, manifest hashes,
+fingerprint match against the recipe's criteria, and BOM
+cross-reference all passed. A non-zero exit writes a structured
+Markdown report describing the specific check that failed. See
+[`aicr evidence verify`](../user/cli-reference.md#aicr-evidence-verify)
+for the full check list and exit-code semantics.
+
+### What to Include in the PR
+
+The recipe-evidence CI gate posts a Markdown summary as a sticky
+comment, so you do not need to inline the verifier output. The PR
+template asks for three additional pieces of context the verifier
+cannot infer:
+
+- **The OCI ref** of the pushed bundle, digest-pinned, so a
+  maintainer can audit it directly:
+  `ghcr.io/<owner>/aicr-evidence@sha256:<digest>`.
+- **The cluster you attested from** — cloud, accelerator SKU, OS,
+  Kubernetes version, node count. The fingerprint dimensions are in
+  the predicate, but the human description is what the maintainer
+  reads first.
+- **Evidence disposition.** If `aicr evidence verify` reported a
+  non-zero exit with a `1` in the JSON output's `exit` field
+  (signature valid, recorded phase results show failures), include a
+  short justification in the PR template's "Evidence disposition"
+  section. The maintainer either applies the `evidence/known-failure`
+  label and merges, or requests changes. See
+  [Exit-1 Review Process](../contributor/maintaining.md#exit-1-review-process)
+  for what counts as an acceptable reason — broadly: optional check
+  not applicable to your hardware, performance ceiling limited by
+  your test bed, or a validator under known active rework.
+
+### If You Cannot Push to a Registry
+
+You can still produce a bundle locally without `--push`. The
+resulting `./out/summary-bundle/` directory is unsigned but
+otherwise complete:
+
+```bash
+aicr validate --recipe recipe.yaml --snapshot snapshot.yaml \
+  --emit-attestation ./out
+aicr evidence verify ./out/summary-bundle
+```
+
+The verifier records the signature step as "skipped (unsigned)" and
+the manifest-hash chain becomes self-consistency only — useful for
+catching accidental corruption during development, but **not
+acceptable for the CI gate**, which requires a signed bundle bound
+to a committed pointer. Two paths forward:
+
+- Coordinate with a maintainer to obtain push access to an
+  NVIDIA-hosted registry.
+- For mechanical changes that touch `recipes/**` but carry no
+  recipe semantics (file renames, comment-only changes, license
+  header sweeps, self-bootstrapping evidence-pipeline changes), ask
+  a maintainer to apply `evidence/exempt` per the
+  [bypass policy](../contributor/maintaining.md#evidenceexempt-bypass-policy).
+  Self-applying that label is not appropriate.
+
+"I don't have the hardware right now, please merge" is **not** a
+valid exempt path — see the bypass policy's "Inappropriate uses."
+
+### Reference
+
+- [Emitting recipe evidence for a PR](../user/validation.md#emitting-recipe-evidence-for-a-pr) — user-facing flag reference and bundle layout
+- [Recipe Evidence Demo](https://github.com/NVIDIA/aicr/blob/main/demos/evidence.md) — full producer-and-consumer walkthrough
+- [Maintaining Recipe Contributions](../contributor/maintaining.md) — maintainer-side review checklist
+- [ADR-007](https://github.com/NVIDIA/aicr/blob/main/docs/design/007-recipe-evidence.md) — bundle format and verifier semantics
 
 ---
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -655,10 +655,8 @@ The verifier records the signature step as "skipped (unsigned)" and
 the manifest-hash chain becomes self-consistency only — useful for
 catching accidental corruption during development, but **not
 acceptable for the CI gate**, which requires a signed bundle bound
-to a committed pointer. Two paths forward:
+to a committed pointer.
 
-- Coordinate with a maintainer to obtain push access to an
-  NVIDIA-hosted registry.
 - For mechanical changes that touch `recipes/**` but carry no
   recipe semantics (file renames, comment-only changes, license
   header sweeps, self-bootstrapping evidence-pipeline changes), ask

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -241,6 +241,96 @@ Valid feature names (from `pkg/evidence/cncf/collector.go`):
 | `pod-autoscaling` | HPA / custom-metrics-driven pod autoscaling |
 | `cluster-autoscaling` | Karpenter (preferred) or EKS managed node-group autoscaling fallback |
 
+## Emitting recipe evidence for a PR
+
+When a recipe PR targets hardware AICR maintainers cannot independently
+re-run, the contributor needs to attach a signed **evidence bundle** so a
+maintainer can verify the recipe offline. `aicr validate` produces the
+bundle as a side effect when `--emit-attestation` is set; adding `--push`
+signs it (cosign keyless via Sigstore) and uploads it to an OCI registry.
+This is a different artifact from the CNCF-submission evidence above —
+the two flag families produce independent outputs and may run from a
+single `aicr validate` invocation.
+
+```bash
+aicr validate \
+  --recipe recipe.yaml \
+  --snapshot snapshot.yaml \
+  --emit-attestation ./out \
+  --push ghcr.io/<owner>/aicr-evidence
+```
+
+After the command finishes:
+
+```text
+./out
+├── pointer.yaml                  # locator; copy into recipes/evidence/
+└── summary-bundle/
+    ├── recipe.yaml               # canonical post-resolution recipe
+    ├── snapshot.yaml             # snapshot at validate-time
+    ├── bom.cdx.json              # CycloneDX BOM (auto-generated from
+    │                             #   recipe + validator catalog when
+    │                             #   --bom is omitted)
+    ├── ctrf/                     # per-phase test results
+    ├── manifest.json             # per-file sha256 inventory
+    ├── statement.intoto.json     # unsigned in-toto Statement
+    └── attestation.intoto.jsonl  # signed (when --push is set)
+```
+
+Commit `pointer.yaml` to `recipes/evidence/<recipe>.yaml`; the bundle
+itself lives in OCI. Then self-verify before opening the PR — the same
+verifier runs against the committed pointer in the CI gate, so exit 0
+locally means the gate will pass:
+
+```bash
+aicr evidence verify recipes/evidence/<recipe>.yaml
+```
+
+**Flag reference:**
+
+| Flag | What it does |
+|------|--------------|
+| `--emit-attestation <dir>` | Write the bundle to `<dir>`. Required to produce evidence. |
+| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. Without it, the bundle is unsigned (development/self-debug only). |
+| `--bom <path>` | Embed an existing CycloneDX BOM instead of the auto-generated one. Pass `make bom` output for an exhaustive BOM that includes chart-default sub-images. |
+| `--identity-token <token>` | Pre-fetched OIDC identity token, skipping the browser flow. Reads `COSIGN_IDENTITY_TOKEN`. |
+| `--oidc-device-flow` | Use OAuth device-code flow instead of opening a browser. Reads `AICR_OIDC_DEVICE_FLOW`. |
+| `--plain-http` | HTTP instead of HTTPS (local-registry tests only). |
+| `--insecure-tls` | Skip TLS verification (self-signed registries). |
+
+**Registry requirements:** the registry must support the OCI 1.1
+Referrers API (or its tag-schema fallback) so the Sigstore Bundle can
+be attached to the artifact. Known-good registries: GHCR, GitLab
+Container Registry, Harbor (≥ 2.8), AWS ECR, Google Artifact Registry,
+Azure Container Registry, JFrog Artifactory. Without referrer support
+the bundle pushes but the signature is not discoverable, and the
+verifier records signature-verify as "skipped (unsigned)" even on a
+signed bundle.
+
+**OIDC token resolution.** `--push` resolves an identity token through
+this precedence chain: `--identity-token` (or `COSIGN_IDENTITY_TOKEN`)
+→ ambient GitHub Actions OIDC (`ACTIONS_ID_TOKEN_REQUEST_URL`
+present) → `--oidc-device-flow` (or `AICR_OIDC_DEVICE_FLOW=true`) →
+interactive browser. CI pipelines typically rely on the ambient
+GitHub Actions path; local workstations get the browser flow.
+
+**Local-only mode (no registry access).** Omitting `--push` still
+produces a complete bundle on disk — the verifier records the
+signature step as "skipped (unsigned)" and the manifest-hash chain
+becomes self-consistency only. Useful for catching accidental
+corruption during development, but unsuitable for the CI gate, which
+requires a signed bundle bound to a pointer.
+
+For the full producer-and-consumer walkthrough — including OCI-only
+verification, the tamper demo, and JSON output for CI gates — see
+[Recipe Evidence Demo](https://github.com/NVIDIA/aicr/blob/main/demos/evidence.md).
+For the bundle format and verifier semantics, see
+[ADR-007](https://github.com/NVIDIA/aicr/blob/main/docs/design/007-recipe-evidence.md).
+For the maintainer-side review checklist, see
+[Maintaining Recipe Contributions](../contributor/maintaining.md).
+For the per-flag reference on `aicr evidence verify`, see
+[CLI reference](cli-reference.md#aicr-evidence-verify).
+
 ## Input modes
 
 Snapshot and recipe can come from a file, an HTTPS URL, or a Kubernetes ConfigMap:


### PR DESCRIPTION
## Summary

Expands the evidence-emission docs so a new recipe contributor can see, in the contributor/integrator surface, exactly how to produce and prepare an evidence bundle before opening a PR — instead of the prior hand-wave at ADR-007.

## Motivation / Context

`aicr validate --emit-attestation` and `aicr evidence verify` are shipped, but the only end-to-end walkthrough lives in `demos/evidence.md`. The contributor/integrator pages either skipped the topic (`docs/user/validation.md` — covers CNCF evidence only) or deferred it to the design doc (`docs/integrator/recipe-development.md` § Submitting Your Recipe). Contributors creating brand-new recipes for hardware AICR maintainers cannot independently re-run had no task-oriented entry point.

Fixes: N/A
Related: ADR-007 (`docs/design/007-recipe-evidence.md`), `demos/evidence.md`

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `docs/user/validation.md`: new `## Emitting recipe evidence for a PR` section between the existing CNCF evidence section and "Input modes". Covers the producer-side `--emit-attestation` / `--push` flow with the command, bundle layout, self-verify step, a flag-reference table, registry/Referrers-API requirements, OIDC token precedence, and the local-only fallback. Treated as a sibling to the existing CNCF-submission evidence section since both are evidence kinds emitted by `aicr validate`.
- `docs/integrator/recipe-development.md`: replaced the stub "Submitting Your Recipe" section with five concrete subsections written for a brand-new contributor (When You Need Evidence, Producing the Bundle, Self-Verifying Before You Open the PR, What to Include in the PR, If You Cannot Push to a Registry). Cross-links to the user/validation.md section above as the per-flag source of truth so the content does not duplicate.
- Anchor slugs were verified against GitHub's slug algorithm before linking (notably `evidenceexempt-bypass-policy` — the `/` in `evidence/exempt` is stripped without replacement).
- No code changes. No new files. No emoji.

## Testing

```bash
# Doc-only PR. No Go changes; lint and test gates unaffected.
# Verified heading structure and anchor slugs by inspection; lychee
# (the CI link checker on docs/**) will run on push.
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — additive documentation only.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, doc-only
- [ ] Linter passes (`make lint`) — N/A, doc-only
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)