### PR TITLE
feat(validators): warm up inference-perf benchmark and make it tunable

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -147,6 +147,19 @@ The validator engine mounts snapshot and recipe data as ConfigMaps:
 | `AICR_NODE_SELECTOR` | User-provided node selector override for inner workloads (comma-separated `key=value` pairs). Set by the `--node-selector` CLI flag. Use `ctx.NodeSelector` to access the parsed value. |
 | `AICR_TOLERATIONS` | User-provided toleration override for inner workloads (comma-separated `key=value:effect` entries). Set by the `--toleration` CLI flag. Use `ctx.Tolerations` to access the parsed value. |
 
+### `inference-perf` benchmark tuning
+
+The `inference-perf` performance check warms vLLM before measuring, so the one-time CUDA-graph/JIT compile cost is excluded from the reported throughput and p99 time-to-first-token (TTFT). These knobs (set on the `inference-perf` catalog entry's `env`, overridable via `aicr ... --data`) retune the benchmark without rebuilding the validator image. An unset knob uses the default below; a value that is not a positive integer **fails the check with `ErrCodeInvalidRequest`** — validated up front, before any workload is deployed — rather than silently falling back to a default and reporting a pass/fail the operator never configured. They are validation *methodology* knobs and live with the validator/catalog; the per-accelerator pass/fail thresholds stay in the recipe overlays.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `AICR_INFERENCE_PERF_CONCURRENCY_PER_GPU` | `16` | Concurrent requests per GPU; total concurrency is this × free GPUs on the chosen node. |
+| `AICR_INFERENCE_PERF_WARMUP_PER_CONCURRENCY` | `1` | Warmup requests per concurrency slot (excluded from stats); one full wave primes every in-flight slot. |
+| `AICR_INFERENCE_PERF_MIN_REQUESTS` | `1000` | Floor on measured request count, so small nodes still get a stable steady-state window. |
+| `AICR_INFERENCE_PERF_REQUESTS_PER_CONCURRENCY` | `8` | Scales measured request count with concurrency; actual count is `max(MIN_REQUESTS, concurrency × this)`. |
+| `AICR_INFERENCE_PERF_INPUT_TOKENS_MEAN` | `128` | Mean prompt input tokens per request. |
+| `AICR_INFERENCE_PERF_OUTPUT_TOKENS_MEAN` | `128` | Mean prompt output tokens per request. |
+
 ## Context API
 
 The `validators.Context` struct provides all dependencies a check needs:

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -77,6 +77,19 @@ validators:
     # ctx itself has expired.
     timeout: 50m
     args: ["inference-perf"]
+    # Benchmark tuning knobs (optional). AIPerf warms up before measuring so
+    # vLLM's one-time CUDA-graph/JIT cost is excluded from the reported p99
+    # TTFT/throughput. Override any of these to retune without rebuilding the
+    # validator image; an unset knob uses the default shown, while a value that
+    # is not a positive integer aborts the check (ErrCodeInvalidRequest) instead
+    # of silently defaulting. The per-accelerator pass/fail thresholds live in
+    # the recipe overlays, not here.
+    #   AICR_INFERENCE_PERF_CONCURRENCY_PER_GPU      (default 16)
+    #   AICR_INFERENCE_PERF_WARMUP_PER_CONCURRENCY   (default 1; warmup reqs per slot)
+    #   AICR_INFERENCE_PERF_MIN_REQUESTS             (default 1000; measured-request floor)
+    #   AICR_INFERENCE_PERF_REQUESTS_PER_CONCURRENCY (default 8; scales requests w/ concurrency)
+    #   AICR_INFERENCE_PERF_INPUT_TOKENS_MEAN        (default 128)
+    #   AICR_INFERENCE_PERF_OUTPUT_TOKENS_MEAN       (default 128)
     env: []
   # Conformance phase
   - name: dra-support

--- a/validators/performance/inference_perf.go
+++ b/validators/performance/inference_perf.go
@@ -34,6 +34,13 @@ func checkInferencePerf(ctx *validators.Context) error {
 		return validators.Skip("no inference-throughput or inference-ttft-p99 constraint in recipe")
 	}
 
+	// Fail closed on a malformed AICR_INFERENCE_PERF_* tuning knob before any
+	// workload is deployed: a typo must not silently benchmark under defaults
+	// and report a pass/fail the operator never configured.
+	if err := validatePerfTuningEnvs(); err != nil {
+		return err
+	}
+
 	// validateInferencePerf returns pkg/errors StructuredError values with the
 	// right codes already (ErrCodeTimeout for deadline exhaustion inside the
 	// pipeline, ErrCodeInternal for infra failures, ErrCodeInvalidRequest for

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -80,10 +80,26 @@ const (
 	// 16 per GPU saturates without overwhelming, based on empirical testing.
 	aiperfConcurrencyPerGPU = 16
 
-	// aiperfMinRequests is the minimum total number of requests to send.
-	// Actual request count is max(aiperfMinRequests, concurrency * 2) to ensure
-	// request_count >= concurrency (AIPerf requirement).
-	aiperfMinRequests = 200
+	// aiperfWarmupPerConcurrency is the number of warmup requests sent per
+	// in-flight concurrency slot before measurement begins. vLLM compiles CUDA
+	// graphs / JIT-warms kernels on its first requests; without warmup that
+	// one-time cost lands inside the measured window and dominates p99 TTFT
+	// (observed ~42s p99 on a cold run). One full concurrency wave primes every
+	// in-flight slot so steady-state latency/throughput are what get measured.
+	// Warmup requests are excluded from AIPerf's reported statistics.
+	aiperfWarmupPerConcurrency = 1
+
+	// aiperfMinRequests is the minimum total number of MEASURED requests to send
+	// (warmup is separate and excluded). Actual request count is
+	// max(aiperfMinRequests, concurrency * aiperfRequestsPerConcurrency) to keep
+	// the steady-state window long enough for a stable throughput/TTFT estimate
+	// while satisfying AIPerf's request_count >= concurrency requirement.
+	aiperfMinRequests = 1000
+
+	// aiperfRequestsPerConcurrency scales the measured request count with the
+	// concurrency level (and therefore GPU count) so larger nodes still run a
+	// multi-wave steady-state measurement rather than a handful of requests.
+	aiperfRequestsPerConcurrency = 8
 
 	// aiperfInputTokensMean is the mean number of input tokens per request.
 	aiperfInputTokensMean = 128
@@ -93,6 +109,22 @@ const (
 
 	// aiperfArtifactDir is where AIPerf writes benchmark result files.
 	aiperfArtifactDir = "/tmp/aiperf"
+
+	// AICR_INFERENCE_PERF_* env vars let operators tune the benchmark without
+	// rebuilding the validator image. Each overrides the like-named constant
+	// above; set them on the inference-perf catalog entry's `env` (editable
+	// in-tree or via `aicr ... --data`). An unset knob uses the constant
+	// default; a value that is not a positive integer aborts the check with
+	// ErrCodeInvalidRequest (see validatePerfTuningEnvs) rather than silently
+	// defaulting. These are validation *methodology* knobs and live with the
+	// validator/catalog; the per-accelerator pass/fail thresholds stay in the
+	// recipe overlays.
+	envConcurrencyPerGPU      = "AICR_INFERENCE_PERF_CONCURRENCY_PER_GPU"
+	envWarmupPerConcurrency   = "AICR_INFERENCE_PERF_WARMUP_PER_CONCURRENCY"
+	envMinRequests            = "AICR_INFERENCE_PERF_MIN_REQUESTS"
+	envRequestsPerConcurrency = "AICR_INFERENCE_PERF_REQUESTS_PER_CONCURRENCY"
+	envInputTokensMean        = "AICR_INFERENCE_PERF_INPUT_TOKENS_MEAN"  //nolint:gosec // G101: env var name for a token-count knob, not a credential
+	envOutputTokensMean       = "AICR_INFERENCE_PERF_OUTPUT_TOKENS_MEAN" //nolint:gosec // G101: env var name for a token-count knob, not a credential
 
 	// inferenceDeploymentName is the DynamoGraphDeployment name for the benchmark
 	// workload. Passed to the template via ${DEPLOYMENT_NAME}.
@@ -388,12 +420,17 @@ func buildInferenceConfig(ctx *validators.Context) (*inferenceWorkloadConfig, er
 			"node", chosen.Name, "allocatable", gpuCountPerNode, "inUse", gpuCountPerNode-freeGPUs, "free", freeGPUs)
 	}
 
+	concurrencyPerGPU, err := intFromEnv(envConcurrencyPerGPU, aiperfConcurrencyPerGPU)
+	if err != nil {
+		return nil, err
+	}
+
 	runID := deriveRunID()
 	config := &inferenceWorkloadConfig{
 		runID:           runID,
 		gpuCount:        gpuCount,
 		gpuCountPerNode: gpuCountPerNode,
-		concurrency:     aiperfConcurrencyPerGPU * gpuCount,
+		concurrency:     concurrencyPerGPU * gpuCount,
 		namespace:       fmt.Sprintf("%s-%s", inferenceWorkloadNamespacePrefix, runID),
 		aiperfJobName:   fmt.Sprintf("%s-%s", aiperfJobNamePrefix, runID),
 	}
@@ -1099,14 +1136,22 @@ func runAIPerfJob(ctx *validators.Context, endpoint string, concurrency int, job
 	// secrets via --image-pull-secret) but the inner aiperf pod hangs in
 	// ImagePullBackOff.
 	pullSecrets := getOwnPullSecrets(ctx)
+
+	job, params, err := buildAIPerfJob(ctx.Namespace, jobName, endpoint, concurrency, pullSecrets)
+	if err != nil {
+		return "", err
+	}
+
+	// Log after building so the reported counts are the ones actually baked into
+	// the benchmark script (honoring concurrency scaling and AICR_INFERENCE_PERF_*
+	// overrides), not the bare constant defaults.
 	slog.Info("Running AIPerf benchmark",
 		"endpoint", endpoint,
 		"model", inferenceModel,
 		"concurrency", concurrency,
-		"requests", aiperfMinRequests,
+		"requests", params.requestCount,
+		"warmup", params.warmupCount,
 		"job", jobName)
-
-	job := buildAIPerfJob(ctx.Namespace, jobName, endpoint, concurrency, pullSecrets)
 
 	// Because jobName is per-run-unique, there is no shared-state pre-clean to
 	// do; only the deferred cleanup runs on exit.
@@ -1114,8 +1159,7 @@ func runAIPerfJob(ctx *validators.Context, endpoint string, concurrency int, job
 	createCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.K8sJobCreationTimeout)
 	defer cancel()
 
-	_, err := ctx.Clientset.BatchV1().Jobs(ctx.Namespace).Create(createCtx, job, metav1.CreateOptions{})
-	if err != nil {
+	if _, err = ctx.Clientset.BatchV1().Jobs(ctx.Namespace).Create(createCtx, job, metav1.CreateOptions{}); err != nil {
 		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create AIPerf Job", err)
 	}
 	defer cleanupAIPerfJob(ctx, jobName)
@@ -1190,6 +1234,53 @@ func getOwnPullSecrets(ctx *validators.Context) []v1.LocalObjectReference {
 	return out
 }
 
+// intFromEnv reads a positive-integer tuning knob from the named env var. It
+// returns def when the var is unset, the parsed value when it is a positive
+// integer, and an ErrCodeInvalidRequest error when it is set but not a positive
+// integer. These knobs change the benchmark methodology and feed a pass/fail
+// gate, so a typo must abort the run rather than silently fall back to a default
+// and ship a result the operator never configured (see validatePerfTuningEnvs,
+// which surfaces the error up front before any workload is deployed).
+func intFromEnv(name string, def int) (int, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s=%q: must be a positive integer", name, raw))
+	}
+	return v, nil
+}
+
+// validatePerfTuningEnvs fails closed if any AICR_INFERENCE_PERF_* knob is set
+// to a non-integer or non-positive value, returning ErrCodeInvalidRequest so a
+// catalog/env typo aborts the check up front — before the (multi-minute)
+// benchmark workload is deployed — instead of silently benchmarking under
+// defaults and reporting a pass/fail the operator did not ask for.
+func validatePerfTuningEnvs() error {
+	for _, name := range []string{
+		envConcurrencyPerGPU, envWarmupPerConcurrency, envMinRequests,
+		envRequestsPerConcurrency, envInputTokensMean, envOutputTokensMean,
+	} {
+		if _, err := intFromEnv(name, 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// aiperfRunParams are the resolved (env-overridable) per-run AIPerf counts that
+// buildAIPerfJob baked into the benchmark script. It returns them so the caller
+// logs the values actually sent to aiperf rather than the bare constant
+// defaults, which diverge once concurrency scaling or AICR_INFERENCE_PERF_*
+// overrides take effect.
+type aiperfRunParams struct {
+	requestCount int
+	warmupCount  int
+}
+
 // buildAIPerfJob constructs the Kubernetes Job spec for running AIPerf.
 // The image (aiperfBaseImage) has aiperf pre-installed at build time — no pip
 // install at runtime. The script wraps aiperf invocation in sentinel markers
@@ -1201,11 +1292,38 @@ func getOwnPullSecrets(ctx *validators.Context) []v1.LocalObjectReference {
 // chain aiperf + echo + cat for sentinel framing. /bin/sh is POSIX-sufficient
 // for everything in the script (set -e, line continuation, echo, cat) and is
 // present in the python:3.12-slim base image, avoiding a bash dependency.
-func buildAIPerfJob(namespace, jobName, endpoint string, concurrency int, pullSecrets []v1.LocalObjectReference) *batchv1.Job {
-	// AIPerf requires request_count >= concurrency.
-	requestCount := aiperfMinRequests
-	if concurrency*2 > requestCount {
-		requestCount = concurrency * 2
+func buildAIPerfJob(namespace, jobName, endpoint string, concurrency int, pullSecrets []v1.LocalObjectReference) (*batchv1.Job, aiperfRunParams, error) {
+	// AIPerf requires request_count >= concurrency. Scale the measured request
+	// count with concurrency so larger GPU counts still get a multi-wave
+	// steady-state window, with a fixed floor for small nodes. Tuning-env reads
+	// are pre-validated by validatePerfTuningEnvs; the error returns here are a
+	// defensive fail-closed against a malformed knob.
+	minRequests, err := intFromEnv(envMinRequests, aiperfMinRequests)
+	if err != nil {
+		return nil, aiperfRunParams{}, err
+	}
+	requestsPerConcurrency, err := intFromEnv(envRequestsPerConcurrency, aiperfRequestsPerConcurrency)
+	if err != nil {
+		return nil, aiperfRunParams{}, err
+	}
+	requestCount := minRequests
+	if scaled := concurrency * requestsPerConcurrency; scaled > requestCount {
+		requestCount = scaled
+	}
+	// Warmup primes vLLM (CUDA graph capture / JIT) before measurement so the
+	// one-time compile cost does not inflate p99 TTFT. Excluded from stats.
+	warmupPerConcurrency, err := intFromEnv(envWarmupPerConcurrency, aiperfWarmupPerConcurrency)
+	if err != nil {
+		return nil, aiperfRunParams{}, err
+	}
+	warmupCount := concurrency * warmupPerConcurrency
+	inputTokensMean, err := intFromEnv(envInputTokensMean, aiperfInputTokensMean)
+	if err != nil {
+		return nil, aiperfRunParams{}, err
+	}
+	outputTokensMean, err := intFromEnv(envOutputTokensMean, aiperfOutputTokensMean)
+	if err != nil {
+		return nil, aiperfRunParams{}, err
 	}
 	// Resolve once so Image and ImagePullPolicy can't drift if env vars
 	// were mutated between two calls (matters in tests; cheap in prod).
@@ -1218,6 +1336,7 @@ aiperf profile "%s" \
   --streaming \
   --concurrency %d \
   --request-count %d \
+  --warmup-request-count %d \
   --prompt-input-tokens-mean %d \
   --prompt-output-tokens-mean %d \
   --output-artifact-dir %s \
@@ -1226,8 +1345,8 @@ echo '%s'
 cat %s/profile_export_aiperf.json
 echo '%s'`,
 		inferenceModel, endpoint,
-		concurrency, requestCount,
-		aiperfInputTokensMean, aiperfOutputTokensMean,
+		concurrency, requestCount, warmupCount,
+		inputTokensMean, outputTokensMean,
 		aiperfArtifactDir,
 		aiperfResultSentinel,
 		aiperfArtifactDir,
@@ -1277,7 +1396,7 @@ echo '%s'`,
 				},
 			},
 		},
-	}
+	}, aiperfRunParams{requestCount: requestCount, warmupCount: warmupCount}, nil
 }
 
 // cleanupAIPerfJob removes the AIPerf Job (if it exists) and waits for

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	validatorv1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -466,13 +467,17 @@ func TestBuildAIPerfJob_PrebuiltImageAndSentinel(t *testing.T) {
 	t.Setenv("AICR_CLI_COMMIT", "")
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
 	t.Setenv("AICR_VALIDATOR_IMAGE_TAG", "")
+	// Neutralize tuning knobs so an AICR_INFERENCE_PERF_* value exported by the
+	// runner can't make buildAIPerfJob error out before these image/sentinel
+	// assertions run.
+	clearTuningEnvs(t)
 
 	pullSecrets := []v1.LocalObjectReference{
 		{Name: "ghcr-mirror-pull"},
 		{Name: "nvcr-pull"},
 	}
 	const jobName = "aicr-aiperf-run-42"
-	job := buildAIPerfJob("test-ns", jobName, "http://frontend.test-ns.svc:8000", 16, pullSecrets)
+	job := mustBuildAIPerfJob(t, "test-ns", jobName, "http://frontend.test-ns.svc:8000", 16, pullSecrets)
 	if job.Name != jobName {
 		t.Errorf("job name = %q, want %q", job.Name, jobName)
 	}
@@ -522,7 +527,8 @@ func TestBuildAIPerfJob_PrebuiltImageAndSentinel(t *testing.T) {
 func TestBuildAIPerfJob_NoPullSecrets(t *testing.T) {
 	// nil/empty pullSecrets must not break construction; the field stays empty
 	// and public-registry pulls work unchanged.
-	job := buildAIPerfJob("test-ns", "aicr-aiperf-run-0", "http://ep:8000", 16, nil)
+	clearTuningEnvs(t)
+	job := mustBuildAIPerfJob(t, "test-ns", "aicr-aiperf-run-0", "http://ep:8000", 16, nil)
 	if len(job.Spec.Template.Spec.ImagePullSecrets) != 0 {
 		t.Errorf("nil pullSecrets should yield empty ImagePullSecrets; got %v",
 			job.Spec.Template.Spec.ImagePullSecrets)
@@ -541,6 +547,9 @@ func TestBuildAIPerfJob_ImagePullPolicy(t *testing.T) {
 	t.Setenv("AICR_CLI_VERSION", "")
 	t.Setenv("AICR_CLI_COMMIT", "")
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
+	// A runner-exported AICR_INFERENCE_PERF_* knob must not fail this
+	// pull-policy test before the policy assertion runs.
+	clearTuningEnvs(t)
 
 	tests := []struct {
 		name   string
@@ -564,7 +573,7 @@ func TestBuildAIPerfJob_ImagePullPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("AICR_VALIDATOR_IMAGE_TAG", tt.envTag)
-			job := buildAIPerfJob("ns", "aicr-aiperf-run-0", "http://ep:8000", 16, nil)
+			job := mustBuildAIPerfJob(t, "ns", "aicr-aiperf-run-0", "http://ep:8000", 16, nil)
 			got := job.Spec.Template.Spec.Containers[0].ImagePullPolicy
 			if got != tt.want {
 				t.Errorf("aiperf ImagePullPolicy = %q, want %q", got, tt.want)
@@ -573,18 +582,46 @@ func TestBuildAIPerfJob_ImagePullPolicy(t *testing.T) {
 	}
 }
 
+// mustBuildAIPerfJob calls buildAIPerfJob and fails the test on error, keeping
+// the many default-path assertions terse. Cases that intentionally exercise a
+// malformed knob assert the error from validatePerfTuningEnvs / intFromEnv
+// directly instead.
+func mustBuildAIPerfJob(t *testing.T, namespace, jobName, endpoint string, concurrency int, pullSecrets []v1.LocalObjectReference) *batchv1.Job {
+	t.Helper()
+	job, _, err := buildAIPerfJob(namespace, jobName, endpoint, concurrency, pullSecrets)
+	if err != nil {
+		t.Fatalf("buildAIPerfJob: unexpected error: %v", err)
+	}
+	return job
+}
+
+// clearTuningEnvs neutralizes the AICR_INFERENCE_PERF_* knobs for the duration
+// of the test so default-output assertions stay hermetic even when the runner
+// environment exports them. intFromEnv treats an empty value as unset, so the
+// constant defaults apply. t.Setenv restores prior values after the test.
+func clearTuningEnvs(t *testing.T) {
+	t.Helper()
+	for _, e := range []string{
+		envConcurrencyPerGPU, envWarmupPerConcurrency, envMinRequests,
+		envRequestsPerConcurrency, envInputTokensMean, envOutputTokensMean,
+	} {
+		t.Setenv(e, "")
+	}
+}
+
 func TestBuildAIPerfJob_RequestCountFloor(t *testing.T) {
+	clearTuningEnvs(t)
 	tests := []struct {
 		name        string
 		concurrency int
 		wantMinReqs int
 	}{
 		{"low concurrency — floor at aiperfMinRequests", 16, aiperfMinRequests},
-		{"high concurrency — 2x concurrency", 500, 1000},
+		{"high concurrency — scaled by aiperfRequestsPerConcurrency", 500, 500 * aiperfRequestsPerConcurrency},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			job := buildAIPerfJob("ns", "aicr-aiperf-run-0", "http://ep:8000", tt.concurrency, nil)
+			job := mustBuildAIPerfJob(t, "ns", "aicr-aiperf-run-0", "http://ep:8000", tt.concurrency, nil)
 			script := job.Spec.Template.Spec.Containers[0].Args[0]
 			needle := fmt.Sprintf("--request-count %d", tt.wantMinReqs)
 			if !strings.Contains(script, needle) {
@@ -592,6 +629,162 @@ func TestBuildAIPerfJob_RequestCountFloor(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildAIPerfJob_Warmup verifies a warmup-request-count is emitted and
+// scales with concurrency, so vLLM's one-time compile cost is excluded from the
+// measured p99 TTFT.
+func TestBuildAIPerfJob_Warmup(t *testing.T) {
+	clearTuningEnvs(t)
+	tests := []struct {
+		name        string
+		concurrency int
+	}{
+		{"low concurrency", 16},
+		{"medium concurrency", 128},
+		{"high concurrency", 500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := mustBuildAIPerfJob(t, "ns", "aicr-aiperf-run-0", "http://ep:8000", tt.concurrency, nil)
+			script := job.Spec.Template.Spec.Containers[0].Args[0]
+			needle := fmt.Sprintf("--warmup-request-count %d", tt.concurrency*aiperfWarmupPerConcurrency)
+			if !strings.Contains(script, needle) {
+				t.Errorf("concurrency=%d: script missing %q; script:\n%s", tt.concurrency, needle, script)
+			}
+		})
+	}
+}
+
+// TestIntFromEnv verifies the catalog-tuning env reader: an unset knob returns
+// the default, a valid positive integer is parsed, and a non-integer / zero /
+// negative value returns an error so a typo in the catalog entry can't silently
+// ship a benchmark run under unintended settings.
+func TestIntFromEnv(t *testing.T) {
+	const (
+		env = "AICR_INFERENCE_PERF_TEST_KNOB"
+		def = 42
+	)
+	tests := []struct {
+		name    string
+		val     string
+		want    int
+		wantErr bool
+	}{
+		{"empty/unset → default", "", def, false},
+		{"valid positive → override", "7", 7, false},
+		{"zero → error", "0", 0, true},
+		{"negative → error", "-3", 0, true},
+		{"non-integer → error", "abc", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always t.Setenv (never leave it to the inherited environment):
+			// it overrides any runner-exported value and restores it after the
+			// subtest, and "" makes intFromEnv treat the knob as unset. This
+			// keeps every case hermetic.
+			t.Setenv(env, tt.val)
+			got, err := intFromEnv(env, def)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("intFromEnv(%q=%q) err = %v, wantErr %v", env, tt.val, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("intFromEnv(%q=%q) = %d, want %d", env, tt.val, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidatePerfTuningEnvs verifies the up-front gate fails closed
+// (ErrCodeInvalidRequest) on a malformed knob and passes when knobs are unset
+// or valid — so a typo aborts before the benchmark workload is deployed.
+func TestValidatePerfTuningEnvs(t *testing.T) {
+	t.Run("all unset → ok", func(t *testing.T) {
+		clearTuningEnvs(t)
+		if err := validatePerfTuningEnvs(); err != nil {
+			t.Errorf("unexpected error with all knobs unset: %v", err)
+		}
+	})
+	t.Run("all valid → ok", func(t *testing.T) {
+		clearTuningEnvs(t)
+		t.Setenv(envMinRequests, "2000")
+		t.Setenv(envConcurrencyPerGPU, "8")
+		if err := validatePerfTuningEnvs(); err != nil {
+			t.Errorf("unexpected error with valid knobs: %v", err)
+		}
+	})
+	t.Run("malformed → ErrCodeInvalidRequest", func(t *testing.T) {
+		clearTuningEnvs(t)
+		t.Setenv(envWarmupPerConcurrency, "lots")
+		err := validatePerfTuningEnvs()
+		if err == nil {
+			t.Fatal("expected an error for a non-integer knob")
+		}
+		if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+			t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+		}
+	})
+}
+
+// TestBuildAIPerfJob_EnvOverrides verifies the AICR_INFERENCE_PERF_* knobs flow
+// into the AIPerf invocation so operators can retune without an image rebuild.
+func TestBuildAIPerfJob_EnvOverrides(t *testing.T) {
+	t.Setenv(envMinRequests, "2000")
+	t.Setenv(envRequestsPerConcurrency, "4") // 100*4=400 < 2000 floor
+	t.Setenv(envWarmupPerConcurrency, "3")   // 100*3=300
+	t.Setenv(envInputTokensMean, "64")
+	t.Setenv(envOutputTokensMean, "256")
+
+	job := mustBuildAIPerfJob(t, "ns", "run-0", "http://ep:8000", 100, nil)
+	script := job.Spec.Template.Spec.Containers[0].Args[0]
+	for _, needle := range []string{
+		"--request-count 2000",
+		"--warmup-request-count 300",
+		"--prompt-input-tokens-mean 64",
+		"--prompt-output-tokens-mean 256",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Errorf("script missing %q; script:\n%s", needle, script)
+		}
+	}
+}
+
+// TestBuildAIPerfJob_ReturnedParams verifies buildAIPerfJob reports the resolved
+// request/warmup counts it baked into the script, so runAIPerfJob can log the
+// values actually sent to aiperf instead of the bare constant defaults.
+func TestBuildAIPerfJob_ReturnedParams(t *testing.T) {
+	t.Run("defaults scale with concurrency", func(t *testing.T) {
+		clearTuningEnvs(t)
+		// 128*8 = 1024 exceeds the 1000 floor, so the count is the scaled value
+		// — exactly the case the old log (which printed the 1000 constant) got
+		// wrong.
+		_, params, err := buildAIPerfJob("ns", "run-0", "http://ep:8000", 128, nil)
+		if err != nil {
+			t.Fatalf("buildAIPerfJob: unexpected error: %v", err)
+		}
+		if params.requestCount != 128*aiperfRequestsPerConcurrency {
+			t.Errorf("requestCount = %d, want %d", params.requestCount, 128*aiperfRequestsPerConcurrency)
+		}
+		if params.warmupCount != 128*aiperfWarmupPerConcurrency {
+			t.Errorf("warmupCount = %d, want %d", params.warmupCount, 128*aiperfWarmupPerConcurrency)
+		}
+	})
+	t.Run("honors env overrides", func(t *testing.T) {
+		clearTuningEnvs(t)
+		t.Setenv(envMinRequests, "2000")
+		t.Setenv(envRequestsPerConcurrency, "4") // 100*4=400 < 2000 floor
+		t.Setenv(envWarmupPerConcurrency, "3")   // 100*3=300
+		_, params, err := buildAIPerfJob("ns", "run-0", "http://ep:8000", 100, nil)
+		if err != nil {
+			t.Fatalf("buildAIPerfJob: unexpected error: %v", err)
+		}
+		if params.requestCount != 2000 {
+			t.Errorf("requestCount = %d, want 2000", params.requestCount)
+		}
+		if params.warmupCount != 300 {
+			t.Errorf("warmupCount = %d, want 300", params.warmupCount)
+		}
+	})
 }
 
 func TestResolveAiperfImage(t *testing.T) {


### PR DESCRIPTION
## Summary

Warm up the `inference-perf` performance benchmark before measuring, and expose its tuning knobs via env so operators can retune without rebuilding the validator image.

## Motivation / Context

The `inference-perf` check benchmarked vLLM from a cold start, so vLLM's one-time CUDA-graph capture / JIT compile cost landed inside the measured window. On an 8× RTX PRO 6000 node (`Qwen3-0.6B`) this produced a misleading p99 TTFT of ~42 s and ~772 tok/s — failing the recipe performance thresholds despite healthy hardware. Warmup is the standard way to measure steady-state serving performance (MLPerf Inference; AIPerf/genai-perf ship `--warmup-request-count` for exactly this).

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — `validators/performance`
- [x] Docs/examples (`docs/`)

## Implementation Notes

- Add `--warmup-request-count` (one full concurrency wave, excluded from AIPerf stats) so the compile/capture cost is primed before measurement.
- Widen the steady-state window: measured request count `max(200, concurrency×2)` → `max(1000, concurrency×8)`.
- Expose knobs via `AICR_INFERENCE_PERF_*` env on the `inference-perf` catalog entry (concurrency-per-GPU, warmup-per-concurrency, min requests, requests-per-concurrency, input/output token means), read with `intFromEnv` (WARN + fall back to default on unset/non-integer/non-positive, mirroring `checkTimeoutFromEnv`).
- Methodology knobs live with the validator/catalog; per-accelerator pass/fail thresholds stay in the recipe overlays ("recipes define *what*, validators determine *how*").

## Testing

Validated end-to-end on a live EKS cluster (8× RTX PRO 6000, `g7e.48xlarge`, `Qwen3-0.6B`):

| Metric | Before (cold) | After (warmup) | Threshold | |
|---|---|---|---|---|
| Throughput | 772.74 tok/s | 36,143.79 tok/s | `≥ 5000` | ✅ |
| TTFT p99 | 41,943 ms | 46.59 ms | `≤ 200 ms` | ✅ |

```bash
go test -race ./validators/performance/... ./pkg/validator/catalog/...   # ok
golangci-lint run -c .golangci.yaml ./validators/performance/...          # 0 issues
go build ./...                                                            # ok
yamllint recipes/validators/catalog.yaml                                  # clean
```

Full `make qualify` was not run locally (e2e needs a Kind/Tilt cluster and `scan` needs grype); the Go test/lint/build/vet gates above pass and the functional change is proven on real hardware. CI covers e2e + scan.

## Risk Assessment

- [x] **Low** — Isolated to the inference-perf benchmark builder; defaults preserve the new behavior; easy to revert.

**Rollout notes:** No migration. Benchmark defaults change (warmup added, larger measured-request window); recipe thresholds unchanged.

## Checklist

- [x] Tests pass locally (`-race`)
- [x] Linter passes (`golangci-lint`, `yamllint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs (`docs/contributor/validator.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
