### PR TITLE
feat(recipe): add bcm service type with overlays

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -113,7 +113,7 @@ body:
       placeholder: |
         - AICR version (CLI `aicr version`, API image tag, or commit SHA):
         - Install method (release binary / build from source / container image):
-        - Platform (eks/gke/aks/oke/kind/lke/other):
+        - Platform (eks/gke/aks/oke/kind/lke/bcm/other):
         - Kubernetes version:
         - OS (ubuntu/cos/other) + version:
         - Kernel version:
@@ -122,7 +122,7 @@ body:
       value: |
         - AICR version (CLI `aicr version`, API image tag, or commit SHA):
         - Install method (release binary / build from source / container image):
-        - Platform (eks/gke/aks/oke/kind/lke/other):
+        - Platform (eks/gke/aks/oke/kind/lke/bcm/other):
         - Kubernetes version:
         - OS (ubuntu/cos/other) + version:
         - Kernel version:

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -112,7 +112,7 @@ paths:
           description: Kubernetes service/environment type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [eks, gke, aks, oke, kind, lke, any]
+            enum: [eks, gke, aks, oke, kind, lke, bcm, any]
             default: any
         - name: accelerator
           in: query
@@ -479,7 +479,7 @@ paths:
           description: Kubernetes service/environment type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [eks, gke, aks, oke, kind, lke, any]
+            enum: [eks, gke, aks, oke, kind, lke, bcm, any]
             default: any
         - name: accelerator
           in: query
@@ -1257,7 +1257,7 @@ components:
         service:
           type: string
           description: Kubernetes service type
-          enum: [eks, gke, aks, oke, kind, lke, any]
+          enum: [eks, gke, aks, oke, kind, lke, bcm, any]
           example: eks
         accelerator:
           type: string

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ NVIDIA AI Cluster Runtime (AICR) is a suite of tooling designed to automate the 
 |------|-------------|
 | **Snapshot** | A captured state of a system including OS, kernel, Kubernetes, GPU, and SystemD configuration. Created by `aicr snapshot` or the Kubernetes agent. |
 | **Recipe** | A generated configuration recommendation containing component references, constraints, and deployment order. Created by `aicr recipe` based on criteria or snapshot analysis. |
-| **Criteria** | Query parameters that define the target environment: `service` (eks/gke/aks/oke/kind/lke), `accelerator` (h100/gb200/b200/a100/l40/rtx-pro-6000), `intent` (training/inference), `os` (ubuntu/rhel/cos/amazonlinux/talos), `platform` (dynamo, kubeflow, nim, runai, slurm), and `nodes`. |
+| **Criteria** | Query parameters that define the target environment: `service` (eks/gke/aks/oke/kind/lke/bcm), `accelerator` (h100/gb200/b200/a100/l40/rtx-pro-6000), `intent` (training/inference), `os` (ubuntu/rhel/cos/amazonlinux/talos), `platform` (dynamo, kubeflow, nim, runai, slurm), and `nodes`. |
 | **Overlay** | A recipe metadata file that extends the base recipe for specific environments. Overlays are matched against criteria using asymmetric matching. |
 | **Mixin** | A composable recipe fragment (`kind: RecipeMixin`) that carries only `constraints` and `componentRefs`. Mixins live in `recipes/mixins/`, are excluded from overlay discovery, and are referenced by leaf overlays via `spec.mixins` to share orthogonal content (e.g., OS constraints, platform components) without duplication. See [ADR-005](design/005-overlay-refactoring.md). |
 | **Bundle** | Deployment artifacts generated from a recipe: Helm values files, Kubernetes manifests, installation scripts, and checksums. |

--- a/docs/contributor/api-server-extending.md
+++ b/docs/contributor/api-server-extending.md
@@ -1088,7 +1088,7 @@ type RecipeRequest struct {
     OS       string `validate:"required,oneof=ubuntu rhel cos"`
     OSVersion string `validate:"omitempty,semver"`
     GPU      string `validate:"required,oneof=h100 gb200 b200 a100 l40 rtx-pro-6000"`
-    Service  string `validate:"omitempty,oneof=eks gke aks oke kind lke"`
+    Service  string `validate:"omitempty,oneof=eks gke aks oke kind lke bcm"`
 }
 
 func handleRecipe(w http.ResponseWriter, r *http.Request) {

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -262,7 +262,7 @@ Supported content types:
 
 | Parameter | Type | Validation | Example |
 |-----------|------|------------|--------|
-| `service` | ServiceType | Enum: eks, gke, aks, oke, kind, lke, any | `service=eks` |
+| `service` | ServiceType | Enum: eks, gke, aks, oke, kind, lke, bcm, any | `service=eks` |
 | `accelerator` | AcceleratorType | Enum: h100, gb200, b200, a100, l40, rtx-pro-6000, any | `accelerator=h100` |
 | `gpu` | AcceleratorType | Alias for accelerator | `gpu=h100` |
 | `intent` | IntentType | Enum: training, inference, any | `intent=training` |

--- a/docs/contributor/cli.md
+++ b/docs/contributor/cli.md
@@ -1703,7 +1703,7 @@ mkdir -p "$OUTPUT_DIR"
 GPU_TYPES=("h100" "gb200" "b200" "a100" "l40" "rtx-pro-6000")
 
 # Kubernetes services
-K8S_SERVICES=("eks" "gke" "aks" "oke" "kind" "lke")
+K8S_SERVICES=("eks" "gke" "aks" "oke" "kind" "lke" "bcm")
 
 # OS distributions
 OS_TYPES=("ubuntu" "rhel" "cos")

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -123,7 +123,7 @@ Criteria define when a recipe matches a user query:
 
 | Field | Type | Description | Example Values |
 |-------|------|-------------|----------------|
-| `service` | String | Kubernetes platform | `eks`, `gke`, `aks`, `oke`, `kind`, `lke` |
+| `service` | String | Kubernetes platform | `eks`, `gke`, `aks`, `oke`, `kind`, `lke`, `bcm` |
 | `accelerator` | String | GPU hardware type | `h100`, `gb200`, `b200`, `a100`, `l40`, `rtx-pro-6000` |
 | `os` | String | Operating system | `ubuntu`, `rhel`, `cos`, `amazonlinux` |
 | `intent` | String | Workload purpose | `training`, `inference` |
@@ -790,7 +790,7 @@ treats those as "unknown" rather than fabricating a match.
 ```yaml
 fingerprint:
   service:
-    value: eks                       # eks | gke | aks | oke | kind | lke
+    value: eks                       # eks | gke | aks | oke | kind | lke | bcm
     source: k8s.node.provider
   accelerator:
     value: h100                      # h100 | gb200 | b200 | a100 | l40 | rtx-pro-6000

--- a/docs/contributor/validations.md
+++ b/docs/contributor/validations.md
@@ -93,7 +93,7 @@ conditions:
 
 **Supported Condition Keys:**
 - `intent`: Workload intent (training, inference)
-- `service`: Kubernetes service (eks, gke, aks, oke, kind, lke)
+- `service`: Kubernetes service (eks, gke, aks, oke, kind, lke, bcm)
 - `accelerator`: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000)
 - `os`: Operating system (ubuntu, rhel, cos, amazonlinux, talos)
 - `platform`: Platform/framework (dynamo, kubeflow, nim, runai, slurm)

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -116,7 +116,7 @@ Generate an optimized configuration recipe based on environment parameters.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `service` | string | any | K8s service: `eks`, `gke`, `aks`, `oke`, `kind`, `lke`, `any` |
+| `service` | string | any | K8s service: `eks`, `gke`, `aks`, `oke`, `kind`, `lke`, `bcm`, `any` |
 | `accelerator` | string | any | GPU type: `h100`, `gb200`, `b200`, `a100`, `l40`, `rtx-pro-6000`, `any` |
 | `gpu` | string | any | Alias for `accelerator` |
 | `intent` | string | any | Workload: `training`, `inference`, `any` |

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -378,7 +378,7 @@ Generate recipes using direct system parameters:
 **Flags:**
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
-| `--service` | | string | K8s service: eks, gke, aks, oke, kind, lke |
+| `--service` | | string | K8s service: eks, gke, aks, oke, kind, lke, bcm |
 | `--accelerator` | `--gpu` | string | Accelerator/GPU type: h100, gb200, b200, a100, l40, rtx-pro-6000 |
 | `--intent` | | string | Workload intent: training, inference |
 | `--os` | | string | OS family: ubuntu, rhel, cos, amazonlinux, talos |

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -154,7 +154,7 @@ _No images extracted._
 
 ### network-operator
 
-- `busybox:1.37@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e`
+- `busybox:1.37@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`
 - `nvcr.io/nvidia/cloud-native/network-operator:v26.1.1`
 - `nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host`
 - `nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2`

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -64,7 +64,7 @@
 // # Query Parameters (GET /v1/recipe)
 //
 // The /v1/recipe endpoint accepts these query parameters for GET requests:
-//   - service: Kubernetes service (eks, gke, aks, oke, kind, lke, any)
+//   - service: Kubernetes service (eks, gke, aks, oke, kind, lke, bcm, any)
 //   - accelerator: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000, any)
 //   - gpu: Alias for accelerator (back-compat)
 //   - intent: Workload intent (training, inference, any)

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -99,7 +99,7 @@ func recipeCmd() *cli.Command {
 		Category: functionalCategoryName,
 		Usage:    "Create optimized recipe for given intent and environment parameters.",
 		Description: `Generate configuration recipe based on specified environment parameters including:
-  - Kubernetes service type (e.g. eks, gke, aks, oke, kind, lke)
+  - Kubernetes service type (e.g. eks, gke, aks, oke, kind, lke, bcm)
   - Accelerator type (e.g. h100, gb200, b200, a100, l40, rtx-pro-6000)
   - Workload intent (e.g. training, inference)
   - GPU node operating system (e.g. ubuntu, rhel, cos, amazonlinux, talos)

--- a/pkg/fingerprint/doc.go
+++ b/pkg/fingerprint/doc.go
@@ -17,7 +17,7 @@
 // criteria.
 //
 // A Fingerprint records the cluster-identity dimensions used to bind
-// a snapshot to a recipe — service (eks/gke/aks/oke/kind/lke),
+// a snapshot to a recipe — service (eks/gke/aks/oke/kind/lke/bcm),
 // accelerator (h100/gb200/b200/a100/l40/rtx-pro-6000), OS
 // (ubuntu/rhel/cos/amazonlinux/talos plus raw VERSION_ID), Kubernetes
 // server version, region, total node count, and GPU node count. Each

--- a/pkg/fingerprint/types.go
+++ b/pkg/fingerprint/types.go
@@ -66,7 +66,7 @@ type OSDimension struct {
 // criteria matched the cluster on which validate ran.
 type Fingerprint struct {
 	// Service is the Kubernetes service / cloud platform
-	// (eks, gke, aks, oke, kind, lke). Sourced from
+	// (eks, gke, aks, oke, kind, lke, bcm). Sourced from
 	// k8s.node.provider (parsed from spec.providerID).
 	Service Dimension `json:"service" yaml:"service"`
 

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -53,6 +53,7 @@ const (
 	CriteriaServiceOKE  CriteriaServiceType = "oke"
 	CriteriaServiceKind CriteriaServiceType = "kind"
 	CriteriaServiceLKE  CriteriaServiceType = "lke"
+	CriteriaServiceBCM  CriteriaServiceType = "bcm"
 )
 
 // ParseCriteriaServiceType parses a string into a CriteriaServiceType.
@@ -79,6 +80,8 @@ func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
 		return CriteriaServiceKind, nil
 	case "lke":
 		return CriteriaServiceLKE, nil
+	case "bcm":
+		return CriteriaServiceBCM, nil
 	default:
 		if DefaultRegistry().Has(FieldService, s) {
 			return CriteriaServiceType(normalizeCriteriaValue(s)), nil
@@ -92,7 +95,7 @@ func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
 // across `--data` configurations; for the union of static + registry
 // (including values contributed by `--data`), use AllCriteriaServiceTypes.
 func GetCriteriaServiceTypes() []string {
-	return []string{"aks", "eks", "gke", "kind", "lke", "oke"}
+	return []string{"aks", "bcm", "eks", "gke", "kind", "lke", "oke"}
 }
 
 // AllCriteriaServiceTypes returns the union of the static OSS list and
@@ -341,7 +344,7 @@ func mergeCriteriaTypes(staticTypes, registered []string) []string {
 // Criteria represents the input parameters for recipe matching.
 // All fields are optional and default to "any" if not specified.
 type Criteria struct {
-	// Service is the Kubernetes service type (eks, gke, aks, oke, kind, lke).
+	// Service is the Kubernetes service type (eks, gke, aks, oke, kind, lke, bcm).
 	Service CriteriaServiceType `json:"service,omitempty" yaml:"service,omitempty"`
 
 	// Accelerator is the GPU/accelerator type (h100, gb200, b200, a100, l40, rtx-pro-6000).

--- a/pkg/recipe/criteria_registry_parse_test.go
+++ b/pkg/recipe/criteria_registry_parse_test.go
@@ -165,7 +165,7 @@ func TestAllCriteriaServiceTypes_UnionWithRegistry(t *testing.T) {
 		DefaultRegistry().Register(FieldService, "ncp-x", OriginExternal)
 		DefaultRegistry().Register(FieldService, "eks", OriginExternal) // already in static — must dedupe
 		got := AllCriteriaServiceTypes()
-		want := []string{"aks", "eks", "gke", "kind", "lke", "ncp-x", "oke"}
+		want := []string{"aks", "bcm", "eks", "gke", "kind", "lke", "ncp-x", "oke"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("AllCriteriaServiceTypes = %v, want %v", got, want)
 		}

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -39,6 +39,8 @@ func TestParseCriteriaServiceType(t *testing.T) {
 		{"oke", "oke", CriteriaServiceOKE, false},
 		{"lke", "lke", CriteriaServiceLKE, false},
 		{"LKE uppercase", "LKE", CriteriaServiceLKE, false},
+		{"bcm", "bcm", CriteriaServiceBCM, false},
+		{"BCM uppercase", "BCM", CriteriaServiceBCM, false},
 		{"self-managed", "self-managed", CriteriaServiceAny, false},
 		{"self", "self", CriteriaServiceAny, false},
 		{"vanilla", "vanilla", CriteriaServiceAny, false},
@@ -699,7 +701,7 @@ func TestGetCriteriaServiceTypes(t *testing.T) {
 	types := GetCriteriaServiceTypes()
 
 	// Should return sorted list
-	expected := []string{"aks", "eks", "gke", "kind", "lke", "oke"}
+	expected := []string{"aks", "bcm", "eks", "gke", "kind", "lke", "oke"}
 	if len(types) != len(expected) {
 		t.Errorf("GetCriteriaServiceTypes() returned %d types, want %d", len(types), len(expected))
 	}

--- a/pkg/recipe/doc.go
+++ b/pkg/recipe/doc.go
@@ -67,6 +67,7 @@
 //   - CriteriaServiceOKE: Oracle OKE
 //   - CriteriaServiceKind: kind (local clusters)
 //   - CriteriaServiceLKE: Linode LKE
+//   - CriteriaServiceBCM: NVIDIA Base Command Manager
 //   - CriteriaServiceAny: Any service (wildcard)
 //
 // Accelerator types for GPU selection:

--- a/pkg/recipe/doc.go
+++ b/pkg/recipe/doc.go
@@ -25,7 +25,7 @@
 // Criteria: Specifies target deployment parameters
 //
 //	type Criteria struct {
-//	    Service     CriteriaServiceType     // eks, gke, aks, oke, kind, lke, any
+//	    Service     CriteriaServiceType     // eks, gke, aks, oke, kind, lke, bcm, any
 //	    Accelerator CriteriaAcceleratorType // h100, gb200, b200, a100, l40, rtx-pro-6000, any
 //	    Intent      CriteriaIntentType      // training, inference, any
 //	    OS          CriteriaOSType          // ubuntu, rhel, cos, amazonlinux, talos, any
@@ -175,7 +175,7 @@
 // # Query Parameters (HTTP API - GET)
 //
 // The HTTP handler accepts these query parameters for GET requests:
-//   - service: eks, gke, aks, oke, kind, lke, any (default: any)
+//   - service: eks, gke, aks, oke, kind, lke, bcm, any (default: any)
 //   - accelerator: h100, gb200, b200, a100, l40, rtx-pro-6000, any (default: any)
 //   - gpu: alias for accelerator (backwards compatibility)
 //   - intent: training, inference, any (default: any)

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -69,7 +69,7 @@
 //	  - os: ubuntu, cos, any (default: any)
 //	  - osv: OS version (e.g., 24.04, 22.04)
 //	  - kernel: kernel version (e.g., 6.8, 5.15.0)
-//	  - service: eks, gke, aks, oke, kind, lke, any (default: any)
+//	  - service: eks, gke, aks, oke, kind, lke, bcm, any (default: any)
 //	  - k8s: Kubernetes version (e.g., 1.33, 1.32)
 //	  - gpu: h100, gb200, b200, a100, l40, rtx-pro-6000, any (default: any)
 //	  - intent: training, inference, any (default: any)

--- a/recipes/overlays/bcm-inference.yaml
+++ b/recipes/overlays/bcm-inference.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: bcm-inference
+
+spec:
+  # Inherits from bcm recipe (BCM-specific settings)
+  base: bcm
+
+  criteria:
+    service: bcm
+    intent: inference
+
+  # Inference gateway components via mixin
+  mixins:
+    - platform-inference
+
+  componentRefs: []

--- a/recipes/overlays/bcm-training.yaml
+++ b/recipes/overlays/bcm-training.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: bcm-training
+
+spec:
+  # Inherits from bcm recipe (BCM-specific settings)
+  base: bcm
+
+  criteria:
+    service: bcm
+    intent: training
+
+  componentRefs: []

--- a/recipes/overlays/bcm.yaml
+++ b/recipes/overlays/bcm.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: bcm
+
+spec:
+  # Inherits from base (implicit when spec.base is empty).
+  # BCM 11.x (`cm-kubernetes-setup`) provisions only the base platform —
+  # Kubernetes control plane, CNI (tigera-operator/calico by default), DNS,
+  # and MetalLB. The NVIDIA runtime stack (GPU Operator, NFD, cert-manager,
+  # Prometheus, nvsentinel, DRA driver, etc.) is delivered by AICR via
+  # base.yaml and applied with the `helmfile` deployer
+  # (`aicr bundle -r recipe.yaml --deployer helmfile -o ./bundles`).
+
+  criteria:
+    service: bcm
+
+  # BCM-specific constraints
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.34"
+
+  # BCM-specific component overrides.
+  # BCM uses `node-role.kubernetes.io/master` for the control-plane label
+  # in addition to the upstream `node-role.kubernetes.io/control-plane`,
+  # and ships `local-path` as the default StorageClass.
+  componentRefs:
+    # Persist Prometheus on the BCM-provisioned local-path StorageClass.
+    - name: kube-prometheus-stack
+      type: Helm
+      overrides:
+        prometheus:
+          prometheusSpec:
+            storageSpec:
+              emptyDir: null
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  storageClassName: local-path
+                  resources:
+                    requests:
+                      storage: 50Gi
+
+    # Tolerate the BCM `master` label so control-plane workloads that
+    # already tolerate `control-plane` schedule on BCM masters as well.
+    - name: nvidia-dra-driver-gpu
+      type: Helm
+      overrides:
+        controller:
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+              operator: Exists
+
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics

--- a/recipes/overlays/h100-bcm-training.yaml
+++ b/recipes/overlays/h100-bcm-training.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-bcm-training
+
+spec:
+  # Inherits from bcm-training recipe (BCM + training settings)
+  base: bcm-training
+
+  criteria:
+    service: bcm
+    accelerator: h100
+    intent: training
+
+  componentRefs:
+    # H100-specific GPU Operator overrides
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - nfd
+        - cert-manager
+        - kube-prometheus-stack
+      overrides:
+        cdi:
+          enabled: true
+        gdrcopy:
+          enabled: true
+
+    - name: nfd
+      type: Helm
+      overrides:
+        topologyUpdater:
+          enable: true
+
+  # Validation checks for H100 on BCM training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics

--- a/recipes/overlays/h100-bcm-ubuntu-training.yaml
+++ b/recipes/overlays/h100-bcm-ubuntu-training.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-bcm-ubuntu-training
+
+spec:
+  # Inherits from h100-bcm-training recipe (H100 + BCM + training settings).
+  # This overlay adds Ubuntu-specific configurations.
+  base: h100-bcm-training
+
+  criteria:
+    service: bcm
+    accelerator: h100
+    os: ubuntu
+    intent: training
+
+  # Ubuntu OS constraints via mixin (defined once in recipes/mixins/os-ubuntu.yaml)
+  mixins:
+    - os-ubuntu
+
+  componentRefs: []
+
+  # Validation is inherited from h100-bcm-training (not OS-specific)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -840,7 +840,7 @@ func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType s
 				{Operator: v1.TolerationOpExists},
 				{Key: "nvidia.com/gpu", Operator: v1.TolerationOpEqual, Value: "present", Effect: v1.TaintEffectNoSchedule},
 			}
-	case recipe.CriteriaServiceAny, recipe.CriteriaServiceAKS, recipe.CriteriaServiceOKE, recipe.CriteriaServiceKind, recipe.CriteriaServiceLKE:
+	case recipe.CriteriaServiceAny, recipe.CriteriaServiceAKS, recipe.CriteriaServiceOKE, recipe.CriteriaServiceKind, recipe.CriteriaServiceLKE, recipe.CriteriaServiceBCM:
 		return nil, nil
 	default:
 		return nil, nil


### PR DESCRIPTION
## Summary

Adds NVIDIA Base Command Manager (BCM) as a first-class `service` value with a `bcm` overlay tree (training + inference, plus an H100 + Ubuntu leaf) so operators can generate validated Helmfile bundles for BCM-managed clusters.

## Motivation / Context

BCM 11.x (`cm-kubernetes-setup`) provisions only the base Kubernetes platform — control plane, CNI, DNS, MetalLB. The NVIDIA runtime stack (GPU Operator, NFD, cert-manager, Prometheus, nvsentinel, DRA driver, etc.) is delivered by AICR via `base.yaml` and applied with the `helmfile` deployer. Argo CD support is a planned follow-up.

Fixes: #1059
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`) — OpenAPI enum
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`pkg/validator`) — exhaustive switch in `validators/performance`
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `CriteriaServiceBCM = "bcm"` added with parser case, alphabetical insertion into `GetCriteriaServiceTypes`, and matching test coverage (`TestParseCriteriaServiceType`, `TestGetCriteriaServiceTypes`, `TestAllCriteriaServiceTypes_UnionWithRegistry`).
- `recipes/overlays/bcm.yaml` inherits `base`, sets `K8s.server.version >= 1.34`, persists `kube-prometheus-stack` on the `local-path` StorageClass (BCM default), and adds `node-role.kubernetes.io/master` tolerations on `nvidia-dra-driver-gpu` so DRA workloads schedule on BCM masters in addition to upstream `control-plane`.
- Intent (`bcm-training`, `bcm-inference`) and leaf (`h100-bcm-training`, `h100-bcm-ubuntu-training`) overlays follow the EKS pattern; `os-ubuntu` mixin is reused.
- `validators/performance/nccl_all_reduce_bw_constraint.go` — added `CriteriaServiceBCM` to the existing `case` that returns `nil, nil` (BCM has no cloud-specific worker scheduling); required by the `exhaustive` lint rule.
- Docs updated per the `CLAUDE.md` enum-audit checklist: `docs/README.md` glossary, `docs/user/{cli,api}-reference.md`, `docs/contributor/{api-server,api-server-extending,cli,data,validations}.md`, OpenAPI enum blocks (3 sites), bug-report issue template, package godoc, and the `aicr recipe` CLI help.
- `docs/user/container-images.md` regenerated via `make bom-docs`; picked up upstream `busybox:1.37` digest drift in the network-operator chart (unrelated to BCM but caught by the regen — committed in the same PR per `CLAUDE.md`).

## Testing

```bash
unset GITLAB_TOKEN && make qualify
```

Result: passes — total coverage 77.1% (threshold 75%), all chainsaw E2E tests pass (22/22), vulnerability scan clean, license headers OK.

Per-package coverage on changed packages (vs `origin/main` baseline):
- `pkg/recipe`: 91.5% (no change)
- `pkg/cli`: 65.2% (no change)
- `validators/performance`: 28.0% (no change — added single case label only)

## Risk Assessment

- [x] **Low** — Additive: new enum value, new overlay files, single switch-case extension. No changes to existing recipes or service types.

**Rollout notes:** None. Backwards compatible.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)