### PR TITLE
feat(validation): scope strict perf floor to accelerator-bound recipes

### DIFF
--- a/pkg/recipe/validation_phase_floor_test.go
+++ b/pkg/recipe/validation_phase_floor_test.go
@@ -98,22 +98,32 @@ var knownGaps = map[string]map[string]bool{
 
 // classification captures the inputs that drive the per-intent floor.
 type classification struct {
-	Intent   CriteriaIntentType
-	Service  CriteriaServiceType
-	Platform CriteriaPlatformType
-	IsKind   bool
+	Intent      CriteriaIntentType
+	Service     CriteriaServiceType
+	Platform    CriteriaPlatformType
+	Accelerator CriteriaAcceleratorType
+	IsKind      bool
 }
 
 // String renders a classification for failure messages.
 func (c classification) String() string {
-	return fmt.Sprintf("intent=%s service=%s platform=%s kind=%t",
-		c.Intent, c.Service, c.Platform, c.IsKind)
+	return fmt.Sprintf("intent=%s service=%s accelerator=%s platform=%s kind=%t",
+		c.Intent, c.Service, c.Accelerator, c.Platform, c.IsKind)
 }
 
 // requiresPerformance reports whether the per-intent floor recommends
 // the performance phase for this classification.
+//
+// Accelerator-unbound intermediates (e.g., eks-training, gke-cos-training)
+// are exempt: their concrete-leaf descendants (h100-eks-training,
+// gb200-eks-training, etc.) carry the perf threshold via per-phase
+// replace, and the threshold value is accelerator-specific so no
+// meaningful constraint exists at the intent layer.
 func (c classification) requiresPerformance() bool {
 	if c.IsKind {
+		return false
+	}
+	if c.Accelerator == "" || c.Accelerator == CriteriaAcceleratorAny {
 		return false
 	}
 	if c.Intent == CriteriaIntentTraining {
@@ -126,10 +136,11 @@ func (c classification) requiresPerformance() bool {
 // classifyOverlay derives the classification from resolved criteria.
 func classifyOverlay(criteria *Criteria) classification {
 	return classification{
-		Intent:   criteria.Intent,
-		Service:  criteria.Service,
-		Platform: criteria.Platform,
-		IsKind:   criteria.Service == CriteriaServiceKind,
+		Intent:      criteria.Intent,
+		Service:     criteria.Service,
+		Platform:    criteria.Platform,
+		Accelerator: criteria.Accelerator,
+		IsKind:      criteria.Service == CriteriaServiceKind,
 	}
 }
 
@@ -299,27 +310,33 @@ func TestOverlayValidationPhaseFloor(t *testing.T) {
 }
 
 // TestClassifyOverlay exercises the classification function across the
-// intent x service x platform matrix.
+// intent x service x platform x accelerator matrix.
 func TestClassifyOverlay(t *testing.T) {
 	tests := []struct {
 		name             string
 		intent           CriteriaIntentType
 		service          CriteriaServiceType
 		platform         CriteriaPlatformType
+		accelerator      CriteriaAcceleratorType
 		wantIsKind       bool
 		wantRequiresPerf bool
 	}{
-		{"training-eks-plain", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, false, true},
-		{"training-aks-kubeflow", CriteriaIntentTraining, CriteriaServiceAKS, CriteriaPlatformKubeflow, false, true},
-		{"training-kind", CriteriaIntentTraining, CriteriaServiceKind, CriteriaPlatformAny, true, false},
-		{"inference-eks-plain", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformAny, false, false},
-		{"inference-eks-dynamo", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, false, true},
-		{"inference-eks-nim", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformNIM, false, true},
-		{"inference-kind-dynamo", CriteriaIntentInference, CriteriaServiceKind, CriteriaPlatformDynamo, true, false},
+		{"training-eks-h100", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, true},
+		{"training-aks-h100-kubeflow", CriteriaIntentTraining, CriteriaServiceAKS, CriteriaPlatformKubeflow, CriteriaAcceleratorH100, false, true},
+		{"training-kind-h100", CriteriaIntentTraining, CriteriaServiceKind, CriteriaPlatformAny, CriteriaAcceleratorH100, true, false},
+		{"inference-eks-h100-plain", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, false},
+		{"inference-eks-h100-dynamo", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, CriteriaAcceleratorH100, false, true},
+		{"inference-eks-h100-nim", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformNIM, CriteriaAcceleratorH100, false, true},
+		{"inference-kind-h100-dynamo", CriteriaIntentInference, CriteriaServiceKind, CriteriaPlatformDynamo, CriteriaAcceleratorH100, true, false},
+		// Accelerator-unbound intermediates: the per-intent floor exempts
+		// them because the perf threshold is accelerator-specific.
+		{"training-eks-no-accelerator", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, "", false, false},
+		{"training-gke-accelerator-any", CriteriaIntentTraining, CriteriaServiceGKE, CriteriaPlatformAny, CriteriaAcceleratorAny, false, false},
+		{"inference-eks-dynamo-no-accelerator", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, "", false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Criteria{Intent: tt.intent, Service: tt.service, Platform: tt.platform}
+			c := &Criteria{Intent: tt.intent, Service: tt.service, Platform: tt.platform, Accelerator: tt.accelerator}
 			class := classifyOverlay(c)
 			if class.IsKind != tt.wantIsKind {
 				t.Errorf("IsKind = %v, want %v", class.IsKind, tt.wantIsKind)


### PR DESCRIPTION
## Summary

Refine `pkg/recipe/validation_phase_floor_test.go::requiresPerformance` to exempt accelerator-unbound classifications (`Criteria.Accelerator` unset or `CriteriaAcceleratorAny`). The perf threshold is accelerator-specific (H100 EKS ≥ 300 GB/s NCCL, GB200 EKS ≥ 40 / 500 GB/s NET / NVLS, RTX Pro 6000 ≥ TBD) so no meaningful constraint exists at the intent layer; concrete-leaf descendants continue to carry their own threshold via per-phase replace.

Drops `AICR_VALIDATION_FLOOR_STRICT=1` warnings from 10 → 5 by exempting the 5 accelerator-unbound intermediates (`aks-training`, `eks-training`, `gke-cos-training`, `lke-training`, `oke-training`).

## Motivation / Context

Closes #1005. Original PR description claimed 10 → 4 by also adding an `inference-perf` placeholder to `h100-eks-ubuntu-inference-nim`. Codex's review (P2) flagged that the `inference-perf` check in `validators/performance/inference_perf_constraint.go:195-197` short-circuits with `"skipped - dynamo-platform not in recipe components"` whenever the resolved recipe lacks `dynamo-platform`. NIM recipes declare `k8s-nim-operator` instead, so the placeholder would satisfy the floor-test letter but never actually run. The NIM block was reverted; the validator extension is tracked in #1010.

Fixes: #1005
Related: #969, #1001, #1006, #1007, #1008, #1010

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes) — test-only refinement
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`) — floor test refinement
- [ ] Bundlers
- [ ] Collectors / snapshotter
- [x] Validator (`pkg/validator`) — floor contract change
- [ ] Core libraries
- [ ] Docs/examples

## Implementation Notes

- **`requiresPerformance` ordering** — accelerator-unset check sits after the Kind check (Kind is already returned-false earlier) and before the intent-specific branches. The Accelerator field uses `CriteriaAcceleratorType`; empty string covers the YAML-unset case and `CriteriaAcceleratorAny` covers the explicit `accelerator: any` case (used in wildcard overlays, though those are already filtered out at `enumerateGateableOverlays`).
- **`TestClassifyOverlay`** updated with the new `accelerator` field on existing cases (all `CriteriaAcceleratorH100` since their resolved-criteria origin all bind H100) and three new cases covering the exempted paths.
- **No data changes** in this PR. The `gb200-eks-ubuntu-inference-dynamo` overlay already has a real `inference-perf` block (added out-of-band), and the NIM equivalent waits on #1010.

## Remaining strict-mode failures after this PR (5)

| Overlay | Blocker | Tracker |
|---|---|---|
| `gb200-oke-ubuntu-inference-dynamo` | OCI testbed | #1007 |
| `h100-aks-ubuntu-inference-dynamo` | Azure testbed | #1006 |
| `h100-eks-ubuntu-inference-nim` | NIM validator support | #1010 |
| `rtx-pro-6000-lke-training` | Linode testbed | #1008 |
| `rtx-pro-6000-lke-ubuntu-training` | Linode testbed | #1008 |

## Testing

```bash
# Default mode — 56/56 subtests pass, knownGaps unchanged
go test ./pkg/recipe/... -run TestOverlayValidationPhaseFloor -v

# Strict mode — failures drop from 10 to 5
AICR_VALIDATION_FLOOR_STRICT=1 go test ./pkg/recipe/... -run TestOverlayValidationPhaseFloor

# Unit tests (with new accelerator-unset cases)
go test ./pkg/recipe/... -run TestClassifyOverlay -v

# Full gate
make qualify   # PASS
```

## Risk Assessment

- [x] **Low** — Test-only refinement; no production code path touched. The exemption codifies an existing convention (perf thresholds live at the accelerator-bound leaf) that was previously enforced only by the warn-only mode.
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** No migration. The floor-test contract is internal CI machinery; no user-facing API surface changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — 3 new cases in `TestClassifyOverlay`
- [ ] I updated docs if user-facing behavior changed — floor-test contract is internal, no user-facing change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)