### PR TITLE
fix(recipes): address BCM overlay gaps from H200 NVL validation

### DIFF
--- a/recipes/components/nvidia-dra-driver-gpu/values.yaml
+++ b/recipes/components/nvidia-dra-driver-gpu/values.yaml
@@ -66,6 +66,16 @@ resources:
 # annotation can never drift from the actual chart pin. Recipes that
 # disable either gpu-operator or nvidia-dra-driver-gpu leave the
 # rendered values untouched.
+#
+# priorityClassName is explicitly neutralized (""), overriding the
+# upstream chart's `system-node-critical` default. This lets the DRA
+# driver install in clusters whose PriorityClass admission restricts
+# `system-node-critical` to kube-system (PSA-restricted, ResourceQuota,
+# or PriorityClassPolicy gates), which AICR cannot assume. The trade-off
+# is that DRA pods can be evicted under node pressure; cluster operators
+# who need them to survive eviction should re-pin via their own overlay.
+# TODO(#1086): revisit whether a higher default (e.g., system-cluster-critical)
+# is safe across all supported services.
 controller:
   priorityClassName: ""
 kubeletPlugin:

--- a/recipes/overlays/bcm-training.yaml
+++ b/recipes/overlays/bcm-training.yaml
@@ -25,4 +25,14 @@ spec:
     service: bcm
     intent: training
 
-  componentRefs: []
+  # Enable GPUDirect Storage (GDS) for BCM training workloads. BCM-provisioned
+  # nodes typically ship NVIDIA-validated NVMe + ConnectX hardware where GDS
+  # delivers a meaningful training I/O perf win (most pronounced on H200 NVL
+  # given its 141GB HBM3e per device). On nodes without compatible hardware
+  # the nvidia-fs DaemonSet is benign — it logs a warning and stays inert.
+  componentRefs:
+    - name: gpu-operator
+      type: Helm
+      overrides:
+        gds:
+          enabled: true

--- a/recipes/overlays/bcm.yaml
+++ b/recipes/overlays/bcm.yaml
@@ -58,10 +58,33 @@ spec:
 
     # Tolerate the BCM `master` label so control-plane workloads that
     # already tolerate `control-plane` schedule on BCM masters as well.
+    # Mirrored onto kubeletPlugin so DRA's kubelet plugin DaemonSet still
+    # schedules on small BCM deployments that combine control-plane and
+    # worker roles on the same node.
+    #
+    # Note: AICR's bundler defaults to appending a blanket {operator: Exists}
+    # to both controller.tolerations and kubeletPlugin.tolerations via the
+    # nodeScheduling paths in recipes/registry.yaml (defaults sourced from
+    # pkg/snapshotter/agent.go DefaultTolerations). The registry maps
+    # controller.tolerations to the `system` scheduling scope and
+    # kubeletPlugin.tolerations to the `accelerated` scope. The specific
+    # entries below are belt-and-suspenders in default mode — the blanket
+    # subsumes them — and only have effect when a user drops the blanket via
+    # --system-node-toleration (controller) or --accelerated-node-toleration
+    # (kubeletPlugin), in which case BCM clusters still need `master`
+    # tolerated explicitly.
     - name: nvidia-dra-driver-gpu
       type: Helm
       overrides:
         controller:
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+              operator: Exists
+        kubeletPlugin:
           tolerations:
             - effect: NoSchedule
               key: node-role.kubernetes.io/master


### PR DESCRIPTION
## Summary

Three small recipe-layer edits surfaced during cluster-side validation of the recently-merged `feat/bcm-service-type` work on a real H200 NVL test cluster: document why DRA `priorityClassName` is neutralized, mirror BCM control-plane tolerations onto DRA's `kubeletPlugin`, and enable GPUDirect Storage for BCM training.

## Motivation / Context

Fixes: part of #1086 (3 of 4 checkboxes; H200 criteria registration deferred to a separate PR per the umbrella issue)
Related: #1087 (integration test for `nvidiaDriverRoot` / `hostPaths.driverInstallDir` lockstep)

Cluster-side validation context:
- BCM-provisioned k8s 1.34.8, Ubuntu 24.04, kernel 6.8.0-71
- 2× NVIDIA H200 NVL (141GB HBM3e each) on `node007`
- gpu-operator v26.3.1, nvidia-dra-driver-gpu 25.12.0
- `aicr validate` deployment+conformance phases pass end-to-end

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

**`recipes/components/nvidia-dra-driver-gpu/values.yaml`** — Document the existing `priorityClassName: ""` neutralization rather than restoring the upstream chart default (`system-node-critical`). The override has been in place since `chore: init repo` (Jan 2026) with no historical PR rationale; the most plausible reason is PriorityClass admission restrictions (PSA, ResourceQuota, PriorityClassPolicy) that AICR cannot assume across all supported services. Restoring the chart default would be a behavior change without a clear test signal, so the conservative path is documentation + a `TODO(#1086)` for revisit. Operators who need DRA pods to survive node-pressure eviction can re-pin via their own overlay.

**`recipes/overlays/bcm.yaml`** — Mirror `controller.tolerations` onto `kubeletPlugin.tolerations`. Followup investigation revealed the AICR bundler appends a blanket `{operator: Exists}` toleration to both paths via `registry.yaml` `nodeScheduling.{system,accelerated}.tolerationPaths` entries (defaults sourced from `pkg/snapshotter/agent.go DefaultTolerations`). The blanket subsumes the specific master+control-plane entries, so the mirror is **functionally a no-op in default mode** — its purpose is symmetry with the existing controller block and override-resilience when a user passes `--system-node-toleration` to drop the blanket. An inline comment documents this relationship so future overlay editors aren't misled. Filed separately as an AICR design question whether the tolerate-all default should be tightened per-service.

**`recipes/overlays/bcm-training.yaml`** — Enable `gds.enabled: true` for the `gpu-operator` componentRef. BCM-provisioned nodes typically ship NVIDIA-validated NVMe + ConnectX hardware where GDS is a meaningful training I/O perf win (most pronounced on H200 NVL given 141GB HBM3e per device). On nodes without compatible hardware the `nvidia-fs` DaemonSet is benign — it logs a warning and stays inert.

## Testing

YAML-only changes; no Go source modified. Per `CLAUDE.local.md` scoped verification policy, ran the checks that match the change surface:

```bash
yamllint -c .yamllint.yaml recipes/components/nvidia-dra-driver-gpu/values.yaml \
                            recipes/overlays/bcm.yaml \
                            recipes/overlays/bcm-training.yaml
# Clean.

go test -count=1 -timeout 180s ./pkg/recipe/...
# ok  github.com/NVIDIA/aicr/pkg/recipe         0.864s
# ok  github.com/NVIDIA/aicr/pkg/recipe/oskind  0.713s

go test -count=1 -timeout 240s ./pkg/bundler/...
# 15 packages, all ok (recipe values flow through the bundler)

# End-to-end recipe + bundle against the BCM overlay chain:
aicr recipe --service bcm --accelerator h100 --os ubuntu --intent training -o /tmp/recipe.yaml
aicr bundle -r /tmp/recipe.yaml --deployer helmfile -o /tmp/bundle
# Generated DRA values show:
#   - controller.tolerations: [master, control-plane, {operator: Exists}]
#   - kubeletPlugin.tolerations: [master, control-plane, {operator: Exists}]
#   - gds.enabled: true on gpu-operator
```

Skipping full `make qualify` because the change is YAML-only — no Go test, e2e, lint, or scan target can regress from these edits. The scoped recipe + bundler tests cover the consumers that parse these files.

## Risk Assessment

- [x] **Low** — Isolated YAML-only changes; no behavior change to the `priorityClassName` (documentation only); the kubeletPlugin tolerations mirror is a no-op in default mode (bundler blanket subsumes it); the BCM GDS enable is additive and benign on hardware that doesn't use them.

**Rollout notes:** None. The GDS daemon is benign on nodes without compatible NVMe/NIC hardware (it logs a warning and stays inert).

## Checklist

- [x] Tests pass locally (scoped: `./pkg/recipe/...` and `./pkg/bundler/...` with `-count=1`)
- [x] Linter passes (`yamllint` on changed files)
- [x] I did not skip/disable tests to make CI green
- [x] N/A — no new functionality requiring new tests; documentation + additive overlay edits
- [x] N/A — no user-facing behavior change beyond the GDS enable, which is BCM-service-internal
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)