### PR TITLE
harden(recipes): direct dependencyRefs from monitoring-CR creators to prometheus-operator-crds

### DIFF
--- a/pkg/recipe/yaml_test.go
+++ b/pkg/recipe/yaml_test.go
@@ -38,6 +38,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -833,6 +834,73 @@ func TestBaseRecipeValidation(t *testing.T) {
 	if len(order) != len(metadata.Spec.ComponentRefs) {
 		t.Errorf("topological sort returned %d components, expected %d",
 			len(order), len(metadata.Spec.ComponentRefs))
+	}
+}
+
+// TestMonitoringCREmittersHaveDirectPrometheusOperatorCRDsEdge enforces
+// issue #928: every component whose Helm chart templates emit
+// monitoring.coreos.com/v1 CRs (PodMonitor / ServiceMonitor / etc.) must
+// declare prometheus-operator-crds in its DIRECT dependencyRefs — not just
+// reachable through a transitive chain. A direct edge survives refactors
+// of intermediate nodes (e.g., removing gpu-operator → kube-prometheus-stack)
+// that would otherwise silently break the helm-diff CRD-registration race
+// described in issue #914.
+//
+// The emitter list is derived from `helm template` of each chart at the
+// version pinned in base.yaml using its checked-in values file. When a
+// chart bump (or values change) flips a chart between emitter and
+// non-emitter status, update this list. The refresh recipe is documented
+// in the test body.
+func TestMonitoringCREmittersHaveDirectPrometheusOperatorCRDsEdge(t *testing.T) {
+	// Components whose chart templates render at least one
+	// monitoring.coreos.com/v1 CR with the values in
+	// recipes/components/<name>/values.yaml.
+	//
+	// To refresh:
+	//   helm template release-<name> <chart> --version <v> \
+	//     -f recipes/components/<name>/values.yaml \
+	//     --namespace test --include-crds \
+	//     | grep -c '^apiVersion: monitoring.coreos.com'
+	//
+	// A non-zero count means the component is an emitter and must
+	// appear below. prometheus-operator-crds itself is excluded
+	// because it IS the producer of the CRDs.
+	emitters := []string{
+		"kube-prometheus-stack",
+		"nvsentinel",
+		"k8s-ephemeral-storage-metrics",
+	}
+
+	content, err := GetEmbeddedFS().ReadFile(baseYAMLFile)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", baseYAMLFile, err)
+	}
+
+	var metadata RecipeMetadata
+	if parseErr := yaml.Unmarshal(content, &metadata); parseErr != nil {
+		t.Fatalf("failed to parse %s: %v", baseYAMLFile, parseErr)
+	}
+
+	byName := make(map[string]ComponentRef, len(metadata.Spec.ComponentRefs))
+	for _, c := range metadata.Spec.ComponentRefs {
+		byName[c.Name] = c
+	}
+
+	const required = "prometheus-operator-crds"
+
+	for _, name := range emitters {
+		t.Run(name, func(t *testing.T) {
+			comp, ok := byName[name]
+			if !ok {
+				t.Fatalf("emitter %q not present in %s", name, baseYAMLFile)
+			}
+			if slices.Contains(comp.DependencyRefs, required) {
+				return
+			}
+			t.Errorf("component %q emits monitoring.coreos.com/v1 CRs but does not declare %q "+
+				"as a DIRECT dependencyRef in %s. A transitive path is not enough — see issue #928. "+
+				"Current dependencyRefs: %v", name, required, baseYAMLFile, comp.DependencyRefs)
+		})
 	}
 }
 

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -55,6 +55,11 @@ spec:
       dependencyRefs:
         - cert-manager
         - gpu-operator
+        # Direct edge so a refactor of an intermediate node (e.g.,
+        # removing gpu-operator → kube-prometheus-stack) cannot
+        # silently break the helm-diff race on nvsentinel's
+        # PodMonitor CR. Issue #928.
+        - prometheus-operator-crds
 
     - name: nodewright-operator
       type: Helm
@@ -83,6 +88,10 @@ spec:
       valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
       dependencyRefs:
         - kube-prometheus-stack
+        # Direct edge so removing the kube-prometheus-stack edge
+        # would not silently break the helm-diff race on this
+        # chart's ServiceMonitor CR. Issue #928.
+        - prometheus-operator-crds
 
     - name: nvidia-dra-driver-gpu
       type: Helm

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -256,12 +256,11 @@ components:
     valueOverrideKeys:
       - nv-sentinel
     # nvsentinel's templates create monitoring.coreos.com/v1 PodMonitor
-    # CRs that prometheus-operator-crds must register first. Ordering
-    # is satisfied transitively in the DAG-stratified helmfile layout:
-    # nvsentinel depends on gpu-operator, which depends on
-    # kube-prometheus-stack, which depends on prometheus-operator-crds,
-    # so by the time nvsentinel's level diffs, the monitoring CRDs are
-    # already registered. Issue #914.
+    # CRs that prometheus-operator-crds must register first. nvsentinel
+    # declares prometheus-operator-crds as a direct dependencyRef in
+    # base.yaml so the DAG-stratified helmfile layout installs the
+    # monitoring CRDs first regardless of any refactor of intermediate
+    # nodes (gpu-operator, kube-prometheus-stack). Issues #914, #928.
     healthCheck:
       assertFile: checks/nvsentinel/health-check.yaml
     helm:


### PR DESCRIPTION
## Summary

Add direct `dependencyRefs: [prometheus-operator-crds]` to every base component whose Helm templates emit `monitoring.coreos.com/v1` CRs (nvsentinel, k8s-ephemeral-storage-metrics) so the DAG-stratified helmfile layout survives refactors of intermediate nodes, plus a Go test that enforces the invariant.

## Motivation / Context

After #926 split `prometheus-operator-crds` out as its own release, several components that create `monitoring.coreos.com/v1` CRs (PodMonitor / ServiceMonitor / etc.) reached the CRDs only via a multi-hop transitive path:

> nvsentinel → gpu-operator → kube-prometheus-stack → prometheus-operator-crds

If anyone removes the `gpu-operator → kube-prometheus-stack` edge in `recipes/overlays/base.yaml` — plausible since gpu-operator doesn't strictly *need* kube-prometheus-stack to install — the helm-diff race on nvsentinel's PodMonitor CR silently returns. No CI test catches it; the failure surfaces only on a fresh-cluster `helmfile apply`. This PR closes that gap by making the edge direct and asserting the invariant in a unit test.

Fixes: #928
Related: #914, #926

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

**Audit method.** Rendered each Helm chart in `recipes/overlays/base.yaml` (and registry/mixins) at its pinned version with its checked-in values file, then grepped for `apiVersion: monitoring.coreos.com`. Install-time emitters at our values:

| Component | CR kinds emitted | Direct edge before | After |
|---|---|---|---|
| `kube-prometheus-stack` | Alertmanager, Prometheus, PrometheusRule, ServiceMonitor (50) | ✅ | ✅ (unchanged) |
| `nvsentinel` | PodMonitor (1) | ❌ (transitive) | ✅ |
| `k8s-ephemeral-storage-metrics` | ServiceMonitor (1) | ❌ (transitive) | ✅ |

Other charts whose RBAC `apiGroups` mention `monitoring.coreos.com` (gpu-operator, network-operator, k8s-nim-operator, kai-scheduler, slinky-slurm-operator) do not emit any monitoring CR in their install-time templates — the operators create those CRs at runtime once their own CRD is reconciled, which is after install ordering matters.

**Test.** `TestMonitoringCREmittersHaveDirectPrometheusOperatorCRDsEdge` in `pkg/recipe/yaml_test.go` enforces a *direct* edge (not just closure membership). Closure is too weak — the very failure the issue describes is "transitive only" silently breaking. The test body documents the `helm template … | grep -c apiVersion: monitoring.coreos.com` refresh recipe for chart bumps.

**nvsentinel registry comment.** Reworded to reflect the direct edge in base.yaml instead of the four-hop chain.

## Testing

```bash
unset GITLAB_TOKEN && make qualify   # passes: tests + race + lint + e2e (22/22 chainsaw) + scan
make bom-docs                        # no diff (no chart pins / values changed)
```

Per-package coverage on `pkg/recipe`:

- Baseline (origin/main): 91.3%
- This branch: 91.3% (test-only addition)

## Risk Assessment

- [x] **Low** — Adds *extra* dependencyRefs edges to two components in base.yaml; DAG-flattening makes the extra edges no-ops while the transitive paths still exist, so install order is unchanged. The new test pins the invariant going forward.

**Rollout notes:** No CLI/API surface change. Generated bundles include the same components in the same install levels (verified by chainsaw `cli-bundle-helmfile` and `cli-recipe-overlays`).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — no user-visible change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)