### PR TITLE
feat(recipes): add nodewright to bcm with reapply-on-reboot

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -20,7 +20,7 @@ A machine-readable **CycloneDX 1.6 JSON** companion to this page is produced by 
 ## Summary
 
 - Components: **26**
-- Unique images: **76**
+- Unique images: **77**
 - Distinct registries: **11**
 
 Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev`, `docker.io`, `gcr.io`, `ghcr.io`, `gke.gcr.io`, `nvcr.io`, `public.ecr.aws`, `quay.io`, `registry.k8s.io`, `us-docker.pkg.dev`
@@ -46,7 +46,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | kueue | helm | kueue | 0.17.1 | 1 |
 | network-operator | helm | nvidia/network-operator | 26.1.1 | 5 |
 | nfd | helm | node-feature-discovery | 0.18.3 | 1 |
-| nodewright-customizations | manifest | — | — | 4 |
+| nodewright-customizations | manifest | — | — | 5 |
 | nodewright-operator | helm | skyhook-operator | v0.15.1 | 3 |
 | nvidia-dra-driver-gpu | helm | nvidia/nvidia-dra-driver-gpu | 25.12.0 | 1 |
 | nvsentinel | helm | nvsentinel | v1.3.0 | 6 |
@@ -167,6 +167,7 @@ _No images extracted._
 ### nodewright-customizations
 
 - `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.2.2@sha256:76913a5deff9513f348dd4b7d66cbca9ea1dd22df63baa4ac2f6b2fa7e93664e`
+- `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.3.0@sha256:f17c951d60b519d097c20a3d9f49668f043a996adb31b9bb4db24a112a8f60a2`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-tuned:0.3.0@sha256:cc99c8c0675f3752f5081f0978ae57174368952ca0bb5fcac07640fe62c156c7`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-tuning-gke:0.1.2@sha256:6671d49f006afdbeefd8858f1fa1216f7748205bc42edab3340210a2cc459a81`
 - `ghcr.io/nvidia/skyhook-packages/shellscript:1.1.1`

--- a/recipes/components/nodewright-customizations/manifests/bcm-setup.yaml
+++ b/recipes/components/nodewright-customizations/manifests/bcm-setup.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Nodewright EKS Ubuntu GPU Customization
+# Minimal templating - only tolerations/nodeSelectors are dynamic for CLI flag support
+#
+# This customization configures BCM nodes with the minimum necessary for AICR to function.
+{{- $cust := index .Values "nodewright-customizations" }}
+{{- if ne (toString (index $cust "enabled")) "false" }}
+---
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  annotations:
+    # Helm hooks ensure this CR is applied after the Skyhook CRD is installed
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: aicr
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  name: setup
+  namespace: {{ .Release.Namespace }}
+spec:
+  autoTaintNewNodes: false
+  # Dynamic: Supports --accelerated-node-toleration CLI flag
+  additionalTolerations:
+    {{- if $cust.acceleratedTolerations }}
+    {{- toYaml $cust.acceleratedTolerations | nindent 4 }}
+    {{- else }}
+    # Tolerate-all default, matching ParseTolerations()/DefaultTolerations()
+    # (operator Exists, no key). Only reached if no acceleratedTolerations are
+    # injected from scheduling defaults/flags.
+    - operator: Exists
+    {{- end }}
+  # Dynamic: Supports --accelerated-node-selector CLI flag
+  {{- if $cust.acceleratedNodeSelector }}
+  nodeSelectors:
+    matchLabels:
+      {{- toYaml $cust.acceleratedNodeSelector | nindent 6 }}
+  {{- end }}
+  # Dynamic: Supports --workload-selector CLI flag
+  {{- if $cust.workloadSelector }}
+  podNonInterruptLabels:
+    matchLabels:
+      {{- toYaml $cust.workloadSelector | nindent 6 }}
+  {{- end }}
+  # Tuning
+  packages:
+    nvidia-setup:
+      image: ghcr.io/nvidia/nodewright-packages/nvidia-setup
+      version: "0.3.0"
+      containerSHA: sha256:f17c951d60b519d097c20a3d9f49668f043a996adb31b9bb4db24a112a8f60a2
+      configMap:
+        {{- if $cust.service }}
+        service: {{ $cust.service }}
+        {{- end }}
+        accelerator: {{ $cust.accelerator }}
+{{- end }}

--- a/recipes/overlays/bcm.yaml
+++ b/recipes/overlays/bcm.yaml
@@ -93,6 +93,29 @@ spec:
               key: node-role.kubernetes.io/control-plane
               operator: Exists
 
+    - name: nodewright-operator
+      type: Helm
+      overrides:
+        controllerManager:
+          manager:
+            env:
+              # Because BCM re-writes the OS on boot, we need to reapply the nodewright customizations on reboot
+              reapplyOnReboot: "true"
+
+    - name: nodewright-customizations
+      type: Helm
+      manifestFiles:
+        - components/nodewright-customizations/manifests/bcm-setup.yaml
+      overrides:
+        service: bcm
+        # The nvidia-setup package is accelerator-agnostic today, so this value
+        # does not change what gets applied. An accelerator is hardcoded here to
+        # avoid a larger change to the setup package; BCM criteria filters on
+        # service only, so any accelerator value would behave identically.
+        accelerator: h100
+      dependencyRefs:
+        - nodewright-operator
+
   validation:
     conformance:
       checks:


### PR DESCRIPTION
## Summary

Add the `nodewright-operator` and `nodewright-customizations` components to the BCM overlay, with `reapplyOnReboot` enabled so nodewright customizations are re-applied after BCM rewrites the OS on boot.

## Motivation / Context

BCM re-writes the node OS on every reboot, which wipes any nodewright customizations applied to the host. Enabling `reapplyOnReboot: "true"` ensures the operator re-applies the BCM setup customizations after each reboot, keeping nodes in the expected state.

Fixes: N/A
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

- Adds `nodewright-operator` (Helm) to `recipes/overlays/bcm.yaml` with `controllerManager.manager.env.reapplyOnReboot: "true"`.
- Adds `nodewright-customizations` (Helm) referencing `components/nodewright-customizations/manifests/bcm-setup.yaml`, with a `dependencyRefs` edge to `nodewright-operator`.
- Node scheduling (selectors/tolerations) for the operator is intentionally left to be supplied at recipe time rather than hardcoded in the overlay.

## Testing

```bash
make qualify
```

## Risk Assessment

- [x] **Low** — Isolated overlay/data change, easy to revert

**Rollout notes:** N/A — additive recipe overlay change.

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
