### PR TITLE
refactor(recipe,validator): per-DataProvider sources + criteria-registry de-globalization

### DIFF
--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -600,21 +600,45 @@ func (s *SnapshotSpec) Resolve() (*SnapshotResolved, error) {
 }
 
 // ResolveCriteria converts the recipe criteria spec from wire-string form
-// to a typed *recipe.Criteria. Nil-receiver tolerant; never returns a nil
-// pointer.
+// to a typed *recipe.Criteria, validating each enum value against the
+// package-global criteria registry. Nil-receiver tolerant; never returns a
+// nil pointer.
+//
+// This is a shim over ResolveCriteriaWithRegistry(recipe.DefaultRegistry()).
+// Callers holding a per-provider registry (e.g., the CLI building criteria
+// against an aicr.Client's own DataProvider) should call
+// ResolveCriteriaWithRegistry directly so config-sourced criteria validate
+// against THAT provider's registered values rather than the package global.
 //
 // Unlike recipe.NewCriteria, the returned Criteria does NOT default
 // unset fields to "any": empty enum fields signal "config did not set
 // this slot" so callers can detect what to copy onto a target Criteria.
 // Nodes < 0 is rejected; Nodes == 0 means unset.
 func (r *RecipeSpec) ResolveCriteria() (*recipe.Criteria, error) {
+	return r.ResolveCriteriaWithRegistry(recipe.DefaultRegistry())
+}
+
+// ResolveCriteriaWithRegistry converts the recipe criteria spec from
+// wire-string form to a typed *recipe.Criteria, validating each enum value
+// against the supplied per-provider registry. A nil reg falls back to the
+// package-global registry via recipe.DefaultRegistry(), so the call is
+// well-defined for callers that have not bound a provider.
+//
+// Routing config-sourced criteria through the per-provider registry is what
+// lets a `--data` overlay's non-OSS criteria value (e.g. service=ncp-internal)
+// supplied via spec.recipe.criteria validate the same way it does on the CLI
+// flag path. See ResolveCriteria for the unset-field semantics.
+func (r *RecipeSpec) ResolveCriteriaWithRegistry(reg *recipe.CriteriaRegistry) (*recipe.Criteria, error) {
+	if reg == nil {
+		reg = recipe.DefaultRegistry()
+	}
 	out := &recipe.Criteria{}
 	if r == nil || r.Criteria == nil {
 		return out, nil
 	}
 	c := r.Criteria
 	if c.Service != "" {
-		v, err := recipe.ParseCriteriaServiceType(c.Service)
+		v, err := reg.ParseService(c.Service)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
 				"invalid spec.recipe.criteria.service", err)
@@ -622,7 +646,7 @@ func (r *RecipeSpec) ResolveCriteria() (*recipe.Criteria, error) {
 		out.Service = v
 	}
 	if c.Accelerator != "" {
-		v, err := recipe.ParseCriteriaAcceleratorType(c.Accelerator)
+		v, err := reg.ParseAccelerator(c.Accelerator)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
 				"invalid spec.recipe.criteria.accelerator", err)
@@ -630,7 +654,7 @@ func (r *RecipeSpec) ResolveCriteria() (*recipe.Criteria, error) {
 		out.Accelerator = v
 	}
 	if c.Intent != "" {
-		v, err := recipe.ParseCriteriaIntentType(c.Intent)
+		v, err := reg.ParseIntent(c.Intent)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
 				"invalid spec.recipe.criteria.intent", err)
@@ -638,7 +662,7 @@ func (r *RecipeSpec) ResolveCriteria() (*recipe.Criteria, error) {
 		out.Intent = v
 	}
 	if c.OS != "" {
-		v, err := recipe.ParseCriteriaOSType(c.OS)
+		v, err := reg.ParseOS(c.OS)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
 				"invalid spec.recipe.criteria.os", err)
@@ -646,7 +670,7 @@ func (r *RecipeSpec) ResolveCriteria() (*recipe.Criteria, error) {
 		out.OS = v
 	}
 	if c.Platform != "" {
-		v, err := recipe.ParseCriteriaPlatformType(c.Platform)
+		v, err := reg.ParsePlatform(c.Platform)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
 				"invalid spec.recipe.criteria.platform", err)

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -258,6 +258,28 @@ func EvictCachedRegistry(dp DataProvider) {
 	registryCache.Delete(dp)
 }
 
+// CachedRegistryCountForTesting returns the number of distinct
+// DataProvider entries currently held in the registry cache. Exposed
+// for tests in the aicr facade that assert Client.Close evicts the
+// cached registry — without this, the only way to observe eviction
+// from outside the recipe package would be to reach into unexported
+// state via reflection.
+//
+// Test-only by convention (the _ForTesting suffix); never call from
+// production code.
+//
+// NOTE: global count across every DataProvider. Tests that need a
+// stable signal scoped to a specific DataProvider should prefer
+// CachedRegistryContainsForTesting.
+func CachedRegistryCountForTesting() int {
+	n := 0
+	registryCache.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 // CachedRegistryContainsForTesting reports whether the registry cache
 // has an entry for the supplied DataProvider. Pair with
 // CachedStoreContainsForTesting in pkg/recipe/metadata_store.go to

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -639,7 +639,17 @@ func (c *Criteria) String() string {
 	return fmt.Sprintf("criteria(%s)", strings.Join(parts, ", "))
 }
 
-// CriteriaOption is a functional option for building Criteria.
+// CriteriaOption is a functional option for building Criteria. Each option
+// resolves its enum value via the package-level ParseCriteria*Type shims,
+// which consult DefaultRegistry() — the registry bound to the package-global
+// DataProvider.
+//
+// For per-provider isolation (e.g., when building Criteria against an
+// aicr.Client's own DataProvider so non-OSS values declared in a `--data`
+// overlay validate against THAT provider's registered values), use
+// RegistryCriteriaOption + BuildCriteriaWithRegistry instead. The two option
+// types deliberately have distinct signatures because RegistryCriteriaOption
+// takes the registry as an explicit parameter; they are not interchangeable.
 type CriteriaOption func(*Criteria) error
 
 // WithCriteriaService sets the service type.
@@ -713,10 +723,16 @@ func WithCriteriaNodes(n int) CriteriaOption {
 	}
 }
 
-// BuildCriteria creates a Criteria from functional options, resolving each
-// field against the package-global criteria registry. It is a shim over
-// BuildCriteriaWithRegistry(DefaultRegistry(), ...); callers holding an
-// explicit per-provider registry should call that directly.
+// BuildCriteria creates a Criteria from functional options. Each option
+// resolves its enum value through the package-level ParseCriteria*Type shims
+// against DefaultRegistry() (the registry bound to the package-global
+// DataProvider).
+//
+// For per-provider isolation, use BuildCriteriaWithRegistry with
+// RegistryCriteriaOption — that path threads an explicit *CriteriaRegistry
+// (typically from GetCriteriaRegistryFor) so registered values from a
+// caller-owned DataProvider's overlays are honored instead of (or in
+// addition to) the package-global registry.
 func BuildCriteria(opts ...CriteriaOption) (*Criteria, error) {
 	c := NewCriteria()
 	for _, opt := range opts {

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -56,15 +56,25 @@ const (
 	CriteriaServiceBCM  CriteriaServiceType = "bcm"
 )
 
-// ParseCriteriaServiceType parses a string into a CriteriaServiceType.
+// ParseCriteriaServiceType parses a string into a CriteriaServiceType using
+// the package-global criteria registry. It is a shim over
+// (*CriteriaRegistry).ParseService bound to DefaultRegistry(); callers
+// holding an explicit registry (e.g., from GetCriteriaRegistryFor) should
+// call the method directly for per-provider isolation.
+func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
+	return DefaultRegistry().ParseService(s)
+}
+
+// ParseService parses a string into a CriteriaServiceType against this
+// registry.
 //
 // The switch arms below are the canonical/aliased fast path for the
 // embedded OSS catalog. Any value not recognized here falls through to
-// the package criteria registry, which the data provider seeds from
-// loaded overlays (embedded + `--data`). This lets internal/proprietary
-// service values (e.g., undisclosed NCPs) be admitted at runtime via
-// `--data` without a binary rebuild.
-func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
+// the registry, which the data provider seeds from loaded overlays
+// (embedded + `--data`). This lets internal/proprietary service values
+// (e.g., undisclosed NCPs) be admitted at runtime via `--data` without a
+// binary rebuild.
+func (reg *CriteriaRegistry) ParseService(s string) (CriteriaServiceType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue, "self-managed", "self", "vanilla":
 		return CriteriaServiceAny, nil
@@ -83,7 +93,7 @@ func ParseCriteriaServiceType(s string) (CriteriaServiceType, error) {
 	case "bcm":
 		return CriteriaServiceBCM, nil
 	default:
-		if DefaultRegistry().Has(FieldService, s) {
+		if reg.Has(FieldService, s) {
 			return CriteriaServiceType(normalizeCriteriaValue(s)), nil
 		}
 		return CriteriaServiceAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid service type: %s", s))
@@ -99,12 +109,19 @@ func GetCriteriaServiceTypes() []string {
 }
 
 // AllCriteriaServiceTypes returns the union of the static OSS list and
-// values currently registered in the package criteria registry, sorted
-// alphabetically. In strict mode the registry contributes only its
+// values currently registered in the package-global criteria registry,
+// sorted alphabetically. In strict mode the registry contributes only its
 // embedded-origin values, so the result matches GetCriteriaServiceTypes
-// (plus any aliases the catalog has explicitly registered).
+// (plus any aliases the catalog has explicitly registered). It is a shim
+// over (*CriteriaRegistry).AllServiceTypes bound to DefaultRegistry().
 func AllCriteriaServiceTypes() []string {
-	return mergeCriteriaTypes(GetCriteriaServiceTypes(), DefaultRegistry().Values(FieldService))
+	return DefaultRegistry().AllServiceTypes()
+}
+
+// AllServiceTypes returns the union of the static OSS list and values
+// registered in this registry, sorted alphabetically.
+func (reg *CriteriaRegistry) AllServiceTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaServiceTypes(), reg.Values(FieldService))
 }
 
 // CriteriaAcceleratorType represents the GPU/accelerator type.
@@ -122,10 +139,17 @@ const (
 	CriteriaAcceleratorRTXPro6000 CriteriaAcceleratorType = "rtx-pro-6000"
 )
 
-// ParseCriteriaAcceleratorType parses a string into a CriteriaAcceleratorType.
-// See ParseCriteriaServiceType for the registry-fallback contract that
-// also applies here.
+// ParseCriteriaAcceleratorType parses a string into a CriteriaAcceleratorType
+// using the package-global criteria registry. Shim over
+// (*CriteriaRegistry).ParseAccelerator bound to DefaultRegistry().
 func ParseCriteriaAcceleratorType(s string) (CriteriaAcceleratorType, error) {
+	return DefaultRegistry().ParseAccelerator(s)
+}
+
+// ParseAccelerator parses a string into a CriteriaAcceleratorType against
+// this registry. See (*CriteriaRegistry).ParseService for the
+// registry-fallback contract that also applies here.
+func (reg *CriteriaRegistry) ParseAccelerator(s string) (CriteriaAcceleratorType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
 		return CriteriaAcceleratorAny, nil
@@ -144,7 +168,7 @@ func ParseCriteriaAcceleratorType(s string) (CriteriaAcceleratorType, error) {
 	case "rtx-pro-6000":
 		return CriteriaAcceleratorRTXPro6000, nil
 	default:
-		if DefaultRegistry().Has(FieldAccelerator, s) {
+		if reg.Has(FieldAccelerator, s) {
 			return CriteriaAcceleratorType(normalizeCriteriaValue(s)), nil
 		}
 		return CriteriaAcceleratorAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid accelerator type: %s", s))
@@ -158,11 +182,17 @@ func GetCriteriaAcceleratorTypes() []string {
 	return []string{"a100", "b200", "gb200", "h100", "h200", "l40", "rtx-pro-6000"}
 }
 
-// AllCriteriaAcceleratorTypes returns the union of the static OSS list
-// and values currently registered in the package criteria registry,
-// sorted alphabetically.
+// AllCriteriaAcceleratorTypes returns the union of the static OSS list and
+// values registered in the package-global criteria registry, sorted
+// alphabetically. Shim over (*CriteriaRegistry).AllAcceleratorTypes.
 func AllCriteriaAcceleratorTypes() []string {
-	return mergeCriteriaTypes(GetCriteriaAcceleratorTypes(), DefaultRegistry().Values(FieldAccelerator))
+	return DefaultRegistry().AllAcceleratorTypes()
+}
+
+// AllAcceleratorTypes returns the union of the static OSS list and values
+// registered in this registry, sorted alphabetically.
+func (reg *CriteriaRegistry) AllAcceleratorTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaAcceleratorTypes(), reg.Values(FieldAccelerator))
 }
 
 // CriteriaIntentType represents the workload intent.
@@ -175,9 +205,17 @@ const (
 	CriteriaIntentInference CriteriaIntentType = "inference"
 )
 
-// ParseCriteriaIntentType parses a string into a CriteriaIntentType.
-// See ParseCriteriaServiceType for the registry-fallback contract.
+// ParseCriteriaIntentType parses a string into a CriteriaIntentType using
+// the package-global criteria registry. Shim over
+// (*CriteriaRegistry).ParseIntent bound to DefaultRegistry().
 func ParseCriteriaIntentType(s string) (CriteriaIntentType, error) {
+	return DefaultRegistry().ParseIntent(s)
+}
+
+// ParseIntent parses a string into a CriteriaIntentType against this
+// registry. See (*CriteriaRegistry).ParseService for the registry-fallback
+// contract.
+func (reg *CriteriaRegistry) ParseIntent(s string) (CriteriaIntentType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
 		return CriteriaIntentAny, nil
@@ -186,7 +224,7 @@ func ParseCriteriaIntentType(s string) (CriteriaIntentType, error) {
 	case "inference":
 		return CriteriaIntentInference, nil
 	default:
-		if DefaultRegistry().Has(FieldIntent, s) {
+		if reg.Has(FieldIntent, s) {
 			return CriteriaIntentType(normalizeCriteriaValue(s)), nil
 		}
 		return CriteriaIntentAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid intent type: %s", s))
@@ -200,11 +238,17 @@ func GetCriteriaIntentTypes() []string {
 	return []string{"inference", "training"}
 }
 
-// AllCriteriaIntentTypes returns the union of the static OSS list and
-// values currently registered in the package criteria registry, sorted
-// alphabetically.
+// AllCriteriaIntentTypes returns the union of the static OSS list and values
+// registered in the package-global criteria registry, sorted alphabetically.
+// Shim over (*CriteriaRegistry).AllIntentTypes.
 func AllCriteriaIntentTypes() []string {
-	return mergeCriteriaTypes(GetCriteriaIntentTypes(), DefaultRegistry().Values(FieldIntent))
+	return DefaultRegistry().AllIntentTypes()
+}
+
+// AllIntentTypes returns the union of the static OSS list and values
+// registered in this registry, sorted alphabetically.
+func (reg *CriteriaRegistry) AllIntentTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaIntentTypes(), reg.Values(FieldIntent))
 }
 
 // CriteriaOSType represents an operating system type.
@@ -222,9 +266,16 @@ const (
 	CriteriaOSTalos       CriteriaOSType = oskind.Talos
 )
 
-// ParseCriteriaOSType parses a string into a CriteriaOSType.
-// See ParseCriteriaServiceType for the registry-fallback contract.
+// ParseCriteriaOSType parses a string into a CriteriaOSType using the
+// package-global criteria registry. Shim over (*CriteriaRegistry).ParseOS
+// bound to DefaultRegistry().
 func ParseCriteriaOSType(s string) (CriteriaOSType, error) {
+	return DefaultRegistry().ParseOS(s)
+}
+
+// ParseOS parses a string into a CriteriaOSType against this registry.
+// See (*CriteriaRegistry).ParseService for the registry-fallback contract.
+func (reg *CriteriaRegistry) ParseOS(s string) (CriteriaOSType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
 		return CriteriaOSAny, nil
@@ -239,7 +290,7 @@ func ParseCriteriaOSType(s string) (CriteriaOSType, error) {
 	case oskind.Talos:
 		return CriteriaOSTalos, nil
 	default:
-		if DefaultRegistry().Has(FieldOS, s) {
+		if reg.Has(FieldOS, s) {
 			return CriteriaOSType(normalizeCriteriaValue(s)), nil
 		}
 		return CriteriaOSAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid os type: %s", s))
@@ -254,11 +305,17 @@ func GetCriteriaOSTypes() []string {
 	return oskind.All()
 }
 
-// AllCriteriaOSTypes returns the union of the static OSS list and
-// values currently registered in the package criteria registry, sorted
-// alphabetically.
+// AllCriteriaOSTypes returns the union of the static OSS list and values
+// registered in the package-global criteria registry, sorted alphabetically.
+// Shim over (*CriteriaRegistry).AllOSTypes.
 func AllCriteriaOSTypes() []string {
-	return mergeCriteriaTypes(GetCriteriaOSTypes(), DefaultRegistry().Values(FieldOS))
+	return DefaultRegistry().AllOSTypes()
+}
+
+// AllOSTypes returns the union of the static OSS list and values registered
+// in this registry, sorted alphabetically.
+func (reg *CriteriaRegistry) AllOSTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaOSTypes(), reg.Values(FieldOS))
 }
 
 // CriteriaPlatformType represents a platform/framework type.
@@ -274,9 +331,17 @@ const (
 	CriteriaPlatformSlurm    CriteriaPlatformType = "slurm"
 )
 
-// ParseCriteriaPlatformType parses a string into a CriteriaPlatformType.
-// See ParseCriteriaServiceType for the registry-fallback contract.
+// ParseCriteriaPlatformType parses a string into a CriteriaPlatformType using
+// the package-global criteria registry. Shim over
+// (*CriteriaRegistry).ParsePlatform bound to DefaultRegistry().
 func ParseCriteriaPlatformType(s string) (CriteriaPlatformType, error) {
+	return DefaultRegistry().ParsePlatform(s)
+}
+
+// ParsePlatform parses a string into a CriteriaPlatformType against this
+// registry. See (*CriteriaRegistry).ParseService for the registry-fallback
+// contract.
+func (reg *CriteriaRegistry) ParsePlatform(s string) (CriteriaPlatformType, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", CriteriaAnyValue:
 		return CriteriaPlatformAny, nil
@@ -291,7 +356,7 @@ func ParseCriteriaPlatformType(s string) (CriteriaPlatformType, error) {
 	case "slurm":
 		return CriteriaPlatformSlurm, nil
 	default:
-		if DefaultRegistry().Has(FieldPlatform, s) {
+		if reg.Has(FieldPlatform, s) {
 			return CriteriaPlatformType(normalizeCriteriaValue(s)), nil
 		}
 		return CriteriaPlatformAny, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid platform type: %s", s))
@@ -306,10 +371,16 @@ func GetCriteriaPlatformTypes() []string {
 }
 
 // AllCriteriaPlatformTypes returns the union of the static OSS list and
-// values currently registered in the package criteria registry, sorted
-// alphabetically.
+// values registered in the package-global criteria registry, sorted
+// alphabetically. Shim over (*CriteriaRegistry).AllPlatformTypes.
 func AllCriteriaPlatformTypes() []string {
-	return mergeCriteriaTypes(GetCriteriaPlatformTypes(), DefaultRegistry().Values(FieldPlatform))
+	return DefaultRegistry().AllPlatformTypes()
+}
+
+// AllPlatformTypes returns the union of the static OSS list and values
+// registered in this registry, sorted alphabetically.
+func (reg *CriteriaRegistry) AllPlatformTypes() []string {
+	return mergeCriteriaTypes(GetCriteriaPlatformTypes(), reg.Values(FieldPlatform))
 }
 
 // mergeCriteriaTypes returns the deduplicated, alphabetically-sorted
@@ -642,11 +713,124 @@ func WithCriteriaNodes(n int) CriteriaOption {
 	}
 }
 
-// BuildCriteria creates a Criteria from functional options.
+// BuildCriteria creates a Criteria from functional options, resolving each
+// field against the package-global criteria registry. It is a shim over
+// BuildCriteriaWithRegistry(DefaultRegistry(), ...); callers holding an
+// explicit per-provider registry should call that directly.
 func BuildCriteria(opts ...CriteriaOption) (*Criteria, error) {
 	c := NewCriteria()
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to apply criteria option", err)
+		}
+	}
+	return c, nil
+}
+
+// RegistryCriteriaOption is a functional option for building a Criteria
+// against an explicit *CriteriaRegistry. Unlike CriteriaOption (which
+// closes over the package-global registry through the ParseCriteria*Type
+// shims), a RegistryCriteriaOption resolves its enum value against the
+// registry threaded in by BuildCriteriaWithRegistry, so a caller holding a
+// per-provider registry (from GetCriteriaRegistryFor) builds and validates
+// criteria against THAT provider's registered values.
+type RegistryCriteriaOption func(reg *CriteriaRegistry, c *Criteria) error
+
+// WithServiceRegistry sets the service type, resolving s against the
+// registry threaded in by BuildCriteriaWithRegistry.
+func WithServiceRegistry(s string) RegistryCriteriaOption {
+	return func(reg *CriteriaRegistry, c *Criteria) error {
+		st, err := reg.ParseService(s)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse service type", err)
+		}
+		c.Service = st
+		return nil
+	}
+}
+
+// WithAcceleratorRegistry sets the accelerator type, resolving s against the
+// registry threaded in by BuildCriteriaWithRegistry.
+func WithAcceleratorRegistry(s string) RegistryCriteriaOption {
+	return func(reg *CriteriaRegistry, c *Criteria) error {
+		at, err := reg.ParseAccelerator(s)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse accelerator type", err)
+		}
+		c.Accelerator = at
+		return nil
+	}
+}
+
+// WithIntentRegistry sets the intent type, resolving s against the registry
+// threaded in by BuildCriteriaWithRegistry.
+func WithIntentRegistry(s string) RegistryCriteriaOption {
+	return func(reg *CriteriaRegistry, c *Criteria) error {
+		it, err := reg.ParseIntent(s)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse intent type", err)
+		}
+		c.Intent = it
+		return nil
+	}
+}
+
+// WithOSRegistry sets the OS type, resolving s against the registry threaded
+// in by BuildCriteriaWithRegistry.
+func WithOSRegistry(s string) RegistryCriteriaOption {
+	return func(reg *CriteriaRegistry, c *Criteria) error {
+		ot, err := reg.ParseOS(s)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse OS type", err)
+		}
+		c.OS = ot
+		return nil
+	}
+}
+
+// WithPlatformRegistry sets the platform type, resolving s against the
+// registry threaded in by BuildCriteriaWithRegistry.
+func WithPlatformRegistry(s string) RegistryCriteriaOption {
+	return func(reg *CriteriaRegistry, c *Criteria) error {
+		pt, err := reg.ParsePlatform(s)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse platform type", err)
+		}
+		c.Platform = pt
+		return nil
+	}
+}
+
+// WithNodesRegistry sets the number of nodes. The registry is unused (node
+// count is not a registry dimension) but the signature matches the other
+// RegistryCriteriaOption builders so all fields compose uniformly through
+// BuildCriteriaWithRegistry.
+func WithNodesRegistry(n int) RegistryCriteriaOption {
+	return func(_ *CriteriaRegistry, c *Criteria) error {
+		if n < 0 {
+			return errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid nodes count: %d (must be >= 0)", n))
+		}
+		c.Nodes = n
+		return nil
+	}
+}
+
+// BuildCriteriaWithRegistry creates a Criteria from registry-aware options,
+// resolving each field against the supplied registry. This is the path
+// per-provider callers (e.g., the CLI holding a registry from
+// GetCriteriaRegistryFor) use to build and validate criteria against a
+// specific provider's registered values rather than the package global.
+//
+// A nil reg falls back to the package-global registry via DefaultRegistry()
+// so the call is still well-defined for callers that have not yet bound a
+// provider.
+func BuildCriteriaWithRegistry(reg *CriteriaRegistry, opts ...RegistryCriteriaOption) (*Criteria, error) {
+	if reg == nil {
+		reg = DefaultRegistry()
+	}
+	c := NewCriteria()
+	for _, opt := range opts {
+		if err := opt(reg, c); err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to apply criteria option", err)
 		}
 	}

--- a/pkg/recipe/criteria_registry.go
+++ b/pkg/recipe/criteria_registry.go
@@ -215,25 +215,89 @@ func (r *CriteriaRegistry) Reset() {
 	r.mu.Unlock()
 }
 
-// defaultRegistry is the process-wide singleton consulted by the
-// ParseCriteria*Type functions. Initialized lazily; access via
-// [DefaultRegistry].
-var (
-	defaultRegistry     *CriteriaRegistry
-	defaultRegistryOnce sync.Once
-)
+// criteriaRegistryCacheEntry holds the lazily-built CriteriaRegistry for a
+// single DataProvider identity. sync.Once gates concurrent first-load callers
+// onto the same registry so two goroutines never construct competing
+// instances for the same provider. This mirrors the per-provider isolation
+// primitive used by storeCache (metadata_store.go) and registryCache
+// (components.go).
+type criteriaRegistryCacheEntry struct {
+	once     sync.Once
+	registry *CriteriaRegistry
+}
 
-// DefaultRegistry returns the process-wide criteria registry, creating
-// it on first access. Threading the registry through every call site
-// would add significant churn for a value that is set once at startup
-// (when the data provider populates it from loaded overlays) and read
-// many times thereafter, so a singleton matches the existing package
-// shape better than dependency injection.
-func DefaultRegistry() *CriteriaRegistry {
-	defaultRegistryOnce.Do(func() {
-		defaultRegistry = newCriteriaRegistry()
+// criteriaRegistryCache holds criteriaRegistryCacheEntry pointers keyed by
+// DataProvider identity. Two callers bound to different DataProvider values
+// populate distinct entries; a single provider value yields a single shared
+// registry regardless of caller goroutine count. EvictCachedCriteriaRegistry
+// drops a single entry so a caller can force a rebuild after rotating a
+// provider's backing data without disturbing other providers.
+var criteriaRegistryCache sync.Map // map[DataProvider]*criteriaRegistryCacheEntry
+
+// GetCriteriaRegistryFor returns the criteria registry for the supplied
+// DataProvider, constructing it lazily on first access. Concurrent callers
+// with the same provider observe the same singleton; distinct providers
+// populate distinct cache entries and never share state. Each per-provider
+// registry honors AICR_CRITERIA_STRICT at construction, exactly like the
+// global default.
+//
+// A nil provider falls back to GetDataProvider() so the legacy global path —
+// DefaultRegistry and the package-level ParseCriteria*Type shims — continues
+// to work transparently and shares a single registry with the embedded
+// provider.
+func GetCriteriaRegistryFor(dp DataProvider) *CriteriaRegistry {
+	if dp == nil {
+		dp = GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
+	}
+	e, _ := criteriaRegistryCache.LoadOrStore(dp, &criteriaRegistryCacheEntry{})
+	entry := e.(*criteriaRegistryCacheEntry)
+	entry.once.Do(func() {
+		entry.registry = newCriteriaRegistry()
 	})
-	return defaultRegistry
+	return entry.registry
+}
+
+// EvictCachedCriteriaRegistry drops the cached criteria registry for the
+// supplied provider so the next GetCriteriaRegistryFor call rebuilds an empty
+// registry. Passing a nil provider is a no-op (callers handle that case
+// explicitly to avoid silently evicting the package-global registry).
+func EvictCachedCriteriaRegistry(dp DataProvider) {
+	if dp == nil {
+		return
+	}
+	criteriaRegistryCache.Delete(dp)
+}
+
+// CachedCriteriaRegistryContainsForTesting reports whether the criteria
+// registry cache has an entry for the supplied DataProvider.
+//
+// Test-only by convention (the _ForTesting suffix); never call from
+// production code.
+func CachedCriteriaRegistryContainsForTesting(dp DataProvider) bool {
+	_, ok := criteriaRegistryCache.Load(dp)
+	return ok
+}
+
+// ResetCriteriaRegistryForTesting drops every cached criteria registry so the
+// next GetCriteriaRegistryFor call rebuilds from scratch. This must only be
+// called from tests.
+func ResetCriteriaRegistryForTesting() {
+	criteriaRegistryCache.Range(func(k, _ any) bool {
+		criteriaRegistryCache.Delete(k)
+		return true
+	})
+}
+
+// DefaultRegistry returns the criteria registry bound to the package-global
+// DataProvider. Threading the registry through every call site would add
+// significant churn for a value that is set once at startup (when the data
+// provider populates it from loaded overlays) and read many times thereafter,
+// so the package-level ParseCriteria*Type shims consult this registry.
+//
+// It delegates to GetCriteriaRegistryFor(GetDataProvider()) so the global
+// path and the embedded-provider path share a single registry instance.
+func DefaultRegistry() *CriteriaRegistry {
+	return GetCriteriaRegistryFor(GetDataProvider()) //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
 }
 
 // normalizeCriteriaValue lower-cases and trims a criteria value to
@@ -245,9 +309,15 @@ func normalizeCriteriaValue(s string) string {
 }
 
 // seedCriteriaRegistry registers each non-empty value from c into the
-// package criteria registry under the given source. Used by the overlay
+// criteria registry bound to dp under the given source. Used by the overlay
 // loader so values declared in YAML overlay catalogs (embedded or
 // `--data`) become valid CLI / API inputs without a binary rebuild.
+//
+// Routing through dp keeps the criteria registry per-provider: loading a
+// provider's metadata store seeds THAT provider's registry, exactly like the
+// metadata store itself is per-provider. A nil dp falls back to the
+// package-global registry via GetCriteriaRegistryFor, preserving the legacy
+// global path.
 //
 // source is the string returned by the DataProvider's Source(path); we
 // translate it to a CriteriaOrigin here so callers don't have to know
@@ -256,7 +326,7 @@ func normalizeCriteriaValue(s string) string {
 // future value) maps to OriginExternal so strict mode fails closed on
 // non-OSS contributions even if a new DataProvider source category is
 // introduced later.
-func seedCriteriaRegistry(c *Criteria, source string) {
+func seedCriteriaRegistry(c *Criteria, source string, dp DataProvider) {
 	if c == nil {
 		return
 	}
@@ -264,7 +334,7 @@ func seedCriteriaRegistry(c *Criteria, source string) {
 	if source == sourceEmbedded {
 		origin = OriginEmbedded
 	}
-	reg := DefaultRegistry()
+	reg := GetCriteriaRegistryFor(dp)
 	reg.Register(FieldService, string(c.Service), origin)
 	reg.Register(FieldAccelerator, string(c.Accelerator), origin)
 	reg.Register(FieldIntent, string(c.Intent), origin)

--- a/pkg/recipe/criteria_registry_test.go
+++ b/pkg/recipe/criteria_registry_test.go
@@ -16,6 +16,7 @@ package recipe
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -319,7 +320,7 @@ func TestSeedCriteriaRegistry(t *testing.T) {
 				OS:          "bottlerocket",
 				Platform:    "nvmesh",
 			}
-			seedCriteriaRegistry(c, tt.source)
+			seedCriteriaRegistry(c, tt.source, nil)
 
 			checks := []struct {
 				field CriteriaField
@@ -346,12 +347,158 @@ func TestSeedCriteriaRegistry(t *testing.T) {
 	}
 }
 
+// buildProviderWithServiceCriteria returns an inMemoryDataProvider whose
+// single overlay declares the supplied custom service criteria value. Loading
+// its metadata store seeds the provider's criteria registry with that value
+// (OriginExternal, since inMemoryDataProvider.Source never returns
+// "embedded"). Used by the per-provider isolation test.
+func buildProviderWithServiceCriteria(t *testing.T, tag, serviceValue string) DataProvider {
+	t.Helper()
+
+	baseYAML := []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`)
+
+	overlayYAML := fmt.Appendf(nil, `kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: %s-overlay
+spec:
+  base: base
+  criteria:
+    service: %s
+  componentRefs: []
+`, tag, serviceValue)
+
+	files := map[string][]byte{
+		"overlays/base.yaml":        baseYAML,
+		"overlays/" + tag + ".yaml": overlayYAML,
+	}
+	return newInMemoryProvider(tag, files)
+}
+
+// TestGetCriteriaRegistryFor_PerProviderIsolation verifies that loading two
+// distinct DataProviders that register DIFFERENT external criteria values
+// seeds two distinct criteria registries with no cross-contamination: each
+// provider's registry knows only its own value.
+func TestGetCriteriaRegistryFor_PerProviderIsolation(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetCriteriaRegistryForTesting)
+
+	const valA = "ncp-alpha"
+	const valB = "ncp-beta"
+
+	dpA := buildProviderWithServiceCriteria(t, "alpha", valA)
+	dpB := buildProviderWithServiceCriteria(t, "beta", valB)
+
+	ctx := context.Background()
+	if _, err := LoadMetadataStoreFor(ctx, dpA); err != nil {
+		t.Fatalf("LoadMetadataStoreFor(A): %v", err)
+	}
+	if _, err := LoadMetadataStoreFor(ctx, dpB); err != nil {
+		t.Fatalf("LoadMetadataStoreFor(B): %v", err)
+	}
+
+	regA := GetCriteriaRegistryFor(dpA)
+	regB := GetCriteriaRegistryFor(dpB)
+
+	if regA == regB {
+		t.Fatal("expected distinct criteria registries for distinct providers")
+	}
+
+	// Each registry must know its own value...
+	if !regA.Has(FieldService, valA) {
+		t.Errorf("registry A missing its own value %q", valA)
+	}
+	if !regB.Has(FieldService, valB) {
+		t.Errorf("registry B missing its own value %q", valB)
+	}
+	// ...and must NOT know the other provider's value.
+	if regA.Has(FieldService, valB) {
+		t.Errorf("registry A leaked provider B's value %q", valB)
+	}
+	if regB.Has(FieldService, valA) {
+		t.Errorf("registry B leaked provider A's value %q", valA)
+	}
+
+	// ParseService routes through the per-provider registry, so each
+	// provider's registry admits its own value and rejects the other's.
+	if _, err := regA.ParseService(valA); err != nil {
+		t.Errorf("regA.ParseService(%q) rejected own value: %v", valA, err)
+	}
+	if _, err := regA.ParseService(valB); err == nil {
+		t.Errorf("regA.ParseService(%q) admitted foreign value", valB)
+	}
+}
+
+// TestEvictCachedCriteriaRegistry verifies that EvictCachedCriteriaRegistry
+// drops the cached entry so the next GetCriteriaRegistryFor rebuilds an empty
+// registry (the seeded value is gone until the catalog is reloaded), and that
+// a nil provider is a no-op that does not clobber other entries.
+func TestEvictCachedCriteriaRegistry(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetCriteriaRegistryForTesting)
+
+	const val = "ncp-evict"
+	dp := buildProviderWithServiceCriteria(t, "evict", val)
+
+	if _, err := LoadMetadataStoreFor(context.Background(), dp); err != nil {
+		t.Fatalf("LoadMetadataStoreFor: %v", err)
+	}
+	first := GetCriteriaRegistryFor(dp)
+	if !first.Has(FieldService, val) {
+		t.Fatalf("seeded registry missing %q", val)
+	}
+	if !CachedCriteriaRegistryContainsForTesting(dp) {
+		t.Fatal("expected cache to contain entry after load")
+	}
+
+	// nil is a no-op: must not panic and must not clobber dp's entry.
+	EvictCachedCriteriaRegistry(nil)
+	if !CachedCriteriaRegistryContainsForTesting(dp) {
+		t.Fatal("EvictCachedCriteriaRegistry(nil) clobbered an existing entry")
+	}
+
+	EvictCachedCriteriaRegistry(dp)
+	if CachedCriteriaRegistryContainsForTesting(dp) {
+		t.Fatal("expected entry dropped after evict")
+	}
+
+	// Next access rebuilds a fresh (empty, not-yet-reseeded) registry.
+	second := GetCriteriaRegistryFor(dp)
+	if second == first {
+		t.Error("expected a fresh registry instance after evict")
+	}
+	if second.Has(FieldService, val) {
+		t.Error("rebuilt registry must be empty until the catalog is reloaded")
+	}
+}
+
+// TestGetCriteriaRegistryFor_StrictPerRegistry verifies each per-provider
+// registry honors AICR_CRITERIA_STRICT at construction independently.
+func TestGetCriteriaRegistryFor_StrictPerRegistry(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "true")
+	t.Cleanup(ResetCriteriaRegistryForTesting)
+
+	dp := newInMemoryProvider("strict-probe", map[string][]byte{})
+	reg := GetCriteriaRegistryFor(dp)
+	if !reg.IsStrict() {
+		t.Error("per-provider registry must inherit AICR_CRITERIA_STRICT=true at construction")
+	}
+}
+
 func TestSeedCriteriaRegistry_NilCriteria(t *testing.T) {
 	reg := DefaultRegistry()
 	reg.Reset()
 	t.Cleanup(reg.Reset)
 	// Must not panic.
-	seedCriteriaRegistry(nil, "embedded")
+	seedCriteriaRegistry(nil, "embedded", nil)
 	if got := reg.Values(FieldService); len(got) != 0 {
 		t.Errorf("nil criteria must not register anything, got %v", got)
 	}
@@ -366,7 +513,7 @@ func TestSeedCriteriaRegistry_SkipsWildcardAndEmpty(t *testing.T) {
 		Accelerator: "",                 // empty must be skipped
 		Intent:      "training",         // real value, must register
 	}
-	seedCriteriaRegistry(c, "embedded")
+	seedCriteriaRegistry(c, "embedded", nil)
 	if reg.Has(FieldService, "any") {
 		t.Error("registry should not record wildcard 'any'")
 	}

--- a/pkg/recipe/loader.go
+++ b/pkg/recipe/loader.go
@@ -28,6 +28,15 @@ import (
 // builder using the overlay's criteria. This allows callers to accept both overlay
 // files and pre-hydrated RecipeResult files transparently.
 func LoadFromFile(ctx context.Context, path, kubeconfig, version string) (*RecipeResult, error) {
+	return LoadFromFileWithProvider(ctx, path, kubeconfig, version, nil)
+}
+
+// LoadFromFileWithProvider is LoadFromFile bound to an explicit DataProvider.
+// Overlay inputs (kind: RecipeMetadata) are hydrated through a builder bound to
+// dp (so external --data overlays resolve against dp, not the package global),
+// and the returned result carries dp via its provider field. A nil dp falls
+// back to the package-global provider (matching LoadFromFile).
+func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version string, dp DataProvider) (*RecipeResult, error) {
 	rec, err := serializer.FromFileWithKubeconfig[RecipeResult](path, kubeconfig)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal,
@@ -53,7 +62,16 @@ func LoadFromFile(ctx context.Context, path, kubeconfig, version string) (*Recip
 					path))
 		}
 
-		builder := NewBuilder(WithVersion(version))
+		// Bind the builder to dp when supplied so the overlay resolves
+		// against the caller's provider; the hydrated result inherits dp
+		// via the metadata store (finalizeRecipeResult threads it through).
+		// A nil dp omits the option, matching LoadFromFile's package-global
+		// behavior exactly.
+		opts := []Option{WithVersion(version)}
+		if dp != nil {
+			opts = append(opts, WithDataProvider(dp))
+		}
+		builder := NewBuilder(opts...)
 		rec, err = builder.BuildFromCriteria(ctx, overlay.Spec.Criteria)
 		if err != nil {
 			return nil, err
@@ -61,6 +79,11 @@ func LoadFromFile(ctx context.Context, path, kubeconfig, version string) (*Recip
 
 		slog.Info("overlay hydrated successfully",
 			"appliedOverlays", rec.Metadata.AppliedOverlays)
+	} else if dp != nil {
+		// Already-hydrated RecipeResult: the builder never runs, so bind the
+		// caller's provider directly so downstream value/manifest reads route
+		// through dp rather than the package global.
+		rec.provider = dp
 	}
 
 	// Empty kind is allowed for backward compatibility with older RecipeResult files

--- a/pkg/recipe/loader_provider_test.go
+++ b/pkg/recipe/loader_provider_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestLayeredProvider builds a LayeredDataProvider over a temp dir holding a
+// minimal external registry.yaml, layered on top of the embedded data so that
+// embedded base overlays remain resolvable.
+func newTestLayeredProvider(t *testing.T) *LayeredDataProvider {
+	t.Helper()
+	tmp := t.TempDir()
+	registry := `apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components: []
+`
+	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"), []byte(registry), 0o600); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+	layered, err := NewLayeredDataProvider(
+		NewEmbeddedDataProvider(GetEmbeddedFS(), "."),
+		LayeredProviderConfig{ExternalDir: tmp},
+	)
+	if err != nil {
+		t.Fatalf("NewLayeredDataProvider: %v", err)
+	}
+	return layered
+}
+
+// writeOverlayFile writes a leaf RecipeMetadata overlay (with criteria) to a
+// temp path and returns the file path.
+func writeOverlayFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "overlay.yaml")
+	overlay := `apiVersion: aicr.nvidia.com/v1alpha1
+kind: RecipeMetadata
+metadata:
+  name: provider-bound-overlay
+spec:
+  criteria:
+    service: eks
+    accelerator: h100
+    intent: training
+`
+	if err := os.WriteFile(path, []byte(overlay), 0o600); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+	return path
+}
+
+func TestLoadFromFileWithProvider(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+
+	t.Run("overlay hydrates and binds provider", func(t *testing.T) {
+		layered := newTestLayeredProvider(t)
+		overlayPath := writeOverlayFile(t)
+
+		rec, err := LoadFromFileWithProvider(t.Context(), overlayPath, "", "vtest", layered)
+		if err != nil {
+			t.Fatalf("LoadFromFileWithProvider() error: %v", err)
+		}
+		if rec == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if rec.Kind != RecipeResultKind {
+			t.Errorf("kind = %q, want %q", rec.Kind, RecipeResultKind)
+		}
+		if len(rec.ComponentRefs) == 0 {
+			t.Error("expected hydrated recipe with component refs")
+		}
+		if rec.DataProvider() != layered {
+			t.Errorf("DataProvider() = %v, want bound layered provider", rec.DataProvider())
+		}
+	})
+
+	t.Run("already-hydrated RecipeResult binds provider", func(t *testing.T) {
+		layered := newTestLayeredProvider(t)
+		dir := t.TempDir()
+		path := filepath.Join(dir, "recipe.yaml")
+		content := "kind: RecipeResult\napiVersion: aicr.nvidia.com/v1alpha1\ncriteria:\n  service: eks\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write recipe: %v", err)
+		}
+
+		rec, err := LoadFromFileWithProvider(t.Context(), path, "", "vtest", layered)
+		if err != nil {
+			t.Fatalf("LoadFromFileWithProvider() error: %v", err)
+		}
+		if rec.DataProvider() != layered {
+			t.Errorf("DataProvider() = %v, want bound layered provider", rec.DataProvider())
+		}
+	})
+
+	t.Run("nil provider behaves like LoadFromFile", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "recipe.yaml")
+		content := "kind: RecipeResult\napiVersion: aicr.nvidia.com/v1alpha1\ncriteria:\n  service: eks\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write recipe: %v", err)
+		}
+
+		rec, err := LoadFromFileWithProvider(t.Context(), path, "", "vtest", nil)
+		if err != nil {
+			t.Fatalf("LoadFromFileWithProvider() error: %v", err)
+		}
+		if rec == nil {
+			t.Fatal("expected non-nil result")
+		}
+		// Nil dp must not bind a provider, matching LoadFromFile.
+		if rec.DataProvider() != nil {
+			t.Errorf("DataProvider() = %v, want nil for nil-dp path", rec.DataProvider())
+		}
+	})
+}

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -429,6 +429,120 @@ func (r *RecipeResult) DataProvider() DataProvider {
 	return r.provider
 }
 
+// BindDataProvider sets the DataProvider on a RecipeResult so downstream
+// value/manifest/data-file reads route through dp rather than the package
+// global. It is the exported binder the aicr.Client facade uses to adopt a
+// RecipeResult decoded from an external source (e.g. a /v1/bundle POST body)
+// onto the Client's own provider — the in-process equivalent of the
+// rec.provider = dp binding loader.go performs for an already-hydrated file.
+// Nil-safe on the receiver. A nil dp leaves the result on the package-global
+// fallback (DataProvider() then returns nil), matching the pre-bind behavior.
+func (r *RecipeResult) BindDataProvider(dp DataProvider) {
+	if r == nil {
+		return
+	}
+	r.provider = dp
+}
+
+// DeepCopy returns an independent copy of r with all exported fields
+// deep-copied: the nested Metadata slices, Criteria, Constraints,
+// ComponentRefs (including their map/slice fields), DeploymentOrder, and
+// Validation config. The unexported provider is intentionally NOT copied —
+// it is left nil so the caller can rebind it (e.g. the aicr.Client facade
+// adopts a recipe by deep-copying first, then BindDataProvider on the copy,
+// so binding never mutates caller-owned state). Nil-safe on the receiver.
+//
+// Used by the facade's AdoptRecipe path: a caller may reuse one *RecipeResult
+// across multiple Clients, and binding a Client's provider must not leak into
+// the caller's pointer or contaminate a sibling Client's binding.
+func (r *RecipeResult) DeepCopy() *RecipeResult {
+	if r == nil {
+		return nil
+	}
+	out := &RecipeResult{
+		Kind:       r.Kind,
+		APIVersion: r.APIVersion,
+		// provider intentionally left nil: BindDataProvider sets it on the copy.
+	}
+
+	// Metadata: scalar Version plus three slices.
+	out.Metadata.Version = r.Metadata.Version
+	if r.Metadata.AppliedOverlays != nil {
+		out.Metadata.AppliedOverlays = make([]string, len(r.Metadata.AppliedOverlays))
+		copy(out.Metadata.AppliedOverlays, r.Metadata.AppliedOverlays)
+	}
+	if r.Metadata.ExcludedOverlays != nil {
+		out.Metadata.ExcludedOverlays = make([]ExcludedOverlay, len(r.Metadata.ExcludedOverlays))
+		copy(out.Metadata.ExcludedOverlays, r.Metadata.ExcludedOverlays)
+	}
+	if r.Metadata.ConstraintWarnings != nil {
+		out.Metadata.ConstraintWarnings = make([]ConstraintWarning, len(r.Metadata.ConstraintWarnings))
+		copy(out.Metadata.ConstraintWarnings, r.Metadata.ConstraintWarnings)
+	}
+
+	// Criteria is all-scalar, so a value copy behind a fresh pointer is a
+	// full deep copy.
+	if r.Criteria != nil {
+		c := *r.Criteria
+		out.Criteria = &c
+	}
+
+	if r.Constraints != nil {
+		out.Constraints = make([]Constraint, len(r.Constraints))
+		copy(out.Constraints, r.Constraints)
+	}
+
+	if r.ComponentRefs != nil {
+		out.ComponentRefs = make([]ComponentRef, len(r.ComponentRefs))
+		for i := range r.ComponentRefs {
+			out.ComponentRefs[i] = cloneComponentRef(r.ComponentRefs[i])
+		}
+	}
+
+	if r.DeploymentOrder != nil {
+		out.DeploymentOrder = make([]string, len(r.DeploymentOrder))
+		copy(out.DeploymentOrder, r.DeploymentOrder)
+	}
+
+	out.Validation = cloneValidationConfig(r.Validation)
+
+	return out
+}
+
+// cloneComponentRef returns a deep copy of a ComponentRef, allocating
+// independent backing storage for every map/slice field so a mutation
+// through the copy can't reach the source.
+func cloneComponentRef(ref ComponentRef) ComponentRef {
+	out := ref // copies scalars and the (to-be-replaced) reference fields
+	if ref.Overrides != nil {
+		// deepCopyAnyMap recurses into nested map[string]any/[]any so a
+		// mutation through the copy can't reach the source's nested values
+		// (a shallow key-copy would share those nested containers).
+		out.Overrides = deepCopyAnyMap(ref.Overrides)
+	}
+	if ref.Patches != nil {
+		out.Patches = make([]string, len(ref.Patches))
+		copy(out.Patches, ref.Patches)
+	}
+	if ref.DependencyRefs != nil {
+		out.DependencyRefs = make([]string, len(ref.DependencyRefs))
+		copy(out.DependencyRefs, ref.DependencyRefs)
+	}
+	if ref.ManifestFiles != nil {
+		out.ManifestFiles = make([]string, len(ref.ManifestFiles))
+		copy(out.ManifestFiles, ref.ManifestFiles)
+	}
+	if ref.PreManifestFiles != nil {
+		out.PreManifestFiles = make([]string, len(ref.PreManifestFiles))
+		copy(out.PreManifestFiles, ref.PreManifestFiles)
+	}
+	if ref.ExpectedResources != nil {
+		out.ExpectedResources = make([]ExpectedResource, len(ref.ExpectedResources))
+		copy(out.ExpectedResources, ref.ExpectedResources)
+	}
+	return out
+}
+
 // Merge merges another RecipeMetadataSpec into this one.
 // The other spec takes precedence for conflicts.
 func (s *RecipeMetadataSpec) Merge(other *RecipeMetadataSpec) {

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -157,15 +157,14 @@ func loadMetadataStore(ctx context.Context) (*MetadataStore, error) {
 // buildMetadataStore performs the actual catalog walk against the supplied
 // provider. It is pure with respect to the package-global DataProvider — the
 // only side effect on package state is the call to seedCriteriaRegistry,
-// which intentionally seeds the package-global criteria registry from every
-// overlay's spec.criteria (Task 4 handles per-provider routing for the
-// component registry; criteria registry continues to use the package global
-// for now).
+// which seeds the criteria registry bound to the supplied provider (via
+// GetCriteriaRegistryFor) from every overlay's spec.criteria. So loading a
+// provider's metadata store seeds THAT provider's criteria registry, exactly
+// like the metadata store and component registry are per-provider.
 //
 // The returned MetadataStore has its provider field set so downstream
-// lookups (e.g., applyRegistryDefaults in Task 4) can route through the
-// originating provider even when the package-global provider has since been
-// swapped.
+// lookups (e.g., applyRegistryDefaults) can route through the originating
+// provider even when the package-global provider has since been swapped.
 func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataStore, error) {
 	// Record cache miss on first load for the provider.
 	recipeCacheMisses.Inc()
@@ -178,10 +177,10 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 	}
 
 	// Staged criteria registry entries. Each overlay's criteria are
-	// appended during the walk but only applied to the global registry
-	// after every later validation (walk completion, base presence,
-	// dependency validation) succeeds. Keeps the registry transactional
-	// with respect to catalog-load success.
+	// appended during the walk but only applied to this provider's
+	// registry after every later validation (walk completion, base
+	// presence, dependency validation) succeeds. Keeps the registry
+	// transactional with respect to catalog-load success.
 	var pendingRegistry []pendingRegistryEntry
 
 	// Load all YAML files from data directory.
@@ -281,7 +280,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 			// found, and dependency validation passes — see the
 			// commit loop below the walk. This prevents a malformed
 			// file later in the walk from leaving partial criteria
-			// values in the package-global registry.
+			// values in this provider's registry.
 			pendingRegistry = append(pendingRegistry, pendingRegistryEntry{
 				criteria: metadata.Spec.Criteria,
 				source:   provider.Source(path),
@@ -305,10 +304,12 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 	}
 
 	// Catalog fully validated — commit staged criteria registrations
-	// to the global registry now. Any earlier error return path above
-	// leaves the registry untouched.
+	// to this provider's registry now. Any earlier error return path
+	// above leaves the registry untouched. Routing through provider
+	// keeps the criteria registry per-provider, mirroring the
+	// per-provider metadata store and component registry.
 	for _, entry := range pendingRegistry {
-		seedCriteriaRegistry(entry.criteria, entry.source)
+		seedCriteriaRegistry(entry.criteria, entry.source, provider)
 	}
 
 	return store, nil
@@ -323,6 +324,29 @@ func EvictCachedStore(dp DataProvider) {
 		return
 	}
 	storeCache.Delete(dp)
+}
+
+// CachedStoreCountForTesting returns the number of distinct DataProvider
+// entries currently held in the metadata-store cache. Exposed for tests
+// in the aicr facade that assert Client.Close evicts the cached store —
+// paired with CachedRegistryCountForTesting in components.go so a single
+// test can verify both halves of the per-Client cache are released.
+//
+// Test-only by convention (the _ForTesting suffix); never call from
+// production code.
+//
+// NOTE: this returns the GLOBAL count across every DataProvider in the
+// package. A parallel test in another package using its own
+// DataProvider will perturb the count. Tests that need a stable signal
+// scoped to a specific DataProvider should prefer
+// CachedStoreContainsForTesting.
+func CachedStoreCountForTesting() int {
+	n := 0
+	storeCache.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
 }
 
 // CachedStoreContainsForTesting reports whether the metadata-store

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -123,6 +123,13 @@ func openExternalFile(baseDir, relPath string, allowSymlinks bool) (*os.File, er
 
 // DataProvider abstracts access to recipe data files.
 // This allows layering external directories over embedded data.
+//
+// Implementations must be comparable per the Go language spec: per-provider
+// caches (the metadata store, component registry, and criteria registry) key
+// by interface value via sync.Map, which panics at runtime if the dynamic
+// type is non-comparable (e.g., a struct containing a slice, map, or func
+// field). The safe and idiomatic shape is methods on a pointer receiver, as
+// the in-tree EmbeddedDataProvider / LayeredDataProvider do.
 type DataProvider interface {
 	// ReadFile reads a file by path (relative to data directory).
 	ReadFile(path string) ([]byte, error)

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -71,7 +71,7 @@ func Load(version, commit string) (*ValidatorCatalog, error) {
 // steps 1-2 but are replaced by step 3 if that env var is set.
 func LoadWithDataProvider(dp recipe.DataProvider, version, commit string) (*ValidatorCatalog, error) {
 	if dp == nil {
-		dp = recipe.GetDataProvider() //nolint:staticcheck // back-compat fallback; tracked by #983/#987
+		dp = recipe.GetDataProvider() //nolint:staticcheck // back-compat fallback for pre-WithDataProvider callers (#983 Stage 2)
 	}
 	data, err := dp.ReadFile("validators/catalog.yaml")
 	if err != nil {

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -38,8 +38,18 @@ type (
 	EnvVar               = v1.EnvVar
 )
 
-// Load reads and parses the validator catalog from the global DataProvider.
-// When the --data flag provides an external directory containing
+// Load reads and parses the validator catalog from the package-global
+// recipe.GetDataProvider(). It is the back-compat entry point for callers that
+// do not thread a per-command DataProvider; provider-aware callers should use
+// LoadWithDataProvider. See LoadWithDataProvider for the image tag resolution
+// rules.
+func Load(version, commit string) (*ValidatorCatalog, error) {
+	return LoadWithDataProvider(nil, version, commit)
+}
+
+// LoadWithDataProvider reads and parses the validator catalog from dp. A nil dp
+// falls back to the package-global recipe.GetDataProvider() so existing callers
+// are unaffected. When the --data flag provides an external directory containing
 // validators/catalog.yaml, the external catalog is merged with the embedded
 // catalog using merge-by-name semantics: external validators override embedded
 // by name, and new validators are appended.
@@ -59,8 +69,11 @@ type (
 //
 // Entries with explicit version tags (e.g., :v1.2.3) are never modified by
 // steps 1-2 but are replaced by step 3 if that env var is set.
-func Load(version, commit string) (*ValidatorCatalog, error) {
-	data, err := recipe.GetDataProvider().ReadFile("validators/catalog.yaml") //nolint:staticcheck // tracked by #983 Stage 2
+func LoadWithDataProvider(dp recipe.DataProvider, version, commit string) (*ValidatorCatalog, error) {
+	if dp == nil {
+		dp = recipe.GetDataProvider() //nolint:staticcheck // back-compat fallback; tracked by #983/#987
+	}
+	data, err := dp.ReadFile("validators/catalog.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read catalog", err)
 	}

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -16,6 +16,7 @@ package catalog
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1111,5 +1112,100 @@ func TestCatalogEmbedding(t *testing.T) {
 	}
 	if strings.Contains(jsonStr, "metadata") {
 		t.Error("Embedded catalog should not contain metadata in JSON")
+	}
+}
+
+// fakeCatalogProvider is a recipe.DataProvider that serves a single,
+// distinct validators/catalog.yaml. It lets a test prove catalog.Load read
+// from the provider it was handed rather than the package global: the
+// embedded catalog has no validator by this name, so seeing it back is
+// proof the explicit provider's bytes were used.
+type fakeCatalogProvider struct {
+	catalogYAML []byte
+	reads       int
+}
+
+func (p *fakeCatalogProvider) ReadFile(path string) ([]byte, error) {
+	if path == "validators/catalog.yaml" {
+		p.reads++
+		return p.catalogYAML, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (p *fakeCatalogProvider) WalkDir(string, fs.WalkDirFunc) error { return nil }
+
+func (p *fakeCatalogProvider) Source(path string) string { return "fake://" + path }
+
+// TestLoadHonorsExplicitProvider proves LoadWithDataProvider reads the catalog
+// from the DataProvider it is handed (not the package global) by serving a
+// distinct catalog whose marker validator does not exist in the embedded data.
+func TestLoadHonorsExplicitProvider(t *testing.T) {
+	const marker = "explicit-provider-marker"
+	dp := &fakeCatalogProvider{catalogYAML: []byte(`
+apiVersion: validator.nvidia.com/v1alpha1
+kind: ValidatorCatalog
+metadata:
+  name: fake-catalog
+  version: "9.9.9"
+validators:
+  - name: ` + marker + `
+    phase: deployment
+    description: "marker validator unique to the fake provider"
+    image: ghcr.io/nvidia/aicr-validators/marker:v9.9.9
+    timeout: 1m
+`)}
+
+	cat, err := LoadWithDataProvider(dp, "", "")
+	if err != nil {
+		t.Fatalf("LoadWithDataProvider() error = %v, want nil", err)
+	}
+	if dp.reads == 0 {
+		t.Error("LoadWithDataProvider() did not call ReadFile on the explicit provider")
+	}
+	if len(cat.Validators) != 1 || cat.Validators[0].Name != marker {
+		t.Errorf("LoadWithDataProvider() returned %d validators (first = %q); want exactly the %q marker — "+
+			"catalog was not read from the explicit provider",
+			len(cat.Validators), firstValidatorName(cat), marker)
+	}
+}
+
+func firstValidatorName(cat *ValidatorCatalog) string {
+	if cat == nil || len(cat.Validators) == 0 {
+		return ""
+	}
+	return cat.Validators[0].Name
+}
+
+// TestLoadDataProvider verifies LoadWithDataProvider honors an explicit
+// DataProvider and falls back to the package-global provider when nil is passed.
+func TestLoadDataProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		dp   recipe.DataProvider
+	}{
+		{
+			name: "explicit embedded provider",
+			dp:   recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "."),
+		},
+		{
+			name: "nil falls back to global",
+			dp:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cat, err := LoadWithDataProvider(tt.dp, "", "")
+			if err != nil {
+				t.Fatalf("LoadWithDataProvider() error = %v, want nil", err)
+			}
+			if cat == nil {
+				t.Fatal("LoadWithDataProvider() returned nil catalog")
+			}
+			if len(cat.Validators) == 0 {
+				t.Error("LoadWithDataProvider() returned catalog with no validators")
+			}
+		})
 	}
 }

--- a/pkg/validator/options.go
+++ b/pkg/validator/options.go
@@ -14,7 +14,11 @@
 
 package validator
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
 
 // Option is a functional option for configuring Validator instances.
 type Option func(*Validator)
@@ -108,5 +112,13 @@ func WithImageRegistryOverride(override string) Option {
 func WithImageTagOverride(override string) Option {
 	return func(v *Validator) {
 		v.ImageTagOverride = override
+	}
+}
+
+// WithDataProvider binds the recipe DataProvider used to load the validator
+// catalog. When unset, the catalog loads from the package-global provider.
+func WithDataProvider(dp recipe.DataProvider) Option {
+	return func(v *Validator) {
+		v.dataProvider = dp
 	}
 }

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
 )
 
@@ -71,6 +72,10 @@ type Validator struct {
 	// container env as AICR_VALIDATOR_IMAGE_TAG. Intended for feature-branch
 	// dev builds whose commit SHA has no published image; typical value: "latest".
 	ImageTagOverride string
+
+	// dataProvider supplies the recipe data files used to load the validator
+	// catalog. When nil, catalog.Load falls back to the package-global provider.
+	dataProvider recipe.DataProvider
 }
 
 // PhaseResult is the outcome of running all validators in a single phase.

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -179,7 +179,7 @@ func (v *Validator) ValidatePhases(
 		return nil, err
 	}
 
-	cat, err := catalog.Load(v.Version, v.Commit)
+	cat, err := catalog.LoadWithDataProvider(v.dataProvider, v.Version, v.Commit)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog", err)
 	}
@@ -237,7 +237,7 @@ func (v *Validator) ValidatePhase(
 	snap *snapshotter.Snapshot,
 ) (*PhaseResult, error) {
 
-	cat, err := catalog.Load(v.Version, v.Commit)
+	cat, err := catalog.LoadWithDataProvider(v.dataProvider, v.Version, v.Commit)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog", err)
 	}


### PR DESCRIPTION
## Summary
Thread an explicit `DataProvider` through the recipe loader, validator catalog, and criteria parsing so consumers can resolve against their own data source instead of the process-global provider/registry. Foundation (PR 1 of 2) for migrating the CLI/REST onto `aicr.Client` (#1077).

## What changes
- `recipe`: `GetCriteriaRegistryFor(dp)` per-provider criteria registry (+ `EvictCachedCriteriaRegistry`); registry-aware parsing + `BuildCriteriaWithRegistry`; `LoadFromFileWithProvider`; `RecipeResult.DeepCopy`/`BindDataProvider`.
- `validator`: `catalog.LoadWithDataProvider(dp, …)` + `WithDataProvider` option.
- `config`: `ResolveCriteriaWithRegistry`.

## Behavior
No consumer-facing behavior change. Global shims are retained for back-compat (`DefaultRegistry`, `ParseCriteria*`, `catalog.Load`, `LoadFromFile`, `config.ResolveCriteria`) so existing callers compile and behave identically. The criteria-registry global is distinct from `SetDataProvider`/`GetDataProvider` (#987, closed); shim removal will be tracked separately.

## Cache lifecycle
This PR adds `criteriaRegistryCache` (per-`DataProvider`, `sync.Map`-backed, lazy via `sync.Once`) alongside the existing `registryCache` (`pkg/recipe/components.go`) and `storeCache` (`pkg/recipe/metadata_store.go`). All three caches grow on first access per `DataProvider` and have `Evict*` primitives but no automatic eviction from this PR alone.

`Client.Close()` wiring that calls `EvictCachedCriteriaRegistry`, `EvictCachedStore`, and `EvictCachedRegistry` for the Client's `DataProvider` lands in #1108. Long-running consumers that churn through Clients should wait for #1108 (or evict manually) to avoid monotonic cache growth.

## Testing
`go build ./...`, `go test -race ./pkg/recipe/... ./pkg/validator/... ./pkg/config/...`, and `golangci-lint` all pass standalone.

Relates to #1077. PR 2 (CLI/API migration) stacks on this branch.
