### PR TITLE
refactor(recipe): drop Cached*CountForTesting helpers (#1079)

### DIFF
--- a/aicr_internal_test.go
+++ b/aicr_internal_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	stderrors "errors"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -585,5 +587,73 @@ func TestClient_CloseDrainsInflightResolve(t *testing.T) {
 	}
 	if recipe.CachedRegistryContainsForTesting(blockedDP) {
 		t.Error("registryCache leaked: blockedDP entry still present after Close (cache repopulated post-Close)")
+	}
+}
+
+// TestClient_NoCacheGrowthAcrossManyCloseCycles is the acceptance-
+// criterion test for the "memory does not grow when N clients are
+// created and released in a loop" requirement.
+//
+// Each NewClient call constructs a fresh LayeredDataProvider (unique
+// pointer identity), so the recipe package's sync.Map caches —
+// storeCache and registryCache, keyed by DataProvider — would
+// accumulate N entries if Close didn't evict them. After each
+// Close, the assertion is scoped to THAT iteration's DataProvider
+// (Contains, not Count), so concurrent sibling tests touching their
+// own DataProvider don't perturb the signal.
+//
+// The DataProvider is captured before Close because Close zeros
+// Client.dp (see Close in aicr.go).
+//
+// N is intentionally large (50) so a regression that leaks a single
+// entry per Close cycle fails on the very first iteration but
+// still exercises the eviction path under sustained load when
+// running with -race.
+//
+// Lives in the internal test package so it can read Client.dp; an
+// external test cannot.
+func TestClient_NoCacheGrowthAcrossManyCloseCycles(t *testing.T) {
+	const N = 50
+
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
+		[]byte("components: []\n"), 0o600); err != nil {
+		t.Fatalf("setup: write registry.yaml: %v", err)
+	}
+
+	for i := 0; i < N; i++ {
+		c, err := NewClient(WithRecipeSource(FilesystemSource(tmp)))
+		if err != nil {
+			t.Fatalf("iteration %d: NewClient: %v", i, err)
+		}
+
+		// ResolveRecipe forces both caches to populate for this
+		// Client's DataProvider. Without this, only registryCache
+		// would gain an entry (from buildDataProvider's construction
+		// path); storeCache wouldn't, and the test would miss the
+		// store-side leak.
+		result, err := c.ResolveRecipe(t.Context(), RecipeRequest{
+			Service:     "eks",
+			Accelerator: "h100",
+			Intent:      "training",
+		})
+		if err != nil {
+			t.Fatalf("iteration %d: ResolveRecipe: %v", i, err)
+		}
+		if result == nil {
+			t.Fatalf("iteration %d: ResolveRecipe returned nil result without error", i)
+		}
+
+		dp := c.dp // capture before Close zeros it
+		if err := c.Close(); err != nil {
+			t.Fatalf("iteration %d: Close: %v", i, err)
+		}
+
+		if recipe.CachedStoreContainsForTesting(dp) {
+			t.Errorf("iteration %d: storeCache not evicted after Close", i)
+		}
+		if recipe.CachedRegistryContainsForTesting(dp) {
+			t.Errorf("iteration %d: registryCache not evicted after Close", i)
+		}
 	}
 }

--- a/aicr_test.go
+++ b/aicr_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/NVIDIA/aicr"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 func TestNewClientRequiresRecipeSource(t *testing.T) {
@@ -769,77 +768,4 @@ func componentNames(r *aicr.RecipeResult) []string {
 		out = append(out, c.Name)
 	}
 	return out
-}
-
-// TestClient_NoCacheGrowthAcrossManyCloseCycles is the acceptance-
-// criterion test for the issue's "memory does not grow when N
-// clients are created and released in a loop" requirement.
-//
-// Each NewClient call constructs a fresh LayeredDataProvider (unique
-// pointer identity), so the recipe package's sync.Map caches —
-// storeCache and registryCache, keyed by DataProvider — would
-// accumulate N entries if Close didn't evict them. The test takes
-// a baseline of both cache counts immediately before the loop and
-// asserts they return to the same value after N iterations. Baseline
-// math insulates the test from any parallel sibling's cache entries
-// (those exist both before and after, so they cancel out in the diff).
-//
-// N is intentionally large (50) so a regression that leaks a single
-// entry per Close cycle would push the delta well past any noise
-// floor; running with -race confirms there's no concurrent map
-// corruption while Close is racing the package-global cache writers.
-//
-// NOT t.Parallel: the recipe-package caches (storeCache, registryCache)
-// are process-global sync.Maps. A parallel sibling test that constructs
-// a Client populates those caches while this test runs, so the
-// baseline-diff arithmetic would catch sibling entries as "growth"
-// from this test's perspective. Running sequentially (during go test's
-// pre-parallel phase) gives a clean baseline at minimal time cost.
-func TestClient_NoCacheGrowthAcrossManyCloseCycles(t *testing.T) {
-	const N = 50
-
-	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
-		t.Fatalf("setup: write registry.yaml: %v", err)
-	}
-
-	baselineStore := recipe.CachedStoreCountForTesting()
-	baselineRegistry := recipe.CachedRegistryCountForTesting()
-
-	for i := 0; i < N; i++ {
-		c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(tmp)))
-		if err != nil {
-			t.Fatalf("iteration %d: NewClient: %v", i, err)
-		}
-
-		// ResolveRecipe forces both caches to populate for this
-		// Client's DataProvider. Without this, only registryCache
-		// would gain an entry (from buildDataProvider's construction
-		// path); storeCache wouldn't, and the test would miss the
-		// store-side leak.
-		if _, err := c.ResolveRecipe(t.Context(), aicr.RecipeRequest{
-			Service:     "eks",
-			Accelerator: "h100",
-			Intent:      "training",
-		}); err != nil {
-			t.Fatalf("iteration %d: ResolveRecipe: %v", i, err)
-		}
-
-		if err := c.Close(); err != nil {
-			t.Fatalf("iteration %d: Close: %v", i, err)
-		}
-	}
-
-	afterStore := recipe.CachedStoreCountForTesting()
-	afterRegistry := recipe.CachedRegistryCountForTesting()
-
-	if delta := afterStore - baselineStore; delta != 0 {
-		t.Errorf("storeCache grew by %d after %d NewClient/Resolve/Close cycles; expected 0 (Close should evict)",
-			delta, N)
-	}
-	if delta := afterRegistry - baselineRegistry; delta != 0 {
-		t.Errorf("registryCache grew by %d after %d NewClient/Resolve/Close cycles; expected 0 (Close should evict)",
-			delta, N)
-	}
 }

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -258,33 +258,11 @@ func EvictCachedRegistry(dp DataProvider) {
 	registryCache.Delete(dp)
 }
 
-// CachedRegistryCountForTesting returns the number of distinct
-// DataProvider entries currently held in the registry cache. Exposed
-// for tests in the aicr facade that assert Client.Close evicts the
-// cached registry — without this, the only way to observe eviction
-// from outside the recipe package would be to reach into unexported
-// state via reflection.
-//
-// Test-only by convention (the _ForTesting suffix); never call from
-// production code.
-//
-// NOTE: global count across every DataProvider. Tests that need a
-// stable signal scoped to a specific DataProvider should prefer
-// CachedRegistryContainsForTesting.
-func CachedRegistryCountForTesting() int {
-	n := 0
-	registryCache.Range(func(_, _ any) bool {
-		n++
-		return true
-	})
-	return n
-}
-
 // CachedRegistryContainsForTesting reports whether the registry cache
 // has an entry for the supplied DataProvider. Pair with
 // CachedStoreContainsForTesting in pkg/recipe/metadata_store.go to
-// verify a single Client's caches are released without depending on
-// the global count.
+// verify a single Client's caches are released. Scoped per-provider so
+// it is robust under parallel test execution.
 //
 // Test-only by convention (the _ForTesting suffix); never call from
 // production code.

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -325,33 +325,10 @@ func EvictCachedStore(dp DataProvider) {
 	storeCache.Delete(dp)
 }
 
-// CachedStoreCountForTesting returns the number of distinct DataProvider
-// entries currently held in the metadata-store cache. Exposed for tests
-// in the aicr facade that assert Client.Close evicts the cached store —
-// paired with CachedRegistryCountForTesting in components.go so a single
-// test can verify both halves of the per-Client cache are released.
-//
-// Test-only by convention (the _ForTesting suffix); never call from
-// production code.
-//
-// NOTE: this returns the GLOBAL count across every DataProvider in the
-// package. A parallel test in another package using its own
-// DataProvider will perturb the count. Tests that need a stable signal
-// scoped to a specific DataProvider should prefer
-// CachedStoreContainsForTesting.
-func CachedStoreCountForTesting() int {
-	n := 0
-	storeCache.Range(func(_, _ any) bool {
-		n++
-		return true
-	})
-	return n
-}
-
 // CachedStoreContainsForTesting reports whether the metadata-store
-// cache has an entry for the supplied DataProvider. Unlike the count
-// helper, this is robust under parallel test execution: each test that
-// uses a distinct DataProvider can observe ONLY its own entry's
+// cache has an entry for the supplied DataProvider. Scoped per-provider
+// so it is robust under parallel test execution: each test that uses a
+// distinct DataProvider can observe ONLY its own entry's
 // presence/absence.
 //
 // Test-only by convention (the _ForTesting suffix); never call from


### PR DESCRIPTION
## Summary

Removes the two `_ForTesting` count-based cache inspection helpers from `pkg/recipe`'s exported surface and moves the only consumer into the internal `aicr` test package where it can use the per-DataProvider `Contains` helpers instead.

## Motivation / Context

`pkg/recipe` is marked **Public (evolving)** in `docs/integrator/public-api.md`. The `_ForTesting` suffix on `CachedStoreCountForTesting` and `CachedRegistryCountForTesting` is convention-only; nothing prevents production callers from using them. The count helpers had a known limitation already documented in the source: their result is global across all DataProviders, so any parallel sibling test perturbs the baseline. Per-provider `Contains*ForTesting` helpers are scoped correctly and the existing test in `aicr_internal_test.go` already prefers them.

Fixes: #1079
Related: #1076 (epic), #1072 (PR that introduced the helpers)

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Other: facade tests (`aicr_test.go`, `aicr_internal_test.go`)

## Implementation Notes

- Deleted `CachedStoreCountForTesting` (`pkg/recipe/metadata_store.go`) and `CachedRegistryCountForTesting` (`pkg/recipe/components.go`).
- Moved `TestClient_NoCacheGrowthAcrossManyCloseCycles` from `aicr_test.go` (external `aicr_test` package) into `aicr_internal_test.go` (internal `aicr` package) so it can read the unexported `Client.dp` field directly.
- Rewrote the assertion: instead of `Count(before) → 50 cycles → Count(after) == before`, the test now captures `dp := c.dp` *before* `Close()` (which zeros the field) and asserts `recipe.CachedStoreContainsForTesting(dp) == false` per iteration. Strictly stronger signal — fails on iteration 1 if eviction is broken, and per-provider scoping is robust to parallel sibling tests.
- The new test also asserts the resolved `*RecipeResult` is non-nil per iteration (resolver contract).
- The surviving `Contains*ForTesting` helpers remain exported but their docstrings were tightened to drop references to the deleted count helpers.

The remaining `Contains*ForTesting` exports are still convention-only test hooks; fully eliminating them is intentionally deferred (a follow-up could move them behind a build tag or relocate them to an internal subpackage). This PR halves the surface today with no production code changes.

## Testing

```bash
make qualify  # passes
```

- Affected tests pass under `-race`: `TestClient_NoCacheGrowthAcrossManyCloseCycles`, `TestClient_CloseDrainsInflightResolve`, `TestClient_NoCachePopulationAfterClose`.
- Coverage delta:
  - `pkg/recipe`: 90.8% → 91.3% (+0.5%, deleted uncovered exported helpers)
  - `github.com/NVIDIA/aicr`: 63.3% → 63.3%

## Risk Assessment

- [x] **Low** — Test-only refactor. No production code paths change. Public test helpers being removed had no callers outside this repo.

**Rollout notes:** N/A — external consumers cannot have been using these correctly (the suffix advertises test-only intent). If anyone was, they get a clear compile-time error and can switch to `Contains*ForTesting`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — internal test surface)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)