### PR TITLE
fix(bundler): quote argocd app-of-apps metadata.name (#1011)

### DIFF
--- a/pkg/bundler/deployer/argocd/argocd_test.go
+++ b/pkg/bundler/deployer/argocd/argocd_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/localformat"
@@ -191,8 +193,8 @@ func TestGenerate_AppName(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read app-of-apps.yaml: %v", err)
 			}
-			if !strings.Contains(string(appOfApps), "name: "+tt.wantName+"\n") {
-				t.Errorf("app-of-apps.yaml missing %q metadata.name; got:\n%s", tt.wantName, appOfApps)
+			if !strings.Contains(string(appOfApps), `name: "`+tt.wantName+`"`+"\n") {
+				t.Errorf("app-of-apps.yaml missing quoted %q metadata.name; got:\n%s", tt.wantName, appOfApps)
 			}
 
 			readme, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
@@ -206,6 +208,64 @@ func TestGenerate_AppName(t *testing.T) {
 			if !strings.Contains(string(readme), "argocd app sync "+tt.wantName) {
 				t.Errorf("README missing `argocd app sync %s`; got snippet:\n%s",
 					tt.wantName, snippetAround(string(readme), "argocd app sync"))
+			}
+		})
+	}
+}
+
+// TestGenerate_AppName_YAMLReservedScalars verifies the rendered
+// app-of-apps.yaml survives a kubectl-equivalent decode when AppName is a
+// DNS-1123-valid scalar that YAML would otherwise interpret as a non-string
+// type (integer, boolean, null, float). ValidateAppName accepts these
+// because DNS-1123 subdomain literally allows them, so the template — not
+// the validator — is responsible for forcing a string scalar.
+//
+// Decode path mirrors what kubectl does: sigs.k8s.io/yaml.YAMLToJSON →
+// unstructured.UnmarshalJSON → GetName(). Without the template's
+// `printf "%q"`, GetName() returns "" for non-string scalars because of
+// the val.(string) type assertion inside getNestedString.
+func TestGenerate_AppName_YAMLReservedScalars(t *testing.T) {
+	tests := []string{"123", "true", "false", "null", "1e3"}
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{
+		{
+			Name: "cert-manager", Namespace: "cert-manager", Chart: "cert-manager",
+			Version: "v1.17.2", Type: "helm",
+			Source: "https://charts.jetstack.io",
+		},
+	}
+	recipeResult.DeploymentOrder = []string{"cert-manager"}
+
+	for _, appName := range tests {
+		t.Run(appName, func(t *testing.T) {
+			outputDir := t.TempDir()
+			g := &Generator{
+				RecipeResult:    recipeResult,
+				ComponentValues: map[string]map[string]any{"cert-manager": {}},
+				Version:         "v0.9.0",
+				AppName:         appName,
+			}
+			if _, err := g.Generate(context.Background(), outputDir); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+
+			raw, err := os.ReadFile(filepath.Join(outputDir, "app-of-apps.yaml"))
+			if err != nil {
+				t.Fatalf("read app-of-apps.yaml: %v", err)
+			}
+
+			jsonBytes, err := sigsyaml.YAMLToJSON(raw)
+			if err != nil {
+				t.Fatalf("YAMLToJSON: %v\nraw:\n%s", err, raw)
+			}
+			u := &unstructured.Unstructured{}
+			if err := u.UnmarshalJSON(jsonBytes); err != nil {
+				t.Fatalf("UnmarshalJSON: %v\njson: %s", err, jsonBytes)
+			}
+			if got := u.GetName(); got != appName {
+				t.Errorf("unstructured.GetName() = %q, want %q; rendered manifest treated metadata.name as a non-string YAML scalar.\nraw:\n%s", got, appName, raw)
 			}
 		})
 	}

--- a/pkg/bundler/deployer/argocd/templates/app-of-apps.yaml.tmpl
+++ b/pkg/bundler/deployer/argocd/templates/app-of-apps.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .AppName }}
+  name: {{ printf "%q" .AppName }}
   namespace: argocd
 spec:
   project: default

--- a/pkg/bundler/deployer/argocd/testdata/helm_and_kustomize/app-of-apps.yaml
+++ b/pkg/bundler/deployer/argocd/testdata/helm_and_kustomize/app-of-apps.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nvidia-stack
+  name: "nvidia-stack"
   namespace: argocd
 spec:
   project: default

--- a/pkg/bundler/deployer/argocd/testdata/helm_and_manifest_only/app-of-apps.yaml
+++ b/pkg/bundler/deployer/argocd/testdata/helm_and_manifest_only/app-of-apps.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nvidia-stack
+  name: "nvidia-stack"
   namespace: argocd
 spec:
   project: default

--- a/pkg/bundler/deployer/argocd/testdata/kustomize_only/app-of-apps.yaml
+++ b/pkg/bundler/deployer/argocd/testdata/kustomize_only/app-of-apps.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nvidia-stack
+  name: "nvidia-stack"
   namespace: argocd
 spec:
   project: default


### PR DESCRIPTION
## Summary

Quote `metadata.name` in the static argocd `app-of-apps.yaml` template so a `--app-name` value that is a DNS-1123-valid YAML-reserved scalar (`123`, `true`, `false`, `null`, `1e3`, …) renders as a string instead of a number/bool/null. Brings the static argocd template in line with the argocd-helm parent template (which already uses Sprig `| quote`).

## Motivation / Context

Follow-up to #1036, which introduced `--app-name`. The argocd deployer emitted `metadata.name: {{ .AppName }}` without quoting. `ValidateAppName` delegates to `k8s.io/apimachinery`'s `IsDNS1123Subdomain`, which legitimately accepts digit-only labels and bare YAML keywords (`123`, `true`, `null`, `1e3`). With the unquoted template, `aicr bundle --deployer argocd --app-name 123 ...` rendered:

```yaml
metadata:
  name: 123
```

`sigs.k8s.io/yaml.YAMLToJSON` (used by kubectl) routes through JSON and emits `"name":123` (number, not string). `unstructured.GetName()` then returns `""` because `getNestedString` does a `val.(string)` type assertion on the `int64`, so `kubectl apply` is rejected with a cryptic metadata-name validation error far from the original `aicr bundle` call site. The sibling argocd-helm parent template at `pkg/bundler/deployer/argocdhelm/argocdhelm.go:446` already applies `| quote`.

Fixes: N/A (cross-review follow-up to merged #1036)
Related: #1011, #1036

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

- Template change: `name: {{ .AppName }}` → `name: {{ printf "%q" .AppName }}`. Go `text/template` has no `quote` pipe; `printf "%q"` produces a Go-style double-quoted string, which is a valid YAML string scalar for the DNS-1123 character set enforced by `ValidateAppName`.
- The static argocd deployer materializes a manifest at bundle time, so this fix has no install-time analogue — the value has to be safe at render time.
- The three regenerated goldens reflect the same `name: "nvidia-stack"` (quoted) form. The existing `TestGenerate_AppName` assertion is tightened from `name: <value>` to `name: "<value>"` so a future regression cannot silently revert.
- Defense-in-depth `ValidateAppName` is unchanged. Tightening the validator to reject digit-only / YAML-keyword names would break operators who legitimately want them; the template fix is the narrower, less surprising option.

## Testing

```bash
# Scoped — full make qualify currently hits unrelated macOS sandbox failures (mktemp blocked)
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/bundler/deployer/argocd/...   # PASS
golangci-lint run -c .golangci.yaml ./pkg/bundler/deployer/argocd/...            # 0 issues
```

New test `TestGenerate_AppName_YAMLReservedScalars` rebuilds the kubectl decode path (`sigs.k8s.io/yaml.YAMLToJSON` → `unstructured.UnmarshalJSON` → `GetName()`) and asserts the rendered `metadata.name` round-trips as a string for `123`, `true`, `false`, `null`, `1e3`. Without the template fix, every subtest fails because `GetName()` returns `""`.

Coverage delta (`pkg/bundler/deployer/argocd`): expected to increase slightly with the new subtests; full `make qualify` will run in CI.

## Risk Assessment

- [x] **Low** — Single-line template change behind defense-in-depth validation, three golden updates, and one new regression test. Default `nvidia-stack` rendering is unchanged behaviorally (`name: nvidia-stack` and `name: "nvidia-stack"` are equivalent YAML strings).

**Rollout notes:** None. The rendered manifest is character-different (`name: "nvidia-stack"` vs `name: nvidia-stack`) but semantically identical for any YAML/JSON parser. Argo CD's `argocd app get/sync` examples in the README are unaffected (already plain text).

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — package-scoped; see Testing
- [x] Linter passes (`make lint`) — package-scoped; see Testing
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (no user-facing behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)