### PR TITLE
fix(recipes): add deployment-phase checks to h100-gke-cos-training

### DIFF
--- a/recipes/overlays/h100-gke-cos-training.yaml
+++ b/recipes/overlays/h100-gke-cos-training.yaml
@@ -75,6 +75,15 @@ spec:
           enable: true
 
   validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"
     performance:
       checks:
         - nccl-all-reduce-bw


### PR DESCRIPTION
## Summary

Add the standard `validation.deployment` block to `recipes/overlays/h100-gke-cos-training.yaml` so `aicr validate --phase deployment` runs against GKE-COS-trained recipes instead of skipping the phase.

## Motivation / Context

The `h100-gke-cos-training` overlay defined `validation.performance` and `validation.conformance` blocks but no `validation.deployment` block. As a result, `aicr validate --phase deployment` against a recipe derived from this overlay reports:

```
phase requested but no checks defined in recipe; phase will be empty: phase=deployment
running validation phase: phase=deployment catalog=4 selected=0
phase completed: phase=deployment status=skipped validators=0 passed=0 failed=0
```

The four deployment-catalog checks (`operator-health`, `expected-resources`, `gpu-operator-version`, `check-nvidia-smi`) are intent- and OS-agnostic — they verify GPU operator + node-level GPU readiness, which matters for training as much as for inference.

The same block already exists on:
- `recipes/overlays/h100-eks-training.yaml`
- `recipes/overlays/h100-aks-training.yaml`
- `recipes/overlays/gb200-eks-training.yaml`

This change brings GKE to parity at the same H100-service-intent layer. (Comment in `h100-eks-training.yaml`: *"Defined at the intent layer (not OS-specific) so all OS variants inherit them."*)

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers
- [ ] Collectors / snapshotter
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries
- [ ] Docs/examples
- [ ] Other

## Implementation Notes

Mirrors `h100-eks-training.yaml`'s `validation.deployment` block exactly — same four checks and the same `Deployment.gpu-operator.version >= v24.6.0` constraint. No new validator catalog entries, no new constraint kinds.

## Testing

```bash
make qualify   # passed
```

End-to-end validation on a live GKE H100 cluster (gke_eidosx_us-central1_aicr-25910389703, k8s v1.35.3-gke.1234000, gpu-operator v26.3.1):

```
$ aicr recipe --data ./recipes --service gke --accelerator h100 \
    --intent training --os cos --platform kubeflow -o recipe.yaml
$ AICR_VALIDATOR_IMAGE_TAG=latest aicr validate \
    --recipe recipe.yaml --phase deployment

running validation phase: phase=deployment catalog=4 selected=4
validator completed: name=operator-health status=passed
validator completed: name=expected-resources status=passed
validator completed: name=gpu-operator-version status=passed
validator completed: name=check-nvidia-smi status=skipped
phase completed: phase=deployment status=passed validators=4 passed=3 failed=0
```

## Risk Assessment

- [x] **Low** — Isolated YAML-only change in a single overlay. Adds checks where none existed; cannot regress existing behavior. Easy to revert.

**Rollout notes:** No migration needed. Recipes regenerated from the updated overlay simply gain a populated `validation.deployment` block.

## Checklist

- [x] Tests pass locally (`make qualify` covers `make test -race` + lint + e2e + scan)
- [x] Linter passes
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, mirrors existing overlay shape exercised by chainsaw `cli-validate-phases` and `cli-recipe-overlays`
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase (`h100-eks-training.yaml`, `h100-aks-training.yaml`)
- [x] Commits are cryptographically signed (`git commit -S`)