### PR TITLE
fix(bundler): fix bugs -  assemble full OCI artifact in path-based child apps; quote chart name (#1034)

### DIFF
--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -696,11 +696,23 @@ func injectValuesIntoSingleSource(app map[string]any, overrideKey string) error 
 	// in single quotes — that's the only YAML scalar style that doesn't
 	// require escaping the embedded double quotes inside `required "..."`,
 	// which would corrupt Helm's parsing of the template.
+	//
+	// Path-based child Applications have no `chart` field — Argo CD's
+	// generic OCI source uses `repoURL` directly as the full artifact
+	// reference and then resolves `path` inside it. We therefore append
+	// .Chart.Name here ourselves so the rendered value is
+	// `<parent namespace>/<chart name>` (e.g. `oci://reg/org/my-bundle`),
+	// matching the artifact the parent Application's `repoURL/chart:tag`
+	// triple resolves to. Without the append, --set repoURL=<parent
+	// namespace> (the contract every other site in this file documents)
+	// produces a child source pointing at `oci://reg/org:tag` — an
+	// artifact that does not exist — and the child Application fails
+	// to sync. See issue #1034.
 	source["repoURL"] = &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Tag:   yamlStringTag,
 		Style: yaml.SingleQuotedStyle,
-		Value: `{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}`,
+		Value: `{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; this template appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}/{{ .Chart.Name }}`,
 	}
 	source["targetRevision"] = &yaml.Node{
 		Kind:  yaml.ScalarNode,
@@ -939,12 +951,20 @@ func writeChartYAML(outputDir, name, version string) (string, int64, error) {
 		return "", 0, err
 	}
 
+	// Quote name and version so OCI artifact paths whose last segment is
+	// a YAML reserved scalar ("null", "true", "false", "yes", "no",
+	// "123", etc.) round-trip as strings instead of getting reinterpreted
+	// by Helm's YAML parser as the underlying scalar type and producing
+	// a chart with an empty Metadata.Name (or a type-mismatch error).
+	// fmt %q emits a Go-quoted string that is also valid YAML for all
+	// printable ASCII; OCI artifact path segments are constrained to
+	// that charset by the docker reference grammar. See issue #1034.
 	var buf strings.Builder
 	buf.WriteString("apiVersion: v2\n")
-	fmt.Fprintf(&buf, "name: %s\n", name)
+	fmt.Fprintf(&buf, "name: %q\n", name)
 	buf.WriteString("description: AICR deployment bundle with dynamic install-time values\n")
 	buf.WriteString("type: application\n")
-	fmt.Fprintf(&buf, "version: %s\n", version)
+	fmt.Fprintf(&buf, "version: %q\n", version)
 
 	content := buf.String()
 	if writeErr := os.WriteFile(chartPath, []byte(content), 0600); writeErr != nil {

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -199,8 +199,11 @@ func TestGenerate(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to read Chart.yaml: %v", err)
 				}
-				if !strings.Contains(string(content), "version: 2.5.0") {
-					t.Error("Chart.yaml should contain version: 2.5.0")
+				// writeChartYAML quotes the version scalar so YAML
+				// reserved scalars (e.g. "1.0", "null") round-trip as
+				// strings; see issue #1034.
+				if !strings.Contains(string(content), `version: "2.5.0"`) {
+					t.Errorf("Chart.yaml should contain version: \"2.5.0\", got:\n%s", string(content))
 				}
 			},
 		},
@@ -1044,12 +1047,19 @@ func TestHelmTemplate_RendersWithSetRepoURL(t *testing.T) {
 		t.Fatalf("Generate() error = %v", err)
 	}
 
-	const wantRepoURL = "oci://example.test/myorg/aicr-bundle"
+	// Under the post-#1032 contract, --set repoURL carries the parent
+	// namespace only — the parent App appends .Chart.Name via its
+	// source.chart field, and (per #1034) the path-based child template
+	// appends /<chart-name> directly into its source.repoURL so Argo
+	// CD's generic OCI source resolves to the same artifact.
+	const setRepoURL = "oci://example.test/myorg"
+	const wantParentRepoURL = setRepoURL
+	const wantChildRepoURL = setRepoURL + "/" + DefaultChartName
 	const wantTagName = "v9.9.9-render-test"
 	cmdCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(cmdCtx, "helm", "template", "test-release", outputDir, //nolint:gosec // controlled args
-		"--set", "repoURL="+wantRepoURL,
+		"--set", "repoURL="+setRepoURL,
 		"--set", "targetRevision="+wantTagName,
 	)
 	out, err := cmd.CombinedOutput()
@@ -1090,8 +1100,8 @@ func TestHelmTemplate_RendersWithSetRepoURL(t *testing.T) {
 	if !ok {
 		t.Fatalf("rendered output missing parent Application 'aicr-stack'\noutput:\n%s", out)
 	}
-	if parent.Spec.Source.RepoURL != wantRepoURL {
-		t.Errorf("parent App repoURL: got %q, want %q", parent.Spec.Source.RepoURL, wantRepoURL)
+	if parent.Spec.Source.RepoURL != wantParentRepoURL {
+		t.Errorf("parent App repoURL: got %q, want %q", parent.Spec.Source.RepoURL, wantParentRepoURL)
 	}
 	if parent.Spec.Source.Chart != DefaultChartName {
 		t.Errorf("parent App chart: got %q, want %q", parent.Spec.Source.Chart, DefaultChartName)
@@ -1104,8 +1114,8 @@ func TestHelmTemplate_RendersWithSetRepoURL(t *testing.T) {
 	if !ok {
 		t.Fatalf("rendered output missing path-based child 'nodewright-customizations'")
 	}
-	if child.Spec.Source.RepoURL != wantRepoURL {
-		t.Errorf("child path-based repoURL: got %q, want %q", child.Spec.Source.RepoURL, wantRepoURL)
+	if child.Spec.Source.RepoURL != wantChildRepoURL {
+		t.Errorf("child path-based repoURL: got %q, want %q (parent namespace + chart name; see #1034)", child.Spec.Source.RepoURL, wantChildRepoURL)
 	}
 	if child.Spec.Source.TargetRevision != wantTagName {
 		t.Errorf("child path-based targetRevision: got %q, want %q", child.Spec.Source.TargetRevision, wantTagName)
@@ -1163,8 +1173,10 @@ func TestGenerate_CustomChartName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Chart.yaml: %v", err)
 	}
-	if !strings.Contains(string(chartBytes), "name: "+customName+"\n") {
-		t.Errorf("Chart.yaml missing custom name %q; got:\n%s", customName, chartBytes)
+	// writeChartYAML quotes the name so OCI artifact paths whose last
+	// segment is a YAML reserved scalar round-trip as strings; see #1034.
+	if !strings.Contains(string(chartBytes), `name: "`+customName+"\"\n") {
+		t.Errorf("Chart.yaml missing quoted custom name %q; got:\n%s", customName, chartBytes)
 	}
 
 	cmdCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -1270,5 +1282,102 @@ func assertGolden(t *testing.T, outDir, goldenDir, relPath string) {
 	}
 	if string(got) != string(want) {
 		t.Errorf("%s differs from golden:\n--- got ---\n%s\n--- want ---\n%s", relPath, got, want)
+	}
+}
+
+// TestInjectValuesIntoSingleSource_AppendsChartName pins the
+// post-#1032 path-based-children fix from issue #1034: path-based
+// child Applications have no `chart` field, so Argo CD's generic OCI
+// source uses `repoURL` directly as the full artifact reference. The
+// rendered template must therefore append .Chart.Name to the
+// install-time --set repoURL value so the assembled URL matches the
+// artifact the parent Application's `repoURL/chart:tag` triple
+// resolves to. Without the append, --set repoURL=oci://reg/org (the
+// contract documented elsewhere in this file) produces a child
+// source pointing at `oci://reg/org:tag` — an artifact that does not
+// exist — and the child Application fails to sync.
+func TestInjectValuesIntoSingleSource_AppendsChartName(t *testing.T) {
+	app := map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"spec": map[string]any{
+			"source": map[string]any{
+				"repoURL":        "https://github.com/myorg/myrepo.git",
+				"targetRevision": "main",
+				"path":           "003-nodewright-customizations",
+			},
+		},
+	}
+
+	if err := injectValuesIntoSingleSource(app, "nodewrightcustomizations"); err != nil {
+		t.Fatalf("injectValuesIntoSingleSource error: %v", err)
+	}
+
+	out, err := yaml.Marshal(app)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error: %v", err)
+	}
+	str := string(out)
+
+	if !strings.Contains(str, `.Values.repoURL }}/{{ .Chart.Name }}`) {
+		t.Errorf("path-based child repoURL should append /{{ .Chart.Name }} after .Values.repoURL so the rendered value is the full OCI artifact reference; got:\n%s", str)
+	}
+	// The error message must direct callers to pass the parent
+	// namespace (the same contract the parent Application uses) so
+	// users don't try to bake the chart name into --set repoURL.
+	if !strings.Contains(str, "do NOT include the chart name") {
+		t.Errorf("required-message must instruct callers not to include the chart name in --set repoURL; got:\n%s", str)
+	}
+}
+
+// TestWriteChartYAML_QuotesYAMLReservedScalarsAsName documents the
+// chart-name quoting fix from issue #1034. Valid OCI artifact paths
+// whose last segment is a YAML reserved scalar ("null", "true",
+// "false", numeric strings, etc.) must round-trip as strings; if
+// emitted unquoted, Helm's YAML parser reinterprets `name: null` as
+// YAML null, chart.Metadata.Name becomes empty, and the chart is
+// rejected by `helm package` / `helm push` with "chart.metadata.name
+// is required".
+func TestWriteChartYAML_QuotesYAMLReservedScalarsAsName(t *testing.T) {
+	tests := []struct {
+		name        string
+		chartName   string
+		wantUnmarsh string
+	}{
+		{"YAML null literal", "null", "null"},
+		{"YAML true literal", "true", "true"},
+		{"YAML false literal", "false", "false"},
+		{"numeric-looking", "123", "123"},
+		{"YAML yes literal", "yes", "yes"},
+		{"hyphenated normal name", "my-bundle", "my-bundle"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			if _, _, err := writeChartYAML(outputDir, tt.chartName, "1.0.0"); err != nil {
+				t.Fatalf("writeChartYAML: %v", err)
+			}
+			content, err := os.ReadFile(filepath.Join(outputDir, "Chart.yaml"))
+			if err != nil {
+				t.Fatalf("read Chart.yaml: %v", err)
+			}
+			var parsed struct {
+				APIVersion string `yaml:"apiVersion"`
+				Name       string `yaml:"name"`
+				Version    string `yaml:"version"`
+			}
+			if err := yaml.Unmarshal(content, &parsed); err != nil {
+				t.Fatalf("Chart.yaml does not unmarshal cleanly for name=%q:\n%s\nerror: %v",
+					tt.chartName, content, err)
+			}
+			if parsed.Name != tt.wantUnmarsh {
+				t.Errorf("Chart.yaml name = %q (after YAML unmarshal), want %q\nraw:\n%s",
+					parsed.Name, tt.wantUnmarsh, content)
+			}
+			if parsed.Version != "1.0.0" {
+				t.Errorf("Chart.yaml version = %q, want \"1.0.0\"\nraw:\n%s",
+					parsed.Version, content)
+			}
+		})
 	}
 }

--- a/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/Chart.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: aicr-bundle
+name: "aicr-bundle"
 description: AICR deployment bundle with dynamic install-time values
 type: application
-version: 1.0.0
+version: "1.0.0"

--- a/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/templates/nodewright-customizations.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/helm_and_manifest_only/templates/nodewright-customizations.yaml
@@ -16,7 +16,7 @@ spec:
                 {{- $dynamic := index .Values "nodewrightcustomizations" | default dict -}}
                 {{- toYaml $dynamic | nindent 16 }}
         path: 002-nodewright-customizations
-        repoURL: '{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}'
+        repoURL: '{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; this template appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}/{{ .Chart.Name }}'
         targetRevision: '{{ .Values.targetRevision | default .Chart.Version }}'
     syncPolicy:
         automated:

--- a/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/Chart.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: aicr-bundle
+name: "aicr-bundle"
 description: AICR deployment bundle with dynamic install-time values
 type: application
-version: 1.0.0
+version: "1.0.0"

--- a/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/templates/gpu-operator-post.yaml
+++ b/pkg/bundler/deployer/argocdhelm/testdata/mixed_component/templates/gpu-operator-post.yaml
@@ -16,7 +16,7 @@ spec:
                 {{- $dynamic := index .Values "gpuoperator" | default dict -}}
                 {{- toYaml $dynamic | nindent 16 }}
         path: 002-gpu-operator-post
-        repoURL: '{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; the parent App appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}'
+        repoURL: '{{ required "repoURL is required: pass --set repoURL=<parent namespace> (e.g., oci://<registry>/<path>) — do NOT include the chart name; this template appends .Chart.Name to assemble the full OCI artifact reference" .Values.repoURL }}/{{ .Chart.Name }}'
         targetRevision: '{{ .Values.targetRevision | default .Chart.Version }}'
     syncPolicy:
         automated:


### PR DESCRIPTION
## Summary

Two argocd-helm OCI publishing bugs against the post-#1032 contract:

1. **P1** — Path-based child Applications were resolving to a non-existent artifact because their `spec.source.repoURL` template never appended `.Chart.Name`. Under #1032's contract (`--set repoURL=<parent namespace>`), the parent App appends `.Chart.Name` via its separate `source.chart` field, but path-based children have no `chart` field — Argo CD's generic OCI source resolves `repoURL` directly. Bundles with manifest-only / mixed-local-chart children silently failed to sync.
2. **P2** — `writeChartYAML` emitted `name:` and `version:` unquoted. Valid OCI artifact paths whose last segment is a YAML reserved scalar (`null`, `true`, `false`, `yes`, `no`, numeric strings) produced `name: null` etc., which Helm's YAML parser interprets as the non-string scalar, failing the chart with "chart.metadata.name is required".

## Motivation / Context

Found via Codex review of `origin/main` at `51eb4b5f`. P1 is a regression introduced today by #1032 (which landed the parent-App + bundle-chart-name fix for #1019 but left the path-based child template on the old `--set repoURL=<full bundle URL>` contract). P2 is a latent corner case that the same review surfaced.

Fixes: #1034
Related: #1032 (the parent-App contract change this PR completes), #1019 (original chart-name bug), #965 (DRA stale-NVML mitigation, unrelated but in the same OCI chain)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`) — `pkg/bundler/deployer/argocdhelm/argocdhelm.go`

## Implementation Notes

**P1 — `injectValuesIntoSingleSource` (line 703).** Append `/{{ .Chart.Name }}` to the rendered `repoURL` value so the assembled URL matches the artifact the parent's `repoURL/chart:tag` triple resolves to. Updated the `required` error message to reflect that the *path-based template itself* is doing the chart-name appending (the parent App also appends it, but via the separate `source.chart` field; the wording was misleading on the child).

**P2 — `writeChartYAML` (line 944).** Emit `name` and `version` via `fmt.Fprintf` with `%q`. OCI artifact path segments are constrained to printable ASCII by the docker reference grammar, which is exactly the safe charset for Go's `%q` (so the rendered YAML is always a clean double-quoted string).

## Testing

```bash
unset GITLAB_TOKEN ; make qualify
# All 22 chainsaw tests pass.
# Coverage: 76.9% > 75% floor.
# Vulnerability scan: clean.
```

**Tests added:**

- `TestInjectValuesIntoSingleSource_AppendsChartName` — asserts the rendered child `source.repoURL` value is `…/{{ .Chart.Name }}` (with the original `required` directive intact).
- `TestWriteChartYAML_QuotesYAMLReservedScalarsAsName` — table-driven case across `null`, `true`, `false`, `123`, `yes`, and a normal name. For each, writes `Chart.yaml` and asserts `yaml.Unmarshal` round-trips `name` back as the expected string.

**Tests updated:**

- `TestHelmTemplate_RendersWithSetRepoURL` — exercises the new contract (`--set repoURL=oci://reg/org`, parent namespace only) end-to-end via real `helm template`. Asserts the parent App's `spec.source.repoURL` equals the parent namespace and the path-based child's `spec.source.repoURL` equals parent-namespace + `/aicr-bundle`. This test was the canary: it was passing under the old contract (full bundle URL) because the parent App's `source.chart` was being ignored at install time; my fix surfaces the contract drift.
- `TestGenerate_CustomChartName` and the existing `version: 2.5.0` assertion updated to expect quoted scalars.
- Golden fixtures (`testdata/helm_and_manifest_only/` and `testdata/mixed_component/`) regenerated: child `repoURL` lines and `Chart.yaml` `name`/`version` lines now reflect the fix.

## Risk Assessment

- [x] **Low** — narrow scope, two-line code change plus assertion updates. No new external dependencies, no surface-area expansion. Bundles produced by this PR are correct for the new contract; bundles produced by the pre-#1032 codepath are unaffected (the child template change is additive — `/{{ .Chart.Name }}` only takes effect under the new `--set repoURL=<parent namespace>` contract).

**Rollout notes:** Anyone who picked up #1032's contract change since today (2026-05-26) needs this fix before publishing argocd-helm bundles with raw-manifest children to OCI. Existing bundles already pushed to OCI work as-is; the fix takes effect on the next `aicr bundle --output oci://…` run.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — via `make qualify`
- [x] Linter passes (`make lint`) — via `make qualify`
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — no user-facing surface change; the error-message text inside the `required` directive is the only "doc" touched
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)