### PR TITLE
feat(recipe): register h200 as first-class accelerator type

### DIFF
--- a/.claude/skills/analyzing-snapshots/SKILL.md
+++ b/.claude/skills/analyzing-snapshots/SKILL.md
@@ -96,6 +96,8 @@ Key fields from `GPU.smi`:
 | `gb300` | gb200 class (Blackwell NVL family) |
 | `b200` | b200 |
 | `h100` | h100 |
+| `gh200` | unresolved — Grace Hopper Superchip, not the discrete H200 GPU (check before h200) |
+| `h200` | h200 (discrete H200 GPU) |
 | `a100` | a100 |
 | `l40` | l40 |
 | `rtx pro 6000` | rtx-pro-6000 |
@@ -272,7 +274,7 @@ aicr recipe \
 | Criteria | Extracted From | Valid Values |
 |----------|---------------|--------------|
 | service | K8s.node.provider / K8s.server.version | eks, gke, aks, oke, kind, lke |
-| accelerator | GPU.smi.gpu.model | h100, gb200, b200, a100, l40, rtx-pro-6000 |
+| accelerator | GPU.smi.gpu.model | h100, h200, gb200, b200, a100, l40, rtx-pro-6000 |
 | os | OS.release.ID | ubuntu, rhel, cos, amazonlinux |
 | intent | User-specified | training, inference |
 | platform | User-specified | dynamo, kubeflow, nim, runai, slurm |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -117,7 +117,7 @@ body:
         - Kubernetes version:
         - OS (ubuntu/cos/other) + version:
         - Kernel version:
-        - GPU type (h100/gb200/b200/a100/l40/rtx-pro-6000/other):
+        - GPU type (h100/h200/gb200/b200/a100/l40/rtx-pro-6000/other):
         - Workload intent (training/inference):
       value: |
         - AICR version (CLI `aicr version`, API image tag, or commit SHA):
@@ -126,7 +126,7 @@ body:
         - Kubernetes version:
         - OS (ubuntu/cos/other) + version:
         - Kernel version:
-        - GPU type (h100/gb200/b200/a100/l40/rtx-pro-6000/other):
+        - GPU type (h100/h200/gb200/b200/a100/l40/rtx-pro-6000/other):
         - Workload intent (training/inference):
     validations:
       required: true

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -120,7 +120,7 @@ paths:
           description: GPU/accelerator type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [h100, gb200, b200, a100, l40, rtx-pro-6000, any]
+            enum: [h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any]
             default: any
         - name: gpu
           in: query
@@ -128,7 +128,7 @@ paths:
           description: Alias for accelerator parameter (backwards compatibility).
           schema:
             type: string
-            enum: [h100, gb200, b200, a100, l40, rtx-pro-6000, any]
+            enum: [h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any]
             default: any
         - name: intent
           in: query
@@ -487,7 +487,7 @@ paths:
           description: GPU/accelerator type. If omitted, treated as "any" (wildcard).
           schema:
             type: string
-            enum: [h100, gb200, b200, a100, l40, rtx-pro-6000, any]
+            enum: [h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any]
             default: any
         - name: gpu
           in: query
@@ -495,7 +495,7 @@ paths:
           description: Alias for accelerator parameter (backwards compatibility).
           schema:
             type: string
-            enum: [h100, gb200, b200, a100, l40, rtx-pro-6000, any]
+            enum: [h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any]
             default: any
         - name: intent
           in: query
@@ -1262,7 +1262,7 @@ components:
         accelerator:
           type: string
           description: GPU/accelerator type
-          enum: [h100, gb200, b200, a100, l40, rtx-pro-6000, any]
+          enum: [h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any]
           example: h100
         intent:
           type: string

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ NVIDIA AI Cluster Runtime (AICR) is a suite of tooling designed to automate the 
 |------|-------------|
 | **Snapshot** | A captured state of a system including OS, kernel, Kubernetes, GPU, and SystemD configuration. Created by `aicr snapshot` or the Kubernetes agent. |
 | **Recipe** | A generated configuration recommendation containing component references, constraints, and deployment order. Created by `aicr recipe` based on criteria or snapshot analysis. |
-| **Criteria** | Query parameters that define the target environment: `service` (eks/gke/aks/oke/kind/lke/bcm), `accelerator` (h100/gb200/b200/a100/l40/rtx-pro-6000), `intent` (training/inference), `os` (ubuntu/rhel/cos/amazonlinux/talos), `platform` (dynamo, kubeflow, nim, runai, slurm), and `nodes`. |
+| **Criteria** | Query parameters that define the target environment: `service` (eks/gke/aks/oke/kind/lke/bcm), `accelerator` (h100/h200/gb200/b200/a100/l40/rtx-pro-6000), `intent` (training/inference), `os` (ubuntu/rhel/cos/amazonlinux/talos), `platform` (dynamo, kubeflow, nim, runai, slurm), and `nodes`. |
 | **Overlay** | A recipe metadata file that extends the base recipe for specific environments. Overlays are matched against criteria using asymmetric matching. |
 | **Mixin** | A composable recipe fragment (`kind: RecipeMixin`) that carries only `constraints` and `componentRefs`. Mixins live in `recipes/mixins/`, are excluded from overlay discovery, and are referenced by leaf overlays via `spec.mixins` to share orthogonal content (e.g., OS constraints, platform components) without duplication. See [ADR-005](design/005-overlay-refactoring.md). |
 | **Bundle** | Deployment artifacts generated from a recipe: Helm values files, Kubernetes manifests, installation scripts, and checksums. |

--- a/docs/contributor/api-server-extending.md
+++ b/docs/contributor/api-server-extending.md
@@ -1087,7 +1087,7 @@ var validate = validator.New()
 type RecipeRequest struct {
     OS       string `validate:"required,oneof=ubuntu rhel cos"`
     OSVersion string `validate:"omitempty,semver"`
-    GPU      string `validate:"required,oneof=h100 gb200 b200 a100 l40 rtx-pro-6000"`
+    GPU      string `validate:"required,oneof=h100 h200 gb200 b200 a100 l40 rtx-pro-6000"`
     Service  string `validate:"omitempty,oneof=eks gke aks oke kind lke bcm"`
 }
 

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -263,7 +263,7 @@ Supported content types:
 | Parameter | Type | Validation | Example |
 |-----------|------|------------|--------|
 | `service` | ServiceType | Enum: eks, gke, aks, oke, kind, lke, bcm, any | `service=eks` |
-| `accelerator` | AcceleratorType | Enum: h100, gb200, b200, a100, l40, rtx-pro-6000, any | `accelerator=h100` |
+| `accelerator` | AcceleratorType | Enum: h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any | `accelerator=h100` |
 | `gpu` | AcceleratorType | Alias for accelerator | `gpu=h100` |
 | `intent` | IntentType | Enum: training, inference, any | `intent=training` |
 | `os` | OSType | Enum: ubuntu, rhel, cos, amazonlinux, talos, any | `os=ubuntu` |

--- a/docs/contributor/cli.md
+++ b/docs/contributor/cli.md
@@ -1700,7 +1700,7 @@ OUTPUT_DIR="recipes"
 mkdir -p "$OUTPUT_DIR"
 
 # GPU types from NVIDIA product line
-GPU_TYPES=("h100" "gb200" "b200" "a100" "l40" "rtx-pro-6000")
+GPU_TYPES=("h100" "h200" "gb200" "b200" "a100" "l40" "rtx-pro-6000")
 
 # Kubernetes services
 K8S_SERVICES=("eks" "gke" "aks" "oke" "kind" "lke" "bcm")

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -124,7 +124,7 @@ Criteria define when a recipe matches a user query:
 | Field | Type | Description | Example Values |
 |-------|------|-------------|----------------|
 | `service` | String | Kubernetes platform | `eks`, `gke`, `aks`, `oke`, `kind`, `lke`, `bcm` |
-| `accelerator` | String | GPU hardware type | `h100`, `gb200`, `b200`, `a100`, `l40`, `rtx-pro-6000` |
+| `accelerator` | String | GPU hardware type | `h100`, `h200`, `gb200`, `b200`, `a100`, `l40`, `rtx-pro-6000` |
 | `os` | String | Operating system | `ubuntu`, `rhel`, `cos`, `amazonlinux` |
 | `intent` | String | Workload purpose | `training`, `inference` |
 | `platform` | String | Platform/framework type | `dynamo`, `kubeflow`, `nim`, `runai`, `slurm` |
@@ -801,7 +801,7 @@ fingerprint:
     value: eks                       # eks | gke | aks | oke | kind | lke | bcm
     source: k8s.node.provider
   accelerator:
-    value: h100                      # h100 | gb200 | b200 | a100 | l40 | rtx-pro-6000
+    value: h100                      # h100 | h200 | gb200 | b200 | a100 | l40 | rtx-pro-6000
     source: gpu.smi.gpu.model
   os:
     value: ubuntu                    # ubuntu | rhel | cos | amazonlinux | talos

--- a/docs/contributor/validations.md
+++ b/docs/contributor/validations.md
@@ -94,7 +94,7 @@ conditions:
 **Supported Condition Keys:**
 - `intent`: Workload intent (training, inference)
 - `service`: Kubernetes service (eks, gke, aks, oke, kind, lke, bcm)
-- `accelerator`: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000)
+- `accelerator`: GPU type (h100, h200, gb200, b200, a100, l40, rtx-pro-6000)
 - `os`: Operating system (ubuntu, rhel, cos, amazonlinux, talos)
 - `platform`: Platform/framework (dynamo, kubeflow, nim, runai, slurm)
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -117,7 +117,7 @@ Generate an optimized configuration recipe based on environment parameters.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `service` | string | any | K8s service: `eks`, `gke`, `aks`, `oke`, `kind`, `lke`, `bcm`, `any` |
-| `accelerator` | string | any | GPU type: `h100`, `gb200`, `b200`, `a100`, `l40`, `rtx-pro-6000`, `any` |
+| `accelerator` | string | any | GPU type: `h100`, `h200`, `gb200`, `b200`, `a100`, `l40`, `rtx-pro-6000`, `any` |
 | `gpu` | string | any | Alias for `accelerator` |
 | `intent` | string | any | Workload: `training`, `inference`, `any` |
 | `os` | string | any | Node OS: `ubuntu`, `rhel`, `cos`, `amazonlinux`, `talos`, `any` |
@@ -821,7 +821,7 @@ openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o ./ts-clien
 
 **"Invalid accelerator type" error:**
 ```shell
-# Use valid values: h100, gb200, b200, a100, l40, rtx-pro-6000, any
+# Use valid values: h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any
 curl "http://localhost:8080/v1/recipe?accelerator=h100"
 ```
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -379,7 +379,7 @@ Generate recipes using direct system parameters:
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--service` | | string | K8s service: eks, gke, aks, oke, kind, lke, bcm |
-| `--accelerator` | `--gpu` | string | Accelerator/GPU type: h100, gb200, b200, a100, l40, rtx-pro-6000 |
+| `--accelerator` | `--gpu` | string | Accelerator/GPU type: h100, h200, gb200, b200, a100, l40, rtx-pro-6000 |
 | `--intent` | | string | Workload intent: training, inference |
 | `--os` | | string | OS family: ubuntu, rhel, cos, amazonlinux, talos |
 | `--platform` | | string | Platform/framework type: dynamo, kubeflow, nim, runai, slurm |

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -65,7 +65,7 @@
 //
 // The /v1/recipe endpoint accepts these query parameters for GET requests:
 //   - service: Kubernetes service (eks, gke, aks, oke, kind, lke, bcm, any)
-//   - accelerator: GPU type (h100, gb200, b200, a100, l40, rtx-pro-6000, any)
+//   - accelerator: GPU type (h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any)
 //   - gpu: Alias for accelerator (back-compat)
 //   - intent: Workload intent (training, inference, any)
 //   - os: Operating system (ubuntu, rhel, cos, amazonlinux, talos, any)

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -100,7 +100,7 @@ func recipeCmd() *cli.Command {
 		Usage:    "Create optimized recipe for given intent and environment parameters.",
 		Description: `Generate configuration recipe based on specified environment parameters including:
   - Kubernetes service type (e.g. eks, gke, aks, oke, kind, lke, bcm)
-  - Accelerator type (e.g. h100, gb200, b200, a100, l40, rtx-pro-6000)
+  - Accelerator type (e.g. h100, h200, gb200, b200, a100, l40, rtx-pro-6000)
   - Workload intent (e.g. training, inference)
   - GPU node operating system (e.g. ubuntu, rhel, cos, amazonlinux, talos)
   - Number of GPU nodes in the cluster

--- a/pkg/fingerprint/doc.go
+++ b/pkg/fingerprint/doc.go
@@ -18,7 +18,7 @@
 //
 // A Fingerprint records the cluster-identity dimensions used to bind
 // a snapshot to a recipe — service (eks/gke/aks/oke/kind/lke/bcm),
-// accelerator (h100/gb200/b200/a100/l40/rtx-pro-6000), OS
+// accelerator (h100/h200/gb200/b200/a100/l40/rtx-pro-6000), OS
 // (ubuntu/rhel/cos/amazonlinux/talos plus raw VERSION_ID), Kubernetes
 // server version, region, total node count, and GPU node count. Each
 // dimension records the resolved value plus an optional source string

--- a/pkg/fingerprint/gpu_sku.go
+++ b/pkg/fingerprint/gpu_sku.go
@@ -28,6 +28,13 @@ var gpuSKURegistry = []struct {
 	{"GB200", "gb200"},
 	{"B200", "b200"},
 	{"H100", "h100"},
+	// GH200 (Grace Hopper Superchip) contains the substring "H200" but is a
+	// distinct Grace-Hopper SKU, not the discrete H200 GPU. It has no
+	// first-class accelerator enum, so match it explicitly before the "H200"
+	// rule and leave it unresolved ("") rather than mislabeling it as h200 —
+	// same reason "GB200" precedes "B200" above.
+	{"GH200", ""},
+	{"H200", "h200"},
 	{"A100", "a100"},
 	{"RTX PRO 6000", "rtx-pro-6000"},
 	{"L40", "l40"},

--- a/pkg/fingerprint/gpu_sku_test.go
+++ b/pkg/fingerprint/gpu_sku_test.go
@@ -24,6 +24,10 @@ func TestParseGPUSKU(t *testing.T) {
 	}{
 		{"H100 80GB HBM3", "NVIDIA H100 80GB HBM3", "h100"},
 		{"H100 PCIe", "NVIDIA H100 PCIe", "h100"},
+		{"H200 NVL", "NVIDIA H200 NVL", "h200"},
+		{"H200 141GB HBM3e", "NVIDIA H200 141GB HBM3e", "h200"},
+		{"GH200 not matched as h200", "NVIDIA GH200 480GB", ""},
+		{"GH200 Grace Hopper", "NVIDIA GH200", ""},
 		{"GB200 NVL72", "NVIDIA GB200", "gb200"},
 		{"GB200 wins over B200 substring", "NVIDIA GB200 NVL72", "gb200"},
 		{"B200", "NVIDIA B200", "b200"},

--- a/pkg/fingerprint/types.go
+++ b/pkg/fingerprint/types.go
@@ -70,7 +70,7 @@ type Fingerprint struct {
 	// k8s.node.provider (parsed from spec.providerID).
 	Service Dimension `json:"service" yaml:"service"`
 
-	// Accelerator is the GPU SKU (h100, gb200, b200, a100, l40,
+	// Accelerator is the GPU SKU (h100, h200, gb200, b200, a100, l40,
 	// rtx-pro-6000). Parsed from gpu.smi.gpu.model.
 	Accelerator Dimension `json:"accelerator" yaml:"accelerator"`
 

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -114,6 +114,7 @@ type CriteriaAcceleratorType string
 const (
 	CriteriaAcceleratorAny        CriteriaAcceleratorType = "any"
 	CriteriaAcceleratorH100       CriteriaAcceleratorType = "h100"
+	CriteriaAcceleratorH200       CriteriaAcceleratorType = "h200"
 	CriteriaAcceleratorGB200      CriteriaAcceleratorType = "gb200"
 	CriteriaAcceleratorB200       CriteriaAcceleratorType = "b200"
 	CriteriaAcceleratorA100       CriteriaAcceleratorType = "a100"
@@ -130,6 +131,8 @@ func ParseCriteriaAcceleratorType(s string) (CriteriaAcceleratorType, error) {
 		return CriteriaAcceleratorAny, nil
 	case "h100":
 		return CriteriaAcceleratorH100, nil
+	case "h200":
+		return CriteriaAcceleratorH200, nil
 	case "gb200":
 		return CriteriaAcceleratorGB200, nil
 	case "b200":
@@ -152,7 +155,7 @@ func ParseCriteriaAcceleratorType(s string) (CriteriaAcceleratorType, error) {
 // types sorted alphabetically. For the union of static + registry, use
 // AllCriteriaAcceleratorTypes.
 func GetCriteriaAcceleratorTypes() []string {
-	return []string{"a100", "b200", "gb200", "h100", "l40", "rtx-pro-6000"}
+	return []string{"a100", "b200", "gb200", "h100", "h200", "l40", "rtx-pro-6000"}
 }
 
 // AllCriteriaAcceleratorTypes returns the union of the static OSS list
@@ -347,7 +350,7 @@ type Criteria struct {
 	// Service is the Kubernetes service type (eks, gke, aks, oke, kind, lke, bcm).
 	Service CriteriaServiceType `json:"service,omitempty" yaml:"service,omitempty"`
 
-	// Accelerator is the GPU/accelerator type (h100, gb200, b200, a100, l40, rtx-pro-6000).
+	// Accelerator is the GPU/accelerator type (h100, h200, gb200, b200, a100, l40, rtx-pro-6000).
 	Accelerator CriteriaAcceleratorType `json:"accelerator,omitempty" yaml:"accelerator,omitempty"`
 
 	// Intent is the workload intent (training, inference).

--- a/pkg/recipe/criteria_registry_parse_test.go
+++ b/pkg/recipe/criteria_registry_parse_test.go
@@ -102,16 +102,16 @@ func TestParseCriteriaServiceType_StrictAcceptsEmbedded(t *testing.T) {
 
 func TestParseCriteriaAcceleratorType_RegistryFallback(t *testing.T) {
 	withRegistry(t, func() {
-		if _, err := ParseCriteriaAcceleratorType("h200"); err == nil {
+		if _, err := ParseCriteriaAcceleratorType("mi300x"); err == nil {
 			t.Fatal("expected error before registration")
 		}
-		DefaultRegistry().Register(FieldAccelerator, "h200", OriginExternal)
-		got, err := ParseCriteriaAcceleratorType("h200")
+		DefaultRegistry().Register(FieldAccelerator, "mi300x", OriginExternal)
+		got, err := ParseCriteriaAcceleratorType("mi300x")
 		if err != nil {
 			t.Fatalf("error = %v", err)
 		}
-		if got != CriteriaAcceleratorType("h200") {
-			t.Errorf("got = %q, want h200", got)
+		if got != CriteriaAcceleratorType("mi300x") {
+			t.Errorf("got = %q, want mi300x", got)
 		}
 	})
 }
@@ -181,7 +181,7 @@ func TestAllCriteriaServiceTypes_UnionWithRegistry(t *testing.T) {
 
 func TestAllCriteriaTypes_AllDimensions(t *testing.T) {
 	withRegistry(t, func() {
-		DefaultRegistry().Register(FieldAccelerator, "h200", OriginExternal)
+		DefaultRegistry().Register(FieldAccelerator, "mi300x", OriginExternal)
 		DefaultRegistry().Register(FieldIntent, "fine-tuning", OriginExternal)
 		DefaultRegistry().Register(FieldOS, "bottlerocket", OriginExternal)
 		DefaultRegistry().Register(FieldPlatform, "nvmesh", OriginExternal)
@@ -192,7 +192,7 @@ func TestAllCriteriaTypes_AllDimensions(t *testing.T) {
 				t.Errorf("AllCriteria%sTypes() missing %q; got %v", field, want, got)
 			}
 		}
-		assertContains("Accelerator", AllCriteriaAcceleratorTypes(), "h200")
+		assertContains("Accelerator", AllCriteriaAcceleratorTypes(), "mi300x")
 		assertContains("Intent", AllCriteriaIntentTypes(), "fine-tuning")
 		assertContains("OS", AllCriteriaOSTypes(), "bottlerocket")
 		assertContains("Platform", AllCriteriaPlatformTypes(), "nvmesh")
@@ -212,11 +212,11 @@ func TestMergeCriteriaTypes_NoMutationOfInput(t *testing.T) {
 func TestCriteriaValidate_AdmitsRegisteredValues(t *testing.T) {
 	withRegistry(t, func() {
 		DefaultRegistry().Register(FieldService, "ncp-customer-x", OriginExternal)
-		DefaultRegistry().Register(FieldAccelerator, "h200", OriginExternal)
+		DefaultRegistry().Register(FieldAccelerator, "mi300x", OriginExternal)
 
 		c := &Criteria{
 			Service:     "ncp-customer-x",
-			Accelerator: "h200",
+			Accelerator: "mi300x",
 			Intent:      CriteriaIntentTraining,
 			OS:          CriteriaOSUbuntu,
 		}

--- a/pkg/recipe/criteria_registry_test.go
+++ b/pkg/recipe/criteria_registry_test.go
@@ -314,7 +314,7 @@ func TestSeedCriteriaRegistry(t *testing.T) {
 
 			c := &Criteria{
 				Service:     "ncp-x",
-				Accelerator: "h200",
+				Accelerator: "mi300x",
 				Intent:      "fine-tuning",
 				OS:          "bottlerocket",
 				Platform:    "nvmesh",
@@ -326,7 +326,7 @@ func TestSeedCriteriaRegistry(t *testing.T) {
 				value string
 			}{
 				{FieldService, "ncp-x"},
-				{FieldAccelerator, "h200"},
+				{FieldAccelerator, "mi300x"},
 				{FieldIntent, "fine-tuning"},
 				{FieldOS, "bottlerocket"},
 				{FieldPlatform, "nvmesh"},

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -72,6 +72,8 @@ func TestParseCriteriaAcceleratorType(t *testing.T) {
 		{"any", "any", CriteriaAcceleratorAny, false},
 		{"h100", "h100", CriteriaAcceleratorH100, false},
 		{"H100 uppercase", "H100", CriteriaAcceleratorH100, false},
+		{"h200", "h200", CriteriaAcceleratorH200, false},
+		{"H200 uppercase", "H200", CriteriaAcceleratorH200, false},
 		{"gb200", "gb200", CriteriaAcceleratorGB200, false},
 		{"b200", "b200", CriteriaAcceleratorB200, false},
 		{"a100", "a100", CriteriaAcceleratorA100, false},
@@ -725,7 +727,7 @@ func TestGetCriteriaAcceleratorTypes(t *testing.T) {
 	types := GetCriteriaAcceleratorTypes()
 
 	// Should return sorted list
-	expected := []string{"a100", "b200", "gb200", "h100", "l40", "rtx-pro-6000"}
+	expected := []string{"a100", "b200", "gb200", "h100", "h200", "l40", "rtx-pro-6000"}
 	if len(types) != len(expected) {
 		t.Errorf("GetCriteriaAcceleratorTypes() returned %d types, want %d", len(types), len(expected))
 	}

--- a/pkg/recipe/doc.go
+++ b/pkg/recipe/doc.go
@@ -26,7 +26,7 @@
 //
 //	type Criteria struct {
 //	    Service     CriteriaServiceType     // eks, gke, aks, oke, kind, lke, bcm, any
-//	    Accelerator CriteriaAcceleratorType // h100, gb200, b200, a100, l40, rtx-pro-6000, any
+//	    Accelerator CriteriaAcceleratorType // h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any
 //	    Intent      CriteriaIntentType      // training, inference, any
 //	    OS          CriteriaOSType          // ubuntu, rhel, cos, amazonlinux, talos, any
 //	    Platform    CriteriaPlatformType    // dynamo, kubeflow, nim, runai, slurm, any
@@ -72,6 +72,7 @@
 //
 // Accelerator types for GPU selection:
 //   - CriteriaAcceleratorH100: NVIDIA H100
+//   - CriteriaAcceleratorH200: NVIDIA H200
 //   - CriteriaAcceleratorGB200: NVIDIA GB200
 //   - CriteriaAcceleratorB200: NVIDIA B200
 //   - CriteriaAcceleratorA100: NVIDIA A100
@@ -176,7 +177,7 @@
 //
 // The HTTP handler accepts these query parameters for GET requests:
 //   - service: eks, gke, aks, oke, kind, lke, bcm, any (default: any)
-//   - accelerator: h100, gb200, b200, a100, l40, rtx-pro-6000, any (default: any)
+//   - accelerator: h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any (default: any)
 //   - gpu: alias for accelerator (backwards compatibility)
 //   - intent: training, inference, any (default: any)
 //   - os: ubuntu, rhel, cos, amazonlinux, talos, any (default: any)

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -71,7 +71,7 @@
 //	  - kernel: kernel version (e.g., 6.8, 5.15.0)
 //	  - service: eks, gke, aks, oke, kind, lke, bcm, any (default: any)
 //	  - k8s: Kubernetes version (e.g., 1.33, 1.32)
-//	  - gpu: h100, gb200, b200, a100, l40, rtx-pro-6000, any (default: any)
+//	  - gpu: h100, h200, gb200, b200, a100, l40, rtx-pro-6000, any (default: any)
 //	  - intent: training, inference, any (default: any)
 //	  - context: true/false - include context metadata (default: false)
 //

--- a/recipes/overlays/h200-any.yaml
+++ b/recipes/overlays/h200-any.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cross-cutting overlay applied via criteria-wildcard matching.
+#
+# This overlay is NOT referenced by any recipe via spec.base or spec.mixins.
+# The resolver picks it up for every H200 query (any service, any intent)
+# because its `service: any` criterion wildcard-matches any service. It
+# contributes the H200-wide deployment-phase floor — the 4 standard checks
+# plus the gpu-operator version pin — without duplicating it in every
+# service+intent leaf.
+#
+# H200 is the same Hopper generation as H100 (same R570/R580 driver line,
+# same gpu-operator support floor), so this mirrors h100-any.yaml. Splitting
+# only becomes necessary if an H200-specific floor delta emerges.
+#
+# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
+# that declare their own `deployment:` block continue to win — their
+# constraint values match the floor here so the override is a no-op.
+#
+# See docs/contributor/data.md#criteria-wildcard-overlays for details.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h200-any
+
+spec:
+  base: base
+
+  criteria:
+    service: any
+    accelerator: h200
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # H200 (Hopper) shares H100's stable gpu-operator support from
+        # v24.6.0 forward. Set as the floor; concrete leaves can tighten.
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"


### PR DESCRIPTION
## Summary

Add `h200` as a built-in accelerator type so users with H200 hardware can pass `--accelerator h200` and have the recipe metadata reflect what's actually deployed. H200 is the same Hopper generation as H100 (same R570/R580 driver line, same gpu-operator support floor, NVML auto-detects everything), so it shares H100's deployment-phase floor via a parallel `h200-any.yaml` criteria-wildcard overlay.

## Motivation / Context

Fixes: checkbox 4 of #1086
Related: #1089 (the BCM overlay-gaps PR that landed checkboxes 1–3 of #1086)

Validated on a real H200 NVL cluster during the BCM service overlay work:
- 2× NVIDIA H200 NVL (141GB HBM3e each), Hopper, compute 9.0
- GFD labels and DRA ResourceSlice correctly identify the device as `NVIDIA H200 NVL`
- The H100 overlay chain produces correct hydrated values when applied to H200 hardware — no functional divergence at the component-values layer

Before this PR:
- Recipe metadata claimed `accelerator: h100` for an H200 cluster — wrong on inspection, breaks reproducibility
- If we ever want H200-specific tuning later (MIG profiles, `gds.enabled` gated on H200's larger HBM, or NVL-form-factor topology), there's no enum key to hang it on

Test infrastructure was already partially in place: `pkg/recipe/criteria_registry_parse_test.go` registered `h200` via `OriginExternal` as the extensibility test value. This PR promotes h200 to first-class and swaps that test value to `mi300x` (a clearly non-built-in accelerator that retains the extensibility-path semantics).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Snapshot / fingerprint (`pkg/fingerprint`)
- [x] Docs/examples (`docs/`)

## Implementation Notes

Surfaces touched per the `.claude/CLAUDE.md` "Adding a new enum value" audit rule:

**Core Go:**
- `pkg/recipe/criteria.go` — new const `CriteriaAcceleratorH200`, parse case, `GetCriteriaAcceleratorTypes()` list, godoc enumeration

**Snapshot detection (the auto-detection half of the enum):**
- `pkg/fingerprint/gpu_sku.go` — add the `H200` ProductName pattern to `gpuSKURegistry` so the snapshot → fingerprint → recipe path resolves real H200 hardware (`NVIDIA H200 NVL`, `…141GB HBM3e`) to `h200` instead of `unknown-sku`. Without this, only the manual `--accelerator h200` path worked; snapshot-driven recipe generation (the path the wrong-metadata problem originates from) never produced `h200`.
- `pkg/fingerprint/gpu_sku_test.go` — H200 NVL + 141GB HBM3e cases

**Deployment-phase floor (so h200 truly mirrors h100):**
- `recipes/overlays/h200-any.yaml` — new criteria-wildcard overlay mirroring `h100-any.yaml` (4 standard checks: operator-health, expected-resources, gpu-operator-version, check-nvidia-smi; plus `gpu-operator >= v24.6.0`, the Hopper floor). Without it, an `--accelerator h200` recipe matched no `h100-*` overlay and landed on bare `base`, silently dropping the deployment validation floor every h100 recipe gets. Mirrors the per-accelerator wildcard pattern from #1001 (`h100-any` / `b200-any` / `gb200-any` / `rtx-pro-6000-any`).

**Tests:**
- `pkg/recipe/criteria_test.go` — parse table covers `h200` and `H200` (uppercase); `TestGetCriteriaAcceleratorTypes` expected list updated
- `pkg/recipe/criteria_registry_parse_test.go` and `criteria_registry_test.go` — `h200` was the OriginExternal extensibility example; swapped to `mi300x` (AMD, clearly non-built-in) so the tests retain their original intent

**API surface:**
- `api/aicr/v1/server.yaml` — all 5 enum blocks (accelerator + gpu alias, on snapshot/recipe endpoints)

**Docs:**
- `docs/README.md` (glossary)
- `docs/user/cli-reference.md`, `docs/user/api-reference.md`
- `docs/contributor/api-server.md`, `docs/contributor/cli.md`, `docs/contributor/data.md`, `docs/contributor/validations.md`, `docs/contributor/api-server-extending.md`
- `.claude/skills/analyzing-snapshots/SKILL.md` — model→accelerator mapping table + valid-values list

**Godoc:**
- `pkg/recipe/doc.go`, `pkg/cli/recipe.go`, `pkg/api/doc.go`, `pkg/server/doc.go`, `pkg/fingerprint/doc.go`, `pkg/fingerprint/types.go`

**Issue templates:**
- `.github/ISSUE_TEMPLATE/bug_report.yml` (GPU type dropdown — 2 occurrences)

**Intentionally not changed:**
- `types.go` top-level "e.g., h100, b200" example comment — `e.g.` is illustrative, not enumerative
- `docs/integrator/components/nodewright.md` — that page lists NodeWright's *current* component support (h100, gb200), which is component-specific scope and would be a false claim to extend
- Various `e.g., h100, gb200` example references in `docs/user/cli-reference.md` and elsewhere — illustrative, not enumerative
- Concrete service-bound `h200-*` leaf overlays (e.g. `h200-bcm-training`) — deferred until there's a real per-service tuning delta; the `h200-any.yaml` floor plus the accelerator-agnostic service overlays cover today's needs

## Testing

```bash
yamllint -c .yamllint.yaml recipes/overlays/h200-any.yaml api/aicr/v1/server.yaml .github/ISSUE_TEMPLATE/bug_report.yml
# Clean.

go test -count=1 ./pkg/recipe/... ./pkg/fingerprint/...
# ok (pkg/recipe 90.8%, pkg/fingerprint 98.1%)

golangci-lint run -c .golangci.yaml ./pkg/fingerprint/...
# 0 issues.

make qualify
# Pass (touched packages pkg/recipe, pkg/fingerprint, recipes all ok).

# End-to-end — h200 now resolves the identical deployment floor as h100:
aicr recipe --service bcm --accelerator h200 --os ubuntu --intent training -o /tmp/h200.yaml
# deployment phase: operator-health, expected-resources, gpu-operator-version,
# check-nvidia-smi + Deployment.gpu-operator.version >= v24.6.0
# (byte-identical to the --accelerator h100 deployment phase)
```

## Risk Assessment

- [x] **Low** — Additive enum value + parallel Hopper-floor overlay + one SKU-detection pattern. No breaking changes; existing `h100` recipes are unaffected; `h200-any.yaml` only matches `accelerator: h200` queries. H200 hardware now auto-detects to `h200` on the snapshot path and inherits the same deployment floor as H100.

**Rollout notes:** None. Existing recipes that use `--accelerator h100` for H200 hardware continue to work; users can opt into the more-accurate `--accelerator h200` at their convenience.

## Checklist

- [x] Tests pass locally (`./pkg/recipe/...`, `./pkg/fingerprint/...`, and `make qualify` for the touched packages)
- [x] Linter passes (`yamllint` + `golangci-lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (`criteria_test.go` parse + Get cases, `gpu_sku_test.go` H200 cases, extensibility tests swapped to `mi300x`)
- [x] I updated docs for user-facing behavior (all enum-enumerating doc pages audited per `.claude/CLAUDE.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
