### PR TITLE
feat(bundler): route registry/manifest reads through recipe-bound provider

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -224,7 +224,7 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	enabledRefs := make([]recipe.ComponentRef, 0, len(recipeResult.ComponentRefs))
 	enabledSet := make(map[string]struct{})
 	for _, ref := range recipeResult.ComponentRefs {
-		setEnabled, ok, overrideErr := b.getSetEnabledOverride(ref.Name)
+		setEnabled, ok, overrideErr := b.getSetEnabledOverride(ref.Name, recipeResult.DataProvider())
 		if overrideErr != nil {
 			return nil, overrideErr
 		}
@@ -297,7 +297,7 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	// Copy external data files before deployer construction so the file list
 	// is available for both the deployer (checksum tracking) and post-generation
 	// attestation. This is a no-op when --data is not set.
-	dataFiles, err := b.copyDataFiles(dir)
+	dataFiles, err := b.copyDataFiles(dir, recipeResult.DataProvider())
 	if err != nil {
 		if _, ok := stderrors.AsType[*errors.StructuredError](err); ok {
 			return nil, err
@@ -317,7 +317,7 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 // buildDeployer constructs the appropriate deployer.Deployer based on config.
 // It handles deployer-specific pre-flight validation and data collection.
 func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe.RecipeResult, componentValues map[string]map[string]any, dataFiles []string) (deployer.Deployer, error) {
-	dynamicValues, err := b.buildDynamicValuesMap()
+	dynamicValues, err := b.buildDynamicValuesMap(recipeResult.DataProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -572,6 +572,7 @@ func deployerResultNames(dt config.DeployerType) (types.BundleType, string) {
 // It loads base values from the recipe, applies user overrides, and applies node selectors.
 func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResult *recipe.RecipeResult) (map[string]map[string]any, error) {
 	componentValues := make(map[string]map[string]any)
+	provider := recipeResult.DataProvider()
 
 	for _, ref := range recipeResult.ComponentRefs {
 		if err := ctx.Err(); err != nil {
@@ -590,7 +591,7 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 
 		// Apply user value overrides from --set flags.
 		// Strip "enabled" key — it controls component inclusion, not Helm chart values.
-		if overrides := b.getValueOverridesForComponent(ref.Name); len(overrides) > 0 {
+		if overrides := b.getValueOverridesForComponent(ref.Name, provider); len(overrides) > 0 {
 			if _, has := overrides["enabled"]; has {
 				filtered := make(map[string]string, len(overrides)-1)
 				for k, v := range overrides {
@@ -614,7 +615,7 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 		}
 
 		// Apply node selectors, tolerations, workload selector, and taints based on component type
-		b.applyNodeSchedulingOverrides(ref.Name, values)
+		b.applyNodeSchedulingOverrides(ref.Name, values, provider)
 
 		componentValues[ref.Name] = values
 	}
@@ -624,7 +625,9 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 
 // getValueOverridesForComponent returns value overrides for a specific component.
 // Uses the component registry to match both exact names and alternative override keys.
-func (b *DefaultBundler) getValueOverridesForComponent(componentName string) map[string]string {
+// The provider argument scopes the registry lookup to the recipe's bound DataProvider;
+// a nil provider falls back to the package-global registry via GetComponentRegistryFor.
+func (b *DefaultBundler) getValueOverridesForComponent(componentName string, provider recipe.DataProvider) map[string]string {
 	if b.Config == nil {
 		return nil
 	}
@@ -640,7 +643,7 @@ func (b *DefaultBundler) getValueOverridesForComponent(componentName string) map
 	}
 
 	// Use component registry to find component by any override key
-	registry, err := recipe.GetComponentRegistry()
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
 		// Fall back to non-hyphenated check if registry fails
 		nonHyphenated := removeHyphens(componentName)
@@ -675,8 +678,9 @@ func (b *DefaultBundler) getValueOverridesForComponent(componentName string) map
 // bundle whose enable/disable state doesn't match the operator's intent, which
 // is the canonical misconfigured-artifact scenario the project rule targets.
 // This allows --set awsebscsidriver:enabled=false to disable a component at bundle time.
-func (b *DefaultBundler) getSetEnabledOverride(componentName string) (bool, bool, error) {
-	overrides := b.getValueOverridesForComponent(componentName)
+// The provider argument scopes the registry lookup to the recipe's bound DataProvider.
+func (b *DefaultBundler) getSetEnabledOverride(componentName string, provider recipe.DataProvider) (bool, bool, error) {
+	overrides := b.getValueOverridesForComponent(componentName, provider)
 	if overrides == nil {
 		return false, false, nil
 	}
@@ -695,13 +699,15 @@ func (b *DefaultBundler) getSetEnabledOverride(componentName string) (bool, bool
 
 // applyNodeSchedulingOverrides applies node selectors and tolerations to component values.
 // Uses the component registry to determine the correct paths for each component.
-func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, values map[string]any) {
+// The provider argument scopes the registry lookup to the recipe's bound DataProvider;
+// a nil provider falls back to the package-global registry via GetComponentRegistryFor.
+func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, values map[string]any, provider recipe.DataProvider) {
 	if b.Config == nil {
 		return
 	}
 
 	// Get component configuration from registry
-	registry, err := recipe.GetComponentRegistry()
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
 		slog.Debug("failed to load component registry for node scheduling",
 			"error", err,
@@ -791,7 +797,7 @@ func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, valu
 	// values map must not block injection; only CLI --set inputs take precedence.
 	if sc := b.Config.StorageClass(); sc != "" {
 		if paths := comp.GetStorageClassPaths(); len(paths) > 0 {
-			explicitOverrides := b.getValueOverridesForComponent(componentName)
+			explicitOverrides := b.getValueOverridesForComponent(componentName, provider)
 			overrides := make(map[string]string, len(paths))
 			for _, path := range paths {
 				if _, isExplicit := explicitOverrides[path]; !isExplicit {
@@ -818,7 +824,7 @@ func (b *DefaultBundler) warnMissingStorageClassForPVCs(ctx context.Context, rec
 		return nil
 	}
 
-	registry, err := recipe.GetComponentRegistry()
+	registry, err := recipe.GetComponentRegistryFor(recipeResult.DataProvider())
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal,
 			"failed to load component registry for storage class warnings", err)
@@ -914,7 +920,7 @@ func (b *DefaultBundler) runComponentValidations(ctx context.Context, recipeResu
 	// Get component registry — required to know which validations to run.
 	// A registry-load failure produces an unvalidated bundle, which is the
 	// opposite of what this tool promises; surface the failure to the user.
-	registry, err := recipe.GetComponentRegistry()
+	registry, err := recipe.GetComponentRegistryFor(recipeResult.DataProvider())
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal,
 			"failed to load component registry for validations", err)
@@ -963,11 +969,14 @@ func (b *DefaultBundler) runComponentValidations(ctx context.Context, recipeResu
 
 // copyDataFiles copies external data files from the --data directory into the bundle.
 // Returns a list of relative paths to the copied files (e.g., "data/overrides.yaml").
-func (b *DefaultBundler) copyDataFiles(dir string) ([]string, error) {
-	provider := recipe.GetDataProvider() //nolint:staticcheck // tracked by #983 Stage 2
-
-	// Check if the provider is a LayeredDataProvider with external files
-	layered, ok := provider.(*recipe.LayeredDataProvider)
+// The provider argument supplies the LayeredDataProvider whose external directory is
+// the source of truth; a nil provider falls back to the package-global provider so
+// pre-WithDataProvider callers (legacy CLI path) still emit the same bundles.
+func (b *DefaultBundler) copyDataFiles(dir string, provider recipe.DataProvider) ([]string, error) {
+	// Check if the provider is a LayeredDataProvider with external files.
+	// EffectiveDataProvider falls back to the package-global provider when the
+	// caller did not bind one (pre-WithDataProvider CLI path).
+	layered, ok := recipe.EffectiveDataProvider(provider).(*recipe.LayeredDataProvider)
 	if !ok {
 		return nil, nil // No external data
 	}
@@ -1206,12 +1215,14 @@ func (b *DefaultBundler) writeRecipeFile(recipeResult *recipe.RecipeResult, dir 
 
 // buildDynamicValuesMap re-keys the config's dynamic values from user override keys
 // (e.g., "gpuoperator") to component names (e.g., "gpu-operator") using the registry.
-func (b *DefaultBundler) buildDynamicValuesMap() (map[string][]string, error) {
+// The provider argument scopes the registry lookup to the recipe's bound DataProvider;
+// a nil provider falls back to the package-global registry via GetComponentRegistryFor.
+func (b *DefaultBundler) buildDynamicValuesMap(provider recipe.DataProvider) (map[string][]string, error) {
 	if !b.Config.HasDynamicValues() {
 		return make(map[string][]string), nil
 	}
 
-	registry, err := recipe.GetComponentRegistry()
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load component registry for dynamic resolution", err)
 	}
@@ -1277,6 +1288,7 @@ func (b *DefaultBundler) collectComponentManifestsByPhase(
 ) (map[string]map[string][]byte, error) {
 
 	result := make(map[string]map[string][]byte)
+	provider := recipeResult.DataProvider()
 
 	for _, ref := range recipeResult.ComponentRefs {
 		if err := ctx.Err(); err != nil {
@@ -1300,10 +1312,14 @@ func (b *DefaultBundler) collectComponentManifestsByPhase(
 
 		componentManifests := make(map[string][]byte, len(paths))
 		for _, manifestPath := range paths {
-			content, err := recipe.GetManifestContent(manifestPath)
+			content, err := recipe.GetManifestContentWithProvider(provider, manifestPath)
 			if err != nil {
 				if stderrors.Is(err, fs.ErrNotExist) {
-					_, hasExternalData := recipe.GetDataProvider().(*recipe.LayeredDataProvider) //nolint:staticcheck // tracked by #983 Stage 2
+					// Honor bound provider for the type assertion when
+					// available; EffectiveDataProvider falls back to the
+					// package-global provider when no provider is bound
+					// (CLI today).
+					_, hasExternalData := recipe.EffectiveDataProvider(provider).(*recipe.LayeredDataProvider)
 					return nil, errors.New(errors.ErrCodeInvalidRequest,
 						missingManifestMessage(manifestPath, ref.Name, hasExternalData))
 				}
@@ -1393,7 +1409,7 @@ func (b *DefaultBundler) injectGKECriticalPriorityQuotas(
 		return pre, nil
 	}
 
-	registry, err := recipe.GetComponentRegistry()
+	registry, err := recipe.GetComponentRegistryFor(recipeResult.DataProvider())
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal,
 			"failed to load component registry for GKE quota synthesis", err)

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -15,8 +15,10 @@
 package bundler
 
 import (
+	"bytes"
 	"context"
 	stderrors "errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -934,7 +936,7 @@ func TestGetValueOverridesForComponent(t *testing.T) {
 				t.Fatalf("New() error = %v", err)
 			}
 
-			result := b.getValueOverridesForComponent(tt.componentName)
+			result := b.getValueOverridesForComponent(tt.componentName, nil)
 			if tt.wantOverrides && result == nil {
 				t.Error("expected overrides, got nil")
 			}
@@ -970,7 +972,7 @@ func TestApplyNodeSchedulingOverrides_EstimatedNodeCount(t *testing.T) {
 	}
 
 	values := make(map[string]any)
-	b.applyNodeSchedulingOverrides("nodewright-operator", values)
+	b.applyNodeSchedulingOverrides("nodewright-operator", values, nil)
 
 	// Path "estimatedNodeCount" is in nodewright-operator's nodeCountPaths; convertMapValue produces int64.
 	got, ok := values["estimatedNodeCount"]
@@ -1057,7 +1059,7 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 				}
 			}
 
-			b.applyNodeSchedulingOverrides("kube-prometheus-stack", values)
+			b.applyNodeSchedulingOverrides("kube-prometheus-stack", values, nil)
 
 			got, ok := component.GetValueByPath(values, scPath)
 			if ok != tt.wantPresent {
@@ -1067,6 +1069,221 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 				t.Errorf("storageClassName = %v, want %q", got, tt.wantValue)
 			}
 		})
+	}
+}
+
+// TestApplyNodeSchedulingOverrides_BoundProvider verifies that
+// applyNodeSchedulingOverrides honors the bound provider parameter when
+// resolving the component registry. The bound provider exposes a component
+// whose name is absent from the embedded registry, so a positive assertion
+// on the injected nodeSelector path proves the helper used the supplied
+// provider rather than the package-global fallback.
+func TestApplyNodeSchedulingOverrides_BoundProvider(t *testing.T) {
+	const uniqueComponent = "task2-bound-provider-only"
+	const nodeSelectorPath = "scheduling.nodeSelector"
+
+	tmpDir := t.TempDir()
+	registryYAML := "apiVersion: aicr.nvidia.com/v1alpha1\n" +
+		"kind: ComponentRegistry\n" +
+		"components:\n" +
+		"  - name: " + uniqueComponent + "\n" +
+		"    displayName: Task 2 Bound Provider Only\n" +
+		"    nodeScheduling:\n" +
+		"      system:\n" +
+		"        nodeSelectorPaths:\n" +
+		"          - " + nodeSelectorPath + "\n"
+	if writeErr := os.WriteFile(filepath.Join(tmpDir, "registry.yaml"), []byte(registryYAML), 0600); writeErr != nil {
+		t.Fatalf("write registry.yaml: %v", writeErr)
+	}
+
+	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
+	layered, layeredErr := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
+		ExternalDir: tmpDir,
+	})
+	if layeredErr != nil {
+		t.Fatalf("NewLayeredDataProvider: %v", layeredErr)
+	}
+	// Drop any cached registry for this provider identity so the test
+	// registry YAML is the source of truth on first read.
+	recipe.EvictCachedRegistry(layered)
+	t.Cleanup(func() { recipe.EvictCachedRegistry(layered) })
+
+	// Sanity check: the embedded (global) registry must NOT know about the
+	// unique component, otherwise the assertion below cannot distinguish
+	// "honored the provider" from "fell back to the global".
+	globalRegistry, err := recipe.GetComponentRegistry()
+	if err != nil {
+		t.Fatalf("GetComponentRegistry: %v", err)
+	}
+	if globalRegistry.Get(uniqueComponent) != nil {
+		t.Fatalf("global registry unexpectedly contains %q; fixture cannot prove provider isolation", uniqueComponent)
+	}
+
+	cfg := config.NewConfig(
+		config.WithSystemNodeSelector(map[string]string{"role": "system"}),
+	)
+	b, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	// With a nil provider the lookup must miss (component unknown to global registry).
+	nilValues := map[string]any{}
+	b.applyNodeSchedulingOverrides(uniqueComponent, nilValues, nil)
+	if got, ok := component.GetValueByPath(nilValues, nodeSelectorPath); ok {
+		t.Fatalf("nil-provider call unexpectedly populated %s = %v; component must be unknown to global registry", nodeSelectorPath, got)
+	}
+
+	// With the bound provider the lookup hits and the nodeSelector lands at the
+	// path the external registry declares.
+	values := map[string]any{}
+	b.applyNodeSchedulingOverrides(uniqueComponent, values, layered)
+
+	got, ok := component.GetValueByPath(values, nodeSelectorPath)
+	if !ok {
+		t.Fatalf("nodeSelector not injected at %s; bound provider was not consulted", nodeSelectorPath)
+	}
+	gotMap, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("nodeSelector at %s = %T %v; want map[string]any", nodeSelectorPath, got, got)
+	}
+	if gotMap["role"] != "system" {
+		t.Errorf("nodeSelector.role = %v, want %q", gotMap["role"], "system")
+	}
+}
+
+// TestBundler_Make_BoundProviderEndToEnd is the canonical end-to-end check for
+// the bundler-provider migration: build a recipe via WithDataProvider(layered)
+// against a real embedded overlay, run bundler.Make, and confirm the emitted
+// values.yaml carries a marker that lives ONLY in the layered (external)
+// provider. If the bundler silently fell back to the package-global embedded
+// data, the marker would be absent and this test would fail.
+//
+// Why this test exists:
+//   - PR #1015 made RecipeResult.GetValuesForComponent honor the bound
+//     provider; this test exercises that path through the bundler entry point
+//     (Make -> extractComponentValues -> GetValuesForComponent).
+//   - Tasks 1-5 of this PR threaded the bound provider through the bundler's
+//     internal helpers (applyNodeSchedulingOverrides, copyDataFiles, etc.).
+//     Those helpers are unit-tested at TestApplyNodeSchedulingOverrides_BoundProvider;
+//     this test is the integration backstop that proves the whole pipeline
+//     stays consistent when a layered provider replaces the global.
+func TestBundler_Make_BoundProviderEndToEnd(t *testing.T) {
+	const markerVersion = "777.77.77-aicr-task6-marker"
+
+	// LayeredDataProvider over a tempdir that overrides exactly two files:
+	//   1. registry.yaml (required by NewLayeredDataProvider; merged into
+	//      embedded so all upstream components remain known).
+	//   2. components/gpu-operator/values.yaml (the base values that
+	//      h100-eks-ubuntu-training inherits via the eks-training overlay,
+	//      which pins valuesFile = components/gpu-operator/values-eks-training.yaml
+	//      and triggers the "base + overlay" merge in
+	//      RecipeResult.GetValuesForComponent — driver.version is only set
+	//      in the base, so our marker passes through into the emitted bundle).
+	tmpData := t.TempDir()
+
+	registryYAML := []byte("apiVersion: aicr.nvidia.com/v1alpha1\n" +
+		"kind: ComponentRegistry\n" +
+		"components: []\n")
+	if err := os.WriteFile(filepath.Join(tmpData, "registry.yaml"), registryYAML, 0o600); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+
+	componentsDir := filepath.Join(tmpData, "components", "gpu-operator")
+	if err := os.MkdirAll(componentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	valuesContent := fmt.Appendf(nil, "driver:\n  version: %q\n", markerVersion)
+	if err := os.WriteFile(filepath.Join(componentsDir, "values.yaml"), valuesContent, 0o600); err != nil {
+		t.Fatalf("write values.yaml: %v", err)
+	}
+
+	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
+	layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
+		ExternalDir: tmpData,
+	})
+	if err != nil {
+		t.Fatalf("NewLayeredDataProvider: %v", err)
+	}
+	// Drop any cached registry for this provider identity so the merged
+	// external registry is the source of truth on first read.
+	recipe.EvictCachedRegistry(layered)
+	t.Cleanup(func() { recipe.EvictCachedRegistry(layered) })
+
+	// Build a recipe through the bound provider. Criteria selects
+	// h100-eks-ubuntu-training, which inherits gpu-operator from eks-training.
+	b := recipe.NewBuilder(recipe.WithDataProvider(layered))
+	criteria := &recipe.Criteria{
+		Service:     recipe.CriteriaServiceEKS,
+		Accelerator: recipe.CriteriaAcceleratorH100,
+		Intent:      recipe.CriteriaIntentTraining,
+		OS:          recipe.CriteriaOSUbuntu,
+	}
+	result, err := b.BuildFromCriteria(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("BuildFromCriteria: %v", err)
+	}
+
+	// Sanity check: the RecipeResult must carry the bound provider — otherwise
+	// the bundler will silently fall back to the package-global and the
+	// assertion below cannot distinguish "honored the provider" from "global
+	// happened to match".
+	if result.DataProvider() != layered {
+		t.Fatalf("result.DataProvider() did not return the layered provider; bound-provider plumbing is broken")
+	}
+
+	// Confirm gpu-operator is in the resolved component list — if criteria
+	// resolution silently dropped it, the marker assertion would vacuously
+	// pass with zero values.yaml files matched.
+	if result.GetComponentRef("gpu-operator") == nil {
+		t.Fatalf("gpu-operator not present in recipe component refs; criteria/overlay drift")
+	}
+
+	bundler, err := New()
+	if err != nil {
+		t.Fatalf("bundler.New: %v", err)
+	}
+
+	outDir := t.TempDir()
+	if _, makeErr := bundler.Make(context.Background(), result, outDir); makeErr != nil {
+		t.Fatalf("bundler.Make: %v", makeErr)
+	}
+
+	// Walk the output and locate the gpu-operator values.yaml. The bundler
+	// emits a numbered per-component directory whose suffix is the component
+	// name (e.g. "001-gpu-operator/values.yaml"), but the exact ordinal
+	// depends on the deployment graph for the resolved overlay — walking by
+	// suffix avoids hardcoding a brittle path.
+	var gpuValuesPath string
+	walkErr := filepath.Walk(outDir, func(p string, info os.FileInfo, innerErr error) error {
+		if innerErr != nil {
+			return innerErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if info.Name() != "values.yaml" {
+			return nil
+		}
+		if strings.HasSuffix(filepath.Dir(p), "-gpu-operator") {
+			gpuValuesPath = p
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk outDir: %v", walkErr)
+	}
+	if gpuValuesPath == "" {
+		t.Fatalf("gpu-operator values.yaml not found under %s; bundler did not emit expected per-component artifact", outDir)
+	}
+
+	data, err := os.ReadFile(gpuValuesPath)
+	if err != nil {
+		t.Fatalf("read emitted gpu-operator values.yaml: %v", err)
+	}
+	if !bytes.Contains(data, []byte(markerVersion)) {
+		t.Errorf("emitted %s missing marker %q — bundler did not honor bound provider\ncontent:\n%s",
+			gpuValuesPath, markerVersion, data)
 	}
 }
 

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -330,7 +330,7 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		// so users see what value to override. When the path doesn't exist, an
 		// empty string stub is created.
 		if dynPaths, ok := g.DynamicValues[ref.Name]; ok {
-			overrideKey, keyErr := resolveOverrideKey(ref.Name)
+			overrideKey, keyErr := resolveOverrideKey(ref.Name, g.RecipeResult.DataProvider())
 			if keyErr != nil {
 				return nil, 0, nil, keyErr
 			}
@@ -502,7 +502,7 @@ func (g *Generator) processFolders(ctx context.Context, tmpDir, outputDir, templ
 		output.Files = append(output.Files, copiedFiles...)
 		output.TotalSize += copySize
 
-		overrideKey, keyErr := resolveOverrideKey(parentComponent)
+		overrideKey, keyErr := resolveOverrideKey(parentComponent, g.RecipeResult.DataProvider())
 		if keyErr != nil {
 			return keyErr
 		}
@@ -963,7 +963,7 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	buf.WriteString("first for those cases.\n\n")
 	buf.WriteString("```bash\n# Local install (pure-Helm-only recipes)\nhelm install aicr-bundle . -n argocd \\\n  --set repoURL=oci://<your-registry>/<path>/aicr-bundle \\\n  --set targetRevision=<chart-version>")
 
-	dynamicSetFlags, flagsErr := buildDynamicSetFlags(g.DynamicValues)
+	dynamicSetFlags, flagsErr := buildDynamicSetFlags(g.DynamicValues, g.RecipeResult.DataProvider())
 	if flagsErr != nil {
 		return "", 0, flagsErr
 	}
@@ -980,7 +980,7 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 		}
 		sort.Strings(compNames)
 		for _, name := range compNames {
-			overrideKey, keyErr := resolveOverrideKey(name)
+			overrideKey, keyErr := resolveOverrideKey(name, g.RecipeResult.DataProvider())
 			if keyErr != nil {
 				return "", 0, keyErr
 			}
@@ -997,7 +997,7 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	return readmePath, int64(len(content)), nil
 }
 
-func buildDynamicSetFlags(dynamicValues map[string][]string) ([]string, error) {
+func buildDynamicSetFlags(dynamicValues map[string][]string, provider recipe.DataProvider) ([]string, error) {
 	if len(dynamicValues) == 0 {
 		return nil, nil
 	}
@@ -1008,7 +1008,7 @@ func buildDynamicSetFlags(dynamicValues map[string][]string) ([]string, error) {
 	}
 	sort.Strings(compNames)
 	for _, name := range compNames {
-		overrideKey, keyErr := resolveOverrideKey(name)
+		overrideKey, keyErr := resolveOverrideKey(name, provider)
 		if keyErr != nil {
 			return nil, keyErr
 		}
@@ -1022,8 +1022,12 @@ func buildDynamicSetFlags(dynamicValues map[string][]string) ([]string, error) {
 // resolveOverrideKey returns the valueOverrideKey for a component (e.g., "gpuOperator"
 // for "gpu-operator"). Returns an error if the registry is unavailable or the component
 // has no override keys — using the wrong key would produce a broken chart.
-func resolveOverrideKey(componentName string) (string, error) {
-	registry, err := recipe.GetComponentRegistry()
+//
+// provider is the recipe-bound DataProvider whose registry is consulted;
+// nil falls back to the deprecated process-global registry for callers
+// that pre-date per-recipe binding.
+func resolveOverrideKey(componentName string, provider recipe.DataProvider) (string, error) {
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
 		return "", errors.Wrap(errors.ErrCodeInternal,
 			"failed to load component registry for override key resolution", err)

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -84,7 +84,7 @@ func TestGenerate(t *testing.T) {
 				}
 
 				// Root values.yaml should ONLY have dynamic stubs
-				key, keyErr := resolveOverrideKey("gpu-operator")
+				key, keyErr := resolveOverrideKey("gpu-operator", nil)
 				if keyErr != nil {
 					t.Fatalf("resolveOverrideKey failed: %v", keyErr)
 				}

--- a/pkg/bundler/deployer/helmfile/helmfile.go
+++ b/pkg/bundler/deployer/helmfile/helmfile.go
@@ -256,7 +256,7 @@ func (g *Generator) writeHelmfileLayout(
 	namespaceByComponent map[string]string,
 ) (bool, error) {
 
-	flags, err := componentFlagsByName(sortedRefs)
+	flags, err := componentFlagsByName(sortedRefs, g.RecipeResult.DataProvider())
 	if err != nil {
 		return false, errors.Wrap(errors.ErrCodeInternal,
 			"failed to load registry for component flags", err)
@@ -433,8 +433,12 @@ type componentFlags struct {
 // release-rendering step does a single registry round-trip.
 // Components not in the registry are absent from the map (treated as
 // all-false).
-func componentFlagsByName(refs []recipe.ComponentRef) (map[string]componentFlags, error) {
-	registry, err := recipe.GetComponentRegistry()
+//
+// provider is the recipe-bound DataProvider whose registry is consulted;
+// nil falls back to the deprecated process-global registry for callers
+// that pre-date per-recipe binding.
+func componentFlagsByName(refs []recipe.ComponentRef, provider recipe.DataProvider) (map[string]componentFlags, error) {
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/doc.go
+++ b/pkg/component/doc.go
@@ -65,8 +65,8 @@
 //	    }
 //	}
 //
-//	func (b *Bundler) Make(ctx context.Context, input recipe.RecipeInput, dir string) (*result.Result, error) {
-//	    return component.MakeBundle(ctx, b.BaseBundler, input, dir, componentConfig)
+//	func (b *Bundler) Make(ctx context.Context, input recipe.RecipeInput, dir string, provider recipe.DataProvider) (*result.Result, error) {
+//	    return component.MakeBundle(ctx, b.BaseBundler, input, dir, componentConfig, provider)
 //	}
 //
 // # Custom Metadata

--- a/pkg/component/generic.go
+++ b/pkg/component/generic.go
@@ -149,8 +149,13 @@ func GenerateBundleMetadataWithExtensions(config map[string]string, cfg Componen
 
 // enrichConfigFromRegistry enriches a ComponentConfig with values from the component registry.
 // This allows bundlers to omit fields that are already defined in the registry.
-func enrichConfigFromRegistry(cfg *ComponentConfig) {
-	registry, err := recipe.GetComponentRegistry()
+//
+// When provider is non-nil, the registry is loaded from the supplied DataProvider
+// for per-tenant isolation. When provider is nil, falls back to the package-global
+// registry for back-compat with callers that have not yet been migrated to the
+// provider-bound pattern.
+func enrichConfigFromRegistry(cfg *ComponentConfig, provider recipe.DataProvider) {
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
 		slog.Debug("component registry not available, using bundler config as-is",
 			"component", cfg.Name,
@@ -201,7 +206,11 @@ func enrichConfigFromRegistry(cfg *ComponentConfig) {
 // writing values.yaml, generating README, generating checksums, and finalizing.
 // Configuration is enriched from the component registry when values are not
 // explicitly set in the ComponentConfig.
-func MakeBundle(ctx context.Context, b *BaseBundler, input recipe.RecipeInput, outputDir string, cfg ComponentConfig) (*result.Result, error) {
+//
+// The provider parameter routes registry lookups through the supplied
+// DataProvider for per-tenant isolation. Pass nil to fall back to the
+// package-global registry.
+func MakeBundle(ctx context.Context, b *BaseBundler, input recipe.RecipeInput, outputDir string, cfg ComponentConfig, provider recipe.DataProvider) (*result.Result, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeTimeout, "context cancelled", err)
 	}
@@ -209,7 +218,7 @@ func MakeBundle(ctx context.Context, b *BaseBundler, input recipe.RecipeInput, o
 	start := time.Now()
 
 	// Enrich config from registry (fills in missing values)
-	enrichConfigFromRegistry(&cfg)
+	enrichConfigFromRegistry(&cfg, provider)
 
 	slog.Debug("generating bundle",
 		"component", cfg.Name,

--- a/pkg/component/generic_test.go
+++ b/pkg/component/generic_test.go
@@ -34,7 +34,7 @@ func TestEnrichConfigFromRegistry(t *testing.T) {
 			Name: "gpu-operator",
 		}
 
-		enrichConfigFromRegistry(&cfg)
+		enrichConfigFromRegistry(&cfg, nil)
 
 		// Verify values were populated from registry
 		comp := registry.Get("gpu-operator")
@@ -70,7 +70,7 @@ func TestEnrichConfigFromRegistry(t *testing.T) {
 			SystemNodeSelectorPaths: []string{"custom.path"},
 		}
 
-		enrichConfigFromRegistry(&cfg)
+		enrichConfigFromRegistry(&cfg, nil)
 
 		// Verify existing values were preserved
 		if cfg.DisplayName != "Custom Display Name" {
@@ -96,7 +96,7 @@ func TestEnrichConfigFromRegistry(t *testing.T) {
 			DisplayName: "",
 		}
 
-		enrichConfigFromRegistry(&cfg)
+		enrichConfigFromRegistry(&cfg, nil)
 
 		// Verify nothing changed
 		if cfg.DisplayName != "" {
@@ -109,7 +109,7 @@ func TestEnrichConfigFromRegistry(t *testing.T) {
 			Name: "gpu-operator",
 		}
 
-		enrichConfigFromRegistry(&cfg)
+		enrichConfigFromRegistry(&cfg, nil)
 
 		// gpu-operator should have scheduling paths
 		if len(cfg.SystemNodeSelectorPaths) == 0 {

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -695,3 +695,23 @@ func getDataProviderGeneration() int {
 	defer dataProviderMu.RUnlock()
 	return dataProviderGeneration
 }
+
+// EffectiveDataProvider returns dp when non-nil, otherwise the package-global
+// DataProvider (via GetDataProvider). This centralizes the bound-first /
+// global-fallback pattern used by callers that need raw provider access
+// (e.g., WalkDir, ReadFile, or type assertions) and cannot route through
+// the *For wrapper variants.
+//
+// Most callers should NOT use this — prefer GetComponentRegistryFor,
+// GetManifestContentWithProvider, or LoadMetadataStoreFor, which already
+// handle the nil-fallback internally.
+//
+// Deprecated note: this helper exists to consolidate the SetDataProvider /
+// GetDataProvider fallback path. When the deprecation completes (#983
+// Stage 3), this helper goes away alongside the global accessor.
+func EffectiveDataProvider(dp DataProvider) DataProvider {
+	if dp == nil {
+		return GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
+	}
+	return dp
+}

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -1311,3 +1311,26 @@ validators:
 		t.Errorf("operator-health image = %q, want %q", firstImage, "example.com/custom/deployment:v2.0.0")
 	}
 }
+
+func TestEffectiveDataProvider(t *testing.T) {
+	// Save / restore global state used by the nil-fallback branch.
+	originalProvider := globalDataProvider
+	originalGen := dataProviderGeneration
+	t.Cleanup(func() {
+		globalDataProvider = originalProvider
+		dataProviderGeneration = originalGen
+	})
+
+	// With non-nil provider: returns dp unchanged.
+	dp := NewEmbeddedDataProvider(GetEmbeddedFS(), "")
+	if got := EffectiveDataProvider(dp); got != dp {
+		t.Errorf("EffectiveDataProvider(dp) = %p, want %p", got, dp)
+	}
+
+	// With nil: falls back to the package-global provider.
+	fallback := NewEmbeddedDataProvider(GetEmbeddedFS(), "")
+	SetDataProvider(fallback) //nolint:staticcheck // test exercises legacy global-provider fallback; tracked by #983 Stage 2
+	if got := EffectiveDataProvider(nil); got != fallback {
+		t.Errorf("EffectiveDataProvider(nil) = %p, want global %p", got, fallback)
+	}
+}


### PR DESCRIPTION
## Summary

Migrates the remaining 10 calls in `pkg/bundler`, `pkg/bundler/deployer/{helmfile,argocdhelm}`, and `pkg/component` to read registry and manifest content through `recipeResult.DataProvider()` instead of the process-global `recipe.GetDataProvider()` / `GetComponentRegistry()` / `GetManifestContent()`.

## Motivation / Context

PR #1015 made `pkg/recipe` fully provider-aware (per-Builder caches, `RecipeResult.DataProvider()` accessor, provider-bound `*For` helpers) but explicitly deferred the bundler-side migration as a follow-up. That left ~10 call sites in `pkg/bundler`, `pkg/bundler/deployer/{helmfile,argocdhelm}`, and `pkg/component` that silently fell back to the global — even when consuming a recipe built with `WithDataProvider(dpA)`. This PR closes that path.

Fixes: N/A
Related: #1015

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

- `pkg/bundler/bundler.go`: 4 methods that already receive `*recipe.RecipeResult` (`warnMissingStorageClassForPVCs`, `runComponentValidations`, `collectComponentManifestsByPhase`, `injectGKECriticalPriorityQuotas`) now use `recipeResult.DataProvider()`.
- 5 internal helpers gained a trailing `provider recipe.DataProvider` parameter (`getValueOverridesForComponent`, `getSetEnabledOverride`, `applyNodeSchedulingOverrides`, `copyDataFiles`, `buildDynamicValuesMap`), derived once from `recipeResult.DataProvider()` at the nearest caller with the result in scope.
- Deployer subpackages: `helmfile.componentFlagsByName`, `argocdhelm.resolveOverrideKey`, `argocdhelm.buildDynamicSetFlags` gain the same trailing parameter. `Deployer.Generate` interface kept unchanged — Generator structs already carry `RecipeResult`, so methods derive provider via `g.RecipeResult.DataProvider()`.
- `pkg/component/generic.go`: `enrichConfigFromRegistry` plumbed identically. Only caller (the deprecated/unused `MakeBundle`) updated.
- `pkg/recipe`: new `EffectiveDataProvider(dp)` helper consolidates the bound-first / global-fallback pattern that the bundler's `copyDataFiles` and `collectComponentManifestsByPhase` needed for raw `WalkDir` / type-assertion calls.

### CLI back-compat preserved

CLI today does not call `WithDataProvider` — `recipeResult.DataProvider()` returns nil — and every migrated call site falls back to the global via `*For` variants (and `EffectiveDataProvider` for the two raw cases). Bundle output is byte-identical for that path. Verified by the new end-to-end test which only triggers the bound-provider path when `WithDataProvider` is used.

### Out of scope (further Stage 2 PRs)

- `pkg/cli/root.go` `SetDataProvider` migration (touches CLI bootstrap)
- `pkg/validator/catalog/catalog.go` `GetDataProvider` read
- `pkg/mirror/discover.go` (2 sites)
- `validators/deployment/expected_resources.go` (1 site)

## Testing

```bash
make qualify
```

New tests:
- `TestApplyNodeSchedulingOverrides_BoundProvider` — unit-level coverage of the bound-provider branch in a representative helper
- `TestBundler_Make_BoundProviderEndToEnd` — integration test: build a recipe via `WithDataProvider(layeredOverTempdir)` with a marker driver version, call `bundler.Make`, walk emitted bundle, assert marker present in `gpu-operator/values.yaml`
- `TestEffectiveDataProvider` — both branches of the new helper

Existing tests pass unchanged.

Coverage:
- `pkg/bundler`: 77.3% -> 77.7% (+0.4%)
- `pkg/component`: 71.0% -> 70.9% (within 0.5% noise floor)
- `pkg/recipe`: 91.5% flat
- Project-wide: 77.0% > 75% floor

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Public API unchanged. All migrated helpers are unexported except `component.MakeBundle` (which is itself `// Deprecated:` with no callers anywhere in the repo). CLI behavior is unchanged; bundle output is byte-identical for the CLI path. gopls IDE deprecation warnings on intentional legacy-global callers are suppressed with `//nolint:staticcheck` — same accepted trade-off as #1015. Project lint stays clean.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (no user-facing changes)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)