### PR TITLE
fix(ci): skip version registration for latest release and sort by semver

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -100,12 +100,23 @@ jobs:
           else
             IS_RELEASE=true
           fi
+
+          # Skip registration when tag = latest release (Latest already covers it)
+          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName 2>/dev/null || true)
+          if [ "$IS_RELEASE" = "true" ] && [ "$TAG" = "$LATEST" ]; then
+            SHOULD_REGISTER=false
+            echo "Tag $TAG is the current latest release — will be shown as 'Latest · $TAG', skipping version entry"
+          else
+            SHOULD_REGISTER=$IS_RELEASE
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
+          echo "should_register=$SHOULD_REGISTER" >> "$GITHUB_OUTPUT"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE, should_register=$SHOULD_REGISTER)"
 
       - name: Register new version from tag
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         env:
           TAG_VERSION: ${{ steps.resolve.outputs.tag }}
         run: |
@@ -129,11 +140,19 @@ jobs:
           EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]'
           yq -i "$EXPR" fern/docs.yml
 
-          echo "--- docs.yml versions after insert ---"
+          # Sort versioned entries by semver descending (Latest stays at [0])
+          SORTED_SLUGS=$(yq '.products[0].versions[1:][].slug' fern/docs.yml | sort -rV)
+          yq -i '.products[0].versions = [.products[0].versions[0]]' fern/docs.yml
+          for slug in $SORTED_SLUGS; do
+            export slug
+            yq -i '.products[0].versions += [{"display-name": env(slug), "path": "versions/" + env(slug) + ".yml", "slug": env(slug), "availability": "stable"}]' fern/docs.yml
+          done
+
+          echo "--- docs.yml versions after insert + sort ---"
           yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Prune old versions
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         run: |
           set -eo pipefail
           KEEP=$((MAX_VERSIONS + 1))  # +1 for the Latest entry at index 0
@@ -226,11 +245,11 @@ jobs:
       # status check "gate", required signatures). PR via API is signed by
       # github-actions[bot] and routes through the standard PR/gate flow.
       - name: Restore unstamped docs.yml for persistence
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         run: cp /tmp/docs.yml.preStamp fern/docs.yml
 
       - name: Open PR for version registry changes
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main


### PR DESCRIPTION
## Summary

Skip version registration when the tag matches the current latest release (already covered by "Latest · vX.Y.Z" stamp) and sort version entries by semver descending after insert.

## Motivation / Context

Fixes: #978
Related: NVIDIA/NVSentinel#1315, NVIDIA/topograph#338

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: .github/workflows/publish-fern-docs.yml

## Implementation Notes

Two changes to the publish workflow, matching NVIDIA/NVSentinel#1315:

1. **Skip latest registration**: New `should_register` output in the resolve step. If the tag equals the current GitHub latest release, `should_register=false` — the "Latest · vX.Y.Z" stamp already covers it. All downstream steps (register, prune, restore, PR) now gate on `should_register` instead of `is_release`.

2. **Semver sort**: After inserting a new version entry, re-sort all versioned entries (index 1+) by semver descending using `sort -rV`. Ensures out-of-order registration (e.g. backported patch releases) doesn't scramble the dropdown.

## Testing

Structural parity with NVIDIA/NVSentinel#1315 (merged) and NVIDIA/topograph#338.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Takes effect on next tag push or workflow_dispatch.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)