### PR TITLE
feat(recipe): per-field union merge for validation phase checks

### DIFF
--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -486,8 +486,8 @@ The gpu-operator version pin from `gb200-any` lands in the hydrated recipe witho
 
 - **Top-level `spec.constraints`** merge by name. A same-named constraint from the more-specific leaf overrides the wildcard's value (the "overridden, new added" rule from the merge algorithm).
 - **`spec.validation.<phase>`** blocks (readiness, deployment, performance, conformance) also merge per-field:
-  - `checks`: deduplicated union, preserving order (wildcard entries first, then leaf-only entries appended).
-  - `constraints`: union by `name`; same-named constraint from the leaf wins (analogous to the top-level constraint merge).
+  - `checks`: an omitted field (nil) inherits the parent's list; an explicit empty list (`checks: []`) clears the inherited list for that phase; a non-empty list unions with the parent's, deduplicated and preserving order (parent entries first, then leaf-only entries appended).
+  - `constraints`: same nil-vs-empty rule as `checks`; a non-empty list unions by `name` with the leaf winning on same-name (analogous to the top-level constraint merge).
   - `nodeSelection`: overlay replaces wholesale when non-nil (full struct replace).
   - `timeout`, `infrastructure`: overlay-wins-if-non-empty.
 
@@ -506,6 +506,21 @@ spec:
 ```
 
 Leaves may still restate the inherited list when it documents intent (e.g., recording which checks the leaf depends on). With per-field union, restating is a no-op: duplicates dedupe against the wildcard's entries.
+
+To intentionally drop an inherited check or constraint, declare the field as an explicit empty list (`checks: []` / `constraints: []`) rather than omitting it. Omission means "inherit"; explicit empty means "clear":
+
+```yaml
+# recipes/overlays/h100-eks-ubuntu-training-slurm.yaml — Slurm-managed
+# clusters bypass slurmd for K8s-native NCCL tests, so the leaf clears
+# the inherited performance phase rather than running it.
+spec:
+  validation:
+    performance:
+      checks: []        # Explicit clear — drops inherited nccl-all-reduce-bw.
+      constraints: []   # Same — clears the inherited >= 300 floor.
+```
+
+This distinction is preserved by `yaml.v3`: a YAML `[]` decodes as a non-nil empty slice (clear), while an omitted or `null` field decodes as nil (inherit).
 
 Criteria-wildcard overlays are only appropriate when the content is genuinely uniform across the wildcard dimension. If the value diverges (e.g., H100 NCCL targets differ by cloud: AKS ≥ 100, EKS ≥ 300, GKE ≥ 250), keep it inline in each service-specific overlay — collapsing divergent values to a lowest-common-denominator wildcard silently weakens validation.
 

--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -482,12 +482,16 @@ The gpu-operator version pin from `gb200-any` lands in the hydrated recipe witho
 | Adopt-by-default is desired for new matching overlays | Each consumer should reference it explicitly |
 | You want to add `validation` blocks (mixins don't carry validation) | You only need `constraints` / `componentRefs` |
 
-**Precedence when a wildcard overlay and a service-specific leaf collide.** `FindMatchingOverlays` sorts its returned leaves by `Criteria.Specificity()` ascending, so less-specific overlays merge first and more-specific overlays merge last. Two different merge rules apply — they are not the same:
+**Precedence when a wildcard overlay and a service-specific leaf collide.** `FindMatchingOverlays` sorts its returned leaves by `Criteria.Specificity()` ascending, so less-specific overlays merge first and more-specific overlays merge last. Both top-level constraints and `spec.validation.<phase>` blocks merge per-field — the more-specific leaf adds to or overrides the wildcard's block without replacing it wholesale:
 
 - **Top-level `spec.constraints`** merge by name. A same-named constraint from the more-specific leaf overrides the wildcard's value (the "overridden, new added" rule from the merge algorithm).
-- **`spec.validation.<phase>`** blocks (deployment, performance, conformance) are **replaced wholesale** when a later overlay defines the same phase — no field-level merge. The leaf's `checks` and `constraints` replace the wildcard's entire block.
+- **`spec.validation.<phase>`** blocks (readiness, deployment, performance, conformance) also merge per-field:
+  - `checks`: deduplicated union, preserving order (wildcard entries first, then leaf-only entries appended).
+  - `constraints`: union by `name`; same-named constraint from the leaf wins (analogous to the top-level constraint merge).
+  - `nodeSelection`: overlay replaces wholesale when non-nil (full struct replace).
+  - `timeout`, `infrastructure`: overlay-wins-if-non-empty.
 
-This distinction matters. To override only one value in the wildcard's deployment phase from the example above, a service-specific leaf must restate **every** `check` it wants to keep AND every constraint, because the wildcard's block is replaced wholesale once the leaf declares the same phase:
+A leaf that only needs to tighten one constraint can declare just that constraint — the wildcard's checks and other constraints are inherited automatically:
 
 ```yaml
 # recipes/overlays/gb200-eks-training.yaml — illustrative; real leaf has
@@ -495,17 +499,13 @@ This distinction matters. To override only one value in the wildcard's deploymen
 spec:
   validation:
     deployment:
-      checks:                            # Must restate every check —
-        - operator-health                # else the wildcard's checks are
-        - expected-resources             # dropped and the phase is skipped.
-        - gpu-operator-version
-        - check-nvidia-smi
+      # `checks` omitted — wildcard's 4 standard checks are inherited.
       constraints:
         - name: Deployment.gpu-operator.version
           value: ">= v25.10.1"           # Tighten past the wildcard's floor.
 ```
 
-Setting only `constraints` (or only a subset of `checks`) drops the wildcard's remaining check names, which causes `filterEntriesByRecipe` to return zero entries for them and the corresponding phase to be skipped entirely — the opposite of the "tighten one value" intent.
+Leaves may still restate the inherited list when it documents intent (e.g., recording which checks the leaf depends on). With per-field union, restating is a no-op: duplicates dedupe against the wildcard's entries.
 
 Criteria-wildcard overlays are only appropriate when the content is genuinely uniform across the wildcard dimension. If the value diverges (e.g., H100 NCCL targets differ by cloud: AKS ≥ 100, EKS ≥ 300, GKE ≥ 250), keep it inline in each service-specific overlay — collapsing divergent values to a lowest-common-denominator wildcard silently weakens validation.
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -155,6 +155,7 @@ Only use this pattern when the content is truly uniform across the wildcard dime
 **Merge rules:**
 - Constraints: same-named overridden, new added
 - ComponentRefs: same-named merged field-by-field, new added
+- `validation.<phase>` blocks merge per-field: `checks` union and deduplicate, `constraints` merge by name (overlay wins on same-name), `nodeSelection` replaced wholesale when set, `timeout`/`infrastructure` overlay-wins-if-non-empty
 - Criteria: not inherited (each recipe defines its own)
 - Mixin constraints/components must not conflict with the inheritance chain or other mixins
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -155,7 +155,7 @@ Only use this pattern when the content is truly uniform across the wildcard dime
 **Merge rules:**
 - Constraints: same-named overridden, new added
 - ComponentRefs: same-named merged field-by-field, new added
-- `validation.<phase>` blocks merge per-field: `checks` union and deduplicate, `constraints` merge by name (overlay wins on same-name), `nodeSelection` replaced wholesale when set, `timeout`/`infrastructure` overlay-wins-if-non-empty
+- `validation.<phase>` blocks merge per-field: `checks` and `constraints` union and deduplicate when non-empty (`constraints` by name, overlay wins on same-name); an explicit empty list (`checks: []` / `constraints: []`) **clears** the inherited list, while an omitted/null field **inherits** it; `nodeSelection` replaced wholesale when set; `timeout`/`infrastructure` overlay-wins-if-non-empty
 - Criteria: not inherited (each recipe defines its own)
 - Mixin constraints/components must not conflict with the inheritance chain or other mixins
 

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -476,28 +476,22 @@ func (s *RecipeMetadataSpec) Merge(other *RecipeMetadataSpec) {
 		return s.ComponentRefs[i].Name < s.ComponentRefs[j].Name
 	})
 
-	// Merge validation config - overlay phases take precedence. Phase
-	// pointers are cloned (not aliased) so successive merges cannot mutate
-	// the source's cached ValidationConfig — a previous version aliased
-	// other.Validation when s.Validation was nil, then later writes through
-	// s.Validation.Deployment etc. corrupted whichever overlay's cached
-	// metadata the alias pointed at.
+	// Merge validation config. Each phase merges field-by-field so leaf
+	// overlays can add or override checks/constraints without restating the
+	// entire inherited block. See issue #1000 for the rationale — the prior
+	// per-phase pointer replace was the only list-shaped field with replace
+	// semantics, and it silently dropped inherited checks when a descendant
+	// declared its own phase block. Phase pointers are still cloned (not
+	// aliased) when the destination's phase is nil so successive merges
+	// cannot mutate the source's cached ValidationConfig.
 	if other.Validation != nil {
 		if s.Validation == nil {
 			s.Validation = cloneValidationConfig(other.Validation)
 		} else {
-			if other.Validation.Readiness != nil {
-				s.Validation.Readiness = cloneValidationPhase(other.Validation.Readiness)
-			}
-			if other.Validation.Deployment != nil {
-				s.Validation.Deployment = cloneValidationPhase(other.Validation.Deployment)
-			}
-			if other.Validation.Performance != nil {
-				s.Validation.Performance = cloneValidationPhase(other.Validation.Performance)
-			}
-			if other.Validation.Conformance != nil {
-				s.Validation.Conformance = cloneValidationPhase(other.Validation.Conformance)
-			}
+			s.Validation.Readiness = mergeValidationPhase(s.Validation.Readiness, other.Validation.Readiness)
+			s.Validation.Deployment = mergeValidationPhase(s.Validation.Deployment, other.Validation.Deployment)
+			s.Validation.Performance = mergeValidationPhase(s.Validation.Performance, other.Validation.Performance)
+			s.Validation.Conformance = mergeValidationPhase(s.Validation.Conformance, other.Validation.Conformance)
 		}
 	}
 

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -614,6 +614,47 @@ func TestBothBuildPathsProduceIdenticalContent(t *testing.T) {
 	t.Logf("verified %d leaf overlays through both build paths", leafCount)
 }
 
+// TestSlurmLeavesClearInheritedPerformancePhase is a regression guard for
+// issue #1000: leaves like h100-eks-ubuntu-training-slurm and
+// h100-gke-cos-training-slurm declare `performance.checks: []` /
+// `constraints: []` to drop the K8s-native nccl-all-reduce-bw check, which
+// bypasses slurmd on a Slurm-managed cluster. The fix in mergeValidationPhase
+// distinguishes an omitted overlay list (nil → inherit) from an explicit
+// empty list (`[]` → clear), so these recipes resolve with no performance
+// checks and the phase is skipped by FilterEntriesByValidation.
+func TestSlurmLeavesClearInheritedPerformancePhase(t *testing.T) {
+	ctx := context.Background()
+	store, err := loadMetadataStore(ctx)
+	if err != nil {
+		t.Fatalf("failed to load metadata store: %v", err)
+	}
+
+	for _, name := range []string{
+		"h100-eks-ubuntu-training-slurm",
+		"h100-gke-cos-training-slurm",
+	} {
+		t.Run(name, func(t *testing.T) {
+			leaf, ok := store.GetRecipeByName(name)
+			if !ok {
+				t.Fatalf("overlay %q not found in store", name)
+			}
+			result, err := store.BuildRecipeResult(ctx, leaf.Spec.Criteria)
+			if err != nil {
+				t.Fatalf("BuildRecipeResult failed: %v", err)
+			}
+			if result.Validation == nil || result.Validation.Performance == nil {
+				t.Fatalf("performance phase missing from resolved recipe")
+			}
+			if got := result.Validation.Performance.Checks; len(got) != 0 {
+				t.Errorf("performance.checks = %v, want empty — Slurm leaf must drop inherited K8s-native checks", got)
+			}
+			if got := result.Validation.Performance.Constraints; len(got) != 0 {
+				t.Errorf("performance.constraints = %v, want empty — Slurm leaf must drop inherited K8s-native constraints", got)
+			}
+		})
+	}
+}
+
 // TestEvaluatorFailingLeafExcludesCandidate verifies that when a leaf overlay's
 // constraints fail evaluation, no ancestor overlay is used as a fallback
 // candidate. With maximal leaf selection, ancestors are not independent

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -1245,6 +1245,82 @@ func TestMergeValidationConfig(t *testing.T) {
 		}
 	})
 
+	// Regression for #1000 review feedback: an overlay declaring
+	// `checks: []` / `constraints: []` (non-nil empty, distinguishable
+	// from a nil/omitted field) must clear the inherited list, not
+	// inherit it. The Slurm leaves (h100-*-training-slurm) rely on this
+	// to drop the K8s-native nccl-all-reduce-bw check on slurmd clusters.
+	t.Run("phase explicit empty checks clears inherited", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					Checks: []string{"nccl-all-reduce-bw"},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					Checks: []string{}, // explicit clear
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		got := base.Validation.Performance.Checks
+		if len(got) != 0 {
+			t.Errorf("checks = %v, want empty (explicit clear must drop inherited entries)", got)
+		}
+	})
+
+	t.Run("phase explicit empty constraints clears inherited", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					Constraints: []Constraint{{Name: "nccl-all-reduce-bw", Value: ">= 300"}},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					Constraints: []Constraint{}, // explicit clear
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		got := base.Validation.Performance.Constraints
+		if len(got) != 0 {
+			t.Errorf("constraints = %v, want empty (explicit clear must drop inherited entries)", got)
+		}
+	})
+
+	t.Run("phase nil checks inherits from base", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					Checks: []string{"nccl-all-reduce-bw"},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					// Checks is nil (field omitted) — base must be inherited.
+					Constraints: []Constraint{{Name: "x", Value: "1"}},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		got := base.Validation.Performance.Checks
+		want := []string{"nccl-all-reduce-bw"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("checks = %v, want %v (nil overlay list must inherit base)", got, want)
+		}
+	})
+
 	t.Run("union merge does not mutate source slices", func(t *testing.T) {
 		// Repeat the alias-safety guarantee for the union path: writing into
 		// the merged result must not leak through to the source's Checks/Constraints.

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -982,8 +982,11 @@ func TestMergeValidationConfig(t *testing.T) {
 		if base.Validation.Deployment.Timeout != "10m" {
 			t.Errorf("deployment timeout = %q, want 10m (from overlay)", base.Validation.Deployment.Timeout)
 		}
-		if len(base.Validation.Deployment.Checks) != 2 {
-			t.Errorf("deployment checks len = %d, want 2 (from overlay)", len(base.Validation.Deployment.Checks))
+		// After switching to per-field union semantics, the overlay's checks
+		// are unioned with the base's. Both blocks list "expected-resources",
+		// so dedupe collapses to 2 unique entries — base then overlay-only.
+		if got, want := base.Validation.Deployment.Checks, []string{"expected-resources", "check-nvidia-smi"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("deployment checks = %v, want %v (base ∪ overlay, deduped, preserving order)", got, want)
 		}
 		if base.Validation.Performance == nil {
 			t.Fatal("performance should be added from overlay")
@@ -1058,6 +1061,228 @@ func TestMergeValidationConfig(t *testing.T) {
 		}
 		if dest.Validation.Conformance == source.Conformance {
 			t.Error("dest.Validation.Conformance aliases source.Conformance — phase pointers must be cloned")
+		}
+	})
+
+	// Per-field union-merge semantics — see issue #1000. Each phase's Checks
+	// and Constraints union with the base instead of replacing it wholesale.
+	t.Run("phase checks union deduplicates preserving order", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Checks: []string{"operator-health", "expected-resources", "gpu-operator-version"},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					// "expected-resources" duplicates base; "check-nvidia-smi"
+					// is overlay-only and must be appended after base entries.
+					Checks: []string{"expected-resources", "check-nvidia-smi"},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		want := []string{"operator-health", "expected-resources", "gpu-operator-version", "check-nvidia-smi"}
+		if got := base.Validation.Deployment.Checks; !reflect.DeepEqual(got, want) {
+			t.Errorf("checks = %v, want %v (union, dedup, preserve order)", got, want)
+		}
+	})
+
+	t.Run("phase constraints union with overlay overriding same name", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Constraints: []Constraint{
+						{Name: "Deployment.gpu-operator.version", Value: ">= v25.10.0"},
+						{Name: "Deployment.operator.replicas", Value: ">= 1"},
+					},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Constraints: []Constraint{
+						// Same name — overlay value wins.
+						{Name: "Deployment.gpu-operator.version", Value: ">= v25.10.1"},
+						// New name — appended.
+						{Name: "Deployment.driver.version", Value: ">= 570.0"},
+					},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		got := base.Validation.Deployment.Constraints
+		byName := make(map[string]string, len(got))
+		for _, c := range got {
+			byName[c.Name] = c.Value
+		}
+		if len(byName) != 3 {
+			t.Errorf("constraints len = %d, want 3 unique by name", len(byName))
+		}
+		if byName["Deployment.gpu-operator.version"] != ">= v25.10.1" {
+			t.Errorf("gpu-operator.version = %q, want overlay value >= v25.10.1",
+				byName["Deployment.gpu-operator.version"])
+		}
+		if byName["Deployment.operator.replicas"] != ">= 1" {
+			t.Errorf("operator.replicas = %q, want preserved base value >= 1",
+				byName["Deployment.operator.replicas"])
+		}
+		if byName["Deployment.driver.version"] != ">= 570.0" {
+			t.Errorf("driver.version = %q, want overlay-added value >= 570.0",
+				byName["Deployment.driver.version"])
+		}
+	})
+
+	t.Run("phase NodeSelection overlay wins when set", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					NodeSelection: &NodeSelection{
+						Selector: map[string]string{"role": "base"},
+						MaxNodes: 4,
+					},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					NodeSelection: &NodeSelection{
+						Selector: map[string]string{"role": "overlay"},
+						MaxNodes: 8,
+					},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		ns := base.Validation.Performance.NodeSelection
+		if ns == nil {
+			t.Fatal("performance NodeSelection should not be nil")
+		}
+		if ns.Selector["role"] != "overlay" || ns.MaxNodes != 8 {
+			t.Errorf("NodeSelection = %+v, want overlay-wins (role=overlay, maxNodes=8)", ns)
+		}
+	})
+
+	t.Run("phase NodeSelection inherited when overlay omits it", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					NodeSelection: &NodeSelection{
+						Selector: map[string]string{"role": "base"},
+					},
+					Checks: []string{"nccl-test"},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Performance: &ValidationPhase{
+					// Overlay touches only checks; NodeSelection must inherit.
+					Checks: []string{"inference-perf"},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		ns := base.Validation.Performance.NodeSelection
+		if ns == nil || ns.Selector["role"] != "base" {
+			t.Errorf("NodeSelection = %+v, want base preserved when overlay omits it", ns)
+		}
+	})
+
+	t.Run("phase scalar fields overlay wins when set", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Timeout:        "5m",
+					Infrastructure: "base-infra",
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Timeout:        "10m",
+					Infrastructure: "overlay-infra",
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		if base.Validation.Deployment.Timeout != "10m" {
+			t.Errorf("timeout = %q, want 10m (overlay-wins)", base.Validation.Deployment.Timeout)
+		}
+		if base.Validation.Deployment.Infrastructure != "overlay-infra" {
+			t.Errorf("infrastructure = %q, want overlay-infra (overlay-wins)",
+				base.Validation.Deployment.Infrastructure)
+		}
+	})
+
+	t.Run("phase scalar fields inherited when overlay omits them", func(t *testing.T) {
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Timeout:        "5m",
+					Infrastructure: "base-infra",
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					// Overlay defines block but omits scalars — must inherit.
+					Checks: []string{"new-check"},
+				},
+			},
+		}
+		base.Merge(&overlay)
+
+		if base.Validation.Deployment.Timeout != "5m" {
+			t.Errorf("timeout = %q, want 5m preserved from base", base.Validation.Deployment.Timeout)
+		}
+		if base.Validation.Deployment.Infrastructure != "base-infra" {
+			t.Errorf("infrastructure = %q, want base-infra preserved", base.Validation.Deployment.Infrastructure)
+		}
+	})
+
+	t.Run("union merge does not mutate source slices", func(t *testing.T) {
+		// Repeat the alias-safety guarantee for the union path: writing into
+		// the merged result must not leak through to the source's Checks/Constraints.
+		source := &ValidationConfig{
+			Deployment: &ValidationPhase{
+				Checks:      []string{"operator-health"},
+				Constraints: []Constraint{{Name: "Deployment.gpu-operator.version", Value: ">= v25.10.0"}},
+			},
+		}
+		base := RecipeMetadataSpec{
+			Validation: &ValidationConfig{
+				Deployment: &ValidationPhase{
+					Checks:      []string{"expected-resources"},
+					Constraints: []Constraint{{Name: "Deployment.driver.version", Value: ">= 570.0"}},
+				},
+			},
+		}
+		overlay := RecipeMetadataSpec{Validation: source}
+		base.Merge(&overlay)
+
+		// Mutate the merged result — source must remain unchanged.
+		base.Validation.Deployment.Checks[0] = "mutated"
+		base.Validation.Deployment.Constraints[0].Value = "mutated"
+
+		if source.Deployment.Checks[0] != "operator-health" {
+			t.Errorf("source.Checks[0] = %q, want operator-health — union merge leaked to source",
+				source.Deployment.Checks[0])
+		}
+		if source.Deployment.Constraints[0].Value != ">= v25.10.0" {
+			t.Errorf("source.Constraints[0].Value = %q, union merge leaked to source",
+				source.Deployment.Constraints[0].Value)
 		}
 	})
 }

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -1116,25 +1116,18 @@ func TestMergeValidationConfig(t *testing.T) {
 		}
 		base.Merge(&overlay)
 
+		// Assert the slice directly: order must be base entries first (with
+		// same-name values replaced by overlay), then overlay-only additions
+		// appended. A map-based assertion would hide order regressions and
+		// duplicate-name leaks.
 		got := base.Validation.Deployment.Constraints
-		byName := make(map[string]string, len(got))
-		for _, c := range got {
-			byName[c.Name] = c.Value
+		want := []Constraint{
+			{Name: "Deployment.gpu-operator.version", Value: ">= v25.10.1"},
+			{Name: "Deployment.operator.replicas", Value: ">= 1"},
+			{Name: "Deployment.driver.version", Value: ">= 570.0"},
 		}
-		if len(byName) != 3 {
-			t.Errorf("constraints len = %d, want 3 unique by name", len(byName))
-		}
-		if byName["Deployment.gpu-operator.version"] != ">= v25.10.1" {
-			t.Errorf("gpu-operator.version = %q, want overlay value >= v25.10.1",
-				byName["Deployment.gpu-operator.version"])
-		}
-		if byName["Deployment.operator.replicas"] != ">= 1" {
-			t.Errorf("operator.replicas = %q, want preserved base value >= 1",
-				byName["Deployment.operator.replicas"])
-		}
-		if byName["Deployment.driver.version"] != ">= 570.0" {
-			t.Errorf("driver.version = %q, want overlay-added value >= 570.0",
-				byName["Deployment.driver.version"])
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("constraints = %#v, want %#v", got, want)
 		}
 	})
 
@@ -1272,9 +1265,16 @@ func TestMergeValidationConfig(t *testing.T) {
 		overlay := RecipeMetadataSpec{Validation: source}
 		base.Merge(&overlay)
 
-		// Mutate the merged result — source must remain unchanged.
-		base.Validation.Deployment.Checks[0] = "mutated"
-		base.Validation.Deployment.Constraints[0].Value = "mutated"
+		// Under base-first union, base entries occupy index 0 and source
+		// entries are appended at index 1+. Mutate the source-derived index
+		// so a missing copy would observably leak back to source — mutating
+		// index 0 would only catch base aliasing, not source aliasing.
+		if len(base.Validation.Deployment.Checks) < 2 || len(base.Validation.Deployment.Constraints) < 2 {
+			t.Fatalf("unexpected merged sizes: checks=%d constraints=%d",
+				len(base.Validation.Deployment.Checks), len(base.Validation.Deployment.Constraints))
+		}
+		base.Validation.Deployment.Checks[1] = "mutated"
+		base.Validation.Deployment.Constraints[1].Value = "mutated"
 
 		if source.Deployment.Checks[0] != "operator-health" {
 			t.Errorf("source.Checks[0] = %q, want operator-health — union merge leaked to source",

--- a/pkg/recipe/validation.go
+++ b/pkg/recipe/validation.go
@@ -78,6 +78,112 @@ func cloneValidationConfig(v *ValidationConfig) *ValidationConfig {
 	}
 }
 
+// mergeValidationPhase merges overlay into base, returning a freshly allocated
+// phase with no aliased state. Semantics mirror the top-level merge:
+//   - Checks: deduplicated union, preserving order (base entries first,
+//     then overlay-only entries appended).
+//   - Constraints: union by Name, overlay value wins on same-name (analogous
+//     to top-level RecipeMetadataSpec.Constraints).
+//   - NodeSelection: overlay replaces if non-nil; otherwise base is preserved.
+//   - Timeout, Infrastructure: overlay-wins-if-non-empty.
+//
+// If overlay is nil, base is returned untouched. If base is nil, overlay is
+// deep-cloned to avoid aliasing into the source's cached metadata.
+func mergeValidationPhase(base, overlay *ValidationPhase) *ValidationPhase {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		return cloneValidationPhase(overlay)
+	}
+
+	out := &ValidationPhase{
+		Timeout:        base.Timeout,
+		Infrastructure: base.Infrastructure,
+	}
+	if overlay.Timeout != "" {
+		out.Timeout = overlay.Timeout
+	}
+	if overlay.Infrastructure != "" {
+		out.Infrastructure = overlay.Infrastructure
+	}
+
+	// Checks: union, deduplicated, base order preserved.
+	if len(base.Checks)+len(overlay.Checks) > 0 {
+		seen := make(map[string]bool, len(base.Checks)+len(overlay.Checks))
+		out.Checks = make([]string, 0, len(base.Checks)+len(overlay.Checks))
+		for _, c := range base.Checks {
+			if !seen[c] {
+				seen[c] = true
+				out.Checks = append(out.Checks, c)
+			}
+		}
+		for _, c := range overlay.Checks {
+			if !seen[c] {
+				seen[c] = true
+				out.Checks = append(out.Checks, c)
+			}
+		}
+	}
+
+	// Constraints: union by Name, overlay wins on same-name. Order preserves
+	// base appearance, then overlay-only additions in overlay order.
+	if len(base.Constraints)+len(overlay.Constraints) > 0 {
+		overlayByName := make(map[string]Constraint, len(overlay.Constraints))
+		for _, c := range overlay.Constraints {
+			overlayByName[c.Name] = c
+		}
+		seen := make(map[string]bool, len(base.Constraints)+len(overlay.Constraints))
+		out.Constraints = make([]Constraint, 0, len(base.Constraints)+len(overlay.Constraints))
+		for _, c := range base.Constraints {
+			if seen[c.Name] {
+				continue
+			}
+			seen[c.Name] = true
+			if ov, ok := overlayByName[c.Name]; ok {
+				out.Constraints = append(out.Constraints, ov)
+			} else {
+				out.Constraints = append(out.Constraints, c)
+			}
+		}
+		for _, c := range overlay.Constraints {
+			if seen[c.Name] {
+				continue
+			}
+			seen[c.Name] = true
+			out.Constraints = append(out.Constraints, c)
+		}
+	}
+
+	// NodeSelection: overlay-wins-if-non-nil (full struct replace).
+	if overlay.NodeSelection != nil {
+		out.NodeSelection = cloneNodeSelection(overlay.NodeSelection)
+	} else if base.NodeSelection != nil {
+		out.NodeSelection = cloneNodeSelection(base.NodeSelection)
+	}
+
+	return out
+}
+
+// cloneNodeSelection returns a deep copy of ns with independent backing
+// map and slice, so callers writing through the clone cannot reach the
+// source's cached metadata.
+func cloneNodeSelection(ns *NodeSelection) *NodeSelection {
+	if ns == nil {
+		return nil
+	}
+	out := *ns
+	if ns.Selector != nil {
+		out.Selector = make(map[string]string, len(ns.Selector))
+		maps.Copy(out.Selector, ns.Selector)
+	}
+	if ns.ExcludeNodes != nil {
+		out.ExcludeNodes = make([]string, len(ns.ExcludeNodes))
+		copy(out.ExcludeNodes, ns.ExcludeNodes)
+	}
+	return &out
+}
+
 // cloneValidationPhase returns a deep copy of p with independent backing
 // slices and a freshly allocated NodeSelection, so callers writing through
 // the clone cannot reach the source's cached metadata.
@@ -94,17 +200,6 @@ func cloneValidationPhase(p *ValidationPhase) *ValidationPhase {
 		out.Checks = make([]string, len(p.Checks))
 		copy(out.Checks, p.Checks)
 	}
-	if p.NodeSelection != nil {
-		ns := *p.NodeSelection
-		if p.NodeSelection.Selector != nil {
-			ns.Selector = make(map[string]string, len(p.NodeSelection.Selector))
-			maps.Copy(ns.Selector, p.NodeSelection.Selector)
-		}
-		if p.NodeSelection.ExcludeNodes != nil {
-			ns.ExcludeNodes = make([]string, len(p.NodeSelection.ExcludeNodes))
-			copy(ns.ExcludeNodes, p.NodeSelection.ExcludeNodes)
-		}
-		out.NodeSelection = &ns
-	}
+	out.NodeSelection = cloneNodeSelection(p.NodeSelection)
 	return &out
 }

--- a/pkg/recipe/validation.go
+++ b/pkg/recipe/validation.go
@@ -80,10 +80,16 @@ func cloneValidationConfig(v *ValidationConfig) *ValidationConfig {
 
 // mergeValidationPhase merges overlay into base, returning a freshly allocated
 // phase with no aliased state. Semantics mirror the top-level merge:
-//   - Checks: deduplicated union, preserving order (base entries first,
-//     then overlay-only entries appended).
-//   - Constraints: union by Name, overlay value wins on same-name (analogous
-//     to top-level RecipeMetadataSpec.Constraints).
+//   - Checks: an omitted overlay list (nil) inherits the base list; an
+//     explicit empty list ([]string{}, from YAML `checks: []`) clears the
+//     inherited list — needed by leaves like h100-eks-ubuntu-training-slurm
+//     that must drop K8s-native checks (e.g., nccl-all-reduce-bw) which
+//     don't apply to slurmd-managed clusters. A non-empty overlay list
+//     unions with the base list, deduplicated, preserving order (base
+//     entries first, then overlay-only entries appended).
+//   - Constraints: same nil-vs-empty rule as Checks. A non-empty overlay
+//     list unions with the base by Name; overlay value wins on same-name
+//     (analogous to top-level RecipeMetadataSpec.Constraints).
 //   - NodeSelection: overlay replaces if non-nil; otherwise base is preserved.
 //   - Timeout, Infrastructure: overlay-wins-if-non-empty.
 //
@@ -108,8 +114,14 @@ func mergeValidationPhase(base, overlay *ValidationPhase) *ValidationPhase {
 		out.Infrastructure = overlay.Infrastructure
 	}
 
-	// Checks: union, deduplicated, base order preserved.
-	if len(base.Checks)+len(overlay.Checks) > 0 {
+	// Checks: explicit empty (non-nil, len 0) clears; nil inherits; non-empty
+	// unions with base. yaml.v3 decodes `checks: []` as non-nil empty and an
+	// omitted/null key as nil, so authors can intentionally drop inherited
+	// checks (e.g., Slurm leaves dropping nccl-all-reduce-bw).
+	switch {
+	case overlay.Checks != nil && len(overlay.Checks) == 0:
+		out.Checks = []string{}
+	case len(base.Checks)+len(overlay.Checks) > 0:
 		seen := make(map[string]bool, len(base.Checks)+len(overlay.Checks))
 		out.Checks = make([]string, 0, len(base.Checks)+len(overlay.Checks))
 		for _, c := range base.Checks {
@@ -126,9 +138,13 @@ func mergeValidationPhase(base, overlay *ValidationPhase) *ValidationPhase {
 		}
 	}
 
-	// Constraints: union by Name, overlay wins on same-name. Order preserves
+	// Constraints: same nil-vs-empty rule as Checks. Non-empty overlay
+	// unions by Name; overlay value wins on same-name. Order preserves
 	// base appearance, then overlay-only additions in overlay order.
-	if len(base.Constraints)+len(overlay.Constraints) > 0 {
+	switch {
+	case overlay.Constraints != nil && len(overlay.Constraints) == 0:
+		out.Constraints = []Constraint{}
+	case len(base.Constraints)+len(overlay.Constraints) > 0:
 		overlayByName := make(map[string]Constraint, len(overlay.Constraints))
 		for _, c := range overlay.Constraints {
 			overlayByName[c.Name] = c

--- a/pkg/recipe/validation.go
+++ b/pkg/recipe/validation.go
@@ -151,7 +151,9 @@ func mergeValidationPhase(base, overlay *ValidationPhase) *ValidationPhase {
 				continue
 			}
 			seen[c.Name] = true
-			out.Constraints = append(out.Constraints, c)
+			// Use the resolved overlay winner so intra-overlay duplicates
+			// honor the same last-wins rule the base-override branch uses.
+			out.Constraints = append(out.Constraints, overlayByName[c.Name])
 		}
 	}
 

--- a/recipes/overlays/b200-any.yaml
+++ b/recipes/overlays/b200-any.yaml
@@ -18,12 +18,9 @@
 # The resolver picks it up for every B200 query (any service, any intent)
 # and contributes the B200-wide deployment-phase floor — the 4 standard
 # checks plus the gpu-operator version pin — without duplicating it in
-# every leaf.
-#
-# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
-# that declare their own `deployment:` block win. Concrete leaves that do
-# (e.g., b200-gke-cos-training) match the floor value here so the override
-# is a no-op today.
+# every leaf. Per-field union merge (see pkg/recipe/metadata.go) means
+# concrete leaves that declare their own `deployment:` block add to or
+# override this floor without dropping its inherited checks.
 #
 # See docs/contributor/data.md#criteria-wildcard-overlays for details.
 

--- a/recipes/overlays/gb200-any.yaml
+++ b/recipes/overlays/gb200-any.yaml
@@ -26,10 +26,11 @@
 # fabric instead of carrying one cross-service number that is rarely
 # correct for two fabrics.
 #
-# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
+# Per-field union merge (see pkg/recipe/metadata.go) means concrete leaves
 # that declare their own `deployment:` block (e.g., gb200-eks-training,
-# gb200-eks-inference) continue to win — their constraint values match
-# the floor here so the override is a no-op.
+# gb200-eks-inference) add to or override this floor without dropping its
+# inherited checks — same-name constraints from the leaf win, additional
+# checks are appended.
 #
 # See docs/contributor/data.md#criteria-wildcard-overlays for details.
 

--- a/recipes/overlays/h100-any.yaml
+++ b/recipes/overlays/h100-any.yaml
@@ -21,10 +21,11 @@
 # plus the gpu-operator version pin — without duplicating it in every
 # service+intent leaf.
 #
-# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
+# Per-field union merge (see pkg/recipe/metadata.go) means concrete leaves
 # that declare their own `deployment:` block (e.g., h100-eks-training,
-# h100-aks-training, h100-eks-ubuntu-inference-dynamo) continue to win —
-# their constraint values match the floor here so the override is a no-op.
+# h100-aks-training, h100-eks-ubuntu-inference-dynamo) add to or override
+# this floor without dropping its inherited checks — same-name constraints
+# from the leaf win, additional checks are appended.
 #
 # See docs/contributor/data.md#criteria-wildcard-overlays for details.
 

--- a/recipes/overlays/h200-any.yaml
+++ b/recipes/overlays/h200-any.yaml
@@ -25,9 +25,10 @@
 # same gpu-operator support floor), so this mirrors h100-any.yaml. Splitting
 # only becomes necessary if an H200-specific floor delta emerges.
 #
-# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
-# that declare their own `deployment:` block continue to win — their
-# constraint values match the floor here so the override is a no-op.
+# Per-field union merge (see pkg/recipe/metadata.go) means concrete leaves
+# that declare their own `deployment:` block add to or override this floor
+# without dropping its inherited checks — same-name constraints from the
+# leaf win, additional checks are appended.
 #
 # See docs/contributor/data.md#criteria-wildcard-overlays for details.
 

--- a/recipes/overlays/rtx-pro-6000-any.yaml
+++ b/recipes/overlays/rtx-pro-6000-any.yaml
@@ -20,9 +20,10 @@
 # the 4 standard checks plus the gpu-operator version pin — without
 # duplicating it in every leaf.
 #
-# Per-phase replace semantics in pkg/recipe/metadata.go mean concrete leaves
-# that declare their own `deployment:` block win. None of the current
-# rtx-pro-6000-lke-* leaves do, so they all inherit this floor.
+# Per-field union merge (see pkg/recipe/metadata.go) means concrete leaves
+# that declare their own `deployment:` block add to or override this floor
+# without dropping its inherited checks — same-name constraints from the
+# leaf win, additional checks are appended.
 #
 # See docs/contributor/data.md#criteria-wildcard-overlays for details.
 

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
@@ -67,8 +67,8 @@ spec:
         - check-nvidia-smi
       constraints:
         # RTX PRO 6000 Blackwell needs the Blackwell-era gpu-operator floor.
-        # Match the rtx-pro-6000-any.yaml wildcard so the per-phase replace
-        # semantics keep the version pin intact.
+        # Matches the rtx-pro-6000-any.yaml wildcard's pin; per-field union
+        # merge would inherit it anyway, but restating it documents intent.
         - name: Deployment.gpu-operator.version
           value: ">= v25.10.0"
     performance:

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-nim.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-nim.yaml
@@ -62,8 +62,8 @@ spec:
         - check-nvidia-smi
       constraints:
         # RTX PRO 6000 Blackwell needs the Blackwell-era gpu-operator floor.
-        # Match the rtx-pro-6000-any.yaml wildcard so the per-phase replace
-        # semantics keep the version pin intact.
+        # Matches the rtx-pro-6000-any.yaml wildcard's pin; per-field union
+        # merge would inherit it anyway, but restating it documents intent.
         - name: Deployment.gpu-operator.version
           value: ">= v25.10.0"
     conformance:


### PR DESCRIPTION
## Summary

Switch `validation.{phase}` merge from per-phase pointer replace to per-field union, matching the semantics already used at the top level for `constraints` and `componentRefs`. Leaves can now add or override checks and phase-level constraints without restating the entire inherited block.

This is a **merge-semantics correction**, not a two-file patch. External overlay authors and downstream tenant overlays that depend on the new per-field rules — including the nil-vs-empty contract for clearing inherited lists — pick up the corrected behavior automatically.

## Motivation / Context

`RecipeMetadataSpec.Merge` was the only list-shaped field with replace semantics — if a leaf overlay declared a `deployment:` block, the leaf's block fully overwrote the inherited one. This was a silent footgun: future leaves that add a `deployment:` block (to set one constraint or one extra check) would silently drop every inherited check unless the author remembered to re-state them. The five `*-any.yaml` wildcard overlays carried YAML comments warning about this; comments are a weak guard, so the merge itself is now safe by construction.

Fixes: #1000
Related: #1001 (which added the warning comments that this PR removes), #969 (which exposed the issue)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: recipe overlays (`recipes/overlays/*.yaml`)

## Implementation Notes

Per-field merge rules in `mergeValidationPhase`:

- **`Checks`** — three-way semantics on the overlay field:
  - `nil` (field omitted in YAML) → inherit the base list unchanged.
  - non-nil empty (`checks: []`) → **explicitly clear** the inherited list. Required by Slurm leaves (`h100-eks-ubuntu-training-slurm`, `h100-gke-cos-training-slurm`) to drop the K8s-native `nccl-all-reduce-bw` check that bypasses slurmd on Slurm-managed clusters.
  - non-empty → deduplicated union with base; base entries first, then overlay-only entries appended.
- **`Constraints`** — same nil-vs-empty rule. Non-empty unions by `Name`; overlay wins on same-name (analogous to top-level `RecipeMetadataSpec.Constraints`).
- **`NodeSelection`** — overlay replaces wholesale when non-nil; otherwise base preserved. Full struct replace because per-field semantics aren't obvious and the struct is small.
- **`Timeout`, `Infrastructure`** — overlay-wins-if-non-empty.

The nil-vs-empty distinction is preserved end-to-end by `yaml.v3`: YAML `checks: []` decodes as a non-nil empty slice (clear), while an omitted or `null` key decodes as nil (inherit).

A new `mergeValidationPhase` helper in `pkg/recipe/validation.go` encapsulates this. The existing `cloneValidationPhase` was refactored to share a new `cloneNodeSelection` helper. The `Merge` site in `metadata.go` now calls `mergeValidationPhase` for all four phase pointers in one line each.

The five `*-any.yaml` wildcard overlays (b200, gb200, h100, h200, rtx-pro-6000) had their "Per-phase replace semantics" warning comments replaced with a positive description of the new union semantics. Two `rtx-pro-6000-eks-ubuntu-inference-*` leaves had their inline comments updated similarly. Docs in `docs/contributor/data.md` and `docs/integrator/recipe-development.md` now describe both the per-field union and the nil-vs-empty clear contract.

## Testing

```bash
make qualify
```

Results:
- All Go tests pass (with `-race`).
- `golangci-lint` clean (0 issues on `./pkg/recipe/...`).
- Chainsaw e2e tests: 22 passed / 0 failed.
- Vulnerability scan: clean.

Test coverage in `pkg/recipe/metadata_test.go` (`TestMergeValidationConfig`):
- Union-merge core: `phase_checks_union_deduplicates_preserving_order`, `phase_constraints_union_with_overlay_overriding_same_name` (slice-order asserted via `reflect.DeepEqual`).
- `NodeSelection`: overlay-wins-when-set and inherited-when-overlay-omits-it.
- Scalar fields: `phase_scalar_fields_overlay_wins_when_set` and `phase_scalar_fields_inherited_when_overlay_omits_them`.
- Nil-vs-empty contract: `phase_explicit_empty_checks_clears_inherited`, `phase_explicit_empty_constraints_clears_inherited`, `phase_nil_checks_inherits_from_base`.
- Alias safety: `union_merge_does_not_mutate_source_slices` (mutates the source-derived index 1 under base-first union).

Resolution-level regression guard in `pkg/recipe/metadata_store_test.go`:
- `TestSlurmLeavesClearInheritedPerformancePhase` — loads the real metadata store and resolves `h100-eks-ubuntu-training-slurm` and `h100-gke-cos-training-slurm` through `BuildRecipeResult`, asserting `performance.checks` and `performance.constraints` resolve to empty so `FilterEntriesByValidation` skips the phase.

Coverage:
- `pkg/recipe`: 91.3% → 91.9% (+0.6%)
- `mergeValidationPhase`: 97.7%
- `Merge`: 97.4%

## Risk Assessment

- [x] **Medium** — Touches merge semantics that affect every recipe rendering a `validation.<phase>` block. Existing leaves that re-state the full inherited list still produce identical resolved output. Leaves that rely on `checks: []` to clear inherited lists (Slurm leaves) keep their previous behavior because the nil-vs-empty contract is preserved.

**Rollout notes:** No migration needed for in-repo overlays. External/tenant overlays that previously relied on the per-phase pointer-replace semantics to wholesale override should:
- Continue to work unchanged if they restated the full inherited list (union dedupes).
- Migrate from "restate everything to override one value" to declaring only the override (cleaner, less duplication).
- Continue to use `checks: []` / `constraints: []` to explicitly clear inherited lists — that contract is preserved.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)