### PR TITLE
feat(recipes): add inference-perf to gb200-eks-ubuntu-inference-dynamo

### DIFF
--- a/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
@@ -59,6 +59,26 @@ spec:
         - kai-scheduler
 
   validation:
+    performance:
+      checks:
+        - inference-perf
+      # PLACEHOLDER NUMBERS — pending empirical tuning on GB200 with
+      # Qwen/Qwen3-0.6B (concurrency=16/GPU, 1× p6e-gb200.36xlarge node,
+      # 4 vllmDecodeWorkers, vllm-runtime:0.9.0, image+DRA caches warm).
+      # Reference baseline from the passing validation run that informed
+      # these thresholds: throughput ≈ 18,093 tok/s, TTFT p99 ≈ 219 ms.
+      # Run-to-run variance on the same node is ~7% on throughput and a
+      # few ms on TTFT. These floors sit well below the reference numbers
+      # to act as a smoke-test gate rather than a tight perf SLO.
+      # Tighten once a reference dataset is published — for the small
+      # Qwen3-0.6B model the per-GPU compute advantage of GB200 over
+      # H100 is not exercised, so TTFT lands higher than naive
+      # Blackwell-vs-Hopper intuition suggests.
+      constraints:
+        - name: inference-throughput
+          value: ">= 10000"
+        - name: inference-ttft-p99
+          value: "<= 500"
     conformance:
       checks:
         - platform-health


### PR DESCRIPTION
## Summary

Add an `inference-perf` performance validator (with placeholder thresholds) to `recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml` so `aicr validate --phase performance` actually runs against GB200 EKS Dynamo deployments. Today the phase resolves to zero validators and silently no-ops.

## Motivation / Context

The H100 inference-dynamo siblings (`h100-eks-ubuntu-inference-dynamo.yaml`, `h100-gke-cos-inference-dynamo.yaml`) ship a `validation.performance.checks: [inference-perf]` block; the GB200 siblings (`gb200-eks-ubuntu-inference-dynamo.yaml`, `gb200-oke-ubuntu-inference-dynamo.yaml`) do not. Running `aicr validate --phase performance` against a GB200 EKS Dynamo cluster prints:

```
[cli] phase requested but no checks defined in recipe; phase will be empty: phase=performance
[cli] running validation phase: phase=performance catalog=4 selected=0
[cli] phase completed: phase=performance status=skipped validators=0 passed=0 failed=0
```

This PR closes that gap for the **GB200 EKS** leaf. (OKE sibling is out of scope — separate PR.)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

- **Mirrored shape** from `h100-eks-ubuntu-inference-dynamo.yaml`: `validation.performance.checks: [inference-perf]` plus `inference-throughput` / `inference-ttft-p99` constraints.
- **Thresholds are explicit placeholders**, intentionally loose:
  - `inference-throughput >= 10000 tok/s`
  - `inference-ttft-p99 <= 500 ms`
- **Measured baseline on a live cluster** (`p6e-gb200.36xlarge`, 1× GPU node = 4 GB200 GPUs, `4 vllmDecodeWorker` replicas pinned to that node, `Qwen/Qwen3-0.6B`, `concurrency=16/GPU`): **throughput ≈ 18,093 tok/s, TTFT p99 ≈ 219 ms**. The floors above sit ~45% below throughput and ~56% below TTFT, deliberately giving headroom for run-to-run variance and not-yet-tuned configurations.
- **Inline comment** captures both the measured numbers and a non-obvious caveat: on small models like Qwen3-0.6B the per-GPU compute advantage of GB200 over H100 isn't exercised — TTFT lands *higher* than naive Blackwell-vs-Hopper intuition would suggest. Future maintainers tightening these thresholds should not assume "GB200 ≥ H100" without empirical re-tuning.

## Testing

```bash
make qualify   # PASS — tests + lint + e2e + scan + repo-specific checks
```

Live cluster validation on an EKS GB200 cluster:

```
[cli] validator completed: name=inference-perf status=passed
[cli] Inference throughput: 18093.35 tokens/sec
[cli] Inference TTFT p99: 219.28 ms
[cli] phase completed: phase=performance status=passed validators=1 passed=1 failed=0 duration=2m20.553723083s
```

Both metrics well inside the placeholder floors, status `passed`.

## Risk Assessment

- [x] **Low** — Isolated change, single leaf overlay, ~17 added lines. No effect on recipes that don't resolve to `gb200-eks-ubuntu-inference-dynamo`. Reversible by removing the `performance:` block.

**Rollout notes:** None. New validator coverage; doesn't modify any existing constraint or deployment.

## Out of scope

- Adding the same block to `gb200-oke-ubuntu-inference-dynamo.yaml` — should be a separate PR after access to an OKE GB200 test bed.
- Tightening thresholds beyond the placeholder floors — gated on more reference runs being captured and published.
- The DRA pre-allocation refresh observation from the cluster-side investigation (DRA's `containerEdits` came back empty before a DRA-pod restart) — captured separately as a follow-up to #973.

## Checklist

- [x] Tests pass locally (`make qualify`)
- [x] Linter passes (`make lint` — included in qualify)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (the new `inference-perf` validator catalog entry exists; recipe-engine validation only)
- [x] Changes follow existing patterns in the codebase (mirrors H100 sibling)
- [x] Commits are cryptographically signed (`git commit -S`)
