### PR TITLE
feat(recipes): apply nodewright generic tuning to rtx-pro-6000 EKS

### DIFF
--- a/recipes/components/nodewright-customizations/manifests/no-op.yaml
+++ b/recipes/components/nodewright-customizations/manifests/no-op.yaml
@@ -46,8 +46,10 @@ spec:
     {{- if $cust.acceleratedTolerations }}
     {{- toYaml $cust.acceleratedTolerations | nindent 4 }}
     {{- else }}
-    - key: dedicated
-      operator: Exists
+    # Tolerate-all default, matching ParseTolerations()/DefaultTolerations()
+    # (operator Exists, no key). Only reached if no acceleratedTolerations are
+    # injected from scheduling defaults/flags.
+    - operator: Exists
     {{- end }}
   # Dynamic: Supports --accelerated-node-selector CLI flag
   {{- if $cust.acceleratedNodeSelector }}

--- a/recipes/components/nodewright-customizations/manifests/tuning-generic.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning-generic.yaml
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Nodewright GKE Container-Optimized OS (COS) GPU Customization
-# Minimal templating - only tolerations/nodeSelectors are dynamic for CLI flag support
+# Nodewright GPU customization that runs ONLY the nvidia-tuned "generic"
+# profile (no nvidia-setup).
 #
-# This customization configures GPU nodes on ContainerOptimized OS with:
-# - Sysctl kernel tuning parameters
-# NOTE: runtimeRequired is NOT used here because GKE COS is largely immutable and so
-# the optimizations that can be made are limited to those which are not disruptive.
+# Used by targets where the shared tuning.yaml does not apply: tuning.yaml also
+# renders nvidia-setup, which only ships baked-in (service, accelerator) configs
+# for eks-h100 / eks-gb200 and fails on any other combination — so it cannot be
+# used with accelerator=generic.
+#
+# nvidia-tuned's "generic" profile (nodewright-packages 0.2.4+) is
+# self-contained: safe baseline GPU tuning (governor=performance, iommu=pt, BBR,
+# modest sysctls) with NO InfiniBand/hugepage/ACS/CPU-isolation settings. That
+# baseline fits PCIe accelerators such as RTX PRO 6000 (no NVLink fabric, EFA
+# unused, platform-provisioned kernel) without the HGX/DGX assumptions the
+# h100/gb200 profiles bake in.
+#
+# Minimal templating - only tolerations/nodeSelectors are dynamic for CLI flag support.
 {{- $cust := index .Values "nodewright-customizations" }}
 {{- if ne (toString (index $cust "enabled")) "false" }}
 ---
@@ -38,6 +47,7 @@ metadata:
   name: tuning
   namespace: {{ .Release.Namespace }}
 spec:
+  runtimeRequired: true
   # Default: true. Disable with --set nodewrightcustomizations:autoTaintNewNodes=false
   autoTaintNewNodes: {{ ne (toString ($cust.autoTaintNewNodes | default true)) "false" }}
   # Dynamic: Supports --accelerated-node-toleration CLI flag
@@ -62,17 +72,25 @@ spec:
     matchLabels:
       {{- toYaml $cust.workloadSelector | nindent 6 }}
   {{- end }}
-  # Tuning
+  # Tuning: nvidia-tuned generic profile only (no nvidia-setup).
   packages:
-    tuning:
-      image: ghcr.io/nvidia/nodewright-packages/nvidia-tuning-gke
-      version: "0.1.2"
-      containerSHA: sha256:6671d49f006afdbeefd8858f1fa1216f7748205bc42edab3340210a2cc459a81
+    nvidia-tuned:
+      image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
+      version: "0.3.0"
+      containerSHA: sha256:cc99c8c0675f3752f5081f0978ae57174368952ca0bb5fcac07640fe62c156c7
+      # Bootloader params in the generic profile (iommu=pt, init_on_alloc=0, ...)
+      # require a reboot to take effect.
       interrupt:
-        type: service
-        services:
-          - systemd-sysctl
+        type: reboot
+      env:
+        - name: INTERRUPT
+          value: "true"
       configMap:
+        {{- if $cust.intent }}
         intent: {{ $cust.intent }}
+        {{- end }}
         accelerator: {{ $cust.accelerator }}
+        {{- if $cust.service }}
+        service: {{ $cust.service }}
+        {{- end }}
 {{- end }}

--- a/recipes/components/nodewright-customizations/manifests/tuning.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning.yaml
@@ -46,8 +46,10 @@ spec:
     {{- if $cust.acceleratedTolerations }}
     {{- toYaml $cust.acceleratedTolerations | nindent 4 }}
     {{- else }}
-    - key: dedicated
-      operator: Exists
+    # Tolerate-all default, matching ParseTolerations()/DefaultTolerations()
+    # (operator Exists, no key). Only reached if no acceleratedTolerations are
+    # injected from scheduling defaults/flags.
+    - operator: Exists
     {{- end }}
   # Dynamic: Supports --accelerated-node-selector CLI flag
   {{- if $cust.acceleratedNodeSelector }}

--- a/recipes/overlays/h200-eks-training.yaml
+++ b/recipes/overlays/h200-eks-training.yaml
@@ -84,6 +84,12 @@ spec:
       checks:
         - nccl-all-reduce-bw
       constraints:
+        # Conservative floor inherited from h100-eks-training. H200 (HBM3e,
+        # ~4.8 TB/s) sustains higher NCCL all-reduce bandwidth on EFA than H100
+        # (HBM3, ~3.35 TB/s), so this floor is loose: it passes well below
+        # H200's real performance envelope and won't catch regressions until
+        # they fall near the H100 level. Tighten once empirical H200/EFA
+        # numbers are available.
         - name: nccl-all-reduce-bw
           value: ">= 300"
     conformance:

--- a/recipes/overlays/rtx-pro-6000-eks-inference.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-inference.yaml
@@ -37,14 +37,37 @@ spec:
       value: ">= 1.32.4"
 
   componentRefs:
-    # RTX PRO 6000 GPU Operator dependencies
-    # Single-card inference SKU — no NVLink, no NCCL multi-node tuning needed
+    # RTX PRO 6000 GPU Operator dependencies + node tuning.
+    # Node tuning uses the nodewright "generic" nvidia-tuned profile rather than
+    # the shared tuning.yaml: tuning.yaml also renders nvidia-setup, which only
+    # ships eks-h100/eks-gb200 configs and fails on any other target. The
+    # generic profile is safe baseline GPU tuning that omits the NVLink/
+    # InfiniBand/hugepage/CPU-isolation settings the h100/gb200 profiles carry —
+    # which don't apply to these PCIe RTX PRO 6000 nodes (no NVLink fabric).
     - name: gpu-operator
       type: Helm
       dependencyRefs:
         - nfd
         - cert-manager
         - kube-prometheus-stack
+        - nodewright-customizations
+
+    - name: nodewright-customizations
+      type: Helm
+      # tuning-generic.yaml runs only nvidia-tuned (generic profile); it omits
+      # the nvidia-setup packages, which only support eks-h100/eks-gb200 and
+      # would fail on accelerator=generic. nvidia-setup's kernel/EFA steps are
+      # also unneeded here: the platform provisions the kernel and EFA is unused.
+      manifestFiles:
+        - components/nodewright-customizations/manifests/tuning-generic.yaml
+      overrides:
+        service: eks
+        # No rtx-pro-6000 profile exists in nvidia-tuned (only h100/gb200/
+        # generic); generic is the supported baseline profile for this target.
+        accelerator: generic
+        intent: inference
+      dependencyRefs:
+        - nodewright-operator
 
     - name: nfd
       type: Helm


### PR DESCRIPTION
## Summary

Wire `nodewright-customizations` with `accelerator=generic` into the rtx-pro-6000 EKS inference overlay, so RTX PRO 6000 nodes get a baseline GPU node-tuning profile — closing a gap vs `h100`/`gb200`/`b200`, which already wire tuning.

## Motivation / Context

The `rtx-pro-6000` EKS overlays deployed only `nodewright-operator` (the controller) with **no** `nodewright-customizations`, so aicr applied no tuning profile (left entirely to the platform). `nvidia-tuned` has no `rtx-pro-6000` profile; the `generic` profile is purpose-built for single-GPU cloud VMs and deliberately omits the NVLink/InfiniBand/hugepage/CPU-isolation settings the `h100`/`gb200` profiles carry. It already ships in `nvidia-tuned` 0.3.0 — the version the tuning manifest pins.

Fixes: N/A
Related: NVIDIA/nodewright-packages#37 (adds the `generic` profile)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — `recipes/overlays`

## Implementation Notes

- Added the `nodewright-customizations` componentRef to `rtx-pro-6000-eks-inference.yaml` — the `<accelerator>-<service>-<intent>` level, mirroring `h100-eks-inference`/`gb200-eks-inference`. The `-ubuntu-inference`, `-dynamo`, and `-nim` leaves inherit it via overlay merge (the established convention; leaves never re-declare tuning).
- `overrides.accelerator=generic` (the recipe criteria stays `rtx-pro-6000`); added `nodewright-customizations` to the `gpu-operator` `dependencyRefs` for ordering, same as h100.
- eks rtx-pro-6000 is inference-only, so this is a single-file change (no training counterpart).

## Alternatives Considered

**Option 1 — no-op manifest (`no-op.yaml`):** wire `nodewright-customizations` as a no-op placeholder (a `shellscript` package that just echoes). This satisfies the `gpu-operator` dependency and keeps the "customization present" pattern, but applies **no** tuning — leaving node tuning entirely to the platform/NCP (the status quo on b40). Rejected in favor of Option 2 (`tuning-generic.yaml`, which actually applies the `nvidia-tuned` `generic` profile). The no-op remains the safe fallback if the nodewright team determines RTX PRO 6000 should **not** run `nvidia-tuned` standalone — e.g. if it must run `nvidia-setup`'s kernel/EFA steps first (which today support only `eks-h100`/`eks-gb200`).

## Additional Changes (cross-cutting — disclosed for the next reader)

Beyond the rtx-pro-6000 tuning, this PR includes two changes that touch shared/other files:

1. **Toleration-default consistency fix (affects all recipes, not just rtx-pro-6000).** The `additionalTolerations` *fallback* in `tuning.yaml`, `tuning-gke.yaml`, and `no-op.yaml` (and the new `tuning-generic.yaml`) changes from `[{ key: dedicated, operator: Exists }]` to the tolerate-all `[{ operator: Exists }]`. This matches `ParseTolerations()` / `DefaultTolerations()` and the `assert-tuning-defaults.yaml` chainsaw fixture; the previous templates were inconsistent (subset matching masked it), so this closes a real gap. It affects every recipe rendering these manifests — **h100, gb200, b200, b40, GKE** — but only the *fallback* branch (when no `acceleratedTolerations` are injected from scheduling defaults/flags); the default/flag path is unchanged. (Raised by CodeRabbit and @mchmarny.)

2. **`h200-eks-training` NCCL-floor doc.** A comment noting the inherited `nccl-all-reduce-bw >= 300` floor is h100-sourced and loose for H200's HBM3e bandwidth — flagged to tighten once empirical H200/EFA numbers exist. (Addresses a review nit from #1102.)

## Testing

- `yamllint` clean; `go test ./pkg/recipe/...` pass; no golden fixtures to regenerate.
- Generated the `eks/rtx-pro-6000/ubuntu/inference/dynamo` recipe + bundle: the recipe gains `nodewright-customizations`, and the rendered Skyhook CR sets `accelerator: generic` against `nvidia-tuned` 0.3.0 (the profile that ships `generic`).
- Render-verified only; not yet applied on a live RTX PRO 6000 cluster. CI (KWOK + Tier-1 deploy matrices) covers recipe rendering and deployment.

## Risk Assessment

- [x] **Low** — Additive overlay change following an established pattern; easy to revert.

**Rollout notes:** New deploys of rtx-pro-6000 EKS recipes will now apply the `nvidia-generic` tuned profile via nodewright. No migration.

## Checklist

- [x] Tests pass locally (`go test ./pkg/recipe/...`)
- [x] Linter passes (`yamllint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — overlay change; covered by recipe-resolution + CI render tests)
- [x] I updated docs if user-facing behavior changed (N/A — no new component/flag; nodewright-customizations already documented)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)


