### PR TITLE
feat(recipe): push owner-token guard down to pkg/recipe.RecipeResult

### DIFF
--- a/pkg/recipe/builder.go
+++ b/pkg/recipe/builder.go
@@ -174,5 +174,11 @@ func (b *Builder) buildWithStore(ctx context.Context, c *Criteria, buildFn func(
 		result.Metadata.Version = b.Version
 	}
 
+	// Stamp owner so cross-Builder result mixing is rejected at the
+	// consumption point (see RecipeResult.AssertOwnedBy). The Builder
+	// pointer identity is the token — zero-cost and unforgeable from
+	// outside the package because owner is unexported.
+	result.owner = b
+
 	return result, nil
 }

--- a/pkg/recipe/builder_test.go
+++ b/pkg/recipe/builder_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
+	errs "github.com/NVIDIA/aicr/pkg/errors"
 )
 
 // TestBuilder_BuildFromCriteria_ContextCancellation tests context cancellation
@@ -549,5 +551,106 @@ func TestBuilder_TwoProviders_ConcurrentBuild(t *testing.T) {
 		if slices.Contains(names, "alpha-only-component") {
 			t.Errorf("resultsB[%d] leaked alpha-only-component: %v", i, names)
 		}
+	}
+}
+
+// TestRecipeResult_OwnerStampedByBuilder verifies the producing Builder
+// is stamped on the result via the unexported owner field. The Owner()
+// accessor returns it for comparison; AssertOwnedBy(b) returns nil for
+// the producer and ErrCodeInvalidRequest for any other Builder.
+func TestRecipeResult_OwnerStampedByBuilder(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	dp := buildIsolationProvider(t, "alpha-only")
+	b := NewBuilder(WithDataProvider(dp))
+
+	r, err := b.BuildFromCriteria(context.Background(), &Criteria{Service: "eks"})
+	if err != nil {
+		t.Fatalf("BuildFromCriteria: %v", err)
+	}
+	if r.Owner() != b {
+		t.Errorf("Owner() = %v, want %v", r.Owner(), b)
+	}
+	if err := r.AssertOwnedBy(b); err != nil {
+		t.Errorf("AssertOwnedBy(producer) = %v, want nil", err)
+	}
+}
+
+// TestRecipeResult_AssertOwnedBy_RejectsCrossBuilder is the pkg/recipe-level
+// analog of TestClient_CrossClientBundleRejected (pkg/client/v1) — it
+// proves the owner-token guard fires at the layer where the data lives,
+// not just at the facade boundary. Two Builders with different
+// DataProviders produce results that AssertOwnedBy refuses to attribute
+// to the other, with ErrCodeInvalidRequest.
+func TestRecipeResult_AssertOwnedBy_RejectsCrossBuilder(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	dpA := buildIsolationProvider(t, "alpha-only")
+	dpB := buildIsolationProvider(t, "beta-only")
+	bA := NewBuilder(WithDataProvider(dpA))
+	bB := NewBuilder(WithDataProvider(dpB))
+
+	rA, err := bA.BuildFromCriteria(context.Background(), &Criteria{Service: "eks"})
+	if err != nil {
+		t.Fatalf("BuildFromCriteria(A): %v", err)
+	}
+
+	err = rA.AssertOwnedBy(bB)
+	if err == nil {
+		t.Fatal("AssertOwnedBy(other Builder) = nil; expected ErrCodeInvalidRequest")
+	}
+	var se *errs.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *errors.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != errs.ErrCodeInvalidRequest {
+		t.Errorf("error code = %s, want %s", se.Code, errs.ErrCodeInvalidRequest)
+	}
+}
+
+// TestRecipeResult_AssertOwnedBy_NilCases covers the documented nil
+// handling: nil receiver is vacuously owned (returns nil), nil Builder
+// argument is rejected, and a non-nil result with nil owner (no
+// provenance — e.g., LoadFromFile path) is rejected.
+func TestRecipeResult_AssertOwnedBy_NilCases(t *testing.T) {
+	var nilResult *RecipeResult
+	b := NewBuilder()
+
+	if err := nilResult.AssertOwnedBy(b); err != nil {
+		t.Errorf("nil receiver returned %v, want nil", err)
+	}
+
+	r := &RecipeResult{} // constructed outside Builder — no owner
+	if err := r.AssertOwnedBy(nil); err == nil {
+		t.Error("AssertOwnedBy(nil) returned nil; expected rejection")
+	}
+	if err := r.AssertOwnedBy(b); err == nil {
+		t.Error("AssertOwnedBy on owner-less result returned nil; expected rejection")
+	}
+}
+
+// TestRecipeResult_DeepCopy_DropsOwner pins the deep-copy contract: the
+// copy carries the public payload but loses the owner stamp, so adopted
+// recipes (e.g., the facade's AdoptRecipe path) cannot be passed back
+// through ownership-checked entry points without re-building.
+func TestRecipeResult_DeepCopy_DropsOwner(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+	t.Cleanup(ResetComponentRegistryForTesting)
+
+	dp := buildIsolationProvider(t, "alpha-only")
+	b := NewBuilder(WithDataProvider(dp))
+
+	r, err := b.BuildFromCriteria(context.Background(), &Criteria{Service: "eks"})
+	if err != nil {
+		t.Fatalf("BuildFromCriteria: %v", err)
+	}
+	copy := r.DeepCopy()
+	if copy.Owner() != nil {
+		t.Errorf("DeepCopy.Owner() = %v, want nil", copy.Owner())
+	}
+	if err := copy.AssertOwnedBy(b); err == nil {
+		t.Error("AssertOwnedBy on deep-copied result returned nil; expected rejection (no provenance)")
 	}
 }

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -417,6 +417,28 @@ type RecipeResult struct {
 	// provider, in which case DataProvider() returns nil and callers fall
 	// back to GetDataProvider().
 	provider DataProvider
+
+	// owner identifies the *Builder that produced this RecipeResult.
+	// Stamped by Builder.buildWithStore (covers BuildFromCriteria and
+	// BuildFromCriteriaWithEvaluator) using the Builder's pointer
+	// identity — zero-cost, naturally unique, and unforgeable from
+	// outside the package because the field is unexported.
+	//
+	// Consumers that hold a *Builder reference can call AssertOwnedBy
+	// to refuse a RecipeResult produced by a different Builder before
+	// reading values via GetValuesForComponent. This pushes the
+	// cross-provider safety guard down from the aicr facade (where it
+	// only protected facade callers) to the layer where the bug
+	// actually lives — protecting direct pkg/recipe.Builder importers
+	// the same way.
+	//
+	// Nil when the result was constructed outside Builder (e.g.,
+	// LoadFromFile decoding a pre-hydrated RecipeResult file).
+	// AssertOwnedBy treats nil owner as "no provenance" and rejects;
+	// callers that legitimately load results externally should rebind
+	// via BindDataProvider and consume read-only without going through
+	// ownership-checked entry points.
+	owner *Builder
 }
 
 // DataProvider returns the DataProvider that produced this result, or nil
@@ -427,6 +449,68 @@ func (r *RecipeResult) DataProvider() DataProvider {
 		return nil
 	}
 	return r.provider
+}
+
+// Owner returns the *Builder that produced this RecipeResult, or nil when
+// the result was constructed outside the Builder path (e.g., a recipe file
+// loaded via LoadFromFile that was never re-built locally). Nil-safe on
+// the receiver. Returned identity is for comparison only; callers should
+// not mutate the Builder.
+func (r *RecipeResult) Owner() *Builder {
+	if r == nil {
+		return nil
+	}
+	return r.owner
+}
+
+// AssertOwnedBy returns nil when this RecipeResult was produced by b, and
+// ErrCodeInvalidRequest otherwise. The check uses pointer identity on the
+// unexported owner field stamped by Builder.buildWithStore at build time.
+//
+// Use this from consumer entry points that hold a *Builder reference and
+// want to refuse a RecipeResult produced elsewhere before reading values
+// (e.g., calling GetValuesForComponent). Two Builders with different
+// DataProviders would otherwise mix component refs from one provider with
+// file reads from the other — the same bug class the facade-level
+// assertOwns in pkg/client/v1 protects against, but enforced at the layer
+// where the data lives so external pkg/recipe.Builder importers are
+// covered too.
+//
+// A nil receiver returns nil (vacuously owned by anything) so the helper
+// composes with chained nil-checks. A nil b argument returns
+// ErrCodeInvalidRequest — callers must pass the Builder they want to
+// assert against.
+//
+// A nil owner on a non-nil result is rejected: the result has no provenance
+// and cannot prove it belongs to b. Callers that load results externally
+// (e.g., recipe YAML from disk) and want to consume them must rebuild via
+// Builder or skip the owner-checked entry points; BindDataProvider + the
+// non-checked accessors remain available for that path.
+func (r *RecipeResult) AssertOwnedBy(b *Builder) error {
+	if r == nil {
+		return nil
+	}
+	if b == nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"AssertOwnedBy requires a non-nil *Builder")
+	}
+	if r.owner == nil {
+		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"RecipeResult has no owner (constructed outside Builder); cross-builder operations are not permitted",
+			map[string]any{
+				"expectedOwner": fmt.Sprintf("%p", b),
+				"actualOwner":   "<nil>",
+			})
+	}
+	if r.owner != b {
+		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"RecipeResult was produced by a different Builder; cross-builder operations are not permitted",
+			map[string]any{
+				"expectedOwner": fmt.Sprintf("%p", b),
+				"actualOwner":   fmt.Sprintf("%p", r.owner),
+			})
+	}
+	return nil
 }
 
 // BindDataProvider sets the DataProvider on a RecipeResult so downstream
@@ -463,6 +547,10 @@ func (r *RecipeResult) DeepCopy() *RecipeResult {
 		Kind:       r.Kind,
 		APIVersion: r.APIVersion,
 		// provider intentionally left nil: BindDataProvider sets it on the copy.
+		// owner intentionally left nil: the copy has no producer Builder, so
+		// AssertOwnedBy rejects it. The facade's AdoptRecipe path rebinds
+		// the provider but does not rebind owner — adopted recipes can be
+		// read but not consumed via ownership-checked entry points.
 	}
 
 	// Metadata: scalar Version plus three slices.


### PR DESCRIPTION
## Summary

Push the cross-Builder safety guard from the `aicr` facade down to `recipe.RecipeResult`, so direct `pkg/recipe.Builder` importers get the same protection the facade callers already have.

## Motivation / Context

`pkg/client/v1.assertOwns` in `aicr.go` rejects a `RecipeResult` produced by `Client A` from being passed to `Client B.BundleComponents` / `ValidateState`. That guard lives only at the facade layer; direct `pkg/recipe.Builder` consumers (which the `pkg/recipe` package's "Public (evolving)" tier explicitly allows) get no protection. After the per-Builder isolation work in #1107, any external project that constructs two Builders today (e.g., for tenant isolation) hits the same bug class once they trust the per-Builder routing.

Push the guard to the layer where the data lives so it covers both call paths.

Fixes: #1080
Related: #1076 (epic — this is the last open child)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other:

## Implementation Notes

- `recipe.RecipeResult` gains unexported `owner *Builder` field next to the existing `provider` field. Pointer identity is the token — zero-cost, naturally unique, unforgeable from outside the package.
- `Builder.buildWithStore` stamps `result.owner = b` before returning, covering both `BuildFromCriteria` and `BuildFromCriteriaWithEvaluator` via the shared code path.
- New `(*RecipeResult).Owner() *Builder` returns the producer for comparison.
- New `(*RecipeResult).AssertOwnedBy(b *Builder) error` returns `nil` for the producer; `ErrCodeInvalidRequest` (with producer/expected `%p` pointers in context) for any other Builder. Nil-safe on the receiver (vacuously owned); nil `b` argument is rejected (must specify what to assert against); nil owner on a non-nil result is rejected (no provenance — e.g., `LoadFromFile` path).
- `DeepCopy` leaves `owner` nil — mirrors how `provider` is also left nil. Adopted-recipe flows (`AdoptRecipe`) cannot pass deep-copies back through ownership-checked entry points without re-building.

**No facade or in-tree caller changes.** The existing `pkg/client/v1.assertOwns` continues to function as before; the new recipe-level check is additive defense-in-depth for external `pkg/recipe.Builder` importers and a foundation for future `pkg/recipe`-level enforcement (e.g., `GetValuesForComponent` checks).

## Testing

```bash
go test -race ./pkg/recipe/...   # pass
make lint                         # 0 issues
```

New tests in `pkg/recipe/builder_test.go`:

- `TestRecipeResult_OwnerStampedByBuilder` — happy path.
- `TestRecipeResult_AssertOwnedBy_RejectsCrossBuilder` — analog of `pkg/client/v1.TestClient_CrossClientBundleRejected`; exercises the rejection without going through the facade (satisfies the issue's test acceptance criterion).
- `TestRecipeResult_AssertOwnedBy_NilCases` — pins documented nil handling.
- `TestRecipeResult_DeepCopy_DropsOwner` — pins the deep-copy contract.

## Risk Assessment

- [x] **Low** — Additive change. New unexported field, new methods, no signature changes on existing exports. No in-tree caller updates required. Facade-level guard untouched.
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** External Go importers that hold `*pkg/recipe.Builder` can now call `result.AssertOwnedBy(b)` before consuming a `RecipeResult` to verify provenance. Recommended but optional; existing call patterns continue to work.

## Checklist

- [x] Tests pass locally (`go test -race ./pkg/recipe/...`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added tests for the new functionality
- [x] No user-facing behavior change; docs unchanged
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
