### PR TITLE
fix(kwok): make argocd OCI repoURL per-lane (follow-up to #1047)

### DIFF
--- a/kwok/scripts/validate-scheduling.sh
+++ b/kwok/scripts/validate-scheduling.sh
@@ -756,17 +756,27 @@ generate_bundle() {
             # pass it through to `helm install --set repoURL=…` without
             # duplicating the runner→service-DNS rewrite rule.
             #
-            # Per PR #1032's contract change (and #1035's enforcement on the
-            # parent App template), --set repoURL must carry the PARENT
-            # NAMESPACE ONLY — without the per-recipe chart name. The
-            # argocd-helm parent Application appends .Chart.Name via its
-            # separate `source.chart` field; path-based child Applications
-            # append /{{ .Chart.Name }} via their template, so both halves
-            # resolve to the same artifact regardless of which Argo source
-            # type the cluster picks. The pushed artifact lives at
-            # oci://…/aicr/<recipe>:<tag>; the recipe segment is the chart
-            # name, which Argo appends itself.
-            OCI_IN_CLUSTER_REF="oci://registry.aicr-registry.svc.cluster.local:5000/aicr"
+            # Per-lane assignment — the two lanes resolve the in-cluster
+            # OCI URL differently:
+            #
+            #   - argocd-oci: the bundle's `nvidia-stack` root application
+            #     references the artifact by its full path. Pass the full
+            #     "aicr/<recipe>" form here so `--repo` and the root app's
+            #     `repoURL` both match the pushed artifact at
+            #     oci://…/aicr/<recipe>:<tag>.
+            #
+            #   - argocd-helm-oci: per PR #1032's contract change (and
+            #     #1035's enforcement on the parent App template), --set
+            #     repoURL must carry the PARENT NAMESPACE ONLY — without
+            #     the per-recipe chart name. The argocd-helm parent
+            #     Application appends .Chart.Name via its separate
+            #     `source.chart` field; passing the full path here would
+            #     resolve to oci://…/aicr/<recipe>/<recipe>:<tag> and 404.
+            if [[ "$DEPLOYER" == "argocd-helm-oci" ]]; then
+                OCI_IN_CLUSTER_REF="oci://registry.aicr-registry.svc.cluster.local:5000/aicr"
+            else
+                OCI_IN_CLUSTER_REF="oci://registry.aicr-registry.svc.cluster.local:5000/aicr/${recipe}"
+            fi
             local in_cluster_repo="$OCI_IN_CLUSTER_REF"
 
             # Map our deployer-matrix name to aicr's --deployer value.
@@ -774,7 +784,11 @@ generate_bundle() {
             [[ "$DEPLOYER" == "argocd-helm-oci" ]] && deployer_arg="argocd-helm"
 
             log_info "Bundling for ${deployer_arg}, pushing to ${OCI_REF}"
-            log_info "Argo CD will pull from ${in_cluster_repo}/${recipe}:${tag} (parent namespace + .Chart.Name appended by the parent App)"
+            if [[ "$DEPLOYER" == "argocd-helm-oci" ]]; then
+                log_info "Argo CD will pull from ${in_cluster_repo}/${recipe}:${tag} (parent namespace + .Chart.Name appended by the parent App)"
+            else
+                log_info "Argo CD will pull from ${in_cluster_repo}:${tag}"
+            fi
             # When --output is an oci:// reference, `aicr bundle` writes the
             # local bundle to ./bundle (relative to CWD) — there's no way to
             # redirect it to an absolute path. cd into WORK_DIR so the local


### PR DESCRIPTION
## Summary

Follow-up to #1047 — restore the per-recipe segment for the `argocd-oci` lane, which was incorrectly stripped together with `argocd-helm-oci`.

## Motivation / Context

PR #1047 fixed the `argocd-helm-oci` repoURL contract (PR #1032 / #1035) by removing the per-recipe segment from `OCI_IN_CLUSTER_REF`. But the assignment lives inside the shared `argocd-oci|argocd-helm-oci)` case branch ([line 722](https://github.com/NVIDIA/aicr/blob/main/kwok/scripts/validate-scheduling.sh#L722)), so the change applied to **both** lanes. Codex flagged this on the post-merge review:

- `argocd-helm-oci` (intended target): parent App template appends `.Chart.Name` itself → parent-only repoURL is correct → currently green.
- `argocd-oci` (collateral damage): root `nvidia-stack` app references the artifact by full path → it now tries `oci://…/aicr:<tag>`, but the artifact lives at `oci://…/aicr/<recipe>:<tag>` → 404.

This PR makes the assignment per-lane:

```bash
if [[ "$DEPLOYER" == "argocd-helm-oci" ]]; then
    OCI_IN_CLUSTER_REF="oci://registry.aicr-registry.svc.cluster.local:5000/aicr"
else
    OCI_IN_CLUSTER_REF="oci://registry.aicr-registry.svc.cluster.local:5000/aicr/${recipe}"
fi
```

The `log_info` line at 777 is split per-lane too so each prints the URL it will actually dereference.

Fixes: N/A (no dedicated tracking issue)
Related: #1047, #1032, #1035

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: KWOK deployer matrix test wrapper (`kwok/scripts/validate-scheduling.sh`)

## Implementation Notes

Matches the existing per-lane conditional pattern in the same branch:

- Line 742: `[[ "$DEPLOYER" == "argocd-helm-oci" ]]` → adjust tag format
- Line 763: `[[ "$DEPLOYER" == "argocd-helm-oci" ]] && deployer_arg="argocd-helm"` → adjust deployer arg
- **New (this PR)**: `[[ "$DEPLOYER" == "argocd-helm-oci" ]]` → adjust in-cluster repoURL form

The explanatory comment block is replaced with a per-lane explanation citing both contracts.

The `flux-oci` branch at line ~844 is untouched (still `aicr/${recipe}`) — Flux deploys via OCIRepository CR with the full path baked in, doesn't go through any `repoURL` template indirection.

## Testing

```bash
bash -n kwok/scripts/validate-scheduling.sh   # pass
shellcheck kwok/scripts/validate-scheduling.sh # only pre-existing SC1091 info on line 101
```

Both pass. **Full `make qualify` was skipped** because this is an infra-only change to a CI shell script — Go tests, e2e, vulnerability scan, and yamllint cannot regress from a bash conditional. Per `CLAUDE.local.md`'s doc-only/infra-only carve-out, scoped checks are the appropriate gate here.

CI itself is the real validation: after this lands and PRs rebase onto main, both `argocd-oci` and `argocd-helm-oci` Tier-1 matrix jobs should be green.

## Risk Assessment

- [x] **Low** — Tightly scoped follow-up to #1047. The diff replaces a single unconditional assignment with a per-lane conditional that exactly restores pre-#1047 behavior on `argocd-oci`. Easy revert.

**Rollout notes:** No runtime impact. After merge, every open PR's `argocd-oci` Tier-1 jobs should clear; `argocd-helm-oci` jobs continue passing (the PR #1047 fix is preserved).

## Checklist

- [x] Tests pass locally (`bash -n` + `shellcheck` — infra-only change, full `make qualify` not applicable)
- [x] Linter passes (shellcheck, no new warnings)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (N/A — contract realignment)
- [ ] I updated docs if user-facing behavior changed (N/A — CI internal)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
