### PR TITLE
Add hkii to copy-pr-bot trustees

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -30,3 +30,4 @@ additional_trustees:
   - xdu31
   - yuanchen8911
   - JRosenboimNVIDIA
+  - hkii


### PR DESCRIPTION
Adds my GitHub handle to the `additional_trustees` list so copy-pr-bot mirrors my PRs into the internal CI runners automatically.

Onboarding step before opening larger feature PRs against this repo (e.g., the upcoming embeddable Go library surface).

## Test plan
- [ ] copy-pr-bot picks up a subsequent PR from `hkii` without requiring `/ok to test`