### PR TITLE
feat(recipe): extensible criteria values via catalog-driven runtime registry (#998)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ test: ## Runs unit tests with race detector and coverage (use -short to skip int
 	@set -e; \
 	echo "Running tests with race detector..."; \
 	KUBEBUILDER_ASSETS=$$(setup-envtest use -p path 2>/dev/null || echo "") \
+	AICR_CRITERIA_STRICT=1 \
 	GOFLAGS="-mod=vendor" go test -short -count=1 -race -timeout=$(TEST_TIMEOUT) -covermode=atomic -coverprofile=coverage.out $$(go list ./... | grep -v -e /tests/chainsaw/ -e /validators) || exit 1; \
 	echo "Test coverage:"; \
 	go tool cover -func=coverage.out | tail -1

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1678,10 +1678,14 @@ exist in someone's `--data` directory.
 ### Seeding the registry
 
 The metadata-store loader (`pkg/recipe/metadata_store.go`) walks every
-overlay during catalog load and calls `seedCriteriaRegistry(metadata.
-Spec.Criteria, provider.Source(path))`. The provider's `Source` returns
-`"embedded"` / `"external"` / `"merged"`; the seed helper maps the
-first to `OriginEmbedded` and the rest to `OriginEmbedded` (default-fail-safe).
+overlay during catalog load and stages each overlay's criteria for
+registration. The provider's `Source(path)` returns `"embedded"` /
+`"external"` / `"merged"`; the seed helper maps `"embedded"` to
+`OriginEmbedded` and every non-embedded source (including `"merged"`
+and any unknown future category) to `OriginExternal`. The registration
+is *deferred* until after all overlays parse cleanly, the base recipe
+is present, and dependency validation passes — partial catalog loads
+never leak into the registry.
 
 ### Eager load via `LoadCatalog`
 

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1624,6 +1624,96 @@ func initDataProvider(cmd *cli.Command) error {
 
 ---
 
+## Criteria Registry
+
+The criteria registry is a process-global cache of valid criteria values
+(`service`, `accelerator`, `intent`, `os`, `platform`) populated from
+loaded overlays. It is the mechanism by which a `--data` overlay can
+introduce a new criteria value (e.g., `service: ncp-internal`) and have
+it admitted by `ParseCriteriaServiceType` without a code change.
+
+### Why a registry
+
+Before the registry existed, each `ParseCriteria*Type` had a hardcoded
+`switch` of valid string values; an unknown value returned
+`ErrCodeInvalidRequest` before the overlay catalog was even consulted.
+That made it impossible to add a new criteria value via `--data` —
+internal/proprietary values required either a fork or an upstream
+contribution, neither of which scales for undisclosed NCPs or
+proprietary product overlays.
+
+The registry decouples *which values are valid* from *what the OSS
+binary knows about*. The fast-path switch arms remain for canonical
+aliases (`self-managed → any`, `al2 → amazonlinux`), and any value not
+matched there falls through to the registry, which is seeded by the
+overlay loader on catalog load.
+
+### Origin tracking
+
+Each registered value carries a `CriteriaOrigin`:
+
+- `OriginEmbedded` — declared in an overlay loaded from the binary's
+  embedded data filesystem (the OSS catalog).
+- `OriginExternal` — declared in an overlay loaded from `--data`.
+
+When the same value is registered from both sources, embedded wins —
+`Register` never downgrades an embedded value to external, so strict
+mode lookups remain stable across reloads.
+
+### Strict mode
+
+Strict mode hides external-origin entries from registry lookups,
+restoring the pre-registry behavior in which only OSS canonical values
+validate. Three sources can enable it (logical OR):
+
+1. `--criteria-strict` CLI flag (added on `aicr recipe`).
+2. `spec.recipe.criteriaStrict: true` in `--config`.
+3. `AICR_CRITERIA_STRICT=1` env var (read at `DefaultRegistry()` init).
+
+Strict mode is intended for **OSS CI gates** — `make qualify` exports
+`AICR_CRITERIA_STRICT=1` for the unit-test step so the upstream catalog
+cannot accidentally start depending on internal-only values that only
+exist in someone's `--data` directory.
+
+### Seeding the registry
+
+The metadata-store loader (`pkg/recipe/metadata_store.go`) walks every
+overlay during catalog load and calls `seedCriteriaRegistry(metadata.
+Spec.Criteria, provider.Source(path))`. The provider's `Source` returns
+`"embedded"` / `"external"` / `"merged"`; the seed helper maps the
+first to `OriginEmbedded` and the rest to `OriginEmbedded` (default-fail-safe).
+
+### Eager load via `LoadCatalog`
+
+The metadata store loads lazily on first read. Because criteria
+validation runs *before* the recipe build pulls the catalog, a fresh
+process with `--data` would otherwise reject a custom criteria value on
+the very first call — the registry would still be empty.
+
+`recipe.LoadCatalog(ctx)` forces an eager catalog parse, seeding the
+registry. The CLI `recipe` Action calls it right after
+`initDataProvider` so the registry is populated before any
+`ParseCriteria*Type` lookup. **Any future caller that wires its own
+`--data` (e.g., a new API server flag) must also call `LoadCatalog`
+right after `SetDataProvider` for the same reason.**
+
+### API surface
+
+| Function | Purpose |
+|---|---|
+| `DefaultRegistry()` | Returns the process-wide singleton (lazy-init). |
+| `(*CriteriaRegistry).Register(field, value, origin)` | Records a value; embedded never downgrades. |
+| `(*CriteriaRegistry).Has(field, value)` | Lookup; respects strict mode (external hidden when strict). |
+| `(*CriteriaRegistry).HasEmbedded(field, value)` | Embedded-only lookup, regardless of strict. |
+| `(*CriteriaRegistry).Values(field)` | Sorted union of known values for help / autocomplete. |
+| `(*CriteriaRegistry).SetStrict(bool)` | Toggle strict mode. Composes with `AICR_CRITERIA_STRICT`. |
+| `(*CriteriaRegistry).Reset()` | Test helper; re-reads `AICR_CRITERIA_STRICT` from env. |
+| `LoadCatalog(ctx)` | Eager catalog load — call after `SetDataProvider`. |
+| `AllCriteria{Service,Accelerator,Intent,OS,Platform}Types()` | Union of static OSS list + currently-registered values. |
+| `GetCriteria{Service,Accelerator,Intent,OS,Platform}Types()` | Static OSS list only (stable; not affected by `--data`). |
+
+---
+
 ## See Also
 
 - [Recipe Development Guide](../integrator/recipe-development.md) - Adding and modifying recipe data

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -49,6 +49,8 @@ navigation:
         path: integrator/gke-tcpxo-networking.md
       - page: Recipe Development
         path: integrator/recipe-development.md
+      - page: Data Extension
+        path: integrator/data-extension.md
       - page: Validator Extension
         path: integrator/validator-extension.md
       - section: Components

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -1,0 +1,238 @@
+# Data Extension via `--data`
+
+Extend AICR's embedded recipe catalog with your own overlays, components, and
+criteria values at runtime — no fork, no rebuild. This is how operators add
+private/proprietary content (internal cloud providers, in-house GPU SKUs,
+commercial platforms, customer-specific scheduling) on top of the OSS catalog
+shipped with the binary.
+
+The `--data <dir>` flag layers an external directory on top of the embedded
+catalog. The embedded catalog is precedence-low; your directory is
+precedence-high. Adding a file under the right path either supplements (for
+catalog content) or overrides (for component files) the embedded equivalent.
+
+## Use cases
+
+| Need | How `--data` helps |
+|---|---|
+| Add a non-public Kubernetes service (`service=ncp-internal`) | Drop an overlay declaring that criteria value; the criteria registry admits it. |
+| Add a proprietary platform (`platform=runai`, `platform=nvmesh`) | Same — an overlay's `spec.criteria.platform` registers the value. |
+| Add a future GPU SKU before AICR's next release | Add `accelerator: <name>` in an overlay; CLI / API admit it on the fly. |
+| Add an internal component (e.g., an in-house operator) | Add a component definition under `components/` and reference it in an overlay or mixin. |
+| Override an embedded chart version / values file | Drop a same-path file under your `--data` dir; external takes precedence. |
+| Customize per-deployment scheduling without an overlay | Use `--config aicr-config.yaml` with `bundle.scheduling.*` — `--data` is for catalog content, not per-cluster ephemera. |
+
+## Folder layout
+
+The external directory mirrors AICR's embedded `recipes/` tree. Drop only the
+paths you need; AICR loads any subset.
+
+```
+my-external-data/
+├── registry.yaml             # REQUIRED — your component definitions
+├── mixins/                   # Optional — composable overlay fragments
+│   └── platform-internal.yaml
+├── overlays/                 # Optional — your overlays (flat or subdirs ok)
+│   └── ncp-internal-h100-training.yaml
+├── components/               # Optional — Helm values, raw manifests, etc.
+│   └── my-internal-operator/
+│       ├── values.yaml
+│       └── manifests/
+│           ├── namespace.yaml
+│           └── rbac.yaml
+└── catalog/                  # Optional — validator catalog overrides
+    └── validators-extra.yaml
+```
+
+The loader walks the tree recursively (`filepath.WalkDir`), so subdirectories
+inside `overlays/` are supported and useful for organizing by service / customer
+/ team:
+
+```
+overlays/
+├── ncp-customer-a/
+│   ├── h100-training.yaml
+│   └── h100-inference.yaml
+├── ncp-customer-b/
+│   └── gb200-training.yaml
+└── runai/
+    └── h100-eks-training.yaml
+```
+
+## `registry.yaml` is required
+
+Even if your directory only adds overlays (no new components), AICR requires a
+`registry.yaml` at the root. The minimal stub is:
+
+```yaml
+apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components: []
+```
+
+External components in this file are merged with the embedded registry; on
+name collision, the external definition wins.
+
+## Adding a criteria value (the registry path)
+
+Criteria value validation (`service`, `accelerator`, `intent`, `os`,
+`platform`) is data-driven: the static OSS list is the fast path, and the
+runtime *criteria registry* picks up any value declared in a loaded overlay's
+`spec.criteria`. So **adding a new value to an overlay automatically makes it
+a valid CLI / API input.** No code change, no rebuild.
+
+Example overlay for an internal NCP:
+
+```yaml
+apiVersion: aicr.nvidia.com/v1alpha1
+kind: RecipeMetadata
+metadata:
+  name: ncp-internal-h100-training
+spec:
+  base: base
+  criteria:
+    service: ncp-internal       # NEW — registers as a valid --service value
+    accelerator: h100
+    intent: training
+  componentRefs:
+    - { name: gpu-operator }
+    - { name: my-internal-operator }
+```
+
+Run it:
+
+```shell
+aicr recipe \
+  --service ncp-internal \
+  --accelerator h100 \
+  --intent training \
+  --data ./my-external-data \
+  --output recipe.yaml
+```
+
+Without `--data`, `--service ncp-internal` is rejected (the value isn't in
+the embedded catalog and the registry hasn't been seeded). With `--data`
+pointing at the overlay above, the registry registers `ncp-internal` at
+catalog-load time and the CLI admits it.
+
+The same applies to `accelerator`, `intent`, `os`, and `platform` — any
+field on a `RecipeMetadata`'s `spec.criteria`.
+
+## Adding a component
+
+`registry.yaml` declares the component's identity and source:
+
+```yaml
+apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components:
+  - name: my-internal-operator
+    displayName: My Internal Operator
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/my-internal-operator
+      defaultVersion: v1.2.3
+```
+
+…or, for a Kustomize-shipped component:
+
+```yaml
+  - name: my-kustomize-app
+    displayName: My Kustomize App
+    kustomize:
+      defaultSource: https://github.com/example/my-app
+      defaultPath: deploy/production
+      defaultTag: v1.0.0
+```
+
+A `values.yaml` (Helm) or `kustomization.yaml` (Kustomize) at
+`components/<name>/` is picked up automatically.
+
+Reference the component from an overlay's `componentRefs:` to include it in
+recipes that match the overlay's criteria.
+
+## Precedence rules
+
+| Resource | Behavior |
+|---|---|
+| `registry.yaml` | **Merged**: embedded + external. On name collision, external wins. |
+| Files in `components/`, `mixins/`, `overlays/`, `catalog/` | **Replaced**: any external file at the same relative path completely replaces the embedded equivalent. No partial-content merge. |
+
+When in doubt, `aicr --debug recipe ... --data <dir>` logs the resolved source
+(`embedded` / `external` / `merged`) for every loaded file.
+
+## Strict mode — gating the OSS catalog
+
+`--criteria-strict` (or `AICR_CRITERIA_STRICT=1`, or
+`spec.recipe.criteriaStrict: true` in `--config`) rejects any criteria value
+not in the embedded OSS catalog, ignoring `--data` contributions entirely.
+
+This is intended for **CI gates** in the OSS repo so the upstream catalog
+cannot accidentally start depending on internal-only values during
+development. Integrator workflows that legitimately need `--data`-supplied
+values should leave it off.
+
+```shell
+# Internal: accepts ncp-internal because --data registered it.
+aicr recipe --service ncp-internal --data ./internal -o /dev/null
+
+# OSS CI: rejects ncp-internal even though --data registered it,
+# because strict mode hides external contributions.
+AICR_CRITERIA_STRICT=1 \
+  aicr recipe --service ncp-internal --data ./internal -o /dev/null
+# → error: invalid service type: ncp-internal
+```
+
+`make qualify` in the OSS repo runs unit tests with `AICR_CRITERIA_STRICT=1`
+exported automatically.
+
+## Verifying what loaded
+
+Use `aicr --debug` to inspect external-data discovery and per-file source
+resolution:
+
+```shell
+aicr --debug recipe --service eks --accelerator h100 --data ./my-external-data
+```
+
+Sample output (truncated):
+
+```text
+[cli] initializing external data provider: directory=./my-external-data
+[cli] layered data provider initialized: external_dir=./my-external-data external_files=12
+[cli] data provider set: generation=1
+[cli] external data provider initialized successfully: directory=./my-external-data
+[cli] building recipe from criteria: criteria=criteria(service=eks, accelerator=h100, intent=any, os=any)
+[cli] recipe generation completed: output=stdout components=8 overlays=2
+```
+
+Tab-completion for `--service` / `--accelerator` / `--os` / `--intent` /
+`--platform` reflects values from the registry at the moment the help text is
+rendered. Run with `--data` early in the command line to populate it before
+shell completion kicks in.
+
+## Pinning your extension catalog
+
+Treat your `--data` directory like any other artifact: tag it (git tag, OCI
+tag, semver) and pin which AICR binary version it was tested against. The
+overlay schema is the AICR YAML schema; bumping AICR may add new optional
+fields but rarely changes existing ones, so backward compatibility is the
+default — but check the AICR release notes when you upgrade the binary.
+
+Typical organization patterns:
+
+- **One repo per team / customer.** Each team owns its overlay catalog and
+  releases it independently of AICR.
+- **One central internal repo.** A single org-wide `--data` catalog with
+  per-team subdirectories (`overlays/team-a/`, `overlays/team-b/`).
+- **OCI distribution.** Package the directory into an OCI artifact and pull
+  on demand; `aicr` itself doesn't care about source, only that the path
+  contains a `registry.yaml` and the expected sub-tree.
+
+## Related
+
+- [Recipe Development](recipe-development.md) — overlay schema, criteria fields, mixins, base recipe
+- [Data Architecture](../contributor/data.md) — internals of the layered data provider and criteria registry
+- [CLI Reference](../user/cli-reference.md) — `--data`, `--criteria-strict`, `--debug` flag definitions
+- [Component Catalog](../user/component-catalog.md) — embedded component list (the baseline you're extending)
+- [Validator Extension](validator-extension.md) — adding custom validators (also via `--data`)

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -27,7 +27,7 @@ catalog content) or overrides (for component files) the embedded equivalent.
 The external directory mirrors AICR's embedded `recipes/` tree. Drop only the
 paths you need; AICR loads any subset.
 
-```
+```text
 my-external-data/
 ├── registry.yaml             # REQUIRED — your component definitions
 ├── mixins/                   # Optional — composable overlay fragments
@@ -48,7 +48,7 @@ The loader walks the tree recursively (`filepath.WalkDir`), so subdirectories
 inside `overlays/` are supported and useful for organizing by service / customer
 / team:
 
-```
+```text
 overlays/
 ├── ncp-customer-a/
 │   ├── h100-training.yaml

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -73,7 +73,7 @@ components: []
 External components in this file are merged with the embedded registry; on
 name collision, the external definition wins.
 
-## Adding a criteria value (the registry path)
+## Adding a criteria value
 
 Criteria value validation (`service`, `accelerator`, `intent`, `os`,
 `platform`) is data-driven: the static OSS list is the fast path, and the

--- a/docs/integrator/index.md
+++ b/docs/integrator/index.md
@@ -22,6 +22,7 @@ This section is for integrators who:
 | [AKS GPU Setup](aks-gpu-setup.md) | AKS prerequisites: Kubernetes 1.34+ (DRA GA), GPU driver setup, DRA configuration |
 | [Talos Integration](talos-integration.md) | Running AICR on Talos Linux |
 | [Recipe Development](recipe-development.md) | Creating and modifying recipe metadata for custom environments |
+| [Data Extension](data-extension.md) | Extending the embedded catalog via `--data` — overlays, components, and runtime criteria values without a rebuild |
 | [Validator Extension](validator-extension.md) | Adding custom validators and overriding embedded ones via `--data` |
 | [NodeWright Component](components/nodewright.md) | NodeWright component reference and configuration |
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -422,6 +422,9 @@ Integrators can extend or override embedded recipe data using the `--data` flag 
 - Private component values with organization-specific settings
 - Extended registries with internal Helm charts
 - Rapid iteration without rebuilding binaries
+- New criteria values (service / accelerator / OS / intent / platform) admitted at runtime via the catalog-driven [criteria registry](data-extension.md#adding-a-criteria-value-the-registry-path) — no rebuild required
+
+See [Data Extension](data-extension.md) for the full walkthrough (folder layout, registry rules, strict mode, debugging). The summary below is for quick reference.
 
 #### Directory structure
 
@@ -455,6 +458,7 @@ aicr --debug recipe --service eks --data ./my-data
 - Overlays: Same `metadata.name` replaces embedded
 - Registry: Merged; same-named components replaced
 - Values: External valuesFile references take precedence
+- Criteria values: External overlays' `spec.criteria` values become valid CLI / API inputs at runtime via the criteria registry; `--criteria-strict` (or `AICR_CRITERIA_STRICT=1`) rejects external-only values for OSS CI gates
 
 **Validation:**
 ```bash

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -422,7 +422,7 @@ Integrators can extend or override embedded recipe data using the `--data` flag 
 - Private component values with organization-specific settings
 - Extended registries with internal Helm charts
 - Rapid iteration without rebuilding binaries
-- New criteria values (service / accelerator / OS / intent / platform) admitted at runtime via the catalog-driven [criteria registry](data-extension.md#adding-a-criteria-value-the-registry-path) — no rebuild required
+- New criteria values (service / accelerator / OS / intent / platform) admitted at runtime via the catalog-driven [criteria registry](data-extension.md#adding-a-criteria-value) — no rebuild required
 
 See [Data Extension](data-extension.md) for the full walkthrough (folder layout, registry rules, strict mode, debugging). The summary below is for quick reference.
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -387,6 +387,9 @@ Generate recipes using direct system parameters:
 | `--output` | `-o` | string | Output file (default: stdout) |
 | `--format` | `-f` | string | Format: json, yaml (default: yaml) |
 | `--data` | | string | External data directory to overlay on embedded data (see [External Data](#external-data-directory)) |
+| `--criteria-strict` | | bool | Reject criteria values not in the embedded OSS catalog; ignores values registered from `--data`. Also honored via `AICR_CRITERIA_STRICT=1` or `spec.recipe.criteriaStrict: true` in `--config`. Intended for OSS CI gates. |
+
+> **Service / Accelerator / OS / Intent / Platform value listings above are the OSS-embedded set.** When `--data` registers additional values (e.g., undisclosed providers, proprietary platforms), the CLI admits them at runtime through the criteria registry — see [Data Extension](../integrator/data-extension.md). `--criteria-strict` restores the OSS-only set regardless of what `--data` contributes.
 
 **Examples:**
 ```shell
@@ -2251,6 +2254,7 @@ AICR respects standard environment variables:
 | `AICR_LOG_PREFIX` | Override the CLI logger prefix | `cli` |
 | `AICR_REQUESTS` | Default for `aicr snapshot --requests`. Comma-separated `name=quantity` pairs (e.g. `cpu=500m,memory=1Gi,ephemeral-storage=1Gi`). Unspecified resources keep the built-in privileged or restricted defaults. | unset |
 | `AICR_LIMITS` | Default for `aicr snapshot --limits`. Comma-separated `name=quantity` pairs (e.g. `cpu=1,memory=2Gi,ephemeral-storage=2Gi`). Unspecified resources keep the built-in defaults. With `--require-gpu`, the default `nvidia.com/gpu=1` is applied only when this list does not already contain that key — explicit `nvidia.com/gpu=N` wins. | unset |
+| `AICR_CRITERIA_STRICT` | When set to `1` / `true` / `yes` / `on`, equivalent to `--criteria-strict` on every `aicr recipe` invocation: rejects criteria values not in the embedded OSS catalog regardless of `--data` contributions. Intended for OSS CI gates; `make qualify` exports it automatically for the unit-test step. | unset |
 | `NO_COLOR` | Suppress ANSI color codes in CLI logger output (de-facto standard, see [no-color.org](https://no-color.org/)) | unset |
 
 ## Exit Codes

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -29,36 +29,52 @@ import (
 )
 
 func recipeCmdFlags() []cli.Flag {
+	// Help text + shell completions draw from AllCriteria*Types so values
+	// introduced by --data overlays are discoverable. Before --data is
+	// processed the registry is empty, so the listed values match the
+	// embedded OSS set; once a data provider is initialized later in the
+	// Action the registry is populated, but flag Usage strings have
+	// already been formatted by then — discoverability in --help is on
+	// a best-effort basis when --data is co-resident on disk for an
+	// interactive `aicr recipe --data X --help`. The registry-aware
+	// validation still works regardless.
 	return []cli.Flag{
 		withCompletions(&cli.StringFlag{
 			Name:     "service",
-			Usage:    fmt.Sprintf("Kubernetes service type (e.g. %s)", strings.Join(recipe.GetCriteriaServiceTypes(), ", ")),
+			Usage:    fmt.Sprintf("Kubernetes service type (e.g. %s)", strings.Join(recipe.AllCriteriaServiceTypes(), ", ")),
 			Category: catQueryParameters,
-		}, recipe.GetCriteriaServiceTypes),
+		}, recipe.AllCriteriaServiceTypes),
 		withCompletions(&cli.StringFlag{
 			Name:     "accelerator",
 			Aliases:  []string{"gpu"},
-			Usage:    fmt.Sprintf("Accelerator/GPU type (e.g. %s)", strings.Join(recipe.GetCriteriaAcceleratorTypes(), ", ")),
+			Usage:    fmt.Sprintf("Accelerator/GPU type (e.g. %s)", strings.Join(recipe.AllCriteriaAcceleratorTypes(), ", ")),
 			Category: catQueryParameters,
-		}, recipe.GetCriteriaAcceleratorTypes),
+		}, recipe.AllCriteriaAcceleratorTypes),
 		withCompletions(&cli.StringFlag{
 			Name:     "intent",
-			Usage:    fmt.Sprintf("Workload intent (e.g. %s)", strings.Join(recipe.GetCriteriaIntentTypes(), ", ")),
+			Usage:    fmt.Sprintf("Workload intent (e.g. %s)", strings.Join(recipe.AllCriteriaIntentTypes(), ", ")),
 			Category: catQueryParameters,
-		}, recipe.GetCriteriaIntentTypes),
+		}, recipe.AllCriteriaIntentTypes),
 		withCompletions(&cli.StringFlag{
 			Name:     "os",
-			Usage:    fmt.Sprintf("Operating system type of the GPU node (e.g. %s)", strings.Join(recipe.GetCriteriaOSTypes(), ", ")),
+			Usage:    fmt.Sprintf("Operating system type of the GPU node (e.g. %s)", strings.Join(recipe.AllCriteriaOSTypes(), ", ")),
 			Category: catQueryParameters,
-		}, recipe.GetCriteriaOSTypes),
+		}, recipe.AllCriteriaOSTypes),
 		withCompletions(&cli.StringFlag{
 			Name:     "platform",
-			Usage:    fmt.Sprintf("Platform/framework type to include in the runtime (e.g. %s)", strings.Join(recipe.GetCriteriaPlatformTypes(), ", ")),
+			Usage:    fmt.Sprintf("Platform/framework type to include in the runtime (e.g. %s)", strings.Join(recipe.AllCriteriaPlatformTypes(), ", ")),
 			Category: catQueryParameters,
-		}, recipe.GetCriteriaPlatformTypes),
+		}, recipe.AllCriteriaPlatformTypes),
 		&cli.IntFlag{
 			Name:     "nodes",
 			Usage:    "Number of worker/GPU nodes in the cluster",
+			Category: catQueryParameters,
+		},
+		&cli.BoolFlag{
+			Name: "criteria-strict",
+			Usage: `Reject criteria values not in the embedded OSS catalog (ignore --data contributions).
+	Use in CI gates so the upstream catalog cannot accidentally depend on internal-only values.
+	Also honored via AICR_CRITERIA_STRICT=1.`,
 			Category: catQueryParameters,
 		},
 		&cli.StringFlag{
@@ -127,6 +143,31 @@ Override snapshot-detected criteria:
 
 			if err = initDataProvider(cmd, cfg); err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+			}
+
+			// Eagerly load the catalog so the criteria registry is
+			// populated before any ParseCriteria*Type call. The metadata
+			// store cache is otherwise lazy and the first call would not
+			// run until inside buildRecipeFromCmdWithConfig — after
+			// criteria validation, when the registry-based fallback
+			// can't help yet.
+			if err = recipe.LoadCatalog(ctx); err != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed to load recipe catalog", err)
+			}
+
+			// Apply criteria-strict AFTER the catalog has loaded —
+			// LoadCatalog populated the registry from every overlay's
+			// spec.criteria; strict mode then hides external-origin
+			// entries from subsequent ParseCriteria*Type lookups.
+			//
+			// Three sources can enable strict mode (logical OR):
+			//   1. --criteria-strict CLI flag
+			//   2. spec.recipe.criteriaStrict in --config
+			//   3. AICR_CRITERIA_STRICT env var (honored at registry init)
+			// AICR_CRITERIA_STRICT is read when DefaultRegistry() is first
+			// constructed, so we only need to apply the flag + config here.
+			if cmd.Bool("criteria-strict") || cfg.Recipe().IsCriteriaStrict() {
+				recipe.DefaultRegistry().SetStrict(true)
 			}
 
 			outFormat, err := parseRecipeOutputFormat(cmd, cfg)

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -151,8 +151,12 @@ Override snapshot-detected criteria:
 			// run until inside buildRecipeFromCmdWithConfig — after
 			// criteria validation, when the registry-based fallback
 			// can't help yet.
+			//
+			// PropagateOrWrap preserves the inner error code so YAML
+			// parse failures surface as ErrCodeInvalidRequest instead of
+			// being masked as ErrCodeInternal.
 			if err = recipe.LoadCatalog(ctx); err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to load recipe catalog", err)
+				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load recipe catalog")
 			}
 
 			// Apply criteria-strict AFTER the catalog has loaded —

--- a/pkg/config/accessors.go
+++ b/pkg/config/accessors.go
@@ -88,3 +88,15 @@ func (r *RecipeSpec) DataDir() string {
 	}
 	return r.Data
 }
+
+// IsCriteriaStrict returns spec.recipe.criteriaStrict flattened to a
+// plain bool (false when unset). Mirrors the --criteria-strict CLI
+// flag. The pointer-to-bool shape on RecipeSpec lets the spec
+// distinguish nil (absent) from &false (explicit opt-out); this
+// accessor is for callers that only care about the effective value.
+func (r *RecipeSpec) IsCriteriaStrict() bool {
+	if r == nil || r.CriteriaStrict == nil {
+		return false
+	}
+	return *r.CriteriaStrict
+}

--- a/pkg/config/accessors_test.go
+++ b/pkg/config/accessors_test.go
@@ -45,6 +45,9 @@ func TestAccessors_NilTolerant(t *testing.T) {
 	if got := nilRecipe.DataDir(); got != "" {
 		t.Errorf("nil RecipeSpec DataDir = %q, want empty", got)
 	}
+	if got := nilRecipe.IsCriteriaStrict(); got {
+		t.Errorf("nil RecipeSpec IsCriteriaStrict = %v, want false", got)
+	}
 }
 
 func TestAccessors_EmptyReturnsEmpty(t *testing.T) {
@@ -60,6 +63,30 @@ func TestAccessors_EmptyReturnsEmpty(t *testing.T) {
 	}
 	if got := r.DataDir(); got != "" {
 		t.Errorf("empty RecipeSpec DataDir = %q", got)
+	}
+	if got := r.IsCriteriaStrict(); got {
+		t.Errorf("empty RecipeSpec IsCriteriaStrict = %v, want false", got)
+	}
+}
+
+func TestRecipeSpec_IsCriteriaStrict(t *testing.T) {
+	tru, fls := true, false
+	tests := []struct {
+		name string
+		ptr  *bool
+		want bool
+	}{
+		{"nil pointer absent in YAML", nil, false},
+		{"explicit false opt-out", &fls, false},
+		{"explicit true opt-in", &tru, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &config.RecipeSpec{CriteriaStrict: tt.ptr}
+			if got := r.IsCriteriaStrict(); got != tt.want {
+				t.Errorf("IsCriteriaStrict() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,15 @@ type RecipeSpec struct {
 	Input    *RecipeInputSpec  `yaml:"input,omitempty" json:"input,omitempty"`
 	Output   *RecipeOutputSpec `yaml:"output,omitempty" json:"output,omitempty"`
 	Data     string            `yaml:"data,omitempty" json:"data,omitempty"`
+
+	// CriteriaStrict, when true, rejects criteria values not in the
+	// embedded OSS catalog (i.e., hides registry entries contributed by
+	// `--data` overlays). Mirrors the `--criteria-strict` CLI flag and
+	// the AICR_CRITERIA_STRICT environment variable; any of the three
+	// enabling it is sufficient. Pointer so the spec layer can
+	// distinguish nil (absent in YAML/JSON) from &false (explicit
+	// opt-out); the resolved layer flattens to plain bool.
+	CriteriaStrict *bool `yaml:"criteriaStrict,omitempty" json:"criteriaStrict,omitempty"`
 }
 
 // CriteriaSpec mirrors the recipe query parameters. Field names and string

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -55,6 +56,13 @@ const (
 )
 
 // ParseCriteriaServiceType parses a string into a CriteriaServiceType.
+//
+// The switch arms below are the canonical/aliased fast path for the
+// embedded OSS catalog. Any value not recognized here falls through to
+// the package criteria registry, which the data provider seeds from
+// loaded overlays (embedded + `--data`). This lets internal/proprietary
+// service values (e.g., undisclosed NCPs) be admitted at runtime via
+// `--data` without a binary rebuild.
 func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue, "self-managed", "self", "vanilla":
@@ -72,13 +80,28 @@ func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
 	case "lke":
 		return CriteriaServiceLKE, nil
 	default:
+		if DefaultRegistry().Has(FieldService, s) {
+			return CriteriaServiceType(normalizeCriteriaValue(s)), nil
+		}
 		return CriteriaServiceAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid service type: %s", s))
 	}
 }
 
-// GetCriteriaServiceTypes returns all supported service types sorted alphabetically.
+// GetCriteriaServiceTypes returns the static OSS-embedded service types
+// sorted alphabetically. This is the canonical OSS list and is stable
+// across `--data` configurations; for the union of static + registry
+// (including values contributed by `--data`), use AllCriteriaServiceTypes.
 func GetCriteriaServiceTypes() []string {
 	return []string{"aks", "eks", "gke", "kind", "lke", "oke"}
+}
+
+// AllCriteriaServiceTypes returns the union of the static OSS list and
+// values currently registered in the package criteria registry, sorted
+// alphabetically. In strict mode the registry contributes only its
+// embedded-origin values, so the result matches GetCriteriaServiceTypes
+// (plus any aliases the catalog has explicitly registered).
+func AllCriteriaServiceTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaServiceTypes(), DefaultRegistry().Values(FieldService))
 }
 
 // CriteriaAcceleratorType represents the GPU/accelerator type.
@@ -96,6 +119,8 @@ const (
 )
 
 // ParseCriteriaAcceleratorType parses a string into a CriteriaAcceleratorType.
+// See ParseCriteriaServiceType for the registry-fallback contract that
+// also applies here.
 func ParseCriteriaAcceleratorType(s string) (CriteriaAcceleratorType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
@@ -113,13 +138,25 @@ func ParseCriteriaAcceleratorType(s string) (CriteriaAcceleratorType, error) {
 	case "rtx-pro-6000":
 		return CriteriaAcceleratorRTXPro6000, nil
 	default:
+		if DefaultRegistry().Has(FieldAccelerator, s) {
+			return CriteriaAcceleratorType(normalizeCriteriaValue(s)), nil
+		}
 		return CriteriaAcceleratorAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid accelerator type: %s", s))
 	}
 }
 
-// GetCriteriaAcceleratorTypes returns all supported accelerator types sorted alphabetically.
+// GetCriteriaAcceleratorTypes returns the static OSS-embedded accelerator
+// types sorted alphabetically. For the union of static + registry, use
+// AllCriteriaAcceleratorTypes.
 func GetCriteriaAcceleratorTypes() []string {
 	return []string{"a100", "b200", "gb200", "h100", "l40", "rtx-pro-6000"}
+}
+
+// AllCriteriaAcceleratorTypes returns the union of the static OSS list
+// and values currently registered in the package criteria registry,
+// sorted alphabetically.
+func AllCriteriaAcceleratorTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaAcceleratorTypes(), DefaultRegistry().Values(FieldAccelerator))
 }
 
 // CriteriaIntentType represents the workload intent.
@@ -133,6 +170,7 @@ const (
 )
 
 // ParseCriteriaIntentType parses a string into a CriteriaIntentType.
+// See ParseCriteriaServiceType for the registry-fallback contract.
 func ParseCriteriaIntentType(s string) (CriteriaIntentType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
@@ -142,13 +180,25 @@ func ParseCriteriaIntentType(s string) (CriteriaIntentType, error) {
 	case "inference":
 		return CriteriaIntentInference, nil
 	default:
+		if DefaultRegistry().Has(FieldIntent, s) {
+			return CriteriaIntentType(normalizeCriteriaValue(s)), nil
+		}
 		return CriteriaIntentAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid intent type: %s", s))
 	}
 }
 
-// GetCriteriaIntentTypes returns all supported intent types sorted alphabetically.
+// GetCriteriaIntentTypes returns the static OSS-embedded intent types
+// sorted alphabetically. For the union of static + registry, use
+// AllCriteriaIntentTypes.
 func GetCriteriaIntentTypes() []string {
 	return []string{"inference", "training"}
+}
+
+// AllCriteriaIntentTypes returns the union of the static OSS list and
+// values currently registered in the package criteria registry, sorted
+// alphabetically.
+func AllCriteriaIntentTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaIntentTypes(), DefaultRegistry().Values(FieldIntent))
 }
 
 // CriteriaOSType represents an operating system type.
@@ -167,6 +217,7 @@ const (
 )
 
 // ParseCriteriaOSType parses a string into a CriteriaOSType.
+// See ParseCriteriaServiceType for the registry-fallback contract.
 func ParseCriteriaOSType(s string) (CriteriaOSType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
@@ -182,15 +233,26 @@ func ParseCriteriaOSType(s string) (CriteriaOSType, error) {
 	case oskind.Talos:
 		return CriteriaOSTalos, nil
 	default:
+		if DefaultRegistry().Has(FieldOS, s) {
+			return CriteriaOSType(normalizeCriteriaValue(s)), nil
+		}
 		return CriteriaOSAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid os type: %s", s))
 	}
 }
 
-// GetCriteriaOSTypes returns all supported OS types sorted alphabetically.
-// Delegates to oskind.All so the list stays in sync with the canonical
-// constants without duplication.
+// GetCriteriaOSTypes returns the static OSS-embedded OS types sorted
+// alphabetically. Delegates to oskind.All so the list stays in sync
+// with the canonical constants without duplication. For the union of
+// static + registry, use AllCriteriaOSTypes.
 func GetCriteriaOSTypes() []string {
 	return oskind.All()
+}
+
+// AllCriteriaOSTypes returns the union of the static OSS list and
+// values currently registered in the package criteria registry, sorted
+// alphabetically.
+func AllCriteriaOSTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaOSTypes(), DefaultRegistry().Values(FieldOS))
 }
 
 // CriteriaPlatformType represents a platform/framework type.
@@ -207,6 +269,7 @@ const (
 )
 
 // ParseCriteriaPlatformType parses a string into a CriteriaPlatformType.
+// See ParseCriteriaServiceType for the registry-fallback contract.
 func ParseCriteriaPlatformType(s string) (CriteriaPlatformType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
@@ -222,13 +285,57 @@ func ParseCriteriaPlatformType(s string) (CriteriaPlatformType, error) {
 	case "slurm":
 		return CriteriaPlatformSlurm, nil
 	default:
+		if DefaultRegistry().Has(FieldPlatform, s) {
+			return CriteriaPlatformType(normalizeCriteriaValue(s)), nil
+		}
 		return CriteriaPlatformAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid platform type: %s", s))
 	}
 }
 
-// GetCriteriaPlatformTypes returns all supported platform types sorted alphabetically.
+// GetCriteriaPlatformTypes returns the static OSS-embedded platform
+// types sorted alphabetically. For the union of static + registry, use
+// AllCriteriaPlatformTypes.
 func GetCriteriaPlatformTypes() []string {
 	return []string{"dynamo", "kubeflow", "nim", "runai", "slurm"}
+}
+
+// AllCriteriaPlatformTypes returns the union of the static OSS list and
+// values currently registered in the package criteria registry, sorted
+// alphabetically.
+func AllCriteriaPlatformTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaPlatformTypes(), DefaultRegistry().Values(FieldPlatform))
+}
+
+// mergeCriteriaTypes returns the deduplicated, alphabetically-sorted
+// union of two value slices. Used by the AllCriteria*Types helpers to
+// combine the embedded OSS list with registry-discovered values.
+func mergeCriteriaTypes(staticTypes, registered []string) []string {
+	if len(registered) == 0 {
+		// Return a copy so callers cannot mutate the canonical static slice.
+		out := make([]string, len(staticTypes))
+		copy(out, staticTypes)
+		return out
+	}
+	seen := make(map[string]struct{}, len(staticTypes)+len(registered))
+	out := make([]string, 0, len(staticTypes)+len(registered))
+	for _, v := range staticTypes {
+		v = normalizeCriteriaValue(v)
+		if _, dup := seen[v]; dup || v == "" {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, v := range registered {
+		v = normalizeCriteriaValue(v)
+		if _, dup := seen[v]; dup || v == "" {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Criteria represents the input parameters for recipe matching.

--- a/pkg/recipe/criteria_registry.go
+++ b/pkg/recipe/criteria_registry.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// CriteriaField enumerates the criteria dimensions tracked by the registry.
+// Using typed constants instead of bare strings prevents stringly-typed
+// mismatches between registration sites and lookup sites.
+type CriteriaField string
+
+const (
+	// FieldService is the Kubernetes service criteria dimension
+	// (e.g., eks, gke, aks, …).
+	FieldService CriteriaField = "service"
+	// FieldAccelerator is the GPU/accelerator criteria dimension
+	// (e.g., h100, gb200, …).
+	FieldAccelerator CriteriaField = "accelerator"
+	// FieldIntent is the workload intent criteria dimension
+	// (e.g., training, inference).
+	FieldIntent CriteriaField = "intent"
+	// FieldOS is the GPU node operating-system criteria dimension
+	// (e.g., ubuntu, cos, …).
+	FieldOS CriteriaField = "os"
+	// FieldPlatform is the platform/framework criteria dimension
+	// (e.g., kubeflow, nim, …).
+	FieldPlatform CriteriaField = "platform"
+)
+
+// CriteriaOrigin identifies whether a registered value came from the
+// embedded OSS catalog or from a runtime-mounted external catalog (--data).
+// Strict mode uses the distinction to reject external-only values when
+// validating the upstream catalog in CI.
+type CriteriaOrigin int
+
+const (
+	// OriginEmbedded marks values contributed by overlays loaded from the
+	// AICR binary's embedded data filesystem (i.e., the OSS catalog).
+	OriginEmbedded CriteriaOrigin = iota
+	// OriginExternal marks values contributed by overlays loaded from
+	// `--data` (the per-invocation extension path).
+	OriginExternal
+)
+
+// strictModeEnvVar is the environment variable that toggles strict-mode
+// criteria validation when set to a truthy value ("1", "true", "yes",
+// case-insensitive). Wired into CI via the Makefile and honored on every
+// invocation so the upstream OSS catalog cannot accidentally depend on
+// external-only criteria values.
+const strictModeEnvVar = "AICR_CRITERIA_STRICT"
+
+// CriteriaRegistry holds the catalog-discovered set of valid criteria
+// values per dimension, with origin tracking so strict mode can
+// distinguish embedded (OSS) from external (--data) contributions.
+//
+// The static switch arms inside ParseCriteria{Service,Accelerator,Intent,
+// OS,Platform}Type remain the fast path for canonical / aliased values
+// (e.g., "self-managed" → "any", "al2" → "amazonlinux"). Anything the
+// switches do not recognize falls through to the registry on lookup.
+type CriteriaRegistry struct {
+	mu     sync.RWMutex
+	values map[CriteriaField]map[string]CriteriaOrigin
+	strict bool
+}
+
+// newCriteriaRegistry constructs an empty registry. Use
+// [DefaultRegistry] for the package singleton consulted by
+// ParseCriteria*Type. Constructor is unexported so external callers
+// cannot accidentally create a competing instance that would silently
+// fail to seed parse-time validation.
+func newCriteriaRegistry() *CriteriaRegistry {
+	r := &CriteriaRegistry{
+		values: make(map[CriteriaField]map[string]CriteriaOrigin),
+	}
+	r.strict = isStrictModeFromEnv()
+	return r
+}
+
+// Register records value under field with the given origin. Empty values
+// and the wildcard "any" are ignored — they never need to be registered
+// because the Parse functions handle them via the fast path. If the same
+// (field, value) pair has been registered before, OriginEmbedded wins
+// over OriginExternal so that an external overlay redeclaring a public
+// value does not downgrade the value's origin and silently break strict
+// mode.
+func (r *CriteriaRegistry) Register(field CriteriaField, value string, origin CriteriaOrigin) {
+	value = normalizeCriteriaValue(value)
+	if value == "" || value == CriteriaAnyValue {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	bucket, ok := r.values[field]
+	if !ok {
+		bucket = make(map[string]CriteriaOrigin)
+		r.values[field] = bucket
+	}
+	existing, present := bucket[value]
+	if present && existing == OriginEmbedded {
+		// Do not downgrade embedded to external.
+		return
+	}
+	bucket[value] = origin
+}
+
+// Has reports whether value is known for field, regardless of origin.
+// Returns false in strict mode unless the value originates from an
+// embedded overlay.
+func (r *CriteriaRegistry) Has(field CriteriaField, value string) bool {
+	value = normalizeCriteriaValue(value)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	bucket, ok := r.values[field]
+	if !ok {
+		return false
+	}
+	origin, present := bucket[value]
+	if !present {
+		return false
+	}
+	if r.strict && origin != OriginEmbedded {
+		return false
+	}
+	return true
+}
+
+// HasEmbedded reports whether value is known for field from the
+// embedded OSS catalog, ignoring external contributions. Used by tests
+// and by introspection paths that explicitly need the OSS-only set.
+func (r *CriteriaRegistry) HasEmbedded(field CriteriaField, value string) bool {
+	value = normalizeCriteriaValue(value)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	bucket, ok := r.values[field]
+	if !ok {
+		return false
+	}
+	origin, present := bucket[value]
+	return present && origin == OriginEmbedded
+}
+
+// Values returns the registered values for field as a sorted slice.
+// In strict mode, only embedded values are returned. The result is a
+// copy so callers may mutate it freely.
+func (r *CriteriaRegistry) Values(field CriteriaField) []string {
+	r.mu.RLock()
+	bucket, ok := r.values[field]
+	if !ok {
+		r.mu.RUnlock()
+		return nil
+	}
+	strict := r.strict
+	out := make([]string, 0, len(bucket))
+	for v, origin := range bucket {
+		if strict && origin != OriginEmbedded {
+			continue
+		}
+		out = append(out, v)
+	}
+	r.mu.RUnlock()
+	sort.Strings(out)
+	return out
+}
+
+// SetStrict toggles strict-mode validation. In strict mode, registry
+// lookups admit only OriginEmbedded values; external contributions are
+// hidden as if they had never been registered. The upstream OSS CI gate
+// turns this on (via AICR_CRITERIA_STRICT) so the embedded catalog
+// cannot accidentally depend on internal-only values.
+func (r *CriteriaRegistry) SetStrict(strict bool) {
+	r.mu.Lock()
+	r.strict = strict
+	r.mu.Unlock()
+}
+
+// IsStrict reports whether the registry is in strict mode.
+func (r *CriteriaRegistry) IsStrict() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.strict
+}
+
+// Reset clears all registered values and the strict flag. Intended for
+// use in tests that need a clean slate between cases.
+func (r *CriteriaRegistry) Reset() {
+	r.mu.Lock()
+	r.values = make(map[CriteriaField]map[string]CriteriaOrigin)
+	r.strict = isStrictModeFromEnv()
+	r.mu.Unlock()
+}
+
+// defaultRegistry is the process-wide singleton consulted by the
+// ParseCriteria*Type functions. Initialized lazily; access via
+// [DefaultRegistry].
+var (
+	defaultRegistry     *CriteriaRegistry
+	defaultRegistryOnce sync.Once
+)
+
+// DefaultRegistry returns the process-wide criteria registry, creating
+// it on first access. Threading the registry through every call site
+// would add significant churn for a value that is set once at startup
+// (when the data provider populates it from loaded overlays) and read
+// many times thereafter, so a singleton matches the existing package
+// shape better than dependency injection.
+func DefaultRegistry() *CriteriaRegistry {
+	defaultRegistryOnce.Do(func() {
+		defaultRegistry = newCriteriaRegistry()
+	})
+	return defaultRegistry
+}
+
+// normalizeCriteriaValue lower-cases and trims a criteria value to
+// match the normalization performed inside the ParseCriteria*Type
+// switches, so registered values compare against parsed input
+// case-insensitively.
+func normalizeCriteriaValue(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// seedCriteriaRegistry registers each non-empty value from c into the
+// package criteria registry under the given source. Used by the overlay
+// loader so values declared in YAML overlay catalogs (embedded or
+// `--data`) become valid CLI / API inputs without a binary rebuild.
+//
+// source is the string returned by the DataProvider's Source(path); we
+// translate it to a CriteriaOrigin here so callers don't have to know
+// about the registry's internal enum.
+func seedCriteriaRegistry(c *Criteria, source string) {
+	if c == nil {
+		return
+	}
+	origin := OriginEmbedded
+	if source == sourceExternal {
+		origin = OriginExternal
+	}
+	reg := DefaultRegistry()
+	reg.Register(FieldService, string(c.Service), origin)
+	reg.Register(FieldAccelerator, string(c.Accelerator), origin)
+	reg.Register(FieldIntent, string(c.Intent), origin)
+	reg.Register(FieldOS, string(c.OS), origin)
+	reg.Register(FieldPlatform, string(c.Platform), origin)
+}
+
+// isStrictModeFromEnv reads AICR_CRITERIA_STRICT and returns true when
+// it is set to a truthy value. Recognized truthy spellings: "1", "true",
+// "yes", "on" (case-insensitive).
+func isStrictModeFromEnv() bool {
+	switch normalizeCriteriaValue(os.Getenv(strictModeEnvVar)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/recipe/criteria_registry.go
+++ b/pkg/recipe/criteria_registry.go
@@ -109,6 +109,13 @@ func (r *CriteriaRegistry) Register(field CriteriaField, value string, origin Cr
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Lazy-init the outer map so a zero-value or externally constructed
+	// CriteriaRegistry (i.e., one not built via newCriteriaRegistry /
+	// DefaultRegistry) does not panic on first Register.
+	if r.values == nil {
+		r.values = make(map[CriteriaField]map[string]CriteriaOrigin)
+	}
+
 	bucket, ok := r.values[field]
 	if !ok {
 		bucket = make(map[string]CriteriaOrigin)
@@ -244,14 +251,18 @@ func normalizeCriteriaValue(s string) string {
 //
 // source is the string returned by the DataProvider's Source(path); we
 // translate it to a CriteriaOrigin here so callers don't have to know
-// about the registry's internal enum.
+// about the registry's internal enum. Only the literal "embedded" sentinel
+// maps to OriginEmbedded — anything else (external, merged, or an unknown
+// future value) maps to OriginExternal so strict mode fails closed on
+// non-OSS contributions even if a new DataProvider source category is
+// introduced later.
 func seedCriteriaRegistry(c *Criteria, source string) {
 	if c == nil {
 		return
 	}
-	origin := OriginEmbedded
-	if source == sourceExternal {
-		origin = OriginExternal
+	origin := OriginExternal
+	if source == sourceEmbedded {
+		origin = OriginEmbedded
 	}
 	reg := DefaultRegistry()
 	reg.Register(FieldService, string(c.Service), origin)

--- a/pkg/recipe/criteria_registry_parse_test.go
+++ b/pkg/recipe/criteria_registry_parse_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+// withRegistry runs fn against a clean DefaultRegistry, restoring the
+// original state on exit so individual tests don't leak registrations
+// into siblings that share the package singleton.
+//
+// Strict mode is forced off here because tests in this file describe
+// the default permissive behavior; cases that exercise strict mode
+// call SetStrict(true) explicitly inside the test body. Forcing it off
+// makes the tests robust to AICR_CRITERIA_STRICT being set in the
+// surrounding environment (e.g., make qualify sets it to gate the
+// upstream catalog).
+func withRegistry(t *testing.T, fn func()) {
+	t.Helper()
+	reg := DefaultRegistry()
+	reg.Reset()
+	reg.SetStrict(false)
+	t.Cleanup(func() {
+		reg.Reset()
+	})
+	fn()
+}
+
+func TestParseCriteriaServiceType_RegistryFallback(t *testing.T) {
+	withRegistry(t, func() {
+		// Without registration, an unknown value must still error so OSS
+		// behavior is preserved when no external catalog has been loaded.
+		if _, err := ParseCriteriaServiceType("ncp-customer-x"); err == nil {
+			t.Fatal("expected error for unknown service before registration")
+		}
+
+		// After registering an external value (as if loaded via --data),
+		// parsing must admit it and return the value typed.
+		DefaultRegistry().Register(FieldService, "ncp-customer-x", OriginExternal)
+		got, err := ParseCriteriaServiceType("ncp-customer-x")
+		if err != nil {
+			t.Fatalf("ParseCriteriaServiceType after Register error = %v", err)
+		}
+		if got != CriteriaServiceType("ncp-customer-x") {
+			t.Errorf("ParseCriteriaServiceType = %q, want ncp-customer-x", got)
+		}
+
+		// Whitespace + case normalization must match the fast-path behavior.
+		got, err = ParseCriteriaServiceType("  NCP-CUSTOMER-X  ")
+		if err != nil {
+			t.Fatalf("normalized lookup error = %v", err)
+		}
+		if got != CriteriaServiceType("ncp-customer-x") {
+			t.Errorf("normalized = %q, want ncp-customer-x", got)
+		}
+	})
+}
+
+func TestParseCriteriaServiceType_StrictRejectsExternal(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldService, "ncp-customer-x", OriginExternal)
+		DefaultRegistry().SetStrict(true)
+
+		if _, err := ParseCriteriaServiceType("ncp-customer-x"); err == nil {
+			t.Error("strict mode must reject external-only values")
+		}
+		// Canonical OSS values must still pass in strict mode.
+		if _, err := ParseCriteriaServiceType("eks"); err != nil {
+			t.Errorf("strict mode must still admit OSS canonical values; got %v", err)
+		}
+	})
+}
+
+func TestParseCriteriaServiceType_StrictAcceptsEmbedded(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldService, "self-managed-overlay", OriginEmbedded)
+		DefaultRegistry().SetStrict(true)
+		got, err := ParseCriteriaServiceType("self-managed-overlay")
+		if err != nil {
+			t.Fatalf("strict mode rejected an embedded value: %v", err)
+		}
+		if got != CriteriaServiceType("self-managed-overlay") {
+			t.Errorf("got = %q, want self-managed-overlay", got)
+		}
+	})
+}
+
+func TestParseCriteriaAcceleratorType_RegistryFallback(t *testing.T) {
+	withRegistry(t, func() {
+		if _, err := ParseCriteriaAcceleratorType("h200"); err == nil {
+			t.Fatal("expected error before registration")
+		}
+		DefaultRegistry().Register(FieldAccelerator, "h200", OriginExternal)
+		got, err := ParseCriteriaAcceleratorType("h200")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if got != CriteriaAcceleratorType("h200") {
+			t.Errorf("got = %q, want h200", got)
+		}
+	})
+}
+
+func TestParseCriteriaIntentType_RegistryFallback(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldIntent, "fine-tuning", OriginExternal)
+		got, err := ParseCriteriaIntentType("fine-tuning")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if got != CriteriaIntentType("fine-tuning") {
+			t.Errorf("got = %q, want fine-tuning", got)
+		}
+	})
+}
+
+func TestParseCriteriaOSType_RegistryFallback(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldOS, "bottlerocket", OriginExternal)
+		got, err := ParseCriteriaOSType("bottlerocket")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if got != CriteriaOSType("bottlerocket") {
+			t.Errorf("got = %q, want bottlerocket", got)
+		}
+	})
+}
+
+func TestParseCriteriaPlatformType_RegistryFallback(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldPlatform, "nvmesh", OriginExternal)
+		got, err := ParseCriteriaPlatformType("nvmesh")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if got != CriteriaPlatformType("nvmesh") {
+			t.Errorf("got = %q, want nvmesh", got)
+		}
+	})
+}
+
+func TestAllCriteriaServiceTypes_UnionWithRegistry(t *testing.T) {
+	withRegistry(t, func() {
+		base := GetCriteriaServiceTypes()
+		if got := AllCriteriaServiceTypes(); !reflect.DeepEqual(got, base) {
+			t.Errorf("empty registry must yield static list, got %v want %v", got, base)
+		}
+
+		DefaultRegistry().Register(FieldService, "ncp-x", OriginExternal)
+		DefaultRegistry().Register(FieldService, "eks", OriginExternal) // already in static — must dedupe
+		got := AllCriteriaServiceTypes()
+		want := []string{"aks", "eks", "gke", "kind", "lke", "ncp-x", "oke"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("AllCriteriaServiceTypes = %v, want %v", got, want)
+		}
+
+		// Strict mode hides external contributions but preserves static list.
+		DefaultRegistry().SetStrict(true)
+		got = AllCriteriaServiceTypes()
+		if !reflect.DeepEqual(got, base) {
+			t.Errorf("strict AllCriteriaServiceTypes = %v, want %v (static only)", got, base)
+		}
+	})
+}
+
+func TestAllCriteriaTypes_AllDimensions(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldAccelerator, "h200", OriginExternal)
+		DefaultRegistry().Register(FieldIntent, "fine-tuning", OriginExternal)
+		DefaultRegistry().Register(FieldOS, "bottlerocket", OriginExternal)
+		DefaultRegistry().Register(FieldPlatform, "nvmesh", OriginExternal)
+
+		assertContains := func(field string, got []string, want string) {
+			t.Helper()
+			if !slices.Contains(got, want) {
+				t.Errorf("AllCriteria%sTypes() missing %q; got %v", field, want, got)
+			}
+		}
+		assertContains("Accelerator", AllCriteriaAcceleratorTypes(), "h200")
+		assertContains("Intent", AllCriteriaIntentTypes(), "fine-tuning")
+		assertContains("OS", AllCriteriaOSTypes(), "bottlerocket")
+		assertContains("Platform", AllCriteriaPlatformTypes(), "nvmesh")
+	})
+}
+
+func TestMergeCriteriaTypes_NoMutationOfInput(t *testing.T) {
+	static := []string{"a", "b", "c"}
+	original := make([]string, len(static))
+	copy(original, static)
+	_ = mergeCriteriaTypes(static, []string{"d"})
+	if !reflect.DeepEqual(static, original) {
+		t.Errorf("mergeCriteriaTypes mutated input slice: got %v, want %v", static, original)
+	}
+}
+
+func TestCriteriaValidate_AdmitsRegisteredValues(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldService, "ncp-customer-x", OriginExternal)
+		DefaultRegistry().Register(FieldAccelerator, "h200", OriginExternal)
+
+		c := &Criteria{
+			Service:     "ncp-customer-x",
+			Accelerator: "h200",
+			Intent:      CriteriaIntentTraining,
+			OS:          CriteriaOSUbuntu,
+		}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate() with registered values rejected: %v", err)
+		}
+	})
+}
+
+func TestCriteriaValidate_StrictRejectsExternal(t *testing.T) {
+	withRegistry(t, func() {
+		DefaultRegistry().Register(FieldService, "ncp-customer-x", OriginExternal)
+		DefaultRegistry().SetStrict(true)
+		c := &Criteria{Service: "ncp-customer-x"}
+		if err := c.Validate(); err == nil {
+			t.Error("strict-mode Validate must reject external-only value")
+		}
+	})
+}

--- a/pkg/recipe/criteria_registry_test.go
+++ b/pkg/recipe/criteria_registry_test.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestCriteriaRegistry_Register(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	tests := []struct {
+		name     string
+		field    CriteriaField
+		value    string
+		origin   CriteriaOrigin
+		wantHas  bool
+		wantEmb  bool
+		wantVals []string
+	}{
+		{"external service", FieldService, "ncp-x", OriginExternal, true, false, []string{"ncp-x"}},
+		{"embedded accelerator", FieldAccelerator, "h100", OriginEmbedded, true, true, []string{"h100"}},
+		{"empty value ignored", FieldService, "", OriginEmbedded, false, false, nil},
+		{"any wildcard ignored", FieldService, "any", OriginEmbedded, false, false, nil},
+		{"whitespace trimmed", FieldOS, "  ubuntu  ", OriginEmbedded, true, true, []string{"ubuntu"}},
+		{"case normalized", FieldPlatform, "Kubeflow", OriginEmbedded, true, true, []string{"kubeflow"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newCriteriaRegistry()
+			r.Register(tt.field, tt.value, tt.origin)
+			normalized := normalizeCriteriaValue(tt.value)
+			if got := r.Has(tt.field, normalized); got != tt.wantHas {
+				t.Errorf("Has(%q, %q) = %v, want %v", tt.field, normalized, got, tt.wantHas)
+			}
+			if got := r.HasEmbedded(tt.field, normalized); got != tt.wantEmb {
+				t.Errorf("HasEmbedded(%q, %q) = %v, want %v", tt.field, normalized, got, tt.wantEmb)
+			}
+			if got := r.Values(tt.field); !reflect.DeepEqual(got, tt.wantVals) {
+				t.Errorf("Values(%q) = %v, want %v", tt.field, got, tt.wantVals)
+			}
+		})
+	}
+}
+
+func TestCriteriaRegistry_EmbeddedNotDowngraded(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	r := newCriteriaRegistry()
+	r.Register(FieldService, "ncp-x", OriginEmbedded)
+	r.Register(FieldService, "ncp-x", OriginExternal) // attempted downgrade
+	if !r.HasEmbedded(FieldService, "ncp-x") {
+		t.Error("embedded origin must survive a later external registration")
+	}
+}
+
+func TestCriteriaRegistry_ExternalUpgradedToEmbedded(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	r := newCriteriaRegistry()
+	r.Register(FieldService, "ncp-x", OriginExternal)
+	r.Register(FieldService, "ncp-x", OriginEmbedded)
+	if !r.HasEmbedded(FieldService, "ncp-x") {
+		t.Error("later embedded registration must upgrade an external value")
+	}
+}
+
+func TestCriteriaRegistry_StrictMode(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	r := newCriteriaRegistry()
+	r.Register(FieldService, "eks", OriginEmbedded)
+	r.Register(FieldService, "ncp-internal", OriginExternal)
+
+	// Permissive: both visible.
+	if !r.Has(FieldService, "eks") {
+		t.Error("permissive mode must admit embedded values")
+	}
+	if !r.Has(FieldService, "ncp-internal") {
+		t.Error("permissive mode must admit external values")
+	}
+	if got := r.Values(FieldService); !reflect.DeepEqual(got, []string{"eks", "ncp-internal"}) {
+		t.Errorf("Values permissive = %v, want [eks ncp-internal]", got)
+	}
+
+	// Strict: only embedded.
+	r.SetStrict(true)
+	if !r.Has(FieldService, "eks") {
+		t.Error("strict mode must still admit embedded values")
+	}
+	if r.Has(FieldService, "ncp-internal") {
+		t.Error("strict mode must reject external values")
+	}
+	if got := r.Values(FieldService); !reflect.DeepEqual(got, []string{"eks"}) {
+		t.Errorf("Values strict = %v, want [eks]", got)
+	}
+}
+
+func TestCriteriaRegistry_Reset(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	r := newCriteriaRegistry()
+	r.Register(FieldService, "ncp-x", OriginExternal)
+	r.SetStrict(true)
+
+	r.Reset()
+	if r.Has(FieldService, "ncp-x") {
+		t.Error("Reset must clear registered values")
+	}
+	if r.IsStrict() {
+		t.Error("Reset must restore strict flag from env (unset → false)")
+	}
+}
+
+func TestCriteriaRegistry_ResetReadsEnv(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "true")
+	r := newCriteriaRegistry()
+	if !r.IsStrict() {
+		t.Error("new registry must inherit AICR_CRITERIA_STRICT=true")
+	}
+	r.SetStrict(false)
+	r.Reset()
+	if !r.IsStrict() {
+		t.Error("Reset must re-read AICR_CRITERIA_STRICT")
+	}
+}
+
+func TestCriteriaRegistry_Values_NilForUnknownField(t *testing.T) {
+	r := newCriteriaRegistry()
+	if got := r.Values(FieldPlatform); got != nil {
+		t.Errorf("unknown field must return nil slice, got %v", got)
+	}
+}
+
+func TestCriteriaRegistry_ConcurrentAccess(t *testing.T) {
+	r := newCriteriaRegistry()
+	const goroutines = 16
+	const perGoroutine = 64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for g := range goroutines {
+		go func() {
+			defer wg.Done()
+			for i := range perGoroutine {
+				origin := OriginEmbedded
+				if (g+i)%2 == 1 {
+					origin = OriginExternal
+				}
+				r.Register(FieldService, "ncp-shared", origin)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				_ = r.Has(FieldService, "ncp-shared")
+				_ = r.HasEmbedded(FieldService, "ncp-shared")
+				_ = r.Values(FieldService)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if !r.HasEmbedded(FieldService, "ncp-shared") {
+		t.Error("at least one OriginEmbedded write must have stuck")
+	}
+}
+
+func TestIsStrictModeFromEnv(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"no", false},
+		{"off", false},
+		{"1", true},
+		{"true", true},
+		{"True", true},
+		{"YES", true},
+		{"on", true},
+		{"  TRUE ", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Setenv(strictModeEnvVar, tt.raw)
+			if got := isStrictModeFromEnv(); got != tt.want {
+				t.Errorf("isStrictModeFromEnv(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRegistry_Singleton(t *testing.T) {
+	a := DefaultRegistry()
+	b := DefaultRegistry()
+	if a != b {
+		t.Error("DefaultRegistry must return the same singleton on every call")
+	}
+}
+
+func TestSeedCriteriaRegistry(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	tests := []struct {
+		name       string
+		source     string
+		wantOrigin CriteriaOrigin
+	}{
+		{"embedded source", "embedded", OriginEmbedded},
+		{"external source", "external", OriginExternal},
+		{"merged falls back to embedded", "merged", OriginEmbedded},
+		{"unknown source falls back to embedded", "", OriginEmbedded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := DefaultRegistry()
+			reg.Reset()
+			t.Cleanup(reg.Reset)
+
+			c := &Criteria{
+				Service:     "ncp-x",
+				Accelerator: "h200",
+				Intent:      "fine-tuning",
+				OS:          "bottlerocket",
+				Platform:    "nvmesh",
+			}
+			seedCriteriaRegistry(c, tt.source)
+
+			checks := []struct {
+				field CriteriaField
+				value string
+			}{
+				{FieldService, "ncp-x"},
+				{FieldAccelerator, "h200"},
+				{FieldIntent, "fine-tuning"},
+				{FieldOS, "bottlerocket"},
+				{FieldPlatform, "nvmesh"},
+			}
+			for _, ck := range checks {
+				if !reg.Has(ck.field, ck.value) {
+					t.Errorf("registry.Has(%q, %q) = false; want registered", ck.field, ck.value)
+				}
+				gotEmbedded := reg.HasEmbedded(ck.field, ck.value)
+				wantEmbedded := tt.wantOrigin == OriginEmbedded
+				if gotEmbedded != wantEmbedded {
+					t.Errorf("registry.HasEmbedded(%q, %q) = %v, want %v",
+						ck.field, ck.value, gotEmbedded, wantEmbedded)
+				}
+			}
+		})
+	}
+}
+
+func TestSeedCriteriaRegistry_NilCriteria(t *testing.T) {
+	reg := DefaultRegistry()
+	reg.Reset()
+	t.Cleanup(reg.Reset)
+	// Must not panic.
+	seedCriteriaRegistry(nil, "embedded")
+	if got := reg.Values(FieldService); len(got) != 0 {
+		t.Errorf("nil criteria must not register anything, got %v", got)
+	}
+}
+
+func TestSeedCriteriaRegistry_SkipsWildcardAndEmpty(t *testing.T) {
+	reg := DefaultRegistry()
+	reg.Reset()
+	t.Cleanup(reg.Reset)
+	c := &Criteria{
+		Service:     CriteriaServiceAny, // "any" must be skipped
+		Accelerator: "",                 // empty must be skipped
+		Intent:      "training",         // real value, must register
+	}
+	seedCriteriaRegistry(c, "embedded")
+	if reg.Has(FieldService, "any") {
+		t.Error("registry should not record wildcard 'any'")
+	}
+	if reg.Has(FieldAccelerator, "") {
+		t.Error("registry should not record empty value")
+	}
+	if !reg.HasEmbedded(FieldIntent, "training") {
+		t.Error("real value must register")
+	}
+}

--- a/pkg/recipe/criteria_registry_test.go
+++ b/pkg/recipe/criteria_registry_test.go
@@ -15,6 +15,9 @@
 package recipe
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"testing"
@@ -203,6 +206,86 @@ func TestIsStrictModeFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoadCatalog_DoesNotLeakRegistryOnFailure(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+
+	// Build an external data directory with a well-formed overlay that
+	// would introduce a custom service value, followed by a malformed
+	// overlay that fails YAML parsing. The well-formed overlay is
+	// processed first (lexical filepath.WalkDir order) — under the
+	// pre-fix behavior it would have seeded the registry before the
+	// second file's parse error aborted the load.
+	tmp := t.TempDir()
+	overlaysDir := filepath.Join(tmp, "overlays")
+	if err := os.MkdirAll(overlaysDir, 0o755); err != nil {
+		t.Fatalf("mkdir overlays: %v", err)
+	}
+	writeFile := func(rel, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(tmp, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	writeFile("registry.yaml", `apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components: []
+`)
+	writeFile("overlays/01-good.yaml", `apiVersion: aicr.nvidia.com/v1alpha1
+kind: RecipeMetadata
+metadata:
+  name: pending-leak-overlay
+spec:
+  base: base
+  criteria:
+    service: pending-leak-service
+    accelerator: h100
+    intent: training
+  componentRefs: []
+`)
+	// Malformed YAML — fails decode, aborts the walk.
+	writeFile("overlays/02-bad.yaml", "this: : not yaml\n  ::\n")
+
+	layered, err := NewLayeredDataProvider(
+		NewEmbeddedDataProvider(GetEmbeddedFS(), ""),
+		LayeredProviderConfig{ExternalDir: tmp},
+	)
+	if err != nil {
+		t.Fatalf("NewLayeredDataProvider: %v", err)
+	}
+
+	// Snapshot + restore process globals so this test does not poison
+	// the singleton state observed by tests that run after it.
+	prev := GetDataProvider()
+	t.Cleanup(func() {
+		SetDataProvider(prev)
+		ResetMetadataStoreForTesting()
+		DefaultRegistry().Reset()
+	})
+	SetDataProvider(layered)
+	ResetMetadataStoreForTesting()
+	DefaultRegistry().Reset()
+
+	if loadErr := LoadCatalog(context.Background()); loadErr == nil {
+		t.Fatal("expected LoadCatalog to error on malformed overlay")
+	}
+	if DefaultRegistry().Has(FieldService, "pending-leak-service") {
+		t.Error("malformed catalog load leaked staged criteria into registry; " +
+			"deferred commit must skip registry mutation when validation fails")
+	}
+}
+
+func TestCriteriaRegistry_RegisterOnZeroValue(t *testing.T) {
+	// External callers may legally construct &CriteriaRegistry{} (the
+	// type is exported even though newCriteriaRegistry is not); Register
+	// must defensively initialize the inner map instead of panicking on
+	// nil-map assignment.
+	var r CriteriaRegistry
+	r.Register(FieldService, "ncp-zero", OriginExternal)
+	if !r.Has(FieldService, "ncp-zero") {
+		t.Error("Register on a zero-value CriteriaRegistry must succeed")
+	}
+}
+
 func TestDefaultRegistry_Singleton(t *testing.T) {
 	a := DefaultRegistry()
 	b := DefaultRegistry()
@@ -220,8 +303,8 @@ func TestSeedCriteriaRegistry(t *testing.T) {
 	}{
 		{"embedded source", "embedded", OriginEmbedded},
 		{"external source", "external", OriginExternal},
-		{"merged falls back to embedded", "merged", OriginEmbedded},
-		{"unknown source falls back to embedded", "", OriginEmbedded},
+		{"merged is strict-safe external", "merged", OriginExternal},
+		{"unknown source is strict-safe external", "", OriginExternal},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -179,6 +179,12 @@ func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
 				store.Base = &metadata
 			} else {
 				store.Overlays[metadata.Metadata.Name] = &metadata
+				// Seed the criteria registry so ParseCriteria*Type can
+				// admit values introduced by this overlay (especially
+				// from external `--data` catalogs). Origin is keyed off
+				// the data provider's Source(path) so strict mode can
+				// later distinguish embedded vs external contributions.
+				seedCriteriaRegistry(metadata.Spec.Criteria, provider.Source(path))
 			}
 
 			return nil
@@ -227,6 +233,19 @@ func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
 		return nil, aicrerrors.New(aicrerrors.ErrCodeInternal, "metadata store not initialized")
 	}
 	return cachedMetadataStore, nil
+}
+
+// LoadCatalog eagerly loads the recipe catalog into the package cache,
+// which has the side effect of seeding the criteria registry from every
+// overlay's spec.criteria. Call this immediately after SetDataProvider
+// so that subsequent ParseCriteria*Type lookups see values contributed
+// by `--data` overlays. The CLI calls it at the top of `aicr recipe`
+// Action and the API server should call it at startup; if the catalog
+// is malformed, this surfaces the error before any criteria validation
+// runs (and before the registry is half-populated).
+func LoadCatalog(ctx context.Context) error {
+	_, err := loadMetadataStore(ctx)
+	return err
 }
 
 // ResetMetadataStoreForTesting clears the cached metadata store so that

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -58,6 +58,14 @@ type MetadataStore struct {
 	ValuesFiles map[string][]byte
 }
 
+// pendingRegistryEntry stages an overlay's criteria + provider source so the
+// loader can defer the actual seedCriteriaRegistry call until after the
+// full catalog passes validation.
+type pendingRegistryEntry struct {
+	criteria *Criteria
+	source   string
+}
+
 // loadMetadataStore loads and caches the metadata store from the data provider.
 // The cache is keyed by DataProvider generation, so SetDataProvider callers see
 // the new content on the next invocation rather than being stuck on the
@@ -85,6 +93,13 @@ func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
 			Mixins:      make(map[string]*RecipeMixin),
 			ValuesFiles: make(map[string][]byte),
 		}
+
+		// Staged criteria registry entries. Each overlay's criteria are
+		// appended during the walk but only applied to the global registry
+		// after every later validation (walk completion, base presence,
+		// dependency validation) succeeds. Keeps the registry transactional
+		// with respect to catalog-load success.
+		var pendingRegistry []pendingRegistryEntry
 
 		provider := GetDataProvider()
 
@@ -179,12 +194,17 @@ func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
 				store.Base = &metadata
 			} else {
 				store.Overlays[metadata.Metadata.Name] = &metadata
-				// Seed the criteria registry so ParseCriteria*Type can
-				// admit values introduced by this overlay (especially
-				// from external `--data` catalogs). Origin is keyed off
-				// the data provider's Source(path) so strict mode can
-				// later distinguish embedded vs external contributions.
-				seedCriteriaRegistry(metadata.Spec.Criteria, provider.Source(path))
+				// Stage this overlay's criteria for registration; the
+				// actual call to seedCriteriaRegistry is deferred until
+				// after every overlay parses cleanly, the base recipe is
+				// found, and dependency validation passes — see the
+				// commit loop below the walk. This prevents a malformed
+				// file later in the walk from leaving partial criteria
+				// values in the package-global registry.
+				pendingRegistry = append(pendingRegistry, pendingRegistryEntry{
+					criteria: metadata.Spec.Criteria,
+					source:   provider.Source(path),
+				})
 			}
 
 			return nil
@@ -204,6 +224,13 @@ func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
 		if err := store.Base.Spec.ValidateDependencies(); err != nil {
 			cachedMetadataErr = aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "base recipe validation failed", err)
 			return
+		}
+
+		// Catalog fully validated — commit staged criteria registrations
+		// to the global registry now. Any earlier `return` path above
+		// leaves the registry untouched.
+		for _, entry := range pendingRegistry {
+			seedCriteriaRegistry(entry.criteria, entry.source)
 		}
 
 		cachedMetadataStore = store

--- a/tests/chainsaw/cli/criteria-registry/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/criteria-registry/chainsaw-test.yaml
@@ -95,10 +95,24 @@ spec:
             content: |
               set -eu
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
-              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
-                -o /dev/null 2>&1
+              WORK="/tmp/chainsaw-criteria-registry"
+              ERR="${WORK}/ncp-rejected-without-data.err"
+              if ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                   -o /dev/null 2>"${ERR}"; then
+                echo "FAIL: expected non-zero exit, got success" >&2
+                cat "${ERR}" >&2
+                exit 1
+              fi
+              # Assert the failure reason is criteria validation, not an
+              # incidental runtime error.
+              grep -qi "invalid service type" "${ERR}" || {
+                echo "FAIL: expected 'invalid service type' in error, got:" >&2
+                cat "${ERR}" >&2
+                exit 1
+              }
+              grep -q "ncp-internal" "${ERR}"
             check:
-              ($error != null): true
+              ($error == null): true
 
     - name: ncp-admitted-with-data
       description: --data overlay registers ncp-internal; CLI must admit it.
@@ -136,10 +150,21 @@ spec:
               set -eu
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-criteria-registry"
-              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
-                --data "${WORK}" --criteria-strict -o /dev/null 2>&1
+              ERR="${WORK}/strict-flag-rejects-external.err"
+              if ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                   --data "${WORK}" --criteria-strict -o /dev/null 2>"${ERR}"; then
+                echo "FAIL: --criteria-strict did not reject external value" >&2
+                cat "${ERR}" >&2
+                exit 1
+              fi
+              grep -qi "invalid service type" "${ERR}" || {
+                echo "FAIL: expected 'invalid service type' in error, got:" >&2
+                cat "${ERR}" >&2
+                exit 1
+              }
+              grep -q "ncp-internal" "${ERR}"
             check:
-              ($error != null): true
+              ($error == null): true
 
     - name: strict-flag-admits-oss
       description: --criteria-strict must still admit canonical OSS values (eks, h100, training).
@@ -166,10 +191,21 @@ spec:
               set -eu
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-criteria-registry"
-              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
-                --data "${WORK}" -o /dev/null 2>&1
+              ERR="${WORK}/strict-env-var-rejects-external.err"
+              if ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                   --data "${WORK}" -o /dev/null 2>"${ERR}"; then
+                echo "FAIL: AICR_CRITERIA_STRICT=1 did not reject external value" >&2
+                cat "${ERR}" >&2
+                exit 1
+              fi
+              grep -qi "invalid service type" "${ERR}" || {
+                echo "FAIL: expected 'invalid service type' in error, got:" >&2
+                cat "${ERR}" >&2
+                exit 1
+              }
+              grep -q "ncp-internal" "${ERR}"
             check:
-              ($error != null): true
+              ($error == null): true
 
     - name: strict-via-config-rejects-external
       description: spec.recipe.criteriaStrict=true in --config must reject ncp-internal too.
@@ -179,10 +215,21 @@ spec:
               set -eu
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-criteria-registry"
-              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
-                --data "${WORK}" --config "${WORK}/strict-config.yaml" -o /dev/null 2>&1
+              ERR="${WORK}/strict-via-config-rejects-external.err"
+              if ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                   --data "${WORK}" --config "${WORK}/strict-config.yaml" -o /dev/null 2>"${ERR}"; then
+                echo "FAIL: spec.recipe.criteriaStrict did not reject external value" >&2
+                cat "${ERR}" >&2
+                exit 1
+              fi
+              grep -qi "invalid service type" "${ERR}" || {
+                echo "FAIL: expected 'invalid service type' in error, got:" >&2
+                cat "${ERR}" >&2
+                exit 1
+              }
+              grep -q "ncp-internal" "${ERR}"
             check:
-              ($error != null): true
+              ($error == null): true
       cleanup:
         - script:
             content: |

--- a/tests/chainsaw/cli/criteria-registry/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/criteria-registry/chainsaw-test.yaml
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cli-criteria-registry
+spec:
+  description: |
+    End-to-end coverage for issue #998 — extensible criteria values via the
+    catalog-driven runtime registry. Verifies that an overlay loaded from
+    `--data` with a non-OSS criteria value (e.g., service=ncp-internal,
+    platform=nvmesh) becomes a valid CLI input without rebuilding the
+    binary, and that `--criteria-strict` (and the AICR_CRITERIA_STRICT
+    env var, and spec.recipe.criteriaStrict in --config) reject it again.
+  timeouts:
+    exec: 30s
+  steps:
+    - name: setup-fixtures
+      description: Create an external --data dir with overlays carrying non-OSS criteria values.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              rm -rf "${WORK}" && mkdir -p "${WORK}/overlays"
+
+              # Minimal registry.yaml (required by the data provider).
+              cat > "${WORK}/registry.yaml" << 'EOF'
+              apiVersion: aicr.nvidia.com/v1alpha1
+              kind: ComponentRegistry
+              components: []
+              EOF
+
+              # Overlay declaring an internal-only service value.
+              cat > "${WORK}/overlays/ncp-internal-overlay.yaml" << 'EOF'
+              apiVersion: aicr.nvidia.com/v1alpha1
+              kind: RecipeMetadata
+              metadata:
+                name: ncp-internal-h100-training
+              spec:
+                base: base
+                criteria:
+                  service: ncp-internal
+                  accelerator: h100
+                  intent: training
+                componentRefs: []
+              EOF
+
+              # Overlay declaring a proprietary platform value (e.g., nvmesh).
+              cat > "${WORK}/overlays/nvmesh-overlay.yaml" << 'EOF'
+              apiVersion: aicr.nvidia.com/v1alpha1
+              kind: RecipeMetadata
+              metadata:
+                name: eks-h100-nvmesh
+              spec:
+                base: base
+                criteria:
+                  service: eks
+                  accelerator: h100
+                  intent: training
+                  platform: nvmesh
+                componentRefs: []
+              EOF
+
+              # AICRConfig that toggles criteriaStrict via --config (separate
+              # from the --criteria-strict CLI flag).
+              cat > "${WORK}/strict-config.yaml" << 'EOF'
+              kind: AICRConfig
+              apiVersion: aicr.nvidia.com/v1alpha1
+              metadata:
+                name: strict
+              spec:
+                recipe:
+                  criteriaStrict: true
+              EOF
+
+    - name: ncp-rejected-without-data
+      description: Internal service value must be rejected without --data (no overlay registers it).
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                -o /dev/null 2>&1
+            check:
+              ($error != null): true
+
+    - name: ncp-admitted-with-data
+      description: --data overlay registers ncp-internal; CLI must admit it.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                --data "${WORK}" -o "${WORK}/ncp-recipe.yaml"
+              test -f "${WORK}/ncp-recipe.yaml"
+            check:
+              ($error == null): true
+
+    - name: nvmesh-platform-admitted-with-data
+      description: --data overlay registers platform=nvmesh; CLI must admit it.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              ${AICR_BIN} recipe --service eks --accelerator h100 --intent training --platform nvmesh \
+                --data "${WORK}" -o "${WORK}/nvmesh-recipe.yaml"
+              test -f "${WORK}/nvmesh-recipe.yaml"
+            check:
+              ($error == null): true
+
+    - name: strict-flag-rejects-external
+      description: --criteria-strict must hide external values and reject ncp-internal.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                --data "${WORK}" --criteria-strict -o /dev/null 2>&1
+            check:
+              ($error != null): true
+
+    - name: strict-flag-admits-oss
+      description: --criteria-strict must still admit canonical OSS values (eks, h100, training).
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              ${AICR_BIN} recipe --service eks --accelerator h100 --intent training \
+                --data "${WORK}" --criteria-strict -o "${WORK}/oss-recipe.yaml"
+              test -f "${WORK}/oss-recipe.yaml"
+            check:
+              ($error == null): true
+
+    - name: strict-env-var-rejects-external
+      description: AICR_CRITERIA_STRICT=1 must compose with --data and reject external values.
+      try:
+        - script:
+            env:
+              - name: AICR_CRITERIA_STRICT
+                value: "1"
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                --data "${WORK}" -o /dev/null 2>&1
+            check:
+              ($error != null): true
+
+    - name: strict-via-config-rejects-external
+      description: spec.recipe.criteriaStrict=true in --config must reject ncp-internal too.
+      try:
+        - script:
+            content: |
+              set -eu
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-criteria-registry"
+              ${AICR_BIN} recipe --service ncp-internal --accelerator h100 --intent training \
+                --data "${WORK}" --config "${WORK}/strict-config.yaml" -o /dev/null 2>&1
+            check:
+              ($error != null): true
+      cleanup:
+        - script:
+            content: |
+              rm -rf /tmp/chainsaw-criteria-registry


### PR DESCRIPTION
## Summary

Make `service` / `accelerator` / `intent` / `os` / `platform` criteria values extensible at runtime via the `--data` overlay catalog. A `--data` overlay declaring `spec.criteria.service: ncp-internal` (or any other proprietary value) becomes a valid CLI / API input — no fork, no rebuild.

## Motivation / Context

The criteria validation switches in `pkg/recipe/criteria.go` were hardcoded enum-style: an unknown value returned `ErrCodeInvalidRequest` before the overlay catalog was even consulted. That made it impossible to add undisclosed NCPs, proprietary platforms (`runai`, `nvmesh`), or new GPU SKUs via `--data` without forking AICR or contributing the value upstream.

Fixes: #998
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/config` (new `criteriaStrict` field + accessor)

## Implementation Notes

Three coupled pieces; they have no observable behavior unless landed together, hence the single-PR scope agreed on the issue.

1. **Registry** (`pkg/recipe/criteria_registry.go`) — process-global singleton, `sync.RWMutex`-guarded, per-(field, value) `Origin` tag (`Embedded` / `External`). Embedded never downgrades on subsequent external `Register`. `SetStrict` + `AICR_CRITERIA_STRICT` env var baseline.

2. **Parser fallback** (`pkg/recipe/criteria.go`) — each `ParseCriteria*Type`'s `default:` branch consults `DefaultRegistry().Has(field, value)` before returning the existing error. `GetCriteria*Types()` stays unchanged (static OSS list); new `AllCriteria*Types()` returns the static + registry union for CLI `--help` / autocomplete.

3. **CLI deferred validation + LoadCatalog** (`pkg/cli/recipe.go`) — `--criteria-strict` flag added; `recipe.LoadCatalog(ctx)` called right after `initDataProvider` so the registry is populated *before* any `ParseCriteria*Type` lookup (the metadata store is otherwise lazy). `cfg.Recipe().IsCriteriaStrict()` honors `spec.recipe.criteriaStrict` in `--config`. Strict mode composes via OR across all three sources (flag, config, env).

**Operational notes:**
- The aicrd API server currently has no `--data` flag wired, so it uses the embedded catalog only — registry stays OSS-clean by construction. If `--data` is ever added to the server, the caller MUST invoke `recipe.LoadCatalog(ctx)` immediately after `recipe.SetDataProvider(...)` for the same eager-load reason documented for the CLI; the registry design doc calls this out.
- `make qualify`'s unit-test step now exports `AICR_CRITERIA_STRICT=1` so the upstream catalog cannot accidentally start depending on internal-only values during dev.

## Testing

```bash
make qualify
```

Result: passes — 22 chainsaw tests (incl. the new `cli-criteria-registry`), unit tests pass with `AICR_CRITERIA_STRICT=1` in the env, total coverage **76.5%** (≥ 75% threshold), no vulnerabilities, license headers OK.

**Test coverage added:**
- `pkg/recipe/criteria_registry_test.go` — registry Register / Has / HasEmbedded / Values / Reset / strict-mode / env-var parsing / concurrent access / `seedCriteriaRegistry`
- `pkg/recipe/criteria_registry_parse_test.go` — fallback per dimension, strict rejection of external, `AllCriteria*Types` union, `Criteria.Validate` registry path
- `pkg/config/accessors_test.go` — `IsCriteriaStrict` tri-state (nil / explicit false / explicit true)
- `tests/chainsaw/cli/criteria-registry/` — end-to-end: rejection without `--data`, admission with `--data` (service + platform dimensions), strict rejection via flag, env var, and config-file

**Per-package coverage delta on changed packages:**
- `pkg/recipe`: 90.0% (no regression)
- `pkg/cli`, `pkg/config`: unchanged

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Backward compatible.
- All existing criteria values continue to validate (the static switch arms remain as the fast path).
- `GetCriteria*Types()` returns the same OSS list; only the new `AllCriteria*Types()` family is registry-aware, so consumers that explicitly want the OSS-only list don't change behavior.
- Default behavior (no `--data`, no `--criteria-strict`) is unchanged.
- If `make qualify`'s `AICR_CRITERIA_STRICT=1` ever exposes accidental drift in the embedded catalog (e.g., an overlay declaring an external-only value), the test would fail — that's the intent, and it's the change's safety net for the OSS catalog.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)