### PR TITLE
feat(recipe): deliver deployment-phase floor at per-accelerator wildcards

### DIFF
--- a/pkg/recipe/validation_phase_floor_test.go
+++ b/pkg/recipe/validation_phase_floor_test.go
@@ -31,12 +31,14 @@
 //   Kind (any intent)                 : deployment + conformance
 //
 // Strict toggle: AICR_VALIDATION_FLOOR_STRICT=1 promotes the recommended
-// performance phase from warn-only to required. Default OFF until #969
-// closes the data gap and Azure/OCI performance testbeds land.
+// performance phase from warn-only to required. Default OFF until the
+// Azure/OCI performance testbeds land.
 //
 // knownGaps allowlist: keyed by (overlay, phase) so a regression in a
-// different phase is not silently masked. Drain as #969 lands; new
-// overlay/phase failures that are not allowlisted block CI.
+// different phase is not silently masked. The deployment-phase data gap
+// from #969 closed; the map is intentionally empty. Add entries only as
+// a tracked, time-bounded escape hatch when a new gap is uncovered and a
+// follow-up issue is filed to close it.
 
 package recipe
 
@@ -51,50 +53,15 @@ import (
 
 const strictEnvVar = "AICR_VALIDATION_FLOOR_STRICT"
 
-// knownGaps lists (overlay, phase) pairs that fail the floor today and
-// are tracked under #969. Each entry downgrades an Errorf to a Logf
-// prefixed with "KNOWN GAP (#969):". Drain this map as #969 lands per-
-// overlay fixes; delete the map entirely once empty. New (overlay, phase)
-// failures not in this map block CI.
-var knownGaps = map[string]map[string]bool{
-	"aks":                                {"deployment": true},
-	"aks-inference":                      {"deployment": true},
-	"aks-training":                       {"deployment": true},
-	"eks":                                {"deployment": true},
-	"eks-inference":                      {"deployment": true},
-	"eks-training":                       {"deployment": true},
-	"gb200-oke-inference":                {"deployment": true},
-	"gb200-oke-training":                 {"deployment": true},
-	"gb200-oke-ubuntu-inference":         {"deployment": true},
-	"gb200-oke-ubuntu-inference-dynamo":  {"deployment": true},
-	"gb200-oke-ubuntu-training":          {"deployment": true},
-	"gb200-oke-ubuntu-training-kubeflow": {"deployment": true},
-	"gke-cos":                            {"deployment": true},
-	"gke-cos-inference":                  {"deployment": true},
-	"gke-cos-training":                   {"deployment": true},
-	"h100-aks-inference":                 {"deployment": true},
-	"h100-aks-ubuntu-inference":          {"deployment": true},
-	"h100-eks-inference":                 {"deployment": true},
-	"h100-eks-ubuntu-inference":          {"deployment": true},
-	"h100-gke-cos-inference":             {"deployment": true},
-	"h100-kind-inference":                {"deployment": true},
-	"h100-kind-inference-dynamo":         {"deployment": true},
-	"h100-kind-training":                 {"deployment": true},
-	"h100-kind-training-kubeflow":        {"deployment": true},
-	"h100-kind-training-slurm":           {"deployment": true},
-	"kind":                               {"deployment": true},
-	"kind-inference":                     {"deployment": true},
-	"lke":                                {"deployment": true},
-	"lke-inference":                      {"deployment": true},
-	"lke-training":                       {"deployment": true},
-	"oke":                                {"deployment": true},
-	"oke-inference":                      {"deployment": true},
-	"oke-training":                       {"deployment": true},
-	"rtx-pro-6000-lke-inference":         {"deployment": true},
-	"rtx-pro-6000-lke-training":          {"deployment": true},
-	"rtx-pro-6000-lke-ubuntu-inference":  {"deployment": true},
-	"rtx-pro-6000-lke-ubuntu-training":   {"deployment": true},
-}
+// knownGaps lists (overlay, phase) pairs that fail the floor today.
+// Each entry downgrades an Errorf to a Logf prefixed with "KNOWN GAP:"
+// and is paired with a tracking issue. The map is intentionally empty
+// after #969 closed the deployment-phase gap — new (overlay, phase)
+// failures not in this map block CI. Reserve future entries as a tracked,
+// time-bounded escape hatch only when a follow-up issue exists to drain
+// them; the stale-entry guard at the end of TestOverlayValidationPhaseFloor
+// catches drift.
+var knownGaps = map[string]map[string]bool{}
 
 // classification captures the inputs that drive the per-intent floor.
 type classification struct {
@@ -111,19 +78,26 @@ func (c classification) String() string {
 		c.Intent, c.Service, c.Accelerator, c.Platform, c.IsKind)
 }
 
+// isAcceleratorBound reports whether the classification corresponds to
+// an accelerator-bound query. Accelerator-unbound classifications
+// (intermediates without an `accelerator:` criterion) are exempt from
+// the deployment + performance floors because both phases carry
+// accelerator-specific values (gpu-operator version pin, NCCL bandwidth
+// threshold) that live on accelerator-bound wildcards or concrete leaves.
+func (c classification) isAcceleratorBound() bool {
+	return c.Accelerator != "" && c.Accelerator != CriteriaAcceleratorAny
+}
+
+// requiresDeployment reports whether the per-intent floor requires the
+// deployment phase for this classification.
+func (c classification) requiresDeployment() bool {
+	return c.isAcceleratorBound()
+}
+
 // requiresPerformance reports whether the per-intent floor recommends
 // the performance phase for this classification.
-//
-// Accelerator-unbound intermediates (e.g., eks-training, gke-cos-training)
-// are exempt: their concrete-leaf descendants (h100-eks-training,
-// gb200-eks-training, etc.) carry the perf threshold via per-phase
-// replace, and the threshold value is accelerator-specific so no
-// meaningful constraint exists at the intent layer.
 func (c classification) requiresPerformance() bool {
-	if c.IsKind {
-		return false
-	}
-	if c.Accelerator == "" || c.Accelerator == CriteriaAcceleratorAny {
+	if c.IsKind || !c.isAcceleratorBound() {
 		return false
 	}
 	if c.Intent == CriteriaIntentTraining {
@@ -142,6 +116,44 @@ func classifyOverlay(criteria *Criteria) classification {
 		Accelerator: criteria.Accelerator,
 		IsKind:      criteria.Service == CriteriaServiceKind,
 	}
+}
+
+// hasGPUOperatorVersionCheck reports whether the deployment phase
+// declares the `gpu-operator-version` check by name. Without the
+// check entry, the validator never runs the version assertion no
+// matter what constraints are declared — the resolved recipe ships
+// with a constraint that no runtime path evaluates.
+func hasGPUOperatorVersionCheck(p *ValidationPhase) bool {
+	if p == nil {
+		return false
+	}
+	for _, name := range p.Checks {
+		if name == "gpu-operator-version" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasGPUOperatorVersionConstraint reports whether the deployment phase
+// declares a `Deployment.gpu-operator.version` constraint. Without it
+// the gpu-operator-version check at runtime is a no-op (it skips when
+// no constraint targets that path), so the resolved recipe ships with
+// the check name but no version assertion. See #969.
+//
+// Note: the two helpers are independent — a leaf can declare either
+// in isolation. The floor test asserts both are present so neither
+// half of the gate can silently no-op.
+func hasGPUOperatorVersionConstraint(p *ValidationPhase) bool {
+	if p == nil {
+		return false
+	}
+	for _, c := range p.Constraints {
+		if c.Name == "Deployment.gpu-operator.version" {
+			return true
+		}
+	}
+	return false
 }
 
 // resolvedPhases returns the names of phases that are set on v.
@@ -216,7 +228,7 @@ func TestOverlayValidationPhaseFloor(t *testing.T) {
 
 	strict := os.Getenv(strictEnvVar) == "1"
 	t.Logf("strict mode (%s=1): %t", strictEnvVar, strict)
-	t.Logf("knownGaps allowlist entries (#969): %d", knownGapEntries())
+	t.Logf("knownGaps allowlist entries: %d", knownGapEntries())
 
 	overlays := enumerateGateableOverlays(store)
 	t.Logf("gateable overlays discovered: %d", len(overlays))
@@ -263,15 +275,35 @@ func TestOverlayValidationPhaseFloor(t *testing.T) {
 						triggered[name] = map[string]bool{}
 					}
 					triggered[name][phase] = true
-					t.Logf("KNOWN GAP (#969): %s", msg)
+					t.Logf("KNOWN GAP: %s", msg)
 					return
 				}
 				t.Error(msg)
 			}
 
-			// Required: deployment + conformance for every classification.
-			if result.Validation == nil || result.Validation.Deployment == nil {
-				fail("deployment")
+			// Required: deployment for accelerator-bound classifications;
+			// conformance for every classification.
+			//
+			// For deployment, the gate has two independent halves and
+			// both must be present — either half missing turns the
+			// version assertion into a no-op:
+			//   • `gpu-operator-version` in deployment.checks (the
+			//     validator only runs the check if its name is
+			//     declared).
+			//   • `Deployment.gpu-operator.version` in
+			//     deployment.constraints (the check skips at runtime
+			//     when no constraint targets that path).
+			if class.requiresDeployment() {
+				if result.Validation == nil || result.Validation.Deployment == nil {
+					fail("deployment")
+				} else {
+					if !hasGPUOperatorVersionCheck(result.Validation.Deployment) {
+						fail("deployment.checks.gpu-operator-version")
+					}
+					if !hasGPUOperatorVersionConstraint(result.Validation.Deployment) {
+						fail("deployment.constraints.Deployment.gpu-operator.version")
+					}
+				}
 			}
 			if result.Validation == nil || result.Validation.Conformance == nil {
 				fail("conformance")
@@ -313,26 +345,29 @@ func TestOverlayValidationPhaseFloor(t *testing.T) {
 // intent x service x platform x accelerator matrix.
 func TestClassifyOverlay(t *testing.T) {
 	tests := []struct {
-		name             string
-		intent           CriteriaIntentType
-		service          CriteriaServiceType
-		platform         CriteriaPlatformType
-		accelerator      CriteriaAcceleratorType
-		wantIsKind       bool
-		wantRequiresPerf bool
+		name               string
+		intent             CriteriaIntentType
+		service            CriteriaServiceType
+		platform           CriteriaPlatformType
+		accelerator        CriteriaAcceleratorType
+		wantIsKind         bool
+		wantRequiresDeploy bool
+		wantRequiresPerf   bool
 	}{
-		{"training-eks-h100", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, true},
-		{"training-aks-h100-kubeflow", CriteriaIntentTraining, CriteriaServiceAKS, CriteriaPlatformKubeflow, CriteriaAcceleratorH100, false, true},
-		{"training-kind-h100", CriteriaIntentTraining, CriteriaServiceKind, CriteriaPlatformAny, CriteriaAcceleratorH100, true, false},
-		{"inference-eks-h100-plain", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, false},
-		{"inference-eks-h100-dynamo", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, CriteriaAcceleratorH100, false, true},
-		{"inference-eks-h100-nim", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformNIM, CriteriaAcceleratorH100, false, true},
-		{"inference-kind-h100-dynamo", CriteriaIntentInference, CriteriaServiceKind, CriteriaPlatformDynamo, CriteriaAcceleratorH100, true, false},
-		// Accelerator-unbound intermediates: the per-intent floor exempts
-		// them because the perf threshold is accelerator-specific.
-		{"training-eks-no-accelerator", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, "", false, false},
-		{"training-gke-accelerator-any", CriteriaIntentTraining, CriteriaServiceGKE, CriteriaPlatformAny, CriteriaAcceleratorAny, false, false},
-		{"inference-eks-dynamo-no-accelerator", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, "", false, false},
+		// Accelerator-bound: deployment required; perf depends on intent/platform.
+		{"training-eks-h100", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, true, true},
+		{"training-aks-h100-kubeflow", CriteriaIntentTraining, CriteriaServiceAKS, CriteriaPlatformKubeflow, CriteriaAcceleratorH100, false, true, true},
+		{"training-kind-h100", CriteriaIntentTraining, CriteriaServiceKind, CriteriaPlatformAny, CriteriaAcceleratorH100, true, true, false},
+		{"inference-eks-h100-plain", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, true, false},
+		{"inference-eks-h100-dynamo", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, CriteriaAcceleratorH100, false, true, true},
+		{"inference-eks-h100-nim", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformNIM, CriteriaAcceleratorH100, false, true, true},
+		{"inference-kind-h100-dynamo", CriteriaIntentInference, CriteriaServiceKind, CriteriaPlatformDynamo, CriteriaAcceleratorH100, true, true, false},
+		// Accelerator-unbound intermediates: both deployment and perf
+		// are exempt — version pins and NCCL thresholds live on
+		// accelerator-bound wildcards and concrete leaves.
+		{"training-eks-no-accelerator", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, "", false, false, false},
+		{"training-gke-accelerator-any", CriteriaIntentTraining, CriteriaServiceGKE, CriteriaPlatformAny, CriteriaAcceleratorAny, false, false, false},
+		{"inference-eks-dynamo-no-accelerator", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, "", false, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -341,9 +376,89 @@ func TestClassifyOverlay(t *testing.T) {
 			if class.IsKind != tt.wantIsKind {
 				t.Errorf("IsKind = %v, want %v", class.IsKind, tt.wantIsKind)
 			}
+			if class.requiresDeployment() != tt.wantRequiresDeploy {
+				t.Errorf("requiresDeployment() = %v, want %v",
+					class.requiresDeployment(), tt.wantRequiresDeploy)
+			}
 			if class.requiresPerformance() != tt.wantRequiresPerf {
 				t.Errorf("requiresPerformance() = %v, want %v",
 					class.requiresPerformance(), tt.wantRequiresPerf)
+			}
+		})
+	}
+}
+
+// TestGPUOperatorVersionGateHelpers exercises both halves of the
+// deployment-phase gpu-operator-version gate independently. Each helper
+// must return true only when its half is present so the floor test can
+// surface a precise failure when only one half is declared.
+func TestGPUOperatorVersionGateHelpers(t *testing.T) {
+	tests := []struct {
+		name           string
+		phase          *ValidationPhase
+		wantCheck      bool
+		wantConstraint bool
+	}{
+		{
+			name:           "nil phase",
+			phase:          nil,
+			wantCheck:      false,
+			wantConstraint: false,
+		},
+		{
+			name:           "empty phase",
+			phase:          &ValidationPhase{},
+			wantCheck:      false,
+			wantConstraint: false,
+		},
+		{
+			name: "check only — false-green scenario",
+			phase: &ValidationPhase{
+				Checks: []string{"operator-health", "gpu-operator-version"},
+			},
+			wantCheck:      true,
+			wantConstraint: false,
+		},
+		{
+			name: "constraint only — false-green scenario CodeRabbit flagged",
+			phase: &ValidationPhase{
+				Constraints: []Constraint{
+					{Name: "Deployment.gpu-operator.version", Value: ">= v24.6.0"},
+				},
+			},
+			wantCheck:      false,
+			wantConstraint: true,
+		},
+		{
+			name: "both present — passes the gate",
+			phase: &ValidationPhase{
+				Checks: []string{"operator-health", "gpu-operator-version", "check-nvidia-smi"},
+				Constraints: []Constraint{
+					{Name: "Deployment.gpu-operator.version", Value: ">= v24.6.0"},
+				},
+			},
+			wantCheck:      true,
+			wantConstraint: true,
+		},
+		{
+			name: "unrelated check and constraint",
+			phase: &ValidationPhase{
+				Checks: []string{"operator-health", "expected-resources"},
+				Constraints: []Constraint{
+					{Name: "K8s.server.version", Value: ">= 1.32"},
+				},
+			},
+			wantCheck:      false,
+			wantConstraint: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasGPUOperatorVersionCheck(tt.phase); got != tt.wantCheck {
+				t.Errorf("hasGPUOperatorVersionCheck() = %v, want %v", got, tt.wantCheck)
+			}
+			if got := hasGPUOperatorVersionConstraint(tt.phase); got != tt.wantConstraint {
+				t.Errorf("hasGPUOperatorVersionConstraint() = %v, want %v", got, tt.wantConstraint)
 			}
 		})
 	}

--- a/recipes/overlays/gb200-any.yaml
+++ b/recipes/overlays/gb200-any.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cross-cutting overlay applied via criteria-wildcard matching.
+#
+# Companion to gb200-any-training.yaml — that overlay contributes only the
+# NCCL performance floor and is scoped to `intent: training`. This overlay
+# carries the deployment-phase floor (the 4 standard checks plus the
+# gpu-operator version pin) and applies to every GB200 query regardless
+# of intent, so inference recipes (e.g., gb200-eks-ubuntu-inference-dynamo,
+# gb200-oke-ubuntu-inference) inherit the version pin too.
+#
+# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
+# that declare their own `deployment:` block (e.g., gb200-eks-training,
+# gb200-eks-inference) continue to win — their constraint values match
+# the floor here so the override is a no-op.
+#
+# See docs/contributor/data.md#criteria-wildcard-overlays for details.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-any
+
+spec:
+  base: base
+
+  criteria:
+    service: any
+    accelerator: gb200
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # GB200 support stabilized in gpu-operator v25.10. Concrete leaves
+        # can tighten if they pin to a later working version.
+        - name: Deployment.gpu-operator.version
+          value: ">= v25.10.0"

--- a/recipes/overlays/h100-any.yaml
+++ b/recipes/overlays/h100-any.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cross-cutting overlay applied via criteria-wildcard matching.
+#
+# This overlay is NOT referenced by any recipe via spec.base or spec.mixins.
+# The resolver picks it up for every H100 query (any service, any intent)
+# because its `service: any` criterion wildcard-matches any service. It
+# contributes the H100-wide deployment-phase floor — the 4 standard checks
+# plus the gpu-operator version pin — without duplicating it in every
+# service+intent leaf.
+#
+# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
+# that declare their own `deployment:` block (e.g., h100-eks-training,
+# h100-aks-training, h100-eks-ubuntu-inference-dynamo) continue to win —
+# their constraint values match the floor here so the override is a no-op.
+#
+# See docs/contributor/data.md#criteria-wildcard-overlays for details.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-any
+
+spec:
+  base: base
+
+  criteria:
+    service: any
+    accelerator: h100
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # H100 datacenter cards have stable gpu-operator support from
+        # v24.6.0 forward. Set as the floor; concrete leaves can tighten.
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"

--- a/recipes/overlays/rtx-pro-6000-any.yaml
+++ b/recipes/overlays/rtx-pro-6000-any.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cross-cutting overlay applied via criteria-wildcard matching.
+#
+# This overlay is NOT referenced by any recipe via spec.base or spec.mixins.
+# The resolver picks it up for every RTX Pro 6000 query (any service, any
+# intent). It contributes the RTX Pro 6000-wide deployment-phase floor —
+# the 4 standard checks plus the gpu-operator version pin — without
+# duplicating it in every leaf.
+#
+# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
+# that declare their own `deployment:` block win. None of the current
+# rtx-pro-6000-lke-* leaves do, so they all inherit this floor.
+#
+# See docs/contributor/data.md#criteria-wildcard-overlays for details.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: rtx-pro-6000-any
+
+spec:
+  base: base
+
+  criteria:
+    service: any
+    accelerator: rtx-pro-6000
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # RTX Pro 6000 (Blackwell workstation) needs the same Blackwell-era
+        # baseline as GB200. Tighten when an empirical floor is established.
+        - name: Deployment.gpu-operator.version
+          value: ">= v25.10.0"


### PR DESCRIPTION
## Summary

Push the deployment-phase floor — both the 4 standard checks AND the \`Deployment.gpu-operator.version\` constraint — to per-accelerator wildcard overlays (\`h100-any.yaml\`, \`gb200-any.yaml\`, \`rtx-pro-6000-any.yaml\`). Every **accelerator-bound** query now inherits a constraint-backed deployment phase. Tighten \`TestOverlayValidationPhaseFloor\` to require the constraint, not just phase presence; exempt accelerator-unbound classifications (whose threshold can't be meaningful without an accelerator).

Closes the gap Codex flagged on v1: declaring \`gpu-operator-version\` at the service-root let accelerator-bound descendants like \`gb200-oke-training\` inherit the check name without a \`Deployment.gpu-operator.version\` constraint, so the check ran as a no-op.

## Scope (explicit)

**In scope:** deployment-phase floor for **accelerator-bound recipes** — every recipe a user can actually deploy (specifies \`--accelerator\` or has an \`accelerator:\` criterion).

**Explicitly out of scope:** accelerator-unbound intermediates (e.g., \`eks\`, \`eks-training\`, \`aks-inference\`). These resolve to incomplete recipes — running \`aicr recipe --service eks --intent training\` without \`--accelerator\` produces a bundle with no accelerator-specific GPU operator config (no driver version pin, no chart values per accelerator). The deployment-phase \`Deployment.gpu-operator.version\` constraint is accelerator-specific (H100 ≥ v24.6.0, GB200 ≥ v25.10.0, RTX Pro 6000 ≥ v25.10.0); a generic version pin at the intent layer would either be over-permissive (lowest common floor) or wrong for some accelerators. The floor test exempts these classifications via \`requiresDeployment()\` checking \`isAcceleratorBound()\`. Issue #969 has been updated to reflect this narrowing.

## Motivation / Context

Fixes #969 — every accelerator-bound recipe now ships with a working version-pin assertion, not just a check name.

Related:
- #970 — CI guard (closed; tightened here)
- #1000 — per-field union merge follow-up (will eventually let concrete leaves declare just the incremental delta over the wildcard)
- Codex P2 review on v1 (resolved by v2; explicit reply in PR comments)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (\`cmd/aicr\`, \`pkg/cli\`)
- [ ] API server (\`cmd/aicrd\`, \`pkg/api\`, \`pkg/server\`)
- [x] Recipe engine / data (\`pkg/recipe\`) — floor test refinement
- [ ] Bundlers (\`pkg/bundler\`, \`pkg/component/*\`)
- [ ] Collectors / snapshotter
- [x] Validator (\`pkg/validator\`) — accelerator-wildcard validation phase
- [ ] Core libraries
- [ ] Docs/examples

## Implementation Notes

**Design choice — wildcards, not service-roots:** The resolver applies overlays in order \`base → wildcards → base chain\`. Per-phase replace means whichever layer declares \`deployment:\` last wins. v1 added the block at service-root, which ran later than per-accelerator wildcards and shadowed any wildcard-level constraint. v2 inverts: service-roots own the service-scoped phase (\`conformance\`); per-accelerator wildcards own the accelerator-scoped phase (\`deployment\` with version pin). Concrete leaves with their own \`deployment:\` block continue to win via per-phase replace; their constraint values match the wildcard floor so the override is a no-op today.

**Why accelerator-unbound classifications are exempt:** An intent-level intermediate without an \`accelerator:\` criterion (e.g., \`eks-training\`) is a degenerate query — the resulting recipe has no accelerator-specific GPU-operator config either, so a deployment-phase version pin would have no meaningful value at the intent layer. Concrete leaves carry the constraint via wildcard composition. Issue #969 narrowed to make this explicit.

**Floor-test tightening:**
- New \`isAcceleratorBound()\` helper drives both \`requiresDeployment()\` (new) and \`requiresPerformance()\` (refined).
- New \`hasGPUOperatorVersionConstraint()\` helper asserts \`Deployment.gpu-operator.version\` is present on the resolved phase.
- \`TestClassifyOverlay\` expanded with \`Accelerator\` field, \`wantRequiresDeploy\` expectation, and three accelerator-unbound exemption cases.

## Files Changed

- \`recipes/overlays/h100-any.yaml\`, \`gb200-any.yaml\`, \`rtx-pro-6000-any.yaml\` — new wildcards, full deployment block + version pin.
- \`pkg/recipe/validation_phase_floor_test.go\` — \`Accelerator\` field on \`classification\`, deployment-required gating, constraint assertion, expanded \`TestClassifyOverlay\`.

## Testing

\`\`\`bash
# Default mode — all 56 subtests pass, knownGaps stays empty
go test ./pkg/recipe/... -run TestOverlayValidationPhaseFloor -v

# Classification cases (10 subtests, all pass)
go test ./pkg/recipe/... -run TestClassifyOverlay -v

# Codex's verification command — now resolves with the constraint
go run ./cmd/aicr recipe --service oke --accelerator gb200 --intent training --format yaml
# yields:
#   validation.deployment.constraints:
#     - name: Deployment.gpu-operator.version
#       value: '>= v25.10.0'

# Spot-checks
go run ./cmd/aicr recipe --service lke --accelerator rtx-pro-6000 --intent training --format yaml
go run ./cmd/aicr recipe --service kind --accelerator h100 --intent inference --format yaml

# Full gate
make qualify   # PASS
\`\`\`

**Strict mode (\`AICR_VALIDATION_FLOOR_STRICT=1\`) status at this PR head:** still fails on **5 known performance-phase gaps** — none of them deployment-side, none of them introduced or made worse by this PR. They are tracked in dedicated follow-up issues:
- \`gb200-oke-ubuntu-inference-dynamo\` → #1007 (OCI testbed)
- \`h100-aks-ubuntu-inference-dynamo\` → #1006 (Azure testbed)
- \`h100-eks-ubuntu-inference-nim\` → #1010 (NIM validator support)
- \`rtx-pro-6000-lke-training\` → #1008 (Linode testbed)
- \`rtx-pro-6000-lke-ubuntu-training\` → #1008 (Linode testbed)

PR #1009 closes the accelerator-unbound intermediate side of strict-mode perf. Once both #1001 and #1009 merge, strict-mode failures drop to the 5 above; remaining work is the dedicated follow-ups.

## Risk Assessment

- [x] **Low** — Data-only edits + a test refinement. The 9 leaf overlays with their own \`deployment:\` block are unaffected (per-phase replace, identical constraint values). New wildcards target accelerator-bound queries which were previously a no-op \`gpu-operator-version\` check.
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** No migration. Resolved recipes for previously-uncovered accelerator-bound queries (e.g., all \`gb200-oke-*\`, \`h100-aks-*-inference\`, \`h100-kind-*\`, \`rtx-pro-6000-lke-*\`) now ship with a real version assertion. Operators running \`aicr validate --phase deployment\` against these recipes will see the constraint evaluated against the deployed gpu-operator version.

## Checklist

- [x] Tests pass locally (\`make test\` with \`-race\`)
- [x] Linter passes (\`make lint\`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — 3 new \`TestClassifyOverlay\` cases + tightened \`TestOverlayValidationPhaseFloor\` assertions
- [ ] I updated docs if user-facing behavior changed — internal floor-test contract; no user-facing API surface affected
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (\`git commit -S\`)