### PR TITLE
feat(recipes): add RTX PRO 6000 Blackwell (B40) overlays for EKS

### DIFF
--- a/pkg/recipe/conformance_test.go
+++ b/pkg/recipe/conformance_test.go
@@ -301,6 +301,144 @@ func TestConformanceRecipeInvariants(t *testing.T) {
 			wantDRAConstraint: false,
 		},
 		{
+			name: "rtx-pro-6000-eks-inference",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorRTXPro6000
+				c.Intent = CriteriaIntentInference
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+				"agentgateway-crds",
+				"agentgateway",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"inference-gateway",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+			},
+			wantDRAConstraint: false,
+		},
+		{
+			name: "rtx-pro-6000-eks-ubuntu-inference",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorRTXPro6000
+				c.OS = CriteriaOSUbuntu
+				c.Intent = CriteriaIntentInference
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+				"agentgateway-crds",
+				"agentgateway",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"inference-gateway",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+			},
+			wantDRAConstraint: false,
+		},
+		{
+			name: "rtx-pro-6000-eks-ubuntu-inference-dynamo",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorRTXPro6000
+				c.OS = CriteriaOSUbuntu
+				c.Intent = CriteriaIntentInference
+				c.Platform = CriteriaPlatformDynamo
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+				"agentgateway-crds",
+				"agentgateway",
+				"grove",
+				"dynamo-platform",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"inference-gateway",
+				"gang-scheduling",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+				"robust-controller",
+				"secure-accelerator-access",
+			},
+			wantDRAConstraint: true,
+		},
+		{
+			name: "rtx-pro-6000-eks-ubuntu-inference-nim",
+			criteria: func() *Criteria {
+				c := NewCriteria()
+				c.Service = CriteriaServiceEKS
+				c.Accelerator = CriteriaAcceleratorRTXPro6000
+				c.OS = CriteriaOSUbuntu
+				c.Intent = CriteriaIntentInference
+				c.Platform = CriteriaPlatformNIM
+				return c
+			},
+			requiredComponents: []string{
+				"cert-manager",
+				"gpu-operator",
+				"kube-prometheus-stack",
+				"prometheus-adapter",
+				"nvidia-dra-driver-gpu",
+				"kai-scheduler",
+				"agentgateway-crds",
+				"agentgateway",
+				"k8s-nim-operator",
+			},
+			requiredChecks: []string{
+				"platform-health",
+				"gpu-operator-health",
+				"dra-support",
+				"accelerator-metrics",
+				"ai-service-metrics",
+				"inference-gateway",
+				"gang-scheduling",
+				"pod-autoscaling",
+				"cluster-autoscaling",
+				"robust-controller",
+				"secure-accelerator-access",
+			},
+			wantDRAConstraint: true,
+		},
+		{
 			name: "h100-gke-cos-inference-dynamo",
 			criteria: func() *Criteria {
 				c := NewCriteria()

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -1890,6 +1890,11 @@ func TestNFDTopologyUpdater_OverlayCoverage(t *testing.T) {
 		// B200 GKE COS platform variants (GKE uses COS, no Ubuntu variant)
 		{"b200-gke-cos-training-kubeflow", criteria{CriteriaServiceGKE, CriteriaAcceleratorB200, CriteriaOSCOS, CriteriaIntentTraining, CriteriaPlatformKubeflow}, true},
 		{"b200-gke-cos-inference-dynamo", criteria{CriteriaServiceGKE, CriteriaAcceleratorB200, CriteriaOSCOS, CriteriaIntentInference, CriteriaPlatformDynamo}, true},
+		// RTX Pro 6000 EKS variants
+		{"rtx-pro-6000-eks-inference", criteria{CriteriaServiceEKS, CriteriaAcceleratorRTXPro6000, "", CriteriaIntentInference, ""}, true},
+		{"rtx-pro-6000-eks-ubuntu-inference", criteria{CriteriaServiceEKS, CriteriaAcceleratorRTXPro6000, CriteriaOSUbuntu, CriteriaIntentInference, ""}, true},
+		{"rtx-pro-6000-eks-ubuntu-inference-dynamo", criteria{CriteriaServiceEKS, CriteriaAcceleratorRTXPro6000, CriteriaOSUbuntu, CriteriaIntentInference, CriteriaPlatformDynamo}, true},
+		{"rtx-pro-6000-eks-ubuntu-inference-nim", criteria{CriteriaServiceEKS, CriteriaAcceleratorRTXPro6000, CriteriaOSUbuntu, CriteriaIntentInference, CriteriaPlatformNIM}, true},
 		// Kind-chain — TU must be OFF (KWOK/kind has no kubelet podResources socket)
 		// Intent-level kind overlays
 		{"h100-kind-training", criteria{CriteriaServiceKind, CriteriaAcceleratorH100, "", CriteriaIntentTraining, ""}, false},

--- a/recipes/overlays/rtx-pro-6000-eks-inference.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-inference.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: rtx-pro-6000-eks-inference
+
+spec:
+  # Inherits from eks-inference recipe (EKS + inference settings).
+  # Targets the AWS g7e instance family (8x RTX PRO 6000 Blackwell Server
+  # Edition; internal codename B40). The deployment-phase floor (4 checks
+  # + Deployment.gpu-operator.version >= v25.10.0) is contributed by the
+  # rtx-pro-6000-any.yaml wildcard overlay via criteria-wildcard match.
+  base: eks-inference
+
+  criteria:
+    service: eks
+    accelerator: rtx-pro-6000
+    intent: inference
+
+  # Specific constraints for RTX PRO 6000 on EKS inference workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+
+  componentRefs:
+    # RTX PRO 6000 GPU Operator dependencies
+    # Single-card inference SKU — no NVLink, no NCCL multi-node tuning needed
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - nfd
+        - cert-manager
+        - kube-prometheus-stack
+
+    - name: nfd
+      type: Helm
+      overrides:
+        topologyUpdater:
+          enable: true
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: rtx-pro-6000-eks-ubuntu-inference-dynamo
+
+spec:
+  # Inherits from rtx-pro-6000-eks-ubuntu-inference (RTX PRO 6000 + EKS + Ubuntu inference settings)
+  # Adds Dynamo inference platform components.
+  base: rtx-pro-6000-eks-ubuntu-inference
+
+  criteria:
+    service: eks
+    accelerator: rtx-pro-6000
+    os: ubuntu
+    intent: inference
+    platform: dynamo
+
+  # DRA requires Kubernetes 1.34+ (GA)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.34"
+
+  componentRefs:
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      overrides:
+        gpuResourcesEnabledOverride: true
+
+    - name: grove
+      type: Helm
+      source: oci://ghcr.io/ai-dynamo/grove
+      version: "v0.1.0-alpha.6"
+      valuesFile: components/grove/values.yaml
+
+    - name: dynamo-platform
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      version: "1.0.2"
+      valuesFile: components/dynamo-platform/values.yaml
+      dependencyRefs:
+        - grove
+        - cert-manager
+        - kube-prometheus-stack
+        - gpu-operator
+        - kai-scheduler
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # RTX PRO 6000 Blackwell needs the Blackwell-era gpu-operator floor.
+        # Match the rtx-pro-6000-any.yaml wildcard so the per-phase replace
+        # semantics keep the version pin intact.
+        - name: Deployment.gpu-operator.version
+          value: ">= v25.10.0"
+    performance:
+      checks:
+        - inference-perf
+      # Placeholder thresholds — pending empirical tuning on RTX PRO 6000
+      # Blackwell Server Edition (g7e.48xlarge, 8x). Current values are
+      # loose smoke-test floors derived from the H100 reference; tighten
+      # once reference runs are published.
+      constraints:
+        - name: inference-throughput
+          value: ">= 5000"
+        - name: inference-ttft-p99
+          value: "<= 200"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-nim.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-nim.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: rtx-pro-6000-eks-ubuntu-inference-nim
+
+spec:
+  # Inherits from rtx-pro-6000-eks-ubuntu-inference (RTX PRO 6000 + EKS + Ubuntu inference settings)
+  # Adds NVIDIA NIM Operator for managing NIM microservice deployments.
+  base: rtx-pro-6000-eks-ubuntu-inference
+
+  criteria:
+    service: eks
+    accelerator: rtx-pro-6000
+    os: ubuntu
+    intent: inference
+    platform: nim
+
+  # DRA requires Kubernetes 1.34+ (GA)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.34"
+
+  componentRefs:
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      overrides:
+        gpuResourcesEnabledOverride: true
+
+    - name: k8s-nim-operator
+      type: Helm
+      source: https://helm.ngc.nvidia.com/nvidia
+      version: "3.1.0"
+      valuesFile: components/k8s-nim-operator/values.yaml
+      dependencyRefs:
+        - cert-manager
+        - gpu-operator
+      expectedResources:
+        - kind: Deployment
+          namespace: nvidia-nim
+          name: k8s-nim-operator
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # RTX PRO 6000 Blackwell needs the Blackwell-era gpu-operator floor.
+        # Match the rtx-pro-6000-any.yaml wildcard so the per-phase replace
+        # semantics keep the version pin intact.
+        - name: Deployment.gpu-operator.version
+          value: ">= v25.10.0"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - inference-gateway
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: rtx-pro-6000-eks-ubuntu-inference
+
+spec:
+  # Inherits from rtx-pro-6000-eks-inference recipe (RTX PRO 6000 + EKS + inference settings)
+  # This overlay adds Ubuntu-specific configurations
+  base: rtx-pro-6000-eks-inference
+
+  criteria:
+    service: eks
+    accelerator: rtx-pro-6000
+    os: ubuntu
+    intent: inference
+
+  # Ubuntu OS constraints via mixin
+  mixins:
+    - os-ubuntu
+
+  # Constraints for RTX PRO 6000 on EKS with Ubuntu for inference workloads
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+
+  componentRefs: []
+
+  # Validation is inherited from rtx-pro-6000-eks-inference (not OS-specific)


### PR DESCRIPTION
## Summary

Adds the four missing EKS overlays for the `rtx-pro-6000` accelerator enum, mirroring the H100 EKS inference layout: a service-bound parent, an Ubuntu OS leaf, and Dynamo + NIM platform leaves.

## Motivation / Context

The `rtx-pro-6000` enum is declared in `pkg/recipe/criteria.go` but its only overlays today target LKE + Workstation Edition. AWS now exposes RTX PRO 6000 Blackwell as the `g7e.48xlarge` instance family (8× RTX PRO 6000 Blackwell **Server Edition**, internal codename B40), so `aicr recipe --service eks --accelerator rtx-pro-6000` had no resolvable leaf. Reference cluster: `dgxcloud/mk8s/manifests:clusters/av-teststudio-prod/av-teststudio-40-prod-1/cluster-spec.yaml` (internal GitLab) — runs gpu-operator driver `580.105.08`, CDI on, DRA off, EFA on.

Fixes: #1045
Related: #1003 (sibling L40/L40S effort), #969 (validation phase floor)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

(YAML data + two existing Go test tables extended to cover the new overlays. No production Go code changes.)

## Implementation Notes

Layout mirrors `h100-eks-ubuntu-inference{,-dynamo,-nim}.yaml`:

| New overlay | Inherits from | Validation contract |
|---|---|---|
| `rtx-pro-6000-eks-inference` | `eks-inference` | conformance declared; deployment phase inherited from `rtx-pro-6000-any.yaml` wildcard |
| `rtx-pro-6000-eks-ubuntu-inference` | `rtx-pro-6000-eks-inference` | inherits from parent + wildcard |
| `rtx-pro-6000-eks-ubuntu-inference-dynamo` | `rtx-pro-6000-eks-ubuntu-inference` | self-declares deployment + performance + conformance (Dynamo platform replaces wildcard `deployment:`) |
| `rtx-pro-6000-eks-ubuntu-inference-nim` | `rtx-pro-6000-eks-ubuntu-inference` | self-declares deployment + conformance (NIM platform replaces wildcard `deployment:`) |

Key decisions:

- **K8s version pin**: `>= 1.32.4` for the base/Ubuntu leaves (matches H100 EKS), `>= 1.34` for Dynamo/NIM leaves (DRA GA requirement, matches H100 EKS Dynamo/NIM).
- **gpu-operator floor**: `>= v25.10.0` (Blackwell-era), matching the `rtx-pro-6000-any.yaml` wildcard. Dynamo and NIM self-declare the same value so the per-phase replace semantics keep the version pin intact.
- **No `nodewright-customizations`**: matches the existing `rtx-pro-6000-lke-*` pattern. The H100 EKS overlays add this for H100-specific kernel tuning; that's not the established convention for RTX Pro 6000 single-card inference.
- **No NCCL bandwidth threshold**: single-node inference is the dominant use case, no NVLink between cards on PCIe Blackwell Server Edition.
- **Conformance check sets**: plain inference leaves use the 8-check LKE set (no gang-scheduling); Dynamo/NIM use the 11-check H100 set (adds gang-scheduling, robust-controller, secure-accelerator-access).
- **Performance phase**: Dynamo leaf has a placeholder `inference-perf` block with the same loose smoke-test thresholds as the H100 Dynamo overlay, to be tightened once reference runs are published. NIM leaf omits performance to match the H100 NIM overlay (warn-only under the phase floor; not required).
- **SKU edition**: a single `rtx-pro-6000` enum still covers both Workstation (LKE) and Server (EKS) Edition. Per #1045, splitting them into separate enum values is deferred unless an empirical floor difference forces it.
- **`knownGaps` deferred (not added here)**: `pkg/recipe/validation_phase_floor_test.go` marks performance as warn-only for inference-NIM in default mode (`AICR_VALIDATION_FLOOR_STRICT` is not set in any CI workflow today — verified via `grep`). The hygiene check at lines 337-352 fails the test if a `knownGaps` entry doesn't downgrade an actual failure, so adding an entry now for the missing NIM performance phase would be stale-flagged and break the test. This is the same trade-off the floor test itself documents (lines 64-75) for the GB200 OKE training trio. When strict mode is toggled in CI (tracked under #1003 / #969 / #1007), entries for the H100 NIM, the new RTX PRO 6000 NIM, and the OKE GB200 training leaves should land together in that PR — not piecemeal here.

## Testing

```bash
# overlay phase-floor gate (the gate referenced by #1045 and #1003)
go test -v ./pkg/recipe/... -run TestOverlayValidationPhaseFloor

# extended invariant tests (new entries for the 4 EKS RTX PRO 6000 overlays)
go test -v ./pkg/recipe/... -run "TestNFDTopologyUpdater_OverlayCoverage|TestConformanceRecipeInvariants"

# pkg/recipe race + lint
GOFLAGS="-mod=vendor" go test -race ./pkg/recipe/...
golangci-lint run -c .golangci.yaml ./pkg/recipe/...

# full gate
make qualify
```

Results:

- `TestOverlayValidationPhaseFloor` passes for all 4 new overlays (deployment phase inherited from wildcard for plain inference; self-declared for Dynamo/NIM with both halves of the gpu-operator-version gate).
- `TestNFDTopologyUpdater_OverlayCoverage` extended with 4 new entries (`rtx-pro-6000-eks-{inference,ubuntu-inference,ubuntu-inference-dynamo,ubuntu-inference-nim}`); all assert `topologyUpdater.enable=true` and pass.
- `TestConformanceRecipeInvariants` extended with the same 4 entries; resolved component counts and conformance check coverage match the H100 EKS sibling pattern (15/15/17/16 components, 8/8/11/11 conformance checks).
- `golangci-lint`: 0 issues.
- `make qualify`: all 22 chainsaw tests pass, no vulnerabilities, license headers OK, codebase qualification completed.
- Smoke test: `aicr recipe --service eks --accelerator rtx-pro-6000 --os ubuntu --intent inference --platform dynamo` resolves cleanly (17 components, 8 overlays composed).

**Coverage:** YAML data + test additions only — per CLAUDE.md the per-package coverage gate does not apply (no new production Go code). Project-wide `make test-coverage` floor (70%) still passes under `make qualify`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Pure addition of four new overlay files plus two test-table extensions. No existing recipe behavior changes; the new overlays only resolve when a user explicitly queries `--service eks --accelerator rtx-pro-6000`. Easy revert is `rm` of the four files plus reverting the two test edits.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (`TestOverlayValidationPhaseFloor` auto-enumerates; `TestNFDTopologyUpdater_OverlayCoverage` and `TestConformanceRecipeInvariants` extended explicitly to cover the 4 new EKS leaves)
- [x] I updated docs if user-facing behavior changed (no user-facing CLI/API surface changed — overlays are data, discoverable via `aicr criteria list`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
