### PR TITLE
fix(bundler): derive argocd-helm chart name from OCI artifact path

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -361,6 +361,7 @@ func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe
 			ComponentPreManifests:  componentPreManifests,
 			ComponentPostManifests: componentPostManifests,
 			VendorCharts:           b.Config.VendorCharts(),
+			ChartName:              b.Config.BundleChartName(),
 		}, nil
 
 	case config.DeployerArgoCD:

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -169,6 +169,15 @@ type Config struct {
 	// fluxNamespace is the Kubernetes namespace where Flux CRs (HelmRelease,
 	// sources, ArtifactGenerator) are deployed. Defaults to DefaultFluxNamespace.
 	fluxNamespace string
+
+	// bundleChartName overrides the Helm chart name written into Chart.yaml
+	// and used as `source.chart` in the parent Argo Application emitted by
+	// the argocd-helm deployer. Empty means "use the deployer's default"
+	// (currently "aicr-bundle"). For OCI output the CLI sets this to the
+	// last path segment of the published artifact (e.g. "my-bundle" for
+	// "oci://reg/org/my-bundle:v1") so the parent App's `repoURL/chart:
+	// targetRevision` triple resolves against the real artifact. See #1019.
+	bundleChartName string
 }
 
 // Getter methods for read-only access
@@ -340,6 +349,12 @@ func (c *Config) VendorCharts() bool {
 // ArtifactGenerator mode. Empty means the feature is disabled.
 func (c *Config) OCISourceName() string {
 	return c.ociSourceName
+}
+
+// BundleChartName returns the Helm chart name override for the argocd-helm
+// deployer. Empty means "use the deployer's default". See #1019.
+func (c *Config) BundleChartName() string {
+	return c.bundleChartName
 }
 
 // Validate checks if the Config has valid settings.
@@ -572,6 +587,18 @@ func (c *Config) FluxNamespace() string {
 func WithFluxNamespace(ns string) Option {
 	return func(c *Config) {
 		c.fluxNamespace = ns
+	}
+}
+
+// WithBundleChartName sets the Helm chart name written into the argocd-helm
+// bundle's Chart.yaml (and used as `source.chart` in the generated parent
+// Argo Application). Empty leaves the deployer's default in place. The CLI
+// derives this from the OCI `--output` reference's last path segment so
+// the parent App's `repoURL/chart:targetRevision` triple resolves against
+// the actual published artifact. See #1019.
+func WithBundleChartName(name string) Option {
+	return func(c *Config) {
+		c.bundleChartName = name
 	}
 }
 

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -666,6 +666,47 @@ func TestHasDynamicValues_Empty(t *testing.T) {
 	}
 }
 
+// TestWithBundleChartName verifies the override flows to BundleChartName,
+// that the default is empty (so the argocd-helm deployer falls back to
+// its own "aicr-bundle" default), and that the most-recent option wins
+// when both an explicit empty and a non-empty value are supplied.
+func TestWithBundleChartName(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want string
+	}{
+		{
+			name: "default is empty (deployer applies its own default)",
+			opts: nil,
+			want: "",
+		},
+		{
+			name: "explicit override",
+			opts: []Option{WithBundleChartName("my-custom-bundle")},
+			want: "my-custom-bundle",
+		},
+		{
+			name: "empty override is a no-op observable through getter",
+			opts: []Option{WithBundleChartName("")},
+			want: "",
+		},
+		{
+			name: "later option wins",
+			opts: []Option{WithBundleChartName("first"), WithBundleChartName("second")},
+			want: "second",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig(tt.opts...)
+			if got := cfg.BundleChartName(); got != tt.want {
+				t.Errorf("BundleChartName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseDynamicValues(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -96,6 +96,13 @@ import (
 // template placeholders that would otherwise be misparsed).
 const yamlStringTag = "!!str"
 
+// DefaultChartName is the Helm chart name used when ChartName is not set
+// (typically when --output is a local directory). When --output is an OCI
+// reference, the chart name is derived from the last path segment of the
+// repository (e.g. "oci://ghcr.io/org/my-bundle:v1" → "my-bundle") so the
+// parent Application's `source.chart` matches the actual OCI artifact name.
+const DefaultChartName = "aicr-bundle"
+
 // compile-time interface check
 var _ deployer.Deployer = (*Generator)(nil)
 
@@ -108,6 +115,16 @@ type Generator struct {
 	RepoURL          string
 	TargetRevision   string
 	IncludeChecksums bool
+
+	// ChartName is the Helm chart name written into Chart.yaml and used as
+	// the parent Application's `source.chart`. When empty, defaults to
+	// DefaultChartName ("aicr-bundle"). When the bundle is published to an
+	// OCI registry at a non-default artifact name, callers MUST set this
+	// to the registry's last path segment (e.g. "my-bundle" for
+	// "oci://ghcr.io/org/my-bundle:v1") — otherwise the parent App's
+	// `repoURL/chart:tag` assembly resolves to an artifact that does not
+	// exist in the registry. See issue #1019.
+	ChartName string
 
 	// DynamicValues maps component names to their dynamic value paths.
 	DynamicValues map[string][]string
@@ -194,7 +211,9 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	output := &deployer.Output{Files: make([]string, 0)}
 
 	// Write Chart.yaml
-	chartPath, chartSize, err := writeChartYAML(outputDir, deployer.NormalizeVersionWithDefault(g.RecipeResult.Metadata.Version))
+	chartName := g.chartName()
+	chartPath, chartSize, err := writeChartYAML(outputDir, chartName,
+		deployer.NormalizeVersionWithDefault(g.RecipeResult.Metadata.Version))
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write Chart.yaml", err)
 	}
@@ -283,7 +302,7 @@ func (g *Generator) finalizeOutput(ctx context.Context, output *deployer.Output,
 	output.Duration = time.Since(start)
 	output.DeploymentSteps = []string{
 		fmt.Sprintf("cd %s", outputDir),
-		"helm install aicr-bundle .",
+		fmt.Sprintf("helm install %s .", g.chartName()),
 	}
 	return nil
 }
@@ -371,6 +390,12 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 // Argo subsequently renders the chart from OCI it sees the same per-
 // cluster overrides the user passed at helm install — keeping the
 // dynamic-values story working end-to-end.
+// The parent App's `source.chart` is set to `.Chart.Name` so it tracks the
+// chart name Helm renders the bundle under (which equals what `helm push`
+// publishes the artifact as). That keeps the parent App's `repoURL/chart:
+// targetRevision` triple resolvable against the actual OCI artifact even
+// when the user picks a non-default name via `--output oci://reg/path/<name>`.
+// Hardcoding `aicr-bundle` here was the bug in #1019.
 const parentAppTemplate = `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -379,8 +404,8 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: {{ required "repoURL is required: pass --set repoURL=<published bundle URL> (e.g., oci://<registry>/<path>/aicr-bundle)" .Values.repoURL | quote }}
-    chart: aicr-bundle
+    repoURL: {{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL | quote }}
+    chart: {{ .Chart.Name | quote }}
     targetRevision: {{ .Values.targetRevision | default .Chart.Version | quote }}
     helm:
       valuesObject:
@@ -675,7 +700,7 @@ func injectValuesIntoSingleSource(app map[string]any, overrideKey string) error 
 		Kind:  yaml.ScalarNode,
 		Tag:   yamlStringTag,
 		Style: yaml.SingleQuotedStyle,
-		Value: `{{ required "repoURL is required: pass --set repoURL=<published bundle URL> (e.g., oci://<registry>/<path>/aicr-bundle)" .Values.repoURL }}`,
+		Value: `{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}`,
 	}
 	source["targetRevision"] = &yaml.Node{
 		Kind:  yaml.ScalarNode,
@@ -908,7 +933,7 @@ func convertToSingleSourceWithValues(app map[string]any, componentName, override
 	return nil
 }
 
-func writeChartYAML(outputDir, version string) (string, int64, error) {
+func writeChartYAML(outputDir, name, version string) (string, int64, error) {
 	chartPath, err := deployer.SafeJoin(outputDir, "Chart.yaml")
 	if err != nil {
 		return "", 0, err
@@ -916,7 +941,7 @@ func writeChartYAML(outputDir, version string) (string, int64, error) {
 
 	var buf strings.Builder
 	buf.WriteString("apiVersion: v2\n")
-	buf.WriteString("name: aicr-bundle\n")
+	fmt.Fprintf(&buf, "name: %s\n", name)
 	buf.WriteString("description: AICR deployment bundle with dynamic install-time values\n")
 	buf.WriteString("type: application\n")
 	fmt.Fprintf(&buf, "version: %s\n", version)
@@ -928,11 +953,23 @@ func writeChartYAML(outputDir, version string) (string, int64, error) {
 	return chartPath, int64(len(content)), nil
 }
 
+// chartName returns the Helm chart name for this Generator, applying the
+// "aicr-bundle" default when ChartName is unset. Centralized so the value
+// flows consistently into Chart.yaml, the README, and the finalize step.
+func (g *Generator) chartName() string {
+	if g.ChartName == "" {
+		return DefaultChartName
+	}
+	return g.ChartName
+}
+
 func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	readmePath, err := deployer.SafeJoin(outputDir, "README.md")
 	if err != nil {
 		return "", 0, err
 	}
+
+	chartName := g.chartName()
 
 	var buf strings.Builder
 	buf.WriteString("# Argo CD Helm Chart Deployment Bundle\n\n")
@@ -943,16 +980,24 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	buf.WriteString("repoURL=...`, not baked into the chart bytes.\n\n")
 
 	buf.WriteString("## Deploy\n\n")
+	buf.WriteString("`<your-registry>/<path>` below is the **parent namespace** you\n")
+	buf.WriteString("publish into. The chart name (`")
+	buf.WriteString(chartName)
+	buf.WriteString("`) is appended by Helm at\n")
+	buf.WriteString("push time and by the parent Application at sync time — do NOT\n")
+	buf.WriteString("include the chart name in `--set repoURL` or it will be appended\n")
+	buf.WriteString("twice and the parent Application will fail to resolve.\n\n")
 	buf.WriteString("```bash\n")
 	buf.WriteString("# 1. Publish to your chart registry (any HTTPS OCI / Helm chart repo).\n")
 	buf.WriteString("helm package . --destination /tmp/\n")
-	buf.WriteString("helm push /tmp/aicr-bundle-*.tgz oci://<your-registry>/<path>\n\n")
-	buf.WriteString("# 2. Install from the published chart — supply repoURL and\n")
+	fmt.Fprintf(&buf, "helm push /tmp/%s-*.tgz oci://<your-registry>/<path>\n\n", chartName)
+	buf.WriteString("# 2. Install from the published chart — supply repoURL (the\n")
+	buf.WriteString("#    parent namespace, NOT including the chart name) and\n")
 	buf.WriteString("#    targetRevision so the parent Application and path-based child\n")
 	buf.WriteString("#    Applications can pull from the registry you pushed to.\n")
-	buf.WriteString("helm install aicr-bundle oci://<your-registry>/<path>/aicr-bundle \\\n")
+	fmt.Fprintf(&buf, "helm install %s oci://<your-registry>/<path>/%s \\\n", chartName, chartName)
 	buf.WriteString("  --version <chart-version> -n argocd \\\n")
-	buf.WriteString("  --set repoURL=oci://<your-registry>/<path>/aicr-bundle \\\n")
+	buf.WriteString("  --set repoURL=oci://<your-registry>/<path> \\\n")
 	buf.WriteString("  --set targetRevision=<chart-version>\n")
 	buf.WriteString("```\n\n")
 
@@ -961,7 +1006,7 @@ func (g *Generator) writeReadme(outputDir string) (string, int64, error) {
 	buf.WriteString("source is path-based (manifest-only, mixed `-post`) need Argo's\n")
 	buf.WriteString("repo-server to fetch from a remote, so the chart must be published\n")
 	buf.WriteString("first for those cases.\n\n")
-	buf.WriteString("```bash\n# Local install (pure-Helm-only recipes)\nhelm install aicr-bundle . -n argocd \\\n  --set repoURL=oci://<your-registry>/<path>/aicr-bundle \\\n  --set targetRevision=<chart-version>")
+	fmt.Fprintf(&buf, "```bash\n# Local install (pure-Helm-only recipes)\nhelm install %s . -n argocd \\\n  --set repoURL=oci://<your-registry>/<path> \\\n  --set targetRevision=<chart-version>", chartName)
 
 	dynamicSetFlags, flagsErr := buildDynamicSetFlags(g.DynamicValues, g.RecipeResult.DataProvider())
 	if flagsErr != nil {

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -1093,8 +1093,8 @@ func TestHelmTemplate_RendersWithSetRepoURL(t *testing.T) {
 	if parent.Spec.Source.RepoURL != wantRepoURL {
 		t.Errorf("parent App repoURL: got %q, want %q", parent.Spec.Source.RepoURL, wantRepoURL)
 	}
-	if parent.Spec.Source.Chart != "aicr-bundle" {
-		t.Errorf("parent App chart: got %q, want \"aicr-bundle\"", parent.Spec.Source.Chart)
+	if parent.Spec.Source.Chart != DefaultChartName {
+		t.Errorf("parent App chart: got %q, want %q", parent.Spec.Source.Chart, DefaultChartName)
 	}
 	if parent.Spec.Source.TargetRevision != wantTagName {
 		t.Errorf("parent App targetRevision: got %q, want %q", parent.Spec.Source.TargetRevision, wantTagName)
@@ -1123,6 +1123,87 @@ func TestHelmTemplate_RendersWithSetRepoURL(t *testing.T) {
 	}
 	if upstream.Spec.Source.RepoURL != "https://charts.jetstack.io" {
 		t.Errorf("upstream-helm child repoURL should be the upstream chart registry, got %q", upstream.Spec.Source.RepoURL)
+	}
+}
+
+// TestGenerate_CustomChartName verifies the Generator's ChartName field
+// flows into both Chart.yaml's `name:` and the parent Application's
+// `source.chart` at install time. Regression coverage for issue #1019:
+// when a user passes `--output oci://reg/path/my-bundle:tag`, the OCI
+// repository's last segment (`my-bundle`) must propagate so the parent
+// App's `repoURL/chart:targetRevision` triple resolves against the
+// actual published artifact instead of the literal `aicr-bundle`.
+func TestGenerate_CustomChartName(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not available; skipping live-render test")
+	}
+
+	const customName = "my-custom-bundle"
+	outputDir := t.TempDir()
+	rr := newRecipeResult("v1.0.0", []recipe.ComponentRef{
+		{
+			Name: "cert-manager", Namespace: "cert-manager", Chart: "cert-manager",
+			Version: "v1.20.2", Type: recipe.ComponentTypeHelm,
+			Source: "https://charts.jetstack.io",
+		},
+	})
+	rr.DeploymentOrder = []string{"cert-manager"}
+
+	g := &Generator{
+		RecipeResult:    rr,
+		ComponentValues: map[string]map[string]any{"cert-manager": {}},
+		Version:         "v0.0.0-test",
+		ChartName:       customName,
+	}
+	if _, err := g.Generate(context.Background(), outputDir); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	chartBytes, err := os.ReadFile(filepath.Join(outputDir, "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read Chart.yaml: %v", err)
+	}
+	if !strings.Contains(string(chartBytes), "name: "+customName+"\n") {
+		t.Errorf("Chart.yaml missing custom name %q; got:\n%s", customName, chartBytes)
+	}
+
+	cmdCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, "helm", "template", "test-release", outputDir, //nolint:gosec // controlled args
+		"--set", "repoURL=oci://example.test/myorg",
+		"--set", "targetRevision=v1.0.0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\noutput:\n%s", err, out)
+	}
+
+	dec := yaml.NewDecoder(strings.NewReader(string(out)))
+	type appLite struct {
+		Metadata struct{ Name string } `yaml:"metadata"`
+		Spec     struct {
+			Source struct {
+				Chart string `yaml:"chart"`
+			} `yaml:"source"`
+		} `yaml:"spec"`
+	}
+	var foundParentChart string
+	for {
+		var a appLite
+		decErr := dec.Decode(&a)
+		if errors.Is(decErr, io.EOF) {
+			break
+		}
+		if decErr != nil {
+			t.Fatalf("failed to decode rendered YAML: %v\noutput:\n%s", decErr, out)
+		}
+		if a.Metadata.Name == "aicr-stack" {
+			foundParentChart = a.Spec.Source.Chart
+		}
+	}
+	if foundParentChart != customName {
+		t.Errorf("parent App chart: got %q, want %q (rendered chart must match Chart.yaml name)",
+			foundParentChart, customName)
 	}
 }
 

--- a/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/templates/aicr-stack.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/templates/aicr-stack.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: {{ required "repoURL is required: pass --set repoURL=<published bundle URL> (e.g., oci://<registry>/<path>/aicr-bundle)" .Values.repoURL | quote }}
-    chart: aicr-bundle
+    repoURL: {{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL | quote }}
+    chart: {{ .Chart.Name | quote }}
     targetRevision: {{ .Values.targetRevision | default .Chart.Version | quote }}
     helm:
       valuesObject:

--- a/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/templates/nodewright-customizations.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/templates/nodewright-customizations.yaml
@@ -16,7 +16,7 @@ spec:
                 {{- $dynamic := index .Values "nodewrightcustomizations" | default dict -}}
                 {{- toYaml $dynamic | nindent 16 }}
         path: 002-nodewright-customizations
-        repoURL: '{{ required "repoURL is required: pass --set repoURL=<published bundle URL> (e.g., oci://<registry>/<path>/aicr-bundle)" .Values.repoURL }}'
+        repoURL: '{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}'
         targetRevision: '{{ .Values.targetRevision | default .Chart.Version }}'
     syncPolicy:
         automated:

--- a/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/templates/aicr-stack.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/templates/aicr-stack.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: {{ required "repoURL is required: pass --set repoURL=<published bundle URL> (e.g., oci://<registry>/<path>/aicr-bundle)" .Values.repoURL | quote }}
-    chart: aicr-bundle
+    repoURL: {{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL | quote }}
+    chart: {{ .Chart.Name | quote }}
     targetRevision: {{ .Values.targetRevision | default .Chart.Version | quote }}
     helm:
       valuesObject:

--- a/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/templates/gpu-operator-post.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/templates/gpu-operator-post.yaml
@@ -16,7 +16,7 @@ spec:
                 {{- $dynamic := index .Values "gpuoperator" | default dict -}}
                 {{- toYaml $dynamic | nindent 16 }}
         path: 002-gpu-operator-post
-        repoURL: '{{ required "repoURL is required: pass --set repoURL=<published bundle URL> (e.g., oci://<registry>/<path>/aicr-bundle)" .Values.repoURL }}'
+        repoURL: '{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}'
         targetRevision: '{{ .Values.targetRevision | default .Chart.Version }}'
     syncPolicy:
         automated:

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -91,6 +91,11 @@ type bundleCmdOptions struct {
 	plainHTTP     bool
 	insecureTLS   bool
 	imageRefsPath string // Path to write published image references (like ko --image-refs)
+
+	// bundleChartName overrides the chart name written by the argocd-helm
+	// deployer. Derived from ociRef.ChartName() when --output is OCI; the
+	// deployer's "aicr-bundle" default is used when this is empty. See #1019.
+	bundleChartName string
 }
 
 // parseBundleCmdOptions parses and validates command options. The wire
@@ -165,6 +170,13 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		}
 		// For OCI output, use current directory for bundle generation
 		opts.outputDir = "./bundle"
+		// Derive the Helm chart name from the OCI artifact path so the
+		// argocd-helm bundle's Chart.yaml and parent Application
+		// `source.chart` match what `helm push` actually publishes. Without
+		// this the parent App's `repoURL/chart:targetRevision` triple
+		// resolves against an artifact that doesn't exist in the registry
+		// when the user picks a non-default name. See #1019.
+		opts.bundleChartName = opts.ociRef.ChartName()
 	} else {
 		// Resolve local output path to absolute to ensure consistent behavior
 		// regardless of how the binary is invoked.
@@ -625,6 +637,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		config.WithVendorCharts(opts.vendorCharts),
 		config.WithOCISourceName(opts.ociSourceName),
 		config.WithFluxNamespace(opts.fluxNamespace),
+		config.WithBundleChartName(opts.bundleChartName),
 	)
 
 	// Note: binary attestation pre-flight check is handled by bundler.New().

--- a/pkg/cli/bundle_test.go
+++ b/pkg/cli/bundle_test.go
@@ -191,3 +191,49 @@ func TestParseBundleCmdOptions_OCIRepoURLDerivation(t *testing.T) {
 		})
 	}
 }
+
+// TestParseBundleCmdOptions_OCIChartNameDerivation verifies the bundle
+// chart name is derived from the OCI artifact's last path segment when
+// --output is OCI, and stays empty (deployer default applies) for local
+// directory output. Regression coverage for issue #1019.
+func TestParseBundleCmdOptions_OCIChartNameDerivation(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		args          []string
+		wantChartName string
+	}{
+		{
+			name:          "OCI output derives chart name from last path segment",
+			args:          []string{"--recipe", recipePath, "--output", "oci://reg.example.com/myorg/my-bundle:v1", "--deployer", "argocd-helm"},
+			wantChartName: "my-bundle",
+		},
+		{
+			name:          "OCI output with deeply nested repo takes only the tail",
+			args:          []string{"--recipe", recipePath, "--output", "oci://reg.example.com/org/sub/team/custom-bundle:v1", "--deployer", "argocd-helm"},
+			wantChartName: "custom-bundle",
+		},
+		{
+			name:          "local directory output leaves chart name empty",
+			args:          []string{"--recipe", recipePath, "--output", filepath.Join(tmp, "out"), "--deployer", "argocd-helm"},
+			wantChartName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := captureBundleOpts(t, tt.args)
+			if opts == nil {
+				t.Fatal("captureBundleOpts returned nil")
+			}
+			if opts.bundleChartName != tt.wantChartName {
+				t.Errorf("bundleChartName = %q, want %q", opts.bundleChartName, tt.wantChartName)
+			}
+		})
+	}
+}

--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -131,6 +132,36 @@ func (r *Reference) String() string {
 		return fmt.Sprintf("%s%s/%s", uriScheme, r.Registry, r.Repository)
 	}
 	return fmt.Sprintf("%s%s/%s:%s", uriScheme, r.Registry, r.Repository, r.Tag)
+}
+
+// ChartName returns the last path segment of Repository, which is the
+// chart name a Helm consumer (or ArgoCD's `source.chart`) sees when pulling
+// the artifact at `registry/repository:tag`. For non-OCI references and
+// references whose Repository is empty, the empty string is returned;
+// callers should treat that as "no derived chart name available" and
+// apply their own default.
+//
+// Example: oci://ghcr.io/myorg/my-bundle-name:v1
+//   - Registry = "ghcr.io"
+//   - Repository = "myorg/my-bundle-name"
+//   - ChartName() = "my-bundle-name"
+//
+// This is consumed by the argocd-helm bundler so the generated Chart.yaml
+// and parent Application's `source.chart` match what `helm push` actually
+// publishes — see issue #1019.
+func (r *Reference) ChartName() string {
+	if !r.IsOCI || r.Repository == "" {
+		return ""
+	}
+	// path.Base treats Repository as a slash-separated path; the docker
+	// reference parser already normalized separators so a literal Base is
+	// safe. Reject path.Base's sentinel returns ("." and "/") so callers
+	// see an empty string rather than a nonsense chart name.
+	base := path.Base(r.Repository)
+	if base == "." || base == "/" {
+		return ""
+	}
+	return base
 }
 
 // WithTag returns a copy of the reference with the specified tag.

--- a/pkg/oci/reference_test.go
+++ b/pkg/oci/reference_test.go
@@ -242,6 +242,69 @@ func TestReference_WithTag(t *testing.T) {
 	}
 }
 
+func TestReference_ChartName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  *Reference
+		want string
+	}{
+		{
+			name: "local path returns empty",
+			ref:  &Reference{IsOCI: false, LocalPath: "./bundle"},
+			want: "",
+		},
+		{
+			name: "OCI with two-segment repository",
+			ref: &Reference{
+				IsOCI:      true,
+				Registry:   "ghcr.io",
+				Repository: "myorg/my-bundle",
+				Tag:        "v1.0.0",
+			},
+			want: "my-bundle",
+		},
+		{
+			name: "OCI with deeply nested repository",
+			ref: &Reference{
+				IsOCI:      true,
+				Registry:   "ghcr.io",
+				Repository: "myorg/subteam/sub/my-bundle",
+			},
+			want: "my-bundle",
+		},
+		{
+			name: "OCI with single-segment repository",
+			ref: &Reference{
+				IsOCI:      true,
+				Registry:   "localhost:5000",
+				Repository: "my-bundle",
+				Tag:        "latest",
+			},
+			want: "my-bundle",
+		},
+		{
+			name: "OCI with empty repository returns empty",
+			ref: &Reference{
+				IsOCI:      true,
+				Registry:   "ghcr.io",
+				Repository: "",
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.ref.ChartName(); got != tt.want {
+				t.Errorf("Reference.ChartName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEnsureScheme(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Argo CD–Helm bundles published to a non-default OCI artifact name now generate a parent Application whose `source.chart` matches the actual artifact, instead of the hardcoded `aicr-bundle` literal.

## Motivation / Context

When a user runs `aicr bundle --deployer argocd-helm --output oci://<reg>/<org>/<custom-name>:<tag>`, the bundler pushes to `<reg>/<org>/<custom-name>:<tag>` but the generated parent `aicr-stack` Application hardcoded `chart: aicr-bundle`. ArgoCD then tries to resolve `repoURL/chart:tag` against an artifact that does not exist, surfacing as `failed to load target state … not found`. The README also instructed users to pass `--set repoURL=...` with the chart segment included, which would double-suffix the OCI reference.

Fixes: #1019

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

- `oci.Reference.ChartName()` returns the last path segment of `Repository` (e.g., `oci://ghcr.io/org/my-bundle:v1` → `my-bundle`).
- CLI flows that into `bundleCmdOptions.bundleChartName`, then `config.WithBundleChartName(...)`, then `argocdhelm.Generator.ChartName`.
- `Chart.yaml` now writes `name: <chartName>`. The parent Application template uses `{{ .Chart.Name | quote }}` for `source.chart` so the chart name is sourced from the rendered chart at install time — no double source of truth.
- Local-directory output (no `--output oci://`) keeps the existing `aicr-bundle` default, preserving the current behavior for that path.
- `required` directive and README updated to clarify that `--set repoURL` must be the parent namespace (no chart suffix); the parent App appends `.Chart.Name` when assembling the OCI reference.

## Testing

```bash
make qualify   # tests + lint + e2e + scan + license headers — all passed
```

Coverage deltas on touched packages:
- `pkg/bundler/deployer/argocdhelm`: 81.0% → 81.6% (+0.6%)
- `pkg/oci`: 70.1% → 70.3% (+0.2%)
- `pkg/bundler/config`: 97.6% → 97.5% (-0.1%)
- `pkg/cli`: 64.8% → 64.9% (+0.1%)

New tests:
- `Reference_ChartName` — last-segment derivation across single/multi-segment OCI repositories
- `WithBundleChartName` — config option round-trip
- `ParseBundleCmdOptions_OCIChartNameDerivation` — CLI flow for OCI and local-dir output
- `Generate_CustomChartName` — live `helm template` verifies the rendered parent Application's `source.chart` matches the custom name

## Risk Assessment

- [x] **Low** — Isolated change, fully unit-tested, easy to revert. Default behavior for local-directory output is unchanged.

**Rollout notes:** No migration required. Users currently working around the bug by manually patching `aicr-stack` after generation can drop that step.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (README emitted into the bundle was corrected)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)