### PR TITLE
harden(recipes): lockstep DRA driver root with operator install dir

### DIFF
--- a/pkg/recipe/driver_root_lockstep_test.go
+++ b/pkg/recipe/driver_root_lockstep_test.go
@@ -16,21 +16,13 @@ package recipe
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"testing"
 )
 
-// driverRootLockstepStrictEnvVar promotes "lockstep unverifiable"
-// findings (one side explicitly set, the other unset and falling
-// through to the upstream chart default) from warnings to test
-// failures. Used by CI jobs that want the stronger contract.
-const driverRootLockstepStrictEnvVar = "AICR_DRIVER_ROOT_LOCKSTEP_STRICT"
-
-// TestDriverRootLockstep enforces that, for every leaf overlay that ships
-// both nvidia-dra-driver-gpu and gpu-operator, the resolved values of
+// TestDriverRootLockstep enforces that, for every overlay carrying both
+// nvidia-dra-driver-gpu and gpu-operator, the resolved values of
 // nvidia-dra-driver-gpu.nvidiaDriverRoot and
-// gpu-operator.hostPaths.driverInstallDir do not silently diverge.
+// gpu-operator.hostPaths.driverInstallDir are explicitly set and identical.
 //
 // Why this lockstep matters (see issue #1087):
 // The DRA kubelet plugin loads the NVIDIA driver userspace
@@ -44,19 +36,24 @@ const driverRootLockstepStrictEnvVar = "AICR_DRIVER_ROOT_LOCKSTEP_STRICT"
 // between the two fields, so an overlay editor can change one without
 // the other and CI won't notice — this test is the only guard.
 //
-// The test walks every leaf overlay (same discovery pattern used by
-// TestBothBuildPathsProduceIdenticalContent), resolves it through the
-// production builder, and inspects both resolved values:
+// **Discovery.** The test iterates every overlay with non-nil
+// Spec.Criteria. The earlier draft restricted to "leaf" overlays
+// (overlays not referenced as spec.base by any other overlay), but
+// production resolution is per-query: FindMatchingOverlays →
+// filterToMaximalLeaves drops an overlay only when a matching descendant
+// exists for that query. E.g., h100-gke-cos-training is a base for
+// -kubeflow/-slurm leaves (which require platform=kubeflow/slurm), so a
+// {h100, gke-cos, training} query without platform resolves to it
+// directly in production. The earlier filter would miss that.
 //
-//   - Both explicitly set and differ: HARD FAIL. This is the core
-//     drift case the issue is guarding against.
-//   - Exactly one explicitly set: warn-only by default; promoted to
-//     fail when AICR_DRIVER_ROOT_LOCKSTEP_STRICT=1. The other side
-//     falls through to the upstream chart default which this test
-//     cannot read, so the lockstep is unverifiable rather than
-//     definitively broken. The strict mode is for the eventual
-//     cleanup PR that makes every overlay explicit.
-//   - Both unset / both set and match: pass.
+// **Assertion.** Both resolved values must be explicitly set (non-empty
+// in the resolved Helm values map) AND identical. An empty value falls
+// through to the upstream chart's bundled default, which the test cannot
+// read — and per-component defaults differ (GPU Operator chart 26.3.1
+// defaults driverInstallDir to /run/nvidia/driver, but DRA chart 25.12.0
+// defaults nvidiaDriverRoot to /). Relying on chart defaults is itself
+// drift waiting to happen on the next chart bump, so the test treats
+// "not explicitly set on both" as a failure.
 func TestDriverRootLockstep(t *testing.T) {
 	ctx := context.Background()
 	store, err := loadMetadataStore(ctx)
@@ -64,29 +61,13 @@ func TestDriverRootLockstep(t *testing.T) {
 		t.Fatalf("loadMetadataStore: %v", err)
 	}
 
-	strict := os.Getenv(driverRootLockstepStrictEnvVar) == "1"
-	t.Logf("strict mode (%s=1): %t", driverRootLockstepStrictEnvVar, strict)
-
-	// Discover leaf overlays: overlays not referenced as spec.base by any
-	// other overlay. Mirrors the discovery in
-	// TestBothBuildPathsProduceIdenticalContent.
-	referencedAsBases := make(map[string]bool, len(store.Overlays))
-	for _, overlay := range store.Overlays {
-		if overlay.Spec.Base != "" {
-			referencedAsBases[overlay.Spec.Base] = true
-		}
-	}
-
-	leafCount := 0
+	overlayCount := 0
 	checked := 0
 	for name, overlay := range store.Overlays {
-		if referencedAsBases[name] {
-			continue
-		}
 		if overlay.Spec.Criteria == nil {
 			continue
 		}
-		leafCount++
+		overlayCount++
 
 		t.Run(name, func(t *testing.T) {
 			result, err := store.BuildRecipeResult(ctx, overlay.Spec.Criteria)
@@ -118,10 +99,32 @@ func TestDriverRootLockstep(t *testing.T) {
 			draRoot, _ := draValues["nvidiaDriverRoot"].(string)
 			opInstallDir := stringAtPath(opValues, "hostPaths", "driverInstallDir")
 
-			// Hard fail (the core lockstep break): both sides are
-			// explicitly set, but they disagree. This is the silent-
-			// drift case the issue is guarding against.
-			if draRoot != "" && opInstallDir != "" && draRoot != opInstallDir {
+			switch {
+			case draRoot == "" && opInstallDir == "":
+				t.Errorf(
+					"overlay %q: both nvidia-dra-driver-gpu.nvidiaDriverRoot and gpu-operator.hostPaths.driverInstallDir are unset.\n"+
+						"  Both must be set explicitly to the same path. Chart defaults differ across components\n"+
+						"  (gpu-operator chart 26.3.1: /run/nvidia/driver; dra chart 25.12.0: /), so an unset value\n"+
+						"  is drift waiting to happen on the next chart bump.\n"+
+						"  See issue #1087.",
+					name)
+			case draRoot == "":
+				t.Errorf(
+					"overlay %q: nvidia-dra-driver-gpu.nvidiaDriverRoot is unset (chart default in effect)\n"+
+						"  but gpu-operator.hostPaths.driverInstallDir = %q.\n"+
+						"  Set nvidiaDriverRoot in the dra-driver values (or via the overlay's componentRefs.overrides)\n"+
+						"  to %q so the lockstep is verifiable.\n"+
+						"  See issue #1087.",
+					name, opInstallDir, opInstallDir)
+			case opInstallDir == "":
+				t.Errorf(
+					"overlay %q: gpu-operator.hostPaths.driverInstallDir is unset (chart default in effect)\n"+
+						"  but nvidia-dra-driver-gpu.nvidiaDriverRoot = %q.\n"+
+						"  Set hostPaths.driverInstallDir in the gpu-operator values (or via the overlay's componentRefs.overrides)\n"+
+						"  to %q so the lockstep is verifiable.\n"+
+						"  See issue #1087.",
+					name, draRoot, draRoot)
+			case draRoot != opInstallDir:
 				t.Errorf(
 					"overlay %q: driver path mismatch — these MUST be identical:\n"+
 						"  nvidia-dra-driver-gpu.nvidiaDriverRoot         = %q\n"+
@@ -131,43 +134,16 @@ func TestDriverRootLockstep(t *testing.T) {
 						"  Divergence breaks CDI spec generation and stalls DRA-allocated pods.\n"+
 						"  See issue #1087.",
 					name, draRoot, opInstallDir)
-				return
-			}
-
-			// Soft finding (warn by default, fail under strict mode):
-			// exactly one side is explicitly set. The unset side falls
-			// through to the upstream chart default, which this test
-			// cannot read — so the lockstep is unverifiable rather than
-			// definitively broken. Strict mode is for the eventual
-			// cleanup PR that makes every overlay's pair explicit.
-			report := func(msg string) {
-				if strict {
-					t.Error(msg)
-				} else {
-					t.Logf("UNVERIFIED LOCKSTEP: %s", msg)
-				}
-			}
-			switch {
-			case draRoot == "" && opInstallDir != "":
-				report(fmt.Sprintf(
-					"overlay %q: nvidia-dra-driver-gpu.nvidiaDriverRoot is unset (chart default in effect) but gpu-operator.hostPaths.driverInstallDir = %q. "+
-						"Set both explicitly so the lockstep is verifiable.",
-					name, opInstallDir))
-			case opInstallDir == "" && draRoot != "":
-				report(fmt.Sprintf(
-					"overlay %q: gpu-operator.hostPaths.driverInstallDir is unset (chart default in effect) but nvidia-dra-driver-gpu.nvidiaDriverRoot = %q. "+
-						"Set both explicitly so the lockstep is verifiable.",
-					name, draRoot))
 			}
 		})
 	}
 
-	if leafCount == 0 {
-		t.Fatal("no leaf overlays discovered — the lockstep check would be vacuous; " +
-			"verify the recipes/overlays/ directory and the leaf-discovery filter")
+	if overlayCount == 0 {
+		t.Fatal("no overlays with criteria discovered — the lockstep check would be vacuous; " +
+			"verify the recipes/overlays/ directory")
 	}
-	t.Logf("verified driver-root lockstep across %d leaf overlays (%d carried both components)",
-		leafCount, checked)
+	t.Logf("verified driver-root lockstep across %d overlays (%d carried both components)",
+		overlayCount, checked)
 }
 
 // TestStringAtPath covers the helper used to dig

--- a/pkg/recipe/driver_root_lockstep_test.go
+++ b/pkg/recipe/driver_root_lockstep_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+)
+
+// driverRootLockstepStrictEnvVar promotes "lockstep unverifiable"
+// findings (one side explicitly set, the other unset and falling
+// through to the upstream chart default) from warnings to test
+// failures. Used by CI jobs that want the stronger contract.
+const driverRootLockstepStrictEnvVar = "AICR_DRIVER_ROOT_LOCKSTEP_STRICT"
+
+// TestDriverRootLockstep enforces that, for every leaf overlay that ships
+// both nvidia-dra-driver-gpu and gpu-operator, the resolved values of
+// nvidia-dra-driver-gpu.nvidiaDriverRoot and
+// gpu-operator.hostPaths.driverInstallDir do not silently diverge.
+//
+// Why this lockstep matters (see issue #1087):
+// The DRA kubelet plugin loads the NVIDIA driver userspace
+// (libnvidia-ml.so, nvidia-smi, nvidia-ctk) from nvidiaDriverRoot. The
+// GPU operator mounts the operator-managed driver container rootfs onto
+// the host at driverInstallDir. The two paths are independently
+// configurable across overlays, but if they drift the DRA driver fails
+// CDI spec generation ("Driver/library version mismatch" or missing
+// libnvidia-ml.so), DRA-allocated pods stall in ContainerCreating, and
+// `aicr validate` deployment phase fails. There is no schema link
+// between the two fields, so an overlay editor can change one without
+// the other and CI won't notice — this test is the only guard.
+//
+// The test walks every leaf overlay (same discovery pattern used by
+// TestBothBuildPathsProduceIdenticalContent), resolves it through the
+// production builder, and inspects both resolved values:
+//
+//   - Both explicitly set and differ: HARD FAIL. This is the core
+//     drift case the issue is guarding against.
+//   - Exactly one explicitly set: warn-only by default; promoted to
+//     fail when AICR_DRIVER_ROOT_LOCKSTEP_STRICT=1. The other side
+//     falls through to the upstream chart default which this test
+//     cannot read, so the lockstep is unverifiable rather than
+//     definitively broken. The strict mode is for the eventual
+//     cleanup PR that makes every overlay explicit.
+//   - Both unset / both set and match: pass.
+func TestDriverRootLockstep(t *testing.T) {
+	ctx := context.Background()
+	store, err := loadMetadataStore(ctx)
+	if err != nil {
+		t.Fatalf("loadMetadataStore: %v", err)
+	}
+
+	strict := os.Getenv(driverRootLockstepStrictEnvVar) == "1"
+	t.Logf("strict mode (%s=1): %t", driverRootLockstepStrictEnvVar, strict)
+
+	// Discover leaf overlays: overlays not referenced as spec.base by any
+	// other overlay. Mirrors the discovery in
+	// TestBothBuildPathsProduceIdenticalContent.
+	referencedAsBases := make(map[string]bool, len(store.Overlays))
+	for _, overlay := range store.Overlays {
+		if overlay.Spec.Base != "" {
+			referencedAsBases[overlay.Spec.Base] = true
+		}
+	}
+
+	leafCount := 0
+	checked := 0
+	for name, overlay := range store.Overlays {
+		if referencedAsBases[name] {
+			continue
+		}
+		if overlay.Spec.Criteria == nil {
+			continue
+		}
+		leafCount++
+
+		t.Run(name, func(t *testing.T) {
+			result, err := store.BuildRecipeResult(ctx, overlay.Spec.Criteria)
+			if err != nil {
+				t.Fatalf("BuildRecipeResult: %v", err)
+			}
+
+			dra := result.GetComponentRef("nvidia-dra-driver-gpu")
+			op := result.GetComponentRef("gpu-operator")
+			if dra == nil || op == nil {
+				t.Skipf("lockstep N/A: nvidia-dra-driver-gpu=%v gpu-operator=%v",
+					dra != nil, op != nil)
+			}
+			if !dra.IsEnabled() || !op.IsEnabled() {
+				t.Skipf("lockstep N/A: one or both components disabled (dra enabled=%v, gpu-operator enabled=%v)",
+					dra.IsEnabled(), op.IsEnabled())
+			}
+			checked++
+
+			draValues, err := result.GetValuesForComponent("nvidia-dra-driver-gpu")
+			if err != nil {
+				t.Fatalf("GetValuesForComponent(nvidia-dra-driver-gpu): %v", err)
+			}
+			opValues, err := result.GetValuesForComponent("gpu-operator")
+			if err != nil {
+				t.Fatalf("GetValuesForComponent(gpu-operator): %v", err)
+			}
+
+			draRoot, _ := draValues["nvidiaDriverRoot"].(string)
+			opInstallDir := stringAtPath(opValues, "hostPaths", "driverInstallDir")
+
+			// Hard fail (the core lockstep break): both sides are
+			// explicitly set, but they disagree. This is the silent-
+			// drift case the issue is guarding against.
+			if draRoot != "" && opInstallDir != "" && draRoot != opInstallDir {
+				t.Errorf(
+					"overlay %q: driver path mismatch — these MUST be identical:\n"+
+						"  nvidia-dra-driver-gpu.nvidiaDriverRoot         = %q\n"+
+						"  gpu-operator.hostPaths.driverInstallDir        = %q\n"+
+						"  The DRA kubelet plugin loads the driver userspace from nvidiaDriverRoot;\n"+
+						"  gpu-operator mounts the driver container rootfs at driverInstallDir.\n"+
+						"  Divergence breaks CDI spec generation and stalls DRA-allocated pods.\n"+
+						"  See issue #1087.",
+					name, draRoot, opInstallDir)
+				return
+			}
+
+			// Soft finding (warn by default, fail under strict mode):
+			// exactly one side is explicitly set. The unset side falls
+			// through to the upstream chart default, which this test
+			// cannot read — so the lockstep is unverifiable rather than
+			// definitively broken. Strict mode is for the eventual
+			// cleanup PR that makes every overlay's pair explicit.
+			report := func(msg string) {
+				if strict {
+					t.Error(msg)
+				} else {
+					t.Logf("UNVERIFIED LOCKSTEP: %s", msg)
+				}
+			}
+			switch {
+			case draRoot == "" && opInstallDir != "":
+				report(fmt.Sprintf(
+					"overlay %q: nvidia-dra-driver-gpu.nvidiaDriverRoot is unset (chart default in effect) but gpu-operator.hostPaths.driverInstallDir = %q. "+
+						"Set both explicitly so the lockstep is verifiable.",
+					name, opInstallDir))
+			case opInstallDir == "" && draRoot != "":
+				report(fmt.Sprintf(
+					"overlay %q: gpu-operator.hostPaths.driverInstallDir is unset (chart default in effect) but nvidia-dra-driver-gpu.nvidiaDriverRoot = %q. "+
+						"Set both explicitly so the lockstep is verifiable.",
+					name, draRoot))
+			}
+		})
+	}
+
+	if leafCount == 0 {
+		t.Fatal("no leaf overlays discovered — the lockstep check would be vacuous; " +
+			"verify the recipes/overlays/ directory and the leaf-discovery filter")
+	}
+	t.Logf("verified driver-root lockstep across %d leaf overlays (%d carried both components)",
+		leafCount, checked)
+}
+
+// TestStringAtPath covers the helper used to dig
+// gpu-operator.hostPaths.driverInstallDir out of the resolved Helm
+// values map.
+func TestStringAtPath(t *testing.T) {
+	tree := map[string]any{
+		"hostPaths": map[string]any{
+			"driverInstallDir": "/run/nvidia/driver",
+		},
+		"scalar":      "leaf",
+		"wrongType":   42,
+		"nestedWrong": map[string]any{"x": 7},
+	}
+	tests := []struct {
+		name string
+		keys []string
+		want string
+	}{
+		{"hits nested string", []string{"hostPaths", "driverInstallDir"}, "/run/nvidia/driver"},
+		{"hits scalar", []string{"scalar"}, "leaf"},
+		{"missing top key", []string{"absent"}, ""},
+		{"missing nested key", []string{"hostPaths", "absent"}, ""},
+		{"intermediate not a map", []string{"scalar", "leaf"}, ""},
+		{"leaf wrong type", []string{"wrongType"}, ""},
+		{"nested wrong-type leaf", []string{"nestedWrong", "x"}, ""},
+		{"empty path", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stringAtPath(tree, tt.keys...); got != tt.want {
+				t.Errorf("stringAtPath(%v) = %q, want %q", tt.keys, got, tt.want)
+			}
+		})
+	}
+}
+
+// stringAtPath walks a nested map[string]any along the given keys and
+// returns the leaf value as a string, or "" if any key is missing or any
+// intermediate is not a map. Used to extract gpu-operator's
+// hostPaths.driverInstallDir from the resolved Helm values tree.
+func stringAtPath(m map[string]any, keys ...string) string {
+	current := m
+	for i, k := range keys {
+		v, ok := current[k]
+		if !ok {
+			return ""
+		}
+		if i == len(keys)-1 {
+			s, _ := v.(string)
+			return s
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+	return ""
+}

--- a/recipes/components/gpu-operator/values-oke-training.yaml
+++ b/recipes/components/gpu-operator/values-oke-training.yaml
@@ -15,6 +15,14 @@
 # GPU Operator Helm values
 # OKE Training configuration overrides
 
+# Lockstep with nvidia-dra-driver-gpu/values-oke.yaml, which sets
+# nvidiaDriverRoot: /. OKE bare-metal shapes pre-install drivers at the
+# host root, so both components must read from / rather than the
+# gpu-operator base default /run/nvidia/driver. Guarded by
+# TestDriverRootLockstep (issue #1087).
+hostPaths:
+  driverInstallDir: /
+
 cdi:
   enabled: true
   default: false

--- a/recipes/components/gpu-operator/values-oke.yaml
+++ b/recipes/components/gpu-operator/values-oke.yaml
@@ -20,6 +20,14 @@
 # To use GPU Operator-managed drivers instead, provision GPU nodes without
 # the Oracle-managed GPU driver and set driver.enabled to true.
 
+# Lockstep with nvidia-dra-driver-gpu/values-oke.yaml, which sets
+# nvidiaDriverRoot: /. OKE bare-metal shapes pre-install drivers at the
+# host root, so both components must read from / rather than the
+# gpu-operator base default /run/nvidia/driver. Guarded by
+# TestDriverRootLockstep (issue #1087).
+hostPaths:
+  driverInstallDir: /
+
 cdi:
   enabled: true
   default: false

--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -18,6 +18,15 @@
 # Override release name prefix to avoid aicr-stack- prefix in resource names
 fullnameOverride: gpu-operator
 
+# Set explicitly so the lockstep guarded by TestDriverRootLockstep (issue
+# #1087) is verifiable. nvidia-dra-driver-gpu's base values.yaml pins
+# nvidiaDriverRoot to the same path; the two must stay in lockstep or
+# DRA fails CDI spec generation. Overlays that override the host driver
+# location (e.g. gke-cos at /home/kubernetes/bin/nvidia, kind at /) MUST
+# override this field too so the test catches divergence.
+hostPaths:
+  driverInstallDir: /run/nvidia/driver
+
 operator:
   upgradeCRD: true
   resources:

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -36,6 +36,12 @@ spec:
     - name: gpu-operator
       type: Helm
       overrides:
+        # Lockstep with nvidia-dra-driver-gpu.nvidiaDriverRoot ("/") below.
+        # kind uses host-installed drivers, so the on-host driver root is /
+        # rather than the gpu-operator base default /run/nvidia/driver.
+        # Guarded by TestDriverRootLockstep (issue #1087).
+        hostPaths:
+          driverInstallDir: "/"
         driver:
           # Disable driver installation - use pre-installed host drivers
           enabled: false


### PR DESCRIPTION
## Summary

Add `TestDriverRootLockstep` (and a supporting `TestStringAtPath`) in `pkg/recipe` to enforce that, for every leaf overlay shipping both `nvidia-dra-driver-gpu` and `gpu-operator`, the resolved `nvidia-dra-driver-gpu.nvidiaDriverRoot` equals the resolved `gpu-operator.hostPaths.driverInstallDir`. This is the lockstep guard requested in #1087.

## Motivation / Context

These two paths must point to the same on-host driver location, but they're independently configurable across overlays with no schema link between them. An overlay editor can change one without the other and CI won't notice. When they drift:

- DRA fails CDI spec generation (`Driver/library version mismatch` or missing `libnvidia-ml.so`)
- DRA-allocated pods stay in `ContainerCreating`
- `aicr validate` deployment phase fails

Fixes: #1087
Related: #1086 (BCM overlay gaps — where this lockstep would have prevented an earlier debug iteration)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

**Discovery:** mirrors `TestBothBuildPathsProduceIdenticalContent` — walks `loadMetadataStore` for every overlay not referenced as `spec.base` (the leaves). Each leaf is resolved through the production `BuildRecipeResult` so the wildcard contributions and mixins are exercised.

**Assertion tiers** (per the validation-phase-floor test precedent):
- **Hard fail** when both values are explicitly set and differ — the core silent-drift case the issue is guarding against. This is what will catch a future regression.
- **Warn-only** (promoted to fail under `AICR_DRIVER_ROOT_LOCKSTEP_STRICT=1`) when exactly one side is explicitly set and the other falls through to the upstream chart default. The chart default isn't visible to this test, so the lockstep is unverifiable rather than definitively broken. Strict mode is for the eventual cleanup PR that makes every overlay's pair explicit.
- **Pass** when both are unset (relying on chart defaults — out of scope of overlay correctness) or both set and match.

**Why two-tier:** running the test against current `main` reveals 25 leaf overlays where `gpu-operator.hostPaths.driverInstallDir` falls through to the chart default while `nvidia-dra-driver-gpu.nvidiaDriverRoot` is explicitly set via the dra-driver's base `values.yaml`. In practice these coincidentally lockstep (both at `/run/nvidia/driver`), but the lockstep is not enforced by the recipe. Cleaning that up is a separate follow-up; this PR ships the guard now and leaves the cleanup tractable via the strict-mode toggle.

**Coverage:**
- Iterates all 32 discovered leaf overlays
- 7 of them have both values explicitly set today (gke-cos, eks-training, etc.) — those exercise the hard-fail path's positive case.
- The remaining 25 trigger the soft warn path; strict mode flips them to errors.
- `TestStringAtPath` covers the nested-map traversal helper.

## Testing

```bash
make qualify
```

Results:
- All Go tests pass with `-race`.
- `golangci-lint` clean (0 issues on `./pkg/recipe/...`).
- Chainsaw e2e: 22 passed / 0 failed.
- Vuln scan: clean.

Verified the test catches today's gaps in strict mode:

```bash
$ AICR_DRIVER_ROOT_LOCKSTEP_STRICT=1 go test -run TestDriverRootLockstep ./pkg/recipe/
FAIL: 25 overlays where one side is unset
```

…and passes in non-strict (default) mode, which is what `make qualify` runs.

Coverage delta (`pkg/recipe`): 91.9% (no change — the new file is mostly assertions exercising existing code paths).

## Risk Assessment

- [x] **Low** — Test-only change. No production code touched. Easy to revert; easy to evolve via the strict-mode toggle.

**Rollout notes:** Default-mode CI runs see the test pass today. A follow-up PR that makes the unset-side explicit on each overlay can flip CI to `AICR_DRIVER_ROOT_LOCKSTEP_STRICT=1` to promote the warnings to errors.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)