### PR TITLE
fix(bundler): recipe-set scheduling paths override CLI defaults (#982)

### DIFF
--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -709,6 +709,40 @@ func (b *DefaultBundler) getSetEnabledOverride(componentName string, provider re
 	return parsed, true, nil
 }
 
+// preExistingSchedulingPaths returns the subset of dot-notation paths that
+// were already populated in values when scheduling injection began. The
+// bundler captures this snapshot once at the top of applyNodeSchedulingOverrides
+// so a path set by a recipe overlay or --set (e.g., kind.yaml's
+// daemonsets.tolerations: [], bcm.yaml's controller.tolerations) is treated
+// as authoritative for the entire injection chain. Crucially, paths written
+// by an earlier injection step within the same call (e.g., system writing
+// worker.tolerations before accelerated overwrites it) are NOT in the
+// snapshot, so the documented system → accelerated overwrite for shared
+// paths still works.
+func preExistingSchedulingPaths(values map[string]any, paths []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		if _, found := component.GetValueByPath(values, p); found {
+			set[p] = struct{}{}
+		}
+	}
+	return set
+}
+
+// filterPaths returns paths not present in skip.
+func filterPaths(paths []string, skip map[string]struct{}) []string {
+	if len(paths) == 0 || len(skip) == 0 {
+		return paths
+	}
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if _, blocked := skip[p]; !blocked {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // applyNodeSchedulingOverrides applies node selectors and tolerations to component values.
 // Uses the component registry to determine the correct paths for each component.
 // The provider argument scopes the registry lookup to the recipe's bound DataProvider;
@@ -733,37 +767,54 @@ func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, valu
 		return // Unknown component, skip
 	}
 
+	// Snapshot the set of scheduling paths that were populated BEFORE any
+	// injection ran — i.e. by the recipe overlay or by --set values that
+	// have already been merged into the values map. These paths are
+	// authoritative and must not be overwritten by CLI/config defaults
+	// (e.g., kind.yaml's `daemonsets.tolerations: []`, bcm.yaml's careful
+	// BCM-master `controller.tolerations`). Internal writes during this
+	// function (system → accelerated for shared paths like NFD's
+	// worker.tolerations) are NOT in the snapshot, so the documented
+	// "accelerated overrides system" behavior is preserved.
+	allPaths := make([]string, 0, 16)
+	allPaths = append(allPaths, comp.GetSystemNodeSelectorPaths()...)
+	allPaths = append(allPaths, comp.GetSystemTolerationPaths()...)
+	allPaths = append(allPaths, comp.GetAcceleratedNodeSelectorPaths()...)
+	allPaths = append(allPaths, comp.GetAcceleratedTolerationPaths()...)
+	allPaths = append(allPaths, comp.GetWorkloadSelectorPaths()...)
+	recipeSet := preExistingSchedulingPaths(values, allPaths)
+
 	// Apply system node selector
 	if nodeSelector := b.Config.SystemNodeSelector(); len(nodeSelector) > 0 {
-		if paths := comp.GetSystemNodeSelectorPaths(); len(paths) > 0 {
+		if paths := filterPaths(comp.GetSystemNodeSelectorPaths(), recipeSet); len(paths) > 0 {
 			component.ApplyNodeSelectorOverrides(values, nodeSelector, paths...)
 		}
 	}
 
 	// Apply system tolerations
 	if tolerations := b.Config.SystemNodeTolerations(); len(tolerations) > 0 {
-		if paths := comp.GetSystemTolerationPaths(); len(paths) > 0 {
+		if paths := filterPaths(comp.GetSystemTolerationPaths(), recipeSet); len(paths) > 0 {
 			component.ApplyTolerationsOverrides(values, tolerations, paths...)
 		}
 	}
 
 	// Apply accelerated node selector
 	if nodeSelector := b.Config.AcceleratedNodeSelector(); len(nodeSelector) > 0 {
-		if paths := comp.GetAcceleratedNodeSelectorPaths(); len(paths) > 0 {
+		if paths := filterPaths(comp.GetAcceleratedNodeSelectorPaths(), recipeSet); len(paths) > 0 {
 			component.ApplyNodeSelectorOverrides(values, nodeSelector, paths...)
 		}
 	}
 
 	// Apply accelerated tolerations
 	if tolerations := b.Config.AcceleratedNodeTolerations(); len(tolerations) > 0 {
-		if paths := comp.GetAcceleratedTolerationPaths(); len(paths) > 0 {
+		if paths := filterPaths(comp.GetAcceleratedTolerationPaths(), recipeSet); len(paths) > 0 {
 			component.ApplyTolerationsOverrides(values, tolerations, paths...)
 		}
 	}
 
 	// Apply workload selector
 	if workloadSelector := b.Config.WorkloadSelector(); len(workloadSelector) > 0 {
-		if paths := comp.GetWorkloadSelectorPaths(); len(paths) > 0 {
+		if paths := filterPaths(comp.GetWorkloadSelectorPaths(), recipeSet); len(paths) > 0 {
 			component.ApplyNodeSelectorOverrides(values, workloadSelector, paths...)
 		}
 	}

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -632,10 +632,10 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 		// precedence over CLI/config defaults inside
 		// applyNodeSchedulingOverrides. Component default valuesFile values
 		// are intentionally excluded — see authoritativeSchedulingPaths godoc.
-		authoritative := b.computeAuthoritativeSchedulingPaths(&ref, provider, setOverrides)
+		policy := b.computeSchedulingPathPolicy(&ref, provider, setOverrides)
 
 		// Apply node selectors, tolerations, workload selector, and taints based on component type
-		b.applyNodeSchedulingOverrides(ref.Name, values, provider, authoritative)
+		b.applyNodeSchedulingOverrides(ref.Name, values, provider, policy)
 
 		componentValues[ref.Name] = values
 	}
@@ -717,23 +717,42 @@ func (b *DefaultBundler) getSetEnabledOverride(componentName string, provider re
 	return parsed, true, nil
 }
 
-// computeAuthoritativeSchedulingPaths collects every scheduling path declared
-// for the component in the registry, then asks authoritativeSchedulingPaths
-// which of those paths the user explicitly populated. Called once per
-// component before applyNodeSchedulingOverrides so the precedence decision is
-// made from authoritative sources (overlay + --set) rather than the merged
-// values map (which also contains chart default valuesFile data).
-func (b *DefaultBundler) computeAuthoritativeSchedulingPaths(ref *recipe.ComponentRef, provider recipe.DataProvider, setOverrides map[string]string) map[string]struct{} {
+// schedulingPathPolicy is the per-path policy the bundler applies during
+// node-scheduling injection. It is derived from the recipe overlay's
+// inline overrides (componentRefs[].overrides) and CLI --set values; the
+// component's default valuesFile is intentionally NOT consulted so a
+// chart-default toleration shipped in values.yaml (e.g., kueue's
+// `controllerManager.tolerations: [{Exists}]`) does not silently turn
+// --system-node-toleration into a no-op.
+type schedulingPathPolicy struct {
+	// optOut paths are populated by the overlay/--set with an explicitly
+	// empty value (empty slice for tolerations, empty map for selectors).
+	// Injection is skipped entirely — e.g. kind.yaml's
+	// `daemonsets.tolerations: []` keeps GPU operands off the
+	// control-plane by letting the chart default kick in.
+	optOut map[string]struct{}
+	// appendMode paths are populated by the overlay/--set with a
+	// NON-empty toleration list — the overlay's intent is "ALSO tolerate
+	// these", so CLI tolerations augment the overlay list rather than
+	// replace it (e.g. bcm.yaml's `controller.tolerations` for the
+	// BCM-master taints must coexist with the KWOK system-pool taint
+	// passed via --system-node-toleration).
+	appendMode map[string]struct{}
+}
+
+// computeSchedulingPathPolicy classifies every registry-declared scheduling
+// path for the component into optOut / appendMode / (implicit) replace.
+func (b *DefaultBundler) computeSchedulingPathPolicy(ref *recipe.ComponentRef, provider recipe.DataProvider, setOverrides map[string]string) schedulingPathPolicy {
 	if ref == nil {
-		return nil
+		return schedulingPathPolicy{}
 	}
 	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
-		return nil
+		return schedulingPathPolicy{}
 	}
 	comp := registry.Get(ref.Name)
 	if comp == nil {
-		return nil
+		return schedulingPathPolicy{}
 	}
 	allPaths := make([]string, 0, 16)
 	allPaths = append(allPaths, comp.GetSystemNodeSelectorPaths()...)
@@ -741,38 +760,62 @@ func (b *DefaultBundler) computeAuthoritativeSchedulingPaths(ref *recipe.Compone
 	allPaths = append(allPaths, comp.GetAcceleratedNodeSelectorPaths()...)
 	allPaths = append(allPaths, comp.GetAcceleratedTolerationPaths()...)
 	allPaths = append(allPaths, comp.GetWorkloadSelectorPaths()...)
-	return authoritativeSchedulingPaths(ref.Overrides, setOverrides, allPaths)
+	return classifySchedulingPaths(ref.Overrides, setOverrides, allPaths)
 }
 
-// authoritativeSchedulingPaths returns the subset of dot-notation paths that
-// the user explicitly populated via the recipe overlay's inline overrides or
-// a CLI --set flag. Those sources are treated as authoritative and must not
-// be overwritten by CLI/config defaults (e.g., kind.yaml's
-// `daemonsets.tolerations: []`, bcm.yaml's BCM-master `controller.tolerations`).
-//
-// The component's default valuesFile is intentionally NOT consulted: several
-// components (kai-scheduler, kueue, network-operator, aws-efa) ship default
-// values that happen to set registry-declared scheduling paths to a
-// chart-default-equivalent toleration. Treating those as authoritative would
-// silently turn --system-node-toleration / --accelerated-node-toleration into
-// a no-op for those components, breaking a documented CLI surface.
-//
-// CLI --set inputs use dot-notation keys (e.g., "global.tolerations"); inline
-// overrides are nested maps. Both are checked.
-func authoritativeSchedulingPaths(overrides map[string]any, setOverrides map[string]string, paths []string) map[string]struct{} {
-	out := make(map[string]struct{}, len(paths))
-	for _, p := range paths {
-		if overrides != nil {
-			if _, found := component.GetValueByPath(overrides, p); found {
-				out[p] = struct{}{}
-				continue
-			}
-		}
-		if _, found := setOverrides[p]; found {
-			out[p] = struct{}{}
-		}
+// classifySchedulingPaths returns the opt-out / append classification for
+// the given dot-notation paths. A path is opt-out when the overlay or --set
+// resolves it to an empty slice/map; append when it resolves to a non-empty
+// value; otherwise unclassified (treated as replace by the caller).
+func classifySchedulingPaths(overrides map[string]any, setOverrides map[string]string, paths []string) schedulingPathPolicy {
+	policy := schedulingPathPolicy{
+		optOut:     make(map[string]struct{}),
+		appendMode: make(map[string]struct{}),
 	}
-	return out
+	for _, p := range paths {
+		val, hasOverlay := overlayValueAt(overrides, p)
+		_, hasSet := setOverrides[p]
+		if !hasOverlay && !hasSet {
+			continue
+		}
+		// Opt-out is gated on the OVERLAY only: --set passes string values
+		// that cannot meaningfully represent a "no tolerations" sentinel
+		// (an empty-list overlay literal is the canonical opt-out gesture).
+		if hasOverlay && isEmptyOverlayValue(val) {
+			policy.optOut[p] = struct{}{}
+			continue
+		}
+		policy.appendMode[p] = struct{}{}
+	}
+	return policy
+}
+
+// overlayValueAt returns the value at the dot-notation path in the recipe
+// overlay's inline overrides, plus whether the path resolved.
+func overlayValueAt(overrides map[string]any, path string) (any, bool) {
+	if overrides == nil {
+		return nil, false
+	}
+	return component.GetValueByPath(overrides, path)
+}
+
+// isEmptyOverlayValue reports whether v is the recipe author's deliberate
+// "no value here" sentinel — an empty slice/map, an explicit nil, or any
+// representation that yields zero entries. Used to detect opt-out semantics
+// (kind.yaml's `daemonsets.tolerations: []`).
+func isEmptyOverlayValue(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return true
+	case []any:
+		return len(x) == 0
+	case map[string]any:
+		return len(x) == 0
+	case map[any]any:
+		return len(x) == 0
+	default:
+		return false
+	}
 }
 
 // filterPaths returns paths not present in skip.
@@ -789,16 +832,32 @@ func filterPaths(paths []string, skip map[string]struct{}) []string {
 	return out
 }
 
+// splitPaths partitions paths into (append-mode, replace-mode) based on
+// policy.appendMode. Opt-out paths must already be filtered out by the caller.
+func splitPaths(paths []string, appendMode map[string]struct{}) (appendPaths, replacePaths []string) {
+	for _, p := range paths {
+		if _, ok := appendMode[p]; ok {
+			appendPaths = append(appendPaths, p)
+		} else {
+			replacePaths = append(replacePaths, p)
+		}
+	}
+	return
+}
+
 // applyNodeSchedulingOverrides applies node selectors and tolerations to component values.
 // Uses the component registry to determine the correct paths for each component.
 // The provider argument scopes the registry lookup to the recipe's bound DataProvider;
 // a nil provider falls back to the package-global registry via GetComponentRegistryFor.
-// The authoritative argument is the set of paths the user explicitly set via
-// the recipe overlay or --set; those paths are not overwritten by CLI/config
-// defaults. Writes within this function (system → accelerated for shared
-// paths like NFD's worker.tolerations) are NOT in the set, so the documented
-// "accelerated overrides system" behavior is preserved.
-func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, values map[string]any, provider recipe.DataProvider, authoritative map[string]struct{}) {
+//
+// The policy argument carries the per-path opt-out / append classification
+// computed once at the top of extractComponentValues. opt-out paths are
+// skipped entirely; append-mode paths receive CLI tolerations appended to
+// whatever the overlay already wrote (so bcm.yaml's BCM-master tolerations
+// coexist with --system-node-toleration); other paths use REPLACE semantics
+// so the documented system → accelerated overwrite for shared paths like
+// NFD's worker.tolerations still produces "accelerated wins".
+func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, values map[string]any, provider recipe.DataProvider, policy schedulingPathPolicy) {
 	if b.Config == nil {
 		return
 	}
@@ -818,39 +877,52 @@ func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, valu
 		return // Unknown component, skip
 	}
 
-	recipeSet := authoritative
-
-	// Apply system node selector
+	// Apply system node selector. NodeSelector uses REPLACE semantics even
+	// for overlay-set non-empty values — no current overlay sets selector
+	// paths, and the cuj1-training contract assumes CLI replaces.
 	if nodeSelector := b.Config.SystemNodeSelector(); len(nodeSelector) > 0 {
-		if paths := filterPaths(comp.GetSystemNodeSelectorPaths(), recipeSet); len(paths) > 0 {
+		if paths := filterPaths(comp.GetSystemNodeSelectorPaths(), policy.optOut); len(paths) > 0 {
 			component.ApplyNodeSelectorOverrides(values, nodeSelector, paths...)
 		}
 	}
 
-	// Apply system tolerations
+	// Apply system tolerations — split into append-mode (overlay had a
+	// non-empty list, e.g. bcm) and replace-mode (no overlay).
 	if tolerations := b.Config.SystemNodeTolerations(); len(tolerations) > 0 {
-		if paths := filterPaths(comp.GetSystemTolerationPaths(), recipeSet); len(paths) > 0 {
-			component.ApplyTolerationsOverrides(values, tolerations, paths...)
+		if paths := filterPaths(comp.GetSystemTolerationPaths(), policy.optOut); len(paths) > 0 {
+			appendPaths, replacePaths := splitPaths(paths, policy.appendMode)
+			if len(replacePaths) > 0 {
+				component.ApplyTolerationsOverrides(values, tolerations, replacePaths...)
+			}
+			if len(appendPaths) > 0 {
+				component.AppendTolerationsOverrides(values, tolerations, appendPaths...)
+			}
 		}
 	}
 
 	// Apply accelerated node selector
 	if nodeSelector := b.Config.AcceleratedNodeSelector(); len(nodeSelector) > 0 {
-		if paths := filterPaths(comp.GetAcceleratedNodeSelectorPaths(), recipeSet); len(paths) > 0 {
+		if paths := filterPaths(comp.GetAcceleratedNodeSelectorPaths(), policy.optOut); len(paths) > 0 {
 			component.ApplyNodeSelectorOverrides(values, nodeSelector, paths...)
 		}
 	}
 
 	// Apply accelerated tolerations
 	if tolerations := b.Config.AcceleratedNodeTolerations(); len(tolerations) > 0 {
-		if paths := filterPaths(comp.GetAcceleratedTolerationPaths(), recipeSet); len(paths) > 0 {
-			component.ApplyTolerationsOverrides(values, tolerations, paths...)
+		if paths := filterPaths(comp.GetAcceleratedTolerationPaths(), policy.optOut); len(paths) > 0 {
+			appendPaths, replacePaths := splitPaths(paths, policy.appendMode)
+			if len(replacePaths) > 0 {
+				component.ApplyTolerationsOverrides(values, tolerations, replacePaths...)
+			}
+			if len(appendPaths) > 0 {
+				component.AppendTolerationsOverrides(values, tolerations, appendPaths...)
+			}
 		}
 	}
 
 	// Apply workload selector
 	if workloadSelector := b.Config.WorkloadSelector(); len(workloadSelector) > 0 {
-		if paths := filterPaths(comp.GetWorkloadSelectorPaths(), recipeSet); len(paths) > 0 {
+		if paths := filterPaths(comp.GetWorkloadSelectorPaths(), policy.optOut); len(paths) > 0 {
 			component.ApplyNodeSelectorOverrides(values, workloadSelector, paths...)
 		}
 	}

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -603,18 +603,19 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 
 		// Apply user value overrides from --set flags.
 		// Strip "enabled" key — it controls component inclusion, not Helm chart values.
-		if overrides := b.getValueOverridesForComponent(ref.Name, provider); len(overrides) > 0 {
-			if _, has := overrides["enabled"]; has {
-				filtered := make(map[string]string, len(overrides)-1)
-				for k, v := range overrides {
+		setOverrides := b.getValueOverridesForComponent(ref.Name, provider)
+		if len(setOverrides) > 0 {
+			if _, has := setOverrides["enabled"]; has {
+				filtered := make(map[string]string, len(setOverrides)-1)
+				for k, v := range setOverrides {
 					if k == "enabled" {
 						continue
 					}
 					filtered[k] = v
 				}
-				overrides = filtered
+				setOverrides = filtered
 			}
-			if applyErr := component.ApplyMapOverrides(values, overrides); applyErr != nil {
+			if applyErr := component.ApplyMapOverrides(values, setOverrides); applyErr != nil {
 				// User-supplied --set overrides must produce the values the
 				// user asked for; silently dropping them ships a bundle
 				// that doesn't reflect the CLI inputs. Fail loudly so the
@@ -626,8 +627,15 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 			}
 		}
 
+		// Compute the set of scheduling paths the user explicitly populated
+		// (recipe overlay's inline overrides + CLI --set). These take
+		// precedence over CLI/config defaults inside
+		// applyNodeSchedulingOverrides. Component default valuesFile values
+		// are intentionally excluded — see authoritativeSchedulingPaths godoc.
+		authoritative := b.computeAuthoritativeSchedulingPaths(&ref, provider, setOverrides)
+
 		// Apply node selectors, tolerations, workload selector, and taints based on component type
-		b.applyNodeSchedulingOverrides(ref.Name, values, provider)
+		b.applyNodeSchedulingOverrides(ref.Name, values, provider, authoritative)
 
 		componentValues[ref.Name] = values
 	}
@@ -709,24 +717,62 @@ func (b *DefaultBundler) getSetEnabledOverride(componentName string, provider re
 	return parsed, true, nil
 }
 
-// preExistingSchedulingPaths returns the subset of dot-notation paths that
-// were already populated in values when scheduling injection began. The
-// bundler captures this snapshot once at the top of applyNodeSchedulingOverrides
-// so a path set by a recipe overlay or --set (e.g., kind.yaml's
-// daemonsets.tolerations: [], bcm.yaml's controller.tolerations) is treated
-// as authoritative for the entire injection chain. Crucially, paths written
-// by an earlier injection step within the same call (e.g., system writing
-// worker.tolerations before accelerated overwrites it) are NOT in the
-// snapshot, so the documented system → accelerated overwrite for shared
-// paths still works.
-func preExistingSchedulingPaths(values map[string]any, paths []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(paths))
+// computeAuthoritativeSchedulingPaths collects every scheduling path declared
+// for the component in the registry, then asks authoritativeSchedulingPaths
+// which of those paths the user explicitly populated. Called once per
+// component before applyNodeSchedulingOverrides so the precedence decision is
+// made from authoritative sources (overlay + --set) rather than the merged
+// values map (which also contains chart default valuesFile data).
+func (b *DefaultBundler) computeAuthoritativeSchedulingPaths(ref *recipe.ComponentRef, provider recipe.DataProvider, setOverrides map[string]string) map[string]struct{} {
+	if ref == nil {
+		return nil
+	}
+	registry, err := recipe.GetComponentRegistryFor(provider)
+	if err != nil {
+		return nil
+	}
+	comp := registry.Get(ref.Name)
+	if comp == nil {
+		return nil
+	}
+	allPaths := make([]string, 0, 16)
+	allPaths = append(allPaths, comp.GetSystemNodeSelectorPaths()...)
+	allPaths = append(allPaths, comp.GetSystemTolerationPaths()...)
+	allPaths = append(allPaths, comp.GetAcceleratedNodeSelectorPaths()...)
+	allPaths = append(allPaths, comp.GetAcceleratedTolerationPaths()...)
+	allPaths = append(allPaths, comp.GetWorkloadSelectorPaths()...)
+	return authoritativeSchedulingPaths(ref.Overrides, setOverrides, allPaths)
+}
+
+// authoritativeSchedulingPaths returns the subset of dot-notation paths that
+// the user explicitly populated via the recipe overlay's inline overrides or
+// a CLI --set flag. Those sources are treated as authoritative and must not
+// be overwritten by CLI/config defaults (e.g., kind.yaml's
+// `daemonsets.tolerations: []`, bcm.yaml's BCM-master `controller.tolerations`).
+//
+// The component's default valuesFile is intentionally NOT consulted: several
+// components (kai-scheduler, kueue, network-operator, aws-efa) ship default
+// values that happen to set registry-declared scheduling paths to a
+// chart-default-equivalent toleration. Treating those as authoritative would
+// silently turn --system-node-toleration / --accelerated-node-toleration into
+// a no-op for those components, breaking a documented CLI surface.
+//
+// CLI --set inputs use dot-notation keys (e.g., "global.tolerations"); inline
+// overrides are nested maps. Both are checked.
+func authoritativeSchedulingPaths(overrides map[string]any, setOverrides map[string]string, paths []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(paths))
 	for _, p := range paths {
-		if _, found := component.GetValueByPath(values, p); found {
-			set[p] = struct{}{}
+		if overrides != nil {
+			if _, found := component.GetValueByPath(overrides, p); found {
+				out[p] = struct{}{}
+				continue
+			}
+		}
+		if _, found := setOverrides[p]; found {
+			out[p] = struct{}{}
 		}
 	}
-	return set
+	return out
 }
 
 // filterPaths returns paths not present in skip.
@@ -747,7 +793,12 @@ func filterPaths(paths []string, skip map[string]struct{}) []string {
 // Uses the component registry to determine the correct paths for each component.
 // The provider argument scopes the registry lookup to the recipe's bound DataProvider;
 // a nil provider falls back to the package-global registry via GetComponentRegistryFor.
-func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, values map[string]any, provider recipe.DataProvider) {
+// The authoritative argument is the set of paths the user explicitly set via
+// the recipe overlay or --set; those paths are not overwritten by CLI/config
+// defaults. Writes within this function (system → accelerated for shared
+// paths like NFD's worker.tolerations) are NOT in the set, so the documented
+// "accelerated overrides system" behavior is preserved.
+func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, values map[string]any, provider recipe.DataProvider, authoritative map[string]struct{}) {
 	if b.Config == nil {
 		return
 	}
@@ -767,22 +818,7 @@ func (b *DefaultBundler) applyNodeSchedulingOverrides(componentName string, valu
 		return // Unknown component, skip
 	}
 
-	// Snapshot the set of scheduling paths that were populated BEFORE any
-	// injection ran — i.e. by the recipe overlay or by --set values that
-	// have already been merged into the values map. These paths are
-	// authoritative and must not be overwritten by CLI/config defaults
-	// (e.g., kind.yaml's `daemonsets.tolerations: []`, bcm.yaml's careful
-	// BCM-master `controller.tolerations`). Internal writes during this
-	// function (system → accelerated for shared paths like NFD's
-	// worker.tolerations) are NOT in the snapshot, so the documented
-	// "accelerated overrides system" behavior is preserved.
-	allPaths := make([]string, 0, 16)
-	allPaths = append(allPaths, comp.GetSystemNodeSelectorPaths()...)
-	allPaths = append(allPaths, comp.GetSystemTolerationPaths()...)
-	allPaths = append(allPaths, comp.GetAcceleratedNodeSelectorPaths()...)
-	allPaths = append(allPaths, comp.GetAcceleratedTolerationPaths()...)
-	allPaths = append(allPaths, comp.GetWorkloadSelectorPaths()...)
-	recipeSet := preExistingSchedulingPaths(values, allPaths)
+	recipeSet := authoritative
 
 	// Apply system node selector
 	if nodeSelector := b.Config.SystemNodeSelector(); len(nodeSelector) > 0 {

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -1072,6 +1072,206 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 	}
 }
 
+// TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths verifies the
+// precedence rule that recipe-overlay-set scheduling paths are NOT
+// overwritten by CLI/config defaults. This is the fix for #982: kind.yaml
+// sets `daemonsets.tolerations: []` to keep gpu-operator daemons off the
+// control-plane, and bcm.yaml sets `controller.tolerations` to the
+// BCM-master toleration list. Without this guard the bundler-injected
+// default `{Operator: Exists}` would silently replace those values.
+func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
+	registry, err := recipe.GetComponentRegistry()
+	if err != nil {
+		t.Fatalf("GetComponentRegistry() error = %v", err)
+	}
+	gpuOp := registry.Get("gpu-operator")
+	if gpuOp == nil || len(gpuOp.GetAcceleratedTolerationPaths()) == 0 {
+		t.Fatalf("registry missing gpu-operator or accelerated toleration paths")
+	}
+	const tolPath = "daemonsets.tolerations"
+
+	tests := []struct {
+		name        string
+		initial     map[string]any
+		cliTols     []corev1.Toleration
+		wantValue   any
+		description string
+	}{
+		{
+			name: "recipe-set empty slice is preserved (opt-out)",
+			initial: map[string]any{
+				"daemonsets": map[string]any{
+					"tolerations": []any{},
+				},
+			},
+			cliTols:     []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			wantValue:   []any{},
+			description: "kind.yaml: explicit empty list must defeat the default {Exists} injection",
+		},
+		{
+			name: "recipe-set non-empty list is preserved",
+			initial: map[string]any{
+				"daemonsets": map[string]any{
+					"tolerations": []any{
+						map[string]any{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
+					},
+				},
+			},
+			cliTols: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			wantValue: []any{
+				map[string]any{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
+			},
+			description: "bcm-style: deliberate toleration list must not be replaced by CLI default",
+		},
+		{
+			name:    "unset path receives CLI injection",
+			initial: map[string]any{},
+			cliTols: []corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "present", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantValue: []any{
+				map[string]any{"key": "nvidia.com/gpu", "operator": "Equal", "value": "present", "effect": "NoSchedule"},
+			},
+			description: "default flow (eks/gke/etc.): no overlay value, CLI toleration is injected as before",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfig(config.WithAcceleratedNodeTolerations(tt.cliTols))
+			b, err := New(WithConfig(cfg))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			b.applyNodeSchedulingOverrides("gpu-operator", tt.initial, nil)
+
+			got, ok := component.GetValueByPath(tt.initial, tolPath)
+			if !ok {
+				t.Fatalf("%s: %s not present after injection", tt.description, tolPath)
+			}
+			gotList, ok := got.([]any)
+			if !ok {
+				t.Fatalf("%s: %s has wrong type %T (want []any)", tt.description, tolPath, got)
+			}
+			wantList, _ := tt.wantValue.([]any)
+			if !reflect.DeepEqual(gotList, wantList) {
+				t.Errorf("%s:\n  got  = %#v\n  want = %#v", tt.description, gotList, wantList)
+			}
+		})
+	}
+}
+
+// TestPreExistingSchedulingPaths verifies the snapshot helper that records
+// which paths were populated before any scheduling injection ran. The
+// resulting set blocks subsequent overwrites for recipe-set paths while
+// allowing the documented system → accelerated overwrite for shared paths
+// (where the system-pass write is NOT in the snapshot).
+func TestPreExistingSchedulingPaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]any
+		paths  []string
+		want   []string // expected set members (order-independent)
+	}{
+		{
+			name:   "empty paths returns empty set",
+			values: map[string]any{"a": "x"},
+			paths:  nil,
+			want:   nil,
+		},
+		{
+			name: "set top-level path is captured",
+			values: map[string]any{
+				"tolerations": []any{},
+			},
+			paths: []string{"tolerations"},
+			want:  []string{"tolerations"},
+		},
+		{
+			name: "set nested path is captured (empty slice counts as set)",
+			values: map[string]any{
+				"daemonsets": map[string]any{"tolerations": []any{}},
+			},
+			paths: []string{"daemonsets.tolerations", "daemonsets.nodeSelector"},
+			want:  []string{"daemonsets.tolerations"},
+		},
+		{
+			name:   "unset path is not captured",
+			values: map[string]any{},
+			paths:  []string{"daemonsets.tolerations"},
+			want:   nil,
+		},
+		{
+			name: "intermediate non-map is treated as unset",
+			values: map[string]any{
+				"daemonsets": "scalar",
+			},
+			paths: []string{"daemonsets.tolerations"},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preExistingSchedulingPaths(tt.values, tt.paths)
+			if len(got) != len(tt.want) {
+				t.Fatalf("preExistingSchedulingPaths() size = %d, want %d (got=%v)", len(got), len(tt.want), got)
+			}
+			for _, p := range tt.want {
+				if _, ok := got[p]; !ok {
+					t.Errorf("expected %q in set, got %v", p, got)
+				}
+			}
+		})
+	}
+}
+
+// TestFilterPaths verifies the helper that removes pre-existing paths from
+// an injection target list.
+func TestFilterPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		skip  map[string]struct{}
+		want  []string
+	}{
+		{
+			name:  "empty paths returns nil",
+			paths: nil,
+			skip:  map[string]struct{}{"x": {}},
+			want:  nil,
+		},
+		{
+			name:  "empty skip returns input unchanged",
+			paths: []string{"a", "b"},
+			skip:  nil,
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "single blocked path removed",
+			paths: []string{"a", "b", "c"},
+			skip:  map[string]struct{}{"b": {}},
+			want:  []string{"a", "c"},
+		},
+		{
+			name:  "all paths blocked returns empty slice",
+			paths: []string{"a", "b"},
+			skip:  map[string]struct{}{"a": {}, "b": {}},
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterPaths(tt.paths, tt.skip)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterPaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestApplyNodeSchedulingOverrides_BoundProvider verifies that
 // applyNodeSchedulingOverrides honors the bound provider parameter when
 // resolving the component registry. The bound provider exposes a component

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -973,7 +973,7 @@ func TestApplyNodeSchedulingOverrides_EstimatedNodeCount(t *testing.T) {
 	}
 
 	values := make(map[string]any)
-	b.applyNodeSchedulingOverrides("nodewright-operator", values, nil, nil)
+	b.applyNodeSchedulingOverrides("nodewright-operator", values, nil, schedulingPathPolicy{})
 
 	// Path "estimatedNodeCount" is in nodewright-operator's nodeCountPaths; convertMapValue produces int64.
 	got, ok := values["estimatedNodeCount"]
@@ -1060,7 +1060,7 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 				}
 			}
 
-			b.applyNodeSchedulingOverrides("kube-prometheus-stack", values, nil, nil)
+			b.applyNodeSchedulingOverrides("kube-prometheus-stack", values, nil, schedulingPathPolicy{})
 
 			got, ok := component.GetValueByPath(values, scPath)
 			if ok != tt.wantPresent {
@@ -1110,12 +1110,12 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		initial       map[string]any
-		authoritative map[string]struct{}
-		cliTols       []corev1.Toleration
-		wantValue     any
-		description   string
+		name        string
+		initial     map[string]any
+		policy      schedulingPathPolicy
+		cliTols     []corev1.Toleration
+		wantValue   any
+		description string
 	}{
 		{
 			name: "overlay-set empty slice is preserved (opt-out)",
@@ -1124,31 +1124,34 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 					"tolerations": []any{},
 				},
 			},
-			authoritative: map[string]struct{}{tolPath: {}},
-			cliTols:       []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
-			wantValue:     []any{},
-			description:   "kind.yaml: overlay-set empty list must defeat the default {Exists} injection",
+			policy:      schedulingPathPolicy{optOut: map[string]struct{}{tolPath: {}}},
+			cliTols:     []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			wantValue:   []any{},
+			description: "kind.yaml: overlay-set empty list must defeat the default {Exists} injection",
 		},
 		{
-			name: "overlay-set non-empty list is preserved",
+			name: "overlay-set non-empty list — CLI tolerations APPEND",
 			initial: map[string]any{
 				"daemonsets": map[string]any{
 					"tolerations": []any{
-						map[string]any{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
+						map[string]any{"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"},
 					},
 				},
 			},
-			authoritative: map[string]struct{}{tolPath: {}},
-			cliTols:       []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
-			wantValue: []any{
-				map[string]any{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
+			policy: schedulingPathPolicy{appendMode: map[string]struct{}{tolPath: {}}},
+			cliTols: []corev1.Toleration{
+				{Key: "kwok.x-k8s.io/node", Operator: corev1.TolerationOpEqual, Value: "fake", Effect: corev1.TaintEffectNoSchedule},
 			},
-			description: "bcm-style: deliberate toleration list from overlay must not be replaced by CLI default",
+			wantValue: []any{
+				map[string]any{"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"},
+				map[string]any{"key": "kwok.x-k8s.io/node", "operator": "Equal", "value": "fake", "effect": "NoSchedule"},
+			},
+			description: "bcm-style: overlay tolerations must coexist with CLI tolerations (UNION), not be replaced",
 		},
 		{
-			name:          "unset path receives CLI injection",
-			initial:       map[string]any{},
-			authoritative: nil,
+			name:    "unset path receives CLI injection",
+			initial: map[string]any{},
+			policy:  schedulingPathPolicy{},
 			cliTols: []corev1.Toleration{
 				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "present", Effect: corev1.TaintEffectNoSchedule},
 			},
@@ -1158,12 +1161,12 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 			description: "default flow (eks/gke/etc.): no overlay value, CLI toleration is injected as before",
 		},
 		{
-			// REGRESSION GUARD for the review feedback on PR #1082: component
-			// default values files (kai-scheduler, kueue, network-operator,
-			// aws-efa) ship tolerations in their values.yaml that overlap with
-			// registry scheduling paths. They land in `values` via the values
-			// file load — not via overlay overrides or --set — so the
-			// authoritative set is empty and the CLI default MUST still win.
+			// REGRESSION GUARD for PR #1082 review feedback: component default
+			// values files (kai-scheduler, kueue, network-operator, aws-efa)
+			// ship tolerations in their values.yaml that overlap with registry
+			// scheduling paths. They land in `values` via the values-file load
+			// — not via overlay overrides or --set — so the policy is empty
+			// and the CLI default MUST still win (REPLACE).
 			name: "values-file default does not lock the path",
 			initial: map[string]any{
 				"daemonsets": map[string]any{
@@ -1172,7 +1175,7 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 					},
 				},
 			},
-			authoritative: nil, // empty — values file is not authoritative
+			policy: schedulingPathPolicy{}, // values-file is not authoritative
 			cliTols: []corev1.Toleration{
 				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "present", Effect: corev1.TaintEffectNoSchedule},
 			},
@@ -1191,7 +1194,7 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 				t.Fatalf("New() error = %v", err)
 			}
 
-			b.applyNodeSchedulingOverrides("gpu-operator", tt.initial, nil, tt.authoritative)
+			b.applyNodeSchedulingOverrides("gpu-operator", tt.initial, nil, tt.policy)
 
 			got, ok := component.GetValueByPath(tt.initial, tolPath)
 			if !ok {
@@ -1209,94 +1212,102 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 	}
 }
 
-// TestAuthoritativeSchedulingPaths covers the helper that decides which
-// scheduling paths the user explicitly populated (recipe overlay
-// `componentRefs[].overrides` or CLI `--set`). Component default values
-// files are deliberately NOT consulted.
-func TestAuthoritativeSchedulingPaths(t *testing.T) {
+// TestClassifySchedulingPaths covers the helper that splits scheduling
+// paths into opt-out vs append based on the recipe overlay's inline
+// overrides and CLI --set. Component default values files are deliberately
+// NOT consulted — see the godoc on classifySchedulingPaths.
+func TestClassifySchedulingPaths(t *testing.T) {
 	tests := []struct {
 		name         string
 		overrides    map[string]any
 		setOverrides map[string]string
 		paths        []string
-		want         []string // expected set members (order-independent)
+		wantOptOut   []string
+		wantAppend   []string
 	}{
 		{
-			name:  "empty paths returns empty set",
+			name:  "empty paths returns empty policy",
 			paths: nil,
-			want:  nil,
 		},
 		{
-			name: "overlay override (nested map) captures the path",
+			name: "overlay empty slice → opt-out (kind.yaml semantics)",
 			overrides: map[string]any{
 				"daemonsets": map[string]any{
 					"tolerations": []any{},
 				},
 			},
-			paths: []string{"daemonsets.tolerations", "daemonsets.nodeSelector"},
-			want:  []string{"daemonsets.tolerations"},
+			paths:      []string{"daemonsets.tolerations", "daemonsets.nodeSelector"},
+			wantOptOut: []string{"daemonsets.tolerations"},
 		},
 		{
-			name: "empty slice in overlay counts as set (opt-out semantics)",
+			name: "overlay non-empty slice → append (bcm.yaml semantics)",
 			overrides: map[string]any{
-				"daemonsets": map[string]any{
-					"tolerations": []any{},
+				"controller": map[string]any{
+					"tolerations": []any{
+						map[string]any{"key": "node-role.kubernetes.io/master"},
+					},
 				},
 			},
-			paths: []string{"daemonsets.tolerations"},
-			want:  []string{"daemonsets.tolerations"},
+			paths:      []string{"controller.tolerations"},
+			wantAppend: []string{"controller.tolerations"},
 		},
 		{
-			name: "explicit nil leaf counts as set",
-			// GetValueByPath returns (nil, true) for an explicit nil. We
-			// capture the path so a deliberate `tolerations: ~` opt-out is
-			// honored, matching the empty-slice semantics. Helm collapses
-			// nil to "unset" downstream.
+			name: "explicit nil leaf → opt-out (matches empty-slice semantics)",
+			// GetValueByPath returns (nil, true) for an explicit nil leaf,
+			// e.g. `tolerations: ~` in YAML. Helm collapses nil to "unset",
+			// so this is a deliberate opt-out gesture.
 			overrides: map[string]any{
 				"daemonsets": map[string]any{
 					"tolerations": nil,
 				},
 			},
-			paths: []string{"daemonsets.tolerations"},
-			want:  []string{"daemonsets.tolerations"},
+			paths:      []string{"daemonsets.tolerations"},
+			wantOptOut: []string{"daemonsets.tolerations"},
 		},
 		{
-			name:         "--set with exact path match captures the path",
-			setOverrides: map[string]string{"daemonsets.tolerations": "..."},
+			name:         "--set with exact path match → append",
+			setOverrides: map[string]string{"daemonsets.tolerations": "non-empty-string"},
 			paths:        []string{"daemonsets.tolerations"},
-			want:         []string{"daemonsets.tolerations"},
+			wantAppend:   []string{"daemonsets.tolerations"},
 		},
 		{
-			name: "overlay and --set both empty — nothing captured (values-file values ignored)",
-			// This simulates the kai-scheduler/kueue/network-operator/aws-efa
-			// scenario: the values file populates the path but the overlay
-			// and --set don't. authoritativeSchedulingPaths must NOT capture
-			// it; CLI defaults will then overwrite the values-file value.
+			// Simulates kai-scheduler / kueue / network-operator / aws-efa:
+			// the values file populates the path but the overlay and --set
+			// do not. The policy must be empty so the CLI default (REPLACE)
+			// applies — addresses PR #1082 reviewer concern that the CLI
+			// flag would silently become a no-op for those components.
+			name:  "overlay and --set both empty — empty policy (values-file ignored)",
 			paths: []string{"global.tolerations"},
-			want:  nil,
 		},
 		{
-			name: "intermediate non-map is treated as unset",
+			name: "intermediate non-map → unclassified",
 			overrides: map[string]any{
 				"daemonsets": "scalar",
 			},
 			paths: []string{"daemonsets.tolerations"},
-			want:  nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := authoritativeSchedulingPaths(tt.overrides, tt.setOverrides, tt.paths)
-			if len(got) != len(tt.want) {
-				t.Fatalf("authoritativeSchedulingPaths() size = %d, want %d (got=%v)", len(got), len(tt.want), got)
-			}
-			for _, p := range tt.want {
-				if _, ok := got[p]; !ok {
-					t.Errorf("expected %q in set, got %v", p, got)
-				}
-			}
+			got := classifySchedulingPaths(tt.overrides, tt.setOverrides, tt.paths)
+
+			assertSetEqual(t, "optOut", got.optOut, tt.wantOptOut)
+			assertSetEqual(t, "appendMode", got.appendMode, tt.wantAppend)
 		})
+	}
+}
+
+func assertSetEqual(t *testing.T, label string, got map[string]struct{}, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: size = %d, want %d (got=%v, want=%v)", label, len(got), len(want), got, want)
+		return
+	}
+	for _, p := range want {
+		if _, ok := got[p]; !ok {
+			t.Errorf("%s: missing %q (got %v)", label, p, got)
+		}
 	}
 }
 
@@ -1402,7 +1413,7 @@ func TestApplyNodeSchedulingOverrides_BoundProvider(t *testing.T) {
 
 	// With a nil provider the lookup must miss (component unknown to global registry).
 	nilValues := map[string]any{}
-	b.applyNodeSchedulingOverrides(uniqueComponent, nilValues, nil, nil)
+	b.applyNodeSchedulingOverrides(uniqueComponent, nilValues, nil, schedulingPathPolicy{})
 	if got, ok := component.GetValueByPath(nilValues, nodeSelectorPath); ok {
 		t.Fatalf("nil-provider call unexpectedly populated %s = %v; component must be unknown to global registry", nodeSelectorPath, got)
 	}
@@ -1410,7 +1421,7 @@ func TestApplyNodeSchedulingOverrides_BoundProvider(t *testing.T) {
 	// With the bound provider the lookup hits and the nodeSelector lands at the
 	// path the external registry declares.
 	values := map[string]any{}
-	b.applyNodeSchedulingOverrides(uniqueComponent, values, layered, nil)
+	b.applyNodeSchedulingOverrides(uniqueComponent, values, layered, schedulingPathPolicy{})
 
 	got, ok := component.GetValueByPath(values, nodeSelectorPath)
 	if !ok {

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -972,7 +973,7 @@ func TestApplyNodeSchedulingOverrides_EstimatedNodeCount(t *testing.T) {
 	}
 
 	values := make(map[string]any)
-	b.applyNodeSchedulingOverrides("nodewright-operator", values, nil)
+	b.applyNodeSchedulingOverrides("nodewright-operator", values, nil, nil)
 
 	// Path "estimatedNodeCount" is in nodewright-operator's nodeCountPaths; convertMapValue produces int64.
 	got, ok := values["estimatedNodeCount"]
@@ -1059,7 +1060,7 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 				}
 			}
 
-			b.applyNodeSchedulingOverrides("kube-prometheus-stack", values, nil)
+			b.applyNodeSchedulingOverrides("kube-prometheus-stack", values, nil, nil)
 
 			got, ok := component.GetValueByPath(values, scPath)
 			if ok != tt.wantPresent {
@@ -1073,43 +1074,63 @@ func TestApplyNodeSchedulingOverrides_StorageClass(t *testing.T) {
 }
 
 // TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths verifies the
-// precedence rule that recipe-overlay-set scheduling paths are NOT
-// overwritten by CLI/config defaults. This is the fix for #982: kind.yaml
-// sets `daemonsets.tolerations: []` to keep gpu-operator daemons off the
-// control-plane, and bcm.yaml sets `controller.tolerations` to the
-// BCM-master toleration list. Without this guard the bundler-injected
-// default `{Operator: Exists}` would silently replace those values.
+// precedence rule that paths the user explicitly populated via the recipe
+// overlay's inline overrides or CLI --set are NOT overwritten by CLI/config
+// defaults. This is the fix for #982: kind.yaml's `daemonsets.tolerations: []`
+// (an opt-out) and bcm.yaml's `controller.tolerations` (a BCM-master
+// toleration list) must reach the rendered bundle untouched.
+//
+// CRITICALLY, component default values files are intentionally NOT treated
+// as authoritative (see the "values-file default does not lock the path"
+// sub-test). Several components (kai-scheduler, kueue, network-operator,
+// aws-efa) ship a chart-default-equivalent toleration in their values.yaml;
+// treating those as authoritative would silently turn
+// --system-node-toleration / --accelerated-node-toleration into a no-op for
+// those components — a real CLI regression. The bundler computes the
+// authoritative set from ComponentRef.Overrides + --set only, then passes it
+// in. This test drives the function at that contract.
+//
+// gpu-operator's `daemonsets.tolerations` is registry-declared as an
+// accelerated toleration path; we sanity-check the binding via the registry
+// before each run to fail loudly (rather than silently passing) if the
+// registry shape ever changes.
 func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 	registry, err := recipe.GetComponentRegistry()
 	if err != nil {
 		t.Fatalf("GetComponentRegistry() error = %v", err)
 	}
 	gpuOp := registry.Get("gpu-operator")
-	if gpuOp == nil || len(gpuOp.GetAcceleratedTolerationPaths()) == 0 {
-		t.Fatalf("registry missing gpu-operator or accelerated toleration paths")
+	if gpuOp == nil {
+		t.Fatalf("registry missing gpu-operator component")
 	}
 	const tolPath = "daemonsets.tolerations"
+	if !slices.Contains(gpuOp.GetAcceleratedTolerationPaths(), tolPath) {
+		t.Fatalf("gpu-operator accelerated toleration paths must include %q; got %v",
+			tolPath, gpuOp.GetAcceleratedTolerationPaths())
+	}
 
 	tests := []struct {
-		name        string
-		initial     map[string]any
-		cliTols     []corev1.Toleration
-		wantValue   any
-		description string
+		name          string
+		initial       map[string]any
+		authoritative map[string]struct{}
+		cliTols       []corev1.Toleration
+		wantValue     any
+		description   string
 	}{
 		{
-			name: "recipe-set empty slice is preserved (opt-out)",
+			name: "overlay-set empty slice is preserved (opt-out)",
 			initial: map[string]any{
 				"daemonsets": map[string]any{
 					"tolerations": []any{},
 				},
 			},
-			cliTols:     []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
-			wantValue:   []any{},
-			description: "kind.yaml: explicit empty list must defeat the default {Exists} injection",
+			authoritative: map[string]struct{}{tolPath: {}},
+			cliTols:       []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			wantValue:     []any{},
+			description:   "kind.yaml: overlay-set empty list must defeat the default {Exists} injection",
 		},
 		{
-			name: "recipe-set non-empty list is preserved",
+			name: "overlay-set non-empty list is preserved",
 			initial: map[string]any{
 				"daemonsets": map[string]any{
 					"tolerations": []any{
@@ -1117,15 +1138,17 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 					},
 				},
 			},
-			cliTols: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			authoritative: map[string]struct{}{tolPath: {}},
+			cliTols:       []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 			wantValue: []any{
 				map[string]any{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
 			},
-			description: "bcm-style: deliberate toleration list must not be replaced by CLI default",
+			description: "bcm-style: deliberate toleration list from overlay must not be replaced by CLI default",
 		},
 		{
-			name:    "unset path receives CLI injection",
-			initial: map[string]any{},
+			name:          "unset path receives CLI injection",
+			initial:       map[string]any{},
+			authoritative: nil,
 			cliTols: []corev1.Toleration{
 				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "present", Effect: corev1.TaintEffectNoSchedule},
 			},
@@ -1133,6 +1156,30 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 				map[string]any{"key": "nvidia.com/gpu", "operator": "Equal", "value": "present", "effect": "NoSchedule"},
 			},
 			description: "default flow (eks/gke/etc.): no overlay value, CLI toleration is injected as before",
+		},
+		{
+			// REGRESSION GUARD for the review feedback on PR #1082: component
+			// default values files (kai-scheduler, kueue, network-operator,
+			// aws-efa) ship tolerations in their values.yaml that overlap with
+			// registry scheduling paths. They land in `values` via the values
+			// file load — not via overlay overrides or --set — so the
+			// authoritative set is empty and the CLI default MUST still win.
+			name: "values-file default does not lock the path",
+			initial: map[string]any{
+				"daemonsets": map[string]any{
+					"tolerations": []any{
+						map[string]any{"operator": "Exists"},
+					},
+				},
+			},
+			authoritative: nil, // empty — values file is not authoritative
+			cliTols: []corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "present", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantValue: []any{
+				map[string]any{"key": "nvidia.com/gpu", "operator": "Equal", "value": "present", "effect": "NoSchedule"},
+			},
+			description: "component default values file value is overwritten by --accelerated-node-toleration",
 		},
 	}
 
@@ -1144,7 +1191,7 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 				t.Fatalf("New() error = %v", err)
 			}
 
-			b.applyNodeSchedulingOverrides("gpu-operator", tt.initial, nil)
+			b.applyNodeSchedulingOverrides("gpu-operator", tt.initial, nil, tt.authoritative)
 
 			got, ok := component.GetValueByPath(tt.initial, tolPath)
 			if !ok {
@@ -1162,49 +1209,75 @@ func TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths(t *testing.T) {
 	}
 }
 
-// TestPreExistingSchedulingPaths verifies the snapshot helper that records
-// which paths were populated before any scheduling injection ran. The
-// resulting set blocks subsequent overwrites for recipe-set paths while
-// allowing the documented system → accelerated overwrite for shared paths
-// (where the system-pass write is NOT in the snapshot).
-func TestPreExistingSchedulingPaths(t *testing.T) {
+// TestAuthoritativeSchedulingPaths covers the helper that decides which
+// scheduling paths the user explicitly populated (recipe overlay
+// `componentRefs[].overrides` or CLI `--set`). Component default values
+// files are deliberately NOT consulted.
+func TestAuthoritativeSchedulingPaths(t *testing.T) {
 	tests := []struct {
-		name   string
-		values map[string]any
-		paths  []string
-		want   []string // expected set members (order-independent)
+		name         string
+		overrides    map[string]any
+		setOverrides map[string]string
+		paths        []string
+		want         []string // expected set members (order-independent)
 	}{
 		{
-			name:   "empty paths returns empty set",
-			values: map[string]any{"a": "x"},
-			paths:  nil,
-			want:   nil,
+			name:  "empty paths returns empty set",
+			paths: nil,
+			want:  nil,
 		},
 		{
-			name: "set top-level path is captured",
-			values: map[string]any{
-				"tolerations": []any{},
-			},
-			paths: []string{"tolerations"},
-			want:  []string{"tolerations"},
-		},
-		{
-			name: "set nested path is captured (empty slice counts as set)",
-			values: map[string]any{
-				"daemonsets": map[string]any{"tolerations": []any{}},
+			name: "overlay override (nested map) captures the path",
+			overrides: map[string]any{
+				"daemonsets": map[string]any{
+					"tolerations": []any{},
+				},
 			},
 			paths: []string{"daemonsets.tolerations", "daemonsets.nodeSelector"},
 			want:  []string{"daemonsets.tolerations"},
 		},
 		{
-			name:   "unset path is not captured",
-			values: map[string]any{},
-			paths:  []string{"daemonsets.tolerations"},
-			want:   nil,
+			name: "empty slice in overlay counts as set (opt-out semantics)",
+			overrides: map[string]any{
+				"daemonsets": map[string]any{
+					"tolerations": []any{},
+				},
+			},
+			paths: []string{"daemonsets.tolerations"},
+			want:  []string{"daemonsets.tolerations"},
+		},
+		{
+			name: "explicit nil leaf counts as set",
+			// GetValueByPath returns (nil, true) for an explicit nil. We
+			// capture the path so a deliberate `tolerations: ~` opt-out is
+			// honored, matching the empty-slice semantics. Helm collapses
+			// nil to "unset" downstream.
+			overrides: map[string]any{
+				"daemonsets": map[string]any{
+					"tolerations": nil,
+				},
+			},
+			paths: []string{"daemonsets.tolerations"},
+			want:  []string{"daemonsets.tolerations"},
+		},
+		{
+			name:         "--set with exact path match captures the path",
+			setOverrides: map[string]string{"daemonsets.tolerations": "..."},
+			paths:        []string{"daemonsets.tolerations"},
+			want:         []string{"daemonsets.tolerations"},
+		},
+		{
+			name: "overlay and --set both empty — nothing captured (values-file values ignored)",
+			// This simulates the kai-scheduler/kueue/network-operator/aws-efa
+			// scenario: the values file populates the path but the overlay
+			// and --set don't. authoritativeSchedulingPaths must NOT capture
+			// it; CLI defaults will then overwrite the values-file value.
+			paths: []string{"global.tolerations"},
+			want:  nil,
 		},
 		{
 			name: "intermediate non-map is treated as unset",
-			values: map[string]any{
+			overrides: map[string]any{
 				"daemonsets": "scalar",
 			},
 			paths: []string{"daemonsets.tolerations"},
@@ -1214,9 +1287,9 @@ func TestPreExistingSchedulingPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := preExistingSchedulingPaths(tt.values, tt.paths)
+			got := authoritativeSchedulingPaths(tt.overrides, tt.setOverrides, tt.paths)
 			if len(got) != len(tt.want) {
-				t.Fatalf("preExistingSchedulingPaths() size = %d, want %d (got=%v)", len(got), len(tt.want), got)
+				t.Fatalf("authoritativeSchedulingPaths() size = %d, want %d (got=%v)", len(got), len(tt.want), got)
 			}
 			for _, p := range tt.want {
 				if _, ok := got[p]; !ok {
@@ -1329,7 +1402,7 @@ func TestApplyNodeSchedulingOverrides_BoundProvider(t *testing.T) {
 
 	// With a nil provider the lookup must miss (component unknown to global registry).
 	nilValues := map[string]any{}
-	b.applyNodeSchedulingOverrides(uniqueComponent, nilValues, nil)
+	b.applyNodeSchedulingOverrides(uniqueComponent, nilValues, nil, nil)
 	if got, ok := component.GetValueByPath(nilValues, nodeSelectorPath); ok {
 		t.Fatalf("nil-provider call unexpectedly populated %s = %v; component must be unknown to global registry", nodeSelectorPath, got)
 	}
@@ -1337,7 +1410,7 @@ func TestApplyNodeSchedulingOverrides_BoundProvider(t *testing.T) {
 	// With the bound provider the lookup hits and the nodeSelector lands at the
 	// path the external registry declares.
 	values := map[string]any{}
-	b.applyNodeSchedulingOverrides(uniqueComponent, values, layered)
+	b.applyNodeSchedulingOverrides(uniqueComponent, values, layered, nil)
 
 	got, ok := component.GetValueByPath(values, nodeSelectorPath)
 	if !ok {

--- a/pkg/collector/os/grub_test.go
+++ b/pkg/collector/os/grub_test.go
@@ -47,6 +47,7 @@ func TestGrubCollector_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -109,6 +110,7 @@ func TestGrubCollector_ValidatesParsing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}

--- a/pkg/collector/os/kmod_test.go
+++ b/pkg/collector/os/kmod_test.go
@@ -65,6 +65,7 @@ func TestKModCollector_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}

--- a/pkg/collector/os/release_test.go
+++ b/pkg/collector/os/release_test.go
@@ -89,6 +89,7 @@ func TestReleaseCollector_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -159,6 +160,7 @@ func TestReleaseCollector_ValidatesKeyValueParsing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -218,6 +220,7 @@ func TestReleaseCollector_HandlesQuotedValues(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -350,6 +353,7 @@ func TestReleaseCollector_ValidatesCommonFields(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -401,6 +405,7 @@ func TestReleaseCollector_DataTypes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}

--- a/pkg/collector/os/sysctl_test.go
+++ b/pkg/collector/os/sysctl_test.go
@@ -57,6 +57,7 @@ func TestSysctlCollector_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -174,6 +175,7 @@ func TestSysctlCollector_MultiLineKeyValueParsing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -251,6 +253,7 @@ func TestSysctlCollector_SingleLineValues(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}

--- a/pkg/collector/os/sysctl_test.go
+++ b/pkg/collector/os/sysctl_test.go
@@ -131,6 +131,7 @@ func TestSysctlCollector_ExcludesNet(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}
@@ -315,6 +316,7 @@ func TestSysctlCollector_MixedContent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfNotLinux(t)
 
 	ctx := context.TODO()
 	collector := &Collector{}

--- a/pkg/collector/os/testhelpers_test.go
+++ b/pkg/collector/os/testhelpers_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package os
+
+import (
+	"runtime"
+	"testing"
+)
+
+// skipIfNotLinux skips the calling test on non-Linux platforms. The os
+// collectors (grub/sysctl/kmod/release) read /proc/* and /usr/lib/os-release
+// and degrade via slog.Warn on missing files rather than returning errors,
+// so the existing `errors.Is(err, os.ErrNotExist)` skip branches in each
+// integration test never fire on macOS/Windows. Use this helper from any
+// test that depends on those Linux-only paths.
+func skipIfNotLinux(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skipf("skipping Linux-only integration test on %s", runtime.GOOS)
+	}
+}

--- a/pkg/component/overrides.go
+++ b/pkg/component/overrides.go
@@ -171,6 +171,49 @@ func ApplyTolerationsOverrides(values map[string]any, tolerations []corev1.Toler
 	}
 }
 
+// AppendTolerationsOverrides appends CLI tolerations to whatever list is
+// already at each path, instead of replacing it. Used when a recipe overlay
+// has populated the path with a non-empty list (e.g., bcm.yaml's BCM-master
+// `controller.tolerations`): the overlay's intent is "ALSO tolerate these",
+// not "use only these", so the CLI flag's tolerations must augment the
+// overlay list rather than clobber it.
+//
+// If the path is absent or holds an empty/non-slice value, the behavior is
+// identical to ApplyTolerationsOverrides (CLI tolerations become the full
+// list at the path).
+func AppendTolerationsOverrides(values map[string]any, tolerations []corev1.Toleration, paths ...string) {
+	if len(tolerations) == 0 || values == nil {
+		return
+	}
+	if len(paths) == 0 {
+		paths = []string{"tolerations"}
+	}
+	tolList := TolerationsToPodSpec(tolerations)
+	for _, path := range paths {
+		appendTolerationsAtPath(values, tolList, path)
+	}
+}
+
+// appendTolerationsAtPath appends tolerations to the slice at the given
+// dot-notation path. If the path is missing or not a slice, the path is set
+// to the new tolerations list (i.e. identical to setTolerationsAtPath in
+// that case).
+func appendTolerationsAtPath(values map[string]any, tolerations []map[string]any, path string) {
+	parent, key, _ := getOrCreateNestedMap(values, path, false)
+
+	newEntries := make([]any, len(tolerations))
+	for i, t := range tolerations {
+		newEntries[i] = t
+	}
+
+	existing, ok := parent[key].([]any)
+	if !ok {
+		parent[key] = newEntries
+		return
+	}
+	parent[key] = append(existing, newEntries...)
+}
+
 // setTolerationsAtPath sets the tolerations at the specified dot-notation path.
 func setTolerationsAtPath(values map[string]any, tolerations []map[string]any, path string) {
 	parent, key, _ := getOrCreateNestedMap(values, path, false)

--- a/pkg/component/overrides_test.go
+++ b/pkg/component/overrides_test.go
@@ -248,6 +248,103 @@ func TestApplyTolerationsOverrides(t *testing.T) {
 	}
 }
 
+// TestAppendTolerationsOverrides covers the union-semantic append used by the
+// bundler when a recipe overlay populated a non-empty toleration list (e.g.,
+// bcm.yaml's BCM-master `controller.tolerations`). The CLI flag's tolerations
+// must augment the overlay list rather than replace it, so the controller
+// can land on the union of BCM-master and KWOK system-pool taints.
+func TestAppendTolerationsOverrides(t *testing.T) {
+	tests := []struct {
+		name        string
+		values      map[string]any
+		tolerations []corev1.Toleration
+		paths       []string
+		verify      func(t *testing.T, values map[string]any)
+	}{
+		{
+			name: "appends to existing list (BCM union case)",
+			values: map[string]any{
+				"controller": map[string]any{
+					"tolerations": []any{
+						map[string]any{"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"},
+					},
+				},
+			},
+			tolerations: []corev1.Toleration{
+				{Key: "kwok.x-k8s.io/node", Operator: corev1.TolerationOpEqual, Value: "fake", Effect: corev1.TaintEffectNoSchedule},
+			},
+			paths: []string{"controller.tolerations"},
+			verify: func(t *testing.T, values map[string]any) {
+				got, _ := GetValueByPath(values, "controller.tolerations")
+				list, _ := got.([]any)
+				if len(list) != 2 {
+					t.Fatalf("expected 2 tolerations, got %d (%v)", len(list), list)
+				}
+				first, _ := list[0].(map[string]any)
+				if first["key"] != "node-role.kubernetes.io/master" {
+					t.Errorf("existing toleration not preserved as first entry: %v", first)
+				}
+				second, _ := list[1].(map[string]any)
+				if second["key"] != "kwok.x-k8s.io/node" {
+					t.Errorf("appended toleration missing or wrong: %v", second)
+				}
+			},
+		},
+		{
+			name:   "appends to absent path (behaves like replace)",
+			values: map[string]any{},
+			tolerations: []corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			},
+			paths: []string{"daemonsets.tolerations"},
+			verify: func(t *testing.T, values map[string]any) {
+				got, _ := GetValueByPath(values, "daemonsets.tolerations")
+				list, _ := got.([]any)
+				if len(list) != 1 {
+					t.Fatalf("expected 1 toleration, got %d (%v)", len(list), list)
+				}
+			},
+		},
+		{
+			name: "non-slice existing value is replaced",
+			values: map[string]any{
+				"controller": map[string]any{
+					"tolerations": "scalar",
+				},
+			},
+			tolerations: []corev1.Toleration{
+				{Key: "x", Operator: corev1.TolerationOpExists},
+			},
+			paths: []string{"controller.tolerations"},
+			verify: func(t *testing.T, values map[string]any) {
+				got, _ := GetValueByPath(values, "controller.tolerations")
+				list, ok := got.([]any)
+				if !ok || len(list) != 1 {
+					t.Fatalf("expected scalar to be replaced with 1-item slice, got %T: %v", got, got)
+				}
+			},
+		},
+		{
+			name:        "empty tolerations slice is a no-op",
+			values:      map[string]any{"x": "untouched"},
+			tolerations: nil,
+			paths:       []string{"controller.tolerations"},
+			verify: func(t *testing.T, values map[string]any) {
+				if _, found := GetValueByPath(values, "controller.tolerations"); found {
+					t.Error("expected no path written when tolerations is empty")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AppendTolerationsOverrides(tt.values, tt.tolerations, tt.paths...)
+			tt.verify(t, tt.values)
+		})
+	}
+}
+
 func TestTolerationsToPodSpec(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -62,45 +62,23 @@ spec:
             create: false
             name: ""
             data: ""
-          # Exclude control-plane nodes — NFD labels them with GPU features
-          # (shared host kernel) but they lack actual device access, causing
-          # operand init containers to hang and ClusterPolicy to stay notReady.
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/control-plane
-                        operator: DoesNotExist
         # Use chart-default device plugin env in kind (no CDI overrides)
         devicePlugin:
           env: []
-          # Exclude control-plane nodes (see dcgmExporter.affinity comment)
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/control-plane
-                        operator: DoesNotExist
-        gfd:
-          # Exclude control-plane nodes (see dcgmExporter.affinity comment)
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/control-plane
-                        operator: DoesNotExist
-        validator:
-          # Exclude control-plane nodes (see dcgmExporter.affinity comment)
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/control-plane
-                        operator: DoesNotExist
+        # Keep GPU Operator operand DaemonSets off kind control-plane nodes.
+        # The chart default `daemonsets.tolerations: [{operator: Exists}]`
+        # tolerates the control-plane `NoSchedule` taint; combined with NFD
+        # labeling the control-plane (shared host kernel exposes the NVIDIA
+        # PCI device) and GPU Operator setting `nvidia.com/gpu.deploy.*=true`,
+        # operand DaemonSets schedule onto the control-plane where they hang
+        # because there's no real device access, keeping ClusterPolicy
+        # notReady. Removing the catchall toleration restores the
+        # NoSchedule taint as the real exclusion mechanism.
+        # Note: per-operand `affinity` (dcgmExporter/devicePlugin/gfd/validator)
+        # is not exposed by ClusterPolicy and is silently dropped by the chart,
+        # so it cannot be used here.
+        daemonsets:
+          tolerations: []
         # Reduce resource requests for local development
         operator:
           resources:


### PR DESCRIPTION
## Summary

Stop the kind overlay from emitting unsupported `affinity` blocks on
gpu-operator operands, and make the bundler treat recipe-overlay-set
scheduling paths as authoritative so a deliberate empty list (or any
explicit value) is no longer silently clobbered by CLI defaults.

## Motivation / Context

The kind overlay set per-operand `affinity` on `dcgmExporter`,
`devicePlugin`, `gfd`, and `validator` to keep GPU Operator operand
DaemonSets off kind control-plane nodes. `ClusterPolicy.spec.<operand>`
does not expose `affinity`, so the gpu-operator chart silently drops
those keys; combined with NFD labeling the control-plane (host kernel
exposes the NVIDIA PCI device) the operand DaemonSets land on the
control-plane and hang.

While verifying the obvious fix (`daemonsets.tolerations: []` — a key
the chart *does* consume), it became clear the bundler was overwriting
that empty list with the CLI-default `{Operator: Exists}` toleration,
so the kind exclusion would never have taken effect anyway. The same
silent overwrite was also discarding bcm.yaml's careful BCM-master
`controller.tolerations`.

Fixes: #982
Related: bcm overlay regression (no separate issue filed)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — kind overlay
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`) — Linux-only test guards

## Implementation Notes

**kind overlay** (`recipes/overlays/kind.yaml`)

- Drop the four `affinity` blocks (silently dropped by the chart).
- Set `daemonsets.tolerations: []` to remove the catchall toleration
  that lets DaemonSets tolerate `node-role.kubernetes.io/control-plane:NoSchedule`.

**Bundler precedence** (`pkg/bundler/bundler.go`)

`applyNodeSchedulingOverrides` now snapshots scheduling paths populated
*before* injection runs (i.e., by the recipe overlay or `--set` merged
into values) and skips CLI/config-default injection for those. Internal
writes within the function are **not** in the snapshot, so the
documented system → accelerated overwrite for shared paths (e.g.,
NFD `worker.tolerations`) still works:

| Scenario                                         | Pre-PR (buggy)                | Post-PR (correct)              |
|--------------------------------------------------|-------------------------------|---------------------------------|
| kind: overlay sets `daemonsets.tolerations: []`  | `[{Operator: Exists}]`        | `[]` (chart default kicks in)  |
| bcm: overlay sets `controller.tolerations: [...]`| `[{Operator: Exists}]`        | BCM-master list preserved       |
| eks: no overlay, CLI passes GPU toleration       | `[{nvidia.com/gpu, …}]` ✓     | `[{nvidia.com/gpu, …}]` ✓       |
| NFD: shared `worker.tolerations` (system + accel)| accelerated wins ✓            | accelerated wins ✓              |

**Linux-only test guards** (`pkg/collector/os/`)

The os collectors (grub/sysctl/kmod/release) read Linux paths and
degrade via `slog.Warn` instead of returning errors, so the existing
`errors.Is(err, os.ErrNotExist)` skip branches never fired on macOS and
nine integration tests failed locally. Added a shared `skipIfNotLinux`
helper and applied it to the affected tests.

## Testing

```bash
make qualify
# Passed tests 22 / 0 failed / 0 skipped
# 0 issues (lint)
# No vulnerabilities found
```

End-to-end bundle verification:

- `aicr bundle -r kind-recipe.yaml` → `daemonsets.tolerations: []` preserved
- `aicr bundle -r bcm-recipe.yaml` → `controller.tolerations` BCM-master list preserved
- `aicr bundle -r eks-recipe.yaml --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule` → NFD `worker.tolerations` correctly set to the GPU toleration

Unit test coverage added: `TestApplyNodeSchedulingOverrides_RespectsRecipeSetPaths` (kind/bcm/default scenarios) and `TestPreExistingSchedulingPaths`/`TestFilterPaths` (helper functions).

## Risk Assessment

- [x] **Medium** — Behavior change in bundler precedence touches a code path used by every overlay. Audited: only `kind.yaml` and `bcm.yaml` currently set scheduling paths explicitly, both intentional; all other overlays receive identical behavior to before. Existing `cuj1-training-workload` chainsaw test (which depends on shared-path overwrite) passes.

**Rollout notes:** N/A — pure bug fix, no migration. Users whose overlays set scheduling values explicitly will now see those values honored (previously silently discarded).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A, no user-visible flag/API change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)