### PR TITLE
feat(recipes): add nodewright h100 tuning to H200 EKS recipes

### DIFF
--- a/recipes/overlays/h200-eks-inference.yaml
+++ b/recipes/overlays/h200-eks-inference.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h200-eks-inference
+
+spec:
+  # Inherits from eks-inference recipe (EKS + inference settings)
+  base: eks-inference
+
+  criteria:
+    service: eks
+    accelerator: h200
+    intent: inference
+
+  # Specific constraints for H200 on EKS inference workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+
+  componentRefs:
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - nfd
+        - cert-manager
+        - kube-prometheus-stack
+        - nodewright-customizations
+
+    - name: nodewright-customizations
+      type: Helm
+      manifestFiles:
+        - components/nodewright-customizations/manifests/tuning.yaml
+      overrides:
+        service: eks
+        # H200 reuses the h100 nodewright tuning: it is the same Hopper platform
+        # (HGX/DGX-class, NVLink + InfiniBand) and nvidia-setup/nvidia-tuned ship
+        # no h200 target — only eks-h100/eks-gb200. The recipe criteria above
+        # stays h200; only this tuning profile selector is h100.
+        accelerator: h100
+        intent: inference
+      dependencyRefs:
+        - nodewright-operator
+
+    - name: nfd
+      type: Helm
+      overrides:
+        topologyUpdater:
+          enable: true

--- a/recipes/overlays/h200-eks-training.yaml
+++ b/recipes/overlays/h200-eks-training.yaml
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h200-eks-training
+
+spec:
+  # Inherits from eks-training recipe (EKS + training settings)
+  base: eks-training
+
+  criteria:
+    service: eks
+    accelerator: h200
+    intent: training
+
+  # Specific constraints for H200 on EKS training workloads
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+
+  componentRefs:
+    # H200-specific GPU Operator overrides (inherits valuesFile from eks-training)
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - nfd
+        - cert-manager
+        - kube-prometheus-stack
+        - nodewright-customizations
+      overrides:
+        cdi:
+          enabled: true
+        gdrcopy:
+          enabled: true
+
+    - name: nodewright-customizations
+      type: Helm
+      manifestFiles:
+        - components/nodewright-customizations/manifests/tuning.yaml
+      overrides:
+        service: eks
+        # H200 reuses the h100 nodewright tuning: same Hopper platform
+        # (HGX/DGX-class, NVLink + InfiniBand) and nvidia-setup/nvidia-tuned ship
+        # no h200 target — only eks-h100/eks-gb200. The recipe criteria above
+        # stays h200; only this tuning profile selector is h100.
+        accelerator: h100
+        intent: multiNodeTraining
+      dependencyRefs:
+        - nodewright-operator
+
+    - name: nfd
+      type: Helm
+      overrides:
+        topologyUpdater:
+          enable: true
+
+  # Validation checks for H200 on EKS training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"
+    performance:
+      checks:
+        - nccl-all-reduce-bw
+      constraints:
+        - name: nccl-all-reduce-bw
+          value: ">= 300"
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access


### PR DESCRIPTION
## Summary

Add `h200-eks-inference` and `h200-eks-training` overlays so H200 EKS recipes apply nodewright node tuning, reusing the existing **h100** profile.

## Motivation / Context

H200 had only the `h200-any` wildcard overlay and **no** `<accelerator>-<service>-<intent>` EKS overlays, so it applied no nodewright tuning — unlike `h100`/`gb200`/`b200`, which all wire `nodewright-customizations` at that level. H200 is the same Hopper, HGX/DGX-class platform as H100 (NVLink + InfiniBand), and `nvidia-setup`/`nvidia-tuned` ship **no h200 target** (only `eks-h100`/`eks-gb200`), so reusing the h100 tuning is the correct choice.

Fixes: N/A
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — `recipes/overlays`

## Implementation Notes

- New `h200-eks-inference.yaml` / `h200-eks-training.yaml` mirror the `h100-eks-*` overlays (same gpu-operator deps, nfd, constraints, and — for training — the full validation block).
- `criteria.accelerator` is `h200`; only the `nodewright-customizations` tuning override selects `accelerator: h100` (with `intent: inference` / `multiNodeTraining`), so it renders the supported `eks-h100` `nvidia-setup` + h100 `nvidia-tuned` combo via the shared `tuning.yaml`.
- No new manifest needed (unlike the rtx-pro-6000/generic case): `eks-h100` is a fully supported `nvidia-setup` target, so `tuning.yaml` works as-is.

## Testing

- Generated `h200/eks/inference` and `h200/eks/training` recipes: both now apply the `h200-eks-*` overlay and include `nodewright-customizations`.
- Inspected the rendered Skyhook CR: `nvidia-setup-kernel` + `nvidia-tuned` + `nvidia-setup-full`, all `service: eks` / `accelerator: h100` (the supported combo).
- `yamllint` clean; `go test ./pkg/recipe/...` pass. CI (KWOK + Tier-1) covers rendering/deploy.

## Risk Assessment

- [x] **Low** — Two additive overlays following the established h100 pattern; reuses a supported tuning target; easy to revert.

**Rollout notes:** New H200 EKS recipes will apply the h100 `nvidia-tuned` profile + `nvidia-setup` (eks-h100) via nodewright. No migration. If H200-specific tuning is later desired, add an `h200` target upstream in `nodewright-packages` and flip the override.

## Checklist

- [x] Tests pass locally (`go test ./pkg/recipe/...`)
- [x] Linter passes (`yamllint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — overlay change; covered by recipe-resolution + CI render tests)
- [x] I updated docs if user-facing behavior changed (N/A — no new component/flag)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
