### PR TITLE
chore(docs): regenerate BOM after network-operator busybox 1.38 bump (#1073)

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -154,7 +154,7 @@ _No images extracted._
 
 ### network-operator
 
-- `busybox:1.37@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`
+- `busybox:1.38@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d`
 - `nvcr.io/nvidia/cloud-native/network-operator:v26.1.1`
 - `nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host`
 - `nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2`


### PR DESCRIPTION
## Summary

Regenerates `docs/user/container-images.md` to pick up the `busybox:1.37 → 1.38` bump from PR #1073, which missed the BOM regeneration step.

## Motivation / Context

PR #1073 (commit `d9247c82` — `chore(deps): Update busybox Docker tag to v1.38`) updated the busybox image in `recipes/components/network-operator/manifests/ib-node-config-aks.yaml:79,152` from 1.37 to 1.38 (a Renovate auto-bump). The repo's coding guidelines require running `make bom-docs` and committing the regenerated BOM in the same PR whenever a chart version pin, component values file, or registry entry changes — but #1073 did not. As a result, `docs/user/container-images.md` was left listing the stale `busybox:1.37` digest under the `network-operator` section while the actual rendered image was already 1.38.

Detected during BOM verification for PR #1046 (`make bom-docs` produced a single-line drift independent of that PR's chart pins).

Related: #1073 (the source bump)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — corrects stale documentation

## Component(s) Affected

- [x] Docs/examples (`docs/`)

(Single-line refresh of the auto-generated BOM section. No code, no chart, no recipe changes.)

## Implementation Notes

Ran `make bom-docs` on a clean checkout of current `main` (`c5547243`). The only diff is the `busybox` line under `### network-operator`:

```diff
-- `busybox:1.37@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`
++ `busybox:1.38@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d`
```

No other components drift, confirming the doc is otherwise in sync with the registry.

## Testing

```bash
unset GITLAB_TOKEN
make bom-docs
git diff docs/user/container-images.md  # exactly 1 line changed
```

Coverage: docs-only, no Go changes — per CLAUDE.md the per-package coverage gate does not apply.

## Risk Assessment

- [x] **Low** — Trivial documentation refresh, no code or recipe changes, easy to revert.

**Rollout notes:** None. The doc realigns with the image already in use since #1073 merged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, docs-only
- [x] Linter passes (`make lint`) — N/A, docs-only
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, docs-only
- [x] I updated docs if user-facing behavior changed — this PR is the doc update
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
