### PR TITLE
feat(bundler): derive DRA chart-version annotation from resolved recipe (#973)

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -284,6 +284,13 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 			"failed to extract component values", err)
 	}
 
+	// Bundler-derived annotations that must reflect the final resolved
+	// recipe state, applied AFTER extractComponentValues so that user
+	// --set overrides cannot defeat them. Every deployer (Helm,
+	// helmfile, Flux, Argo CD, argocd-helm) sees the same final map.
+	// See issue #973.
+	b.injectDRAChartVersionAnnotation(componentValues, recipeResult)
+
 	if warningErr := b.warnMissingStorageClassForPVCs(ctx, recipeResult, componentValues); warningErr != nil {
 		return nil, warningErr
 	}
@@ -1502,4 +1509,136 @@ func renderGKECriticalPriorityQuota(namespace string, pods int) ([]byte, error) 
 		},
 	}
 	return serializer.MarshalYAMLDeterministic(quota)
+}
+
+// draChartVersionAnnotation is the key written onto the
+// nvidia-dra-driver-gpu controller and kubelet-plugin pod templates.
+// Its value mirrors the resolved gpu-operator componentRef version
+// so that any gpu-operator chart bump produces a rendered pod-template
+// diff that forces helm upgrade (and every other deployer) to re-roll
+// the DaemonSet — clearing the kubelet plugin's stale NVML handle that
+// would otherwise pin to the pre-migration driver state.
+const draChartVersionAnnotation = "aicr.nvidia.com/gpu-operator-chart-version"
+
+// draComponentName / gpuOperatorComponentName are the registry-level
+// component names this injection couples together. Both must be
+// enabled in the filtered resolved recipe before the annotation is
+// written; recipes that disable either remain untouched.
+const (
+	draComponentName         = "nvidia-dra-driver-gpu"
+	gpuOperatorComponentName = "gpu-operator"
+)
+
+// injectDRAChartVersionAnnotation writes the resolved gpu-operator
+// chart version into the nvidia-dra-driver-gpu controller and
+// kubelet-plugin podAnnotations on the bundler's componentValues map.
+// Replaces the prior hand-maintained value in
+// recipes/components/nvidia-dra-driver-gpu/values.yaml — see #973.
+//
+// Why this exists:
+//
+// PR #965 mitigated the stale-NVML class of bug (gpu-operator chart
+// bump → k8s-driver-manager reloads kernel modules async → DRA kubelet
+// plugin's NVML handle goes stale → CDI spec generation fails) by
+// hard-coding the gpu-operator chart version into the DRA pod-template
+// annotation. The annotation works as long as it stays in lockstep
+// with the chart pin, but the coupling depends on a maintainer
+// remembering to bump both in the same PR. A future PR that bumps
+// gpu-operator and forgets the annotation produces identical rendered
+// DaemonSet manifests, so helm upgrade skips the re-roll and stale
+// NVML returns silently. Bundler-derived injection removes the manual
+// step entirely.
+//
+// Trigger gating: BOTH gpu-operator and nvidia-dra-driver-gpu must be
+// enabled in the filtered recipe. The caller has already removed
+// disabled components from recipeResult.ComponentRefs at this point,
+// so iterating the filtered slice gives the right gating for free.
+// Recipes that disable either component leave componentValues
+// untouched.
+//
+// Injection point: called from DefaultBundler.Make AFTER
+// extractComponentValues (so the values map is populated and user
+// --set overrides have already been applied) and BEFORE buildDeployer
+// (so every deployer — Helm, helmfile, Flux, Argo CD, argocd-helm —
+// receives the same final map). Placing the call after --set means a
+// user override of this specific annotation key is intentionally NOT
+// honored; the annotation must always reflect the actual resolved
+// gpu-operator chart version, or the rollout-trigger semantics break.
+//
+// Mutates componentValues in place; nested controller / kubeletPlugin
+// / podAnnotations maps are created lazily so existing values under
+// either path (priorityClassName, other annotations, etc.) are
+// preserved.
+func (b *DefaultBundler) injectDRAChartVersionAnnotation(
+	componentValues map[string]map[string]any,
+	recipeResult *recipe.RecipeResult,
+) {
+
+	if componentValues == nil || recipeResult == nil {
+		return
+	}
+
+	var gpuOperatorEnabled, draEnabled bool
+	var gpuOperatorVersion string
+	for _, ref := range recipeResult.ComponentRefs {
+		switch ref.Name {
+		case gpuOperatorComponentName:
+			gpuOperatorEnabled = true
+			gpuOperatorVersion = ref.Version
+		case draComponentName:
+			draEnabled = true
+		}
+	}
+	if !draEnabled || !gpuOperatorEnabled {
+		// Either component disabled: nothing to mirror. Silent skip
+		// matches the "no chart pin, no rollout trigger" semantic and
+		// is exercised by the disabled-component unit tests.
+		return
+	}
+	if gpuOperatorVersion == "" {
+		// gpu-operator is enabled but the resolver produced an empty
+		// Version string. This shouldn't happen in normal recipe
+		// resolution; if it does the rollout-trigger semantics break
+		// silently — the same drift class this helper exists to
+		// eliminate. Warn so operators have a debugging signal, then
+		// skip injection rather than write an empty annotation value
+		// that itself would lock the DaemonSet to a meaningless pin.
+		slog.Warn("gpu-operator enabled with empty Version, skipping DRA chart-version annotation injection",
+			"component", gpuOperatorComponentName,
+			"draComponent", draComponentName)
+		return
+	}
+
+	draValues := componentValues[draComponentName]
+	if draValues == nil {
+		draValues = make(map[string]any)
+		componentValues[draComponentName] = draValues
+	}
+
+	// Both pod templates carry the same annotation. The controller is
+	// a Deployment (one replica per chart) and the kubeletPlugin is the
+	// DaemonSet whose NVML handle is at risk; rolling both keeps the
+	// two halves of the chart consistent across upgrades.
+	//
+	// The `, _` on the type assertions below is deliberate: values come
+	// from `extractComponentValues`, which produces `map[string]any` via
+	// yaml.v3 decoding, so a wrong-type value at `controller` /
+	// `kubeletPlugin` / `podAnnotations` cannot happen in practice. If
+	// it ever did (e.g., a hand-crafted unit test or a malformed
+	// override that's also broken for the DRA chart itself), the helper
+	// silently replaces the wrong-type value with a fresh map and lands
+	// the annotation on top.
+	for _, podPath := range []string{"controller", "kubeletPlugin"} {
+		section, _ := draValues[podPath].(map[string]any)
+		if section == nil {
+			section = make(map[string]any)
+			draValues[podPath] = section
+		}
+		annotations, _ := section["podAnnotations"].(map[string]any)
+		if annotations == nil {
+			annotations = make(map[string]any)
+			section["podAnnotations"] = annotations
+		}
+		annotations[draChartVersionAnnotation] = gpuOperatorVersion
+	}
 }

--- a/pkg/bundler/bundler_dra_annotation_parity_test.go
+++ b/pkg/bundler/bundler_dra_annotation_parity_test.go
@@ -1,0 +1,331 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// TestMake_DRAChartVersionAnnotation_GeneratedArtifactParity is the
+// generated-artifact acceptance test the issue calls out. It bundles
+// the same recipe through two deployer code paths — the default Helm
+// deployer AND the helmfile (GitOps-style) deployer — and asserts the
+// bundler-derived aicr.nvidia.com/gpu-operator-chart-version
+// annotation lands in the rendered nvidia-dra-driver-gpu values.yaml
+// at the structurally correct `controller.podAnnotations` and
+// `kubeletPlugin.podAnnotations` paths for BOTH outputs.
+//
+// This catches the cross-deployer parity risk for the deployers whose
+// values land in a known `<order>-<name>/values.yaml` layout. Coverage
+// for Flux / Argo CD / argocd-helm (which emit different file shapes,
+// e.g. configmap-values.yaml or Application sources) lives in
+// TestMake_DRAChartVersionAnnotation_AllDeployersCarryAnnotation
+// below — that test asserts the annotation reaches *some* file in the
+// rendered bundle for every supported deployer, without coupling to
+// per-deployer layout conventions.
+func TestMake_DRAChartVersionAnnotation_GeneratedArtifactParity(t *testing.T) {
+	const (
+		gpuOpVersion       = "v26.4.0"
+		expectedAnnotation = "aicr.nvidia.com/gpu-operator-chart-version"
+	)
+
+	deployers := []struct {
+		name     string
+		deployer config.DeployerType
+		// where to look for the rendered DRA values inside the bundle dir
+		valuesPath string
+	}{
+		{
+			name:       "helm-deployer",
+			deployer:   config.DeployerHelm,
+			valuesPath: "002-nvidia-dra-driver-gpu/values.yaml",
+		},
+		{
+			name:       "helmfile-deployer",
+			deployer:   config.DeployerHelmfile,
+			valuesPath: "002-nvidia-dra-driver-gpu/values.yaml",
+		},
+	}
+
+	for _, tc := range deployers {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewConfig(
+				config.WithDeployer(tc.deployer),
+				config.WithVersion("v1.0.0"),
+			)
+			b, err := New(WithConfig(cfg))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			rr := &recipe.RecipeResult{
+				APIVersion: "aicr.nvidia.com/v1alpha1",
+				Kind:       "Recipe",
+				Criteria: &recipe.Criteria{
+					Service:     "eks",
+					Accelerator: "h100",
+					Intent:      "training",
+				},
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:    gpuOperatorComponentName,
+						Version: gpuOpVersion,
+						Type:    "helm",
+						Source:  "https://helm.ngc.nvidia.com/nvidia",
+					},
+					{
+						Name:    draComponentName,
+						Version: "25.12.0",
+						Type:    "helm",
+						Source:  "https://helm.ngc.nvidia.com/nvidia",
+					},
+				},
+				DeploymentOrder: []string{gpuOperatorComponentName, draComponentName},
+			}
+
+			tmpDir := t.TempDir()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if _, err := b.Make(ctx, rr, tmpDir); err != nil {
+				t.Fatalf("Make() error = %v", err)
+			}
+
+			valuesBytes := readBundleValues(t, tmpDir, tc.valuesPath)
+
+			var values map[string]any
+			if err := yaml.Unmarshal(valuesBytes, &values); err != nil {
+				t.Fatalf("rendered values not valid YAML: %v\n%s", err, string(valuesBytes))
+			}
+
+			for _, podPath := range []string{"controller", "kubeletPlugin"} {
+				got := dig(values, podPath, "podAnnotations", expectedAnnotation)
+				if got != gpuOpVersion {
+					t.Errorf("%s: %s.podAnnotations[%s] = %v, want %s\nfull values:\n%s",
+						tc.name, podPath, expectedAnnotation, got, gpuOpVersion,
+						string(valuesBytes))
+				}
+			}
+		})
+	}
+}
+
+// TestMake_DRAChartVersionAnnotation_AllDeployersCarryAnnotation
+// extends parity coverage to all five supported deployers — Helm,
+// helmfile, Flux, Argo CD, and argocd-helm. Each deployer renders the
+// shared componentValues map differently (values.yaml under a numbered
+// subdir for Helm/helmfile; configmap-values.yaml for Flux; embedded
+// in Application source for the Argo CD variants), so a per-path
+// YAML-structure assertion isn't feasible without coupling the test
+// to each deployer's bundle layout.
+//
+// The weaker invariant this test pins instead is: the literal
+// annotation key AND the resolved gpu-operator version must both
+// appear in at least one rendered file inside the deployer's bundle.
+// A future refactor that quietly drops the annotation from one
+// deployer's output shape (e.g. by re-reading the recipe values file
+// from disk instead of consuming the injected componentValues map)
+// fails this assertion immediately. Catches the bundle-layout-drift
+// case Mark called out on PR #1033.
+func TestMake_DRAChartVersionAnnotation_AllDeployersCarryAnnotation(t *testing.T) {
+	const (
+		gpuOpVersion       = "v26.4.0"
+		expectedAnnotation = "aicr.nvidia.com/gpu-operator-chart-version"
+	)
+
+	deployers := []struct {
+		name     string
+		deployer config.DeployerType
+	}{
+		{name: "helm", deployer: config.DeployerHelm},
+		{name: "helmfile", deployer: config.DeployerHelmfile},
+		{name: "flux", deployer: config.DeployerFlux},
+		{name: "argocd", deployer: config.DeployerArgoCD},
+		{name: "argocd-helm", deployer: config.DeployerArgoCDHelm},
+	}
+
+	for _, tc := range deployers {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewConfig(
+				config.WithDeployer(tc.deployer),
+				config.WithVersion("v1.0.0"),
+			)
+			b, err := New(WithConfig(cfg))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			rr := &recipe.RecipeResult{
+				APIVersion: "aicr.nvidia.com/v1alpha1",
+				Kind:       "Recipe",
+				Criteria: &recipe.Criteria{
+					Service:     "eks",
+					Accelerator: "h100",
+					Intent:      "training",
+				},
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:    gpuOperatorComponentName,
+						Version: gpuOpVersion,
+						Type:    recipe.ComponentTypeHelm,
+						Source:  "https://helm.ngc.nvidia.com/nvidia",
+					},
+					{
+						Name:    draComponentName,
+						Version: "25.12.0",
+						Type:    recipe.ComponentTypeHelm,
+						Source:  "https://helm.ngc.nvidia.com/nvidia",
+					},
+				},
+				DeploymentOrder: []string{gpuOperatorComponentName, draComponentName},
+			}
+
+			tmpDir := t.TempDir()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if _, err := b.Make(ctx, rr, tmpDir); err != nil {
+				t.Fatalf("Make() error = %v", err)
+			}
+
+			// Walk the bundle and find any file that contains BOTH the
+			// annotation key AND the expected version. Requiring both
+			// prevents false positives where the key appears in a
+			// comment or doc but the value drifted.
+			found := bundleContainsBoth(t, tmpDir, expectedAnnotation, gpuOpVersion)
+			if !found {
+				t.Errorf("%s: no rendered bundle file contains both %q and %q",
+					tc.name, expectedAnnotation, gpuOpVersion)
+			}
+		})
+	}
+}
+
+// bundleContainsBoth walks bundleDir and returns true if any regular
+// file beneath it contains BOTH needle substrings. Used by the
+// all-deployers parity check to keep per-deployer layout assumptions
+// out of the test body.
+func bundleContainsBoth(t *testing.T, bundleDir, needle1, needle2 string) bool {
+	t.Helper()
+	var found bool
+	err := filepath.Walk(bundleDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() || found {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			// Skip unreadable entries (symlinks, sockets); these aren't
+			// rendered bundle artifacts.
+			return nil
+		}
+		s := string(data)
+		if strings.Contains(s, needle1) && strings.Contains(s, needle2) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", bundleDir, err)
+	}
+	return found
+}
+
+// TestMake_DRAChartVersionAnnotation_DisabledRecipeUnaffected pins
+// the negative case in the rendered output: when nvidia-dra-driver-gpu
+// is filtered out by the caller (via --set or recipe-level disable),
+// the rendered bundle has no DRA values file at all — and the
+// gpu-operator values are emitted without any DRA-related annotation
+// leaking back into them. Bundles in a single deployer here; the
+// gating logic is shared across all deployers so per-deployer
+// coverage is unnecessary.
+func TestMake_DRAChartVersionAnnotation_DisabledRecipeUnaffected(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	rr := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		Criteria: &recipe.Criteria{
+			Service:     "eks",
+			Accelerator: "h100",
+			Intent:      "training",
+		},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    gpuOperatorComponentName,
+				Version: "v26.4.0",
+				Type:    "helm",
+				Source:  "https://helm.ngc.nvidia.com/nvidia",
+			},
+			// nvidia-dra-driver-gpu intentionally omitted.
+		},
+		DeploymentOrder: []string{gpuOperatorComponentName},
+	}
+
+	tmpDir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := b.Make(ctx, rr, tmpDir); err != nil {
+		t.Fatalf("Make() error = %v", err)
+	}
+
+	// DRA directory should not exist when the component is filtered out.
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "002-nvidia-dra-driver-gpu")); !os.IsNotExist(statErr) {
+		t.Errorf("expected no nvidia-dra-driver-gpu directory when DRA is disabled, got stat=%v", statErr)
+	}
+
+	// gpu-operator's own values.yaml must NOT carry the DRA annotation
+	// — guards against an injection bug that wrote into the wrong key.
+	gpuValues := readBundleValues(t, tmpDir, "001-gpu-operator/values.yaml")
+	if strings.Contains(string(gpuValues), "aicr.nvidia.com/gpu-operator-chart-version") {
+		t.Errorf("gpu-operator values unexpectedly contain the DRA chart-version annotation:\n%s",
+			string(gpuValues))
+	}
+}
+
+// readBundleValues loads a per-component values.yaml from a generated
+// bundle directory and fails the test with a clear message if it
+// isn't there. Centralizes the file path / read-error handling so the
+// parity assertions read like declarative checks.
+func readBundleValues(t *testing.T, bundleDir, relPath string) []byte {
+	t.Helper()
+	abs := filepath.Join(bundleDir, relPath)
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		// List the bundle directory so the failure message tells the
+		// reader where the file actually landed (deployers occasionally
+		// shift component subdir numbering).
+		entries, _ := os.ReadDir(bundleDir)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("read %s: %v\nbundle contents: %v", abs, err, names)
+	}
+	return data
+}

--- a/pkg/bundler/bundler_dra_annotation_test.go
+++ b/pkg/bundler/bundler_dra_annotation_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundler
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// TestInjectDRAChartVersionAnnotation_PositiveCase pins the happy
+// path: both gpu-operator and nvidia-dra-driver-gpu enabled in the
+// filtered recipe, gpu-operator version present → the
+// aicr.nvidia.com/gpu-operator-chart-version annotation is written on
+// both the controller and kubeletPlugin pod templates with the
+// resolved chart version.
+func TestInjectDRAChartVersionAnnotation_PositiveCase(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		gpuOperatorComponentName: {},
+		draComponentName:         {},
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: gpuOperatorComponentName, Version: "v26.4.0"},
+			{Name: draComponentName, Version: "25.12.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	for _, podPath := range []string{"controller", "kubeletPlugin"} {
+		got := dig(componentValues[draComponentName], podPath, "podAnnotations", draChartVersionAnnotation)
+		if got != "v26.4.0" {
+			t.Errorf("podAnnotations[%s][%s] = %v, want v26.4.0",
+				podPath, draChartVersionAnnotation, got)
+		}
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_DRAComponentDisabled pins the
+// gating: when nvidia-dra-driver-gpu is absent from the filtered
+// ComponentRefs (already filtered out as disabled by the caller), the
+// helper is a no-op even if gpu-operator is enabled. This is the
+// "negative case" the issue's acceptance criteria call out — proves
+// the gating is correct and no warning fires.
+func TestInjectDRAChartVersionAnnotation_DRAComponentDisabled(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		gpuOperatorComponentName: {},
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: gpuOperatorComponentName, Version: "v26.4.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	if _, ok := componentValues[draComponentName]; ok {
+		t.Errorf("expected no DRA entry in componentValues when DRA component is disabled, got %v",
+			componentValues[draComponentName])
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_GPUOperatorDisabled pins the
+// mirror gating: when gpu-operator is absent (disabled or filtered
+// out), no annotation is written because there's no chart version to
+// mirror.
+func TestInjectDRAChartVersionAnnotation_GPUOperatorDisabled(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		draComponentName: {},
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: draComponentName, Version: "25.12.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	if got := componentValues[draComponentName]; len(got) != 0 {
+		t.Errorf("expected unchanged DRA values when gpu-operator is disabled, got %v", got)
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_GPUOperatorEmptyVersion pins the
+// defensive branch: when gpu-operator IS enabled but its Version field
+// is empty (the resolver shouldn't produce this in practice — see the
+// helper docstring for why), the helper logs a warning and skips
+// injection rather than writing an empty annotation value that would
+// itself lock the DaemonSet to a meaningless pin and erase the
+// "annotation never drifts from the chart pin" guarantee.
+func TestInjectDRAChartVersionAnnotation_GPUOperatorEmptyVersion(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		gpuOperatorComponentName: {},
+		draComponentName:         {},
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: gpuOperatorComponentName, Version: ""},
+			{Name: draComponentName, Version: "25.12.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	if got := componentValues[draComponentName]; len(got) != 0 {
+		t.Errorf("expected unchanged DRA values when gpu-operator Version is empty, got %v", got)
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_PreservesExistingValues
+// documents the additive contract: priorityClassName and any
+// pre-existing podAnnotations from the values file (or from earlier
+// override layers) survive injection. The helper only writes the one
+// annotation key and leaves the rest of the controller / kubeletPlugin
+// sections untouched.
+func TestInjectDRAChartVersionAnnotation_PreservesExistingValues(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		gpuOperatorComponentName: {},
+		draComponentName: {
+			"controller": map[string]any{
+				"priorityClassName": "system-cluster-critical",
+				"podAnnotations": map[string]any{
+					"operator.example.com/other-key": "preserved",
+				},
+			},
+			"kubeletPlugin": map[string]any{
+				"priorityClassName": "system-node-critical",
+			},
+		},
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: gpuOperatorComponentName, Version: "v26.4.0"},
+			{Name: draComponentName, Version: "25.12.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	dra := componentValues[draComponentName]
+	if got := dig(dra, "controller", "priorityClassName"); got != "system-cluster-critical" {
+		t.Errorf("controller.priorityClassName = %v, want system-cluster-critical", got)
+	}
+	if got := dig(dra, "controller", "podAnnotations", "operator.example.com/other-key"); got != "preserved" {
+		t.Errorf("controller.podAnnotations[operator.example.com/other-key] = %v, want preserved", got)
+	}
+	if got := dig(dra, "controller", "podAnnotations", draChartVersionAnnotation); got != "v26.4.0" {
+		t.Errorf("controller.podAnnotations[%s] = %v, want v26.4.0", draChartVersionAnnotation, got)
+	}
+	if got := dig(dra, "kubeletPlugin", "priorityClassName"); got != "system-node-critical" {
+		t.Errorf("kubeletPlugin.priorityClassName = %v, want system-node-critical", got)
+	}
+	if got := dig(dra, "kubeletPlugin", "podAnnotations", draChartVersionAnnotation); got != "v26.4.0" {
+		t.Errorf("kubeletPlugin.podAnnotations[%s] = %v, want v26.4.0", draChartVersionAnnotation, got)
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_OverridesUserSet pins the
+// "internal annotation always reflects the actual chart version"
+// invariant. A user --set that wrote a stale value into the
+// annotation must be overwritten by the bundler-derived value;
+// otherwise the rollout-trigger semantics break and the durable fix
+// degrades into the same drift the manual annotation had. Injection
+// happens AFTER extractComponentValues for exactly this reason.
+func TestInjectDRAChartVersionAnnotation_OverridesUserSet(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		gpuOperatorComponentName: {},
+		draComponentName: {
+			"controller": map[string]any{
+				"podAnnotations": map[string]any{
+					draChartVersionAnnotation: "v25.10.1-stale-from-user-set",
+				},
+			},
+		},
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: gpuOperatorComponentName, Version: "v26.4.0"},
+			{Name: draComponentName, Version: "25.12.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	got := dig(componentValues[draComponentName], "controller", "podAnnotations", draChartVersionAnnotation)
+	if got != "v26.4.0" {
+		t.Errorf("expected user --set value to be overridden by injection: got %v, want v26.4.0", got)
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_VersionVariants documents that
+// the helper mirrors whatever string the resolver wrote into the
+// gpu-operator ComponentRef. Helm chart pins ship with and without a
+// leading "v"; the annotation tracks the exact string so the rendered
+// pod-template diff reliably fires on a chart-pin change of any
+// shape.
+func TestInjectDRAChartVersionAnnotation_VersionVariants(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"v-prefixed", "v26.4.0"},
+		{"unprefixed", "26.4.0"},
+		{"pre-release", "v26.5.0-beta.1"},
+		{"build metadata", "v26.4.0+nvidia.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			componentValues := map[string]map[string]any{
+				gpuOperatorComponentName: {},
+				draComponentName:         {},
+			}
+			rr := &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{Name: gpuOperatorComponentName, Version: tt.version},
+					{Name: draComponentName, Version: "25.12.0"},
+				},
+			}
+			b.injectDRAChartVersionAnnotation(componentValues, rr)
+			got := dig(componentValues[draComponentName], "controller", "podAnnotations", draChartVersionAnnotation)
+			if got != tt.version {
+				t.Errorf("controller annotation = %v, want %v", got, tt.version)
+			}
+		})
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_NilInputs documents the
+// nil-tolerant contract. The bundler's Make method only calls this
+// after extractComponentValues returns a non-nil map and pretty much
+// never with a nil recipe, but defensive nil-handling keeps the
+// helper safe in unit tests and future callers.
+func TestInjectDRAChartVersionAnnotation_NilInputs(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	tests := []struct {
+		name string
+		cv   map[string]map[string]any
+		rr   *recipe.RecipeResult
+	}{
+		{"nil componentValues", nil, &recipe.RecipeResult{}},
+		{"nil recipe result", map[string]map[string]any{}, nil},
+		{"both nil", nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not panic.
+			b.injectDRAChartVersionAnnotation(tt.cv, tt.rr)
+		})
+	}
+}
+
+// TestInjectDRAChartVersionAnnotation_LazyDRAValuesMap pins one
+// implementation detail worth fixing in place: when the DRA component
+// is enabled but its componentValues entry hasn't been initialized
+// yet (no values file, no overrides), the helper still injects by
+// creating the nested map. This matters because every-deployer parity
+// requires the annotation to appear in the rendered chart even when
+// the DRA chart has no other values configured.
+func TestInjectDRAChartVersionAnnotation_LazyDRAValuesMap(t *testing.T) {
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	componentValues := map[string]map[string]any{
+		gpuOperatorComponentName: {},
+		// nvidia-dra-driver-gpu key intentionally absent.
+	}
+	rr := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: gpuOperatorComponentName, Version: "v26.4.0"},
+			{Name: draComponentName, Version: "25.12.0"},
+		},
+	}
+
+	b.injectDRAChartVersionAnnotation(componentValues, rr)
+
+	if _, ok := componentValues[draComponentName]; !ok {
+		t.Fatalf("expected helper to create DRA values entry on demand")
+	}
+	got := dig(componentValues[draComponentName], "controller", "podAnnotations", draChartVersionAnnotation)
+	if got != "v26.4.0" {
+		t.Errorf("controller annotation = %v, want v26.4.0", got)
+	}
+}
+
+// dig walks a nested map[string]any tree by string keys and returns
+// the leaf value, or nil if any intermediate key is missing or has
+// the wrong type. Pulls the noisy type-assertion chain out of every
+// table-test row so the assertions read like the data they describe.
+func dig(m map[string]any, keys ...string) any {
+	cur := any(m)
+	for _, k := range keys {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[k]
+	}
+	return cur
+}

--- a/recipes/components/nvidia-dra-driver-gpu/values.yaml
+++ b/recipes/components/nvidia-dra-driver-gpu/values.yaml
@@ -56,25 +56,17 @@ resources:
   gpus:
     enabled: true
 
-# gpu-operator-chart-version annotation forces a DaemonSet re-roll when
-# the gpu-operator chart (and its managed driver) bumps. The DRA
-# kubelet plugin loads libnvidia-ml.so at pod start and pins to the
-# driver version running at that moment; gpu-operator's k8s-driver-manager
-# reloads the host kernel modules during a driver bump but does NOT
-# restart the sibling DRA DaemonSet (its chart template hasn't changed),
-# leaving the kubelet plugin's NVML handle stale. CDI spec generation
-# then fails with "Driver/library version mismatch" and DRA-allocated
-# pods stay in ContainerCreating.
-#
-# Bumping this annotation value on every gpu-operator chart bump (here:
-# v26.3.1) changes the rendered pod template and forces helm upgrade to
-# roll the DaemonSet, picking up a fresh NVML handle against the
-# now-running driver. Track follow-up to automate this in #973.
+# The aicr.nvidia.com/gpu-operator-chart-version annotation that forces
+# a DaemonSet re-roll on every gpu-operator chart bump (stale-NVML
+# mitigation; see PR #965 for the underlying class of bug) is no longer
+# hand-maintained here. As of #973 it is injected by the bundler from
+# the resolved gpu-operator componentRef version after
+# extractComponentValues and before buildDeployer in
+# pkg/bundler/bundler.go (see injectDRAChartVersionAnnotation), so the
+# annotation can never drift from the actual chart pin. Recipes that
+# disable either gpu-operator or nvidia-dra-driver-gpu leave the
+# rendered values untouched.
 controller:
   priorityClassName: ""
-  podAnnotations:
-    aicr.nvidia.com/gpu-operator-chart-version: v26.3.1
 kubeletPlugin:
   priorityClassName: ""
-  podAnnotations:
-    aicr.nvidia.com/gpu-operator-chart-version: v26.3.1


### PR DESCRIPTION
## Summary

Replace the hand-maintained `aicr.nvidia.com/gpu-operator-chart-version` annotation in `recipes/components/nvidia-dra-driver-gpu/values.yaml` with a bundler-side injection that derives the value from the resolved `gpu-operator` componentRef and writes it onto both `controller` and `kubeletPlugin` `podAnnotations` in the rendered DRA values. The annotation can no longer drift from the actual chart pin.

## Motivation / Context

PR #965 closed the stale-NVML class of bug (gpu-operator chart bump → `k8s-driver-manager` reloads kernel modules async → DRA kubelet plugin's NVML handle goes stale → CDI spec generation fails with `Driver/library version mismatch` → DRA-allocated pods stuck in `ContainerCreating`) by hard-coding the gpu-operator chart version into the DRA pod-template annotation. The annotation works, but only as long as a maintainer remembers to bump both pins in lockstep. A future PR that bumped gpu-operator and forgot the annotation would produce identical rendered DaemonSet manifests, helm upgrade would skip the re-roll, and stale NVML would return silently. `make qualify` did not catch the drift because no static check verified the two pins.

Fixes: #973
Related: #965 (the chart-version annotation this durabilizes), #980 (orthogonal cross-deployer corrective restart), #894 (chart bump that first surfaced the stale-NVML class of bug)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes) — net behavior is identical when gpu-operator chart pin matches the value previously hand-edited; durability change makes future drift impossible

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`) — new `injectDRAChartVersionAnnotation` helper + call site in `DefaultBundler.Make`
- [x] Recipe engine / data (`pkg/recipe`) — no Go change, only `recipes/components/nvidia-dra-driver-gpu/values.yaml` (stripped hand-maintained chart-version string)

## Implementation Notes

**Helper.** `injectDRAChartVersionAnnotation` iterates the filtered `recipeResult.ComponentRefs` (disabled components are removed upstream in `DefaultBundler.Make` at `pkg/bundler/bundler.go:219-257`), extracts the gpu-operator chart version, and gates on BOTH `gpu-operator` and `nvidia-dra-driver-gpu` being enabled. When both are present, it writes `aicr.nvidia.com/gpu-operator-chart-version` onto `controller` and `kubeletPlugin` `podAnnotations` of the nvidia-dra-driver-gpu values map, creating nested maps lazily so existing values (`priorityClassName`, other annotations) are preserved.

**Injection point.** In `DefaultBundler.Make` AFTER `extractComponentValues` — so the values map is populated and user `--set` overrides have already landed — and BEFORE `buildDeployer` — so every deployer receives the same final `componentValues` map. Placing the call AFTER `--set` is deliberate: a user override of this specific annotation key is intentionally NOT honored; the annotation must always reflect the actual resolved gpu-operator chart version, or the rollout-trigger semantics break. `TestInjectDRAChartVersionAnnotation_OverridesUserSet` pins this invariant.

**Cross-deployer parity (structural).** All five supported deployers consume `Generator.ComponentValues[ref.Name]` from the same post-injection map:

| Deployer | Consumption site |
|----------|------------------|
| Helm | `pkg/bundler/deployer/helm/helm.go:144` |
| helmfile | `pkg/bundler/deployer/helmfile/helmfile.go:136` |
| Flux | `pkg/bundler/deployer/flux/helm.go:130` |
| Argo CD | `pkg/bundler/deployer/argocd/argocd.go:552` |
| argocd-helm | `pkg/bundler/deployer/argocdhelm/argocdhelm.go:387` |

The parity test (see Testing) directly exercises both internal consumption shapes — inline values marshal (helmfile) and `localformat.Component.Values` write (Helm, reused by argocd / argocd-helm) — and asserts the annotation lands in the rendered `values.yaml`. The remaining deployers are guaranteed by the single-map design; renaming `Generator.ComponentValues` would break compilation everywhere simultaneously.

**Pattern.** Mirrors the GKE critical-priority quota helper (`pkg/bundler/bundler.go:injectGKECriticalPriorityQuotas`) so readers familiar with that pattern can pick this one up without context-switching.

**Recipe values change.** `recipes/components/nvidia-dra-driver-gpu/values.yaml` no longer carries the chart-version string at all. The old comment block is replaced with a short pointer to this helper. `controller.priorityClassName: ""` and `kubeletPlugin.priorityClassName: ""` remain unchanged.

## Behavior Delta

**Standalone-DRA recipes (DRA enabled, gpu-operator disabled) no longer render the annotation, by design.** The previously hand-maintained annotation lived inside `recipes/components/nvidia-dra-driver-gpu/values.yaml`, so it was written unconditionally whenever the DRA component was bundled — including the (currently unused) case where DRA is deployed without gpu-operator (for example, a host-installed driver via `--set gpuoperator:enabled=false`). The new helper gates on BOTH components being enabled, so a standalone-DRA bundle renders without the annotation.

This is the intended semantic: the annotation exists solely to force a DaemonSet re-roll when the **gpu-operator chart pin** bumps. With gpu-operator disabled, there is no chart pin to mirror and the rollout trigger has nothing to fire on. No in-tree overlay currently exercises this configuration, so the change is theoretical for today's recipes; it is the right shape going forward.

## Testing

```bash
unset GITLAB_TOKEN ; make qualify
# All 22 chainsaw tests pass.
# Coverage: 76.9% (threshold: 75%) — passes the project floor.
# Vulnerability scan: clean.

GOFLAGS="-mod=vendor" go test -coverprofile=/tmp/cover.out ./pkg/bundler
# pkg/bundler coverage 67.0% → 69.0% (+2.0% on this PR)
# injectDRAChartVersionAnnotation: 100% statement coverage
```

**Tests added:**

- **Unit tests** (`pkg/bundler/bundler_dra_annotation_test.go`):
  - positive case both pod paths, annotation matches resolved gpu-operator version
  - negative case nvidia-dra-driver-gpu disabled → no-op, no DRA entry materialized
  - negative case gpu-operator disabled → no-op (pins the Behavior Delta above)
  - preserves existing `priorityClassName` + unrelated annotations under both pod paths
  - overrides user `--set` of the annotation key (proves the "must reflect actual chart version" invariant)
  - version variants: `v`-prefixed, unprefixed, pre-release, build metadata
  - nil-tolerant inputs (nil componentValues, nil recipe, both nil)
  - lazy-creation of `componentValues[nvidia-dra-driver-gpu]` when the entry isn't initialized
- **Generated-artifact parity test** (`pkg/bundler/bundler_dra_annotation_parity_test.go`):
  - bundles the same recipe through the **Helm deployer** AND the **helmfile deployer**, asserts the annotation lands in the rendered DRA `values.yaml` for both outputs. These two deployers exercise both internal consumption shapes; Flux, Argo CD, and argocd-helm are guaranteed by the single-map design described in Implementation Notes.
  - disabled-recipe negative case: when nvidia-dra-driver-gpu is filtered out, the gpu-operator values must not leak any DRA-related annotation key

## Risk Assessment

- [x] **Low** — Isolated bundler-side helper with 100% unit coverage and a cross-deployer parity test. Net rendered output for the current `gpu-operator v26.3.1 / nvidia-dra-driver-gpu v25.12.0` pair is byte-identical to the prior hand-maintained annotation. Easy revert (single function + call site + values comment).

**Rollout notes:** No flag, no opt-in. The next gpu-operator chart bump after this PR lands gets the annotation derived automatically; no values-file edit needed. Existing bundles regenerated from the same gpu-operator pin produce the same output as today. See **Behavior Delta** for the only semantic change (annotation absent when gpu-operator is disabled).

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — via `make qualify`
- [x] Linter passes (`make lint`) — via `make qualify`
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — no user-facing surface; recipe values comment refreshed
- [x] Changes follow existing patterns in the codebase — mirrors `injectGKECriticalPriorityQuotas`
- [x] Commits are cryptographically signed (`git commit -S`)