### PR TITLE
feat(recipe): per-Builder DataProvider isolation; deprecate process globals

### DIFF
--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1591,9 +1591,69 @@ Debug logs include:
 - Source resolution for each file (embedded vs external vs merged)
 - Component merge details (added, overridden, retained)
 
-### Implementation Details
+### Builder-bound providers
 
-The data provider is initialized early in CLI command execution:
+`WithDataProvider` is the canonical way to attach a `DataProvider` to a recipe
+build. The returned `Builder` resolves its metadata store, component registry,
+and per-component values files through the bound provider — never through the
+process-global one. Each call site that builds recipes should construct its
+own provider and pass it through `WithDataProvider`:
+
+```go
+embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "data")
+builder := recipe.NewBuilder(
+    recipe.WithVersion(version),
+    recipe.WithDataProvider(embedded),
+)
+result, err := builder.BuildFromCriteria(ctx, criteria)
+```
+
+The resulting `*RecipeResult` carries the same provider so downstream
+consumers (`GetValuesForComponent`, `GetManifestContentWithProvider`) resolve
+files against the build's provider rather than whatever global is currently
+installed. Recover it via `result.DataProvider()` — nil-safe on the receiver
+and returns nil when the result was built against the package-global fallback.
+
+### Per-Builder isolation
+
+Builders with distinct providers do not share cache state. `LoadMetadataStoreFor`
+and `GetComponentRegistryFor` key their caches by `DataProvider` identity, so a
+process can host multiple tenants concurrently without one tenant's `--data`
+overlay leaking into another's catalog. Use this pattern in multi-tenant
+servers, test harnesses that need clean state per case, or anywhere two
+`Builder` instances may evaluate different inputs at the same time:
+
+```go
+// Each tenant gets its own provider — no cache cross-pollution
+embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
+tenantA := recipe.NewBuilder(recipe.WithDataProvider(embedded))
+tenantB := recipe.NewBuilder(recipe.WithDataProvider(otherProvider))
+
+resA, _ := tenantA.BuildFromCriteria(ctx, criteriaA)
+resB, _ := tenantB.BuildFromCriteria(ctx, criteriaB)
+// resA.DataProvider() != resB.DataProvider()
+// resA.GetValuesForComponent("gpu-operator") reads from embedded
+// resB.GetValuesForComponent("gpu-operator") reads from otherProvider
+```
+
+To force a rebuild on the next read (e.g., after rewriting an external
+overlay on disk), drop the entries for that provider:
+
+```go
+recipe.EvictCachedStore(provider)
+recipe.EvictCachedRegistry(provider)
+```
+
+`Evict*` is a no-op on a nil receiver, and concurrent builders against
+*other* providers are unaffected — eviction is scoped to the supplied
+provider only.
+
+### CLI initialization
+
+The CLI installs a single process-global provider so legacy entry points
+that have no `Builder` in scope (e.g., the criteria registry pre-load,
+manifest helpers without a `RecipeResult`) keep working without threading
+a provider through every call site:
 
 ```go
 // pkg/cli/root.go
@@ -1617,10 +1677,27 @@ func initDataProvider(cmd *cli.Command) error {
 }
 ```
 
-**Global Provider Pattern:**
-- `SetDataProvider()` sets the global data provider
-- `GetDataProvider()` returns the current provider (defaults to embedded)
-- `GetDataProviderGeneration()` returns a counter for cache invalidation
+Single-tenant CLIs and the API server can stay on this pattern. Library
+callers and multi-tenant servers should prefer `WithDataProvider`.
+
+### Back-compat: package-global accessors
+
+The following package-level accessors predate `WithDataProvider` and are
+retained for back-compat. New code should use `WithDataProvider`; see the
+godoc on each for the migration recommendation.
+
+- `SetDataProvider(dp)` — installs the process-global provider. Deprecated;
+  use `recipe.NewBuilder(recipe.WithDataProvider(dp))` instead.
+- `GetDataProvider()` — returns the current process-global provider
+  (embedded by default). Deprecated; recover the Builder-bound provider via
+  `(*RecipeResult).DataProvider()` or pass one explicitly.
+- `GetDataProviderGeneration()` — monotonic counter incremented by
+  `SetDataProvider` so caches keyed on the global can detect a swap.
+- `LoadMetadataStore(ctx)` — convenience wrapper around
+  `LoadMetadataStoreFor(ctx, GetDataProvider())`. Multi-tenant callers
+  should call `LoadMetadataStoreFor` directly with their bound provider.
+- `GetComponentRegistry()` — convenience wrapper around
+  `GetComponentRegistryFor(GetDataProvider())`. Same migration guidance.
 
 ---
 

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1600,7 +1600,7 @@ process-global one. Each call site that builds recipes should construct its
 own provider and pass it through `WithDataProvider`:
 
 ```go
-embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "data")
+embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
 builder := recipe.NewBuilder(
     recipe.WithVersion(version),
     recipe.WithDataProvider(embedded),
@@ -1663,7 +1663,7 @@ func initDataProvider(cmd *cli.Command) error {
         return nil  // Use default embedded provider
     }
 
-    embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "data")
+    embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
     layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
         ExternalDir:   dataDir,
         AllowSymlinks: false,

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -277,8 +277,7 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	// Extract values for each component from the recipe
 	componentValues, err := b.extractComponentValues(ctx, recipeResult)
 	if err != nil {
-		var se *errors.StructuredError
-		if stderrors.As(err, &se) {
+		if _, ok := stderrors.AsType[*errors.StructuredError](err); ok {
 			return nil, err
 		}
 		return nil, errors.Wrap(errors.ErrCodeInternal,
@@ -300,8 +299,7 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	// attestation. This is a no-op when --data is not set.
 	dataFiles, err := b.copyDataFiles(dir)
 	if err != nil {
-		var se *errors.StructuredError
-		if stderrors.As(err, &se) {
+		if _, ok := stderrors.AsType[*errors.StructuredError](err); ok {
 			return nil, err
 		}
 		return nil, errors.Wrap(errors.ErrCodeInternal,
@@ -479,8 +477,7 @@ func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe
 func (b *DefaultBundler) runDeployer(ctx context.Context, d deployer.Deployer, recipeResult *recipe.RecipeResult, dir string, dataFiles []string, start time.Time) (*result.Output, error) {
 	output, err := d.Generate(ctx, dir)
 	if err != nil {
-		var se *errors.StructuredError
-		if stderrors.As(err, &se) {
+		if _, ok := stderrors.AsType[*errors.StructuredError](err); ok {
 			return nil, err
 		}
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to generate bundle", err)
@@ -967,7 +964,7 @@ func (b *DefaultBundler) runComponentValidations(ctx context.Context, recipeResu
 // copyDataFiles copies external data files from the --data directory into the bundle.
 // Returns a list of relative paths to the copied files (e.g., "data/overrides.yaml").
 func (b *DefaultBundler) copyDataFiles(dir string) ([]string, error) {
-	provider := recipe.GetDataProvider()
+	provider := recipe.GetDataProvider() //nolint:staticcheck // tracked by #983 Stage 2
 
 	// Check if the provider is a LayeredDataProvider with external files
 	layered, ok := provider.(*recipe.LayeredDataProvider)
@@ -1306,7 +1303,7 @@ func (b *DefaultBundler) collectComponentManifestsByPhase(
 			content, err := recipe.GetManifestContent(manifestPath)
 			if err != nil {
 				if stderrors.Is(err, fs.ErrNotExist) {
-					_, hasExternalData := recipe.GetDataProvider().(*recipe.LayeredDataProvider)
+					_, hasExternalData := recipe.GetDataProvider().(*recipe.LayeredDataProvider) //nolint:staticcheck // tracked by #983 Stage 2
 					return nil, errors.New(errors.ErrCodeInvalidRequest,
 						missingManifestMessage(manifestPath, ref.Name, hasExternalData))
 				}

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -19,6 +19,7 @@ import (
 	stderrors "errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -352,7 +353,7 @@ func TestMake_SetEnabledOverridesPrecedence(t *testing.T) {
 	}{
 		{
 			name:           "recipe disabled + --set enabled=true => included",
-			recipeEnabled:  boolPtr(false),
+			recipeEnabled:  new(bool),
 			setEnabled:     "true",
 			expectIncluded: true,
 		},
@@ -364,7 +365,7 @@ func TestMake_SetEnabledOverridesPrecedence(t *testing.T) {
 		},
 		{
 			name:           "recipe disabled + no --set => excluded",
-			recipeEnabled:  boolPtr(false),
+			recipeEnabled:  new(bool),
 			setEnabled:     "",
 			expectIncluded: false,
 		},
@@ -378,7 +379,7 @@ func TestMake_SetEnabledOverridesPrecedence(t *testing.T) {
 			// Fail closed: an unparseable --set enabled value must error
 			// out rather than silently ignore the operator's intent.
 			name:          "invalid --set value => error",
-			recipeEnabled: boolPtr(false),
+			recipeEnabled: new(bool),
 			setEnabled:    "ture",
 			expectErr:     true,
 		},
@@ -494,8 +495,6 @@ func TestMake_SetEnabledNotLeakedToHelmValues(t *testing.T) {
 		t.Errorf("expected controller.replicaCount override in values, got:\n%s", valuesStr)
 	}
 }
-
-func boolPtr(b bool) *bool { return &b }
 
 func TestMake_WithValueOverrides(t *testing.T) {
 	cfg := config.NewConfig(
@@ -1300,9 +1299,9 @@ func TestCollectComponentManifests_MissingPath(t *testing.T) {
 			t.Fatalf("NewLayeredDataProvider: %v", layeredErr)
 		}
 
-		original := recipe.GetDataProvider()
-		recipe.SetDataProvider(layered)
-		defer recipe.SetDataProvider(original)
+		original := recipe.GetDataProvider()   //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+		recipe.SetDataProvider(layered)        //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+		defer recipe.SetDataProvider(original) //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
 
 		_, err := bundler.collectComponentManifests(context.Background(), recipeResult)
 		if err == nil {
@@ -1352,7 +1351,7 @@ func TestMake_Reproducible(t *testing.T) {
 	// Generate bundles twice in different directories
 	var fileHashes [2]map[string]string
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		bundler, err := New()
 		if err != nil {
 			t.Fatalf("iteration %d: New() error = %v", i, err)
@@ -1667,5 +1666,109 @@ func TestMake_PreservesTimeoutFromExtractValues(t *testing.T) {
 	if se.Code != errors.ErrCodeTimeout {
 		t.Errorf("expected error code %s, got %s (error: %v)",
 			errors.ErrCodeTimeout, se.Code, err)
+	}
+}
+
+// TestBundlerValueParity_WithRecipeResult pins the invariant that the
+// bundler's extractComponentValues produces values byte-identical (deep-equal)
+// to RecipeResult.GetValuesForComponent for every component in a representative
+// RecipeResult, when run with a vanilla bundler (no --set overrides, no node
+// scheduling configured, so applyNodeSchedulingOverrides is a no-op).
+//
+// This guards against silent drift between the two code paths as the cache
+// layer beneath them is refactored. If this test fails, the bundler has
+// started returning different values than the canonical RecipeResult adapter —
+// investigate before changing the test.
+func TestBundlerValueParity_WithRecipeResult(t *testing.T) {
+	// Build a RecipeResult covering all three value-source shapes:
+	//   - ValuesFile only            → gpu-operator (loads from embedded data)
+	//   - Overrides only             → cert-manager (inline only)
+	//   - ValuesFile + Overrides     → network-operator (hybrid merge)
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:       "gpu-operator",
+				Version:    "v25.3.3",
+				Type:       "helm",
+				Source:     "https://helm.ngc.nvidia.com/nvidia",
+				ValuesFile: "components/gpu-operator/values.yaml",
+			},
+			{
+				Name:    "cert-manager",
+				Version: "v1.15.3",
+				Type:    "helm",
+				Source:  "https://charts.jetstack.io",
+				Overrides: map[string]any{
+					"installCRDs": true,
+					"resources": map[string]any{
+						"requests": map[string]any{
+							"cpu":    "100m",
+							"memory": "128Mi",
+						},
+					},
+				},
+			},
+			{
+				Name:       "network-operator",
+				Version:    "v25.4.0",
+				Type:       "helm",
+				Source:     "https://helm.ngc.nvidia.com/nvidia",
+				ValuesFile: "components/network-operator/values.yaml",
+				Overrides: map[string]any{
+					"deployCR": false,
+				},
+			},
+		},
+	}
+
+	// Vanilla bundler: default config (no --set overrides, no scheduling).
+	// Under these conditions applyNodeSchedulingOverrides is a no-op, so the
+	// two outputs must be deep-equal without any mirroring helper.
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	bundlerValues, err := b.extractComponentValues(context.Background(), recipeResult)
+	if err != nil {
+		t.Fatalf("extractComponentValues() error = %v", err)
+	}
+
+	// Sanity: every ref should have produced an entry; at least one must be
+	// non-empty so the test isn't trivially passing on empty-vs-empty.
+	if len(bundlerValues) != len(recipeResult.ComponentRefs) {
+		t.Fatalf("extractComponentValues returned %d entries, want %d",
+			len(bundlerValues), len(recipeResult.ComponentRefs))
+	}
+	var anyNonEmpty bool
+	for _, v := range bundlerValues {
+		if len(v) > 0 {
+			anyNonEmpty = true
+			break
+		}
+	}
+	if !anyNonEmpty {
+		t.Fatal("all bundler-extracted component values are empty; fixture is not exercising the merge paths")
+	}
+
+	for _, ref := range recipeResult.ComponentRefs {
+		t.Run(ref.Name, func(t *testing.T) {
+			adapted, err := recipeResult.GetValuesForComponent(ref.Name)
+			if err != nil {
+				t.Fatalf("GetValuesForComponent(%q): %v", ref.Name, err)
+			}
+
+			got, ok := bundlerValues[ref.Name]
+			if !ok {
+				t.Fatalf("extractComponentValues missing entry for %q", ref.Name)
+			}
+
+			if !reflect.DeepEqual(adapted, got) {
+				t.Errorf("value mismatch for %q:\n  RecipeResult.GetValuesForComponent: %#v\n  extractComponentValues:             %#v",
+					ref.Name, adapted, got)
+			}
+		})
 	}
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -379,7 +379,7 @@ func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
 	}
 	if dataDir == "" {
 		// Reset to embedded so prior --data state does not leak across runs.
-		recipe.SetDataProvider(embedded)
+		recipe.SetDataProvider(embedded) //nolint:staticcheck // tracked by #983 Stage 2
 		return nil
 	}
 
@@ -393,7 +393,7 @@ func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to initialize external data", err)
 	}
 
-	recipe.SetDataProvider(layered)
+	recipe.SetDataProvider(layered) //nolint:staticcheck // tracked by #983 Stage 2
 
 	slog.Info("external data provider initialized successfully", "directory", dataDir)
 	return nil

--- a/pkg/recipe/adapter.go
+++ b/pkg/recipe/adapter.go
@@ -30,11 +30,30 @@ func GetEmbeddedFS() embed.FS {
 	return recipes.FS
 }
 
-// GetManifestContent retrieves a manifest file from the data provider.
-// Path should be relative to data directory (e.g., "components/network-operator/manifests/nfd-network-rule.yaml").
+// GetManifestContent retrieves a manifest file from the package-global
+// DataProvider. Path should be relative to data directory (e.g.,
+// "components/network-operator/manifests/nfd-network-rule.yaml").
+//
+// This entry point is preserved for back-compat with callers that have no
+// RecipeResult-bound provider available. Callers operating against a
+// per-tenant Builder should prefer GetManifestContentWithProvider so the
+// lookup honors the bound provider.
 func GetManifestContent(path string) ([]byte, error) {
-	provider := GetDataProvider()
-	return provider.ReadFile(path)
+	return GetManifestContentWithProvider(nil, path)
+}
+
+// GetManifestContentWithProvider reads a manifest file from the supplied
+// DataProvider. A nil provider falls back to GetDataProvider() so callers
+// that thread a possibly-nil RecipeResult.DataProvider() through can rely on
+// the global-provider fallback without an explicit nil check.
+//
+// Path should be relative to the data root (e.g.,
+// "components/network-operator/manifests/nfd-network-rule.yaml").
+func GetManifestContentWithProvider(dp DataProvider, path string) ([]byte, error) {
+	if dp == nil {
+		dp = GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
+	}
+	return dp.ReadFile(path)
 }
 
 // RecipeInput is an interface that both Recipe and RecipeResult implement.
@@ -116,6 +135,11 @@ func (r *RecipeResult) GetComponentRef(name string) *ComponentRef {
 //  1. ValuesFile only: Traditional separate file approach
 //  2. Overrides only: Fully self-contained recipe with inline overrides
 //  3. ValuesFile + Overrides: Hybrid - reusable base with recipe-specific tweaks
+//
+// File lookups route through the DataProvider bound to this result (set when
+// the result was built by a Builder via WithDataProvider). When no provider
+// is bound (legacy global-provider path), falls back to GetDataProvider() so
+// existing callers keep working.
 func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error) {
 	ref := r.GetComponentRef(name)
 	if ref == nil {
@@ -130,10 +154,16 @@ func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error
 		return result, nil
 	}
 
+	// Resolve provider once: prefer the result-bound provider (per-tenant
+	// isolation), fall back to the package-global for back-compat with
+	// results built before WithDataProvider was wired through.
+	provider := r.provider
+	if provider == nil {
+		provider = GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
+	}
+
 	// Step 1: Load base and/or overlay values from files (if ValuesFile specified)
 	if ref.ValuesFile != "" {
-		provider := GetDataProvider()
-
 		// Determine if this is an overlay values file (not the base values.yaml)
 		baseValuesFile := fmt.Sprintf("components/%s/values.yaml", name)
 		isOverlay := ref.ValuesFile != baseValuesFile

--- a/pkg/recipe/adapter.go
+++ b/pkg/recipe/adapter.go
@@ -17,7 +17,9 @@ package recipe
 
 import (
 	"embed"
+	stderrors "errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/recipes"
@@ -53,7 +55,14 @@ func GetManifestContentWithProvider(dp DataProvider, path string) ([]byte, error
 	if dp == nil {
 		dp = GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
 	}
-	return dp.ReadFile(path)
+	content, err := dp.ReadFile(path)
+	if err != nil {
+		if stderrors.Is(err, fs.ErrNotExist) {
+			return nil, errors.Wrap(errors.ErrCodeNotFound, fmt.Sprintf("manifest file not found: %q", path), err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to read manifest file %q", path), err)
+	}
+	return content, nil
 }
 
 // RecipeInput is an interface that both Recipe and RecipeResult implement.

--- a/pkg/recipe/adapter_test.go
+++ b/pkg/recipe/adapter_test.go
@@ -16,10 +16,13 @@ package recipe
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"io/fs"
 	"maps"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -800,5 +803,24 @@ func TestGetManifestContentWithProvider_NilFallback(t *testing.T) {
 	}
 	if len(content) == 0 {
 		t.Error("expected non-empty content from global fallback")
+	}
+}
+
+// TestGetManifestContentWithProvider_NotFound verifies that missing manifest
+// files surface as a structured pkg/errors error with ErrCodeNotFound while
+// preserving the underlying fs.ErrNotExist in the wrap chain — bundler
+// callers depend on stderrors.Is(err, fs.ErrNotExist) for distinguishing
+// missing-file errors from internal read failures.
+func TestGetManifestContentWithProvider_NotFound(t *testing.T) {
+	dp := newInMemoryProvider("empty", map[string][]byte{})
+	_, err := GetManifestContentWithProvider(dp, "components/missing/manifests/x.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing manifest, got nil")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("expected ErrCodeNotFound, got %v", err)
+	}
+	if !stderrors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected wrap chain to preserve fs.ErrNotExist, got %v", err)
 	}
 }

--- a/pkg/recipe/adapter_test.go
+++ b/pkg/recipe/adapter_test.go
@@ -16,7 +16,11 @@ package recipe
 
 import (
 	"context"
+	"fmt"
+	"maps"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 const testVersionV2 = "v2.0"
@@ -153,9 +157,7 @@ func TestMergeValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a copy of base to avoid modifying the test data
 			dst := make(map[string]any)
-			for k, v := range tt.base {
-				dst[k] = v
-			}
+			maps.Copy(dst, tt.base)
 
 			// Merge overlay into dst
 			mergeValues(dst, tt.overlay)
@@ -607,4 +609,196 @@ func Test_hasComponentRefs(t *testing.T) {
 			t.Error("expected false for Recipe")
 		}
 	})
+}
+
+// buildIsolatedCriteria returns a Criteria matching the leaf overlay seeded
+// by buildProviderWithValues — keeps the test focused on the bound-provider
+// routing and not on criteria matching.
+func buildIsolatedCriteria(t *testing.T) *Criteria {
+	t.Helper()
+	return &Criteria{Service: "eks"}
+}
+
+// buildProviderWithValues returns an inMemoryDataProvider whose values for
+// the gpu-operator component live only in the bound provider. It seeds:
+//   - an empty registry.yaml
+//   - a base overlay
+//   - a leaf overlay (criteria.service=eks) whose single componentRef points
+//     at gpu-operator with valuesFile = components/gpu-operator/values.yaml
+//   - that values.yaml at the expected path, containing the supplied content
+//
+// Together these let BuildFromCriteria succeed against the bound provider and
+// let RecipeResult.GetValuesForComponent("gpu-operator") read the seeded
+// values exclusively from the bound provider. The valuesPath argument is
+// retained for symmetry with buildProviderWithManifest (so callers can
+// document the path they expect to be read) but is not load-bearing — the
+// component always references components/gpu-operator/values.yaml.
+func buildProviderWithValues(t *testing.T, valuesPath string, values map[string]any) DataProvider {
+	t.Helper()
+
+	valuesBytes, err := yaml.Marshal(values)
+	if err != nil {
+		t.Fatalf("marshal values: %v", err)
+	}
+
+	registryYAML := []byte(`components: []
+`)
+	baseYAML := []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`)
+	overlayYAML := []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: bound-values
+spec:
+  base: base
+  criteria:
+    service: eks
+  componentRefs:
+    - name: gpu-operator
+      type: Helm
+      chart: gpu-operator
+      source: https://helm.ngc.nvidia.com/nvidia
+      version: v25.3.4
+      valuesFile: components/gpu-operator/values.yaml
+`)
+
+	files := map[string][]byte{
+		"registry.yaml":                       registryYAML,
+		"overlays/base.yaml":                  baseYAML,
+		"overlays/bound-values.yaml":          overlayYAML,
+		"components/gpu-operator/values.yaml": valuesBytes,
+	}
+	// valuesPath only documents the expected lookup; the recipe always
+	// references the canonical components/gpu-operator/values.yaml. Sanity-
+	// check that the helper isn't being asked for a non-canonical path
+	// (which would hide a test mistake silently).
+	if valuesPath != "components/gpu-operator/values.yaml" {
+		t.Logf("buildProviderWithValues: note - valuesPath %q is documentation only; component reads components/gpu-operator/values.yaml", valuesPath)
+	}
+	return newInMemoryProvider("bound-values", files)
+}
+
+// buildProviderWithManifest returns an inMemoryDataProvider seeded with a
+// single manifest file at the supplied path. Used to verify that
+// GetManifestContentWithProvider reads from the supplied provider rather
+// than the package-global.
+func buildProviderWithManifest(t *testing.T, path string, content []byte) DataProvider {
+	t.Helper()
+	files := map[string][]byte{
+		path: content,
+	}
+	return newInMemoryProvider(fmt.Sprintf("manifest-%s", path), files)
+}
+
+// TestRecipeResult_GetValuesForComponent_HonorsBoundProvider verifies that
+// when a RecipeResult was built from a Builder bound via WithDataProvider,
+// GetValuesForComponent reads the component's valuesFile from that bound
+// provider — not from the package-global DataProvider. This closes the
+// silent-fallback-to-global path flagged in reviewer feedback on Tasks 4/5.
+func TestRecipeResult_GetValuesForComponent_HonorsBoundProvider(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	dp := buildProviderWithValues(t, "components/gpu-operator/values.yaml", map[string]any{
+		"driver": map[string]any{"version": "999.99.99"},
+	})
+	b := NewBuilder(WithDataProvider(dp))
+	result, err := b.BuildFromCriteria(context.Background(), buildIsolatedCriteria(t))
+	if err != nil {
+		t.Fatalf("BuildFromCriteria: %v", err)
+	}
+
+	// values.yaml exists in the BOUND provider only; the package-global
+	// embedded values.yaml has different content (no driver.version key at
+	// all). If GetValuesForComponent reaches for the global, the type
+	// assertion below will fail.
+	vals, err := result.GetValuesForComponent("gpu-operator")
+	if err != nil {
+		t.Fatalf("GetValuesForComponent: %v", err)
+	}
+
+	driver, ok := vals["driver"].(map[string]any)
+	if !ok {
+		t.Fatalf("driver not a map: %#v", vals["driver"])
+	}
+	if got := driver["version"]; got != "999.99.99" {
+		t.Errorf("driver.version = %v, want from bound provider (999.99.99)", got)
+	}
+}
+
+// TestRecipeResult_GetValuesForComponent_BoundProviderSurvivesGlobalSwap
+// pins the invariant that RecipeResult.provider defeats post-build mutations
+// of the package-global DataProvider. After building a recipe against dpA,
+// swapping the global to dpB (with different values content) must not change
+// what GetValuesForComponent returns — the bound provider wins.
+func TestRecipeResult_GetValuesForComponent_BoundProviderSurvivesGlobalSwap(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	// Build a recipe with bound provider dpA carrying driver.version=111.11.11.
+	dpA := buildProviderWithValues(t, "components/gpu-operator/values.yaml", map[string]any{
+		"driver": map[string]any{"version": "111.11.11"},
+	})
+	b := NewBuilder(WithDataProvider(dpA))
+	result, err := b.BuildFromCriteria(context.Background(), buildIsolatedCriteria(t))
+	if err != nil {
+		t.Fatalf("BuildFromCriteria: %v", err)
+	}
+
+	// Now swap the global to dpB with a DIFFERENT version, AFTER build.
+	dpB := buildProviderWithValues(t, "components/gpu-operator/values.yaml", map[string]any{
+		"driver": map[string]any{"version": "222.22.22"},
+	})
+	saved := GetDataProvider() //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+	t.Cleanup(func() {
+		SetDataProvider(saved) //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+		ResetMetadataStoreForTesting()
+		ResetComponentRegistryForTesting()
+	})
+	SetDataProvider(dpB) //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+
+	// result.GetValuesForComponent MUST read from dpA (the bound provider),
+	// not from dpB which is now the package-global.
+	vals, err := result.GetValuesForComponent("gpu-operator")
+	if err != nil {
+		t.Fatalf("GetValuesForComponent: %v", err)
+	}
+	driver, ok := vals["driver"].(map[string]any)
+	if !ok {
+		t.Fatalf("driver not a map: %#v", vals["driver"])
+	}
+	if got := driver["version"]; got != "111.11.11" {
+		t.Errorf("driver.version = %v, want 111.11.11 (bound provider must beat global swap)", got)
+	}
+}
+
+// TestGetManifestContentWithProvider verifies the explicit-provider variant
+// reads from the supplied DataProvider rather than the package-global.
+func TestGetManifestContentWithProvider(t *testing.T) {
+	dp := buildProviderWithManifest(t, "components/x/manifests/special.yaml", []byte("from-bound\n"))
+	got, err := GetManifestContentWithProvider(dp, "components/x/manifests/special.yaml")
+	if err != nil {
+		t.Fatalf("GetManifestContentWithProvider: %v", err)
+	}
+	if string(got) != "from-bound\n" {
+		t.Errorf("content = %q, want %q", got, "from-bound\n")
+	}
+}
+
+// TestGetManifestContentWithProvider_NilFallback verifies that passing a nil
+// DataProvider falls back to the package-global provider — preserving
+// back-compat for callers that don't have a RecipeResult-bound provider.
+func TestGetManifestContentWithProvider_NilFallback(t *testing.T) {
+	content, err := GetManifestContentWithProvider(nil, "components/network-operator/manifests/nfd-network-rule.yaml")
+	if err != nil {
+		t.Fatalf("GetManifestContentWithProvider(nil): %v", err)
+	}
+	if len(content) == 0 {
+		t.Error("expected non-empty content from global fallback")
+	}
 }

--- a/pkg/recipe/builder.go
+++ b/pkg/recipe/builder.go
@@ -62,6 +62,19 @@ func WithAllowLists(al *AllowLists) Option {
 	}
 }
 
+// WithDataProvider binds the Builder to a specific DataProvider, isolating
+// its metadata store and component registry from the process-global ones at
+// GetDataProvider().
+//
+// Use this from any caller that constructs more than one Builder per process.
+// When unset, the Builder falls back to the package-global DataProvider —
+// preserving the CLI and API server behavior.
+func WithDataProvider(dp DataProvider) Option {
+	return func(b *Builder) {
+		b.dp = dp
+	}
+}
+
 // NewBuilder creates a new Builder instance with the provided functional options.
 func NewBuilder(opts ...Option) *Builder {
 	b := &Builder{}
@@ -79,6 +92,16 @@ func NewBuilder(opts ...Option) *Builder {
 type Builder struct {
 	Version    string
 	AllowLists *AllowLists
+	dp         DataProvider // nil ⇒ fall back to package-global
+}
+
+// DataProvider returns the Builder's bound provider, or nil if none is set
+// and the package-global will be used.
+func (b *Builder) DataProvider() DataProvider {
+	if b == nil {
+		return nil
+	}
+	return b.dp
 }
 
 // BuildFromCriteria creates a RecipeResult payload for the provided criteria.
@@ -130,7 +153,7 @@ func (b *Builder) buildWithStore(ctx context.Context, c *Criteria, buildFn func(
 		recipeBuiltDuration.Observe(time.Since(start).Seconds())
 	}()
 
-	store, err := loadMetadataStore(buildCtx)
+	store, err := LoadMetadataStoreFor(buildCtx, b.dp)
 	if err != nil {
 		return nil, aicrerrors.WrapWithContext(
 			aicrerrors.ErrCodeInternal,

--- a/pkg/recipe/builder_test.go
+++ b/pkg/recipe/builder_test.go
@@ -17,8 +17,12 @@ package recipe
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // TestBuilder_BuildFromCriteria_ContextCancellation tests context cancellation
@@ -262,6 +266,27 @@ func TestWithAllowLists(t *testing.T) {
 	})
 }
 
+// TestNewBuilder_WithDataProvider verifies that WithDataProvider binds the
+// provided DataProvider to the Builder, isolating it from the package-global
+// provider at GetDataProvider().
+func TestNewBuilder_WithDataProvider(t *testing.T) {
+	dp := NewEmbeddedDataProvider(GetEmbeddedFS(), "")
+	b := NewBuilder(WithDataProvider(dp))
+	if got := b.DataProvider(); got != dp {
+		t.Errorf("Builder.DataProvider() = %v, want %v", got, dp)
+	}
+}
+
+// TestNewBuilder_DataProviderNilFallback verifies that when WithDataProvider
+// is not set, Builder.DataProvider() returns nil so callers fall back to the
+// package-global DataProvider — preserving CLI and API server behavior.
+func TestNewBuilder_DataProviderNilFallback(t *testing.T) {
+	b := NewBuilder() // no option set
+	if b.DataProvider() != nil {
+		t.Error("expected nil provider when WithDataProvider not used")
+	}
+}
+
 // TestGetEmbeddedFS tests that the embedded filesystem is accessible.
 func TestGetEmbeddedFS(t *testing.T) {
 	fs := GetEmbeddedFS()
@@ -317,6 +342,9 @@ func TestConstraintEvalResult(t *testing.T) {
 	if passed.Actual != "ubuntu" {
 		t.Errorf("expected actual ubuntu, got %q", passed.Actual)
 	}
+	if passed.Error != nil {
+		t.Errorf("expected Error to be nil, got %v", passed.Error)
+	}
 
 	// Test failed result
 	failed := ConstraintEvalResult{
@@ -327,6 +355,12 @@ func TestConstraintEvalResult(t *testing.T) {
 	if failed.Passed {
 		t.Error("expected Passed to be false")
 	}
+	if failed.Actual != "rhel" {
+		t.Errorf("expected actual rhel, got %q", failed.Actual)
+	}
+	if failed.Error != nil {
+		t.Errorf("expected Error to be nil, got %v", failed.Error)
+	}
 
 	// Test error result
 	errResult := ConstraintEvalResult{
@@ -334,7 +368,186 @@ func TestConstraintEvalResult(t *testing.T) {
 		Actual: "",
 		Error:  errors.New("value not found"),
 	}
+	if errResult.Passed {
+		t.Error("expected Passed to be false")
+	}
+	if errResult.Actual != "" {
+		t.Errorf("expected actual to be empty, got %q", errResult.Actual)
+	}
 	if errResult.Error == nil {
 		t.Error("expected error to be set")
+	}
+}
+
+// buildIsolationProvider returns an inMemoryDataProvider seeded with a
+// minimal registry.yaml, an empty base recipe, and a single leaf overlay
+// whose metadata name is derived from `overlayName`. The overlay declares
+// `criteria.service: eks` and a uniquely-named componentRef
+// (`<overlayName>-component`) so isolation tests can detect both presence
+// (correct provider routing) and leak (wrong provider routing).
+//
+// The componentRef carries minimal Type/Source/Chart fields so
+// finalizeRecipeResult's dependency validation and topological sort pass
+// without a registry hit; applyRegistryDefaults will find no matching
+// entry in the empty registry and leave the ref untouched, which is
+// exactly what these tests want — they care about which overlays land
+// in the result, not registry merging.
+func buildIsolationProvider(t *testing.T, overlayName string) DataProvider {
+	t.Helper()
+
+	registryYAML := []byte(`components: []
+`)
+	baseYAML := []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`)
+	overlayYAML := fmt.Appendf(nil, `kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: %[1]s
+spec:
+  base: base
+  criteria:
+    service: eks
+  componentRefs:
+    - name: %[1]s-component
+      type: Helm
+      chart: example
+      source: https://charts.example.com
+      version: 0.1.0
+`, overlayName)
+
+	files := map[string][]byte{
+		"registry.yaml":                     registryYAML,
+		"overlays/base.yaml":                baseYAML,
+		"overlays/" + overlayName + ".yaml": overlayYAML,
+	}
+	return newInMemoryProvider(overlayName, files)
+}
+
+// componentNames extracts the ordered set of ComponentRef.Name from a
+// RecipeResult. Used by isolation tests to assert which components landed
+// in the merged result.
+func componentNames(r *RecipeResult) []string {
+	if r == nil {
+		return nil
+	}
+	names := make([]string, 0, len(r.ComponentRefs))
+	for _, c := range r.ComponentRefs {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+// TestBuilder_WithDataProvider_UsesBoundProvider verifies that a Builder
+// constructed with WithDataProvider routes BuildFromCriteria through the
+// bound provider end-to-end, and that the resulting RecipeResult carries
+// the same provider via DataProvider() so downstream consumers (e.g.,
+// GetValuesForComponent in Task 6) honor per-tenant isolation.
+func TestBuilder_WithDataProvider_UsesBoundProvider(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	dp := buildIsolationProvider(t, "isolated")
+	b := NewBuilder(WithDataProvider(dp))
+
+	criteria := &Criteria{Service: "eks"}
+	result, err := b.BuildFromCriteria(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("BuildFromCriteria: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Provider should propagate to the result so GetValuesForComponent
+	// (Task 6) honors it.
+	if result.DataProvider() != dp {
+		t.Errorf("RecipeResult.DataProvider() = %v, want bound provider %v", result.DataProvider(), dp)
+	}
+
+	// And the overlay's unique component must land in the result —
+	// proving the bound provider was actually walked, not the global.
+	if got := componentNames(result); !slices.Contains(got, "isolated-component") {
+		t.Errorf("expected isolated-component in result, got %v", got)
+	}
+}
+
+// TestBuilder_DataProvider_NilSafe verifies the nil-safety contract of
+// RecipeResult.DataProvider() — call sites must be able to chain off a
+// possibly-nil result without panicking.
+func TestBuilder_DataProvider_NilSafe(t *testing.T) {
+	var r *RecipeResult
+	if got := r.DataProvider(); got != nil {
+		t.Errorf("nil RecipeResult.DataProvider() = %v, want nil", got)
+	}
+}
+
+// TestBuilder_TwoProviders_ConcurrentBuild verifies that two Builders
+// bound to different providers produce isolated results under concurrent
+// load. With 8 goroutines per provider, the -race detector also catches
+// any shared-state slip introduced by the per-provider caches.
+func TestBuilder_TwoProviders_ConcurrentBuild(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	dpA := buildIsolationProvider(t, "alpha-only")
+	dpB := buildIsolationProvider(t, "beta-only")
+	bA := NewBuilder(WithDataProvider(dpA))
+	bB := NewBuilder(WithDataProvider(dpB))
+
+	const fanout = 8
+	resultsA := make([]*RecipeResult, fanout)
+	resultsB := make([]*RecipeResult, fanout)
+
+	g, gctx := errgroup.WithContext(context.Background())
+	for i := range fanout {
+		g.Go(func() error {
+			r, err := bA.BuildFromCriteria(gctx, &Criteria{Service: "eks"})
+			resultsA[i] = r
+			return err
+		})
+		g.Go(func() error {
+			r, err := bB.BuildFromCriteria(gctx, &Criteria{Service: "eks"})
+			resultsB[i] = r
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("concurrent build: %v", err)
+	}
+
+	for i, r := range resultsA {
+		if r == nil {
+			t.Fatalf("resultsA[%d] is nil", i)
+		}
+		if r.DataProvider() != dpA {
+			t.Errorf("resultsA[%d].DataProvider() = %v, want %v", i, r.DataProvider(), dpA)
+		}
+		names := componentNames(r)
+		if !slices.Contains(names, "alpha-only-component") {
+			t.Errorf("resultsA[%d] missing alpha-only-component: %v", i, names)
+		}
+		if slices.Contains(names, "beta-only-component") {
+			t.Errorf("resultsA[%d] leaked beta-only-component: %v", i, names)
+		}
+	}
+	for i, r := range resultsB {
+		if r == nil {
+			t.Fatalf("resultsB[%d] is nil", i)
+		}
+		if r.DataProvider() != dpB {
+			t.Errorf("resultsB[%d].DataProvider() = %v, want %v", i, r.DataProvider(), dpB)
+		}
+		names := componentNames(r)
+		if !slices.Contains(names, "beta-only-component") {
+			t.Errorf("resultsB[%d] missing beta-only-component: %v", i, names)
+		}
+		if slices.Contains(names, "alpha-only-component") {
+			t.Errorf("resultsB[%d] leaked alpha-only-component: %v", i, names)
+		}
 	}
 }

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -201,46 +201,78 @@ type ComponentValidationConfig struct {
 	Message string `yaml:"message,omitempty"`
 }
 
-// Global component registry, keyed by the DataProvider generation that
-// produced it. SetDataProvider increments the generation; the next call to
-// GetComponentRegistry observes the change and rebuilds the cache so a
-// late-bound external data source actually takes effect.
-var (
-	registryCacheMu  sync.Mutex
-	registryCache    *ComponentRegistry
-	registryCacheErr error
-	registryCacheGen = -1
-)
+// registryCacheEntry holds the lazily-built ComponentRegistry for a single
+// DataProvider identity. sync.Once gates concurrent first-load callers onto
+// the same registry and the same error.
+type registryCacheEntry struct {
+	once     sync.Once
+	registry *ComponentRegistry
+	err      error
+}
 
-// GetComponentRegistry returns the global component registry. The registry is
-// cached, but the cache is invalidated whenever SetDataProvider is called so
-// callers that swap in an external data source see the new content.
-func GetComponentRegistry() (*ComponentRegistry, error) {
-	gen := getDataProviderGeneration()
-	registryCacheMu.Lock()
-	defer registryCacheMu.Unlock()
-	if registryCacheGen == gen && (registryCache != nil || registryCacheErr != nil) {
-		return registryCache, registryCacheErr
+// registryCache holds registryCacheEntry pointers keyed by DataProvider
+// identity. Two callers bound to different DataProvider values populate
+// distinct entries; a single provider value yields a single shared registry
+// regardless of caller goroutine count. EvictCachedRegistry drops a single
+// entry so callers can force a refetch after rotating provider content
+// without disturbing other providers.
+var registryCache sync.Map // map[DataProvider]*registryCacheEntry
+
+// GetComponentRegistryFor returns the component registry for the supplied
+// DataProvider. Concurrent callers with the same provider observe the same
+// singleton; distinct providers populate distinct cache entries and never
+// share state. A nil provider falls back to GetDataProvider() so the legacy
+// GetComponentRegistry entry point continues to work transparently.
+//
+// Note: a first-load error is preserved by sync.Once and returned to every
+// subsequent caller for the same provider until EvictCachedRegistry drops
+// the entry.
+func GetComponentRegistryFor(dp DataProvider) (*ComponentRegistry, error) {
+	if dp == nil {
+		dp = GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
 	}
-	registryCache, registryCacheErr = loadComponentRegistry()
-	registryCacheGen = gen
-	return registryCache, registryCacheErr
+	e, _ := registryCache.LoadOrStore(dp, &registryCacheEntry{})
+	entry := e.(*registryCacheEntry)
+	entry.once.Do(func() {
+		entry.registry, entry.err = loadComponentRegistryFor(dp)
+	})
+	return entry.registry, entry.err
 }
 
-// ResetComponentRegistryForTesting resets the cached registry so it will be
-// reloaded from the current DataProvider on the next call to
-// GetComponentRegistry. This must only be called from tests.
+// GetComponentRegistry returns the component registry for the package-global
+// DataProvider. New callers — especially those that need per-tenant
+// isolation — should use GetComponentRegistryFor directly with a
+// caller-supplied provider.
+func GetComponentRegistry() (*ComponentRegistry, error) {
+	return GetComponentRegistryFor(GetDataProvider()) //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
+}
+
+// EvictCachedRegistry drops the cached registry for the supplied provider
+// so the next GetComponentRegistryFor call rebuilds from source. Passing a
+// nil provider is a no-op (callers handle that case explicitly to avoid
+// silently evicting the package-global registry).
+func EvictCachedRegistry(dp DataProvider) {
+	if dp == nil {
+		return
+	}
+	registryCache.Delete(dp)
+}
+
+// ResetComponentRegistryForTesting drops every cached registry so the next
+// GetComponentRegistryFor call rebuilds from source. This must only be
+// called from tests.
 func ResetComponentRegistryForTesting() {
-	registryCacheMu.Lock()
-	defer registryCacheMu.Unlock()
-	registryCache = nil
-	registryCacheErr = nil
-	registryCacheGen = -1
+	registryCache.Range(func(k, _ any) bool {
+		registryCache.Delete(k)
+		return true
+	})
 }
 
-// loadComponentRegistry loads the component registry from the data provider.
-func loadComponentRegistry() (*ComponentRegistry, error) {
-	provider := GetDataProvider()
+// loadComponentRegistryFor loads the component registry from the supplied
+// provider. It is pure with respect to the package-global DataProvider —
+// callers that need package-global semantics route through
+// GetComponentRegistry, which resolves the provider once at the entry point.
+func loadComponentRegistryFor(provider DataProvider) (*ComponentRegistry, error) {
 	data, err := provider.ReadFile("registry.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read registry.yaml", err)

--- a/pkg/recipe/components_test.go
+++ b/pkg/recipe/components_test.go
@@ -910,3 +910,108 @@ components:
 		t.Errorf("GetType() = %v, want %v", comp.GetType(), ComponentTypeKustomize)
 	}
 }
+
+// buildProviderWithRegistry returns an inMemoryDataProvider whose registry.yaml
+// declares a single component whose name is derived from the supplied tag
+// (e.g., "registry-alpha.yaml" -> component name "alpha-only"). This lets
+// isolation tests verify that the component registry cache keyed by
+// DataProvider populates distinct entries.
+func buildProviderWithRegistry(t *testing.T, tag string) DataProvider {
+	t.Helper()
+	// Derive a component name from the tag for unambiguous assertions.
+	var compName string
+	switch {
+	case strings.Contains(tag, "alpha"):
+		compName = "alpha-only"
+	case strings.Contains(tag, "beta"):
+		compName = "beta-only"
+	default:
+		compName = "evict-only"
+	}
+
+	registryYAML := []byte("apiVersion: aicr.nvidia.com/v1alpha1\n" +
+		"kind: ComponentRegistry\n" +
+		"components:\n" +
+		"  - name: " + compName + "\n" +
+		"    displayName: " + compName + "\n")
+
+	files := map[string][]byte{
+		"registry.yaml": registryYAML,
+	}
+	return newInMemoryProvider(tag, files)
+}
+
+func TestGetComponentRegistry_PerProviderIsolation(t *testing.T) {
+	dpA := buildProviderWithRegistry(t, "registry-alpha.yaml")
+	dpB := buildProviderWithRegistry(t, "registry-beta.yaml")
+
+	rA, err := GetComponentRegistryFor(dpA)
+	if err != nil {
+		t.Fatalf("registry A: %v", err)
+	}
+	rB, err := GetComponentRegistryFor(dpB)
+	if err != nil {
+		t.Fatalf("registry B: %v", err)
+	}
+
+	if rA == rB {
+		t.Fatal("expected distinct registries for distinct providers")
+	}
+	if rA.Get("alpha-only") == nil {
+		t.Errorf("registry A missing alpha-only component")
+	}
+	if rA.Get("beta-only") != nil {
+		t.Errorf("registry A leaked beta-only component")
+	}
+	if rB.Get("beta-only") == nil {
+		t.Errorf("registry B missing beta-only component")
+	}
+	if rB.Get("alpha-only") != nil {
+		t.Errorf("registry B leaked alpha-only component")
+	}
+}
+
+func TestEvictCachedRegistry_Refetches(t *testing.T) {
+	dp := buildProviderWithRegistry(t, "registry-evict.yaml")
+	first, err := GetComponentRegistryFor(dp)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	EvictCachedRegistry(dp)
+	second, err := GetComponentRegistryFor(dp)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first == second {
+		t.Errorf("expected fresh registry after evict")
+	}
+}
+
+func TestEvictCachedRegistry_NilIsNoOp(t *testing.T) {
+	dp := buildProviderWithRegistry(t, "registry-evict.yaml")
+	first, err := GetComponentRegistryFor(dp)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Evicting nil must not disturb other providers' cached entries.
+	EvictCachedRegistry(nil)
+	second, err := GetComponentRegistryFor(dp)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first != second {
+		t.Errorf("expected same cached registry after nil evict, got fresh")
+	}
+}
+
+func TestGetComponentRegistryFor_NilProviderFallsBack(t *testing.T) {
+	// A nil provider routes through GetDataProvider(); the call should
+	// succeed and return the embedded registry without panicking.
+	r, err := GetComponentRegistryFor(nil)
+	if err != nil {
+		t.Fatalf("nil provider: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil registry for nil provider fallback")
+	}
+}

--- a/pkg/recipe/criteria_registry_test.go
+++ b/pkg/recipe/criteria_registry_test.go
@@ -255,13 +255,13 @@ spec:
 
 	// Snapshot + restore process globals so this test does not poison
 	// the singleton state observed by tests that run after it.
-	prev := GetDataProvider()
+	prev := GetDataProvider() //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
 	t.Cleanup(func() {
-		SetDataProvider(prev)
+		SetDataProvider(prev) //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
 		ResetMetadataStoreForTesting()
 		DefaultRegistry().Reset()
 	})
-	SetDataProvider(layered)
+	SetDataProvider(layered) //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
 	ResetMetadataStoreForTesting()
 	DefaultRegistry().Reset()
 

--- a/pkg/recipe/doc.go
+++ b/pkg/recipe/doc.go
@@ -124,6 +124,45 @@
 //	builder := recipe.NewBuilder()
 //	http.HandleFunc("/v1/recipe", builder.HandleRecipes)
 //
+// # Builder-Bound DataProvider (Multi-Tenant)
+//
+// WithDataProvider attaches a DataProvider to the Builder so the metadata
+// store, component registry, and per-component values files all resolve
+// through the bound provider rather than the package-global one. This is
+// the canonical pattern for any caller that constructs more than one Builder
+// per process (multi-tenant servers, library users, test harnesses):
+//
+//	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
+//	tenantA := recipe.NewBuilder(recipe.WithDataProvider(embedded))
+//	tenantB := recipe.NewBuilder(recipe.WithDataProvider(otherProvider))
+//	resA, _ := tenantA.BuildFromCriteria(ctx, criteriaA)
+//	resB, _ := tenantB.BuildFromCriteria(ctx, criteriaB)
+//	// resA.DataProvider() != resB.DataProvider()
+//
+// Caches are keyed by DataProvider identity, so concurrent builders against
+// distinct providers do not share metadata-store or component-registry state.
+// The new public surface for provider-bound builds:
+//
+//   - WithDataProvider(dp DataProvider) Option — binds the Builder to dp.
+//   - LoadMetadataStoreFor(ctx, dp) (*MetadataStore, error) — loads (and
+//     caches) the metadata store for the supplied provider.
+//   - GetComponentRegistryFor(dp) (*ComponentRegistry, error) — returns the
+//     component registry for dp, cached per provider.
+//   - EvictCachedStore(dp) — drops the cached MetadataStore for dp so the
+//     next LoadMetadataStoreFor rebuilds from source.
+//   - EvictCachedRegistry(dp) — drops the cached registry for dp; nil
+//     receiver is a no-op.
+//   - GetManifestContentWithProvider(dp, path) ([]byte, error) — reads a
+//     manifest file from dp; a nil provider falls back to GetDataProvider().
+//   - (*RecipeResult).DataProvider() DataProvider — recovers the bound
+//     provider that produced the result, or nil if the package-global was
+//     used. Nil-safe on the receiver.
+//
+// Single-tenant entry points (the CLI, the API server) may continue to use
+// SetDataProvider / GetDataProvider; those package-global accessors are
+// deprecated in favor of WithDataProvider but remain functional for
+// back-compat.
+//
 // Parse criteria from HTTP request:
 //
 //	criteria, err := recipe.ParseCriteriaFromRequest(r)

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -407,6 +407,26 @@ type RecipeResult struct {
 	// Validation defines multi-phase validation configuration.
 	// Inherited from recipe metadata during merging.
 	Validation *ValidationConfig `json:"validation,omitempty" yaml:"validation,omitempty"`
+
+	// provider is the DataProvider that produced this result. Threaded
+	// through finalizeRecipeResult from the originating MetadataStore so
+	// downstream consumers (e.g., GetValuesForComponent in Task 6) can
+	// route file lookups through the same provider — preserving per-tenant
+	// isolation even when the package-global DataProvider has since been
+	// swapped. Nil when the result was built against the package-global
+	// provider, in which case DataProvider() returns nil and callers fall
+	// back to GetDataProvider().
+	provider DataProvider
+}
+
+// DataProvider returns the DataProvider that produced this result, or nil
+// when the result was built against the package-global provider. Nil-safe
+// on the receiver so call sites can chain freely off a possibly-nil result.
+func (r *RecipeResult) DataProvider() DataProvider {
+	if r == nil {
+		return nil
+	}
+	return r.provider
 }
 
 // Merge merges another RecipeMetadataSpec into this one.

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -31,17 +31,24 @@ import (
 
 const baseRecipeName = "base"
 
-// Global metadata store cache, keyed by the DataProvider generation that
-// produced it. SetDataProvider increments the generation; the next call to
-// loadMetadataStore observes the change and rebuilds the cache so a
-// late-bound external data source actually takes effect. Mirrors the
-// invalidation pattern in components.go (GetComponentRegistry).
-var (
-	metadataStoreMu     sync.Mutex
-	cachedMetadataStore *MetadataStore
-	cachedMetadataErr   error
-	cachedMetadataGen   = -1
-)
+// storeCacheEntry holds a lazily-built MetadataStore (or load error) keyed by
+// the DataProvider identity. sync.Once guarantees that concurrent callers for
+// the same provider populate the entry exactly once and all observe the same
+// singleton; distinct providers populate distinct entries and never share
+// state. This is the in-process multi-tenant isolation primitive that
+// replaces the former package-global cachedMetadataStore/cachedMetadataGen
+// triple — see LoadMetadataStoreFor.
+type storeCacheEntry struct {
+	once  sync.Once
+	store *MetadataStore
+	err   error
+}
+
+// storeCache holds storeCacheEntry pointers keyed by DataProvider identity.
+// Two Builders bound to different DataProvider values populate distinct
+// entries; a single provider value yields a single shared store regardless
+// of caller goroutine count.
+var storeCache sync.Map // map[DataProvider]*storeCacheEntry
 
 // MetadataStore holds the base recipe and all overlays.
 type MetadataStore struct {
@@ -56,6 +63,13 @@ type MetadataStore struct {
 
 	// ValuesFiles contains embedded values file contents indexed by filename.
 	ValuesFiles map[string][]byte
+
+	// provider is the DataProvider that produced this store. Components and
+	// callers that need provider-bound lookups (component registry, manifest
+	// content) should consult this field rather than GetDataProvider() so
+	// per-provider isolation holds even when the package-global provider has
+	// since been swapped.
+	provider DataProvider
 }
 
 // pendingRegistryEntry stages an overlay's criteria + provider source so the
@@ -66,200 +80,218 @@ type pendingRegistryEntry struct {
 	source   string
 }
 
-// loadMetadataStore loads and caches the metadata store from the data provider.
-// The cache is keyed by DataProvider generation, so SetDataProvider callers see
-// the new content on the next invocation rather than being stuck on the
-// embedded-only snapshot captured by the first Init.
-func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
-	gen := getDataProviderGeneration()
-	metadataStoreMu.Lock()
-	defer metadataStoreMu.Unlock()
-	if cachedMetadataGen == gen && (cachedMetadataStore != nil || cachedMetadataErr != nil) {
-		if cachedMetadataErr != nil {
-			return nil, cachedMetadataErr
-		}
-		return cachedMetadataStore, nil
+// LoadMetadataStoreFor loads (and caches) the metadata store for the supplied
+// DataProvider. Concurrent callers with the same provider observe the same
+// singleton; distinct providers populate distinct cache entries and never
+// share state. This is the multi-tenant entry point used by Builders bound
+// via WithDataProvider.
+//
+// A nil provider falls back to GetDataProvider() so the legacy
+// loadMetadataStore(ctx) entry point — which consults the package-global
+// provider — continues to work transparently.
+//
+// Context cancellation that fires during the first build is surfaced but not
+// cached: the storeCacheEntry remains and any future caller for the same
+// provider will see the build-time error preserved by sync.Once. Callers that
+// need to retry after a transient cancellation must drop the entry via
+// EvictCachedStore first.
+//
+// Note: only the first caller's ctx governs the build. Subsequent callers that
+// arrive while the build is in flight block on the same sync.Once and do not
+// observe their own ctx until the first caller's build returns. Callers that
+// need strict per-request deadline enforcement (e.g., HTTP handlers bound by
+// ServerHandlerTimeout running alongside a slower CLI loader) should invoke
+// LoadMetadataStoreFor in a goroutine and select on their own ctx.Done() and
+// the result channel.
+func LoadMetadataStoreFor(ctx context.Context, dp DataProvider) (*MetadataStore, error) {
+	if dp == nil {
+		dp = GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
 	}
-	// Cache miss — rebuild against the current DataProvider generation.
-	cachedMetadataStore = nil
-	cachedMetadataErr = nil
-	cachedMetadataGen = gen
-	build := func() {
-		// Record cache miss on first load
-		recipeCacheMisses.Inc()
+	e, _ := storeCache.LoadOrStore(dp, &storeCacheEntry{})
+	entry := e.(*storeCacheEntry)
+	entry.once.Do(func() {
+		entry.store, entry.err = buildMetadataStore(ctx, dp)
+	})
+	return entry.store, entry.err
+}
 
-		store := &MetadataStore{
-			Overlays:    make(map[string]*RecipeMetadata),
-			Mixins:      make(map[string]*RecipeMixin),
-			ValuesFiles: make(map[string][]byte),
+// loadMetadataStore is the back-compat entry point that consults the
+// package-global DataProvider. New callers — especially those that need
+// per-tenant isolation — should use LoadMetadataStoreFor directly with a
+// caller-supplied provider.
+func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
+	return LoadMetadataStoreFor(ctx, GetDataProvider()) //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
+}
+
+// buildMetadataStore performs the actual catalog walk against the supplied
+// provider. It is pure with respect to the package-global DataProvider — the
+// only side effect on package state is the call to seedCriteriaRegistry,
+// which intentionally seeds the package-global criteria registry from every
+// overlay's spec.criteria (Task 4 handles per-provider routing for the
+// component registry; criteria registry continues to use the package global
+// for now).
+//
+// The returned MetadataStore has its provider field set so downstream
+// lookups (e.g., applyRegistryDefaults in Task 4) can route through the
+// originating provider even when the package-global provider has since been
+// swapped.
+func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataStore, error) {
+	// Record cache miss on first load for the provider.
+	recipeCacheMisses.Inc()
+
+	store := &MetadataStore{
+		Overlays:    make(map[string]*RecipeMetadata),
+		Mixins:      make(map[string]*RecipeMixin),
+		ValuesFiles: make(map[string][]byte),
+		provider:    provider,
+	}
+
+	// Staged criteria registry entries. Each overlay's criteria are
+	// appended during the walk but only applied to the global registry
+	// after every later validation (walk completion, base presence,
+	// dependency validation) succeeds. Keeps the registry transactional
+	// with respect to catalog-load success.
+	var pendingRegistry []pendingRegistryEntry
+
+	// Load all YAML files from data directory.
+	walkErr := provider.WalkDir("", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to walk data directory", err)
+		}
+		if ctx.Err() != nil {
+			return aicrerrors.Wrap(aicrerrors.ErrCodeTimeout, "context canceled during metadata load", ctx.Err())
+		}
+		if d.IsDir() {
+			return nil
 		}
 
-		// Staged criteria registry entries. Each overlay's criteria are
-		// appended during the walk but only applied to the global registry
-		// after every later validation (walk completion, base presence,
-		// dependency validation) succeeds. Keeps the registry transactional
-		// with respect to catalog-load success.
-		var pendingRegistry []pendingRegistryEntry
+		filename := filepath.Base(path)
 
-		provider := GetDataProvider()
+		// Skip health check assert files (not recipe metadata)
+		if strings.Contains(path, "checks/") {
+			return nil
+		}
 
-		// Load all YAML files from data directory
-		err := provider.WalkDir("", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to walk data directory", err)
-			}
-			if ctx.Err() != nil {
-				return aicrerrors.Wrap(aicrerrors.ErrCodeTimeout, "context canceled during metadata load", ctx.Err())
-			}
-			if d.IsDir() {
-				return nil
-			}
-
-			filename := filepath.Base(path)
-
-			// Skip health check assert files (not recipe metadata)
-			if strings.Contains(path, "checks/") {
-				return nil
-			}
-
-			// Handle mixin files (files in the mixins/ directory)
-			if strings.HasPrefix(path, "mixins/") {
-				if !strings.HasSuffix(filename, ".yaml") {
-					return nil
-				}
-				content, readErr := provider.ReadFile(path)
-				if readErr != nil {
-					return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read mixin %s", path), readErr)
-				}
-				var mixin RecipeMixin
-				decoder := yaml.NewDecoder(bytes.NewReader(content))
-				decoder.KnownFields(true)
-				if parseErr := decoder.Decode(&mixin); parseErr != nil {
-					return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse mixin %s (unknown fields are not allowed)", path), parseErr)
-				}
-				if mixin.Kind != RecipeMixinKind {
-					return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-						fmt.Sprintf("mixin file %s has wrong kind %q, expected %q", path, mixin.Kind, RecipeMixinKind))
-				}
-				if _, exists := store.Mixins[mixin.Metadata.Name]; exists {
-					return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-						fmt.Sprintf("duplicate mixin name %q in %s", mixin.Metadata.Name, path))
-				}
-				store.Mixins[mixin.Metadata.Name] = &mixin
-				slog.Debug("loaded mixin", "name", mixin.Metadata.Name, "path", path)
-				return nil
-			}
-
-			// Handle component files (files in the components/ directory)
-			if strings.Contains(path, "components/") {
-				content, readErr := provider.ReadFile(path)
-				if readErr != nil {
-					return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read component file %s", path), readErr)
-				}
-				// Store with relative path (e.g., "components/cert-manager/values.yaml")
-				store.ValuesFiles[path] = content
-				return nil
-			}
-
-			// Skip non-YAML files
+		// Handle mixin files (files in the mixins/ directory)
+		if strings.HasPrefix(path, "mixins/") {
 			if !strings.HasSuffix(filename, ".yaml") {
 				return nil
 			}
-
-			// Skip old data-v1.yaml format and registry.yaml (handled separately)
-			if filename == "data-v1.yaml" || filename == "registry.yaml" {
-				return nil
-			}
-
-			// Read and parse metadata file
 			content, readErr := provider.ReadFile(path)
 			if readErr != nil {
-				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read %s", path), readErr)
+				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read mixin %s", path), readErr)
 			}
-
-			var metadata RecipeMetadata
-			if parseErr := yaml.Unmarshal(content, &metadata); parseErr != nil {
-				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse %s", path), parseErr)
+			var mixin RecipeMixin
+			decoder := yaml.NewDecoder(bytes.NewReader(content))
+			decoder.KnownFields(true)
+			if parseErr := decoder.Decode(&mixin); parseErr != nil {
+				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse mixin %s (unknown fields are not allowed)", path), parseErr)
 			}
-
-			// Skip files with a different kind (e.g., ValidatorCatalog).
-			if metadata.Kind != "" && metadata.Kind != RecipeMetadataKind {
-				slog.Debug("skipping non-recipe YAML", "path", path, "kind", metadata.Kind)
-				return nil
+			if mixin.Kind != RecipeMixinKind {
+				return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					fmt.Sprintf("mixin file %s has wrong kind %q, expected %q", path, mixin.Kind, RecipeMixinKind))
 			}
-
-			// Categorize as base or overlay
-			// base.yaml is now in overlays/ directory but still identified by filename
-			if filename == "base.yaml" && strings.Contains(path, "overlays/") {
-				store.Base = &metadata
-			} else {
-				store.Overlays[metadata.Metadata.Name] = &metadata
-				// Stage this overlay's criteria for registration; the
-				// actual call to seedCriteriaRegistry is deferred until
-				// after every overlay parses cleanly, the base recipe is
-				// found, and dependency validation passes — see the
-				// commit loop below the walk. This prevents a malformed
-				// file later in the walk from leaving partial criteria
-				// values in the package-global registry.
-				pendingRegistry = append(pendingRegistry, pendingRegistryEntry{
-					criteria: metadata.Spec.Criteria,
-					source:   provider.Source(path),
-				})
+			if _, exists := store.Mixins[mixin.Metadata.Name]; exists {
+				return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					fmt.Sprintf("duplicate mixin name %q in %s", mixin.Metadata.Name, path))
 			}
-
+			store.Mixins[mixin.Metadata.Name] = &mixin
+			slog.Debug("loaded mixin", "name", mixin.Metadata.Name, "path", path)
 			return nil
-		})
-
-		if err != nil {
-			cachedMetadataErr = err
-			return
 		}
 
-		if store.Base == nil {
-			cachedMetadataErr = aicrerrors.New(aicrerrors.ErrCodeInternal, "base.yaml not found")
-			return
+		// Handle component files (files in the components/ directory)
+		if strings.Contains(path, "components/") {
+			content, readErr := provider.ReadFile(path)
+			if readErr != nil {
+				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read component file %s", path), readErr)
+			}
+			// Store with relative path (e.g., "components/cert-manager/values.yaml")
+			store.ValuesFiles[path] = content
+			return nil
 		}
 
-		// Validate base recipe dependencies
-		if err := store.Base.Spec.ValidateDependencies(); err != nil {
-			cachedMetadataErr = aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "base recipe validation failed", err)
-			return
+		// Skip non-YAML files
+		if !strings.HasSuffix(filename, ".yaml") {
+			return nil
 		}
 
-		// Catalog fully validated — commit staged criteria registrations
-		// to the global registry now. Any earlier `return` path above
-		// leaves the registry untouched.
-		for _, entry := range pendingRegistry {
-			seedCriteriaRegistry(entry.criteria, entry.source)
+		// Skip old data-v1.yaml format and registry.yaml (handled separately)
+		if filename == "data-v1.yaml" || filename == "registry.yaml" {
+			return nil
 		}
 
-		cachedMetadataStore = store
+		// Read and parse metadata file
+		content, readErr := provider.ReadFile(path)
+		if readErr != nil {
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read %s", path), readErr)
+		}
+
+		var metadata RecipeMetadata
+		if parseErr := yaml.Unmarshal(content, &metadata); parseErr != nil {
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse %s", path), parseErr)
+		}
+
+		// Skip files with a different kind (e.g., ValidatorCatalog).
+		if metadata.Kind != "" && metadata.Kind != RecipeMetadataKind {
+			slog.Debug("skipping non-recipe YAML", "path", path, "kind", metadata.Kind)
+			return nil
+		}
+
+		// Categorize as base or overlay
+		// base.yaml is now in overlays/ directory but still identified by filename
+		if filename == "base.yaml" && strings.Contains(path, "overlays/") {
+			store.Base = &metadata
+		} else {
+			store.Overlays[metadata.Metadata.Name] = &metadata
+			// Stage this overlay's criteria for registration; the
+			// actual call to seedCriteriaRegistry is deferred until
+			// after every overlay parses cleanly, the base recipe is
+			// found, and dependency validation passes — see the
+			// commit loop below the walk. This prevents a malformed
+			// file later in the walk from leaving partial criteria
+			// values in the package-global registry.
+			pendingRegistry = append(pendingRegistry, pendingRegistryEntry{
+				criteria: metadata.Spec.Criteria,
+				source:   provider.Source(path),
+			})
+		}
+
+		return nil
+	})
+
+	if walkErr != nil {
+		return nil, walkErr
 	}
-	build()
 
-	// Caller-scoped cancellation must not poison the cache: a per-request
-	// timeout that fires during the first rebuild would otherwise mark this
-	// generation as permanently failed until SetDataProvider bumps it.
-	// Reset the generation so the next caller with a fresh context retries,
-	// and surface the cancel/timeout error without caching it.
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		buildErr := cachedMetadataErr
-		cachedMetadataStore = nil
-		cachedMetadataErr = nil
-		cachedMetadataGen = -1
-		if buildErr != nil {
-			return nil, buildErr
-		}
-		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeTimeout, "metadata load canceled", ctxErr)
+	if store.Base == nil {
+		return nil, aicrerrors.New(aicrerrors.ErrCodeInternal, "base.yaml not found")
 	}
 
-	if cachedMetadataErr != nil {
-		return nil, cachedMetadataErr
+	// Validate base recipe dependencies
+	if err := store.Base.Spec.ValidateDependencies(); err != nil {
+		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "base recipe validation failed", err)
 	}
-	if cachedMetadataStore == nil {
-		return nil, aicrerrors.New(aicrerrors.ErrCodeInternal, "metadata store not initialized")
+
+	// Catalog fully validated — commit staged criteria registrations
+	// to the global registry now. Any earlier error return path above
+	// leaves the registry untouched.
+	for _, entry := range pendingRegistry {
+		seedCriteriaRegistry(entry.criteria, entry.source)
 	}
-	return cachedMetadataStore, nil
+
+	return store, nil
+}
+
+// EvictCachedStore drops the cached MetadataStore for the supplied provider.
+// No-op when the provider has no cache entry. Safe on nil — callers do not
+// need to guard. Used by tests that mutate a provider's backing data between
+// loads, and by Task 7's eviction tests.
+func EvictCachedStore(dp DataProvider) {
+	if dp == nil {
+		return
+	}
+	storeCache.Delete(dp)
 }
 
 // LoadCatalog eagerly loads the recipe catalog into the package cache,
@@ -275,14 +307,14 @@ func LoadCatalog(ctx context.Context) error {
 	return err
 }
 
-// ResetMetadataStoreForTesting clears the cached metadata store so that
-// tests can reload with different data. Must only be called from tests.
+// ResetMetadataStoreForTesting clears every cached metadata store so tests
+// can reload against fresh providers without leaking state across cases.
+// Must only be called from tests.
 func ResetMetadataStoreForTesting() {
-	metadataStoreMu.Lock()
-	defer metadataStoreMu.Unlock()
-	cachedMetadataStore = nil
-	cachedMetadataErr = nil
-	cachedMetadataGen = -1
+	storeCache.Range(func(k, _ any) bool {
+		storeCache.Delete(k)
+		return true
+	})
 }
 
 // GetValuesFile returns the content of a values file by filename.
@@ -728,7 +760,11 @@ func (s *MetadataStore) mergeOverlayChains(overlays []*RecipeMetadata, mergedSpe
 }
 
 // finalizeRecipeResult validates, sorts, and builds the final RecipeResult.
-func finalizeRecipeResult(criteria *Criteria, mergedSpec *RecipeMetadataSpec, appliedOverlays []string) (*RecipeResult, error) {
+// The provider is consulted when filling in ComponentRef defaults from the
+// component registry so per-provider isolation holds even when the
+// package-global provider has since been swapped. A nil provider falls back
+// to the package-global DataProvider.
+func finalizeRecipeResult(provider DataProvider, criteria *Criteria, mergedSpec *RecipeMetadataSpec, appliedOverlays []string) (*RecipeResult, error) {
 	if err := mergedSpec.ValidateDependencies(); err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "merged recipe validation failed", err)
 	}
@@ -738,7 +774,7 @@ func finalizeRecipeResult(criteria *Criteria, mergedSpec *RecipeMetadataSpec, ap
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to compute deployment order", err)
 	}
 
-	if err := applyRegistryDefaults(mergedSpec.ComponentRefs); err != nil {
+	if err := applyRegistryDefaults(provider, mergedSpec.ComponentRefs); err != nil {
 		return nil, err
 	}
 
@@ -750,6 +786,7 @@ func finalizeRecipeResult(criteria *Criteria, mergedSpec *RecipeMetadataSpec, ap
 		ComponentRefs:   mergedSpec.ComponentRefs,
 		DeploymentOrder: deployOrder,
 		Validation:      mergedSpec.Validation,
+		provider:        provider,
 	}
 	result.Metadata.AppliedOverlays = appliedOverlays
 
@@ -790,7 +827,7 @@ func (s *MetadataStore) BuildRecipeResult(ctx context.Context, criteria *Criteri
 			"hint", "recipe may not be optimized for your environment")
 	}
 
-	return finalizeRecipeResult(criteria, &mergedSpec, appliedOverlays)
+	return finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays)
 }
 
 // BuildRecipeResultWithEvaluator builds a RecipeResult by merging base with matching overlays,
@@ -900,7 +937,7 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 		}
 	}
 
-	result, err := finalizeRecipeResult(criteria, &mergedSpec, appliedOverlays)
+	result, err := finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays)
 	if err != nil {
 		return nil, err
 	}
@@ -1017,8 +1054,13 @@ func mixinComponentRefSafeForMerge(c ComponentRef) (string, bool) {
 // that don't explicitly set them in recipes. Returns an error if the registry
 // cannot be loaded — silently no-op'ing would emit partial ComponentRefs that
 // downstream bundlers would reject far from the root cause.
-func applyRegistryDefaults(refs []ComponentRef) error {
-	registry, err := GetComponentRegistry()
+//
+// The provider parameter routes the registry lookup through a specific
+// DataProvider so per-provider isolation holds even when the package-global
+// provider has since been swapped. A nil provider falls back to the
+// package-global DataProvider via GetComponentRegistryFor.
+func applyRegistryDefaults(provider DataProvider, refs []ComponentRef) error {
+	registry, err := GetComponentRegistryFor(provider)
 	if err != nil {
 		return aicrerrors.PropagateOrWrap(err, aicrerrors.ErrCodeInternal, "failed to get component registry for defaults")
 	}

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -20,10 +20,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"reflect"
+	"slices"
 	"testing"
 
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
 
@@ -755,14 +758,7 @@ func TestMixinOSTalos_AppliesPrivilegedNamespacesAndPreManifests(t *testing.T) {
 		if c.Namespace != w.namespace {
 			t.Errorf("%s: Namespace = %q, want %q", name, c.Namespace, w.namespace)
 		}
-		foundManifest := false
-		for _, p := range c.PreManifestFiles {
-			if p == w.manifestPath {
-				foundManifest = true
-				break
-			}
-		}
-		if !foundManifest {
+		if !slices.Contains(c.PreManifestFiles, w.manifestPath) {
 			t.Errorf("%s: PreManifestFiles = %v, want to contain %q", name, c.PreManifestFiles, w.manifestPath)
 		}
 	}
@@ -1532,5 +1528,208 @@ func TestBuildMixinConstraintWarningReason(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+// inMemoryDataProvider is a minimal DataProvider backed by an in-memory
+// map[path]content. Used to construct distinct DataProvider identities in
+// isolation tests without touching the filesystem or the embedded FS.
+type inMemoryDataProvider struct {
+	files map[string][]byte
+	tag   string
+}
+
+func newInMemoryProvider(tag string, files map[string][]byte) *inMemoryDataProvider {
+	return &inMemoryDataProvider{files: files, tag: tag}
+}
+
+func (p *inMemoryDataProvider) ReadFile(path string) ([]byte, error) {
+	content, ok := p.files[path]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return content, nil
+}
+
+func (p *inMemoryDataProvider) WalkDir(_ string, fn fs.WalkDirFunc) error {
+	for path := range p.files {
+		if err := fn(path, inMemoryDirEntry{name: path}, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *inMemoryDataProvider) Source(path string) string {
+	return p.tag + ":" + path
+}
+
+// inMemoryDirEntry is a minimal fs.DirEntry for in-memory files.
+// All entries are files (IsDir returns false).
+type inMemoryDirEntry struct{ name string }
+
+func (e inMemoryDirEntry) Name() string               { return e.name }
+func (e inMemoryDirEntry) IsDir() bool                { return false }
+func (e inMemoryDirEntry) Type() fs.FileMode          { return 0 }
+func (e inMemoryDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrNotExist }
+
+// buildProviderWithOverlays returns an inMemoryDataProvider that contains a
+// minimal base recipe plus one overlay whose metadata name is derived from the
+// supplied filename (e.g., "alpha-only.yaml" → overlay metadata name
+// "alpha-only"). This lets isolation tests verify that the metadata store
+// cache keyed by DataProvider populates distinct entries.
+func buildProviderWithOverlays(t *testing.T, overlayFileName string) DataProvider {
+	t.Helper()
+	overlayName := overlayFileName
+	if len(overlayName) > len(".yaml") && overlayName[len(overlayName)-len(".yaml"):] == ".yaml" {
+		overlayName = overlayName[:len(overlayName)-len(".yaml")]
+	}
+
+	baseYAML := []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`)
+
+	overlayYAML := fmt.Appendf(nil, `kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: %s
+spec:
+  criteria:
+    service: eks
+  componentRefs: []
+`, overlayName)
+
+	files := map[string][]byte{
+		"overlays/base.yaml":                baseYAML,
+		"overlays/" + overlayName + ".yaml": overlayYAML,
+	}
+	return newInMemoryProvider(overlayName, files)
+}
+
+// TestLoadMetadataStore_PerProviderIsolation verifies that distinct
+// DataProviders populate distinct cache entries. Two Builders against
+// different providers must never share metadata state.
+func TestLoadMetadataStore_PerProviderIsolation(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+
+	dpA := buildProviderWithOverlays(t, "alpha-only.yaml")
+	dpB := buildProviderWithOverlays(t, "beta-only.yaml")
+
+	ctx := context.Background()
+	storeA, err := LoadMetadataStoreFor(ctx, dpA)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor(A): %v", err)
+	}
+	storeB, err := LoadMetadataStoreFor(ctx, dpB)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor(B): %v", err)
+	}
+
+	if storeA == storeB {
+		t.Fatal("expected distinct stores for distinct providers")
+	}
+	if _, ok := storeA.GetRecipeByName("alpha-only"); !ok {
+		t.Errorf("store A missing alpha-only")
+	}
+	if _, ok := storeB.GetRecipeByName("beta-only"); !ok {
+		t.Errorf("store B missing beta-only")
+	}
+	if _, ok := storeA.GetRecipeByName("beta-only"); ok {
+		t.Errorf("store A leaked beta-only")
+	}
+}
+
+// TestEvictCachedStore_Refetches verifies that EvictCachedStore drops the
+// cached entry so the next LoadMetadataStoreFor call rebuilds a fresh store
+// (distinct pointer) for the same provider.
+func TestEvictCachedStore_Refetches(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+
+	dp := buildProviderWithOverlays(t, "evict-store.yaml")
+	ctx := context.Background()
+	first, err := LoadMetadataStoreFor(ctx, dp)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	EvictCachedStore(dp)
+	second, err := LoadMetadataStoreFor(ctx, dp)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first == second {
+		t.Errorf("expected fresh store after evict")
+	}
+}
+
+// TestEvictCachedStore_NilIsNoOp verifies that EvictCachedStore(nil) is a
+// no-op: it must not panic and must not clobber any existing cache entries
+// for other providers.
+func TestEvictCachedStore_NilIsNoOp(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+
+	dp := buildProviderWithOverlays(t, "noop-evict.yaml")
+	ctx := context.Background()
+	before, err := LoadMetadataStoreFor(ctx, dp)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Evicting nil must not panic, must not clobber the seeded entry.
+	EvictCachedStore(nil)
+
+	after, err := LoadMetadataStoreFor(ctx, dp)
+	if err != nil {
+		t.Fatalf("re-fetch: %v", err)
+	}
+	if before != after {
+		t.Errorf("EvictCachedStore(nil) clobbered an unrelated entry")
+	}
+}
+
+// TestLoadMetadataStoreFor_NilProviderFallsBack verifies that passing a nil
+// DataProvider routes through GetDataProvider() instead of panicking, and
+// returns a non-nil store via the global fallback path.
+func TestLoadMetadataStoreFor_NilProviderFallsBack(t *testing.T) {
+	// No identity assertion on the returned store — the global may have been
+	// populated by other tests. Only verify nil dp does not panic and returns
+	// a non-nil store via the global fallback.
+	store, err := LoadMetadataStoreFor(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor(nil): %v", err)
+	}
+	if store == nil {
+		t.Error("expected non-nil store via global fallback")
+	}
+}
+
+// TestLoadMetadataStore_ConcurrentSameProviderIsCached verifies the
+// sync.Once-per-entry guarantee: concurrent LoadMetadataStoreFor calls for
+// the same provider all receive the same singleton pointer.
+func TestLoadMetadataStore_ConcurrentSameProviderIsCached(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+
+	dp := buildProviderWithOverlays(t, "concurrent.yaml")
+	ctx := context.Background()
+
+	g, gctx := errgroup.WithContext(ctx)
+	results := make([]*MetadataStore, 8)
+	for i := range results {
+		g.Go(func() error {
+			s, err := LoadMetadataStoreFor(gctx, dp)
+			results[i] = s
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("concurrent load: %v", err)
+	}
+	for i := 1; i < len(results); i++ {
+		if results[i] != results[0] {
+			t.Errorf("result[%d] is not the cached singleton (got %p, want %p)", i, results[i], results[0])
+		}
 	}
 }

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -1074,7 +1074,7 @@ func TestFinalizeRecipeResultIncludesValidation(t *testing.T) {
 		},
 	}
 	criteria := NewCriteria()
-	result, err := finalizeRecipeResult(criteria, &spec, []string{"base"})
+	result, err := finalizeRecipeResult(nil, criteria, &spec, []string{"base"})
 	if err != nil {
 		t.Fatalf("finalizeRecipeResult() error: %v", err)
 	}

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -605,12 +605,12 @@ func mergeRegistries(embedded, external *ComponentRegistry) *ComponentRegistry {
 // catalogForMerge is a minimal representation for catalog merge operations.
 // Uses generic map types to avoid importing pkg/validator/catalog (which would
 // create a circular dependency). All validator entry fields are preserved through
-// the map[string]interface{} round-trip.
+// the map[string]any round-trip.
 type catalogForMerge struct {
-	APIVersion string                   `yaml:"apiVersion"`
-	Kind       string                   `yaml:"kind"`
-	Metadata   map[string]interface{}   `yaml:"metadata"`
-	Validators []map[string]interface{} `yaml:"validators"`
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   map[string]any   `yaml:"metadata"`
+	Validators []map[string]any `yaml:"validators"`
 }
 
 // getMergedCatalog returns the merged catalogFileName content.
@@ -644,7 +644,7 @@ func mergeCatalogs(embedded, external *catalogForMerge) *catalogForMerge {
 		Kind:       embedded.Kind,
 		Metadata:   embedded.Metadata,
 		Validators: mergeByName(embedded.Validators, external.Validators,
-			func(v map[string]interface{}) string { s, _ := v["name"].(string); return s }),
+			func(v map[string]any) string { s, _ := v["name"].(string); return s }),
 	}
 }
 
@@ -659,16 +659,27 @@ var (
 // This should be called before any recipe operations if using external data.
 // Note: This invalidates cached data, so callers should ensure this is called
 // early in the application lifecycle.
+//
+// Deprecated: prefer recipe.NewBuilder(recipe.WithDataProvider(dp)) to bind
+// a provider to a specific Builder instance. The package-global provider is
+// retained for back-compat with the CLI and API server but will be removed
+// in a future release. See https://github.com/NVIDIA/aicr/issues/983 for the
+// migration plan.
 func SetDataProvider(provider DataProvider) {
 	dataProviderMu.Lock()
 	defer dataProviderMu.Unlock()
 	globalDataProvider = provider
-	dataProviderGeneration++
+	dataProviderGeneration++ // TODO(#983): remove with deprecation
 	slog.Info("data provider set", "generation", dataProviderGeneration)
 }
 
 // GetDataProvider returns the global data provider.
 // Returns the embedded provider if none was set.
+//
+// Deprecated: callers that need a specific provider should hold their own
+// reference (typically obtained from NewLayeredDataProvider or
+// NewEmbeddedDataProvider) and pass it via WithDataProvider rather than
+// relying on package state. See https://github.com/NVIDIA/aicr/issues/983.
 func GetDataProvider() DataProvider {
 	dataProviderMu.Lock()
 	defer dataProviderMu.Unlock()

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -933,7 +933,7 @@ func TestDataProviderGeneration(t *testing.T) {
 
 	// Setting a provider should increment generation
 	embedded := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
-	SetDataProvider(embedded)
+	SetDataProvider(embedded) //nolint:staticcheck // tests legacy global-provider behavior; tracked by #983 Stage 2
 
 	newGen := getDataProviderGeneration()
 	if newGen != startGen+1 {
@@ -941,7 +941,7 @@ func TestDataProviderGeneration(t *testing.T) {
 	}
 
 	// Setting again should increment again
-	SetDataProvider(embedded)
+	SetDataProvider(embedded) //nolint:staticcheck // tests legacy global-provider behavior; tracked by #983 Stage 2
 	if getDataProviderGeneration() != startGen+2 {
 		t.Errorf("expected generation %d, got %d", startGen+2, getDataProviderGeneration())
 	}

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -60,7 +60,7 @@ type (
 // Entries with explicit version tags (e.g., :v1.2.3) are never modified by
 // steps 1-2 but are replaced by step 3 if that env var is set.
 func Load(version, commit string) (*ValidatorCatalog, error) {
-	data, err := recipe.GetDataProvider().ReadFile("validators/catalog.yaml")
+	data, err := recipe.GetDataProvider().ReadFile("validators/catalog.yaml") //nolint:staticcheck // tracked by #983 Stage 2
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read catalog", err)
 	}
@@ -212,8 +212,8 @@ func replaceTag(image, newTag string) string {
 // image tags pushed by the on-push CI workflow.
 // Images with explicit version tags are not modified.
 func replaceLatestWithSHA(image, commit string) string {
-	if strings.HasSuffix(image, ":latest") {
-		return strings.TrimSuffix(image, ":latest") + ":sha-" + commit
+	if rest, ok := strings.CutSuffix(image, ":latest"); ok {
+		return rest + ":sha-" + commit
 	}
 	return image
 }

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -421,9 +421,9 @@ validators:
 	}
 
 	// Save and restore global provider
-	originalProvider := recipe.GetDataProvider()
-	recipe.SetDataProvider(layered)
-	defer recipe.SetDataProvider(originalProvider)
+	originalProvider := recipe.GetDataProvider()   //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+	recipe.SetDataProvider(layered)                //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
+	defer recipe.SetDataProvider(originalProvider) //nolint:staticcheck // exercises legacy global-provider swap; tracked by #983 Stage 2
 
 	// Load catalog — should merge embedded + external
 	cat, err := Load("", "")

--- a/validators/deployment/expected_resources_test.go
+++ b/validators/deployment/expected_resources_test.go
@@ -66,7 +66,7 @@ const (
 // recipe.GetManifestContent simultaneously. Calling it once here from the
 // test goroutine serializes the init.
 func TestMain(m *testing.M) {
-	_ = recipe.GetDataProvider()
+	_ = recipe.GetDataProvider() //nolint:staticcheck // forces global-provider init before parallel tests; tracked by #983 Stage 2
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Summary

Adds per-Builder DataProvider isolation to `pkg/recipe` so it is safe for multi-tenant in-process consumers, plus provider-bound `GetValuesForComponent` / `GetManifestContent` variants. Marks process-global `SetDataProvider` / `GetDataProvider` as deprecated.

## Motivation / Context

`pkg/recipe` was single-tenant by design (concurrency was not required for CLI but plays role in external GO pkg usage and API server). The metadata store and component registry caches were keyed by a global generation counter incremented on `SetDataProvider`. Two `Builder`s against different providers in the same process could share state silently. This makes `pkg/recipe` usable as a library for operators, controllers, in-process testing harnesses, and BOM tooling.

Fixes: #985, #986, #987
Related: #983 (library-readiness epic), #966 (BOM tooling consumer)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`) — nolint comments on existing `SetDataProvider` call sites only
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`) — parity test + `errors.AsType` modernization
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`) — `pkg/validator/catalog` nolint + `CutSuffix` refactor
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`) — `docs/contributor/data.md`, `pkg/recipe/doc.go`

## Implementation Notes

- Replaced generation-counter caches with `sync.Map[DataProvider]*entry` keyed by provider identity. Per-entry `sync.Once` preserves populate-once semantics under concurrent load.
- `Builder.dp` flows to `MetadataStore.provider` to `RecipeResult.provider`, so `RecipeResult.GetValuesForComponent` reads from the same source that built the result.
- Added `EvictCachedStore` / `EvictCachedRegistry` for long-running consumers that retire providers.
- **SA1019 decision:** `nolint` at the call sites (`//nolint:staticcheck // tracked by #983 Stage 2`). gopls IDE warnings on the deprecated calls are inherent to Go's `Deprecated:` lifecycle and cannot be silenced separately from `golangci-lint` — accepted as the canonical mark-first-migrate-later pattern.
- Internal `pkg/recipe` calls were rewritten to consult the bound provider; only fallback branches (`if dp == nil { dp = GetDataProvider() }`) still reach the package-global.

## Testing

```bash
make qualify
```

New tests (all `-race` clean):

- `TestBundlerValueParity_WithRecipeResult` (pins bundler ↔ adapter equivalence)
- `TestNewBuilder_WithDataProvider` / `TestNewBuilder_DataProviderNilFallback`
- `TestLoadMetadataStore_PerProviderIsolation`
- `TestLoadMetadataStore_ConcurrentSameProviderIsCached`
- `TestEvictCachedStore_Refetches` / `_NilIsNoOp`
- `TestLoadMetadataStoreFor_NilProviderFallsBack`
- `TestGetComponentRegistry_PerProviderIsolation`
- `TestEvictCachedRegistry_Refetches` / `_NilIsNoOp`
- `TestGetComponentRegistryFor_NilProviderFallsBack`
- `TestBuilder_WithDataProvider_UsesBoundProvider`
- `TestBuilder_TwoProviders_ConcurrentBuild` (16 concurrent goroutines)
- `TestBuilder_DataProvider_NilSafe`
- `TestRecipeResult_GetValuesForComponent_HonorsBoundProvider`
- `TestGetManifestContentWithProvider` / `_NilFallback`
- `TestRecipeResult_GetValuesForComponent_BoundProviderSurvivesGlobalSwap`

**Coverage:** `pkg/recipe` 90.5% to 91.5% (+1.0%). All 8 new exported symbols have non-zero coverage. Project-wide test-coverage gate (75% floor): 76.9%. No touched-package regression > 0.5%.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:**

- **Cache memory:** monotonically grows with unique providers if callers never evict. In-tree CLI / API server create exactly one provider per process, so the back-compat path is bounded to one entry — same as before.
- **Behavior change:** none for CLI / API server (they don't use `WithDataProvider`). Bundler emits byte-identical bundles (pinned by `TestBundlerValueParity_WithRecipeResult`).
- **Deprecation:** godoc + lint markers only — no symbol removal, no runtime change. Stage 2 migration of in-tree call sites is tracked under #983.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)