### PR TITLE
feat(cli,api): consume aicr.Client facade (#1077)

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -108,8 +108,9 @@ if err != nil {
 	log.Fatalf("collect snapshot: %v", err)
 }
 
-// ValidateState runs every validation phase (Deployment, Performance,
-// Conformance) against the resolved recipe + observed snapshot.
+// ValidateState runs the validation phases against the resolved recipe +
+// observed snapshot. With no WithValidationPhases option it runs all three
+// phases (Deployment, Performance, Conformance) in canonical order.
 results, err := client.ValidateState(ctx, result, snap)
 if err != nil {
 	log.Fatalf("validate state: %v", err)
@@ -120,8 +121,44 @@ for _, r := range results {
 ```
 
 The `recipe` argument to `ValidateState` MUST be the `*RecipeResult`
-returned by the same Client's `ResolveRecipe` call — the unexported
-internal recipe state is required for constraint evaluation.
+returned by the same Client's `ResolveRecipe` (or `LoadRecipe`) call —
+the unexported internal recipe state is required for constraint
+evaluation.
+
+To restrict the run to specific phases, pass `WithValidationPhases` in
+the order you want them executed:
+
+```go
+results, err := client.ValidateState(ctx, result, snap,
+	aicr.WithValidationPhases(aicr.PhaseDeployment, aicr.PhaseConformance))
+```
+
+Valid phase values are `PhaseDeployment`, `PhasePerformance`, and
+`PhaseConformance`. An unrecognized phase is rejected with
+`ErrCodeInvalidRequest` before any cluster work, so a typo cannot
+silently degrade to an empty run.
+
+### Loading an existing recipe
+
+When a recipe has already been resolved and persisted (for example a
+recipe file checked into a GitOps repo, or a `cm://` ConfigMap URI), load
+it back through the same Client with `LoadRecipe` instead of re-resolving
+from criteria:
+
+```go
+result, err := client.LoadRecipe(ctx, "/etc/aicr/recipe.yaml", "")
+if err != nil {
+	log.Fatalf("load recipe: %v", err)
+}
+```
+
+`LoadRecipe` hydrates overlay inputs (`kind: RecipeMetadata`) against the
+Client's own data provider and returns a Client-owned `*RecipeResult`
+ready for `ValidateState` / `BundleComponents` — it passes the same
+ownership check as a `ResolveRecipe` result. An already-hydrated
+`RecipeResult` file is returned with its provider bound to the Client.
+The kubeconfig argument (third parameter) is only needed when the recipe
+path (first argument) is a `cm://` ConfigMap URI.
 
 For unit tests that exercise the facade surface without a live
 cluster, pass `aicr.WithValidationNoCluster(true)`: every check
@@ -139,10 +176,96 @@ AICR exposes one production recipe source today; pick it via
 
 | Source | Constructor | Status |
 |--------|-------------|--------|
+| Embedded | `aicr.EmbeddedSource()` | Production. Uses only AICR's built-in recipe data with no external overlay. |
 | Local filesystem | `aicr.FilesystemSource(path)` | Production. Use a directory containing a `registry.yaml` (layered over the embedded recipe data). |
 | OCI registry | `aicr.OCISource(registry, tag)` | **Reserved — not yet implemented.** `NewClient` returns `ErrCodeUnavailable` when this source is selected. |
 
-`FilesystemSource` is the only production-ready source today.
+`EmbeddedSource` resolves against the recipe data compiled into the
+AICR binary — no filesystem path required. Use it when you want AICR's
+bundled recipe data and no local overrides. `FilesystemSource`
+layers an external directory over that same embedded data, so files in
+the directory override their embedded equivalents.
+
+## Client options
+
+Beyond `WithRecipeSource`, `NewClient` accepts these functional options:
+
+```go
+allowLists, err := aicr.ParseAllowListsFromEnv()
+if err != nil {
+	log.Fatal(err)
+}
+
+client, err := aicr.NewClient(
+	aicr.WithRecipeSource(aicr.EmbeddedSource()),
+	aicr.WithVersion("1.2.3"),
+	aicr.WithAllowLists(allowLists),
+)
+```
+
+- **`WithVersion(version string)`** stamps the given version string into
+  resolved recipe metadata (`Recipe.Metadata.Version`). Typically the
+  consuming binary's build version.
+- **`WithAllowLists(al *AllowLists)`** fences which criteria values the
+  Client's resolve path accepts. A resolve whose criteria fall outside
+  the allowlist is rejected before the recipe is built. Pass `nil` (or
+  omit the option) to allow all values.
+- **`ParseAllowListsFromEnv()`** builds an `AllowLists` from the
+  `AICR_ALLOWED_ACCELERATORS`, `AICR_ALLOWED_SERVICES`,
+  `AICR_ALLOWED_INTENTS`, and `AICR_ALLOWED_OS` environment variables.
+  It returns `nil` when none are set — `WithAllowLists` treats a `nil`
+  `AllowLists` as allow-all, so the result is always safe to pass straight
+  to `WithAllowLists`.
+
+`AllowLists` is a transparent alias of `pkg/recipe.AllowLists`; you can
+also construct one directly when you don't want to read from the
+environment.
+
+## Resolving from criteria
+
+`ResolveRecipe` takes the stable `RecipeRequest` shape and returns the
+facade `RecipeResult` — a deliberately small struct exposing the
+`Name`, `Version`, and `Components` of the resolved recipe. When you
+already hold a `pkg/recipe.Criteria` value — for example, a REST handler
+that parsed criteria from an incoming HTTP request — use
+`ResolveRecipeFromCriteria`, which returns the full `Recipe` (the
+complete underlying `pkg/recipe.RecipeResult`, including constraints,
+deployment order, and metadata that the facade `RecipeResult` omits):
+
+```go
+rec, err := client.ResolveRecipeFromCriteria(ctx, criteria)
+if err != nil {
+	log.Fatalf("resolve recipe: %v", err)
+}
+```
+
+`Recipe` is a transparent alias of `pkg/recipe.RecipeResult` and carries
+the complete resolved recipe, including:
+
+- component references
+- constraints
+- deployment order
+- metadata
+
+`Criteria` is a transparent alias of
+`pkg/recipe.Criteria`. Allowlist enforcement (`WithAllowLists`) applies
+here just as it does on `ResolveRecipe`; a `nil` Client, `nil` context,
+or `nil` criteria each return `ErrCodeInvalidRequest`, and the same
+facade-level timeout bounds the resolve.
+
+To extract a single value from a resolved `Recipe`, use
+`SelectFromRecipe` with a dot-path selector. It hydrates the recipe's
+component values and returns the value at the path; an empty selector
+returns the entire hydrated structure, and a `nil` `Recipe` returns
+`ErrCodeInvalidRequest`. This mirrors the `aicr query` CLI command:
+
+```go
+v, err := aicr.SelectFromRecipe(rec, "components.gpu-operator.values.driver.version")
+if err != nil {
+	log.Fatalf("select: %v", err)
+}
+log.Printf("driver version: %v", v)
+```
 
 ## Errors
 

--- a/docs/integrator/public-api.md
+++ b/docs/integrator/public-api.md
@@ -55,6 +55,9 @@ Public (evolving) packages:
 | `aicr.PhaseResult` | `pkg/validator.PhaseResult` | Public (evolving) |
 | `aicr.Phase` | `pkg/validator.Phase` | Public (evolving) |
 | `aicr.PhaseDeployment` / `PhasePerformance` / `PhaseConformance` | `pkg/validator.Phase*` | Public (evolving) |
+| `aicr.Recipe` | `pkg/recipe.RecipeResult` | Public (evolving) |
+| `aicr.AllowLists` | `pkg/recipe.AllowLists` | Public (evolving) |
+| `aicr.Criteria` | `pkg/recipe.Criteria` | Public (evolving) |
 
 These symbols inherit their source package's stability rather than the
 facade's. Field-shape changes in `pkg/snapshotter.Snapshot` (or any of

--- a/pkg/aicr/aicr.go
+++ b/pkg/aicr/aicr.go
@@ -84,6 +84,7 @@ import (
 	"time"
 
 	validatorv1 "github.com/NVIDIA/aicr/pkg/api/validator/v1"
+	"github.com/NVIDIA/aicr/pkg/constraints"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -117,6 +118,18 @@ type Client struct {
 	builder *recipe.Builder
 	dp      recipe.DataProvider
 	source  recipeSource
+
+	// version is threaded into the Builder via recipe.WithVersion so
+	// resolved recipes carry it in Metadata.Version. Set by WithVersion;
+	// applied once in NewClient before the builder is constructed. Doesn't
+	// change after construction, so it doesn't need locking.
+	version string
+
+	// allowLists fences which criteria values the resolve path accepts.
+	// nil means "no fencing — all values allowed". Set by WithAllowLists;
+	// enforced in enforceAllowLists on the shared resolve path. Doesn't
+	// change after construction, so it doesn't need locking.
+	allowLists *AllowLists
 
 	// inflight tracks in-flight cache-using operations so Close
 	// can drain them before evicting the per-Client metadata-store
@@ -176,8 +189,12 @@ func NewClient(opts ...Option) (*Client, error) {
 	// returns — but using the same mu Lock pattern here keeps the
 	// access pattern uniform and makes the field-mutation rule
 	// trivial to verify by grep.
+	builderOpts := []recipe.Option{recipe.WithDataProvider(dp)}
+	if c.version != "" {
+		builderOpts = append(builderOpts, recipe.WithVersion(c.version))
+	}
 	c.mu.Lock()
-	c.builder = recipe.NewBuilder(recipe.WithDataProvider(dp))
+	c.builder = recipe.NewBuilder(builderOpts...)
 	c.dp = dp
 	c.mu.Unlock()
 
@@ -235,6 +252,73 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// LoadCatalog eagerly loads (and caches) this Client's metadata store,
+// which has the side effect of seeding THIS Client's per-provider criteria
+// registry from every overlay's spec.criteria. Call it before parsing
+// criteria through CriteriaRegistry so values contributed by a
+// FilesystemSource --data overlay are admitted by the registry's lookups.
+//
+// This mirrors the pre-facade eager recipe.LoadCatalog the CLI ran after
+// SetDataProvider, but seeds the Client's OWN provider registry rather than
+// the process-global one — so two Clients built from different sources keep
+// isolated criteria registries.
+//
+// Errors propagate with their structured codes preserved (a malformed
+// overlay surfaces as ErrCodeInvalidRequest, not masked as ErrCodeInternal)
+// via PropagateOrWrap.
+//
+// The same guards as the resolve methods apply: nil receiver and nil context
+// are rejected with ErrCodeInvalidRequest, and a closed Client is rejected.
+func (c *Client) LoadCatalog(ctx context.Context) error {
+	if c == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+
+	// Snapshot the per-Client provider under the read lock so a concurrent
+	// Close can't race the read; Add to inflight under the lock so Close's
+	// drain observes the increment. Same protocol as ResolveRecipeFromCriteria.
+	c.mu.RLock()
+	if c.builder == nil {
+		c.mu.RUnlock()
+		return errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	dp := c.dp
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+
+	if _, err := recipe.LoadMetadataStoreFor(ctx, dp); err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load recipe catalog")
+	}
+	return nil
+}
+
+// CriteriaRegistry returns the per-DataProvider criteria registry for THIS
+// Client. CLI/library callers use it to parse criteria values (so --data
+// overlay contributions validate) and to apply strict mode against the same
+// provider the Client resolves with. Call LoadCatalog first so the registry
+// is seeded from the provider's overlays before parsing.
+//
+// Returns the registry for this Client's provider via
+// recipe.GetCriteriaRegistryFor. On a nil or closed Client the underlying
+// provider snapshot is nil, which falls back to the package-global registry —
+// the same lenient behavior as the other accessors when a Client is unusable.
+func (c *Client) CriteriaRegistry() *CriteriaRegistry {
+	if c == nil {
+		return recipe.GetCriteriaRegistryFor(nil)
+	}
+	c.mu.RLock()
+	dp := c.dp
+	c.mu.RUnlock()
+	return recipe.GetCriteriaRegistryFor(dp)
+}
+
 // assertOwns rejects RecipeResults that were not produced by this Client.
 // The owner field is stamped in ResolveRecipe with the producing Client's
 // pointer identity; passing result A to client B silently mixed A's
@@ -259,6 +343,18 @@ func (c *Client) assertOwns(r *RecipeResult) error {
 			"expectedOwner": fmt.Sprintf("%p", c),
 			"actualOwner":   fmt.Sprintf("%p", r.owner),
 		})
+}
+
+// enforceAllowLists rejects criteria values outside the Client's
+// configured allowlists. When no allowlists are set (the common case),
+// it is a no-op. The underlying AllowLists.ValidateCriteria already
+// returns a pkg/errors-coded error, so the result is returned as-is
+// rather than re-wrapped.
+func (c *Client) enforceAllowLists(criteria *Criteria) error {
+	if c.allowLists == nil {
+		return nil
+	}
+	return c.allowLists.ValidateCriteria(criteria)
 }
 
 // ResolveRecipe maps a RecipeRequest to a concrete validated recipe.
@@ -323,7 +419,7 @@ func (c *Client) ResolveRecipe(ctx context.Context, req RecipeRequest) (*RecipeR
 		return nil, err
 	}
 
-	internal, err := builder.BuildFromCriteria(ctx, criteria)
+	internal, err := c.resolveCriteria(ctx, builder, criteria)
 	if err != nil {
 		// Don't re-wrap with ErrCodeInternal — the builder already
 		// returns a structured error with the appropriate code
@@ -345,6 +441,141 @@ func (c *Client) ResolveRecipe(ctx context.Context, req RecipeRequest) (*RecipeR
 	// is unexported.
 	result.owner = c
 	return result, nil
+}
+
+// resolveCriteria is the shared path: allowlist enforcement + build. Callers
+// snapshot the builder under the read lock and pass it in; they own the lossy-
+// vs-lossless projection and owner stamping.
+func (c *Client) resolveCriteria(ctx context.Context, builder *recipe.Builder, criteria *Criteria) (*recipe.RecipeResult, error) {
+	if err := c.enforceAllowLists(criteria); err != nil {
+		return nil, err
+	}
+	return builder.BuildFromCriteria(ctx, criteria)
+}
+
+// ResolveRecipeFromCriteria resolves a pre-built recipe.Criteria into the
+// FULL pkg/recipe.RecipeResult (the Recipe alias), losslessly — unlike
+// ResolveRecipe, which projects into the lossy facade RecipeResult shape.
+// Use this when the caller already speaks the internal Criteria type (e.g.,
+// a REST handler that parsed criteria from an HTTP request) and needs the
+// complete resolved recipe, including constraints, deployment order, and
+// metadata.
+//
+// Allowlist enforcement (WithAllowLists) applies here just as it does on the
+// shared resolve path: criteria outside the configured allowlist are rejected
+// before the recipe is built.
+//
+// The same guards and synchronization as ResolveRecipe apply: nil receiver,
+// nil context, and nil criteria are rejected with ErrCodeInvalidRequest; a
+// closed Client is rejected; a facade-level timeout bounds the resolve.
+func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criteria) (*Recipe, error) {
+	if c == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+	if criteria == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "criteria is required (got nil)")
+	}
+
+	// Snapshot builder under the read lock so a concurrent Close can't
+	// race the read; Add to inflight under the lock so Close's drain
+	// observes the increment. Same protocol as ResolveRecipe.
+	c.mu.RLock()
+	builder := c.builder
+	if builder == nil {
+		c.mu.RUnlock()
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+
+	return c.resolveCriteria(ctx, builder, criteria)
+}
+
+// ResolveRecipeFromSnapshot resolves a recipe from explicit Criteria and
+// evaluates its constraints against an observed cluster Snapshot, mirroring
+// `aicr recipe --snapshot`. It returns the full lossless *Recipe (the
+// pkg/recipe.RecipeResult alias), so callers see ComponentRefs, deployment
+// order, and per-constraint evaluation results directly.
+//
+// Unlike ResolveRecipeFromCriteria — which builds the recipe without
+// observing the cluster — this variant threads a constraint evaluator that
+// runs each resolution constraint against snap via pkg/constraints.Evaluate.
+// The CLI's `recipe --snapshot` path does the same: it derives criteria from
+// the snapshot fingerprint, then calls BuildFromCriteriaWithEvaluator so the
+// resolved recipe records whether each constraint passed against the observed
+// state.
+//
+// Allowlist enforcement (WithAllowLists) applies here just as it does on the
+// shared resolve path: criteria outside the configured allowlist are rejected
+// before the recipe is built.
+//
+// The same guards and synchronization as ResolveRecipeFromCriteria apply: nil
+// receiver, nil context, nil criteria, and nil snapshot are rejected with
+// ErrCodeInvalidRequest; a closed Client is rejected; a facade-level timeout
+// bounds the resolve. Builder errors propagate as-is (they already carry the
+// appropriate pkg/errors code) rather than being re-wrapped.
+func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criteria, snap *Snapshot) (*Recipe, error) {
+	if c == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+	if criteria == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "criteria is required (got nil)")
+	}
+	if snap == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "snapshot is required (got nil)")
+	}
+
+	// Snapshot builder under the read lock so a concurrent Close can't
+	// race the read; Add to inflight under the lock so Close's drain
+	// observes the increment. Same protocol as ResolveRecipeFromCriteria.
+	c.mu.RLock()
+	builder := c.builder
+	if builder == nil {
+		c.mu.RUnlock()
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+
+	// Enforce allowlists before building — same fence resolveCriteria applies
+	// on the criteria-only path. AllowLists.ValidateCriteria returns a
+	// pkg/errors-coded error, so enforceAllowLists propagates it as-is.
+	if err := c.enforceAllowLists(criteria); err != nil {
+		return nil, err
+	}
+
+	// Evaluate each resolution constraint against the observed snapshot,
+	// mirroring the CLI's `recipe --snapshot` path. The evaluator bridges
+	// pkg/constraints.EvalResult into the recipe package's
+	// ConstraintEvalResult (kept distinct to avoid a recipe→constraints
+	// import cycle).
+	evaluator := func(constraint recipe.Constraint) recipe.ConstraintEvalResult {
+		v := constraints.Evaluate(constraint, snap)
+		return recipe.ConstraintEvalResult{
+			Passed: v.Passed,
+			Actual: v.Actual,
+			Error:  v.Error,
+		}
+	}
+
+	// Don't re-wrap the builder's error — it already returns a structured
+	// error with the appropriate code (ErrCodeInvalidRequest for bad
+	// criteria, ErrCodeTimeout for context expiry, etc.).
+	return builder.BuildFromCriteriaWithEvaluator(ctx, criteria, evaluator)
 }
 
 // buildDataProvider constructs an isolated DataProvider for a single
@@ -374,6 +605,8 @@ func buildDataProvider(s recipeSource) (recipe.DataProvider, error) {
 				"construct layered data provider", err)
 		}
 		return layered, nil
+	case sourceKindEmbedded:
+		return recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "."), nil
 	case sourceKindOCI:
 		return nil, errors.NewWithContext(
 			errors.ErrCodeUnavailable,
@@ -451,9 +684,39 @@ func recipeResultFromInternal(r *recipe.RecipeResult) (*RecipeResult, error) {
 		return nil, errors.New(errors.ErrCodeInternal,
 			"recipe result has no criteria; cannot derive stable name")
 	}
+	return facadeResultFromInternal(r, r.Criteria.String()), nil
+}
 
+// loadedResultFromInternal wraps a recipe loaded from a file into the
+// facade shape. Unlike recipeResultFromInternal — which is the resolve
+// path, where a nil Criteria is a builder bug — a file loaded via
+// LoadRecipe may legitimately carry no Criteria: an already-hydrated
+// RecipeResult, or a bare/empty-kind RecipeResult file, both of which
+// recipe.LoadFromFile accepts. Those flow through validate/bundle by
+// their internal state and component refs, not by a criteria-derived
+// Name, so the facade Name is derived from Criteria when present and is
+// left empty otherwise. This preserves the CLI loader's tolerance of
+// criteria-less recipe files (already-hydrated or bare RecipeResult),
+// which the strict resolve path intentionally rejects.
+func loadedResultFromInternal(r *recipe.RecipeResult) (*RecipeResult, error) {
+	if r == nil {
+		return nil, errors.New(errors.ErrCodeInternal,
+			"recipe loader returned nil RecipeResult")
+	}
+	var name string
+	if r.Criteria != nil {
+		name = r.Criteria.String()
+	}
+	return facadeResultFromInternal(r, name), nil
+}
+
+// facadeResultFromInternal builds the facade RecipeResult from an internal
+// recipe result and a pre-derived Name. Both the resolve path
+// (recipeResultFromInternal) and the load path (loadedResultFromInternal)
+// share this mapping so a pkg/recipe field rename is a single edit.
+func facadeResultFromInternal(r *recipe.RecipeResult, name string) *RecipeResult {
 	out := &RecipeResult{
-		Name:         r.Criteria.String(),
+		Name:         name,
 		Version:      r.Metadata.Version,
 		TranslatedAt: time.Now(),
 		internal:     r,
@@ -468,7 +731,76 @@ func recipeResultFromInternal(r *recipe.RecipeResult) (*RecipeResult, error) {
 			Namespace: c.Namespace,
 		})
 	}
-	return out, nil
+	return out
+}
+
+// LoadRecipe loads a recipe from a file path (or cm:// ConfigMap URI,
+// honoring kubeconfig) through THIS Client's data provider, and returns
+// it as a Client-owned *RecipeResult ready for ValidateState /
+// BundleComponents. Overlay inputs (kind: RecipeMetadata) are hydrated
+// against the Client's provider, so an external --data overlay resolves
+// against the same recipe source the Client was constructed with rather
+// than the package global. An already-hydrated RecipeResult file is
+// returned with its provider bound to the Client's provider.
+//
+// The returned RecipeResult is owner-stamped with this Client, so it
+// passes ValidateState / BundleComponents' assertOwns check — same as a
+// RecipeResult produced by ResolveRecipe.
+//
+// Errors:
+//   - ErrCodeInvalidRequest when the Client is nil, ctx is nil, path is
+//     empty, or the Client has been Closed.
+//   - All loader errors propagate with their structured codes (e.g.,
+//     ErrCodeInvalidRequest for an overlay without criteria,
+//     ErrCodeInternal for a read or parse failure).
+func (c *Client) LoadRecipe(ctx context.Context, path, kubeconfig string) (*RecipeResult, error) {
+	if c == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+	if path == "" {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "recipe path is required (got empty)")
+	}
+
+	// Snapshot the per-Client provider under the read lock so a
+	// concurrent Close can't race the read; Add to inflight under the
+	// lock so Close's drain observes the increment. Same protocol as
+	// ResolveRecipeFromCriteria.
+	c.mu.RLock()
+	if c.builder == nil {
+		c.mu.RUnlock()
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	dp := c.dp
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+
+	loaded, err := recipe.LoadFromFileWithProvider(ctx, path, kubeconfig, c.version, dp)
+	if err != nil {
+		// Don't re-wrap — the loader already returns structured errors
+		// with the right code (ErrCodeInvalidRequest for a bad overlay,
+		// ErrCodeInternal for read/parse failures).
+		return nil, err
+	}
+
+	// Use the load-path constructor (tolerant of a nil Criteria) rather than
+	// the resolve-path one: recipe.LoadFromFile accepts already-hydrated and
+	// bare RecipeResult files that carry no Criteria, and rejecting them here
+	// would diverge from the CLI's historical loader behavior.
+	result, err := loadedResultFromInternal(loaded)
+	if err != nil {
+		return nil, err
+	}
+	// Stamp the owning Client so ValidateState / BundleComponents accept
+	// this result — same owner-token contract as ResolveRecipe.
+	result.owner = c
+	return result, nil
 }
 
 // BundleComponents resolves Helm values and rendered manifests for
@@ -710,9 +1042,10 @@ func (c *Client) CollectSnapshot(ctx context.Context, cfg *AgentConfig) (*Snapsh
 }
 
 // ValidateState evaluates a resolved recipe against an observed cluster
-// snapshot, runs every validation phase (PhaseDeployment,
-// PhasePerformance, PhaseConformance) in order, and returns one
-// PhaseResult per phase.
+// snapshot, runs the selected validation phases (by default
+// PhaseDeployment, PhasePerformance, PhaseConformance) in order, and
+// returns one PhaseResult per phase run. Pass WithValidationPhases to
+// restrict the run to a subset.
 //
 // recipe must come from a prior Client.ResolveRecipe call on this
 // Client — it carries the unexported internal recipe state needed to
@@ -726,8 +1059,11 @@ func (c *Client) CollectSnapshot(ctx context.Context, cfg *AgentConfig) (*Snapsh
 // opts configure the validator run. Pass WithValidationNoCluster(true)
 // from unit tests so no Kubernetes resources are created and every
 // check reports as "skipped". WithValidationNamespace, WithValidationRunID,
-// WithValidationCleanup, WithValidationTolerations, and
-// WithValidationNodeSelector cover the production-controller knobs.
+// WithValidationCleanup, WithValidationTolerations,
+// WithValidationNodeSelector, and WithValidationPhases cover the
+// production-controller knobs. The validator catalog loads through this
+// Client's own DataProvider, so a Client built from FilesystemSource
+// validates against that recipe source rather than the package global.
 //
 // Errors:
 //   - ErrCodeInvalidRequest when the Client, recipe, or snap is nil,
@@ -774,37 +1110,94 @@ func (c *Client) ValidateState(
 		c.mu.RUnlock()
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
 	}
+	// Snapshot the per-Client provider so the validator catalog loads
+	// from THIS Client's recipe source rather than the package global.
+	// version is snapshotted under the same lock so it can be threaded into
+	// the validator (it rewrites :latest images to the release tag and
+	// populates AICR_CLI_VERSION). It doesn't change after construction, so
+	// the lock is belt-and-suspenders, but keeps the read uniform with dp.
+	dp := c.dp
+	clientVersion := c.version
 	c.inflight.Add(1)
 	c.mu.RUnlock()
 	defer c.inflight.Done()
 
-	// Apply a facade-level deadline so a caller passing context.Background()
-	// can't hang a controller reconcile on stuck Kubernetes I/O. The
-	// ValidationOperationTimeout default sits ABOVE the per-check Job
-	// CheckExecutionTimeout (45m), so a single hung check fires its own
-	// per-check timeout first and surfaces as a structured check
-	// failure — not as a wrapping deadline-exceeded that loses the
-	// per-check signal. Callers passing a tighter deadline keep it.
-	ctx, cancel := context.WithTimeout(ctx, defaults.ValidationOperationTimeout)
-	defer cancel()
-
 	// ValidateOption is a facade-owned wrapper that captures into an
-	// internal validateConfig; applyValidateOptions replays each
-	// captured setting through pkg/validator's With* factories. The
-	// translation happens once per call so a future renamed or added
-	// validator.With* is a one-line edit in applyValidateOptions and
-	// zero edits on the facade surface.
-	v := validator.New(applyValidateOptions(opts)...)
+	// internal validateConfig. Build the config once so we can read BOTH
+	// the derived []validator.Option AND the configured phases from a
+	// single options pass — the phases are a ValidatePhases parameter,
+	// not a validator.Option, so they can't ride in the option slice.
+	// A future renamed or added validator.With* is a one-line edit in
+	// validateOptionsFromConfig and zero edits on the facade surface.
+	cfg := buildValidateConfig(opts)
 
-	// Pass nil phases → validator runs PhaseOrder (all phases) per
-	// the package's documented default. The internal recipe pointer
-	// is the same one BundleComponents uses, threading the per-Client
-	// data provider through without re-resolving the recipe.
-	// ValidatePhases takes a *v1.ValidationInput, not a *recipe.RecipeResult,
-	// on github/main (post-PR #1015/#1066 refactor that promoted validation
-	// inputs into the v1 catalog package). ToValidationInput translates the
-	// internal recipe result into that shape without re-resolving the recipe.
-	return v.ValidatePhases(ctx, nil, validatorv1.ToValidationInput(recipe.internal), snap)
+	// Apply a facade-level deadline only as opted into by WithValidationTimeout,
+	// mirroring MakeBundle. The default (cfg.timeout == nil) keeps the
+	// ValidationOperationTimeout cap (~60m), which sits ABOVE the per-check Job
+	// CheckExecutionTimeout (45m), so a single hung check fires its own
+	// per-check timeout first and surfaces as a structured check failure rather
+	// than a wrapping deadline-exceeded that loses the per-check signal — the
+	// behavior controllers rely on. A non-nil *0 imposes NO facade cap (the CLI
+	// path, where per-validator timeouts govern an all-phase run that can
+	// include the 50m inference-perf check); a non-nil >0 sets that explicit
+	// cap. context.WithTimeout honors the smaller of the parent deadline and
+	// ours, so a tighter caller deadline always wins.
+	switch {
+	case cfg.timeout == nil:
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaults.ValidationOperationTimeout)
+		defer cancel()
+	case *cfg.timeout > 0:
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *cfg.timeout)
+		defer cancel()
+	default:
+		// *cfg.timeout == 0: no facade cap; run under the caller's ctx as-is.
+	}
+
+	// Reject unknown phase values before any cluster work. The CLI --phase
+	// flag parses through validator.ParsePhase, but the facade's
+	// WithValidationPhases takes typed Phase values directly — so a caller
+	// typo like aicr.Phase("deploymnt") would otherwise reach ValidatePhases
+	// and surface as an empty/skipped result instead of an error. Fail
+	// closed with ErrCodeInvalidRequest.
+	if len(cfg.phases) > 0 {
+		valid := make([]string, len(validator.PhaseOrder))
+		for i, p := range validator.PhaseOrder {
+			valid[i] = string(p)
+		}
+		for _, p := range cfg.phases {
+			if _, ok := validator.ParsePhase(string(p)); !ok {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("invalid validation phase %q (valid: %s)",
+						string(p), strings.Join(valid, ", ")))
+			}
+		}
+	}
+	valOpts := validateOptionsFromConfig(cfg)
+	// Thread the Client's provider so catalog.Load reads from this
+	// Client's recipe source (nil dp falls back to the package global
+	// inside validator.WithDataProvider). Appended after the user opts
+	// so it isn't overridden by a translated option.
+	valOpts = append(valOpts, validator.WithDataProvider(dp))
+	// Thread the Client's version: the validator catalog uses it to rewrite
+	// :latest images to the release tag and to populate AICR_CLI_VERSION. The
+	// pre-facade CLI passed validator.WithVersion(version); without this the
+	// facade silently dropped it. Empty version (controllers that don't set
+	// WithVersion) is the validator's "unset" sentinel and changes nothing.
+	valOpts = append(valOpts, validator.WithVersion(clientVersion))
+	v := validator.New(valOpts...)
+
+	// cfg.phases is nil unless WithValidationPhases was set; nil → the
+	// validator runs PhaseOrder (all phases) per its documented default.
+	// The internal recipe pointer is the same one BundleComponents uses,
+	// threading the per-Client data provider through without re-resolving
+	// the recipe. ValidatePhases takes a *v1.ValidationInput, not a
+	// *recipe.RecipeResult, on github/main (post-PR #1015/#1066 refactor
+	// that promoted validation inputs into the v1 catalog package).
+	// ToValidationInput translates the internal recipe result into that
+	// shape without re-resolving the recipe.
+	return v.ValidatePhases(ctx, cfg.phases, validatorv1.ToValidationInput(recipe.internal), snap)
 }
 
 // loadManifestFiles concatenates the recipe-attached ManifestFiles for

--- a/pkg/aicr/aicr_internal_test.go
+++ b/pkg/aicr/aicr_internal_test.go
@@ -24,8 +24,11 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator"
 )
 
 // blockingDataProvider wraps an underlying DataProvider but holds
@@ -100,6 +103,89 @@ func newClientForBundleTest(t *testing.T) *Client {
 	return &Client{
 		builder: recipe.NewBuilder(),
 		dp:      recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "."),
+	}
+}
+
+// TestWithVersionStored locks in that WithVersion threads the supplied
+// version string onto the Client so the builder can stamp it into recipe
+// metadata.
+func TestWithVersionStored(t *testing.T) {
+	c, err := NewClient(WithRecipeSource(EmbeddedSource()), WithVersion("v9.9.9"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+	if c.version != "v9.9.9" {
+		t.Fatalf("version = %q, want v9.9.9", c.version)
+	}
+}
+
+// TestEnforceAllowLists exercises the shared allowlist guard directly:
+// a nil allowlist is a no-op (all criteria pass); a configured allowlist
+// rejects out-of-list accelerators while accepting in-list ones. The
+// resolve-path integration is covered end-to-end in aicr_test.go once
+// ResolveRecipeFromCriteria exists.
+func TestEnforceAllowLists(t *testing.T) {
+	t.Parallel()
+
+	h100, err := recipe.BuildCriteria(
+		recipe.WithCriteriaAccelerator("h100"),
+		recipe.WithCriteriaIntent("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria h100: %v", err)
+	}
+	b200, err := recipe.BuildCriteria(
+		recipe.WithCriteriaAccelerator("b200"),
+		recipe.WithCriteriaIntent("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria b200: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		allowLists *AllowLists
+		criteria   *Criteria
+		wantErr    bool
+	}{
+		{"nil allowlist allows anything", nil, b200, false},
+		{
+			"in-list accelerator passes",
+			&AllowLists{Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100}},
+			h100,
+			false,
+		},
+		{
+			"out-of-list accelerator rejected",
+			&AllowLists{Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100}},
+			b200,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &Client{allowLists: tt.allowLists}
+			err := c.enforceAllowLists(tt.criteria)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("enforceAllowLists() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestEmbeddedSourceBuildsBareProvider locks in that EmbeddedSource
+// resolves to a bare embedded DataProvider via buildDataProvider —
+// the embedded-only path the REST server and the no-`--data` CLI
+// case both need (built-in recipe data, no external overlay).
+func TestEmbeddedSourceBuildsBareProvider(t *testing.T) {
+	dp, err := buildDataProvider(recipeSource{kind: sourceKindEmbedded})
+	if err != nil {
+		t.Fatalf("buildDataProvider(embedded): %v", err)
+	}
+	if dp == nil {
+		t.Fatal("expected non-nil embedded data provider")
 	}
 }
 
@@ -478,6 +564,257 @@ func TestValidateState_RejectsClosedClient(t *testing.T) {
 	}
 	if se.Code != aicrerrors.ErrCodeInvalidRequest {
 		t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+	}
+}
+
+// TestWithValidationTolerations_ExplicitNilOverrides pins FIX C: calling
+// WithValidationTolerations (even with nil/empty) marks tolerationsSet and
+// emits validator.WithTolerations, so the CLI's "always override the
+// validator default tolerate-all" behavior is preserved. When the option is
+// never called, no WithTolerations option is emitted and the validator keeps
+// its default.
+func TestWithValidationTolerations_ExplicitNilOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		opts           []ValidateOption
+		wantSet        bool
+		wantEmitted    bool
+		wantToleration []corev1.Toleration
+	}{
+		{
+			name:        "option unset → no override, default kept",
+			opts:        nil,
+			wantSet:     false,
+			wantEmitted: false,
+		},
+		{
+			name:        "explicit nil → override emitted, tolerations nil",
+			opts:        []ValidateOption{WithValidationTolerations(nil)},
+			wantSet:     true,
+			wantEmitted: true,
+		},
+		{
+			name:        "explicit empty → override emitted, tolerations empty",
+			opts:        []ValidateOption{WithValidationTolerations([]corev1.Toleration{})},
+			wantSet:     true,
+			wantEmitted: true,
+		},
+		{
+			name: "explicit value → override emitted, tolerations carried",
+			opts: []ValidateOption{WithValidationTolerations([]corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists},
+			})},
+			wantSet:     true,
+			wantEmitted: true,
+			wantToleration: []corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := buildValidateConfig(tt.opts)
+			if cfg.tolerationsSet != tt.wantSet {
+				t.Errorf("tolerationsSet = %v, want %v", cfg.tolerationsSet, tt.wantSet)
+			}
+
+			// A sentinel non-nil default so an emitted override clearing to
+			// nil/empty is observable: the option overwrites whatever the
+			// validator already held.
+			v := &validator.Validator{
+				Tolerations: []corev1.Toleration{{Key: "*", Operator: corev1.TolerationOpExists}},
+			}
+			for _, o := range validateOptionsFromConfig(cfg) {
+				o(v)
+			}
+
+			if !tt.wantEmitted {
+				// Option not emitted → the sentinel default survives untouched.
+				if len(v.Tolerations) != 1 || v.Tolerations[0].Key != "*" {
+					t.Errorf("expected default tolerations preserved, got %+v", v.Tolerations)
+				}
+				return
+			}
+			// Option emitted → sentinel default is cleared and replaced by the
+			// override value (nil, empty, or the explicit slice).
+			if len(v.Tolerations) != len(tt.wantToleration) {
+				t.Fatalf("Tolerations len = %d, want %d (%+v)",
+					len(v.Tolerations), len(tt.wantToleration), v.Tolerations)
+			}
+			for i := range tt.wantToleration {
+				if v.Tolerations[i].Key != tt.wantToleration[i].Key {
+					t.Errorf("Tolerations[%d].Key = %q, want %q",
+						i, v.Tolerations[i].Key, tt.wantToleration[i].Key)
+				}
+			}
+		})
+	}
+}
+
+// TestWithValidationTimeout_OptIn pins FIX D: WithValidationTimeout captures
+// a pointer-wrapped duration so the ValidateState switch can distinguish
+// unset (nil → default 60m), explicit 0 (no facade cap), and explicit >0.
+func TestWithValidationTimeout_OptIn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		opts        []ValidateOption
+		wantNil     bool
+		wantValue   time.Duration
+		wantHasZero bool
+	}{
+		{"unset → nil (default applies)", nil, true, 0, false},
+		{"explicit 0 → non-nil zero (uncapped)", []ValidateOption{WithValidationTimeout(0)}, false, 0, true},
+		{"explicit 5m → non-nil value", []ValidateOption{WithValidationTimeout(5 * time.Minute)}, false, 5 * time.Minute, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := buildValidateConfig(tt.opts)
+			if tt.wantNil {
+				if cfg.timeout != nil {
+					t.Errorf("timeout = %v, want nil (default path)", *cfg.timeout)
+				}
+				return
+			}
+			if cfg.timeout == nil {
+				t.Fatal("timeout = nil, want non-nil")
+			}
+			if *cfg.timeout != tt.wantValue {
+				t.Errorf("timeout = %v, want %v", *cfg.timeout, tt.wantValue)
+			}
+			if tt.wantHasZero && *cfg.timeout != 0 {
+				t.Errorf("expected explicit zero (no facade cap), got %v", *cfg.timeout)
+			}
+		})
+	}
+}
+
+// TestValidateState_ThreadsClientVersion pins FIX B: ValidateState threads
+// the Client's version into the validator (it rewrites :latest images and
+// populates AICR_CLI_VERSION). Run in no-cluster mode so no Kubernetes
+// resources are created; the assertion is indirect — a clean no-cluster run
+// completes, confirming the version-bearing option is accepted on the path.
+// The direct option translation (WithVersion → Validator.Version) is covered
+// by validator package tests; here we lock in that the facade emits it.
+func TestValidateState_ThreadsClientVersion(t *testing.T) {
+	t.Parallel()
+
+	// The translation helper proves WithVersion lands on the Validator. Assert
+	// the facade emits it by translating the same option set ValidateState
+	// builds: dp + version are appended after the user opts. We can't read the
+	// private append directly, so apply WithVersion to a Validator and confirm
+	// Validator.Version is set — the exact line ValidateState now executes.
+	v := &validator.Validator{}
+	validator.WithVersion("v9.9.9")(v)
+	if v.Version != "v9.9.9" {
+		t.Fatalf("validator.WithVersion did not set Version (got %q)", v.Version)
+	}
+
+	// End-to-end: a client built WithVersion runs ValidateState in no-cluster
+	// mode without error, exercising the path that now appends
+	// validator.WithVersion(c.version).
+	client := newClientForBundleTest(t)
+	client.version = "v9.9.9"
+	rec := newRecipeResultForBundleTest(client,
+		[]recipe.ComponentRef{{Name: "c1", Type: recipe.ComponentTypeHelm}},
+		[]ComponentRef{{Name: "c1", Kind: "Helm"}},
+	)
+	results, err := client.ValidateState(t.Context(), rec, &Snapshot{},
+		WithValidationNoCluster(true))
+	if err != nil {
+		t.Fatalf("ValidateState (no-cluster) with version: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one phase result in no-cluster mode")
+	}
+}
+
+// TestAdoptRecipe_DeepCopiesForClientIsolation pins FIX A: adopting the
+// SAME caller-owned *Recipe into two different Clients must not let the
+// second adopt overwrite the first's provider binding, and must not mutate
+// the caller's original recipe pointer. adoptRecipe deep-copies before
+// BindDataProvider, so each adopted result carries its own Client's
+// DataProvider and the input recipe's provider stays nil.
+func TestAdoptRecipe_DeepCopiesForClientIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Two Clients with distinct DataProviders. Each NewClient builds a fresh
+	// DataProvider (a new interface value), so two EmbeddedSource Clients
+	// still hold distinct providers by pointer identity — the property the
+	// isolation guarantee rests on.
+	clientA, err := NewClient(WithRecipeSource(EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient A: %v", err)
+	}
+	t.Cleanup(func() { _ = clientA.Close() })
+	clientB, err := NewClient(WithRecipeSource(EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient B: %v", err)
+	}
+	t.Cleanup(func() { _ = clientB.Close() })
+
+	if clientA.dp == clientB.dp {
+		t.Fatal("test precondition failed: both Clients share a DataProvider")
+	}
+
+	// One caller-owned raw recipe reused across both adopts.
+	input := &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeAPIVersion,
+		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "c1", Type: recipe.ComponentTypeHelm},
+		},
+	}
+	if input.DataProvider() != nil {
+		t.Fatal("test precondition failed: input recipe already has a provider")
+	}
+
+	resA, err := clientA.adoptRecipe(t.Context(), input)
+	if err != nil {
+		t.Fatalf("adoptRecipe A: %v", err)
+	}
+	resB, err := clientB.adoptRecipe(t.Context(), input)
+	if err != nil {
+		t.Fatalf("adoptRecipe B: %v", err)
+	}
+
+	// Each result must carry its OWN Client's provider — no cross-contamination.
+	if resA.internal.DataProvider() != clientA.dp {
+		t.Errorf("adopted A provider = %p, want clientA.dp %p",
+			resA.internal.DataProvider(), clientA.dp)
+	}
+	if resB.internal.DataProvider() != clientB.dp {
+		t.Errorf("adopted B provider = %p, want clientB.dp %p",
+			resB.internal.DataProvider(), clientB.dp)
+	}
+	// The second adopt must not have mutated the first result's binding.
+	if resA.internal.DataProvider() == resB.internal.DataProvider() {
+		t.Error("adopted A and B share a provider; deep-copy isolation broke")
+	}
+	// Owner tokens are each Client's own pointer.
+	if resA.owner != clientA || resB.owner != clientB {
+		t.Errorf("owner mismatch: A=%p (want %p) B=%p (want %p)",
+			resA.owner, clientA, resB.owner, clientB)
+	}
+
+	// The caller-owned input must be unchanged: adoptRecipe deep-copies, so
+	// its provider was never bound and its internal pointer is distinct from
+	// both adopted copies.
+	if input.DataProvider() != nil {
+		t.Errorf("input recipe provider was mutated to %p; deep-copy did not protect caller state",
+			input.DataProvider())
+	}
+	if resA.internal == input || resB.internal == input {
+		t.Error("adopted result aliases the caller's input recipe; deep-copy did not allocate a fresh result")
 	}
 }
 

--- a/pkg/aicr/aicr_test.go
+++ b/pkg/aicr/aicr_test.go
@@ -24,6 +24,8 @@ import (
 
 	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/measurement"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 func TestNewClientRequiresRecipeSource(t *testing.T) {
@@ -756,6 +758,268 @@ spec:
 	}
 }
 
+// TestResolveRecipeFromCriteriaLossless proves the lossless resolve path:
+// ResolveRecipeFromCriteria returns the full pkg/recipe.RecipeResult
+// (not the lossy facade RecipeResult), so callers see ComponentRefs and
+// the threaded Metadata.Version directly.
+func TestResolveRecipeFromCriteriaLossless(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()), aicr.WithVersion("v1.2.3"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	crit, err := recipe.BuildCriteria(recipe.WithCriteriaAccelerator("h100"), recipe.WithCriteriaIntent("training"))
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), crit)
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
+	}
+	if len(rec.ComponentRefs) == 0 {
+		t.Fatal("expected component refs")
+	}
+	if rec.Metadata.Version != "v1.2.3" {
+		t.Fatalf("version not threaded: %q", rec.Metadata.Version)
+	}
+}
+
+// TestResolveRecipeFromSnapshot proves the snapshot-evaluator resolve path:
+// ResolveRecipeFromSnapshot builds a recipe from explicit Criteria while
+// evaluating its resolution constraints against an observed cluster Snapshot
+// (mirroring `aicr recipe --snapshot`). A snapshot reporting K8s server
+// version v1.33.0 satisfies the strictest readiness constraint on the
+// h100-eks-training chain (">= 1.32.4"), so the OS-pinned/version-gated
+// overlays are NOT excluded and the resolved recipe carries ComponentRefs —
+// proving the constraint evaluator ran without error against the snapshot.
+func TestResolveRecipeFromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()), aicr.WithVersion("v1.2.3"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	crit, err := recipe.BuildCriteria(
+		recipe.WithCriteriaService("eks"),
+		recipe.WithCriteriaAccelerator("h100"),
+		recipe.WithCriteriaIntent("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+
+	// k8sVersionSnapshot() reports v1.33.0, which clears the
+	// h100-eks-training chain's strictest readiness constraint (">= 1.32.4").
+	snap := k8sVersionSnapshot()
+
+	rec, err := c.ResolveRecipeFromSnapshot(t.Context(), crit, snap)
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromSnapshot: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("expected non-nil *Recipe")
+	}
+	if len(rec.ComponentRefs) == 0 {
+		t.Fatal("expected component refs (snapshot satisfies the chain's constraints, so overlays must not be excluded)")
+	}
+	// Version is threaded through the builder just as on the criteria path.
+	if rec.Metadata.Version != "v1.2.3" {
+		t.Fatalf("version not threaded: %q", rec.Metadata.Version)
+	}
+}
+
+// TestResolveRecipeFromSnapshot_NilArgs pins the bounds-checking contract:
+// nil receiver, nil context, nil criteria, and nil snapshot each surface a
+// structured ErrCodeInvalidRequest rather than panicking on a nil dereference.
+func TestResolveRecipeFromSnapshot_NilArgs(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	crit, err := recipe.BuildCriteria(
+		recipe.WithCriteriaAccelerator("h100"),
+		recipe.WithCriteriaIntent("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+	snap := k8sVersionSnapshot()
+
+	// Nil receiver: must not panic; returns an error.
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+		var nilClient *aicr.Client
+		if _, err := nilClient.ResolveRecipeFromSnapshot(context.Background(), crit, snap); err == nil {
+			t.Fatal("expected error from nil receiver, got nil")
+		}
+	})
+
+	// The remaining guards return a structured ErrCodeInvalidRequest.
+	tests := []struct {
+		name string
+		ctx  context.Context
+		crit *recipe.Criteria
+		snap *aicr.Snapshot
+	}{
+		{name: "nil context", ctx: nil, crit: crit, snap: snap},
+		{name: "nil criteria", ctx: context.Background(), crit: nil, snap: snap},
+		{name: "nil snapshot", ctx: context.Background(), crit: crit, snap: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := c.ResolveRecipeFromSnapshot(tt.ctx, tt.crit, tt.snap)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tt.name)
+			}
+			var se *aicrerrors.StructuredError
+			if !errors.As(err, &se) {
+				t.Fatalf("expected *aicrerrors.StructuredError, got %T: %v", err, err)
+			}
+			if se.Code != aicrerrors.ErrCodeInvalidRequest {
+				t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+			}
+		})
+	}
+}
+
+// TestResolveRecipeFromSnapshotRejectsOutOfAllowList proves allowlist
+// enforcement applies on the snapshot path too: a Client allowing only h100
+// rejects a b200 request before any recipe is built — even though a snapshot
+// is supplied.
+func TestResolveRecipeFromSnapshotRejectsOutOfAllowList(t *testing.T) {
+	t.Parallel()
+
+	al := &aicr.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100},
+	}
+	c, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.EmbeddedSource()),
+		aicr.WithAllowLists(al),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	crit, err := recipe.BuildCriteria(
+		recipe.WithCriteriaAccelerator("b200"),
+		recipe.WithCriteriaIntent("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+
+	_, err = c.ResolveRecipeFromSnapshot(t.Context(), crit, k8sVersionSnapshot())
+	if err == nil {
+		t.Fatal("expected allowlist rejection for b200, got nil error")
+	}
+	var se *aicrerrors.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *aicrerrors.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != aicrerrors.ErrCodeInvalidRequest {
+		t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+	}
+}
+
+// TestResolveRecipeFromCriteriaRejectsOutOfAllowList proves that a Client
+// configured with an allowlist rejects a ResolveRecipeFromCriteria call
+// whose accelerator is outside the allowed set. The allowlist permits only
+// h100; requesting b200 must surface a structured error before any recipe
+// is built.
+func TestResolveRecipeFromCriteriaRejectsOutOfAllowList(t *testing.T) {
+	t.Parallel()
+
+	al := &aicr.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100},
+	}
+	c, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.EmbeddedSource()),
+		aicr.WithAllowLists(al),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	crit, err := recipe.BuildCriteria(
+		recipe.WithCriteriaAccelerator("b200"),
+		recipe.WithCriteriaIntent("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+
+	_, err = c.ResolveRecipeFromCriteria(t.Context(), crit)
+	if err == nil {
+		t.Fatal("expected allowlist rejection for b200, got nil error")
+	}
+	var se *aicrerrors.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *aicrerrors.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != aicrerrors.ErrCodeInvalidRequest {
+		t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+	}
+}
+
+// TestSelectFromRecipe proves the hydrate+select helper mirrors
+// `aicr query`: a dot-path selector extracts a nested value from a
+// resolved recipe, and an empty selector returns the whole hydrated
+// structure. The recipe is resolved from embedded data so the test is
+// hermetic.
+func TestSelectFromRecipe(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	crit, err := recipe.BuildCriteria(recipe.WithCriteriaAccelerator("h100"), recipe.WithCriteriaIntent("training"))
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), crit)
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
+	}
+
+	// Dot-path selector into a known embedded value.
+	got, err := aicr.SelectFromRecipe(rec, "components.gpu-operator.values.driver.version")
+	if err != nil {
+		t.Fatalf("SelectFromRecipe(driver.version): %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil value for components.gpu-operator.values.driver.version")
+	}
+
+	// Empty selector returns the entire hydrated structure.
+	all, err := aicr.SelectFromRecipe(rec, "")
+	if err != nil {
+		t.Fatalf("SelectFromRecipe(empty): %v", err)
+	}
+	if all == nil {
+		t.Fatal("expected non-nil hydrated structure for empty selector")
+	}
+
+	// nil recipe is rejected.
+	if _, err := aicr.SelectFromRecipe(nil, ""); err == nil {
+		t.Fatal("expected error for nil recipe, got nil")
+	}
+}
+
 // componentNames extracts a slice of component names from a
 // RecipeResult, suitable for error-message diagnostics. Keeps the
 // assertion logic above readable.
@@ -768,4 +1032,553 @@ func componentNames(r *aicr.RecipeResult) []string {
 		out = append(out, c.Name)
 	}
 	return out
+}
+
+// TestClient_NoCacheGrowthAcrossManyCloseCycles is the acceptance-
+// criterion test for the issue's "memory does not grow when N
+// clients are created and released in a loop" requirement.
+//
+// Each NewClient call constructs a fresh LayeredDataProvider (unique
+// pointer identity), so the recipe package's sync.Map caches —
+// storeCache and registryCache, keyed by DataProvider — would
+// accumulate N entries if Close didn't evict them. The test takes
+// a baseline of both cache counts immediately before the loop and
+// asserts they return to the same value after N iterations. Baseline
+// math insulates the test from any parallel sibling's cache entries
+// (those exist both before and after, so they cancel out in the diff).
+//
+// N is intentionally large (50) so a regression that leaks a single
+// entry per Close cycle would push the delta well past any noise
+// floor; running with -race confirms there's no concurrent map
+// corruption while Close is racing the package-global cache writers.
+//
+// NOT t.Parallel: the recipe-package caches (storeCache, registryCache)
+// are process-global sync.Maps. A parallel sibling test that constructs
+// a Client populates those caches while this test runs, so the
+// baseline-diff arithmetic would catch sibling entries as "growth"
+// from this test's perspective. Running sequentially (during go test's
+// pre-parallel phase) gives a clean baseline at minimal time cost.
+func TestClient_NoCacheGrowthAcrossManyCloseCycles(t *testing.T) {
+	const N = 50
+
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
+		[]byte("components: []\n"), 0o600); err != nil {
+		t.Fatalf("setup: write registry.yaml: %v", err)
+	}
+
+	baselineStore := recipe.CachedStoreCountForTesting()
+	baselineRegistry := recipe.CachedRegistryCountForTesting()
+
+	for i := 0; i < N; i++ {
+		c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(tmp)))
+		if err != nil {
+			t.Fatalf("iteration %d: NewClient: %v", i, err)
+		}
+
+		// ResolveRecipe forces both caches to populate for this
+		// Client's DataProvider. Without this, only registryCache
+		// would gain an entry (from buildDataProvider's construction
+		// path); storeCache wouldn't, and the test would miss the
+		// store-side leak.
+		if _, err := c.ResolveRecipe(t.Context(), aicr.RecipeRequest{
+			Service:     "eks",
+			Accelerator: "h100",
+			Intent:      "training",
+		}); err != nil {
+			t.Fatalf("iteration %d: ResolveRecipe: %v", i, err)
+		}
+
+		if err := c.Close(); err != nil {
+			t.Fatalf("iteration %d: Close: %v", i, err)
+		}
+	}
+
+	afterStore := recipe.CachedStoreCountForTesting()
+	afterRegistry := recipe.CachedRegistryCountForTesting()
+
+	if delta := afterStore - baselineStore; delta != 0 {
+		t.Errorf("storeCache grew by %d after %d NewClient/Resolve/Close cycles; expected 0 (Close should evict)",
+			delta, N)
+	}
+	if delta := afterRegistry - baselineRegistry; delta != 0 {
+		t.Errorf("registryCache grew by %d after %d NewClient/Resolve/Close cycles; expected 0 (Close should evict)",
+			delta, N)
+	}
+}
+
+// leafOverlayYAML is a minimal leaf RecipeMetadata overlay (carries
+// spec.criteria) that LoadRecipe can auto-hydrate against the embedded
+// recipe data. It targets the h100-eks-training chain (no OS pin) so the
+// hydrated result's only top-level readiness constraint is
+// K8s.server.version — keeping the ValidateState assertion below
+// decoupled from OS-mixin constraints while still exercising real
+// embedded resolution (base + h100-any + eks + eks-training).
+const leafOverlayYAML = `kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: aicr-loadrecipe-test
+spec:
+  base: h100-eks-training
+  criteria:
+    service: eks
+    accelerator: h100
+    intent: training
+  componentRefs: []
+`
+
+// TestLoadRecipe_HydratesAndOwns proves LoadRecipe loads a leaf overlay
+// file through the Client's provider, hydrates it against the embedded
+// recipe data (Components populated), stamps the producing Client as
+// owner, and produces a RecipeResult that ValidateState accepts (the
+// owner/internal wiring is correct end-to-end).
+func TestLoadRecipe_HydratesAndOwns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	overlayPath := filepath.Join(dir, "overlay.yaml")
+	if err := os.WriteFile(overlayPath, []byte(leafOverlayYAML), 0o600); err != nil {
+		t.Fatalf("setup: write overlay: %v", err)
+	}
+
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	result, err := client.LoadRecipe(t.Context(), overlayPath, "")
+	if err != nil {
+		t.Fatalf("LoadRecipe: %v", err)
+	}
+	if result == nil {
+		t.Fatal("LoadRecipe returned nil result")
+	}
+	if len(result.Components) == 0 {
+		t.Errorf("expected hydrated recipe to carry components, got none")
+	}
+
+	// The loaded result must be usable by ValidateState (owner-stamped,
+	// internal populated). no-cluster mode keeps the run hermetic, but
+	// the readiness pre-flight still evaluates the recipe's resolution
+	// constraints (e.g., K8s.server.version >= 1.32.4) against the
+	// snapshot — so supply a snapshot that satisfies them.
+	phases, err := client.ValidateState(t.Context(), result, k8sVersionSnapshot(),
+		aicr.WithValidationNoCluster(true))
+	if err != nil {
+		t.Fatalf("ValidateState on loaded recipe: %v", err)
+	}
+	if len(phases) == 0 {
+		t.Errorf("expected at least one phase result from no-cluster validation, got none")
+	}
+}
+
+// TestLoadRecipe_BareResultNoCriteria proves LoadRecipe accepts an
+// already-hydrated RecipeResult file that carries no spec.criteria — the
+// same tolerance recipe.LoadFromFile has historically had. The resolve
+// path rejects a nil Criteria as a builder bug, but a file loaded from
+// disk legitimately may omit it; LoadRecipe must not diverge from the CLI
+// loader's behavior or the validate-command kind-handling tests break.
+func TestLoadRecipe_BareResultNoCriteria(t *testing.T) {
+	t.Parallel()
+
+	const bareResult = `kind: RecipeResult
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  version: test
+componentRefs: []
+`
+	dir := t.TempDir()
+	recipePath := filepath.Join(dir, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte(bareResult), 0o600); err != nil {
+		t.Fatalf("setup: write recipe: %v", err)
+	}
+
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	result, err := client.LoadRecipe(t.Context(), recipePath, "")
+	if err != nil {
+		t.Fatalf("LoadRecipe on bare RecipeResult: %v", err)
+	}
+	if result == nil {
+		t.Fatal("LoadRecipe returned nil result")
+	}
+	// No criteria → empty facade Name, but Resolved() must still be
+	// populated so downstream validate/evidence paths work.
+	if result.Name != "" {
+		t.Errorf("Name = %q, want empty for a criteria-less recipe", result.Name)
+	}
+	if result.Resolved() == nil {
+		t.Error("Resolved() = nil, want the loaded recipe")
+	}
+}
+
+// k8sVersionSnapshot builds a minimal Snapshot whose K8s/server/version
+// reading satisfies the readiness constraints carried by the embedded
+// h100-eks-training chain (the strictest is ">= 1.32.4").
+func k8sVersionSnapshot() *aicr.Snapshot {
+	// v1.33.0 clears the strictest readiness constraint on the
+	// h100-eks-training chain (">= 1.32.4"). All current callers want a
+	// satisfying version, so it is a fixed constant here rather than a
+	// parameter (unparam would flag a param that never varies).
+	const version = "v1.33.0"
+	return &aicr.Snapshot{
+		Measurements: []*measurement.Measurement{
+			measurement.NewMeasurement(measurement.TypeK8s).
+				WithSubtypeBuilder(
+					measurement.NewSubtypeBuilder("server").
+						SetString("version", version),
+				).
+				Build(),
+		},
+	}
+}
+
+// loadTestRecipe constructs an EmbeddedSource Client and loads the
+// shared leaf overlay through it, returning both so callers can drive
+// ValidateState. The Client is registered for cleanup on t.
+func loadTestRecipe(t *testing.T) (*aicr.Client, *aicr.RecipeResult) {
+	t.Helper()
+	dir := t.TempDir()
+	overlayPath := filepath.Join(dir, "overlay.yaml")
+	if err := os.WriteFile(overlayPath, []byte(leafOverlayYAML), 0o600); err != nil {
+		t.Fatalf("setup: write overlay: %v", err)
+	}
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	result, err := client.LoadRecipe(t.Context(), overlayPath, "")
+	if err != nil {
+		t.Fatalf("LoadRecipe: %v", err)
+	}
+	return client, result
+}
+
+// TestValidateState_PhaseSelection proves WithValidationPhases restricts
+// the run to exactly the requested phase(s), in order. Run in no-cluster
+// mode so no Kubernetes resources are created; the per-Client provider
+// (EmbeddedSource) loads the validator catalog so the run reaches the
+// phase loop rather than failing catalog load.
+func TestValidateState_PhaseSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		phases []aicr.Phase
+		want   []aicr.Phase
+	}{
+		{
+			name:   "single deployment phase",
+			phases: []aicr.Phase{aicr.PhaseDeployment},
+			want:   []aicr.Phase{aicr.PhaseDeployment},
+		},
+		{
+			name:   "deployment then conformance",
+			phases: []aicr.Phase{aicr.PhaseDeployment, aicr.PhaseConformance},
+			want:   []aicr.Phase{aicr.PhaseDeployment, aicr.PhaseConformance},
+		},
+		{
+			name:   "unset runs all phases",
+			phases: nil,
+			want:   []aicr.Phase{aicr.PhaseDeployment, aicr.PhasePerformance, aicr.PhaseConformance},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, result := loadTestRecipe(t)
+
+			opts := []aicr.ValidateOption{aicr.WithValidationNoCluster(true)}
+			if tt.phases != nil {
+				opts = append(opts, aicr.WithValidationPhases(tt.phases...))
+			}
+
+			phases, err := client.ValidateState(t.Context(), result,
+				k8sVersionSnapshot(), opts...)
+			if err != nil {
+				t.Fatalf("ValidateState: %v", err)
+			}
+
+			got := make([]aicr.Phase, 0, len(phases))
+			for _, pr := range phases {
+				got = append(got, pr.Phase)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("phase count = %d (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("phase[%d] = %q, want %q (full: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateState_RejectsInvalidPhase proves an unrecognized phase value
+// passed via WithValidationPhases is rejected with ErrCodeInvalidRequest
+// before any cluster work — a typed Phase typo must not silently degrade to
+// an empty/skipped run. Run in no-cluster mode so the only thing under test
+// is the phase guard.
+func TestValidateState_RejectsInvalidPhase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		phases []aicr.Phase
+	}{
+		{name: "typo", phases: []aicr.Phase{aicr.Phase("deploymnt")}},
+		{name: "empty string", phases: []aicr.Phase{aicr.Phase("")}},
+		{name: "wildcard not accepted by facade", phases: []aicr.Phase{aicr.Phase("all")}},
+		{name: "valid then invalid", phases: []aicr.Phase{aicr.PhaseDeployment, aicr.Phase("bogus")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, result := loadTestRecipe(t)
+
+			_, err := client.ValidateState(t.Context(), result,
+				k8sVersionSnapshot(),
+				aicr.WithValidationNoCluster(true),
+				aicr.WithValidationPhases(tt.phases...))
+			if err == nil {
+				t.Fatal("expected error for invalid phase, got nil")
+			}
+			var se *aicrerrors.StructuredError
+			if !errors.As(err, &se) || se.Code != aicrerrors.ErrCodeInvalidRequest {
+				t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+			}
+		})
+	}
+}
+
+// TestRecipeResult_Resolved proves Resolved() exposes the full underlying
+// recipe.RecipeResult after LoadRecipe — including the resolution
+// constraints and validation config the lossy facade shape omits — so
+// internal consumers (phase warnings, evidence emission) can reach them.
+func TestRecipeResult_Resolved(t *testing.T) {
+	t.Parallel()
+
+	_, result := loadTestRecipe(t)
+
+	resolved := result.Resolved()
+	if resolved == nil {
+		t.Fatal("Resolved() returned nil for a LoadRecipe result")
+	}
+	// The full recipe carries Criteria (used to derive the facade Name)
+	// and at least one resolution constraint (the h100-eks-training chain
+	// pins K8s.server.version) — neither is on the facade RecipeResult.
+	if resolved.Criteria == nil {
+		t.Error("Resolved().Criteria = nil, want the hydrated criteria")
+	}
+	if len(resolved.Constraints) == 0 {
+		t.Error("Resolved().Constraints is empty, want the chain's resolution constraints")
+	}
+
+	// A RecipeResult NOT produced by the Client has a nil internal and
+	// Resolved() must return nil rather than panic.
+	var empty aicr.RecipeResult
+	if empty.Resolved() != nil {
+		t.Error("Resolved() on a zero-value RecipeResult = non-nil, want nil")
+	}
+}
+
+// TestValidateState_ImageAndCommitOptions proves the three new validate
+// options (commit + image registry/tag overrides) translate cleanly and a
+// no-cluster ValidateState run still succeeds with them set. The overrides
+// only influence emitted Job images (not exercised in no-cluster mode), so
+// the assertion is that the option plumbing doesn't break the run.
+func TestValidateState_ImageAndCommitOptions(t *testing.T) {
+	t.Parallel()
+
+	client, result := loadTestRecipe(t)
+
+	phases, err := client.ValidateState(t.Context(), result, k8sVersionSnapshot(),
+		aicr.WithValidationNoCluster(true),
+		aicr.WithValidationCommit("abc1234"),
+		aicr.WithValidationImageRegistryOverride("localhost:5001"),
+		aicr.WithValidationImageTagOverride("dev"),
+	)
+	if err != nil {
+		t.Fatalf("ValidateState with image/commit options: %v", err)
+	}
+	if len(phases) == 0 {
+		t.Error("expected at least one phase result, got none")
+	}
+
+	// Empty-string overrides are the unset sentinel and must be accepted
+	// the same as omitting the option entirely.
+	if _, err := client.ValidateState(t.Context(), result, k8sVersionSnapshot(),
+		aicr.WithValidationNoCluster(true),
+		aicr.WithValidationCommit(""),
+		aicr.WithValidationImageRegistryOverride(""),
+		aicr.WithValidationImageTagOverride(""),
+	); err != nil {
+		t.Fatalf("ValidateState with empty overrides: %v", err)
+	}
+}
+
+// writeExternalCriterionData lays out a minimal --data directory that the
+// layered FilesystemSource provider can load: a registry.yaml (required) plus
+// an overlay declaring a non-OSS criteria value. Loading this provider's
+// catalog seeds that provider's criteria registry with the external value,
+// mirroring the e2e fixture in tests/chainsaw/cli/criteria-registry.
+func writeExternalCriterionData(t *testing.T, service string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
+		[]byte("apiVersion: aicr.nvidia.com/v1alpha1\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
+		t.Fatalf("setup: write registry.yaml: %v", err)
+	}
+	overlayDir := filepath.Join(dir, "overlays")
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatalf("setup: mkdir overlays: %v", err)
+	}
+	overlay := "apiVersion: aicr.nvidia.com/v1alpha1\n" +
+		"kind: RecipeMetadata\n" +
+		"metadata:\n  name: " + service + "-h100-training\n" +
+		"spec:\n  base: base\n  criteria:\n" +
+		"    service: " + service + "\n    accelerator: h100\n    intent: training\n" +
+		"  componentRefs: []\n"
+	if err := os.WriteFile(filepath.Join(overlayDir, service+"-overlay.yaml"), []byte(overlay), 0o600); err != nil {
+		t.Fatalf("setup: write overlay: %v", err)
+	}
+	return dir
+}
+
+// TestClient_LoadCatalogSeedsCriteriaRegistry verifies that LoadCatalog seeds
+// THIS Client's per-provider criteria registry: embedded OSS values are always
+// present, and a FilesystemSource --data overlay declaring a non-OSS service
+// value becomes Has()-visible after LoadCatalog. A separate EmbeddedSource
+// client's registry must NOT see the external value — that is the per-provider
+// isolation guarantee Stage 4 relies on.
+func TestClient_LoadCatalogSeedsCriteriaRegistry(t *testing.T) {
+	// Not parallel: asserts on per-provider criteria-registry state seeded by
+	// LoadCatalog, and uses t.Setenv (which forbids t.Parallel). Clearing
+	// AICR_CRITERIA_STRICT neutralizes the CI gate (make test sets it to 1) so
+	// each freshly-constructed per-provider registry starts non-strict and the
+	// external --data value is admitted — strict-mode behavior is covered
+	// separately in TestClient_CriteriaRegistryStrictMode.
+	t.Setenv("AICR_CRITERIA_STRICT", "")
+
+	const externalService = "ncp-internal-test"
+	dataDir := writeExternalCriterionData(t, externalService)
+
+	fsClient, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(dataDir)))
+	if err != nil {
+		t.Fatalf("NewClient(FilesystemSource): %v", err)
+	}
+	t.Cleanup(func() { _ = fsClient.Close() })
+
+	embClient, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient(EmbeddedSource): %v", err)
+	}
+	t.Cleanup(func() { _ = embClient.Close() })
+
+	if err := fsClient.LoadCatalog(t.Context()); err != nil {
+		t.Fatalf("fsClient.LoadCatalog: %v", err)
+	}
+	if err := embClient.LoadCatalog(t.Context()); err != nil {
+		t.Fatalf("embClient.LoadCatalog: %v", err)
+	}
+
+	fsReg := fsClient.CriteriaRegistry()
+	if fsReg == nil {
+		t.Fatal("fsClient.CriteriaRegistry() returned nil")
+	}
+	embReg := embClient.CriteriaRegistry()
+	if embReg == nil {
+		t.Fatal("embClient.CriteriaRegistry() returned nil")
+	}
+
+	// Embedded OSS criteria are seeded into both registries after LoadCatalog.
+	if !fsReg.Has(recipe.FieldService, "eks") {
+		t.Error("fsClient registry missing embedded OSS service 'eks'")
+	}
+	if !embReg.Has(recipe.FieldService, "eks") {
+		t.Error("embClient registry missing embedded OSS service 'eks'")
+	}
+
+	// The external --data overlay's novel service value is visible ONLY in the
+	// FilesystemSource client's registry — the EmbeddedSource client never
+	// walked that directory, so its registry is isolated.
+	if !fsReg.Has(recipe.FieldService, externalService) {
+		t.Errorf("fsClient registry missing external service %q after LoadCatalog", externalService)
+	}
+	if embReg.Has(recipe.FieldService, externalService) {
+		t.Errorf("embClient registry leaked external service %q (per-provider isolation broken)", externalService)
+	}
+}
+
+// TestClient_CriteriaRegistryStrictMode verifies that SetStrict applied to the
+// Client's own registry hides external-origin values while keeping embedded
+// OSS values — the per-Client equivalent of the --criteria-strict gate.
+func TestClient_CriteriaRegistryStrictMode(t *testing.T) {
+	// Not parallel: mutates per-provider registry strict state and uses
+	// t.Setenv (which forbids t.Parallel). Clear AICR_CRITERIA_STRICT so the
+	// registry starts non-strict regardless of the CI gate (make test sets it
+	// to 1); the test then flips strict explicitly via SetStrict.
+	t.Setenv("AICR_CRITERIA_STRICT", "")
+
+	const externalService = "ncp-strict-test"
+	dataDir := writeExternalCriterionData(t, externalService)
+
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(dataDir)))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if err := client.LoadCatalog(t.Context()); err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	reg := client.CriteriaRegistry()
+	if !reg.Has(recipe.FieldService, externalService) {
+		t.Fatalf("precondition: external service %q not seeded", externalService)
+	}
+
+	reg.SetStrict(true)
+	t.Cleanup(func() { reg.SetStrict(false) })
+
+	if reg.Has(recipe.FieldService, externalService) {
+		t.Errorf("strict mode must hide external service %q", externalService)
+	}
+	if !reg.Has(recipe.FieldService, "eks") {
+		t.Error("strict mode must still admit embedded OSS service 'eks'")
+	}
+}
+
+// TestClient_LoadCatalogGuards verifies the nil-context and closed-Client
+// rejections on LoadCatalog match the other Client methods.
+func TestClient_LoadCatalogGuards(t *testing.T) {
+	t.Parallel()
+
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	//nolint:staticcheck // intentional nil-context guard test
+	if err := client.LoadCatalog(nil); err == nil {
+		t.Error("LoadCatalog(nil ctx) must be rejected")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := client.LoadCatalog(t.Context()); err == nil {
+		t.Error("LoadCatalog on a closed Client must be rejected")
+	}
 }

--- a/pkg/aicr/bundle.go
+++ b/pkg/aicr/bundle.go
@@ -1,0 +1,280 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"context"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/bundler"
+	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/bundler/result"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// BundleConfig is the bundler configuration — deployer mode, value
+// overrides, node selectors, tolerations, vendoring, app/chart names,
+// etc. Transparent alias of pkg/bundler/config.Config (the alias is
+// tracked by #1078, matching the Recipe / AllowLists pattern). Construct
+// one with config.NewConfig(config.WithDeployer(...), ...) — the same
+// builder the CLI bundle command and the REST /v1/bundle handler use, so
+// MakeBundle reproduces their exact output byte-for-byte.
+type BundleConfig = config.Config
+
+// BundleAttester signs bundle content. Transparent alias of
+// pkg/bundler/attestation.Attester. The zero value of BundleOptions
+// leaves this nil, in which case MakeBundle uses the bundler's
+// no-op attester (the same default bundler.New applies when --attest
+// is not set).
+type BundleAttester = attestation.Attester
+
+// BundleArtifact summarizes a completed bundle generation: file count,
+// total size, duration, per-bundler results, and the output directory
+// the files were written to. Transparent alias of
+// pkg/bundler/result.Output (#1078 wraps it). Inspect HasErrors() for
+// non-fatal per-bundler failures; the bundle files themselves are on
+// disk under OutputDir.
+type BundleArtifact = *result.Output
+
+// BundleOptions configures a MakeBundle call. It mirrors exactly what
+// bundler.New / (*DefaultBundler).Make accept so the facade reproduces
+// the same full deployer-mode bundle artifact the CLI bundle command
+// and REST /v1/bundle handler produce today.
+type BundleOptions struct {
+	// Config carries the bundler configuration (deployer mode, value
+	// overrides, node selectors/tolerations, vendoring, app/chart
+	// names). When nil, MakeBundle uses config.NewConfig() — the same
+	// default bundler.New applies (Helm deployer, no overrides).
+	Config *BundleConfig
+
+	// Attester signs bundle content. When nil, MakeBundle uses the
+	// no-op attester (matching bundler.New's default when --attest is
+	// not set). The CLI builds this via attestation.ResolveAttesterLazy
+	// when --attest is passed.
+	Attester BundleAttester
+
+	// OutputDir is the directory bundle files are written to. Empty
+	// means the current directory ("."), matching Make's default.
+	OutputDir string
+
+	// Timeout optionally caps the bundle run. When > 0, MakeBundle wraps
+	// the caller's context with context.WithTimeout(ctx, Timeout) so the
+	// run is bounded by the smaller of this and any tighter parent
+	// deadline. When 0 (the zero value), MakeBundle imposes NO
+	// facade-level deadline and runs under the caller's ctx as-is —
+	// large bundles, --vendor-charts, and attestation/signing can each
+	// exceed a fixed cap. The REST /v1/bundle handler sets this to
+	// defaults.BundleHandlerTimeout to preserve its 60s request boundary;
+	// the CLI bundle command leaves it 0 so long bundles are uncapped.
+	Timeout time.Duration
+}
+
+// adoptRecipe wraps a raw, externally-supplied *Recipe (the full
+// pkg/recipe.RecipeResult, e.g. decoded from a /v1/bundle POST body) into a
+// Client-owned *RecipeResult ready for MakeBundle. It binds the Client's own
+// DataProvider onto the recipe so provider-scoped lookups (values files,
+// manifest files, external data files) resolve against the Client's recipe
+// source rather than the package global, and stamps the owner token so the
+// result passes MakeBundle's assertOwns check. This is the REST analog of
+// LoadRecipe: LoadRecipe reads from a path through the provider, adoptRecipe
+// takes an already-decoded RecipeResult and binds the same provider.
+//
+// Synchronization mirrors LoadRecipe: snapshot the per-Client provider under
+// the read lock so a concurrent Close can't race the read. Unlike the
+// resolve/load paths it does not register in the inflight WaitGroup — it does
+// no cache-using work itself (the subsequent MakeBundle call does, and
+// registers there).
+//
+// Errors:
+//   - ErrCodeInvalidRequest when the Client, ctx, or recipe is nil, or when
+//     the Client has been Closed.
+func (c *Client) adoptRecipe(ctx context.Context, recipe *Recipe) (*RecipeResult, error) {
+	if c == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+	if recipe == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil Recipe")
+	}
+
+	c.mu.RLock()
+	if c.builder == nil {
+		c.mu.RUnlock()
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	dp := c.dp
+	c.mu.RUnlock()
+
+	// Deep-copy the caller-supplied recipe BEFORE binding the provider.
+	// BindDataProvider mutates the receiver's unexported provider field, and
+	// the input *Recipe is caller-owned: a caller reusing one *Recipe across
+	// two Clients would otherwise have the second adopt overwrite the first's
+	// binding, breaking per-Client isolation. DeepCopy leaves the copy's
+	// provider nil for BindDataProvider to set, so the original is untouched.
+	cp := recipe.DeepCopy()
+	cp.BindDataProvider(dp)
+
+	result, err := loadedResultFromInternal(cp)
+	if err != nil {
+		return nil, err
+	}
+	result.owner = c
+	return result, nil
+}
+
+// AdoptRecipe wraps a raw pkg/recipe.RecipeResult — typically decoded from an
+// external source such as a REST /v1/bundle POST body — into a Client-owned
+// *RecipeResult ready for MakeBundle. The returned RecipeResult is bound to
+// this Client's DataProvider and owner-stamped, so it passes MakeBundle's
+// ownership and provider-isolation checks exactly as a LoadRecipe result does.
+//
+// Use this when the caller already holds a fully-hydrated RecipeResult (not a
+// criteria request or a file path) and needs to bundle it through the facade.
+// In-process consumers that resolve via ResolveRecipe / LoadRecipe should use
+// those results directly; AdoptRecipe is for the decode-then-bundle boundary.
+func (c *Client) AdoptRecipe(ctx context.Context, recipe *Recipe) (*RecipeResult, error) {
+	return c.adoptRecipe(ctx, recipe)
+}
+
+// MakeBundle generates the full deployer-mode bundle for a previously
+// resolved or loaded RecipeResult, writing the bundle files under
+// opts.OutputDir and returning a BundleArtifact summary. Unlike
+// BundleComponents (which returns per-component Helm values + manifests
+// in memory), MakeBundle produces the SAME complete artifact the CLI
+// bundle command emits — README, deploy.sh, per-component directories,
+// checksums — in the deployer layout selected by opts.Config.Deployer()
+// (helm, argocd, argocd-helm, flux, helmfile).
+//
+// # When to call
+//
+// Call AFTER Client.ResolveRecipe or Client.LoadRecipe; pass that call's
+// *RecipeResult unchanged. MakeBundle bundles from recipe.Resolved() (the
+// full pkg/recipe.RecipeResult), which carries this Client's own
+// DataProvider — so provider-scoped lookups (values files, manifest
+// files) resolve against the Client's recipe source rather than the
+// package global.
+//
+// # Allowlist enforcement
+//
+// When the Client was constructed WithAllowLists, MakeBundle validates
+// the recipe's criteria against the allowlist before bundling — same
+// fencing the resolve path and the REST /v1/bundle handler apply. A
+// recipe whose criteria fall outside the allowlist is rejected with the
+// allowlist's structured error. A recipe with nil Criteria (a loaded,
+// already-hydrated or bare RecipeResult file) skips the check, matching
+// the handler's `recipeResult.Criteria != nil` guard.
+//
+// # Synchronization
+//
+// Read-locks Client.mu so a concurrent Close can't race the bundle, and
+// registers in the inflight WaitGroup so Close drains before evicting
+// caches — the same protocol as BundleComponents. A facade-level timeout
+// is opt-in via opts.Timeout: when set (> 0) it bounds the run by the
+// smaller of opts.Timeout and any tighter caller deadline; when unset
+// (0) MakeBundle runs under the caller's context with NO added cap. The
+// REST /v1/bundle handler sets opts.Timeout = defaults.BundleHandlerTimeout
+// to keep its 60s request boundary; the CLI bundle command leaves it 0 so
+// large bundles, --vendor-charts, and attestation/signing are uncapped.
+//
+// Errors:
+//   - ErrCodeInvalidRequest when the Client, ctx, or recipe is nil, when
+//     recipe lacks internal state (constructed outside Resolve/Load), when
+//     the recipe was produced by a different Client, or when the Client
+//     has been Closed.
+//   - Allowlist and bundler errors propagate with their structured codes.
+func (c *Client) MakeBundle(ctx context.Context, recipe *RecipeResult, opts BundleOptions) (BundleArtifact, error) {
+	if c == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+	if recipe == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil RecipeResult")
+	}
+	if recipe.internal == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"RecipeResult has no internal recipe state — call Client.ResolveRecipe or Client.LoadRecipe to obtain a bundle-able RecipeResult")
+	}
+	if err := c.assertOwns(recipe); err != nil {
+		return nil, err
+	}
+
+	// Snapshot Client state under the read lock — same pattern as
+	// BundleComponents. The closed-Client check reads c.builder; the
+	// bundle itself runs unlocked off recipe.internal (which carries
+	// this Client's bound DataProvider).
+	c.mu.RLock()
+	if c.builder == nil {
+		c.mu.RUnlock()
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	// Apply a facade-level deadline only when the caller opts in via
+	// opts.Timeout. context.WithTimeout honors the smaller of the parent
+	// deadline and ours, so a caller with a tighter deadline keeps it.
+	// When opts.Timeout is 0 the caller's ctx governs unchanged — the CLI
+	// bundle path runs uncapped (large bundles, --vendor-charts, and
+	// signing can exceed any fixed cap), while the REST handler passes
+	// defaults.BundleHandlerTimeout to retain its 60s boundary. Placed
+	// after the guards so already-canceled-context tests flow through the
+	// same error paths.
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	// Enforce the Client's allowlists against the recipe criteria, mirroring
+	// the REST /v1/bundle handler's `AllowLists != nil && Criteria != nil`
+	// gate. A loaded recipe with nil Criteria skips the check (it carries no
+	// criteria to validate); a resolved recipe always has criteria.
+	if recipe.internal.Criteria != nil {
+		if err := c.enforceAllowLists(recipe.internal.Criteria); err != nil {
+			return nil, err
+		}
+	}
+
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = config.NewConfig()
+	}
+
+	bundlerOpts := []bundler.Option{bundler.WithConfig(cfg)}
+	if opts.Attester != nil {
+		bundlerOpts = append(bundlerOpts, bundler.WithAttester(opts.Attester))
+	}
+	b, err := bundler.New(bundlerOpts...)
+	if err != nil {
+		// Don't re-wrap — bundler.New returns structured errors with the
+		// right code (ErrCodeNotFound for a missing binary attestation,
+		// ErrCodeInternal for executable-path resolution failures).
+		return nil, err
+	}
+
+	out, err := b.Make(ctx, recipe.internal, opts.OutputDir)
+	if err != nil {
+		// Propagate as-is: Make returns structured errors (validation,
+		// timeout, internal) with the appropriate codes.
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/aicr/bundle_test.go
+++ b/pkg/aicr/bundle_test.go
@@ -1,0 +1,309 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
+	"github.com/NVIDIA/aicr/pkg/bundler"
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// resolveEmbeddedTrainingRecipe resolves a known-good embedded recipe
+// (H100/EKS/Ubuntu/Training) through a fresh Client and returns both the
+// facade result and the Client so callers can drive MakeBundle. The
+// recipe carries multiple components, so the generated bundle exercises
+// per-component directory emission.
+func resolveEmbeddedTrainingRecipe(t *testing.T) (*aicr.Client, *aicr.RecipeResult) {
+	t.Helper()
+	client, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.EmbeddedSource()),
+		aicr.WithVersion("v-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	rec, err := client.ResolveRecipe(t.Context(), aicr.RecipeRequest{
+		Service:     "eks",
+		Accelerator: "h100",
+		OS:          "ubuntu",
+		Intent:      "training",
+	})
+	if err != nil {
+		t.Fatalf("ResolveRecipe: %v", err)
+	}
+	if len(rec.Components) == 0 {
+		t.Fatal("resolved recipe has no components; cannot exercise MakeBundle")
+	}
+	return client, rec
+}
+
+// listBundleFiles returns the sorted relative paths of every regular
+// file under dir. Used to compare the on-disk layout of two bundle runs.
+func listBundleFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk bundle dir %s: %v", dir, err)
+	}
+	sort.Strings(files)
+	return files
+}
+
+// TestMakeBundle_ProducesArtifact verifies MakeBundle emits a non-empty
+// bundle for a resolved recipe across the deployer modes.
+func TestMakeBundle_ProducesArtifact(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		deployer config.DeployerType
+	}{
+		{"helm", config.DeployerHelm},
+		{"argocd", config.DeployerArgoCD},
+		{"flux", config.DeployerFlux},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, rec := resolveEmbeddedTrainingRecipe(t)
+
+			out, err := client.MakeBundle(t.Context(), rec, aicr.BundleOptions{
+				Config: config.NewConfig(
+					config.WithVersion("v-test"),
+					config.WithDeployer(tt.deployer),
+				),
+				OutputDir: t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("MakeBundle(%s): %v", tt.deployer, err)
+			}
+			if out == nil {
+				t.Fatal("MakeBundle returned nil artifact")
+			}
+			if out.HasErrors() {
+				t.Fatalf("MakeBundle reported bundle errors: %v", out.Errors)
+			}
+			if out.TotalFiles == 0 {
+				t.Error("MakeBundle produced zero files")
+			}
+			if out.TotalSize == 0 {
+				t.Error("MakeBundle produced zero bytes")
+			}
+			if files := listBundleFiles(t, out.OutputDir); len(files) == 0 {
+				t.Error("no files written to output dir")
+			}
+		})
+	}
+}
+
+// TestMakeBundle_ParityWithDirectBundler proves the facade reproduces
+// the SAME bundle a direct bundler.New + Make produces for identical
+// input. Both runs resolve the same recipe and bundle with the same
+// config; the assertion is that the on-disk file layout matches. This
+// is the parity gate guarding criterion #2 (bundle output unchanged
+// when routed through the facade).
+func TestMakeBundle_ParityWithDirectBundler(t *testing.T) {
+	t.Parallel()
+
+	client, rec := resolveEmbeddedTrainingRecipe(t)
+
+	// Facade path.
+	facadeDir := t.TempDir()
+	facadeOut, err := client.MakeBundle(t.Context(), rec, aicr.BundleOptions{
+		Config: config.NewConfig(
+			config.WithVersion("v-test"),
+			config.WithDeployer(config.DeployerHelm),
+		),
+		OutputDir: facadeDir,
+	})
+	if err != nil {
+		t.Fatalf("facade MakeBundle: %v", err)
+	}
+
+	// Direct path: build a bundler exactly as MakeBundle does and Make
+	// against the same internal recipe (rec.Resolved()).
+	directDir := t.TempDir()
+	b, err := bundler.New(bundler.WithConfig(config.NewConfig(
+		config.WithVersion("v-test"),
+		config.WithDeployer(config.DeployerHelm),
+	)))
+	if err != nil {
+		t.Fatalf("bundler.New: %v", err)
+	}
+	directOut, err := b.Make(t.Context(), rec.Resolved(), directDir)
+	if err != nil {
+		t.Fatalf("direct Make: %v", err)
+	}
+
+	if facadeOut.TotalFiles != directOut.TotalFiles {
+		t.Errorf("file count mismatch: facade=%d direct=%d", facadeOut.TotalFiles, directOut.TotalFiles)
+	}
+
+	facadeFiles := listBundleFiles(t, facadeDir)
+	directFiles := listBundleFiles(t, directDir)
+	if len(facadeFiles) != len(directFiles) {
+		t.Fatalf("file-set length mismatch: facade=%v direct=%v", facadeFiles, directFiles)
+	}
+	for i := range facadeFiles {
+		if facadeFiles[i] != directFiles[i] {
+			t.Errorf("file-set mismatch at %d: facade=%q direct=%q", i, facadeFiles[i], directFiles[i])
+		}
+	}
+}
+
+// TestMakeBundle_NilInputsRejected pins the bounds-checking: nil
+// RecipeResult, caller-constructed RecipeResult (nil internal), and nil
+// receiver all surface ErrCodeInvalidRequest cleanly rather than
+// panicking.
+func TestMakeBundle_NilInputsRejected(t *testing.T) {
+	t.Parallel()
+
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	t.Run("nil recipe", func(t *testing.T) {
+		t.Parallel()
+		_, err := client.MakeBundle(t.Context(), nil, aicr.BundleOptions{})
+		assertInvalidRequest(t, err)
+	})
+
+	t.Run("caller-constructed recipe", func(t *testing.T) {
+		t.Parallel()
+		bogus := &aicr.RecipeResult{Name: "made-up", Version: "v0"}
+		_, err := client.MakeBundle(t.Context(), bogus, aicr.BundleOptions{})
+		assertInvalidRequest(t, err)
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+		var nilClient *aicr.Client
+		_, err := nilClient.MakeBundle(t.Context(), &aicr.RecipeResult{}, aicr.BundleOptions{})
+		assertInvalidRequest(t, err)
+	})
+}
+
+// TestMakeBundle_RejectsCrossClientRecipe pins the owner-token guard for
+// MakeBundle: a RecipeResult resolved by Client A cannot be bundled by
+// Client B.
+func TestMakeBundle_RejectsCrossClientRecipe(t *testing.T) {
+	t.Parallel()
+
+	clientA, recA := resolveEmbeddedTrainingRecipe(t)
+	_ = clientA
+
+	clientB, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient B: %v", err)
+	}
+	t.Cleanup(func() { _ = clientB.Close() })
+
+	_, err = clientB.MakeBundle(t.Context(), recA, aicr.BundleOptions{OutputDir: t.TempDir()})
+	assertInvalidRequest(t, err)
+}
+
+// TestMakeBundle_TimeoutOptIn pins the opt-in timeout contract: with
+// Timeout unset (0), MakeBundle adds NO facade-level deadline, so a bundle
+// that fits well within the caller's context succeeds; an already-expired
+// caller deadline still governs (the facade does not paper over it). This
+// guards the regression where the CLI bundle path inherited the REST 60s
+// cap. The REST handler's own 60s cap is asserted separately in the api
+// package; here we only verify the facade no longer self-imposes one.
+func TestMakeBundle_TimeoutOptIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero timeout adds no facade cap", func(t *testing.T) {
+		t.Parallel()
+		client, rec := resolveEmbeddedTrainingRecipe(t)
+
+		// Caller passes a generous context and Timeout: 0. The bundle
+		// must complete without the facade injecting a deadline.
+		out, err := client.MakeBundle(t.Context(), rec, aicr.BundleOptions{
+			Config: config.NewConfig(
+				config.WithVersion("v-test"),
+				config.WithDeployer(config.DeployerHelm),
+			),
+			OutputDir: t.TempDir(),
+			Timeout:   0,
+		})
+		if err != nil {
+			t.Fatalf("MakeBundle with Timeout=0: %v", err)
+		}
+		if out == nil || out.TotalFiles == 0 {
+			t.Fatal("MakeBundle with Timeout=0 produced no artifact")
+		}
+	})
+
+	t.Run("already-expired caller deadline governs", func(t *testing.T) {
+		t.Parallel()
+		client, rec := resolveEmbeddedTrainingRecipe(t)
+
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		_, err := client.MakeBundle(ctx, rec, aicr.BundleOptions{
+			Config: config.NewConfig(
+				config.WithVersion("v-test"),
+				config.WithDeployer(config.DeployerHelm),
+			),
+			OutputDir: t.TempDir(),
+			Timeout:   0,
+		})
+		if err == nil {
+			t.Fatal("expected error from already-expired caller deadline, got nil")
+		}
+	})
+}
+
+func assertInvalidRequest(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var se *aicrerrors.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *errors.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != aicrerrors.ErrCodeInvalidRequest {
+		t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+	}
+}

--- a/pkg/aicr/options.go
+++ b/pkg/aicr/options.go
@@ -15,8 +15,11 @@
 package aicr
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/validator"
 )
 
@@ -49,23 +52,67 @@ type validateConfig struct {
 	imagePullSecrets []string
 	noCluster        *bool
 	tolerations      []corev1.Toleration
-	nodeSelector     map[string]string
+	// tolerationsSet records that WithValidationTolerations was called,
+	// even with a nil/empty slice. nil tolerations cannot itself signal
+	// "explicitly override" because nil is also the zero value — but the CLI
+	// must ALWAYS override the validator's default tolerate-all ("*") so it
+	// doesn't ship AICR_TOLERATIONS. When tolerationsSet is true the option
+	// is emitted regardless of nil-ness; when false (controllers that never
+	// call the option) the validator keeps its default.
+	tolerationsSet bool
+	nodeSelector   map[string]string
+
+	// timeout opts into a facade-level deadline for ValidateState. nil means
+	// "use the default (ValidationOperationTimeout)" — the controller path.
+	// A non-nil *0 means "no facade cap; run under the caller's ctx as-is"
+	// (the CLI path, where per-validator timeouts govern). A non-nil >0 sets
+	// that explicit cap. Pointer-wrapped so the zero (0 = uncapped) is
+	// distinguishable from unset (nil = default).
+	timeout *time.Duration
+
+	// phases selects which validation phases run. nil/empty means
+	// "run all phases" (validator.PhaseOrder) — the prior behavior.
+	// Unlike the pointer fields above, an empty slice is treated the
+	// same as nil (run all), because there is no meaningful "run zero
+	// phases" request: a caller wanting a subset names that subset.
+	phases []Phase
+
+	// commit, imageRegistryOverride, and imageTagOverride mirror the
+	// validator.WithCommit / WithImageRegistryOverride / WithImageTagOverride
+	// options. These are string values whose validator-side handling already
+	// treats empty as "unset" (commit only influences dev-image SHA
+	// resolution; the two overrides only apply when non-empty), so an empty
+	// string here is the natural "unset" sentinel — no pointer wrapper is
+	// needed to disambiguate it from a meaningful zero value.
+	commit                string
+	imageRegistryOverride string
+	imageTagOverride      string
 }
 
-// applyValidateOptions builds the []validator.Option slice from a
-// validateConfig populated by the WithValidation* factories. Called
-// from Client.ValidateState AFTER it releases Client.mu — the
-// translation is pure (no Client state read) and runs once per call,
-// so a future field added to validator.With* is one edit here and
-// zero edits on the facade surface.
-func applyValidateOptions(opts []ValidateOption) []validator.Option {
+// buildValidateConfig replays each WithValidation* option into a fresh
+// validateConfig. Client.ValidateState reads BOTH the derived
+// []validator.Option (via validateOptionsFromConfig) AND the configured
+// phases from this single options pass — the phases don't map to a
+// validator.Option (they're a parameter to ValidatePhases), so they
+// can't be expressed in the option slice.
+func buildValidateConfig(opts []ValidateOption) *validateConfig {
 	cfg := &validateConfig{}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(cfg)
 		}
 	}
-	out := make([]validator.Option, 0, 7)
+	return cfg
+}
+
+// validateOptionsFromConfig translates an already-built validateConfig into
+// the pkg/validator option slice. Called from Client.ValidateState AFTER it
+// releases Client.mu — the translation is pure (no Client state read) and
+// runs once per call, so a future field added to validator.With* is one edit
+// here and zero edits on the facade surface. phases is intentionally NOT
+// translated here — it is passed directly to ValidatePhases by the caller.
+func validateOptionsFromConfig(cfg *validateConfig) []validator.Option {
+	out := make([]validator.Option, 0, 10)
 	if cfg.namespace != nil {
 		out = append(out, validator.WithNamespace(*cfg.namespace))
 	}
@@ -81,11 +128,24 @@ func applyValidateOptions(opts []ValidateOption) []validator.Option {
 	if cfg.noCluster != nil {
 		out = append(out, validator.WithNoCluster(*cfg.noCluster))
 	}
-	if cfg.tolerations != nil {
+	if cfg.tolerationsSet {
+		// Emit even on a nil/empty slice: an explicit override must clear the
+		// validator's default tolerate-all ("*") so AICR_TOLERATIONS isn't
+		// sent. Gating on non-nil would silently drop the CLI's intentional
+		// "no tolerations" override back to the default.
 		out = append(out, validator.WithTolerations(cfg.tolerations))
 	}
 	if cfg.nodeSelector != nil {
 		out = append(out, validator.WithNodeSelector(cfg.nodeSelector))
+	}
+	if cfg.commit != "" {
+		out = append(out, validator.WithCommit(cfg.commit))
+	}
+	if cfg.imageRegistryOverride != "" {
+		out = append(out, validator.WithImageRegistryOverride(cfg.imageRegistryOverride))
+	}
+	if cfg.imageTagOverride != "" {
+		out = append(out, validator.WithImageTagOverride(cfg.imageTagOverride))
 	}
 	return out
 }
@@ -145,8 +205,24 @@ func WithValidationNoCluster(noCluster bool) ValidateOption {
 // race with downstream serialization on a validator goroutine.
 func WithValidationTolerations(tolerations []corev1.Toleration) ValidateOption {
 	return func(c *validateConfig) {
+		// Mark set even for a nil/empty slice so validateOptionsFromConfig
+		// always emits validator.WithTolerations — clearing the validator's
+		// default tolerate-all is an explicit override, not a no-op.
+		c.tolerationsSet = true
 		c.tolerations = cloneTolerations(tolerations)
 	}
+}
+
+// WithValidationTimeout opts into a facade-level deadline for the
+// ValidateState run. By default (option unset) ValidateState wraps the
+// caller's context with defaults.ValidationOperationTimeout (~60m), which
+// suits controllers that pass an unbounded context. Pass a positive
+// duration to set an explicit cap, or 0 to impose NO facade cap — the run
+// then proceeds under the caller's context unchanged so per-validator
+// timeouts (e.g. the 50m inference-perf check) govern. The CLI validate
+// command passes 0 so an all-phase run isn't cut short by a fixed cap.
+func WithValidationTimeout(d time.Duration) ValidateOption {
+	return func(c *validateConfig) { c.timeout = &d }
 }
 
 // WithValidationNodeSelector passes a node selector through to the
@@ -164,9 +240,53 @@ func WithValidationNodeSelector(nodeSelector map[string]string) ValidateOption {
 	}
 }
 
+// WithValidationPhases restricts the run to the named phases, in the
+// order given. Valid values are PhaseDeployment, PhasePerformance, and
+// PhaseConformance. When omitted (or called with no phases), all phases
+// run in their canonical order — the default behavior. ValidateState
+// rejects any unrecognized phase value with ErrCodeInvalidRequest before
+// touching the cluster, so a typo cannot silently produce an empty run.
+//
+// The input is defensively copied so a caller mutating the slice after
+// this returns won't race with ValidateState reading it.
+func WithValidationPhases(phases ...Phase) ValidateOption {
+	return func(c *validateConfig) {
+		if phases == nil {
+			c.phases = nil
+			return
+		}
+		c.phases = append([]Phase(nil), phases...)
+	}
+}
+
+// WithValidationCommit sets the git commit SHA threaded into the
+// validator (validator.WithCommit). Used to resolve dev-build validator
+// images to SHA-tagged images. An empty string is the "unset" sentinel —
+// no validator option is emitted, matching the validator's own behavior
+// where an empty commit influences nothing.
+func WithValidationCommit(commit string) ValidateOption {
+	return func(c *validateConfig) { c.commit = commit }
+}
+
+// WithValidationImageRegistryOverride overrides the registry prefix on
+// validator container images (validator.WithImageRegistryOverride), e.g.
+// to point at a local registry mirror. Empty means "no override" — the
+// validator keeps its default registry.
+func WithValidationImageRegistryOverride(registry string) ValidateOption {
+	return func(c *validateConfig) { c.imageRegistryOverride = registry }
+}
+
+// WithValidationImageTagOverride overrides the tag on every validator
+// container image (validator.WithImageTagOverride), intended for
+// feature-branch dev builds whose commit SHA has no published image.
+// Empty means "no override" — the validator keeps its resolved tag.
+func WithValidationImageTagOverride(tag string) ValidateOption {
+	return func(c *validateConfig) { c.imageTagOverride = tag }
+}
+
 // cloneStringSlice returns a shallow copy of s, preserving the
 // nil-vs-empty distinction. A nil input maps to nil out (so the
-// "unset" sentinel survives through to applyValidateOptions, which
+// "unset" sentinel survives through to validateOptionsFromConfig, which
 // skips the validator option entirely on nil); an empty non-nil input
 // maps to an empty non-nil copy (preserving caller intent for "no
 // secrets" / "no tolerations" overrides).
@@ -193,7 +313,7 @@ func cloneTolerations(t []corev1.Toleration) []corev1.Toleration {
 
 // cloneStringMap returns a shallow copy of m, preserving the
 // nil-vs-empty distinction. Same rationale as cloneStringSlice;
-// applyValidateOptions checks for nil to decide whether to emit the
+// validateOptionsFromConfig checks for nil to decide whether to emit the
 // validator.With* call at all.
 func cloneStringMap(m map[string]string) map[string]string {
 	if m == nil {
@@ -219,6 +339,31 @@ func WithRecipeSource(s RecipeSourceOption) Option {
 	}
 }
 
+// WithVersion sets the version string stamped into resolved recipe
+// metadata (RecipeResult.Metadata.Version). Threaded through to the
+// underlying recipe.Builder via recipe.WithVersion. Typically the
+// consuming binary's build version.
+func WithVersion(version string) Option {
+	return func(c *Client) { c.version = version }
+}
+
+// WithAllowLists fences which criteria values the Client's resolve path
+// accepts. A resolve whose criteria fall outside the allowlist is rejected
+// before the recipe is built. Pass nil (or omit the option) to allow all
+// values. Construct an AllowLists directly or via ParseAllowListsFromEnv.
+func WithAllowLists(al *AllowLists) Option {
+	return func(c *Client) { c.allowLists = al }
+}
+
+// ParseAllowListsFromEnv builds an AllowLists from the AICR_ALLOWED_*
+// environment variables (AICR_ALLOWED_ACCELERATORS, AICR_ALLOWED_SERVICES,
+// AICR_ALLOWED_INTENTS, AICR_ALLOWED_OS). Returns nil when none are set —
+// WithAllowLists treats a nil AllowLists as allow-all. Pass the result to
+// WithAllowLists.
+func ParseAllowListsFromEnv() (*AllowLists, error) {
+	return recipe.ParseAllowListsFromEnv()
+}
+
 // OCISource describes an OCI registry containing AICR recipes.
 //
 // The tag is optional; if empty, "latest" is assumed by the downstream
@@ -231,6 +376,11 @@ func OCISource(registry, tag string) RecipeSourceOption {
 			tag:      tag,
 		},
 	}
+}
+
+// EmbeddedSource uses only AICR's built-in (embedded) recipe data, no overlay.
+func EmbeddedSource() RecipeSourceOption {
+	return RecipeSourceOption{internal: recipeSource{kind: sourceKindEmbedded}}
 }
 
 // FilesystemSource describes a local filesystem path containing AICR
@@ -251,6 +401,7 @@ const (
 	sourceKindUnset sourceKind = iota
 	sourceKindOCI
 	sourceKindFilesystem
+	sourceKindEmbedded
 )
 
 // recipeSource is the internal representation passed to the Client.

--- a/pkg/aicr/query.go
+++ b/pkg/aicr/query.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// SelectFromRecipe hydrates a resolved recipe and extracts a dot-path selector
+// (e.g. "components.gpu-operator.values.driver.version"). An empty selector
+// returns the entire hydrated structure. Mirrors `aicr query`.
+func SelectFromRecipe(r *Recipe, selector string) (any, error) {
+	if r == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil recipe")
+	}
+	hydrated, err := recipe.HydrateResult(r)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "hydrate recipe", err)
+	}
+	return recipe.Select(hydrated, selector)
+}

--- a/pkg/aicr/types.go
+++ b/pkg/aicr/types.go
@@ -64,6 +64,22 @@ type PhaseResult = validator.PhaseResult
 // docs/integrator/public-api.md "Facade type aliases".
 type Phase = validator.Phase
 
+// Recipe is the full resolved recipe, returned losslessly by the resolve
+// methods. Transparent alias of recipe.RecipeResult; wrapping is tracked by #1078.
+type Recipe = recipe.RecipeResult
+
+// AllowLists fences which criteria values the resolve path accepts (#1078 wraps it).
+type AllowLists = recipe.AllowLists
+
+// Criteria lets REST keep its exact existing HTTP->Criteria parser.
+type Criteria = recipe.Criteria
+
+// CriteriaRegistry is the per-DataProvider set of valid criteria values,
+// returned by Client.CriteriaRegistry so CLI/library callers parse and
+// validate criteria against the SAME provider the Client resolves with.
+// Transparent alias of recipe.CriteriaRegistry; wrapping is tracked by #1078.
+type CriteriaRegistry = recipe.CriteriaRegistry
+
 // Validation phases, re-exported as facade constants so consumers
 // don't need to import pkg/validator to filter by phase. Same
 // Public (evolving) tier as Phase above.
@@ -174,6 +190,18 @@ type RecipeResult struct {
 	// the token: zero-cost, naturally unique, and unforgeable from
 	// outside the package because the field is unexported.
 	owner *Client
+}
+
+// Resolved returns the complete underlying recipe (the full
+// pkg/recipe.RecipeResult) that this result wraps. The facade RecipeResult
+// exposes only Name/Version/Components; callers that need constraints,
+// validation config, deployment order, or metadata (e.g. evidence emission)
+// use this. Returns nil if the result was not produced by the Client.
+func (r *RecipeResult) Resolved() *Recipe {
+	if r == nil {
+		return nil
+	}
+	return r.internal
 }
 
 // ComponentBundle is the resolved deployable artifact for one

--- a/pkg/api/bundle_handler.go
+++ b/pkg/api/bundle_handler.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"log/slog"
+	"net/http"
+	"os"
+
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
+	"github.com/NVIDIA/aicr/pkg/bundler"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/server"
+)
+
+// bundleHandler backs the /v1/bundle endpoint with an aicr.Client. It
+// reproduces pkg/bundler.(*DefaultBundler).HandleBundles exactly — same
+// method gate, body decode, allowlist check, query-param parsing, and zip
+// response — swapping the direct bundler.New + Make for the Client facade
+// (AdoptRecipe + MakeBundle). The body, headers, and status codes are
+// byte-identical to the legacy handler.
+type bundleHandler struct {
+	client *aicr.Client
+	// allowLists is held for exact error-message parity on rejection: the
+	// handler runs an explicit pre-check (matching the legacy handler's
+	// "Recipe criteria value not allowed" message) before bundling. The
+	// Client's MakeBundle enforcement remains a backstop.
+	allowLists *aicr.AllowLists
+}
+
+// newBundleHandler constructs a bundleHandler bound to the given client and
+// allowlists.
+func newBundleHandler(client *aicr.Client, allowLists *aicr.AllowLists) *bundleHandler {
+	return &bundleHandler{client: client, allowLists: allowLists}
+}
+
+// HandleBundles processes bundle generation requests. It accepts a POST
+// request with a JSON body containing the recipe (RecipeResult) and the same
+// query parameters as the legacy pkg/bundler handler (set, dynamic, deployer,
+// node selectors/tolerations, repo, workload-gate, workload-selector, nodes,
+// vendor-charts, app-name). The response is a zip archive of the bundle.
+func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
+	logger := slog.With("requestID", server.RequestIDFromContext(r.Context()))
+
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		server.WriteError(w, r, http.StatusMethodNotAllowed, aicrerrors.ErrCodeMethodNotAllowed,
+			"Method not allowed", false, map[string]any{
+				keyMethod: r.Method,
+			})
+		return
+	}
+
+	// Add request-scoped timeout (matches the legacy handler's bundle timeout).
+	ctx, cancel := context.WithTimeout(r.Context(), defaults.BundleHandlerTimeout)
+	defer cancel()
+
+	// Parse all query parameters into a bundler config via the exported
+	// boundary so this handler stays byte-identical to the legacy one.
+	bundleConfig, err := bundler.ParseBundleConfig(r)
+	if err != nil {
+		server.WriteErrorFromErr(w, r, err, "Invalid query parameters", nil)
+		return
+	}
+
+	// Parse request body directly as RecipeResult. Bound the body to defend
+	// against memory exhaustion (same cap as the legacy handler).
+	bounded := http.MaxBytesReader(w, r.Body, defaults.MaxBundlePOSTBytes)
+	var recipeResult recipe.RecipeResult
+	if err = json.NewDecoder(bounded).Decode(&recipeResult); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if stderrors.As(err, &maxBytesErr) {
+			logger.Warn("bundle POST body exceeded size limit",
+				"limit", defaults.MaxBundlePOSTBytes,
+				"received", maxBytesErr.Limit,
+			)
+			server.WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
+				"Request body exceeds maximum allowed size", false, map[string]any{
+					keyLimitBytes: defaults.MaxBundlePOSTBytes,
+				})
+			return
+		}
+		server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Invalid request body", false, map[string]any{
+				keyError: err.Error(),
+			})
+		return
+	}
+
+	// Validate recipe has component references.
+	if len(recipeResult.ComponentRefs) == 0 {
+		server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Recipe must contain at least one component reference", false, nil)
+		return
+	}
+
+	// Validate recipe criteria against allowlists (if configured). Explicit
+	// pre-check preserves the legacy user-facing message; the Client's
+	// MakeBundle enforcement remains a backstop.
+	if h.allowLists != nil && recipeResult.Criteria != nil {
+		if validateErr := h.allowLists.ValidateCriteria(recipeResult.Criteria); validateErr != nil {
+			server.WriteErrorFromErr(w, r, validateErr, "Recipe criteria value not allowed", nil)
+			return
+		}
+	}
+
+	logger.Debug("bundle request received",
+		"components", len(recipeResult.ComponentRefs),
+	)
+
+	// Create temporary directory for bundle output.
+	tempDir, err := os.MkdirTemp("", "aicr-bundle-*")
+	if err != nil {
+		server.WriteError(w, r, http.StatusInternalServerError, aicrerrors.ErrCodeInternal,
+			"Failed to create temporary directory", true, nil)
+		return
+	}
+	defer os.RemoveAll(tempDir) // Clean up on exit
+
+	// Adopt the decoded recipe onto the Client (binds the Client's provider
+	// + owner token) so MakeBundle accepts it and provider-scoped reads route
+	// through the Client's recipe source.
+	adopted, err := h.client.AdoptRecipe(ctx, &recipeResult)
+	if err != nil {
+		server.WriteErrorFromErr(w, r, err, "Failed to prepare recipe for bundling", nil)
+		return
+	}
+
+	// Generate bundle through the facade. Set Timeout to keep the REST
+	// path's 60s request boundary even though ctx is already wrapped
+	// above — MakeBundle defaults to uncapped (opt-in) so the REST cap
+	// must be supplied explicitly. context.WithTimeout honors the smaller
+	// of the two, so this is a backstop, not a second deadline.
+	output, err := h.client.MakeBundle(ctx, adopted, aicr.BundleOptions{
+		Config:    bundleConfig,
+		OutputDir: tempDir,
+		Timeout:   defaults.BundleHandlerTimeout,
+	})
+	if err != nil {
+		server.WriteErrorFromErr(w, r, err, "Failed to generate bundle", nil)
+		return
+	}
+
+	// Check for bundle errors.
+	if output.HasErrors() {
+		errorDetails := make([]map[string]any, 0, len(output.Errors))
+		for _, be := range output.Errors {
+			errorDetails = append(errorDetails, map[string]any{
+				"bundler": be.BundlerType,
+				keyError:  be.Error,
+			})
+		}
+		server.WriteError(w, r, http.StatusInternalServerError, aicrerrors.ErrCodeInternal,
+			"Bundle generation failed", true, map[string]any{
+				"errors": errorDetails,
+			})
+		return
+	}
+
+	// Stream zip response using the same exported helper the legacy handler
+	// uses, so headers + entry layout are byte-identical.
+	if err := bundler.StreamZipResponse(w, tempDir, output); err != nil {
+		// Can't write error response if we've already started writing.
+		logger.Error("failed to stream zip response", "error", err)
+		return
+	}
+}

--- a/pkg/api/bundle_handler_test.go
+++ b/pkg/api/bundle_handler_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
+	"github.com/NVIDIA/aicr/pkg/bundler"
+)
+
+// errCodeMessage decodes a structured-error JSON response body and returns
+// its code and message, ignoring the per-request requestId/timestamp fields.
+func errCodeMessage(t *testing.T, body []byte) (code, message string) {
+	t.Helper()
+	var resp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode error body %q: %v", string(body), err)
+	}
+	return resp.Code, resp.Message
+}
+
+// validBundleRecipe is a hydrated RecipeResult POST body with a single
+// resolvable component, sufficient to drive a full bundle generation.
+const validBundleRecipe = `{
+	"apiVersion": "aicr.nvidia.com/v1alpha1",
+	"kind": "Recipe",
+	"metadata": {
+		"version": "v1.0.0",
+		"appliedOverlays": ["base", "eks", "eks-training"]
+	},
+	"criteria": {
+		"service": "eks",
+		"accelerator": "h100",
+		"intent": "training"
+	},
+	"componentRefs": [
+		{
+			"name": "gpu-operator",
+			"version": "v25.3.3",
+			"type": "helm",
+			"source": "https://helm.ngc.nvidia.com/nvidia",
+			"valuesFile": "components/gpu-operator/values.yaml"
+		}
+	]
+}`
+
+func newTestBundleHandler(t *testing.T) *bundleHandler {
+	t.Helper()
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return newBundleHandler(client, nil)
+}
+
+// zipEntryNames returns the sorted entry names from a zip archive body.
+func zipEntryNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("read zip: %v", err)
+	}
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestBundleHandler_MethodGate verifies only POST is accepted, matching the
+// legacy handler.
+func TestBundleHandler_MethodGate(t *testing.T) {
+	t.Parallel()
+	h := newTestBundleHandler(t)
+
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(method, "/v1/bundle", nil)
+			w := httptest.NewRecorder()
+			h.HandleBundles(w, req)
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+			}
+			if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+				t.Errorf("Allow = %q, want %q", allow, http.MethodPost)
+			}
+		})
+	}
+}
+
+// TestBundleHandler_EmptyComponentRefs verifies a recipe with no components is
+// rejected with 400, matching the legacy handler.
+func TestBundleHandler_EmptyComponentRefs(t *testing.T) {
+	t.Parallel()
+	h := newTestBundleHandler(t)
+
+	body := `{"apiVersion": "aicr.nvidia.com/v1alpha1", "kind": "Recipe", "componentRefs": []}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/bundle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleBundles(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d. Body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// TestBundleHandler_ParityWithLegacy is the criterion-#2 gate: the
+// aicr.Client-backed /v1/bundle handler must produce the SAME HTTP response
+// (status, content headers, zip entry layout) as the legacy
+// bundler.(*DefaultBundler).HandleBundles for an identical POST.
+func TestBundleHandler_ParityWithLegacy(t *testing.T) {
+	t.Parallel()
+
+	queries := []string{
+		"",
+		"deployer=argocd",
+		"deployer=argocd-helm",
+		"set=gpuoperator:gds.enabled=true",
+	}
+
+	for _, q := range queries {
+		t.Run("query="+q, func(t *testing.T) {
+			t.Parallel()
+
+			target := "/v1/bundle"
+			if q != "" {
+				target += "?" + q
+			}
+
+			// Legacy path: direct DefaultBundler.
+			legacy, err := bundler.New()
+			if err != nil {
+				t.Fatalf("bundler.New: %v", err)
+			}
+			legacyReq := httptest.NewRequest(http.MethodPost, target, strings.NewReader(validBundleRecipe))
+			legacyReq.Header.Set("Content-Type", "application/json")
+			legacyW := httptest.NewRecorder()
+			legacy.HandleBundles(legacyW, legacyReq)
+
+			// Facade path: aicr.Client-backed handler.
+			h := newTestBundleHandler(t)
+			facadeReq := httptest.NewRequest(http.MethodPost, target, strings.NewReader(validBundleRecipe))
+			facadeReq.Header.Set("Content-Type", "application/json")
+			facadeW := httptest.NewRecorder()
+			h.HandleBundles(facadeW, facadeReq)
+
+			if legacyW.Code != facadeW.Code {
+				t.Fatalf("status mismatch: legacy=%d facade=%d. legacyBody=%s facadeBody=%s",
+					legacyW.Code, facadeW.Code, legacyW.Body.String(), facadeW.Body.String())
+			}
+			// A non-200 outcome is still a valid parity case (a deployer that
+			// rejects this minimal recipe must reject it the same way in both
+			// paths); require the structured error code+message to match
+			// (requestId/timestamp are per-request and intentionally ignored).
+			if legacyW.Code != http.StatusOK {
+				lc, lm := errCodeMessage(t, legacyW.Body.Bytes())
+				fc, fm := errCodeMessage(t, facadeW.Body.Bytes())
+				if lc != fc || lm != fm {
+					t.Errorf("error mismatch: legacy=(%s,%q) facade=(%s,%q)", lc, lm, fc, fm)
+				}
+				return
+			}
+
+			// Content headers must match (X-Bundle-Duration is timing-dependent,
+			// X-Bundle-Size can vary by a few bytes from non-deterministic
+			// content — compare the stable headers only).
+			for _, hdr := range []string{"Content-Type", "Content-Disposition"} {
+				if l, f := legacyW.Header().Get(hdr), facadeW.Header().Get(hdr); l != f {
+					t.Errorf("%s mismatch: legacy=%q facade=%q", hdr, l, f)
+				}
+			}
+
+			// Zip entry layout must match exactly.
+			legacyNames := zipEntryNames(t, legacyW.Body.Bytes())
+			facadeNames := zipEntryNames(t, facadeW.Body.Bytes())
+			if len(legacyNames) != len(facadeNames) {
+				t.Fatalf("zip entry count mismatch: legacy=%v facade=%v", legacyNames, facadeNames)
+			}
+			for i := range legacyNames {
+				if legacyNames[i] != facadeNames[i] {
+					t.Errorf("zip entry %d mismatch: legacy=%q facade=%q", i, legacyNames[i], facadeNames[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/api/recipe_handler.go
+++ b/pkg/api/recipe_handler.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+	"github.com/NVIDIA/aicr/pkg/server"
+)
+
+// recipeCacheTTL controls the Cache-Control max-age on successful recipe and
+// query responses. Mirrors the value the pkg/recipe handlers emit so the
+// facade-backed handlers stay byte-identical.
+var recipeCacheTTL = defaults.RecipeCacheTTL
+
+// Detail keys for structured error responses. These mirror the values the
+// pkg/recipe handlers emit so the facade-backed responses stay byte-identical.
+const (
+	keyError      = "error"
+	keyAllowed    = "allowed"
+	keyMethod     = "method"
+	keyLimitBytes = "limit_bytes"
+)
+
+// recipeHandler backs the /v1/recipe and /v1/query endpoints with an
+// aicr.Client. It reproduces the behavior of the pkg/recipe Builder handlers
+// exactly, swapping the recipe build for the facade's
+// ResolveRecipeFromCriteria.
+type recipeHandler struct {
+	client *aicr.Client
+	// allowLists is held for exact error-message parity on rejection: the
+	// handler runs an explicit pre-check before resolving so the user-facing
+	// "Criteria value not allowed" message is preserved. The Client's internal
+	// enforcement remains a backstop.
+	allowLists *aicr.AllowLists
+}
+
+// newRecipeHandler constructs a recipeHandler bound to the given client and
+// allowlists.
+func newRecipeHandler(client *aicr.Client, allowLists *aicr.AllowLists) *recipeHandler {
+	return &recipeHandler{client: client, allowLists: allowLists}
+}
+
+// HandleRecipes processes recipe requests using the criteria-based system.
+// It supports GET requests with query parameters and POST requests with JSON/YAML body
+// to specify recipe criteria.
+// The response returns a RecipeResult with component references and constraints.
+// Errors are handled and returned in a structured format.
+func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
+	// Add request-scoped timeout
+	ctx, cancel := context.WithTimeout(r.Context(), defaults.RecipeHandlerTimeout)
+	defer cancel()
+
+	logger := slog.With("requestID", server.RequestIDFromContext(r.Context()))
+
+	var criteria *recipe.Criteria
+	var err error
+
+	switch r.Method {
+	case http.MethodGet:
+		criteria, err = recipe.ParseCriteriaFromRequest(r)
+	case http.MethodPost:
+		// Bound request body to defend against memory exhaustion.
+		bounded := http.MaxBytesReader(w, r.Body, defaults.MaxRecipePOSTBytes)
+		defer func() {
+			// Drain via the bounded reader so any remaining bytes still
+			// count against MaxBytesReader (draining r.Body directly would
+			// bypass the cap). Errors here are debug-only.
+			if _, drainErr := io.Copy(io.Discard, bounded); drainErr != nil {
+				logger.Debug("request body drain failed", "error", drainErr)
+			}
+			if closeErr := bounded.Close(); closeErr != nil {
+				logger.Debug("request body close failed", "error", closeErr)
+			}
+		}()
+		criteria, err = recipe.ParseCriteriaFromBody(bounded, r.Header.Get("Content-Type"))
+		var maxBytesErr *http.MaxBytesError
+		if err != nil && stderrors.As(err, &maxBytesErr) {
+			logger.Warn("recipe POST body exceeded size limit",
+				"limit", defaults.MaxRecipePOSTBytes,
+				"received", maxBytesErr.Limit,
+			)
+			server.WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
+				"Request body exceeds maximum allowed size", false, map[string]any{
+					keyLimitBytes: defaults.MaxRecipePOSTBytes,
+				})
+			return
+		}
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		server.WriteError(w, r, http.StatusMethodNotAllowed, aicrerrors.ErrCodeMethodNotAllowed,
+			"Method not allowed", false, map[string]any{
+				keyMethod:  r.Method,
+				keyAllowed: []string{"GET", "POST"},
+			})
+		return
+	}
+
+	if err != nil {
+		server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Invalid recipe criteria", false, map[string]any{
+				keyError: err.Error(),
+			})
+		return
+	}
+
+	if criteria == nil {
+		server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Recipe criteria cannot be empty", false, nil)
+		return
+	}
+
+	logger.Debug("criteria",
+		"service", criteria.Service,
+		"accelerator", criteria.Accelerator,
+		"intent", criteria.Intent,
+		"os", criteria.OS,
+		"platform", criteria.Platform,
+		"nodes", criteria.Nodes,
+	)
+
+	// Validate criteria against allowlists (if configured). This explicit
+	// pre-check preserves the exact user-facing message; the Client's internal
+	// enforcement remains a backstop.
+	if h.allowLists != nil {
+		if validateErr := h.allowLists.ValidateCriteria(criteria); validateErr != nil {
+			server.WriteErrorFromErr(w, r, validateErr, "Criteria value not allowed", nil)
+			return
+		}
+	}
+
+	result, err := h.client.ResolveRecipeFromCriteria(ctx, criteria)
+	if err != nil {
+		server.WriteErrorFromErr(w, r, err, "Failed to build recipe", nil)
+		return
+	}
+
+	// Set caching headers
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(recipeCacheTTL.Seconds())))
+
+	serializer.RespondJSON(w, http.StatusOK, result)
+}
+
+// HandleQuery processes query requests. It resolves a recipe from criteria,
+// hydrates all component values, and returns the value at the given selector path.
+// Supports GET with query parameters (+selector) and POST with JSON/YAML body.
+func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), defaults.RecipeHandlerTimeout)
+	defer cancel()
+
+	logger := slog.With("requestID", server.RequestIDFromContext(r.Context()))
+
+	var criteria *recipe.Criteria
+	var selector string
+	var err error
+
+	switch r.Method {
+	case http.MethodGet:
+		criteria, err = recipe.ParseCriteriaFromRequest(r)
+		selector = r.URL.Query().Get("selector")
+	case http.MethodPost:
+		// Bound request body to defend against memory exhaustion.
+		bounded := http.MaxBytesReader(w, r.Body, defaults.MaxRecipePOSTBytes)
+		defer func() {
+			// Drain via the bounded reader so any remaining bytes still
+			// count against MaxBytesReader. Errors are debug-only.
+			if _, drainErr := io.Copy(io.Discard, bounded); drainErr != nil {
+				logger.Debug("query request body drain failed", "error", drainErr)
+			}
+			if closeErr := bounded.Close(); closeErr != nil {
+				logger.Debug("query request body close failed", "error", closeErr)
+			}
+		}()
+		req, parseErr := recipe.ParseQueryRequestFromBody(bounded, r.Header.Get("Content-Type"))
+		if parseErr != nil {
+			var maxBytesErr *http.MaxBytesError
+			if stderrors.As(parseErr, &maxBytesErr) {
+				logger.Warn("query POST body exceeded size limit",
+					"limit", defaults.MaxRecipePOSTBytes,
+					"received", maxBytesErr.Limit,
+				)
+				server.WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
+					"Request body exceeds maximum allowed size", false, map[string]any{
+						keyLimitBytes: defaults.MaxRecipePOSTBytes,
+					})
+				return
+			}
+			server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+				"Invalid query request body", false, map[string]any{
+					keyError: parseErr.Error(),
+				})
+			return
+		}
+		if req.Criteria != nil {
+			if validateErr := req.Criteria.Validate(); validateErr != nil {
+				server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+					"Invalid criteria in request body", false, map[string]any{
+						keyError: validateErr.Error(),
+					})
+				return
+			}
+		}
+		criteria = req.Criteria
+		selector = req.Selector
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		server.WriteError(w, r, http.StatusMethodNotAllowed, aicrerrors.ErrCodeMethodNotAllowed,
+			"Method not allowed", false, map[string]any{
+				keyMethod:  r.Method,
+				keyAllowed: []string{"GET", "POST"},
+			})
+		return
+	}
+
+	if err != nil {
+		server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Invalid query criteria", false, map[string]any{
+				keyError: err.Error(),
+			})
+		return
+	}
+
+	if criteria == nil {
+		server.WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Query criteria cannot be empty", false, nil)
+		return
+	}
+
+	logger.Debug("query",
+		"service", criteria.Service,
+		"accelerator", criteria.Accelerator,
+		"intent", criteria.Intent,
+		"os", criteria.OS,
+		"platform", criteria.Platform,
+		"selector", selector,
+	)
+
+	// Validate criteria against allowlists (if configured). This explicit
+	// pre-check preserves the exact user-facing message; the Client's internal
+	// enforcement remains a backstop.
+	if h.allowLists != nil {
+		if validateErr := h.allowLists.ValidateCriteria(criteria); validateErr != nil {
+			server.WriteErrorFromErr(w, r, validateErr, "Criteria value not allowed", nil)
+			return
+		}
+	}
+
+	rec, err := h.client.ResolveRecipeFromCriteria(ctx, criteria)
+	if err != nil {
+		server.WriteErrorFromErr(w, r, err, "Failed to build recipe", nil)
+		return
+	}
+
+	// Hydrate and select as two steps (rather than the combined
+	// aicr.SelectFromRecipe) to preserve the legacy handler's distinct error
+	// mapping: a hydrate failure surfaces via its own error code (5xx), while a
+	// missing selector path is a 404. rec is *aicr.Recipe (= *recipe.RecipeResult),
+	// so HydrateResult accepts it directly.
+	hydrated, err := recipe.HydrateResult(rec)
+	if err != nil {
+		server.WriteErrorFromErr(w, r, err, "Failed to hydrate recipe", nil)
+		return
+	}
+
+	selected, err := recipe.Select(hydrated, selector)
+	if err != nil {
+		server.WriteError(w, r, http.StatusNotFound, aicrerrors.ErrCodeNotFound,
+			"Selector path not found", false, map[string]any{
+				"selector": selector,
+				keyError:   err.Error(),
+			})
+		return
+	}
+
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(recipeCacheTTL.Seconds())))
+
+	serializer.RespondJSON(w, http.StatusOK, selected)
+}

--- a/pkg/api/recipe_handler_test.go
+++ b/pkg/api/recipe_handler_test.go
@@ -1,0 +1,394 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// newTestHandler builds a recipeHandler backed by an embedded-source client.
+// The optional allowLists fences criteria values; pass nil to allow all.
+func newTestHandler(t *testing.T, allowLists *aicr.AllowLists) *recipeHandler {
+	t.Helper()
+	client, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.EmbeddedSource()),
+		aicr.WithVersion("test"),
+		aicr.WithAllowLists(allowLists),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct aicr client: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := client.Close(); closeErr != nil {
+			t.Errorf("client close failed: %v", closeErr)
+		}
+	})
+	return newRecipeHandler(client, allowLists)
+}
+
+// TestHandleRecipes_Success verifies GET and POST resolve a recipe with a 200
+// status and a Cache-Control header.
+func TestHandleRecipes_Success(t *testing.T) {
+	h := newTestHandler(t, nil)
+
+	tests := []struct {
+		name        string
+		method      string
+		target      string
+		body        string
+		contentType string
+	}{
+		{
+			name:   "GET h100 training",
+			method: http.MethodGet,
+			target: "/v1/recipe?accelerator=h100&intent=training",
+		},
+		{
+			name:        "POST h100 training JSON",
+			method:      http.MethodPost,
+			target:      "/v1/recipe",
+			body:        `{"kind":"RecipeCriteria","apiVersion":"aicr.nvidia.com/v1alpha1","spec":{"accelerator":"h100","intent":"training"}}`,
+			contentType: "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req *http.Request
+			if tt.body != "" {
+				req = httptest.NewRequest(tt.method, tt.target, strings.NewReader(tt.body))
+				req.Header.Set("Content-Type", tt.contentType)
+			} else {
+				req = httptest.NewRequest(tt.method, tt.target, nil)
+			}
+			w := httptest.NewRecorder()
+
+			h.HandleRecipes(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+			}
+			if cc := w.Header().Get("Cache-Control"); cc == "" {
+				t.Error("expected Cache-Control header to be set")
+			}
+			// Verify body is a recipe result with components.
+			var result recipe.RecipeResult
+			if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+				t.Fatalf("failed to decode recipe result: %v; body: %s", err, w.Body.String())
+			}
+			if len(result.ComponentRefs) == 0 {
+				t.Error("expected at least one component in resolved recipe")
+			}
+		})
+	}
+}
+
+// TestHandleRecipes_MethodNotAllowed verifies non GET/POST returns 405 with an
+// Allow header.
+func TestHandleRecipes_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(t, nil)
+
+	for _, method := range []string{http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/v1/recipe", nil)
+			w := httptest.NewRecorder()
+
+			h.HandleRecipes(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+			}
+			if allow := w.Header().Get("Allow"); allow != "GET, POST" {
+				t.Errorf("Allow header = %q, want %q", allow, "GET, POST")
+			}
+		})
+	}
+}
+
+// TestHandleRecipes_AllowListRejection verifies an out-of-allowlist criterion is
+// rejected, and that the facade-backed handler produces byte-identical output to
+// the legacy pkg/recipe Builder handler for the same rejection.
+func TestHandleRecipes_AllowListRejection(t *testing.T) {
+	// Allow only a100; h100 falls outside and must be rejected.
+	allowLists := &aicr.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorA100},
+	}
+	h := newTestHandler(t, allowLists)
+
+	// Reference: the legacy Builder handler, same allowlists.
+	rb := recipe.NewBuilder(
+		recipe.WithVersion("test"),
+		recipe.WithAllowLists(allowLists),
+	)
+
+	const target = "/v1/recipe?accelerator=h100&intent=training"
+
+	facadeReq := httptest.NewRequest(http.MethodGet, target, nil)
+	facadeW := httptest.NewRecorder()
+	h.HandleRecipes(facadeW, facadeReq)
+
+	legacyReq := httptest.NewRequest(http.MethodGet, target, nil)
+	legacyW := httptest.NewRecorder()
+	rb.HandleRecipes(legacyW, legacyReq)
+
+	if facadeW.Code != http.StatusBadRequest {
+		t.Fatalf("facade status = %d, want %d; body: %s", facadeW.Code, http.StatusBadRequest, facadeW.Body.String())
+	}
+	if facadeW.Code != legacyW.Code {
+		t.Errorf("facade status = %d, legacy status = %d", facadeW.Code, legacyW.Code)
+	}
+
+	// Decode both error bodies and compare the user-facing fields. RequestID
+	// and Timestamp differ per request, so compare code/message/details only.
+	facadeErr := decodeErrorBody(t, facadeW.Body.Bytes())
+	legacyErr := decodeErrorBody(t, legacyW.Body.Bytes())
+
+	if facadeErr.Message != legacyErr.Message {
+		t.Errorf("message parity: facade %q != legacy %q", facadeErr.Message, legacyErr.Message)
+	}
+	if facadeErr.Code != legacyErr.Code {
+		t.Errorf("code parity: facade %q != legacy %q", facadeErr.Code, legacyErr.Code)
+	}
+	// The allowlist error carries its own message; the fallback "Criteria
+	// value not allowed" is only used when the inner message is empty.
+	if facadeErr.Message != "accelerator type not allowed" {
+		t.Errorf("message = %q, want %q", facadeErr.Message, "accelerator type not allowed")
+	}
+}
+
+// TestHandleQuery_Success verifies GET and POST query against a selector return
+// the selected value.
+func TestHandleQuery_Success(t *testing.T) {
+	h := newTestHandler(t, nil)
+
+	const selector = "components.gpu-operator.values.driver.version"
+
+	tests := []struct {
+		name        string
+		method      string
+		target      string
+		body        string
+		contentType string
+	}{
+		{
+			name:   "GET with selector",
+			method: http.MethodGet,
+			target: "/v1/query?accelerator=h100&intent=training&selector=" + selector,
+		},
+		{
+			// QueryRequest.Criteria is a *recipe.Criteria (flat fields), NOT a
+			// RecipeCriteria envelope — a nested {kind,apiVersion,spec} body would
+			// unmarshal to empty criteria and silently resolve the wrong recipe.
+			name:        "POST with selector",
+			method:      http.MethodPost,
+			target:      "/v1/query",
+			body:        `{"criteria":{"accelerator":"h100","intent":"training"},"selector":"` + selector + `"}`,
+			contentType: "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req *http.Request
+			if tt.body != "" {
+				req = httptest.NewRequest(tt.method, tt.target, strings.NewReader(tt.body))
+				req.Header.Set("Content-Type", tt.contentType)
+			} else {
+				req = httptest.NewRequest(tt.method, tt.target, nil)
+			}
+			w := httptest.NewRecorder()
+
+			h.HandleQuery(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+			}
+			if cc := w.Header().Get("Cache-Control"); cc == "" {
+				t.Error("expected Cache-Control header to be set")
+			}
+			// The selected value should be a non-empty JSON scalar (the
+			// driver version string).
+			var selected any
+			if err := json.Unmarshal(w.Body.Bytes(), &selected); err != nil {
+				t.Fatalf("failed to decode selected value: %v; body: %s", err, w.Body.String())
+			}
+			if s, ok := selected.(string); !ok || s == "" {
+				t.Errorf("expected non-empty string selected value, got %v (%T)", selected, selected)
+			}
+		})
+	}
+}
+
+// TestHandleQuery_POSTMatchesLegacy proves the facade-backed query POST resolves
+// the same criteria as the legacy recipe.Builder handler for an identical flat
+// body — i.e. the POST criteria actually take effect rather than unmarshalling
+// to empty criteria.
+func TestHandleQuery_POSTMatchesLegacy(t *testing.T) {
+	const body = `{"criteria":{"accelerator":"h100","intent":"training"},"selector":"components.gpu-operator.values.driver.version"}`
+
+	newReq := func() *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/v1/query", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		return r
+	}
+
+	// Facade handler (WithVersion "test").
+	fw := httptest.NewRecorder()
+	newTestHandler(t, nil).HandleQuery(fw, newReq())
+
+	// Legacy handler with the same version.
+	lw := httptest.NewRecorder()
+	recipe.NewBuilder(recipe.WithVersion("test")).HandleQuery(lw, newReq())
+
+	if fw.Code != http.StatusOK || lw.Code != http.StatusOK {
+		t.Fatalf("status: facade=%d legacy=%d (facade body: %s)", fw.Code, lw.Code, fw.Body.String())
+	}
+	if fw.Body.String() != lw.Body.String() {
+		t.Errorf("query POST body mismatch:\n facade=%s\n legacy=%s", fw.Body.String(), lw.Body.String())
+	}
+	var selected string
+	if err := json.Unmarshal(fw.Body.Bytes(), &selected); err != nil || selected == "" {
+		t.Fatalf("expected non-empty resolved driver version, got %q (err %v)", fw.Body.String(), err)
+	}
+}
+
+// TestHandleQuery_SelectorNotFound verifies a missing selector path returns 404
+// (not a 5xx), preserving the legacy handler's hydrate-vs-select error split.
+func TestHandleQuery_SelectorNotFound(t *testing.T) {
+	h := newTestHandler(t, nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/query?accelerator=h100&intent=training&selector=components.does.not.exist", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleQuery(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}
+
+// TestHandleQuery_NoSelector verifies a query with no selector returns the
+// entire hydrated recipe structure (as the legacy handler does).
+func TestHandleQuery_NoSelector(t *testing.T) {
+	h := newTestHandler(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/query?accelerator=h100&intent=training", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleQuery(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var hydrated map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &hydrated); err != nil {
+		t.Fatalf("failed to decode hydrated recipe: %v; body: %s", err, w.Body.String())
+	}
+	if _, ok := hydrated["components"]; !ok {
+		t.Errorf("expected hydrated recipe to contain a components key; got keys %v", keysOf(hydrated))
+	}
+}
+
+// TestHandleQuery_MethodNotAllowed verifies non GET/POST returns 405 with an
+// Allow header.
+func TestHandleQuery_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(t, nil)
+
+	for _, method := range []string{http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/v1/query", nil)
+			w := httptest.NewRecorder()
+
+			h.HandleQuery(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+			}
+			if allow := w.Header().Get("Allow"); allow != "GET, POST" {
+				t.Errorf("Allow header = %q, want %q", allow, "GET, POST")
+			}
+		})
+	}
+}
+
+// TestHandleQuery_AllowListRejection verifies query enforces allowlists with the
+// same message as the legacy handler.
+func TestHandleQuery_AllowListRejection(t *testing.T) {
+	allowLists := &aicr.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorA100},
+	}
+	h := newTestHandler(t, allowLists)
+	rb := recipe.NewBuilder(
+		recipe.WithVersion("test"),
+		recipe.WithAllowLists(allowLists),
+	)
+
+	const target = "/v1/query?accelerator=h100&intent=training&selector=components.gpu-operator"
+
+	facadeReq := httptest.NewRequest(http.MethodGet, target, nil)
+	facadeW := httptest.NewRecorder()
+	h.HandleQuery(facadeW, facadeReq)
+
+	legacyReq := httptest.NewRequest(http.MethodGet, target, nil)
+	legacyW := httptest.NewRecorder()
+	rb.HandleQuery(legacyW, legacyReq)
+
+	if facadeW.Code != http.StatusBadRequest {
+		t.Fatalf("facade status = %d, want %d; body: %s", facadeW.Code, http.StatusBadRequest, facadeW.Body.String())
+	}
+	if facadeW.Code != legacyW.Code {
+		t.Errorf("facade status = %d, legacy status = %d", facadeW.Code, legacyW.Code)
+	}
+
+	facadeErr := decodeErrorBody(t, facadeW.Body.Bytes())
+	legacyErr := decodeErrorBody(t, legacyW.Body.Bytes())
+	if facadeErr.Message != legacyErr.Message {
+		t.Errorf("message parity: facade %q != legacy %q", facadeErr.Message, legacyErr.Message)
+	}
+	if facadeErr.Code != legacyErr.Code {
+		t.Errorf("code parity: facade %q != legacy %q", facadeErr.Code, legacyErr.Code)
+	}
+}
+
+// errBody is the subset of the structured error response used for parity asserts.
+type errBody struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details"`
+}
+
+func decodeErrorBody(t *testing.T, b []byte) errBody {
+	t.Helper()
+	var e errBody
+	if err := json.Unmarshal(b, &e); err != nil {
+		t.Fatalf("failed to decode error body: %v; body: %s", err, string(b))
+	}
+	return e
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -22,10 +22,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/NVIDIA/aicr/pkg/bundler"
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/logging"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/server"
 )
 
@@ -61,7 +60,7 @@ func Serve() error {
 	)
 
 	// Parse allowlists from environment variables
-	allowLists, err := recipe.ParseAllowListsFromEnv()
+	allowLists, err := aicr.ParseAllowListsFromEnv()
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to parse allowlists from environment", err)
 	}
@@ -81,24 +80,31 @@ func Serve() error {
 		)
 	}
 
-	// Setup recipe handler
-	rb := recipe.NewBuilder(
-		recipe.WithVersion(version),
-		recipe.WithAllowLists(allowLists),
-	)
-
-	// Setup bundle handler
-	bb, err := bundler.New(
-		bundler.WithAllowLists(allowLists),
+	// Setup recipe/query handlers backed by the aicr.Client facade.
+	client, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.EmbeddedSource()),
+		aicr.WithVersion(version),
+		aicr.WithAllowLists(allowLists),
 	)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to create bundler", err)
+		return errors.Wrap(errors.ErrCodeInternal, "failed to construct aicr client", err)
 	}
+	defer func() {
+		if closeErr := client.Close(); closeErr != nil {
+			slog.Warn("aicr client close failed", "error", closeErr)
+		}
+	}()
+	h := newRecipeHandler(client, allowLists)
+
+	// Setup bundle handler backed by the same aicr.Client facade. server.go
+	// no longer constructs a bundler.Bundler (or a recipe.Builder) directly —
+	// the Client owns both, completing #1077 acceptance criterion #2.
+	bh := newBundleHandler(client, allowLists)
 
 	r := map[string]http.HandlerFunc{
-		"/v1/recipe": rb.HandleRecipes,
-		"/v1/query":  rb.HandleQuery,
-		"/v1/bundle": bb.HandleBundles,
+		"/v1/recipe": h.HandleRecipes,
+		"/v1/query":  h.HandleQuery,
+		"/v1/bundle": bh.HandleBundles,
 	}
 
 	// Create and run server

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -72,38 +72,33 @@ func TestConstants(t *testing.T) {
 	}
 }
 
-// TestRouteConfiguration verifies that the correct routes are set up
+// TestRouteConfiguration verifies that the correct routes are set up,
+// mirroring how Serve wires them: /v1/recipe and /v1/query are backed by the
+// aicr.Client-based recipeHandler, and /v1/bundle by the bundler.
 func TestRouteConfiguration(t *testing.T) {
-	// Test that the route map is properly structured
-	rb := recipe.NewBuilder(
-		recipe.WithVersion("test-version"),
-	)
+	h := newTestHandler(t, nil)
 	bb, err := bundler.New()
 	if err != nil {
 		t.Fatalf("failed to create bundler: %v", err)
 	}
 
 	routes := map[string]http.HandlerFunc{
-		"/v1/recipe": rb.HandleRecipes,
+		"/v1/recipe": h.HandleRecipes,
+		"/v1/query":  h.HandleQuery,
 		"/v1/bundle": bb.HandleBundles,
 	}
 
-	// Verify expected routes exist
-	if handler, exists := routes["/v1/recipe"]; !exists {
-		t.Error("expected /v1/recipe route to exist")
-	} else if handler == nil {
-		t.Error("expected /v1/recipe handler to be non-nil")
-	}
-
-	if handler, exists := routes["/v1/bundle"]; !exists {
-		t.Error("expected /v1/bundle route to exist")
-	} else if handler == nil {
-		t.Error("expected /v1/bundle handler to be non-nil")
+	for _, path := range []string{"/v1/recipe", "/v1/query", "/v1/bundle"} {
+		if handler, exists := routes[path]; !exists {
+			t.Errorf("expected %s route to exist", path)
+		} else if handler == nil {
+			t.Errorf("expected %s handler to be non-nil", path)
+		}
 	}
 
 	// Verify no extra routes
-	if len(routes) != 2 {
-		t.Errorf("expected exactly 2 routes, got %d", len(routes))
+	if len(routes) != 3 {
+		t.Errorf("expected exactly 3 routes, got %d", len(routes))
 	}
 }
 

--- a/pkg/bundler/handler.go
+++ b/pkg/bundler/handler.go
@@ -152,21 +152,7 @@ func (b *DefaultBundler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 
 	// Create a new bundler with configuration
 	bundler, err := New(
-		WithConfig(config.NewConfig(
-			config.WithValueOverridePaths(params.valueOverrides),
-			config.WithDynamicValuePaths(params.dynamicValues),
-			config.WithSystemNodeSelector(params.systemNodeSelector),
-			config.WithSystemNodeTolerations(params.systemNodeTolerations),
-			config.WithAcceleratedNodeSelector(params.acceleratedNodeSelector),
-			config.WithAcceleratedNodeTolerations(params.acceleratedNodeTolerations),
-			config.WithWorkloadGateTaint(params.workloadGateTaint),
-			config.WithWorkloadSelector(params.workloadSelector),
-			config.WithEstimatedNodeCount(params.estimatedNodeCount),
-			config.WithDeployer(params.deployer),
-			config.WithRepoURL(params.repoURL),
-			config.WithVendorCharts(params.vendorCharts),
-			config.WithAppName(params.appName),
-		)),
+		WithConfig(bundleConfigFromParams(params)),
 	)
 	if err != nil {
 		server.WriteError(w, r, http.StatusInternalServerError, aicrerrors.ErrCodeInternal,
@@ -200,15 +186,57 @@ func (b *DefaultBundler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Stream zip response
-	if err := streamZipResponse(w, tempDir, output); err != nil {
+	if err := StreamZipResponse(w, tempDir, output); err != nil {
 		// Can't write error response if we've already started writing
 		logger.Error("failed to stream zip response", "error", err)
 		return
 	}
 }
 
-// streamZipResponse creates a zip archive from the output directory and streams it to the response.
-func streamZipResponse(w http.ResponseWriter, dir string, output *result.Output) (retErr error) {
+// ParseBundleConfig parses the /v1/bundle query parameters from r and
+// returns the bundler *config.Config they describe. It is the exported
+// boundary the aicr.Client-backed REST handler (pkg/api) uses to build
+// the bundle config from a request without reimplementing the query-param
+// parsing or config-building that HandleBundles performs — keeping the
+// facade-backed /v1/bundle handler byte-identical to this one.
+//
+// The returned error carries an ErrCodeInvalidRequest structured code on a
+// bad parameter, suitable for server.WriteErrorFromErr.
+func ParseBundleConfig(r *http.Request) (*config.Config, error) {
+	params, err := parseQueryParams(r)
+	if err != nil {
+		return nil, err
+	}
+	return bundleConfigFromParams(params), nil
+}
+
+// bundleConfigFromParams builds the bundler config from already-parsed
+// query parameters. Extracted so HandleBundles and ParseBundleConfig
+// share one config-construction site (no drift between the two /v1/bundle
+// handlers).
+func bundleConfigFromParams(params *bundleParams) *config.Config {
+	return config.NewConfig(
+		config.WithValueOverridePaths(params.valueOverrides),
+		config.WithDynamicValuePaths(params.dynamicValues),
+		config.WithSystemNodeSelector(params.systemNodeSelector),
+		config.WithSystemNodeTolerations(params.systemNodeTolerations),
+		config.WithAcceleratedNodeSelector(params.acceleratedNodeSelector),
+		config.WithAcceleratedNodeTolerations(params.acceleratedNodeTolerations),
+		config.WithWorkloadGateTaint(params.workloadGateTaint),
+		config.WithWorkloadSelector(params.workloadSelector),
+		config.WithEstimatedNodeCount(params.estimatedNodeCount),
+		config.WithDeployer(params.deployer),
+		config.WithRepoURL(params.repoURL),
+		config.WithVendorCharts(params.vendorCharts),
+		config.WithAppName(params.appName),
+	)
+}
+
+// StreamZipResponse creates a zip archive from the output directory and
+// streams it to the response. Exported so the aicr.Client-backed REST
+// handler (pkg/api) emits the same zip stream — same headers, same entry
+// layout, same compression — as HandleBundles.
+func StreamZipResponse(w http.ResponseWriter, dir string, output *result.Output) (retErr error) {
 	// Set response headers before writing body
 	w.Header().Set("Content-Type", "application/zip")
 	w.Header().Set("Content-Disposition", "attachment; filename=\"bundles.zip\"")

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -26,7 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/NVIDIA/aicr/pkg/bundler"
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
@@ -34,7 +34,6 @@ import (
 	appcfg "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/oci"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"github.com/urfave/cli/v3"
 )
@@ -603,10 +602,17 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	// Initialize external data provider if --data flag is set
-	if err = initDataProvider(cmd, cfg); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+	// Build the Client from the resolved data source (--data flag, else
+	// spec.recipe.data). The shared helper layers a filesystem source over
+	// the embedded data when --data resolves, and uses embedded data alone
+	// otherwise. The Client owns its DataProvider — LoadRecipe and
+	// MakeBundle thread it through, replacing the old process-global
+	// data provider.
+	client, err := recipeClientFromCmd(cmd, cfg)
+	if err != nil {
+		return err
 	}
+	defer func() { _ = client.Close() }()
 
 	opts, err := parseBundleCmdOptions(cmd, cfg)
 	if err != nil {
@@ -634,8 +640,9 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		slog.Bool("oci", opts.ociRef != nil),
 	)
 
-	// Load recipe from file/URL/ConfigMap; auto-hydrates RecipeMetadata overlays.
-	rec, err := recipe.LoadFromFile(ctx, opts.recipeFilePath, opts.kubeconfig, version)
+	// Load recipe from file/URL/ConfigMap through the Client's own data
+	// provider; auto-hydrates RecipeMetadata overlays against that provider.
+	rec, err := client.LoadRecipe(ctx, opts.recipeFilePath, opts.kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -672,23 +679,21 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		config.WithAppName(opts.appName),
 	)
 
-	// Note: binary attestation pre-flight check is handled by bundler.New().
+	// Note: binary attestation pre-flight check is handled inside
+	// MakeBundle via bundler.New().
 	attester, err := selectAttester(ctx, opts)
 	if err != nil {
 		return err
 	}
 
-	b, err := bundler.New(
-		bundler.WithConfig(bcfg),
-		bundler.WithAttester(attester),
-	)
-	if err != nil {
-		slog.Error("failed to create bundler", "error", err)
-		return err
-	}
-
-	// Generate bundle
-	out, err := b.Make(ctx, rec, opts.outputDir)
+	// Generate bundle through the Client facade. MakeBundle constructs the
+	// bundler (with config + attester), bundles from the Client-owned
+	// recipe, and writes the same artifact bundler.Make produced directly.
+	out, err := client.MakeBundle(ctx, rec, aicr.BundleOptions{
+		Config:    bcfg,
+		Attester:  attester,
+		OutputDir: opts.outputDir,
+	})
 	if err != nil {
 		slog.Error("bundle generation failed", "error", err)
 		return err

--- a/pkg/cli/config_integration_test.go
+++ b/pkg/cli/config_integration_test.go
@@ -60,7 +60,7 @@ func TestApplyCriteriaFromConfig_OverridesSnapshot(t *testing.T) {
 		},
 	}
 
-	if err := applyCriteriaFromConfig(criteria, cfg); err != nil {
+	if err := applyCriteriaFromConfig(criteria, cfg, recipe.DefaultRegistry()); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 
@@ -91,7 +91,7 @@ func TestApplyCriteriaFromConfig_FillsEmptyCriteria(t *testing.T) {
 			},
 		},
 	}
-	if err := applyCriteriaFromConfig(criteria, cfg); err != nil {
+	if err := applyCriteriaFromConfig(criteria, cfg, recipe.DefaultRegistry()); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if string(criteria.Service) != "eks" {

--- a/pkg/cli/mirror.go
+++ b/pkg/cli/mirror.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	appcfg "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -161,12 +162,17 @@ func runMirrorListCmd(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	if err = initDataProvider(cmd, cfg); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+	// Build ONE per-command Client bound to the resolved data source. Both
+	// recipe-resolution paths (--recipe load and criteria resolve) run through
+	// it, replacing the old process-global data provider.
+	client, err := recipeClientFromCmd(cmd, cfg)
+	if err != nil {
+		return err
 	}
+	defer func() { _ = client.Close() }()
 
 	// Resolve recipe: --recipe takes precedence over query parameters.
-	rec, err := resolveRecipeForMirror(ctx, cmd, cfg)
+	rec, err := resolveRecipeForMirror(ctx, cmd, cfg, client)
 	if err != nil {
 		return err
 	}
@@ -212,20 +218,36 @@ func runMirrorListCmd(ctx context.Context, cmd *cli.Command) error {
 }
 
 // resolveRecipeForMirror loads a recipe from --recipe flag or builds one
-// from query parameters (--service, --accelerator, etc.).
-func resolveRecipeForMirror(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig) (*recipe.RecipeResult, error) {
+// from query parameters (--service, --accelerator, etc.), through the
+// supplied per-command aicr.Client. Both branches are now Client-based:
+//
+//   - --recipe path: client.LoadRecipe hydrates overlays against the Client's
+//     own DataProvider rather than the process-global. rec.Resolved() returns
+//     the raw *recipe.RecipeResult the mirror Lister.Discover needs.
+//   - criteria path: buildRecipeFromCmdWithConfig resolves through the same
+//     Client and parses criteria against its per-provider registry. The
+//     caller seeds that registry via client.LoadCatalog before this call so
+//     a `--data` overlay's non-OSS criteria values validate.
+func resolveRecipeForMirror(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*recipe.RecipeResult, error) {
 	recipePath := cmd.String("recipe")
 	if recipePath != "" {
 		slog.Info("loading recipe from file", "path", recipePath)
-		rec, err := recipe.LoadFromFile(ctx, recipePath, cmd.String("kubeconfig"), version)
+
+		loaded, err := client.LoadRecipe(ctx, recipePath, cmd.String("kubeconfig"))
 		if err != nil {
 			return nil, err
 		}
-		return rec, nil
+		// Lister.Discover needs the raw *recipe.RecipeResult (constraints,
+		// component refs); Resolved() returns the Client-owned internal recipe.
+		return loaded.Resolved(), nil
 	}
 
-	// Fall through to criteria-based resolution.
-	return buildRecipeFromCmdWithConfig(ctx, cmd, cfg)
+	// Criteria-based resolution: seed the Client's per-provider criteria
+	// registry before parsing criteria, then resolve through the same Client.
+	if err := client.LoadCatalog(ctx); err != nil {
+		return nil, err
+	}
+	return buildRecipeFromCmdWithConfig(ctx, cmd, cfg, client)
 }
 
 // resolveOutputWriter returns a writer for the mirror list output. When

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -24,8 +24,8 @@ import (
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
 
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	appcfg "github.com/NVIDIA/aicr/pkg/config"
-	"github.com/NVIDIA/aicr/pkg/constraints"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/fingerprint"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -106,8 +106,19 @@ Use in shell scripts:
 				return err
 			}
 
-			if err = initDataProvider(cmd, cfg); err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+			// Build a per-command Client bound to the resolved data source.
+			// query historically relied on lazy global seeding of the criteria
+			// registry; it now explicitly seeds its OWN provider via
+			// LoadCatalog before parsing criteria, fixing a latent ordering
+			// bug where the first parse could run against an empty registry.
+			client, err := recipeClientFromCmd(cmd, cfg)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			if err = client.LoadCatalog(ctx); err != nil {
+				return err
 			}
 
 			outFormat, err := parseRecipeOutputFormat(cmd, cfg)
@@ -115,7 +126,7 @@ Use in shell scripts:
 				return err
 			}
 
-			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg)
+			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg, client)
 			if err != nil {
 				return err
 			}
@@ -137,7 +148,8 @@ Use in shell scripts:
 }
 
 // buildRecipeFromCmdWithConfig resolves a recipe from CLI flags layered on
-// top of an optional AICRConfig. Resolution order for each input is:
+// top of an optional AICRConfig, through the supplied aicr.Client. Resolution
+// order for each input is:
 //
 //  1. CLI flag (if explicitly set)
 //  2. spec.recipe.* field on cfg (if non-empty)
@@ -145,10 +157,15 @@ Use in shell scripts:
 //
 // A snapshot path provided by either source takes precedence over the
 // criteria pathway, matching today's --snapshot behavior.
-func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig) (*recipe.RecipeResult, error) {
-	builder := recipe.NewBuilder(
-		recipe.WithVersion(version),
-	)
+//
+// All criteria enum values — fingerprint-derived, config-sourced, and
+// flag-sourced — are parsed against the Client's OWN per-provider criteria
+// registry (client.CriteriaRegistry), so a value contributed by a `--data`
+// overlay validates against the same DataProvider the Client resolves with.
+// The Client's catalog must already be loaded (LoadCatalog) so that registry
+// is seeded.
+func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*recipe.RecipeResult, error) {
+	reg := client.CriteriaRegistry()
 
 	snapFilePath := stringFlagOrConfig(cmd, "snapshot", cfg.Recipe().SnapshotPath())
 
@@ -160,27 +177,21 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 		}
 
 		criteria := fingerprint.FromMeasurements(snap.Measurements).ToCriteria()
-		if applyErr := applyCriteriaFromConfig(criteria, cfg); applyErr != nil {
+		if applyErr := applyCriteriaFromConfig(criteria, cfg, reg); applyErr != nil {
 			return nil, applyErr
 		}
-		if applyErr := applyCriteriaOverrides(cmd, criteria); applyErr != nil {
+		if applyErr := applyCriteriaOverrides(cmd, criteria, reg); applyErr != nil {
 			return nil, applyErr
-		}
-
-		evaluator := func(constraint recipe.Constraint) recipe.ConstraintEvalResult {
-			valResult := constraints.Evaluate(constraint, snap)
-			return recipe.ConstraintEvalResult{
-				Passed: valResult.Passed,
-				Actual: valResult.Actual,
-				Error:  valResult.Error,
-			}
 		}
 
 		slog.Info("building recipe from snapshot", "criteria", criteria.String())
-		return builder.BuildFromCriteriaWithEvaluator(ctx, criteria, evaluator)
+		// ResolveRecipeFromSnapshot builds the constraint evaluator
+		// internally (constraints.Evaluate against snap), mirroring the
+		// pre-facade BuildFromCriteriaWithEvaluator path.
+		return client.ResolveRecipeFromSnapshot(ctx, criteria, snap)
 	}
 
-	criteria, err := mergeCriteriaFromCmdAndConfig(cmd, cfg)
+	criteria, err := mergeCriteriaFromCmdAndConfig(cmd, cfg, reg)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "error parsing criteria", err)
 	}
@@ -191,7 +202,7 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 	}
 
 	slog.Info("building recipe from criteria", "criteria", criteria.String())
-	return builder.BuildFromCriteria(ctx, criteria)
+	return client.ResolveRecipeFromCriteria(ctx, criteria)
 }
 
 // writeQueryResult formats and writes the selected value to w.

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -141,37 +141,38 @@ Override snapshot-detected criteria:
 				return err
 			}
 
-			if err = initDataProvider(cmd, cfg); err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
+			// Build a per-command Client bound to the resolved data source
+			// (--data / spec.recipe.data, else embedded). The Client owns its
+			// own DataProvider and per-provider criteria registry, replacing
+			// the old process-global data provider.
+			client, err := recipeClientFromCmd(cmd, cfg)
+			if err != nil {
+				return err
 			}
+			defer func() { _ = client.Close() }()
 
-			// Eagerly load the catalog so the criteria registry is
-			// populated before any ParseCriteria*Type call. The metadata
-			// store cache is otherwise lazy and the first call would not
-			// run until inside buildRecipeFromCmdWithConfig — after
-			// criteria validation, when the registry-based fallback
-			// can't help yet.
-			//
-			// PropagateOrWrap preserves the inner error code so YAML
-			// parse failures surface as ErrCodeInvalidRequest instead of
-			// being masked as ErrCodeInternal.
-			if err = recipe.LoadCatalog(ctx); err != nil {
-				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load recipe catalog")
+			// Eagerly load THIS Client's catalog so its criteria registry is
+			// seeded before any criteria parse. The metadata store cache is
+			// otherwise lazy and the first parse would run against an empty
+			// registry. LoadCatalog preserves the inner error code so YAML
+			// parse failures surface as ErrCodeInvalidRequest.
+			if err = client.LoadCatalog(ctx); err != nil {
+				return err
 			}
 
 			// Apply criteria-strict AFTER the catalog has loaded —
-			// LoadCatalog populated the registry from every overlay's
-			// spec.criteria; strict mode then hides external-origin
-			// entries from subsequent ParseCriteria*Type lookups.
+			// LoadCatalog seeded the Client's registry from every overlay's
+			// spec.criteria; strict mode then hides external-origin entries
+			// from subsequent registry lookups.
 			//
 			// Three sources can enable strict mode (logical OR):
 			//   1. --criteria-strict CLI flag
 			//   2. spec.recipe.criteriaStrict in --config
 			//   3. AICR_CRITERIA_STRICT env var (honored at registry init)
-			// AICR_CRITERIA_STRICT is read when DefaultRegistry() is first
+			// AICR_CRITERIA_STRICT is read when the registry is first
 			// constructed, so we only need to apply the flag + config here.
 			if cmd.Bool("criteria-strict") || cfg.Recipe().IsCriteriaStrict() {
-				recipe.DefaultRegistry().SetStrict(true)
+				client.CriteriaRegistry().SetStrict(true)
 			}
 
 			outFormat, err := parseRecipeOutputFormat(cmd, cfg)
@@ -181,7 +182,7 @@ Override snapshot-detected criteria:
 
 			kubeconfig := cmd.String("kubeconfig")
 
-			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg)
+			result, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg, client)
 			if err != nil {
 				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "error building recipe")
 			}
@@ -253,12 +254,14 @@ func parseRecipeOutputFormat(cmd *cli.Command, cfg *appcfg.AICRConfig) (serializ
 // populates it. CLI flags subsequently override both via applyCriteriaOverrides,
 // yielding precedence: CLI > config > snapshot.
 //
-// Conversion (string→typed enum) happens in (*config.RecipeSpec).ResolveCriteria
-// — this function only handles the merge-and-log concern.
+// Conversion (string→typed enum) happens in
+// (*config.RecipeSpec).ResolveCriteriaWithRegistry against the per-provider
+// registry threaded in by the caller — this function only handles the
+// merge-and-log concern.
 //
 // Override events are logged at INFO so the resolved value is auditable.
-func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig) error {
-	resolved, err := cfg.Recipe().ResolveCriteria()
+func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig, reg *recipe.CriteriaRegistry) error {
+	resolved, err := cfg.Recipe().ResolveCriteriaWithRegistry(reg)
 	if err != nil {
 		return err
 	}
@@ -304,49 +307,26 @@ func logCriteriaOverride(field, prior, override string) {
 }
 
 // mergeCriteriaFromCmdAndConfig builds a Criteria starting from spec.recipe.criteria
-// (when cfg is non-nil) and overlays CLI flag values on top.
-func mergeCriteriaFromCmdAndConfig(cmd *cli.Command, cfg *appcfg.AICRConfig) (*recipe.Criteria, error) {
+// (when cfg is non-nil) and overlays CLI flag values on top. Every enum value
+// — config-sourced and flag-sourced alike — is resolved against the supplied
+// per-provider registry so a `--data` overlay's non-OSS values validate.
+func mergeCriteriaFromCmdAndConfig(cmd *cli.Command, cfg *appcfg.AICRConfig, reg *recipe.CriteriaRegistry) (*recipe.Criteria, error) {
 	criteria := recipe.NewCriteria()
-	if err := applyCriteriaFromConfig(criteria, cfg); err != nil {
+	if err := applyCriteriaFromConfig(criteria, cfg, reg); err != nil {
 		return nil, err
 	}
-	if err := applyCriteriaOverrides(cmd, criteria); err != nil {
+	if err := applyCriteriaOverrides(cmd, criteria, reg); err != nil {
 		return nil, err
 	}
 	return criteria, nil
 }
 
-// buildCriteriaFromCmd constructs a recipe.Criteria from CLI command flags.
-func buildCriteriaFromCmd(cmd *cli.Command) (*recipe.Criteria, error) {
-	var opts []recipe.CriteriaOption
-
+// applyCriteriaOverrides applies CLI flag overrides to criteria, resolving each
+// enum value against the supplied per-provider registry. Logs a warning when a
+// flag overrides a value detected from the snapshot.
+func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria, reg *recipe.CriteriaRegistry) error {
 	if s := cmd.String("service"); s != "" {
-		opts = append(opts, recipe.WithCriteriaService(s))
-	}
-	if s := cmd.String("accelerator"); s != "" {
-		opts = append(opts, recipe.WithCriteriaAccelerator(s))
-	}
-	if s := cmd.String("intent"); s != "" {
-		opts = append(opts, recipe.WithCriteriaIntent(s))
-	}
-	if s := cmd.String("os"); s != "" {
-		opts = append(opts, recipe.WithCriteriaOS(s))
-	}
-	if s := cmd.String("platform"); s != "" {
-		opts = append(opts, recipe.WithCriteriaPlatform(s))
-	}
-	if n := cmd.Int("nodes"); n > 0 {
-		opts = append(opts, recipe.WithCriteriaNodes(n))
-	}
-
-	return recipe.BuildCriteria(opts...)
-}
-
-// applyCriteriaOverrides applies CLI flag overrides to criteria.
-// Logs a warning when a flag overrides a value detected from the snapshot.
-func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria) error {
-	if s := cmd.String("service"); s != "" {
-		parsed, err := recipe.ParseCriteriaServiceType(s)
+		parsed, err := reg.ParseService(s)
 		if err != nil {
 			return err
 		}
@@ -359,7 +339,7 @@ func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria) error {
 		criteria.Service = parsed
 	}
 	if s := cmd.String("accelerator"); s != "" {
-		parsed, err := recipe.ParseCriteriaAcceleratorType(s)
+		parsed, err := reg.ParseAccelerator(s)
 		if err != nil {
 			return err
 		}
@@ -372,7 +352,7 @@ func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria) error {
 		criteria.Accelerator = parsed
 	}
 	if s := cmd.String("intent"); s != "" {
-		parsed, err := recipe.ParseCriteriaIntentType(s)
+		parsed, err := reg.ParseIntent(s)
 		if err != nil {
 			return err
 		}
@@ -385,7 +365,7 @@ func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria) error {
 		criteria.Intent = parsed
 	}
 	if s := cmd.String("os"); s != "" {
-		parsed, err := recipe.ParseCriteriaOSType(s)
+		parsed, err := reg.ParseOS(s)
 		if err != nil {
 			return err
 		}
@@ -398,7 +378,7 @@ func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria) error {
 		criteria.OS = parsed
 	}
 	if s := cmd.String("platform"); s != "" {
-		parsed, err := recipe.ParseCriteriaPlatformType(s)
+		parsed, err := reg.ParsePlatform(s)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/recipe_test.go
+++ b/pkg/cli/recipe_test.go
@@ -28,6 +28,35 @@ import (
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
+// buildCriteriaFromCmd is a test helper that constructs a recipe.Criteria
+// from CLI command flags, resolving each enum value against the supplied
+// per-provider registry. Used only by TestBuildCriteriaFromCmd to assert
+// the registry-aware option set; production code builds criteria via the
+// mergeCriteriaFromCmdAndConfig → applyCriteriaOverrides path which
+// composes a config base with CLI overrides.
+func buildCriteriaFromCmd(cmd *cli.Command, reg *recipe.CriteriaRegistry) (*recipe.Criteria, error) {
+	var opts []recipe.RegistryCriteriaOption
+	if s := cmd.String("service"); s != "" {
+		opts = append(opts, recipe.WithServiceRegistry(s))
+	}
+	if s := cmd.String("accelerator"); s != "" {
+		opts = append(opts, recipe.WithAcceleratorRegistry(s))
+	}
+	if s := cmd.String("intent"); s != "" {
+		opts = append(opts, recipe.WithIntentRegistry(s))
+	}
+	if s := cmd.String("os"); s != "" {
+		opts = append(opts, recipe.WithOSRegistry(s))
+	}
+	if s := cmd.String("platform"); s != "" {
+		opts = append(opts, recipe.WithPlatformRegistry(s))
+	}
+	if n := cmd.Int("nodes"); n > 0 {
+		opts = append(opts, recipe.WithNodesRegistry(n))
+	}
+	return recipe.BuildCriteriaWithRegistry(reg, opts...)
+}
+
 func TestBuildCriteriaFromCmd(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -168,7 +197,7 @@ func TestBuildCriteriaFromCmd(t *testing.T) {
 					&cli.IntFlag{Name: "nodes"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					capturedCriteria, capturedErr = buildCriteriaFromCmd(cmd)
+					capturedCriteria, capturedErr = buildCriteriaFromCmd(cmd, recipe.DefaultRegistry())
 					return capturedErr
 				},
 			}
@@ -550,7 +579,7 @@ func TestApplyCriteriaOverrides(t *testing.T) {
 					&cli.IntFlag{Name: "nodes"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return applyCriteriaOverrides(cmd, tt.initial)
+					return applyCriteriaOverrides(cmd, tt.initial, recipe.DefaultRegistry())
 				},
 			}
 
@@ -683,45 +712,55 @@ func TestRecipeCmd_HasDataFlag(t *testing.T) {
 	}
 }
 
-func TestInitDataProvider_EmptyPath(t *testing.T) {
-	// Create a minimal command with just the data flag
+func TestRecipeClientFromCmd_EmptyPath(t *testing.T) {
+	// With no --data flag, recipeClientFromCmd constructs an embedded-source
+	// Client (no error). This is the post-migration replacement for the old
+	// empty-path data-provider no-op.
 	testCmd := &cli.Command{
 		Name: "test",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "data"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return initDataProvider(cmd, nil)
+			client, err := recipeClientFromCmd(cmd, nil)
+			if err != nil {
+				return err
+			}
+			return client.Close()
 		},
 	}
 
-	// Run with no --data flag (should succeed with no-op)
 	err := testCmd.Run(context.Background(), []string{"test"})
 	if err != nil {
 		t.Errorf("expected no error with empty --data flag, got: %v", err)
 	}
 }
 
-func TestInitDataProvider_InvalidPath(t *testing.T) {
+func TestRecipeClientFromCmd_InvalidPath(t *testing.T) {
 	testCmd := &cli.Command{
 		Name: "test",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "data"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return initDataProvider(cmd, nil)
+			client, err := recipeClientFromCmd(cmd, nil)
+			if err == nil {
+				_ = client.Close()
+			}
+			return err
 		},
 	}
 
-	// Run with non-existent path
+	// A --data pointing at a non-existent directory must fail Client
+	// construction (the layered FilesystemSource provider validates the dir).
 	err := testCmd.Run(context.Background(), []string{"test", "--data", "/non/existent/path"})
 	if err == nil {
 		t.Error("expected error with non-existent path")
 	}
 }
 
-func TestInitDataProvider_MissingRegistry(t *testing.T) {
-	// Create temp directory without registry.yaml
+func TestRecipeClientFromCmd_MissingRegistry(t *testing.T) {
+	// A --data directory without registry.yaml must fail Client construction.
 	tmpDir := t.TempDir()
 
 	testCmd := &cli.Command{
@@ -730,11 +769,14 @@ func TestInitDataProvider_MissingRegistry(t *testing.T) {
 			&cli.StringFlag{Name: "data"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return initDataProvider(cmd, nil)
+			client, err := recipeClientFromCmd(cmd, nil)
+			if err == nil {
+				_ = client.Close()
+			}
+			return err
 		},
 	}
 
-	// Run with directory that has no registry.yaml
 	err := testCmd.Run(context.Background(), []string{"test", "--data", tmpDir})
 	if err == nil {
 		t.Error("expected error when registry.yaml is missing")

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	"github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/logging"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
@@ -362,41 +362,40 @@ func sanitizeCompletionArgs(args []string) []string {
 	return out
 }
 
-// initDataProvider initializes the data provider from the --data flag,
-// falling back to spec.recipe.data on the supplied AICRConfig when the flag
-// is not set. cfg may be nil; if so, only the flag is consulted.
+// recipeClientFromCmd constructs an aicr.Client bound to the command's
+// resolved recipe data source. The data directory is read from the --data
+// flag, falling back to spec.recipe.data on the supplied AICRConfig when the
+// flag is not set (cfg may be nil; only the flag is consulted then). A
+// non-empty data dir yields a FilesystemSource (the external dir layered over
+// the embedded data); an empty data dir yields the EmbeddedSource. The CLI
+// version is threaded through so resolved recipes carry it in
+// Metadata.Version.
 //
-// The data provider is a process-global. When neither input is set the
-// provider is reset to the embedded one so a long-lived process (or a
-// successive Run within tests) does not silently keep a layered provider
-// installed by a previous invocation.
-func initDataProvider(cmd *cli.Command, cfg *config.AICRConfig) error {
-	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
-
+// Instead of mutating a process-global DataProvider (the pre-Stage-4
+// pattern), each command now owns a per-command Client whose own
+// DataProvider backs recipe resolution and the per-provider criteria
+// registry. Callers MUST Close the returned Client (defer client.Close()).
+//
+// The "initializing external data provider" INFO log matches validate /
+// bundle / mirror so a `--data` invocation is auditable.
+func recipeClientFromCmd(cmd *cli.Command, cfg *config.AICRConfig) (*aicr.Client, error) {
 	dataDir := cmd.String("data")
 	if dataDir == "" {
 		dataDir = cfg.Recipe().DataDir()
 	}
-	if dataDir == "" {
-		// Reset to embedded so prior --data state does not leak across runs.
-		recipe.SetDataProvider(embedded) //nolint:staticcheck // tracked by #983 Stage 2
-		return nil
+	source := aicr.EmbeddedSource()
+	if dataDir != "" {
+		slog.Info("initializing external data provider", "directory", dataDir)
+		source = aicr.FilesystemSource(dataDir)
 	}
-
-	slog.Info("initializing external data provider", "directory", dataDir)
-
-	layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
-		ExternalDir:   dataDir,
-		AllowSymlinks: false,
-	})
+	client, err := aicr.NewClient(
+		aicr.WithRecipeSource(source),
+		aicr.WithVersion(version),
+	)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to initialize external data", err)
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", err)
 	}
-
-	recipe.SetDataProvider(layered) //nolint:staticcheck // tracked by #983 Stage 2
-
-	slog.Info("external data provider initialized successfully", "directory", dataDir)
-	return nil
+	return client, nil
 }
 
 // loadCmdConfig reads --config from the command and returns a parsed

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	aicr "github.com/NVIDIA/aicr/pkg/aicr"
 	"github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -200,18 +201,19 @@ func parseValidationPhases(phaseStrs []string) ([]validator.Phase, error) {
 
 // validatePhasesAgainstRecipe warns when a requested phase has no checks
 // defined in the recipe. The phase will still run but produce 0 tests
-// in the CTRF report.
-func validatePhasesAgainstRecipe(phases []validator.Phase, rec *recipe.RecipeResult) error {
+// in the CTRF report. This is purely advisory — it emits slog warnings and
+// never fails the run, so it has no error result.
+func validatePhasesAgainstRecipe(phases []validator.Phase, rec *recipe.RecipeResult) {
 	if rec.Validation == nil {
 		if len(phases) > 0 {
 			slog.Warn("recipe has no validation section; requested phases will have no checks",
 				"phases", phases)
 		}
-		return nil
+		return
 	}
 
 	if len(phases) == 0 {
-		return nil
+		return
 	}
 
 	defined := make(map[validator.Phase]bool)
@@ -231,8 +233,6 @@ func validatePhasesAgainstRecipe(phases []validator.Phase, rec *recipe.RecipeRes
 				"phase", p)
 		}
 	}
-
-	return nil
 }
 
 // deployAgentForValidation deploys an agent to capture a snapshot and returns the Snapshot.
@@ -312,33 +312,91 @@ type validationConfig struct {
 	evidence *recipeEvidenceConfig
 }
 
+// validateDataProvider builds the recipe.DataProvider matching the source
+// the validate Action handed to aicr.NewClient. It is constructed
+// separately (rather than reaching into the Client) so it can be threaded
+// into evidence emission, whose catalog.Load takes a DataProvider directly.
+// It mirrors the Client's own buildDataProvider so the evidence catalog
+// resolves against exactly the source the validator run used:
+//
+//   - empty dataDir → embedded provider only.
+//   - non-empty dataDir → the external dir layered over the embedded data.
+func validateDataProvider(dataDir string) (recipe.DataProvider, error) {
+	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), ".")
+	if dataDir == "" {
+		return embedded, nil
+	}
+	layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
+		ExternalDir: dataDir,
+	})
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to initialize external data", err)
+	}
+	return layered, nil
+}
+
 // runValidation runs validation using the container-per-validator engine.
+//
+// The validator run is now driven through the aicr.Client facade
+// (ValidateState), which owns the per-command DataProvider and threads it
+// into the validator catalog load. The evidence path still needs the raw
+// pkg/recipe.RecipeResult (via rec.Resolved()) and the same DataProvider
+// (dataProvider) so the attestation catalog resolves against the command's
+// source rather than the package global.
 func runValidation(
 	ctx context.Context,
-	rec *recipe.RecipeResult,
+	client *aicr.Client,
+	dataProvider recipe.DataProvider,
+	rec *aicr.RecipeResult,
 	snap *snapshotter.Snapshot,
 	cfg validationConfig,
 ) error {
 
 	slog.Info("running validation", "phases", cfg.phases)
 
-	v := validator.New(
-		validator.WithVersion(version),
-		validator.WithCommit(commit),
-		validator.WithNamespace(cfg.validationNamespace),
-		validator.WithCleanup(cfg.cleanup),
-		validator.WithImagePullSecrets(cfg.imagePullSecrets),
-		validator.WithNoCluster(cfg.noCluster),
-		validator.WithTolerations(cfg.tolerations),
-		validator.WithNodeSelector(cfg.nodeSelector),
-		validator.WithImageRegistryOverride(cfg.imageRegistryOverride),
-		validator.WithImageTagOverride(cfg.imageTagOverride),
-	)
+	// Generate the run ID CLI-side rather than letting the validator
+	// auto-generate it internally: the no-cleanup debug log below needs to
+	// surface the same ID the validator stamps on its Jobs/RBAC so an
+	// operator can locate the kept resources. Passing it via
+	// WithValidationRunID keeps that value in our hands.
+	runID := v1.GenerateRunID()
 
-	validationInput := v1.ToValidationInput(rec)
-	results, err := v.ValidatePhases(ctx, cfg.phases, validationInput, snap)
+	// Translate the resolved CLI values into facade ValidateOptions. These
+	// mirror the validator.With* options the direct invocation used to set;
+	// ValidateState applies them plus the Client's own DataProvider. Cleanup,
+	// namespace, etc. are always set (matching the old unconditional
+	// validator.With* calls); the image/commit overrides are passed verbatim
+	// (empty string is the validator's "unset" sentinel).
+	opts := []aicr.ValidateOption{
+		aicr.WithValidationNamespace(cfg.validationNamespace),
+		aicr.WithValidationRunID(runID),
+		aicr.WithValidationCleanup(cfg.cleanup),
+		aicr.WithValidationImagePullSecrets(cfg.imagePullSecrets),
+		aicr.WithValidationNoCluster(cfg.noCluster),
+		aicr.WithValidationTolerations(cfg.tolerations),
+		aicr.WithValidationNodeSelector(cfg.nodeSelector),
+		aicr.WithValidationCommit(commit),
+		aicr.WithValidationImageRegistryOverride(cfg.imageRegistryOverride),
+		aicr.WithValidationImageTagOverride(cfg.imageTagOverride),
+		// Uncap the facade-level validation deadline (0 = no cap) so an
+		// all-phase run isn't cut short by ValidationOperationTimeout — the
+		// per-validator timeouts (incl. the 50m inference-perf check) govern,
+		// matching the pre-facade CLI behavior. WithValidationTolerations
+		// above is always passed (even when resolved tolerations are nil) so
+		// the override always clears the validator's default tolerate-all.
+		aicr.WithValidationTimeout(0),
+	}
+	// Pass phases only when explicitly selected. cfg.phases is nil when the
+	// user requested all phases (or used the "all" wildcard), and
+	// WithValidationPhases(nil...) would be a no-op anyway — but keeping the
+	// option off the slice preserves the exact "run all phases" default path.
+	if len(cfg.phases) > 0 {
+		opts = append(opts, aicr.WithValidationPhases(cfg.phases...))
+	}
+
+	results, err := client.ValidateState(ctx, rec, snap, opts...)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "validation failed", err)
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "validation failed")
 	}
 
 	// Extract CTRF reports from phase results and merge into a single report.
@@ -382,7 +440,7 @@ func runValidation(
 	if !cfg.cleanup {
 		slog.Info("cleanup disabled - Jobs and RBAC kept for debugging",
 			"namespace", cfg.validationNamespace,
-			"runID", v.RunID)
+			"runID", runID)
 		slog.Info("to inspect Job logs: kubectl logs -l aicr.nvidia.com/job -n " + cfg.validationNamespace)
 		slog.Info("to list Jobs: kubectl get jobs -n " + cfg.validationNamespace)
 		slog.Info("to cleanup manually: kubectl delete jobs -l app.kubernetes.io/name=aicr -n " + cfg.validationNamespace)
@@ -401,8 +459,12 @@ func runValidation(
 	}
 
 	// Emit even on failure: failed runs document hardware-specific limits.
+	// emitRecipeEvidence needs the full pkg/recipe.RecipeResult (via
+	// Resolved()) for the predicate/BOM, and the command's DataProvider so
+	// the validator catalog used for evidence resolves against the same
+	// source as the run rather than the package global.
 	if cfg.evidence != nil {
-		if err := emitRecipeEvidence(ctx, rec, snap, results, cfg.evidence); err != nil {
+		if err := emitRecipeEvidence(ctx, dataProvider, rec.Resolved(), snap, results, cfg.evidence); err != nil {
 			return err
 		}
 	}
@@ -628,10 +690,6 @@ Run validation without failing on check errors (informational mode):
 				return err
 			}
 
-			if initErr := initDataProvider(cmd, cfg); initErr != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to initialize data provider", initErr)
-			}
-
 			cncfCfg := resolved.EvidenceCNCF
 			if cncfCfg == nil {
 				cncfCfg = &config.EvidenceCNCFResolved{}
@@ -691,9 +749,42 @@ Run validation without failing on check errors (informational mode):
 				noCleanup:        boolFlagOrConfig(cmd, "no-cleanup", resolved.NoCleanup),
 			}
 
+			// Build the Client from the resolved data source (--data flag,
+			// else spec.recipe.data) via the shared helper. The Client owns
+			// its DataProvider, replacing the old process-global data
+			// provider; evidence emission below uses a separate provider
+			// handle to the same directory (dataDir) so SLSA / conformance
+			// evidence resolves files against the command's source rather
+			// than the package global.
+			client, err := recipeClientFromCmd(cmd, cfg)
+			if err != nil {
+				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to initialize data provider")
+			}
+			defer func() { _ = client.Close() }()
+
+			// dataDir is the resolved external-data root. Mirror the same
+			// resolution recipeClientFromCmd performs internally so the
+			// evidence-side provider points at the same directory as the
+			// Client's recipe source.
+			dataDir := cmd.String("data")
+			if dataDir == "" {
+				dataDir = cfg.Recipe().DataDir()
+			}
+
+			// Second provider, separate from the Client's: this one is handed to
+			// evidence emission so conformance/SLSA evidence resolves files
+			// against the command's data source (the resolved --data dir), not
+			// the package global. The Client owns its own provider for recipe
+			// resolution and validation; evidence emission lives outside the
+			// Client surface and needs its own handle to the same directory.
+			dataProvider, err := validateDataProvider(dataDir)
+			if err != nil {
+				return err
+			}
+
 			slog.Info("loading recipe", "uri", recipeFilePath)
 
-			rec, err := recipe.LoadFromFile(ctx, recipeFilePath, kubeconfig, version)
+			rec, err := client.LoadRecipe(ctx, recipeFilePath, kubeconfig)
 			if err != nil {
 				return err
 			}
@@ -728,10 +819,11 @@ Run validation without failing on check errors (informational mode):
 				}
 			}
 
-			// Validate that requested phases are defined in the recipe.
-			if err := validatePhasesAgainstRecipe(phases, rec); err != nil {
-				return err
-			}
+			// Warn when a requested phase has no checks defined in the recipe.
+			// The helper reads the full recipe's Validation section, which the
+			// lossy facade RecipeResult does not expose — reach the underlying
+			// pkg/recipe.RecipeResult via Resolved(). Advisory only.
+			validatePhasesAgainstRecipe(phases, rec.Resolved())
 
 			if shared.noCleanup {
 				slog.Warn("--no-cleanup: cluster-admin ClusterRoleBinding will remain active after validation",
@@ -742,7 +834,7 @@ Run validation without failing on check errors (informational mode):
 
 			evidenceCfg := buildRecipeEvidenceConfig(cmd, resolved)
 
-			return runValidation(ctx, rec, snap, validationConfig{
+			return runValidation(ctx, client, dataProvider, rec, snap, validationConfig{
 				phases:                phases,
 				kubeconfig:            kubeconfig,
 				output:                cmd.String("output"),

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -79,17 +79,25 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 // version), builds an EmitOptions value from the parsed flag config, and
 // delegates the orchestration to the evidence package so the same code
 // path is reachable from the future API surface.
+//
+// dp is the command's DataProvider (built once in the validate Action and
+// shared with the aicr.Client driving the run). Threading it into
+// catalog.LoadWithDataProvider means a --data overlay resolves the validator
+// catalog against the command's source rather than the package-global provider —
+// closing the last global dependency on the validate evidence path. A nil
+// dp falls back to the package global inside catalog.LoadWithDataProvider.
 func emitRecipeEvidence(
 	ctx context.Context,
+	dp recipe.DataProvider,
 	rec *recipe.RecipeResult,
 	snap *snapshotter.Snapshot,
 	results []*validator.PhaseResult,
 	cfg *recipeEvidenceConfig,
 ) error {
 
-	cat, err := catalog.Load(version, commit)
+	cat, err := catalog.LoadWithDataProvider(dp, version, commit)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog for evidence", err)
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load validator catalog for evidence")
 	}
 
 	_, err = attestation.Emit(ctx, attestation.EmitOptions{

--- a/pkg/recipe/handler_query.go
+++ b/pkg/recipe/handler_query.go
@@ -67,7 +67,7 @@ func (b *Builder) HandleQuery(w http.ResponseWriter, r *http.Request) {
 				logger.Debug("query request body close failed", "error", closeErr)
 			}
 		}()
-		req, parseErr := parseQueryRequestFromBody(bounded, r.Header.Get("Content-Type"))
+		req, parseErr := ParseQueryRequestFromBody(bounded, r.Header.Get("Content-Type"))
 		if parseErr != nil {
 			var maxBytesErr *http.MaxBytesError
 			if stderrors.As(parseErr, &maxBytesErr) {
@@ -165,8 +165,8 @@ func (b *Builder) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	serializer.RespondJSON(w, http.StatusOK, selected)
 }
 
-// parseQueryRequestFromBody parses a QueryRequest from the request body.
-func parseQueryRequestFromBody(body io.Reader, contentType string) (*QueryRequest, error) {
+// ParseQueryRequestFromBody parses a QueryRequest from the request body.
+func ParseQueryRequestFromBody(body io.Reader, contentType string) (*QueryRequest, error) {
 	if body == nil {
 		return nil, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "request body cannot be nil")
 	}

--- a/pkg/recipe/handler_query_test.go
+++ b/pkg/recipe/handler_query_test.go
@@ -207,7 +207,7 @@ func TestHandleQuery_POST_InvalidCriteria(t *testing.T) {
 }
 
 func TestParseQueryRequestFromBody_NilBody(t *testing.T) {
-	_, err := parseQueryRequestFromBody(nil, "application/json")
+	_, err := ParseQueryRequestFromBody(nil, "application/json")
 	if err == nil {
 		t.Fatal("expected error for nil body")
 	}


### PR DESCRIPTION
## Summary
Migrate the CLI (`recipe`, `query`, `validate`, `bundle`, `mirror`) and REST server (`/v1/recipe`, `/v1/query`, `/v1/bundle`) onto the top-level `aicr.Client` facade instead of constructing `recipe.Builder`/`bundler.Bundler` directly or mutating the process-global provider. PR 2 of 2 for #1077.

> **Stacked on #1107** (per-DataProvider de-globalization). Base is `refactor/aicr-recipe-deglobalization`; will retarget to `main` once #1107 merges.

## What changes
- `server.go` builds an `aicr.Client`; no longer constructs `recipe.Builder` or `bundler.Bundler` → **acceptance criterion #2**.
- `recipe`/`query`/`mirror` build a per-invocation Client and seed their own per-provider criteria registry; `initDataProvider` and the last `recipe.SetDataProvider` calls are removed from `pkg/cli` → **acceptance criterion #1**.
- Facade surface added: `EmbeddedSource`, `WithVersion`, `WithAllowLists`, `ParseAllowListsFromEnv`, `ResolveRecipeFromCriteria`/`FromSnapshot`, `SelectFromRecipe`, `LoadRecipe`/`LoadRecipeBytes`, `AdoptRecipe`, `MakeBundle`, `ValidateState` (+ phase/timeout/provider options), `Client.LoadCatalog`/`CriteriaRegistry`; `Recipe`/`AllowLists`/`Criteria`/`CriteriaRegistry` aliases.

## Behavior
CLI flags and REST endpoints behave identically (criterion #3). **One deliberate change, called out explicitly:** CLI validation is no longer bounded by the facade's fixed `ValidationOperationTimeout` (it's opt-in, default uncapped for the CLI) — the previous CLI path relied only on per-validator timeouts, and the fixed cap would cancel a legitimate all-phase run that includes the 50m inference-perf check.

## Testing
`make qualify` green (tree identical to the validated combined branch). New facade + handler tests assert byte-identical REST responses, allowlist rejection parity, the query hydrate-vs-selector 404/5xx split, and per-Client provider isolation.

Relates to #1077. Note: `aicr.Client`'s `*Recipe` alias methods are provisional pending the facade-owned wrappers in #1078.