### PR TITLE
fix(kwok): require Succeeded operationState in argocd sync gate

### DIFF
--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -21,6 +21,7 @@ on:
     paths:
       - 'recipes/**'
       - 'kwok/**'
+      - 'tests/chainsaw/kwok/**'
       - '.github/workflows/kwok-recipes.yaml'
       - '.github/actions/kwok-test/**'
       - '!**.md'
@@ -30,6 +31,7 @@ on:
     paths:
       - 'recipes/**'
       - 'kwok/**'
+      - 'tests/chainsaw/kwok/**'
       - '.github/workflows/kwok-recipes.yaml'
       - '.github/actions/kwok-test/**'
       - '!**.md'

--- a/tests/chainsaw/kwok/argocd-sync/chainsaw-test.yaml
+++ b/tests/chainsaw/kwok/argocd-sync/chainsaw-test.yaml
@@ -114,12 +114,25 @@ spec:
                 # The 4-arm OR is encoded as a single JMESPath expression
                 # because YAML doesn't accept multi-line mapping keys.
                 # Field paths are relative to `status:` here (e.g.,
-                # `sync.status` not `status.sync.status`). Arms:
-                #   1. Synced + Healthy                                — canonical pass
-                #   2. Synced + Progressing                            — KWOK pod-readiness sim gap (ADR-008)
-                #   3. OutOfSync + Healthy + op.phase == 'Succeeded'   — operator mutation (ClusterPolicy, DeviceClass)
-                #   4. Synced + Degraded + op.phase == 'Succeeded'     — health controller divergence after a successful op
-                ((sync.status == 'Synced' && health.status == 'Healthy') || (sync.status == 'Synced' && health.status == 'Progressing') || (sync.status == 'OutOfSync' && health.status == 'Healthy' && operationState.phase == 'Succeeded') || (sync.status == 'Synced' && health.status == 'Degraded' && operationState.phase == 'Succeeded')): true
+                # `sync.status` not `status.sync.status`). All four arms
+                # require `operationState.phase == 'Succeeded'` so that
+                # an Application can only count as passing AFTER Argo
+                # CD has completed at least one sync operation. For an
+                # App-of-Apps, that's the gate ensuring the child
+                # Applications have been materialized before the
+                # selector's "every Application in argocd ns" sweep
+                # accepts the root alone — otherwise the assertion
+                # races ahead and passes on the root's transient
+                # Synced state, returning before children even exist.
+                # See #1061 (and #1050 for the migration that
+                # introduced the race).
+                #
+                # Arms:
+                #   1. Synced + Healthy        — canonical pass
+                #   2. Synced + Progressing    — KWOK pod-readiness sim gap (ADR-008)
+                #   3. OutOfSync + Healthy     — operator mutation (ClusterPolicy, DeviceClass)
+                #   4. Synced + Degraded       — health controller divergence after a successful op
+                (operationState.phase == 'Succeeded' && ((sync.status == 'Synced' && health.status == 'Healthy') || (sync.status == 'Synced' && health.status == 'Progressing') || (sync.status == 'OutOfSync' && health.status == 'Healthy') || (sync.status == 'Synced' && health.status == 'Degraded'))): true
       catch:
         - script:
             content: |


### PR DESCRIPTION
## Summary

Tighten the argocd-* KWOK chainsaw sync gate so all four arms of the pass-state predicate require `operationState.phase == 'Succeeded'`. Removes a race in which the assertion could PASS within ~4-5 s of `helm install` — before Argo CD had completed its initial App-of-Apps sync and created the child Applications.

Also add `tests/chainsaw/kwok/**` to the `KWOK Cluster Validation` workflow path filters so the scenarios actually re-run on edit (per Codex review of the first push).

## Motivation / Context

The chainsaw assertion at `tests/chainsaw/kwok/argocd-sync/chainsaw-test.yaml` says "every `Application` in the argocd namespace must satisfy the pass predicate." Right after `helm install` of an argocd-helm-oci bundle, the **only** Application present is the root App-of-Apps. The controller can briefly set the root's `sync.status=Synced` (manifest matches cluster) before running the sync operation that creates the children. In that window the assertion sees a single matching Application that satisfies arm 1 or arm 2 and returns PASS — children haven't been created yet, so they aren't in the match set.

Pre-#1050, the bash `wait_for_argocd_sync` loop avoided the race accidentally: its polling overhead took long enough that children materialized between iterations and joined the pass-check by the time it re-listed.

**Evidence the race is real** (issue #1061 has the full table):

| Run | SHA | Outcome |
|---|---|---|
| `26523455927` (initial) | `8b5ef744` | ❌ |
| `26523455927` (re-run) | `8b5ef744` (same) | ✅ |

Same commit, different result — textbook race-condition signature. Per-job failure rate is low (~1-3%), but with 68 parallel Tier 1 jobs the workflow surfaces it on a meaningful fraction of runs, costing CI minutes and re-runs.

Fixes: #1061
Related: #1050 (the chainsaw migration that introduced the race), #962 (the parent tracking issue)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling (`.github/workflows/kwok-recipes.yaml` path filter expansion)

## Component(s) Affected

- [x] Other: KWOK CI scenarios (`tests/chainsaw/kwok/argocd-sync/`) and workflow path filters

## Implementation Notes

**Predicate change.** The JMESPath OR previously required `operationState.phase == 'Succeeded'` only on arms 3 and 4 (the relaxations for operator mutation and health-controller divergence). Arms 1 and 2 (`Synced + Healthy` / `Synced + Progressing`) could match purely on `sync.status` + `health.status`, which is what the App-of-Apps root briefly satisfies before its sync operation runs. Moving the `operationState.phase` guard out as a conjunct that gates all four arms ensures an Application only passes after Argo CD has completed at least one sync operation.

```yaml
# Before — only arms 3, 4 required Succeeded
((Synced && Healthy) || (Synced && Progressing) || (OutOfSync && Healthy && Succeeded) || (Synced && Degraded && Succeeded)): true

# After — all four arms require Succeeded
(Succeeded && ((Synced && Healthy) || (Synced && Progressing) || (OutOfSync && Healthy) || (Synced && Degraded))): true
```

**Why this isn't too strict.** Within the existing 5-minute assertion timeout, Argo CD's automated sync completes well within the budget (typical KWOK convergence: 30-90 s including child sync). The four sync/health combinations the old bash gate accepted remain valid; only the "pre-sync transient" window is now rejected.

**Workflow path filter.** `.github/workflows/kwok-recipes.yaml` previously gated KWOK on `recipes/**`, `kwok/**`, the workflow file, and `.github/actions/kwok-test/**`. PR #1050 introduced `tests/chainsaw/kwok/` as the new home for the migrated argocd / flux chainsaw scenarios, but didn't expand the filter — so edits to the scenarios silently skipped KWOK CI. The first push of this PR exhibited the symptom (0 KWOK jobs scheduled, caught by Codex review). Added `tests/chainsaw/kwok/**` to both `push.paths` and `pull_request.paths`.

**Flux sibling not affected.** `tests/chainsaw/kwok/flux-sync/chainsaw-test.yaml` asserts `Ready=True` conditions on `HelmRelease` and `Kustomization`, which already require their controllers to have completed reconciliation. No parallel change needed.

**Comment block updated** to explain why all four arms now share the `operationState.phase` requirement.

## Testing

- `yamllint tests/chainsaw/kwok/argocd-sync/chainsaw-test.yaml` — clean
- `chainsaw lint test -f tests/chainsaw/kwok/argocd-sync/chainsaw-test.yaml` — "The document is valid"
- `yamllint .github/workflows/kwok-recipes.yaml` — clean
- KWOK validation in CI is the canonical proof: with the path-filter fix in place, this PR now triggers the full 68-job Tier 1 matrix. If the original race survives, the same `5 pods total, 3 unscheduled` signature reappears; if the fix lands, the assertion converges normally or times out at 5 m with a clear "child apps not Succeeded" diagnostic.
- `make qualify` was not run end-to-end: change is test-infrastructure-only (no Go, no recipes, no docs-sidebar impact), and the relevant gates (yamllint, chainsaw lint) pass.

## Risk Assessment

- [x] **Low** — Single-file YAML predicate change + workflow path-filter expansion. The assertion still accepts all the same sync/health combinations as before, just gated behind a real terminal state. Worst case if the predicate is too strict: assertion times out at 5 m on a real-but-slow convergence rather than racing past it. Easy revert.

**Rollout notes:** No flag, no opt-in. The next KWOK run after merge exercises the new predicate. Existing passing PRs are unaffected. The path-filter expansion is purely additive.

## Follow-up

Codex review noted that the old bash gate had an explicit child-Application count guard, while this fix uses root-sync success as the materialization proxy. The proxy is sufficient for the reported flake (root cannot reach `Succeeded` without having created children), but a follow-up "wait for `root.status.resources` non-empty" step would restore full pre-#1050 parity for cases where the count itself is the invariant. Tracked for a follow-up if reviewers want belt-and-suspenders.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A (no Go change)
- [x] Linter passes (`make lint`) — `yamllint` clean on both touched files, `chainsaw lint` valid
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A (the change IS in the test infrastructure)
- [x] I updated docs if user-facing behavior changed — N/A (no user-facing surface)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)