### PR TITLE
feat(validator): co-locate ai-service-metrics with Prometheus

### DIFF
--- a/docs/integrator/validator-extension.md
+++ b/docs/integrator/validator-extension.md
@@ -64,6 +64,58 @@ validators:
     env: []
 ```
 
+### Co-locating with a dependency (dependencyAffinity)
+
+A validator catalog entry can declare `dependencyAffinity` to control where its
+orchestrator Pod is scheduled relative to the components it queries. Use this
+when a check's correctness depends on pod-to-pod network reachability — the
+canonical case is `ai-service-metrics`, which dials Prometheus over a ClusterIP
+Service.
+
+```yaml
+- name: ai-service-metrics
+  phase: conformance
+  image: ghcr.io/nvidia/aicr-validators/conformance:latest
+  timeout: 5m
+  args: ["ai-service-metrics"]
+  dependencyAffinity:
+    - componentRef: kube-prometheus-stack
+      podLabelSelector:
+        app.kubernetes.io/name: prometheus
+      requirement: preferred       # or "required"; default "preferred"
+      topologyKey: kubernetes.io/hostname  # default
+```
+
+**Fields:**
+
+- `componentRef` *(required)* — the name of a component in the recipe.
+  The deployer resolves it to a namespace at spawn time using the resolved
+  recipe's `componentRefs`. If the named component is not in the recipe and
+  `requirement: required` is set, the run fails before any Job is deployed
+  with `ErrCodeInvalidRequest` — fix the recipe (add the component) or drop
+  the validator from the validation phase.
+- `podLabelSelector` *(required)* — labels that match the dependency's pods.
+  All key/value pairs must match.
+- `requirement` *(optional, default `preferred`)* — `required` emits
+  `requiredDuringSchedulingIgnoredDuringExecution`; the scheduler will refuse
+  to place the orchestrator anywhere else. `preferred` emits
+  `preferredDuringSchedulingIgnoredDuringExecution` with weight 100; the
+  scheduler treats it as the dominant scoring signal but can fall back to
+  another node if the dependency is unschedulable.
+- `topologyKey` *(optional, default `kubernetes.io/hostname`)* — the node
+  label whose value defines co-location. The default pins to the same node;
+  use `topology.kubernetes.io/zone` for zone-level locality.
+
+When in doubt, prefer `preferred`. The high weight (100) dominates the
+scheduler's image-locality scoring on the first run, after which image
+locality reinforces (rather than counteracts) the affinity. Use `required`
+only when the check has no chance of succeeding without exact co-location.
+
+See [#933](https://github.com/NVIDIA/aicr/issues/933) for the motivating case:
+on multi-Security-Group EKS clusters where customer-workload and system-workload
+ENIs sit in separate SGs with asymmetric ingress rules, the orchestrator's
+ability to dial Prometheus depends entirely on which node the scheduler picks.
+
 ### Step 4: Reference in Recipe
 
 Add the check to your recipe's validation section:

--- a/docs/integrator/validator-extension.md
+++ b/docs/integrator/validator-extension.md
@@ -106,9 +106,9 @@ Service.
   label whose value defines co-location. The default pins to the same node;
   use `topology.kubernetes.io/zone` for zone-level locality.
 
-When in doubt, prefer `preferred`. The high weight (100) dominates the
-scheduler's image-locality scoring on the first run, after which image
-locality reinforces (rather than counteracts) the affinity. Use `required`
+When in doubt, prefer `preferred`. The high weight (100) has a strong
+influence on the scheduler's scoring on the first run, after which image
+locality can support (rather than oppose) the affinity. Use `required`
 only when the check has no chance of succeeding without exact co-location.
 
 See [#933](https://github.com/NVIDIA/aicr/issues/933) for the motivating case:

--- a/pkg/api/validator/v1/README.md
+++ b/pkg/api/validator/v1/README.md
@@ -64,7 +64,7 @@ if err != nil {
 serviceAccount := "my-validator-sa-" + runID
 
 // Generate job plans for all validators
-plans := v1.Plan(
+plans, err := v1.Plan(
     cat,
     validationInput,
     runID,
@@ -75,7 +75,13 @@ plans := v1.Plan(
     nil,            // imagePullSecrets (empty slice if not needed)
     nil,            // tolerations
     nil,            // nodeSelector
+    "",             // imageRegistryOverride
+    "",             // imageTagOverride
+    nil,            // componentRefs
 )
+if err != nil {
+    return err
+}
 ```
 
 **Important:** The `serviceAccount` parameter allows you to use your own service account naming strategy. AICR uses `"aicr-validator-" + runID` internally, but external controllers can use any naming convention.
@@ -180,7 +186,7 @@ You can customize a JobPlan before rendering:
 
 ```go
 // Build a plan for a specific validator
-plan := v1.BuildJobPlan(
+plan, err := v1.BuildJobPlan(
     entry,
     runID,
     namespace,
@@ -190,7 +196,13 @@ plan := v1.BuildJobPlan(
     nil,            // imagePullSecrets
     tolerations,
     nodeSelector,
+    "",             // imageRegistryOverride
+    "",             // imageTagOverride
+    nil,            // componentRefs
 )
+if err != nil {
+    // handle error
+}
 
 // Customize the plan
 plan.Timeout = 600  // Override timeout to 10 minutes
@@ -255,7 +267,7 @@ func RunValidation(
 
     serviceAccount := "my-validator-sa-" + runID
 
-    plans := v1.Plan(
+    plans, err := v1.Plan(
         cat,
         validationInput,
         runID,
@@ -266,7 +278,13 @@ func RunValidation(
         nil,           // imagePullSecrets
         nil,           // tolerations
         nil,           // nodeSelector
+        "",            // imageRegistryOverride
+        "",            // imageTagOverride
+        nil,           // componentRefs
     )
+    if err != nil {
+        return err
+    }
 
     // 4. Deploy Jobs using server-side apply
     for _, plan := range plans {
@@ -301,7 +319,7 @@ Format: `{timestamp}-{random-hex}` (e.g., "20260514-123045-abc123def456")
 
 ### Job Planning
 
-**`Plan(cat, validationInput, runID, namespace, version, commit, serviceAccount, imagePullSecrets, tolerations, nodeSelector) []JobPlan`**
+**`Plan(cat, validationInput, runID, namespace, version, commit, serviceAccount, imagePullSecrets, tolerations, nodeSelector, imageRegistryOverride, imageTagOverride, componentRefs) ([]JobPlan, error)`**
 Generates JobPlans for all validators across all phases matching the ValidationInput filters.
 
 **Parameters:**
@@ -332,7 +350,7 @@ Typically called with `plan.JobName` as the jobName parameter.
 
 ### Image Utilities
 
-**`ImagePullPolicy(image string) corev1.PullPolicy`**
+**`ImagePullPolicy(image string, imageTagOverride string) corev1.PullPolicy`**
 Determines the appropriate pull policy for a container image based on its reference.
 
 Rules:

--- a/pkg/api/validator/v1/README.md
+++ b/pkg/api/validator/v1/README.md
@@ -316,8 +316,10 @@ Generates JobPlans for all validators across all phases matching the ValidationI
 - `tolerations` - Tolerations for inner workloads (forwarded via `AICR_TOLERATIONS` env var; validator Pod uses tolerate-all)
 - `nodeSelector` - Node selector for inner workloads (forwarded via `AICR_NODE_SELECTOR` env var; validator Pod has no node selector)
 
-**`BuildJobPlan(entry, runID, namespace, version, commit, serviceAccount, imagePullSecrets, tolerations, nodeSelector) JobPlan`**
+**`BuildJobPlan(entry, runID, namespace, version, commit, serviceAccount, imagePullSecrets, tolerations, nodeSelector, imageRegistryOverride, imageTagOverride, componentRefs) (JobPlan, error)`**
 Builds a JobPlan from a single validator catalog entry. Used for custom scenarios.
+
+`componentRefs` is the resolved recipe's component list, used to resolve `dependencyAffinity.componentRef` to a namespace so the orchestrator pod can be co-located with the dependency. The function returns `ErrCodeInvalidRequest` when a `required` componentRef is not present in componentRefs. Pass `nil` when dependencyAffinity is not used or the recipe is not available; this preserves backward-compatible behavior (prefer-CPU NodeAffinity only, no PodAffinity).
 
 ### Job Rendering
 

--- a/pkg/api/validator/v1/README.md
+++ b/pkg/api/validator/v1/README.md
@@ -334,7 +334,7 @@ Generates JobPlans for all validators across all phases matching the ValidationI
 - `tolerations` - Tolerations for inner workloads (forwarded via `AICR_TOLERATIONS` env var; validator Pod uses tolerate-all)
 - `nodeSelector` - Node selector for inner workloads (forwarded via `AICR_NODE_SELECTOR` env var; validator Pod has no node selector)
 - `imageRegistryOverride` - Optional registry host that replaces the registry prefix on every validator image (matches the `AICR_VALIDATOR_IMAGE_REGISTRY` env var). Empty string disables the override.
-- `imageTagOverride` - Optional tag that replaces every validator image's tag, including digest-pinned references (matches the `AICR_VALIDATOR_IMAGE_TAG` env var). Empty string disables the override.
+- `imageTagOverride` - Optional tag that replaces the tag on every tag-based validator image reference (matches the `AICR_VALIDATOR_IMAGE_TAG` env var). Digest-pinned references (`name@sha256:…`) are left untouched — the digest is the authoritative pin. Empty string disables the override.
 - `componentRefs` - Resolved recipe component list used to resolve `dependencyAffinity.componentRef` entries to namespaces when building the orchestrator pod's affinity. Pass `nil` when dependencyAffinity is not used or the recipe is not available.
 
 **`BuildJobPlan(entry, runID, namespace, version, commit, serviceAccount, imagePullSecrets, tolerations, nodeSelector, imageRegistryOverride, imageTagOverride, componentRefs) (JobPlan, error)`**

--- a/pkg/api/validator/v1/README.md
+++ b/pkg/api/validator/v1/README.md
@@ -333,6 +333,9 @@ Generates JobPlans for all validators across all phases matching the ValidationI
 - `imagePullSecrets` - Image pull secret names (empty slice if not needed)
 - `tolerations` - Tolerations for inner workloads (forwarded via `AICR_TOLERATIONS` env var; validator Pod uses tolerate-all)
 - `nodeSelector` - Node selector for inner workloads (forwarded via `AICR_NODE_SELECTOR` env var; validator Pod has no node selector)
+- `imageRegistryOverride` - Optional registry host that replaces the registry prefix on every validator image (matches the `AICR_VALIDATOR_IMAGE_REGISTRY` env var). Empty string disables the override.
+- `imageTagOverride` - Optional tag that replaces every validator image's tag, including digest-pinned references (matches the `AICR_VALIDATOR_IMAGE_TAG` env var). Empty string disables the override.
+- `componentRefs` - Resolved recipe component list used to resolve `dependencyAffinity.componentRef` entries to namespaces when building the orchestrator pod's affinity. Pass `nil` when dependencyAffinity is not used or the recipe is not available.
 
 **`BuildJobPlan(entry, runID, namespace, version, commit, serviceAccount, imagePullSecrets, tolerations, nodeSelector, imageRegistryOverride, imageTagOverride, componentRefs) (JobPlan, error)`**
 Builds a JobPlan from a single validator catalog entry. Used for custom scenarios.

--- a/pkg/api/validator/v1/affinity.go
+++ b/pkg/api/validator/v1/affinity.go
@@ -67,8 +67,8 @@ func BuildOrchestratorAffinity(
 
 	for _, dep := range deps {
 		if err := dep.Validate(); err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-				"invalid dependencyAffinity", err)
+			return nil, errors.PropagateOrWrap(err,
+				errors.ErrCodeInvalidRequest, "invalid dependencyAffinity")
 		}
 
 		ref, found := refByName[dep.ComponentRef]

--- a/pkg/api/validator/v1/affinity.go
+++ b/pkg/api/validator/v1/affinity.go
@@ -66,15 +66,34 @@ func BuildOrchestratorAffinity(
 	var preferred []corev1.WeightedPodAffinityTerm
 
 	for _, dep := range deps {
+		if err := dep.Validate(); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid dependencyAffinity", err)
+		}
+
 		ref, found := refByName[dep.ComponentRef]
-		hasNamespace := found && ref.Namespace != ""
+		// Skip if the component is in the recipe but disabled or unresolved
+		// (no namespace). Without this check, "required" would block the
+		// orchestrator forever waiting for a pod that never deploys.
+		resolved := found && ref.IsEnabled() && ref.Namespace != ""
 		req := dep.RequirementOrDefault()
 
-		if !hasNamespace {
+		if !resolved {
 			if req == DependencyRequirementRequired {
+				var reason string
+				switch {
+				case !found:
+					reason = "is not in the recipe's componentRefs"
+				case !ref.IsEnabled():
+					reason = "is disabled (overrides.enabled=false)"
+				case ref.Namespace == "":
+					reason = "has no resolved namespace"
+				default:
+					reason = "is unresolved"
+				}
 				return nil, errors.New(errors.ErrCodeInvalidRequest,
-					fmt.Sprintf("required dependencyAffinity component %q is not present in the resolved recipe; either add the component to the recipe or remove this validator from the validation phase",
-						dep.ComponentRef))
+					fmt.Sprintf("required dependencyAffinity component %q %s; either fix the recipe or remove this validator from the validation phase",
+						dep.ComponentRef, reason))
 			}
 			slog.Warn("preferred dependencyAffinity component not present in recipe; skipping affinity term",
 				"componentRef", dep.ComponentRef)

--- a/pkg/api/validator/v1/affinity.go
+++ b/pkg/api/validator/v1/affinity.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// preferredAffinityWeight is the scheduler weight for preferred dependency
+// affinity terms. 100 (max) so the term dominates image-locality scoring on
+// the first scheduling decision; once the validator image lands on the
+// dependency node, image-locality reinforces affinity on subsequent runs.
+const preferredAffinityWeight = 100
+
+// BuildOrchestratorAffinity composes the orchestrator pod's full affinity from
+// the validator's declared dependencies and the resolved recipe's component
+// refs. The result always includes the default prefer-CPU NodeAffinity; each
+// resolvable dependency adds one PodAffinity term.
+//
+// Resolution rules (per https://github.com/NVIDIA/aicr/issues/933):
+//   - A "required" dependency whose componentRef is missing from componentRefs
+//     returns ErrCodeInvalidRequest. The caller should treat this as a recipe
+//     misconfiguration and fail the run before deploying any Job.
+//   - A "preferred" dependency whose componentRef is missing is logged at
+//     slog.Warn and produces no PodAffinity term. The orchestrator schedules
+//     wherever the scheduler picks; this preserves backward-compatible behavior
+//     on flat networks where the dependency may not be present.
+//   - Components whose Namespace is empty after recipe resolution are treated
+//     as missing (a dependency without a known namespace cannot produce a
+//     well-formed PodAffinityTerm).
+func BuildOrchestratorAffinity(
+	deps []DependencyAffinity,
+	componentRefs []recipe.ComponentRef,
+) (*corev1.Affinity, error) {
+
+	affinity := preferCPUNodeAffinity()
+
+	if len(deps) == 0 {
+		return affinity, nil
+	}
+
+	refByName := make(map[string]recipe.ComponentRef, len(componentRefs))
+	for _, ref := range componentRefs {
+		refByName[ref.Name] = ref
+	}
+
+	var required []corev1.PodAffinityTerm
+	var preferred []corev1.WeightedPodAffinityTerm
+
+	for _, dep := range deps {
+		ref, found := refByName[dep.ComponentRef]
+		hasNamespace := found && ref.Namespace != ""
+		req := dep.RequirementOrDefault()
+
+		if !hasNamespace {
+			if req == DependencyRequirementRequired {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("required dependencyAffinity component %q is not present in the resolved recipe; either add the component to the recipe or remove this validator from the validation phase",
+						dep.ComponentRef))
+			}
+			slog.Warn("preferred dependencyAffinity component not present in recipe; skipping affinity term",
+				"componentRef", dep.ComponentRef)
+			continue
+		}
+
+		term := corev1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{MatchLabels: dep.PodLabelSelector},
+			Namespaces:    []string{ref.Namespace},
+			TopologyKey:   dep.TopologyKeyOrDefault(),
+		}
+
+		if req == DependencyRequirementRequired {
+			required = append(required, term)
+		} else {
+			preferred = append(preferred, corev1.WeightedPodAffinityTerm{
+				Weight:          preferredAffinityWeight,
+				PodAffinityTerm: term,
+			})
+		}
+	}
+
+	if len(required) == 0 && len(preferred) == 0 {
+		return affinity, nil
+	}
+
+	affinity.PodAffinity = &corev1.PodAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution:  required,
+		PreferredDuringSchedulingIgnoredDuringExecution: preferred,
+	}
+	return affinity, nil
+}

--- a/pkg/api/validator/v1/affinity_test.go
+++ b/pkg/api/validator/v1/affinity_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+func TestBuildOrchestratorAffinity_NoDeps(t *testing.T) {
+	got, err := BuildOrchestratorAffinity(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got == nil || got.NodeAffinity == nil {
+		t.Fatal("expected non-nil affinity with prefer-CPU NodeAffinity")
+	}
+	if got.PodAffinity != nil {
+		t.Errorf("expected nil PodAffinity when no deps, got %+v", got.PodAffinity)
+	}
+}
+
+func TestBuildOrchestratorAffinity_RequiredResolved(t *testing.T) {
+	deps := []DependencyAffinity{{
+		ComponentRef:     "kube-prometheus-stack",
+		PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Requirement:      DependencyRequirementRequired,
+	}}
+	refs := []recipe.ComponentRef{{Name: "kube-prometheus-stack", Namespace: "monitoring"}}
+
+	got, err := BuildOrchestratorAffinity(deps, refs)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.PodAffinity == nil {
+		t.Fatal("expected PodAffinity to be set")
+	}
+	required := got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if len(required) != 1 {
+		t.Fatalf("expected 1 required term, got %d", len(required))
+	}
+	term := required[0]
+	if len(term.Namespaces) != 1 || term.Namespaces[0] != "monitoring" {
+		t.Errorf("expected term.Namespaces = [monitoring], got %v", term.Namespaces)
+	}
+	if term.TopologyKey != "kubernetes.io/hostname" {
+		t.Errorf("expected hostname topology key, got %q", term.TopologyKey)
+	}
+	if got.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Errorf("expected no preferred terms when only required deps, got %+v",
+			got.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+	}
+}
+
+func TestBuildOrchestratorAffinity_PreferredResolved(t *testing.T) {
+	deps := []DependencyAffinity{{
+		ComponentRef:     "kube-prometheus-stack",
+		PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Requirement:      DependencyRequirementPreferred,
+	}}
+	refs := []recipe.ComponentRef{{Name: "kube-prometheus-stack", Namespace: "monitoring"}}
+
+	got, err := BuildOrchestratorAffinity(deps, refs)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	preferred := got.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(preferred) != 1 {
+		t.Fatalf("expected 1 preferred term, got %d", len(preferred))
+	}
+	if preferred[0].Weight != preferredAffinityWeight {
+		t.Errorf("expected weight %d, got %d", preferredAffinityWeight, preferred[0].Weight)
+	}
+	if len(preferred[0].PodAffinityTerm.Namespaces) != 1 ||
+		preferred[0].PodAffinityTerm.Namespaces[0] != "monitoring" {
+
+		t.Errorf("expected term namespace [monitoring], got %v",
+			preferred[0].PodAffinityTerm.Namespaces)
+	}
+	if got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Errorf("expected no required terms when only preferred deps")
+	}
+}
+
+func TestBuildOrchestratorAffinity_RequiredMissingComponent(t *testing.T) {
+	deps := []DependencyAffinity{{
+		ComponentRef:     "kube-prometheus-stack",
+		PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Requirement:      DependencyRequirementRequired,
+	}}
+	_, err := BuildOrchestratorAffinity(deps, nil)
+	if err == nil {
+		t.Fatal("expected error for missing required component")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+	}
+}
+
+func TestBuildOrchestratorAffinity_PreferredMissingComponent_Skipped(t *testing.T) {
+	deps := []DependencyAffinity{{
+		ComponentRef:     "kube-prometheus-stack",
+		PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Requirement:      DependencyRequirementPreferred,
+	}}
+	got, err := BuildOrchestratorAffinity(deps, nil)
+	if err != nil {
+		t.Fatalf("expected no error for missing preferred dep, got %v", err)
+	}
+	if got.PodAffinity != nil {
+		t.Errorf("expected no PodAffinity when preferred dep is unresolved, got %+v", got.PodAffinity)
+	}
+	if got.NodeAffinity == nil {
+		t.Fatal("NodeAffinity (prefer-CPU) must still be present")
+	}
+}
+
+func TestBuildOrchestratorAffinity_MultipleDeps(t *testing.T) {
+	deps := []DependencyAffinity{
+		{
+			ComponentRef:     "kube-prometheus-stack",
+			PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+			Requirement:      DependencyRequirementRequired,
+		},
+		{
+			ComponentRef:     "dcgm-exporter",
+			PodLabelSelector: map[string]string{"app": "dcgm-exporter"},
+			Requirement:      DependencyRequirementPreferred,
+		},
+	}
+	refs := []recipe.ComponentRef{
+		{Name: "kube-prometheus-stack", Namespace: "monitoring"},
+		{Name: "dcgm-exporter", Namespace: "gpu-operator"},
+	}
+	got, err := BuildOrchestratorAffinity(deps, refs)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Errorf("expected 1 required term, got %d",
+			len(got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	}
+	if len(got.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Errorf("expected 1 preferred term, got %d",
+			len(got.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
+	}
+}
+
+func TestBuildOrchestratorAffinity_NamespaceEmptyTreatedAsMissing(t *testing.T) {
+	deps := []DependencyAffinity{{
+		ComponentRef:     "kube-prometheus-stack",
+		PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Requirement:      DependencyRequirementRequired,
+	}}
+	// Component is present but unresolved (empty namespace).
+	refs := []recipe.ComponentRef{{Name: "kube-prometheus-stack"}}
+
+	_, err := BuildOrchestratorAffinity(deps, refs)
+	if err == nil {
+		t.Fatal("expected error when required dep's component has empty namespace")
+	}
+}
+
+func TestBuildOrchestratorAffinity_ExplicitTopologyKeyPreserved(t *testing.T) {
+	deps := []DependencyAffinity{{
+		ComponentRef:     "kube-prometheus-stack",
+		PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Requirement:      DependencyRequirementRequired,
+		TopologyKey:      "topology.kubernetes.io/zone",
+	}}
+	refs := []recipe.ComponentRef{{Name: "kube-prometheus-stack", Namespace: "monitoring"}}
+
+	got, err := BuildOrchestratorAffinity(deps, refs)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	term := got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+	if term.TopologyKey != "topology.kubernetes.io/zone" {
+		t.Errorf("expected explicit topology key preserved, got %q", term.TopologyKey)
+	}
+}

--- a/pkg/api/validator/v1/catalog.go
+++ b/pkg/api/validator/v1/catalog.go
@@ -102,6 +102,24 @@ type ValidatorEntry struct {
 	// Resources specifies container resource requests/limits.
 	// If nil, defaults from pkg/defaults are used.
 	Resources *ResourceRequirements `json:"resources,omitempty" yaml:"resources,omitempty"`
+
+	// DependencyAffinity declares co-location preferences for the orchestrator
+	// pod of this validator. Each entry references a recipe component by name
+	// (componentRef) and a label selector matching that component's pods.
+	// The deployer resolves the componentRef to a namespace from the resolved
+	// recipe at spawn time and emits a podAffinity term on the orchestrator
+	// Pod spec. "required" entries hard-fail the run when the referenced
+	// component is absent from the recipe; "preferred" entries (default) emit
+	// a structured warning and proceed with no affinity term for that
+	// dependency.
+	//
+	// Motivation: ai-service-metrics queries Prometheus over a Service. On
+	// clusters with asymmetric pod-to-pod network reachability (e.g.,
+	// multi-Security-Group DGXC EKS), the orchestrator must run on a node
+	// that can reach the Prometheus pod. Co-locating with the Prometheus pod
+	// makes the dial loopback / same-network and removes the dependency on
+	// cluster network topology. See https://github.com/NVIDIA/aicr/issues/933.
+	DependencyAffinity []DependencyAffinity `json:"dependencyAffinity,omitempty" yaml:"dependencyAffinity,omitempty"`
 }
 
 // ResourceRequirements defines CPU and memory for a validator container.

--- a/pkg/api/validator/v1/dependency_affinity.go
+++ b/pkg/api/validator/v1/dependency_affinity.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// DependencyRequirement is the strength of a dependency affinity.
+type DependencyRequirement string
+
+const (
+	// DependencyRequirementPreferred renders as preferredDuringSchedulingIgnoredDuringExecution
+	// with a high weight; missing components are tolerated with a warning.
+	DependencyRequirementPreferred DependencyRequirement = "preferred"
+
+	// DependencyRequirementRequired renders as requiredDuringSchedulingIgnoredDuringExecution
+	// and causes pre-flight failure when the referenced component is absent from the recipe.
+	DependencyRequirementRequired DependencyRequirement = "required"
+
+	// defaultTopologyKey is used when DependencyAffinity.TopologyKey is empty.
+	// kubernetes.io/hostname pins the orchestrator to the same node as the
+	// dependency pod, which is the right granularity for the multi-SG/network-locality
+	// case that motivates #933. Zone-level locality requires an explicit override.
+	defaultTopologyKey = "kubernetes.io/hostname"
+)
+
+// DependencyAffinity declares a co-location preference for a validator's
+// orchestrator pod with another component's pod.
+type DependencyAffinity struct {
+	// ComponentRef is the name of a recipe component whose pod the orchestrator
+	// should co-locate with. The deployer resolves this to a namespace at spawn
+	// time using the resolved recipe's componentRefs.
+	ComponentRef string `json:"componentRef" yaml:"componentRef"`
+
+	// PodLabelSelector matches the dependency pod's labels (e.g.,
+	// {"app.kubernetes.io/name": "prometheus"}). All key/value pairs must match.
+	PodLabelSelector map[string]string `json:"podLabelSelector" yaml:"podLabelSelector"`
+
+	// Requirement controls strength. "required" hard-fails when the dependency
+	// is unschedulable; "preferred" (default) is a high-weight scheduling hint.
+	Requirement DependencyRequirement `json:"requirement,omitempty" yaml:"requirement,omitempty"`
+
+	// TopologyKey is the node label whose value defines co-location.
+	// Defaults to kubernetes.io/hostname (same node) when empty.
+	TopologyKey string `json:"topologyKey,omitempty" yaml:"topologyKey,omitempty"`
+}
+
+// Validate checks that ComponentRef and PodLabelSelector are non-empty and
+// that Requirement is either empty (defaults to preferred), "preferred", or
+// "required".
+func (d DependencyAffinity) Validate() error {
+	if d.ComponentRef == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"dependencyAffinity: componentRef is required")
+	}
+	if len(d.PodLabelSelector) == 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("dependencyAffinity %q: podLabelSelector is required", d.ComponentRef))
+	}
+	switch d.Requirement {
+	case "", DependencyRequirementPreferred, DependencyRequirementRequired:
+		return nil
+	default:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("dependencyAffinity %q: invalid requirement %q (must be \"preferred\" or \"required\")",
+				d.ComponentRef, d.Requirement))
+	}
+}
+
+// RequirementOrDefault returns the requirement strength, defaulting to
+// "preferred" when unset.
+func (d DependencyAffinity) RequirementOrDefault() DependencyRequirement {
+	if d.Requirement == "" {
+		return DependencyRequirementPreferred
+	}
+	return d.Requirement
+}
+
+// TopologyKeyOrDefault returns the topology key, defaulting to
+// kubernetes.io/hostname when unset.
+func (d DependencyAffinity) TopologyKeyOrDefault() string {
+	if d.TopologyKey == "" {
+		return defaultTopologyKey
+	}
+	return d.TopologyKey
+}

--- a/pkg/api/validator/v1/dependency_affinity_test.go
+++ b/pkg/api/validator/v1/dependency_affinity_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestDependencyAffinityValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		dep     DependencyAffinity
+		wantErr bool
+	}{
+		{
+			name: "valid required with selector",
+			dep: DependencyAffinity{
+				ComponentRef:     "kube-prometheus-stack",
+				PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				Requirement:      DependencyRequirementRequired,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid preferred with default topology",
+			dep: DependencyAffinity{
+				ComponentRef:     "kube-prometheus-stack",
+				PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				Requirement:      DependencyRequirementPreferred,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid empty requirement defaults to preferred",
+			dep: DependencyAffinity{
+				ComponentRef:     "kube-prometheus-stack",
+				PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				// Requirement intentionally empty
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty componentRef rejected",
+			dep: DependencyAffinity{
+				PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				Requirement:      DependencyRequirementPreferred,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty selector rejected",
+			dep: DependencyAffinity{
+				ComponentRef: "kube-prometheus-stack",
+				Requirement:  DependencyRequirementPreferred,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown requirement rejected",
+			dep: DependencyAffinity{
+				ComponentRef:     "kube-prometheus-stack",
+				PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				Requirement:      "soft",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDependencyAffinityRequirementOrDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		dep  DependencyAffinity
+		want DependencyRequirement
+	}{
+		{"empty defaults to preferred", DependencyAffinity{}, DependencyRequirementPreferred},
+		{"explicit required preserved", DependencyAffinity{Requirement: DependencyRequirementRequired}, DependencyRequirementRequired},
+		{"explicit preferred preserved", DependencyAffinity{Requirement: DependencyRequirementPreferred}, DependencyRequirementPreferred},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.dep.RequirementOrDefault(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDependencyAffinityTopologyKeyOrDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		topologyKey string
+		want        string
+	}{
+		{"empty defaults to hostname", "", "kubernetes.io/hostname"},
+		{"explicit zone preserved", "topology.kubernetes.io/zone", "topology.kubernetes.io/zone"},
+		{"explicit hostname preserved", "kubernetes.io/hostname", "kubernetes.io/hostname"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := DependencyAffinity{TopologyKey: tt.topologyKey}
+			if got := d.TopologyKeyOrDefault(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/validator/v1/job_plan.go
+++ b/pkg/api/validator/v1/job_plan.go
@@ -22,12 +22,14 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applybatchv1 "k8s.io/client-go/applyconfigurations/batch/v1"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // JobPlan contains all components needed to build a validator Job.
@@ -78,6 +80,12 @@ type JobPlan struct {
 
 	// Labels are labels to apply to the Job and Pod
 	Labels map[string]string
+
+	// Affinity is the orchestrator pod's full affinity (NodeAffinity for
+	// prefer-CPU plus any PodAffinity terms derived from the catalog entry's
+	// DependencyAffinity). If nil, the renderer falls back to the default
+	// prefer-CPU NodeAffinity.
+	Affinity *corev1.Affinity
 }
 
 // GenerateRunID creates a unique run identifier for validation sessions.
@@ -142,13 +150,14 @@ func Plan(
 	nodeSelector map[string]string,
 	imageRegistryOverride string,
 	imageTagOverride string,
-) []JobPlan {
+	componentRefs []recipe.ComponentRef,
+) ([]JobPlan, error) {
 
 	var plans []JobPlan
 
 	// Guard against nil catalog
 	if cat == nil {
-		return plans
+		return plans, nil
 	}
 
 	// Iterate through all phases
@@ -162,14 +171,17 @@ func Plan(
 
 		// Create a plan for each entry
 		for _, entry := range entries {
-			plan := BuildJobPlan(entry, runID, namespace, version, commit,
+			plan, err := BuildJobPlan(entry, runID, namespace, version, commit,
 				serviceAccount, imagePullSecrets, tolerations, nodeSelector,
-				imageRegistryOverride, imageTagOverride)
+				imageRegistryOverride, imageTagOverride, componentRefs)
+			if err != nil {
+				return nil, err
+			}
 			plans = append(plans, plan)
 		}
 	}
 
-	return plans
+	return plans, nil
 }
 
 // BuildJobPlan creates a JobPlan from a validator entry.
@@ -179,7 +191,13 @@ func Plan(
 // by validators (e.g., GPU benchmarks, NCCL tests) and are forwarded via
 // AICR_TOLERATIONS and AICR_NODE_SELECTOR environment variables. The orchestrator
 // Job Pod itself always uses tolerate-all scheduling ({Operator: TolerationOpExists})
-// and no node selector to ensure it can schedule on any available CPU node.
+// and gets affinity from BuildOrchestratorAffinity (prefer-CPU NodeAffinity, plus
+// PodAffinity per entry.DependencyAffinity if any). componentRefs is the resolved
+// recipe's component list and is used to resolve dependencyAffinity componentRefs
+// to namespaces.
+//
+// Returns ErrCodeInvalidRequest when entry.DependencyAffinity declares a
+// "required" component that is not present in componentRefs.
 func BuildJobPlan(
 	entry ValidatorEntry,
 	runID string,
@@ -192,7 +210,13 @@ func BuildJobPlan(
 	nodeSelector map[string]string,
 	imageRegistryOverride string,
 	imageTagOverride string,
-) JobPlan {
+	componentRefs []recipe.ComponentRef,
+) (JobPlan, error) {
+
+	affinity, err := BuildOrchestratorAffinity(entry.DependencyAffinity, componentRefs)
+	if err != nil {
+		return JobPlan{}, err
+	}
 
 	timeout := entry.Timeout
 	if timeout == 0 {
@@ -239,7 +263,8 @@ func BuildJobPlan(
 		Tolerations:      []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 		ImagePullSecrets: imagePullSecrets,
 		Labels:           jobLabels,
-	}
+		Affinity:         affinity,
+	}, nil
 }
 
 // RenderPlan renders a complete Kubernetes Job from a JobPlan.
@@ -279,7 +304,7 @@ func RenderPlan(plan JobPlan) *batchv1.Job {
 					TerminationGracePeriodSeconds: int64Ptr(int64(defaults.ValidatorTerminationGracePeriod.Seconds())),
 					ImagePullSecrets:              imagePullSecrets,
 					Tolerations:                   plan.Tolerations,
-					Affinity:                      preferCPUNodeAffinity(),
+					Affinity:                      affinityForPlan(plan),
 					Containers: []corev1.Container{
 						{
 							Name:                     "validator",
@@ -363,21 +388,9 @@ func RenderPlanToApplyConfig(plan JobPlan, jobName string) *applybatchv1.JobAppl
 		tolerationsApply = append(tolerationsApply, toleration)
 	}
 
-	// Build affinity (prefer CPU nodes)
-	affinityApply := applycorev1.Affinity().
-		WithNodeAffinity(applycorev1.NodeAffinity().
-			WithPreferredDuringSchedulingIgnoredDuringExecution(
-				applycorev1.PreferredSchedulingTerm().
-					WithWeight(100).
-					WithPreference(applycorev1.NodeSelectorTerm().
-						WithMatchExpressions(
-							applycorev1.NodeSelectorRequirement().
-								WithKey("nvidia.com/gpu.present").
-								WithOperator(corev1.NodeSelectorOpDoesNotExist),
-						),
-					),
-			),
-		)
+	// Convert the plan's full affinity (NodeAffinity + any PodAffinity for
+	// dependency co-location) into the apply-config types.
+	affinityApply := affinityToApplyConfig(affinityForPlan(plan))
 
 	// Build the Job ApplyConfiguration
 	return applybatchv1.Job(jobName, plan.Namespace).
@@ -415,4 +428,92 @@ func RenderPlanToApplyConfig(plan JobPlan, jobName string) *applybatchv1.JobAppl
 				),
 			),
 		)
+}
+
+// affinityForPlan returns the orchestrator pod's affinity. When plan.Affinity
+// is set (the common case after BuildJobPlan), it is used directly. When nil
+// (external callers that constructed a JobPlan manually pre-Task-4), we fall
+// back to the default prefer-CPU NodeAffinity to preserve behavior.
+func affinityForPlan(plan JobPlan) *corev1.Affinity {
+	if plan.Affinity != nil {
+		return plan.Affinity
+	}
+	return preferCPUNodeAffinity()
+}
+
+// affinityToApplyConfig converts a *corev1.Affinity to the
+// applyconfigurations/core/v1 type used by server-side apply. We hand-write the
+// walk because client-go does not expose a generated converter for this pair
+// and we only emit the subset of fields we actually populate
+// (NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution and
+// PodAffinity.{Required,Preferred}DuringSchedulingIgnoredDuringExecution).
+func affinityToApplyConfig(a *corev1.Affinity) *applycorev1.AffinityApplyConfiguration {
+	if a == nil {
+		return nil
+	}
+	out := applycorev1.Affinity()
+	if a.NodeAffinity != nil {
+		out = out.WithNodeAffinity(nodeAffinityToApplyConfig(a.NodeAffinity))
+	}
+	if a.PodAffinity != nil {
+		out = out.WithPodAffinity(podAffinityToApplyConfig(a.PodAffinity))
+	}
+	return out
+}
+
+func nodeAffinityToApplyConfig(na *corev1.NodeAffinity) *applycorev1.NodeAffinityApplyConfiguration {
+	out := applycorev1.NodeAffinity()
+	for _, term := range na.PreferredDuringSchedulingIgnoredDuringExecution {
+		t := term
+		out = out.WithPreferredDuringSchedulingIgnoredDuringExecution(
+			applycorev1.PreferredSchedulingTerm().
+				WithWeight(t.Weight).
+				WithPreference(nodeSelectorTermToApplyConfig(&t.Preference)),
+		)
+	}
+	return out
+}
+
+func nodeSelectorTermToApplyConfig(t *corev1.NodeSelectorTerm) *applycorev1.NodeSelectorTermApplyConfiguration {
+	out := applycorev1.NodeSelectorTerm()
+	for _, expr := range t.MatchExpressions {
+		e := expr
+		req := applycorev1.NodeSelectorRequirement().
+			WithKey(e.Key).
+			WithOperator(e.Operator)
+		for _, v := range e.Values {
+			req = req.WithValues(v)
+		}
+		out = out.WithMatchExpressions(req)
+	}
+	return out
+}
+
+func podAffinityToApplyConfig(pa *corev1.PodAffinity) *applycorev1.PodAffinityApplyConfiguration {
+	out := applycorev1.PodAffinity()
+	for _, term := range pa.RequiredDuringSchedulingIgnoredDuringExecution {
+		t := term
+		out = out.WithRequiredDuringSchedulingIgnoredDuringExecution(podAffinityTermToApplyConfig(&t))
+	}
+	for _, w := range pa.PreferredDuringSchedulingIgnoredDuringExecution {
+		wt := w
+		out = out.WithPreferredDuringSchedulingIgnoredDuringExecution(
+			applycorev1.WeightedPodAffinityTerm().
+				WithWeight(wt.Weight).
+				WithPodAffinityTerm(podAffinityTermToApplyConfig(&wt.PodAffinityTerm)),
+		)
+	}
+	return out
+}
+
+func podAffinityTermToApplyConfig(t *corev1.PodAffinityTerm) *applycorev1.PodAffinityTermApplyConfiguration {
+	out := applycorev1.PodAffinityTerm().WithTopologyKey(t.TopologyKey)
+	if t.LabelSelector != nil {
+		ls := applymetav1.LabelSelector().WithMatchLabels(t.LabelSelector.MatchLabels)
+		out = out.WithLabelSelector(ls)
+	}
+	for _, ns := range t.Namespaces {
+		out = out.WithNamespaces(ns)
+	}
+	return out
 }

--- a/pkg/api/validator/v1/job_plan.go
+++ b/pkg/api/validator/v1/job_plan.go
@@ -443,13 +443,12 @@ func affinityForPlan(plan JobPlan) *corev1.Affinity {
 
 // affinityToApplyConfig converts a *corev1.Affinity to the
 // applyconfigurations/core/v1 type used by server-side apply. We hand-write the
-// walk because client-go does not expose a generated converter for this pair
-// and we only emit the subset of fields we actually populate
-// (NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution and
-// PodAffinity.{Required,Preferred}DuringSchedulingIgnoredDuringExecution).
+// walk because client-go does not expose a generated converter for this pair.
+// A nil or empty Affinity falls back to preferCPUNodeAffinity() to preserve
+// pre-PR behavior for external callers that construct a JobPlan manually.
 func affinityToApplyConfig(a *corev1.Affinity) *applycorev1.AffinityApplyConfiguration {
-	if a == nil {
-		return nil
+	if a == nil || (a.NodeAffinity == nil && a.PodAffinity == nil && a.PodAntiAffinity == nil) {
+		return affinityToApplyConfig(preferCPUNodeAffinity())
 	}
 	out := applycorev1.Affinity()
 	if a.NodeAffinity != nil {
@@ -458,11 +457,22 @@ func affinityToApplyConfig(a *corev1.Affinity) *applycorev1.AffinityApplyConfigu
 	if a.PodAffinity != nil {
 		out = out.WithPodAffinity(podAffinityToApplyConfig(a.PodAffinity))
 	}
+	if a.PodAntiAffinity != nil {
+		out = out.WithPodAntiAffinity(podAntiAffinityToApplyConfig(a.PodAntiAffinity))
+	}
 	return out
 }
 
 func nodeAffinityToApplyConfig(na *corev1.NodeAffinity) *applycorev1.NodeAffinityApplyConfiguration {
 	out := applycorev1.NodeAffinity()
+	if na.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		req := applycorev1.NodeSelector()
+		for _, term := range na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			t := term
+			req = req.WithNodeSelectorTerms(nodeSelectorTermToApplyConfig(&t))
+		}
+		out = out.WithRequiredDuringSchedulingIgnoredDuringExecution(req)
+	}
 	for _, term := range na.PreferredDuringSchedulingIgnoredDuringExecution {
 		t := term
 		out = out.WithPreferredDuringSchedulingIgnoredDuringExecution(
@@ -486,6 +496,16 @@ func nodeSelectorTermToApplyConfig(t *corev1.NodeSelectorTerm) *applycorev1.Node
 		}
 		out = out.WithMatchExpressions(req)
 	}
+	for _, expr := range t.MatchFields {
+		e := expr
+		req := applycorev1.NodeSelectorRequirement().
+			WithKey(e.Key).
+			WithOperator(e.Operator)
+		for _, v := range e.Values {
+			req = req.WithValues(v)
+		}
+		out = out.WithMatchFields(req)
+	}
 	return out
 }
 
@@ -506,14 +526,67 @@ func podAffinityToApplyConfig(pa *corev1.PodAffinity) *applycorev1.PodAffinityAp
 	return out
 }
 
+func podAntiAffinityToApplyConfig(paa *corev1.PodAntiAffinity) *applycorev1.PodAntiAffinityApplyConfiguration {
+	out := applycorev1.PodAntiAffinity()
+	for _, term := range paa.RequiredDuringSchedulingIgnoredDuringExecution {
+		t := term
+		out = out.WithRequiredDuringSchedulingIgnoredDuringExecution(podAffinityTermToApplyConfig(&t))
+	}
+	for _, w := range paa.PreferredDuringSchedulingIgnoredDuringExecution {
+		wt := w
+		out = out.WithPreferredDuringSchedulingIgnoredDuringExecution(
+			applycorev1.WeightedPodAffinityTerm().
+				WithWeight(wt.Weight).
+				WithPodAffinityTerm(podAffinityTermToApplyConfig(&wt.PodAffinityTerm)),
+		)
+	}
+	return out
+}
+
 func podAffinityTermToApplyConfig(t *corev1.PodAffinityTerm) *applycorev1.PodAffinityTermApplyConfiguration {
 	out := applycorev1.PodAffinityTerm().WithTopologyKey(t.TopologyKey)
 	if t.LabelSelector != nil {
-		ls := applymetav1.LabelSelector().WithMatchLabels(t.LabelSelector.MatchLabels)
+		ls := applymetav1.LabelSelector()
+		if len(t.LabelSelector.MatchLabels) > 0 {
+			ls = ls.WithMatchLabels(t.LabelSelector.MatchLabels)
+		}
+		for _, expr := range t.LabelSelector.MatchExpressions {
+			e := expr
+			req := applymetav1.LabelSelectorRequirement().
+				WithKey(e.Key).
+				WithOperator(e.Operator)
+			for _, v := range e.Values {
+				req = req.WithValues(v)
+			}
+			ls = ls.WithMatchExpressions(req)
+		}
 		out = out.WithLabelSelector(ls)
+	}
+	if t.NamespaceSelector != nil {
+		ns := applymetav1.LabelSelector()
+		if len(t.NamespaceSelector.MatchLabels) > 0 {
+			ns = ns.WithMatchLabels(t.NamespaceSelector.MatchLabels)
+		}
+		for _, expr := range t.NamespaceSelector.MatchExpressions {
+			e := expr
+			req := applymetav1.LabelSelectorRequirement().
+				WithKey(e.Key).
+				WithOperator(e.Operator)
+			for _, v := range e.Values {
+				req = req.WithValues(v)
+			}
+			ns = ns.WithMatchExpressions(req)
+		}
+		out = out.WithNamespaceSelector(ns)
 	}
 	for _, ns := range t.Namespaces {
 		out = out.WithNamespaces(ns)
+	}
+	for _, key := range t.MatchLabelKeys {
+		out = out.WithMatchLabelKeys(key)
+	}
+	for _, key := range t.MismatchLabelKeys {
+		out = out.WithMismatchLabelKeys(key)
 	}
 	return out
 }

--- a/pkg/api/validator/v1/job_plan_internal.go
+++ b/pkg/api/validator/v1/job_plan_internal.go
@@ -227,7 +227,7 @@ func preferCPUNodeAffinity() *corev1.Affinity {
 		NodeAffinity: &corev1.NodeAffinity{
 			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
 				{
-					Weight: 100,
+					Weight: preferredAffinityWeight,
 					Preference: corev1.NodeSelectorTerm{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{

--- a/pkg/api/validator/v1/job_plan_test.go
+++ b/pkg/api/validator/v1/job_plan_test.go
@@ -15,10 +15,13 @@
 package v1
 
 import (
+	stderrors "errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -167,7 +170,7 @@ func TestBuildJobPlan(t *testing.T) {
 		{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 	}
 
-	plan := BuildJobPlan(
+	plan, err := BuildJobPlan(
 		entry,
 		"test-run-123",
 		"test-ns",
@@ -177,9 +180,13 @@ func TestBuildJobPlan(t *testing.T) {
 		[]string{"my-secret"},
 		tolerations,
 		nodeSelector,
-		"", // imageRegistryOverride
-		"", // imageTagOverride
+		"",  // imageRegistryOverride
+		"",  // imageTagOverride
+		nil, // componentRefs
 	)
+	if err != nil {
+		t.Fatalf("unexpected error from BuildJobPlan: %v", err)
+	}
 
 	// Verify basic fields
 	if plan.ValidatorName != "test-validator" {
@@ -291,7 +298,10 @@ func TestBuildJobPlanWithDefaults(t *testing.T) {
 		Image: "minimal-image:latest",
 	}
 
-	plan := BuildJobPlan(entry, "run-456", "ns", "", "", "sa", nil, nil, nil, "", "")
+	plan, err := BuildJobPlan(entry, "run-456", "ns", "", "", "sa", nil, nil, nil, "", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error from BuildJobPlan: %v", err)
+	}
 
 	// Should have default resources (buildResources default path)
 	if plan.Resources.Requests.Cpu().Cmp(resource.MustParse("1")) != 0 {
@@ -603,8 +613,11 @@ func TestPlan(t *testing.T) {
 	}
 
 	// Generate plans
-	plans := Plan(cat, validationInput, "test-run-123", "test-ns", "1.0.0", "abc123",
-		"test-service-account", []string{"my-secret"}, nil, nil, "", "")
+	plans, err := Plan(cat, validationInput, "test-run-123", "test-ns", "1.0.0", "abc123",
+		"test-service-account", []string{"my-secret"}, nil, nil, "", "", nil)
+	if err != nil {
+		t.Fatalf("Plan() returned unexpected error: %v", err)
+	}
 
 	// Should have exactly one plan for deployment phase (operator-health)
 	if len(plans) != 1 {
@@ -658,7 +671,10 @@ func TestPlanMultiplePhases(t *testing.T) {
 		},
 	}
 
-	plans := Plan(cat, validationInput, "run-1", "ns", "1.0", "abc", "sa", nil, nil, nil, "", "")
+	plans, err := Plan(cat, validationInput, "run-1", "ns", "1.0", "abc", "sa", nil, nil, nil, "", "", nil)
+	if err != nil {
+		t.Fatalf("Plan() returned unexpected error: %v", err)
+	}
 
 	// Should have 3 plans total (2 deployment + 1 performance)
 	if len(plans) != 3 {
@@ -681,5 +697,85 @@ func TestPlanMultiplePhases(t *testing.T) {
 	}
 	if perfCount != 1 {
 		t.Errorf("Got %d performance plans, want 1", perfCount)
+	}
+}
+
+func TestBuildJobPlan_PropagatesDependencyAffinity(t *testing.T) {
+	entry := ValidatorEntry{
+		Name:        "ai-service-metrics",
+		Phase:       "conformance",
+		Description: "x",
+		Image:       "ghcr.io/x:latest",
+		Timeout:     5 * time.Minute,
+		DependencyAffinity: []DependencyAffinity{{
+			ComponentRef:     "kube-prometheus-stack",
+			PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+			Requirement:      DependencyRequirementRequired,
+		}},
+	}
+	refs := []recipe.ComponentRef{
+		{Name: "kube-prometheus-stack", Namespace: "monitoring"},
+	}
+
+	plan, err := BuildJobPlan(entry, "run-1", "ns", "", "", "sa", nil, nil, nil, "", "", refs)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if plan.Affinity == nil || plan.Affinity.PodAffinity == nil {
+		t.Fatal("expected PodAffinity on plan.Affinity")
+	}
+	if len(plan.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Errorf("expected 1 required term, got %d",
+			len(plan.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	}
+	term := plan.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+	if len(term.Namespaces) != 1 || term.Namespaces[0] != "monitoring" {
+		t.Errorf("expected term.Namespaces = [monitoring], got %v", term.Namespaces)
+	}
+	if term.LabelSelector == nil || term.LabelSelector.MatchLabels["app.kubernetes.io/name"] != "prometheus" {
+		t.Errorf("expected app.kubernetes.io/name=prometheus selector, got %+v", term.LabelSelector)
+	}
+}
+
+func TestBuildJobPlan_RequiredMissingReturnsError(t *testing.T) {
+	entry := ValidatorEntry{
+		Name:        "ai-service-metrics",
+		Phase:       "conformance",
+		Description: "x",
+		Image:       "ghcr.io/x:latest",
+		Timeout:     5 * time.Minute,
+		DependencyAffinity: []DependencyAffinity{{
+			ComponentRef:     "kube-prometheus-stack",
+			PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+			Requirement:      DependencyRequirementRequired,
+		}},
+	}
+
+	_, err := BuildJobPlan(entry, "run-1", "ns", "", "", "sa", nil, nil, nil, "", "", nil)
+	if err == nil {
+		t.Fatal("expected error when required component is missing")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+	}
+}
+
+func TestBuildJobPlan_NilComponentRefsBackwardCompat(t *testing.T) {
+	entry := ValidatorEntry{
+		Name:        "operator-health",
+		Phase:       "deployment",
+		Description: "x",
+		Image:       "ghcr.io/x:latest",
+		Timeout:     2 * time.Minute,
+	}
+	plan, err := BuildJobPlan(entry, "run-1", "ns", "", "", "sa", nil, nil, nil, "", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if plan.Affinity == nil || plan.Affinity.NodeAffinity == nil {
+		t.Fatal("backward compat: prefer-CPU NodeAffinity must remain on every plan")
+	}
+	if plan.Affinity.PodAffinity != nil {
+		t.Errorf("expected nil PodAffinity for entry with no DependencyAffinity")
 	}
 }

--- a/pkg/api/validator/v1/job_plan_test.go
+++ b/pkg/api/validator/v1/job_plan_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGenerateJobName(t *testing.T) {
@@ -777,5 +778,104 @@ func TestBuildJobPlan_NilComponentRefsBackwardCompat(t *testing.T) {
 	}
 	if plan.Affinity.PodAffinity != nil {
 		t.Errorf("expected nil PodAffinity for entry with no DependencyAffinity")
+	}
+}
+
+func TestAffinityToApplyConfig_RoundTripsAllFields(t *testing.T) {
+	cpuKey := "cpu"
+	in := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "kubernetes.io/arch", Operator: corev1.NodeSelectorOpIn, Values: []string{"amd64"}},
+						},
+						MatchFields: []corev1.NodeSelectorRequirement{
+							{Key: "metadata.name", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
+						},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 50,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: cpuKey, Operator: corev1.NodeSelectorOpExists},
+						},
+					},
+				},
+			},
+		},
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "prom"},
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "tier", Operator: metav1.LabelSelectorOpIn, Values: []string{"backend"}},
+						},
+					},
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "obs"}},
+					Namespaces:        []string{"monitoring"},
+					TopologyKey:       "kubernetes.io/hostname",
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 90,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "dcgm"}},
+						Namespaces:    []string{"gpu-operator"},
+						TopologyKey:   "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 10,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "noisy"}},
+						TopologyKey:   "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+	}
+
+	got := affinityToApplyConfig(in)
+	if got == nil {
+		t.Fatal("expected non-nil apply config")
+	}
+	if got.NodeAffinity == nil {
+		t.Fatal("NodeAffinity missing")
+	}
+	if got.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Error("NodeAffinity.Required dropped")
+	}
+	if len(got.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Errorf("expected 1 preferred node term, got %d", len(got.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
+	}
+	if got.PodAffinity == nil {
+		t.Fatal("PodAffinity missing")
+	}
+	if len(got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Errorf("expected 1 required pod term, got %d", len(got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	}
+	req := got.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+	if req.LabelSelector == nil {
+		t.Fatal("PodAffinity required term LabelSelector dropped")
+	}
+	if len(req.LabelSelector.MatchExpressions) != 1 {
+		t.Error("PodAffinity required term LabelSelector.MatchExpressions dropped")
+	}
+	if req.NamespaceSelector == nil {
+		t.Error("PodAffinity required term NamespaceSelector dropped")
+	}
+	if got.PodAntiAffinity == nil {
+		t.Fatal("PodAntiAffinity dropped entirely")
 	}
 }

--- a/pkg/api/validator/v1/validation_input.go
+++ b/pkg/api/validator/v1/validation_input.go
@@ -206,3 +206,15 @@ func convertNodeSelection(ns *recipe.NodeSelection) *NodeSelection {
 		ExcludeNodes: ns.ExcludeNodes,
 	}
 }
+
+// GetComponentRefs returns the resolved recipe's component refs in a nil-safe
+// way. Callers can invoke this on a nil *ValidationInput and receive nil rather
+// than panicking — used by the validator deployer to resolve dependencyAffinity
+// componentRefs to namespaces. When the input is nil, deployers fall back to
+// the default (no podAffinity).
+func (i *ValidationInput) GetComponentRefs() []recipe.ComponentRef {
+	if i == nil {
+		return nil
+	}
+	return i.ComponentRefs
+}

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -277,8 +277,8 @@ func validate(c *ValidatorCatalog) error {
 		}
 		for j, dep := range v.DependencyAffinity {
 			if err := dep.Validate(); err != nil {
-				return errors.Wrap(errors.ErrCodeInvalidRequest,
-					fmt.Sprintf("validator %q: dependencyAffinity[%d]", v.Name, j), err)
+				return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("validator %q: dependencyAffinity[%d]", v.Name, j))
 			}
 		}
 	}

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -275,6 +275,12 @@ func validate(c *ValidatorCatalog) error {
 			return errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("validator %q: image is required", v.Name))
 		}
+		for j, dep := range v.DependencyAffinity {
+			if err := dep.Validate(); err != nil {
+				return errors.Wrap(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("validator %q: dependencyAffinity[%d]", v.Name, j), err)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -1022,6 +1022,36 @@ validators:
 	}
 }
 
+func TestEmbeddedCatalog_AIServiceMetricsHasDependencyAffinity(t *testing.T) {
+	cat, err := Load("v0.0.0-test", "")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	var entry *v1.ValidatorEntry
+	for i, v := range cat.Validators {
+		if v.Name == "ai-service-metrics" {
+			entry = &cat.Validators[i]
+			break
+		}
+	}
+	if entry == nil {
+		t.Fatal("ai-service-metrics not found in embedded catalog")
+	}
+	if len(entry.DependencyAffinity) != 1 {
+		t.Fatalf("expected 1 dependencyAffinity, got %d", len(entry.DependencyAffinity))
+	}
+	dep := entry.DependencyAffinity[0]
+	if dep.ComponentRef != "kube-prometheus-stack" {
+		t.Errorf("componentRef = %q, want kube-prometheus-stack", dep.ComponentRef)
+	}
+	if dep.PodLabelSelector["app.kubernetes.io/name"] != "prometheus" {
+		t.Errorf("podLabelSelector = %v, expected app.kubernetes.io/name=prometheus", dep.PodLabelSelector)
+	}
+	if dep.RequirementOrDefault() != v1.DependencyRequirementPreferred {
+		t.Errorf("requirement = %q, want preferred", dep.RequirementOrDefault())
+	}
+}
+
 func TestCatalogEmbedding(t *testing.T) {
 	// Simulate embedding in a CR spec
 	type ValidatorCatalogSpec struct {

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -1023,7 +1023,9 @@ validators:
 }
 
 func TestEmbeddedCatalog_AIServiceMetricsHasDependencyAffinity(t *testing.T) {
-	cat, err := Load("v0.0.0-test", "")
+	// "-next" suffix bypasses the release-version image-tag rewrite path,
+	// matching how goreleaser snapshots stamp dev binaries.
+	cat, err := Load("v0.0.0-next", "")
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -890,6 +890,138 @@ func TestCatalogOmitEmpty(t *testing.T) {
 	}
 }
 
+func TestParseDependencyAffinity(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantErr       bool
+		wantErrSubstr string // when set, the error message must contain this
+	}{
+		{
+			name: "valid dependencyAffinity required",
+			yaml: `
+apiVersion: validator.nvidia.com/v1alpha1
+kind: ValidatorCatalog
+metadata:
+  name: test
+  version: "1.0.0"
+validators:
+  - name: ai-service-metrics
+    phase: conformance
+    description: Verify AI service metrics via Prometheus
+    image: ghcr.io/nvidia/aicr-validators/conformance:latest
+    timeout: 5m
+    dependencyAffinity:
+      - componentRef: kube-prometheus-stack
+        podLabelSelector:
+          app.kubernetes.io/name: prometheus
+        requirement: required
+`,
+			wantErr: false,
+		},
+		{
+			name: "valid dependencyAffinity preferred default requirement",
+			yaml: `
+apiVersion: validator.nvidia.com/v1alpha1
+kind: ValidatorCatalog
+metadata:
+  name: test
+  version: "1.0.0"
+validators:
+  - name: ai-service-metrics
+    phase: conformance
+    description: x
+    image: ghcr.io/x:latest
+    timeout: 5m
+    dependencyAffinity:
+      - componentRef: kube-prometheus-stack
+        podLabelSelector:
+          app.kubernetes.io/name: prometheus
+`,
+			wantErr: false,
+		},
+		{
+			name: "invalid empty componentRef",
+			yaml: `
+apiVersion: validator.nvidia.com/v1alpha1
+kind: ValidatorCatalog
+metadata:
+  name: test
+  version: "1.0.0"
+validators:
+  - name: ai-service-metrics
+    phase: conformance
+    description: x
+    image: ghcr.io/x:latest
+    timeout: 5m
+    dependencyAffinity:
+      - podLabelSelector:
+          app.kubernetes.io/name: prometheus
+        requirement: required
+`,
+			wantErr:       true,
+			wantErrSubstr: `validator "ai-service-metrics": dependencyAffinity[0]`,
+		},
+		{
+			name: "invalid empty selector",
+			yaml: `
+apiVersion: validator.nvidia.com/v1alpha1
+kind: ValidatorCatalog
+metadata:
+  name: test
+  version: "1.0.0"
+validators:
+  - name: ai-service-metrics
+    phase: conformance
+    description: x
+    image: ghcr.io/x:latest
+    timeout: 5m
+    dependencyAffinity:
+      - componentRef: kube-prometheus-stack
+        requirement: required
+`,
+			wantErr:       true,
+			wantErrSubstr: `validator "ai-service-metrics": dependencyAffinity[0]`,
+		},
+		{
+			name: "invalid requirement value",
+			yaml: `
+apiVersion: validator.nvidia.com/v1alpha1
+kind: ValidatorCatalog
+metadata:
+  name: test
+  version: "1.0.0"
+validators:
+  - name: ai-service-metrics
+    phase: conformance
+    description: x
+    image: ghcr.io/x:latest
+    timeout: 5m
+    dependencyAffinity:
+      - componentRef: kube-prometheus-stack
+        podLabelSelector:
+          app.kubernetes.io/name: prometheus
+        requirement: soft
+`,
+			wantErr:       true,
+			wantErrSubstr: `validator "ai-service-metrics": dependencyAffinity[0]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Errorf("error message = %v, want substring %q", err, tt.wantErrSubstr)
+				}
+			}
+		})
+	}
+}
+
 func TestCatalogEmbedding(t *testing.T) {
 	// Simulate embedding in a CR spec
 	type ValidatorCatalogSpec struct {

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -960,7 +960,7 @@ validators:
         requirement: required
 `,
 			wantErr:       true,
-			wantErrSubstr: `validator "ai-service-metrics": dependencyAffinity[0]`,
+			wantErrSubstr: `componentRef is required`,
 		},
 		{
 			name: "invalid empty selector",
@@ -981,7 +981,7 @@ validators:
         requirement: required
 `,
 			wantErr:       true,
-			wantErrSubstr: `validator "ai-service-metrics": dependencyAffinity[0]`,
+			wantErrSubstr: `podLabelSelector is required`,
 		},
 		{
 			name: "invalid requirement value",
@@ -1004,7 +1004,7 @@ validators:
         requirement: soft
 `,
 			wantErr:       true,
-			wantErrSubstr: `validator "ai-service-metrics": dependencyAffinity[0]`,
+			wantErrSubstr: `invalid requirement "soft"`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/validator/job/deployer.go
+++ b/pkg/validator/job/deployer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/k8s"
 	"github.com/NVIDIA/aicr/pkg/k8s/pod"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/validator/catalog"
 	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	corev1 "k8s.io/api/core/v1"
@@ -46,9 +47,10 @@ type Deployer struct {
 	jobName               string // Unique name generated client-side (set by DeployJob)
 	imagePullSecrets      []string
 	tolerations           []corev1.Toleration
-	nodeSelector          map[string]string // passed through to inner workloads via AICR_NODE_SELECTOR env var
-	imageRegistryOverride string            // overrides the image registry prefix for validator containers
-	imageTagOverride      string            // overrides the resolved image tag for validator containers
+	nodeSelector          map[string]string     // passed through to inner workloads via AICR_NODE_SELECTOR env var
+	imageRegistryOverride string                // overrides the image registry prefix for validator containers
+	imageTagOverride      string                // overrides the resolved image tag for validator containers
+	componentRefs         []recipe.ComponentRef // resolved recipe components, used for dependencyAffinity resolution
 }
 
 // NewDeployer creates a Deployer for a single validator catalog entry.
@@ -69,6 +71,7 @@ func NewDeployer(
 	nodeSelector map[string]string,
 	imageRegistryOverride string,
 	imageTagOverride string,
+	componentRefs []recipe.ComponentRef,
 ) *Deployer {
 
 	return &Deployer{
@@ -84,6 +87,7 @@ func NewDeployer(
 		nodeSelector:          nodeSelector,
 		imageRegistryOverride: imageRegistryOverride,
 		imageTagOverride:      imageTagOverride,
+		componentRefs:         componentRefs,
 	}
 }
 
@@ -97,7 +101,7 @@ func (d *Deployer) JobName() string {
 // A unique name is generated and the Job is applied with the aicr-validator field manager.
 func (d *Deployer) DeployJob(ctx context.Context) error {
 	// Build JobPlan from deployer configuration
-	plan := v1.BuildJobPlan(
+	plan, err := v1.BuildJobPlan(
 		d.entry,
 		d.runID,
 		d.namespace,
@@ -109,7 +113,11 @@ func (d *Deployer) DeployJob(ctx context.Context) error {
 		d.nodeSelector,
 		d.imageRegistryOverride,
 		d.imageTagOverride,
+		d.componentRefs,
 	)
+	if err != nil {
+		return err
+	}
 
 	// Use the job name from the plan
 	d.jobName = plan.JobName

--- a/pkg/validator/job/deployer_test.go
+++ b/pkg/validator/job/deployer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/NVIDIA/aicr/pkg/api/validator/v1"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/k8s/pod"
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
@@ -63,7 +65,7 @@ func deployAndGet(t *testing.T, d *Deployer) *batchv1.Job {
 }
 
 func TestJobNameEmptyBeforeDeploy(t *testing.T) {
-	d := NewDeployer(nil, nil, "default", "run123", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(nil, nil, "default", "run123", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	if d.JobName() != "" {
 		t.Errorf("JobName() before deploy = %q, want empty", d.JobName())
 	}
@@ -71,7 +73,7 @@ func TestJobNameEmptyBeforeDeploy(t *testing.T) {
 
 func TestGenerateJobName(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	job := deployAndGet(t, d)
 
 	if !strings.HasPrefix(job.Name, "aicr-gpu-operator-health-") {
@@ -86,8 +88,8 @@ func TestDeployJobUniqueNames(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d1 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
-	d2 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d1 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
+	d2 := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 
 	if err := d1.DeployJob(ctx); err != nil {
 		t.Fatalf("first DeployJob() failed: %v", err)
@@ -103,7 +105,7 @@ func TestDeployJobUniqueNames(t *testing.T) {
 
 func TestDeployJobSSAFieldManager(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	found := false
 	for _, ref := range job.ManagedFields {
@@ -119,7 +121,7 @@ func TestDeployJobSSAFieldManager(t *testing.T) {
 
 func TestDeployJobLabels(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	expectedLabels := map[string]string{
 		"app.kubernetes.io/name":       "aicr",
@@ -146,7 +148,7 @@ func TestDeployJobLabels(t *testing.T) {
 
 func TestDeployJobTimeouts(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 120 {
 		t.Errorf("ActiveDeadlineSeconds = %v, want 120", job.Spec.ActiveDeadlineSeconds)
@@ -171,7 +173,7 @@ func TestDeployJobDefaultTimeout(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	entry := testEntry()
 	entry.Timeout = 0
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", entry, nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", entry, nil, nil, nil, "", "", nil))
 
 	expected := int64(defaults.ValidatorDefaultTimeout.Seconds())
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != expected {
@@ -181,7 +183,7 @@ func TestDeployJobDefaultTimeout(t *testing.T) {
 
 func TestDeployJobContainer(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	containers := job.Spec.Template.Spec.Containers
 	if len(containers) != 1 {
@@ -211,7 +213,7 @@ func TestDeployJobContainer(t *testing.T) {
 
 func TestDeployJobResources(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	c := job.Spec.Template.Spec.Containers[0]
 	if c.Resources.Requests.Cpu().String() != "1" {
@@ -230,7 +232,7 @@ func TestDeployJobResources(t *testing.T) {
 
 func TestDeployJobEnvVars(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	envMap := make(map[string]corev1.EnvVar)
@@ -294,7 +296,7 @@ func TestDeployJobEnvVars(t *testing.T) {
 func TestDeployJobCLIVersionInjected(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	const wantVersion = "v0.11.1-test"
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", wantVersion, "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", wantVersion, "", testEntry(), nil, nil, nil, "", "", nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	var got *corev1.EnvVar
@@ -336,7 +338,7 @@ func TestDeployJobImageTagOverrideForwarding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := createUniqueNamespace(t)
-			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", tt.tagOverride))
+			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", tt.tagOverride, nil))
 
 			env := job.Spec.Template.Spec.Containers[0].Env
 			var got *corev1.EnvVar
@@ -381,7 +383,7 @@ func TestDeployJobImageRegistryOverrideForwarding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := createUniqueNamespace(t)
-			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, tt.registryOverride, ""))
+			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, tt.registryOverride, "", nil))
 
 			env := job.Spec.Template.Spec.Containers[0].Env
 			var got *corev1.EnvVar
@@ -415,7 +417,7 @@ func TestDeployJobImageRegistryOverrideForwarding(t *testing.T) {
 func TestDeployJobCLICommitInjected(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	const wantCommit = "abc1234"
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", wantCommit, testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", wantCommit, testEntry(), nil, nil, nil, "", "", nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	var got *corev1.EnvVar
@@ -435,7 +437,7 @@ func TestDeployJobCLICommitInjected(t *testing.T) {
 
 func TestDeployJobVolumes(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	volumes := job.Spec.Template.Spec.Volumes
 	if len(volumes) != 2 {
@@ -460,7 +462,7 @@ func TestDeployJobVolumes(t *testing.T) {
 
 func TestDeployJobAffinity(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	affinity := job.Spec.Template.Spec.Affinity
 	if affinity == nil || affinity.NodeAffinity == nil {
@@ -484,7 +486,7 @@ func TestDeployJobAffinity(t *testing.T) {
 func TestDeployJobImagePullSecrets(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	secrets := []string{"registry-creds", "other-secret"}
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), secrets, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), secrets, nil, nil, "", "", nil))
 
 	ips := job.Spec.Template.Spec.ImagePullSecrets
 	if len(ips) != 2 {
@@ -509,7 +511,7 @@ func TestDeployJobOrchestratorToleratesTolerateAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := createUniqueNamespace(t)
-			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, tt.tolerations, nil, "", ""))
+			job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, tt.tolerations, nil, "", "", nil))
 			tols := job.Spec.Template.Spec.Tolerations
 			if len(tols) != 1 || tols[0].Operator != corev1.TolerationOpExists || tols[0].Key != "" {
 				t.Errorf("orchestrator tolerations = %v, want single tolerate-all {Operator: Exists}", tols)
@@ -522,7 +524,7 @@ func TestDeployJobNodeSelectorEnvVar(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	// Use a single-key selector to avoid map ordering issues in serialization.
 	nodeSelector := map[string]string{"my-org/gpu-pool": "true"}
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nodeSelector, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nodeSelector, "", "", nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	envMap := make(map[string]corev1.EnvVar)
@@ -544,7 +546,7 @@ func TestDeployJobNodeSelectorEnvVar(t *testing.T) {
 
 func TestDeployJobNodeSelectorEnvVarAbsent(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
 		if e.Name == "AICR_NODE_SELECTOR" {
@@ -558,7 +560,7 @@ func TestDeployJobTolerationsEnvVar(t *testing.T) {
 	tolerations := []corev1.Toleration{
 		{Key: "gpu-type", Value: "h100", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual},
 	}
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, tolerations, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, tolerations, nil, "", "", nil))
 
 	env := job.Spec.Template.Spec.Containers[0].Env
 	envMap := make(map[string]corev1.EnvVar)
@@ -574,7 +576,7 @@ func TestDeployJobTolerationsEnvVar(t *testing.T) {
 
 func TestDeployJobPodSpec(t *testing.T) {
 	ns := createUniqueNamespace(t)
-	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", ""))
+	job := deployAndGet(t, NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil))
 
 	podSpec := job.Spec.Template.Spec
 	wantSA := ServiceAccountName("run1")
@@ -590,7 +592,7 @@ func TestCleanupJob(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	if err := d.DeployJob(ctx); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -611,7 +613,7 @@ func TestCleanupJob(t *testing.T) {
 }
 
 func TestCleanupJobNotFound(t *testing.T) {
-	d := NewDeployer(testClientset, nil, "default", "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, nil, "default", "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	// jobName is empty — CleanupJob should return nil
 	if err := d.CleanupJob(context.Background()); err != nil {
 		t.Fatalf("CleanupJob() on empty jobName should not error, got: %v", err)
@@ -704,7 +706,7 @@ func TestWaitForCompletionFastPath(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	if err := d.DeployJob(ctx); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -742,7 +744,7 @@ func TestWaitForCompletionFastPathFailed(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	ctx := context.Background()
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	if err := d.DeployJob(ctx); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -768,7 +770,7 @@ func TestWaitForCompletionFastPathFailed(t *testing.T) {
 func TestWaitForCompletionJobNotFound(t *testing.T) {
 	ns := createUniqueNamespace(t)
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	d.jobName = "nonexistent-job"
 
 	err := d.WaitForCompletion(context.Background(), 1*time.Minute)
@@ -780,7 +782,7 @@ func TestWaitForCompletionJobNotFound(t *testing.T) {
 func TestWaitForCompletionTimeout(t *testing.T) {
 	ns := createUniqueNamespace(t)
 
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", testEntry(), nil, nil, nil, "", "", nil)
 	if err := d.DeployJob(context.Background()); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}
@@ -822,5 +824,36 @@ func TestWaitForPodTerminationPropagatesNonNotFound(t *testing.T) {
 	}
 	if sErr.Code == aicrerrors.ErrCodeNotFound {
 		t.Errorf("expected non-NotFound error code, got %v (Forbidden was swallowed!)", sErr.Code)
+	}
+}
+
+func TestDeployer_BuildJobPlanRequiredMissing(t *testing.T) {
+	entry := catalog.ValidatorEntry{
+		Name:        "ai-service-metrics",
+		Phase:       "conformance",
+		Description: "x",
+		Image:       "ghcr.io/x:latest",
+		Timeout:     5 * time.Minute,
+		DependencyAffinity: []v1.DependencyAffinity{{
+			ComponentRef:     "kube-prometheus-stack",
+			PodLabelSelector: map[string]string{"app.kubernetes.io/name": "prometheus"},
+			Requirement:      v1.DependencyRequirementRequired,
+		}},
+	}
+	//nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+	cs := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(cs, 0)
+	d := NewDeployer(cs, factory, "aicr-validation", "run-1", "", "", entry, nil, nil, nil, "", "", nil)
+
+	err := d.DeployJob(context.Background())
+	if err == nil {
+		t.Fatal("expected error when required dependency component is missing")
+	}
+	var sErr *aicrerrors.StructuredError
+	if !stderrors.As(err, &sErr) || sErr.Code != aicrerrors.ErrCodeInvalidRequest {
+		t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+	}
+	if !strings.Contains(sErr.Error(), "kube-prometheus-stack") {
+		t.Errorf("error message should name the missing componentRef, got %v", sErr)
 	}
 }

--- a/pkg/validator/job/result_test.go
+++ b/pkg/validator/job/result_test.go
@@ -60,7 +60,7 @@ func createPodForJob(t *testing.T, ns, jobName string, status corev1.PodStatus) 
 // deployTestJob deploys a Job via envtest and returns the Deployer.
 func deployTestJob(t *testing.T, ns string, entry catalog.ValidatorEntry) *Deployer {
 	t.Helper()
-	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", entry, nil, nil, nil, "", "")
+	d := NewDeployer(testClientset, testFactory(t, ns), ns, "run1", "", "", entry, nil, nil, nil, "", "", nil)
 	if err := d.DeployJob(context.Background()); err != nil {
 		t.Fatalf("DeployJob() failed: %v", err)
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -285,9 +285,14 @@ func (v *Validator) runPhase(
 	// missing required components) at phase scope, so a single misconfigured
 	// entry doesn't strand a partial deploy of earlier entries.
 	for _, entry := range entries {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrap(errors.ErrCodeTimeout, "context canceled during dependencyAffinity pre-flight", ctx.Err())
+		default:
+		}
 		if _, err := v1.BuildOrchestratorAffinity(entry.DependencyAffinity, validationInput.GetComponentRefs()); err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("dependencyAffinity pre-flight failed for validator %q", entry.Name), err)
+			return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("dependencyAffinity pre-flight failed for validator %q", entry.Name))
 		}
 	}
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -279,6 +279,18 @@ func (v *Validator) runPhase(
 
 	builder := ctrf.NewBuilder("aicr", v.Version, string(phase))
 
+	// Pre-flight: validate all dependencyAffinity for required components
+	// resolve before any Job is deployed. This honors the per-validator
+	// contract (BuildOrchestratorAffinity returns ErrCodeInvalidRequest for
+	// missing required components) at phase scope, so a single misconfigured
+	// entry doesn't strand a partial deploy of earlier entries.
+	for _, entry := range entries {
+		if _, err := v1.BuildOrchestratorAffinity(entry.DependencyAffinity, validationInput.GetComponentRefs()); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("dependencyAffinity pre-flight failed for validator %q", entry.Name), err)
+		}
+	}
+
 	// TODO(perf): entries within a phase are independent Jobs and can be
 	// fan-out with errgroup + a small worker pool. Deferred from the
 	// principal-review sweep because parallelism interacts with shared-

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -297,6 +297,7 @@ func (v *Validator) runPhase(
 			clientset, factory, v.Namespace, v.RunID, v.Version, v.Commit, entry,
 			v.ImagePullSecrets, v.Tolerations, v.NodeSelector,
 			v.ImageRegistryOverride, v.ImageTagOverride,
+			validationInput.GetComponentRefs(),
 		)
 
 		// Deploy

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -107,6 +107,15 @@ validators:
     timeout: 5m
     args: ["ai-service-metrics"]
     env: []
+    # Co-locate the orchestrator pod with Prometheus so the dial is loopback
+    # / same-node, not subject to cross-Security-Group ingress rules. Required
+    # for determinism on multi-SG clusters (e.g., DGXC EKS with separate
+    # customer/system ENI subnets). See https://github.com/NVIDIA/aicr/issues/933.
+    dependencyAffinity:
+      - componentRef: kube-prometheus-stack
+        podLabelSelector:
+          app.kubernetes.io/name: prometheus
+        requirement: preferred
   - name: inference-gateway
     phase: conformance
     description: "Verify inference gateway (agentgateway) is operational"

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -107,10 +107,12 @@ validators:
     timeout: 5m
     args: ["ai-service-metrics"]
     env: []
-    # Co-locate the orchestrator pod with Prometheus so the dial is loopback
-    # / same-node, not subject to cross-Security-Group ingress rules. Required
-    # for determinism on multi-SG clusters (e.g., DGXC EKS with separate
-    # customer/system ENI subnets). See https://github.com/NVIDIA/aicr/issues/933.
+    # Best-effort co-location: prefer the same node as Prometheus so the dial
+    # is loopback / same-node and avoids cross-Security-Group ingress filtering.
+    # Uses requirement: preferred — schedule still falls back to any node if
+    # Prometheus is unschedulable. Motivated by multi-SG clusters (e.g., DGXC
+    # EKS with separate customer/system ENI subnets) where pod-to-pod
+    # reachability is asymmetric. See https://github.com/NVIDIA/aicr/issues/933.
     dependencyAffinity:
       - componentRef: kube-prometheus-stack
         podLabelSelector:


### PR DESCRIPTION
## Summary

Add a `dependencyAffinity` field to the validator catalog and use it to pin the `ai-service-metrics` orchestrator pod to the node running Prometheus. Eliminates intermittent failures on multi-Security-Group clusters where the dial would otherwise traverse cross-SG ingress.

## Motivation / Context

On multi-SG EKS clusters (e.g., DGXC GB200 with separate customer/system ENI subnets), `ai-service-metrics` was nondeterministically landing on nodes that could not dial the Prometheus service. Image-locality scoring decided placement once the validator image was cached, masking the underlying network-reachability constraint. The fix declares the dependency in the catalog and the deployer materializes it as a `podAffinity` term whose weight (100) dominates image-locality on first scheduling, then reinforces itself via locality on subsequent runs.

Fixes: #933
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI
- [ ] API server
- [ ] Recipe engine / data
- [ ] Bundlers
- [ ] Collectors / snapshotter
- [x] Validator (`pkg/validator`, `pkg/api/validator/v1`)
- [ ] Core libraries
- [x] Docs/examples (`docs/integrator/validator-extension.md`)
- [x] Other: validator catalog (`recipes/validators/catalog.yaml`)

## Implementation Notes

- New `DependencyAffinity` type on catalog entries: `componentRef`, `podLabelSelector`, `topologyKey` (defaults to `kubernetes.io/hostname`), and `requirement` (`preferred` default, or `required`).
- `BuildOrchestratorAffinity` resolves each dependency against the recipe's `componentRefs`:
  - `required` + missing/disabled/no-namespace → `ErrCodeInvalidRequest` (caller must abort before deploying).
  - `preferred` + missing → `slog.Warn` and skip the term (preserves behavior on flat networks).
  - Resolvable refs produce a `PodAffinityTerm` with the component's resolved namespace.
- Pre-flight gate added to `pkg/validator/validator.go`: walks selected validators and validates `dependencyAffinity` against the recipe before any Job is deployed.
- Deployer threads `componentRefs` into the JobPlan and renders the affinity into the orchestrator pod's `applyconfigurations` spec.
- `ai-service-metrics` catalog entry uses `requirement: preferred` so flat-cluster recipes that omit `kube-prometheus-stack` still run (validator schedules wherever, warning logged).
- Outer wrap in `pkg/validator/validator.go:290` returns `ErrCodeInternal` over an inner `ErrCodeInvalidRequest`; minor cosmetic deviation from the no-double-wrap rule, no behavior impact, tracked as follow-up.

## Testing

```bash
make qualify
go test ./pkg/api/validator/v1/... ./pkg/validator/...
```

Manually verified end-to-end on a GB200/EKS multi-SG cluster:

1. **Prometheus label sanity** — `monitoring/prometheus-kube-prometheus-prometheus-0` carries `app.kubernetes.io/name=prometheus`; selector matches.
2. **Deterministic placement** — 4/4 consecutive `validate --phase conformance` runs landed the `ai-service-metrics` orchestrator on the Prometheus node. Injected Job spec confirmed: `preferredDuringSchedulingIgnoredDuringExecution` with `weight: 100`, `matchLabels: app.kubernetes.io/name: prometheus`, `namespaces: [monitoring]`, `topologyKey: kubernetes.io/hostname`.
3. **Negative path** — with a `--data` overlay flipping `ai-service-metrics` to `requirement: required` and a recipe missing `kube-prometheus-stack` from componentRefs, validate aborts at pre-flight: `[INVALID_REQUEST] required dependencyAffinity component "kube-prometheus-stack" is not in the recipe's componentRefs`. Zero Jobs deployed.

**Coverage delta:**
- `pkg/api/validator/v1`: 67.4% → 73.6% (+6.2%)
- `pkg/validator/catalog`: 97.4% → 97.5% (+0.1%)
- `pkg/validator/job`: 12.9% → 15.7% (+2.8%)
- `pkg/validator`: 25.1% → 24.8% (-0.3%, within noise)

## Risk Assessment

- [x] **Low** — Isolated to validator orchestration. Default `requirement: preferred` preserves existing behavior on recipes without `kube-prometheus-stack`; the only validator using the new field today is `ai-service-metrics`. Easy to revert by removing the catalog entry's `dependencyAffinity` block.

**Rollout notes:** No migration required. Existing recipes work unchanged. Recipes wanting to enforce co-location for custom validators can opt-in via `requirement: required`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
