### PR TITLE
fix(ci): drop privileged grants from /ok-to-test fork path

### DIFF
--- a/.github/workflows/ok-to-test.yaml
+++ b/.github/workflows/ok-to-test.yaml
@@ -14,7 +14,14 @@
 
 # Allows maintainers to run the full qualification suite on fork PRs
 # by commenting "/ok-to-test" on the PR. This runs in the base repo
-# context, so id-token: write and other elevated permissions are available.
+# context, but only grants the minimum permissions needed because the
+# called qualification workflow checks out and runs fork-controlled
+# local actions (`./.github/actions/*`). Privileged grants
+# (id-token: write, security-events: write) are deliberately withheld
+# here so a malicious fork cannot mint OIDC tokens or upload to code
+# scanning. Steps that need those tokens are either already gated to
+# non-fork PRs (e.g. SLSA predicate) or degrade gracefully on permission
+# denial (e.g. SARIF upload via continue-on-error).
 
 name: OK to Test
 
@@ -75,7 +82,5 @@ jobs:
     permissions:
       actions: read
       contents: read
-      id-token: write
-      security-events: write
     with:
       ref: ${{ needs.authorize.outputs.ref }}


### PR DESCRIPTION
## Summary

Drop `id-token: write` and `security-events: write` from the `/ok-to-test` → `qualification.yaml` call so fork-controlled local actions cannot mint OIDC tokens scoped to `NVIDIA/aicr` or write to code scanning.

## Motivation / Context

`ok-to-test.yaml` reads `pr.head.sha` and passes it to `qualification.yaml`, which checks out that ref and then runs `./.github/actions/*` local actions. Those paths resolve against the workspace, so once a maintainer types `/ok-to-test`, the fork PR author's `action.yml` content executes with whatever permissions the caller granted — currently `id-token: write` and `security-events: write`.

A "maintainer approved the run" gate isn't enough here: reviewers rarely audit `.github/actions/**` in a fork before greenlighting tests, and this is the standard pwn-request pattern GitHub's security lab warns about. The repo already uses the safer `workflow_run` + guarded-checkout pattern in `on-push-comment.yaml`.

Fixes: #1063
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/ok-to-test.yaml`

## Implementation Notes

Minimal-blast-radius fix. The called jobs already degrade gracefully without these tokens:

- `cli-e2e`: only the `Generate SLSA predicate` step needs `id-token: write`, and it's already gated by `if: github.event.pull_request.head.repo.fork == false`. Chainsaw tests run fine without OIDC.
- `security-scan`: the SARIF upload step has `continue-on-error: true`, so missing `security-events: write` results in a logged notice rather than a job failure.

A larger refactor (split workflows, or load actions from base ref) was considered but rejected as out of scope — withholding the grants closes the exploit at the caller layer without restructuring qualification.

## Testing

`make qualify` is not affected by this change (workflow-only). The change will be exercised by the next fork PR + `/ok-to-test` cycle; the expected difference is a single `::notice::` line from the SARIF upload skip and no change to other jobs.

## Risk Assessment

- [x] **Low** — Isolated workflow change, easy to revert.

**Rollout notes:** No migration. If a future qualification step legitimately needs OIDC or SARIF upload on fork PRs, the safer path is to move it behind a `workflow_run`-triggered job that does not check out fork code.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)  — N/A, workflow-only change
- [x] Linter passes (`make lint`) — yamllint clean on the changed file
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)