### PR TITLE
fix(recipes): stop setting gpu-operator driverInstallDir to / on kind and oke

### DIFF
--- a/pkg/recipe/driver_root_lockstep_test.go
+++ b/pkg/recipe/driver_root_lockstep_test.go
@@ -19,22 +19,46 @@ import (
 	"testing"
 )
 
-// TestDriverRootLockstep enforces that, for every overlay carrying both
-// nvidia-dra-driver-gpu and gpu-operator, the resolved values of
+// TestDriverRootLockstep guards the relationship between
 // nvidia-dra-driver-gpu.nvidiaDriverRoot and
-// gpu-operator.hostPaths.driverInstallDir are explicitly set and identical.
+// gpu-operator.hostPaths.driverInstallDir across every overlay carrying
+// both components.
 //
-// Why this lockstep matters (see issue #1087):
+// Why this matters (see issue #1087):
 // The DRA kubelet plugin loads the NVIDIA driver userspace
-// (libnvidia-ml.so, nvidia-smi, nvidia-ctk) from nvidiaDriverRoot. The
-// GPU operator mounts the operator-managed driver container rootfs onto
-// the host at driverInstallDir. The two paths are independently
-// configurable across overlays, but if they drift the DRA driver fails
-// CDI spec generation ("Driver/library version mismatch" or missing
-// libnvidia-ml.so), DRA-allocated pods stall in ContainerCreating, and
-// `aicr validate` deployment phase fails. There is no schema link
-// between the two fields, so an overlay editor can change one without
-// the other and CI won't notice — this test is the only guard.
+// (libnvidia-ml.so, nvidia-smi, nvidia-ctk) from nvidiaDriverRoot. When
+// the GPU operator MANAGES the driver (driver.enabled true), it installs
+// the driver container rootfs onto the host at driverInstallDir, and DRA
+// must read from that same path or CDI spec generation fails
+// ("Driver/library version mismatch" / missing libnvidia-ml.so),
+// DRA-allocated pods stall in ContainerCreating, and `aicr validate`
+// deployment phase fails. There is no schema link between the two fields,
+// so an overlay editor can drift one without the other and CI won't
+// notice — this test is the only guard.
+//
+// **Two distinct invariants.** The original draft of this test (PR #1106)
+// asserted the two values are always identical. That is wrong, and forcing
+// it caused a regression: to make nvidiaDriverRoot ("/") and
+// driverInstallDir match on the kind and oke overlays, #1106 set
+// driverInstallDir: "/". But driverInstallDir is the host path the
+// operator-validator bind-mounts as the driver-validation container's
+// rootfs target, and runc rejects a mount whose destination is "/"
+// ("mountpoint is on the top of rootfs") — crash-looping
+// nvidia-operator-validator, stalling ClusterPolicy, and hanging every
+// GPU-on-kind run (and oke, had it been in CI). The corrected model:
+//
+//  1. driverInstallDir is NEVER "/", for any overlay that includes
+//     gpu-operator — it is a mount destination, illegal regardless of
+//     driver.enabled or whether nvidia-dra-driver-gpu is present. (Hard
+//     invariant; this is the regression guard, checked before the
+//     DRA-dependent skips so a gpu-operator-only overlay can't slip past.)
+//  2. nvidiaDriverRoot == driverInstallDir is required ONLY when the
+//     operator manages the driver (gpu-operator driver.enabled true / unset
+//     → chart default true). Then both must be explicitly set and equal.
+//     When driver.enabled is false (host-installed drivers, e.g. kind/oke),
+//     the two are independent: nvidiaDriverRoot is the host driver-userspace
+//     location (legitimately "/"), while driverInstallDir is only the
+//     validator's mount target (the base default /run/nvidia/driver).
 //
 // **Discovery.** The test iterates every overlay with non-nil
 // Spec.Criteria. The earlier draft restricted to "leaf" overlays
@@ -46,14 +70,14 @@ import (
 // {h100, gke-cos, training} query without platform resolves to it
 // directly in production. The earlier filter would miss that.
 //
-// **Assertion.** Both resolved values must be explicitly set (non-empty
-// in the resolved Helm values map) AND identical. An empty value falls
-// through to the upstream chart's bundled default, which the test cannot
-// read — and per-component defaults differ (GPU Operator chart 26.3.1
-// defaults driverInstallDir to /run/nvidia/driver, but DRA chart 25.12.0
-// defaults nvidiaDriverRoot to /). Relying on chart defaults is itself
-// drift waiting to happen on the next chart bump, so the test treats
-// "not explicitly set on both" as a failure.
+// **Why "explicitly set" matters for the lockstep case.** An empty value
+// falls through to the upstream chart's bundled default, which the test
+// cannot read — and per-component defaults differ (GPU Operator chart
+// 26.3.1 defaults driverInstallDir to /run/nvidia/driver, but DRA chart
+// 25.12.0 defaults nvidiaDriverRoot to /). Relying on chart defaults is
+// itself drift waiting to happen on the next chart bump, so when the
+// lockstep applies the test treats "not explicitly set on both" as a
+// failure.
 func TestDriverRootLockstep(t *testing.T) {
 	ctx := context.Background()
 	store, err := loadMetadataStore(ctx)
@@ -77,6 +101,44 @@ func TestDriverRootLockstep(t *testing.T) {
 
 			dra := result.GetComponentRef("nvidia-dra-driver-gpu")
 			op := result.GetComponentRef("gpu-operator")
+
+			// Resolve gpu-operator values once (when present) so the hard
+			// invariant below and the lockstep checks share them.
+			var opValues map[string]any
+			if op != nil {
+				opValues, err = result.GetValuesForComponent("gpu-operator")
+				if err != nil {
+					t.Fatalf("GetValuesForComponent(gpu-operator): %v", err)
+				}
+			}
+
+			// Hard invariant, enforced for every overlay that includes
+			// gpu-operator — independent of nvidia-dra-driver-gpu and of the
+			// operator's own driver.enabled setting. driverInstallDir is the
+			// operator-validator's bind-mount destination, so "/" is illegal:
+			// runc rejects mounting over the container rootfs and
+			// nvidia-operator-validator crash-loops. This is the guard for the
+			// #1106 regression, so it must run BEFORE the DRA-dependent skips
+			// below — otherwise a gpu-operator-only overlay (DRA absent or
+			// disabled) could set driverInstallDir: "/" and slip past unchecked.
+			if op != nil {
+				if opInstallDir := stringAtPath(opValues, "hostPaths", "driverInstallDir"); opInstallDir == "/" {
+					t.Errorf(
+						"overlay %q: gpu-operator.hostPaths.driverInstallDir = %q is invalid.\n"+
+							"  driverInstallDir is bind-mounted as the driver-validation container's rootfs target;\n"+
+							"  runc rejects a mount whose destination is \"/\" (\"mountpoint is on the top of rootfs\"),\n"+
+							"  crash-looping nvidia-operator-validator and stalling ClusterPolicy.\n"+
+							"  Use a real subdirectory (the base default /run/nvidia/driver). For host-installed\n"+
+							"  drivers at the host root, set nvidia-dra-driver-gpu.nvidiaDriverRoot: / instead —\n"+
+							"  that field may be \"/\"; driverInstallDir may not.\n"+
+							"  See issue #1087.",
+						name, opInstallDir)
+					return
+				}
+			}
+
+			// The nvidiaDriverRoot == driverInstallDir lockstep additionally
+			// requires both components present and enabled.
 			if dra == nil || op == nil {
 				t.Skipf("lockstep N/A: nvidia-dra-driver-gpu=%v gpu-operator=%v",
 					dra != nil, op != nil)
@@ -91,13 +153,20 @@ func TestDriverRootLockstep(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetValuesForComponent(nvidia-dra-driver-gpu): %v", err)
 			}
-			opValues, err := result.GetValuesForComponent("gpu-operator")
-			if err != nil {
-				t.Fatalf("GetValuesForComponent(gpu-operator): %v", err)
-			}
 
 			draRoot, _ := draValues["nvidiaDriverRoot"].(string)
 			opInstallDir := stringAtPath(opValues, "hostPaths", "driverInstallDir")
+
+			// The nvidiaDriverRoot == driverInstallDir lockstep only applies
+			// when the operator installs the driver. With driver.enabled false
+			// (host-installed drivers), the operator manages no driver, so the
+			// DRA userspace root and the validator mount target are independent
+			// and may legitimately differ (e.g. kind/oke: "/" vs
+			// /run/nvidia/driver).
+			if !boolAtPath(opValues, true, "driver", "enabled") {
+				t.Skipf("lockstep N/A: gpu-operator manages no driver (driver.enabled=false); "+
+					"nvidiaDriverRoot=%q and driverInstallDir=%q are independent", draRoot, opInstallDir)
+			}
 
 			switch {
 			case draRoot == "" && opInstallDir == "":
@@ -203,4 +272,69 @@ func stringAtPath(m map[string]any, keys ...string) string {
 		current = next
 	}
 	return ""
+}
+
+// TestBoolAtPath covers the helper used to read gpu-operator's
+// driver.enabled out of the resolved Helm values map, including the
+// fallback to the caller-supplied default when the path is absent or the
+// leaf is not a bool (e.g. unset → chart default true).
+func TestBoolAtPath(t *testing.T) {
+	tree := map[string]any{
+		"driver": map[string]any{
+			"enabled": false,
+		},
+		"truthy":    true,
+		"wrongType": "nope",
+		"nested":    map[string]any{"x": 7},
+	}
+	tests := []struct {
+		name string
+		def  bool
+		keys []string
+		want bool
+	}{
+		{"hits nested false", true, []string{"driver", "enabled"}, false},
+		{"hits scalar true", false, []string{"truthy"}, true},
+		{"missing top key → default", true, []string{"absent"}, true},
+		{"missing nested key → default", true, []string{"driver", "absent"}, true},
+		{"intermediate not a map → default", true, []string{"truthy", "x"}, true},
+		{"leaf wrong type → default", true, []string{"wrongType"}, true},
+		{"nested wrong-type leaf → default", false, []string{"nested", "x"}, false},
+		{"empty path → default", true, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boolAtPath(tree, tt.def, tt.keys...); got != tt.want {
+				t.Errorf("boolAtPath(%v, def=%v) = %v, want %v", tt.keys, tt.def, got, tt.want)
+			}
+		})
+	}
+}
+
+// boolAtPath walks a nested map[string]any along the given keys and returns
+// the leaf bool, or def if any key is missing, any intermediate is not a
+// map, or the leaf is not a bool. Used to read gpu-operator's
+// driver.enabled (which falls back to the chart default — true — when an
+// overlay does not set it).
+func boolAtPath(m map[string]any, def bool, keys ...string) bool {
+	current := m
+	for i, k := range keys {
+		v, ok := current[k]
+		if !ok {
+			return def
+		}
+		if i == len(keys)-1 {
+			b, isBool := v.(bool)
+			if !isBool {
+				return def
+			}
+			return b
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return def
+		}
+		current = next
+	}
+	return def
 }

--- a/recipes/components/gpu-operator/values-oke-training.yaml
+++ b/recipes/components/gpu-operator/values-oke-training.yaml
@@ -15,13 +15,14 @@
 # GPU Operator Helm values
 # OKE Training configuration overrides
 
-# Lockstep with nvidia-dra-driver-gpu/values-oke.yaml, which sets
-# nvidiaDriverRoot: /. OKE bare-metal shapes pre-install drivers at the
-# host root, so both components must read from / rather than the
-# gpu-operator base default /run/nvidia/driver. Guarded by
-# TestDriverRootLockstep (issue #1087).
-hostPaths:
-  driverInstallDir: /
+# hostPaths.driverInstallDir is intentionally left at the gpu-operator base
+# default /run/nvidia/driver: it is the host path the operator-validator
+# bind-mounts as the driver-validation container's rootfs target, and "/" is
+# rejected by runc ("mountpoint is on the top of rootfs"), crash-looping
+# nvidia-operator-validator. nvidia-dra-driver-gpu/values-oke.yaml keeps
+# nvidiaDriverRoot: / (host-installed driver userspace at the host root); the
+# two are independent here because gpu-operator manages no driver
+# (driver.enabled: false below). See TestDriverRootLockstep (#1087).
 
 cdi:
   enabled: true

--- a/recipes/components/gpu-operator/values-oke.yaml
+++ b/recipes/components/gpu-operator/values-oke.yaml
@@ -20,13 +20,14 @@
 # To use GPU Operator-managed drivers instead, provision GPU nodes without
 # the Oracle-managed GPU driver and set driver.enabled to true.
 
-# Lockstep with nvidia-dra-driver-gpu/values-oke.yaml, which sets
-# nvidiaDriverRoot: /. OKE bare-metal shapes pre-install drivers at the
-# host root, so both components must read from / rather than the
-# gpu-operator base default /run/nvidia/driver. Guarded by
-# TestDriverRootLockstep (issue #1087).
-hostPaths:
-  driverInstallDir: /
+# hostPaths.driverInstallDir is intentionally left at the gpu-operator base
+# default /run/nvidia/driver: it is the host path the operator-validator
+# bind-mounts as the driver-validation container's rootfs target, and "/" is
+# rejected by runc ("mountpoint is on the top of rootfs"), crash-looping
+# nvidia-operator-validator. nvidia-dra-driver-gpu/values-oke.yaml keeps
+# nvidiaDriverRoot: / (host-installed driver userspace at the host root); the
+# two are independent here because gpu-operator manages no driver
+# (driver.enabled: false below). See TestDriverRootLockstep (#1087).
 
 cdi:
   enabled: true

--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -18,12 +18,18 @@
 # Override release name prefix to avoid aicr-stack- prefix in resource names
 fullnameOverride: gpu-operator
 
-# Set explicitly so the lockstep guarded by TestDriverRootLockstep (issue
-# #1087) is verifiable. nvidia-dra-driver-gpu's base values.yaml pins
-# nvidiaDriverRoot to the same path; the two must stay in lockstep or
-# DRA fails CDI spec generation. Overlays that override the host driver
-# location (e.g. gke-cos at /home/kubernetes/bin/nvidia, kind at /) MUST
-# override this field too so the test catches divergence.
+# driverInstallDir is the host path the operator-validator bind-mounts as
+# the driver-validation container's rootfs target; it must never be "/"
+# (runc rejects mounting over the container rootfs, crash-looping
+# nvidia-operator-validator). Set explicitly here so TestDriverRootLockstep
+# (issue #1087) can verify it. When the operator MANAGES the driver
+# (driver.enabled true), this must equal nvidia-dra-driver-gpu's
+# nvidiaDriverRoot or DRA fails CDI spec generation — change one and you
+# MUST change the other in lockstep. When the operator manages no driver
+# (driver.enabled false, host-installed drivers), the two are independent:
+# driverInstallDir stays at this base default while nvidiaDriverRoot tracks
+# the host driver-userspace location (e.g. kind/oke at "/", gke-cos at
+# /home/kubernetes/bin/nvidia).
 hostPaths:
   driverInstallDir: /run/nvidia/driver
 

--- a/recipes/overlays/kind.yaml
+++ b/recipes/overlays/kind.yaml
@@ -36,12 +36,16 @@ spec:
     - name: gpu-operator
       type: Helm
       overrides:
-        # Lockstep with nvidia-dra-driver-gpu.nvidiaDriverRoot ("/") below.
-        # kind uses host-installed drivers, so the on-host driver root is /
-        # rather than the gpu-operator base default /run/nvidia/driver.
-        # Guarded by TestDriverRootLockstep (issue #1087).
-        hostPaths:
-          driverInstallDir: "/"
+        # hostPaths.driverInstallDir is intentionally NOT overridden here: it
+        # inherits the gpu-operator base default /run/nvidia/driver. This is
+        # the host path the operator-validator bind-mounts as the
+        # driver-validation container's rootfs target — setting it to "/"
+        # makes runc reject the mount ("mountpoint is on the top of rootfs"),
+        # crash-looping nvidia-operator-validator and stalling ClusterPolicy.
+        # nvidia-dra-driver-gpu.nvidiaDriverRoot stays "/" (host-installed
+        # driver userspace lives at the host root); the two fields are
+        # independent here because gpu-operator manages no driver
+        # (driver.enabled: false below). See TestDriverRootLockstep (#1087).
         driver:
           # Disable driver installation - use pre-installed host drivers
           enabled: false


### PR DESCRIPTION
## Summary

Stop setting `gpu-operator.hostPaths.driverInstallDir: "/"` on the `kind` and `oke` overlays — `/` is an illegal bind-mount destination that crash-loops `nvidia-operator-validator` and hangs every GPU-on-kind CI job. Also corrects `TestDriverRootLockstep` so its invariant reflects the real relationship between the two driver-path fields.

## Motivation / Context

PR #1106 (which implemented issue #1087) added `hostPaths.driverInstallDir: "/"` to the `kind` and `oke` overlays so the value would match `nvidia-dra-driver-gpu.nvidiaDriverRoot` (`"/"`) and satisfy the new lockstep test.

But `driverInstallDir` is the host path the operator-validator **bind-mounts as the `driver-validation` container's rootfs target**. runc rejects a mount whose destination is `/`:

```
runc create failed: ... error mounting "/" to rootfs at "/":
mountpoint ".../driver-validation/rootfs" is on the top of rootfs
```

So `nvidia-operator-validator` enters `Init:CrashLoopBackOff`, `ClusterPolicy` never reaches Ready, and the gpu-operator Helm `--wait` install retries 5× until it times out (~1h "hang").

Timeline confirms the cause is #1106, not any runner/infra change (kernel, kind node image digest, NVIDIA driver, and nvidia-container-toolkit are all byte-identical between the last green and first red runs):

- main nightly GPU: green 05-29 01:20 → **red 05-30 01:14** (#1106 merged 05-29 21:28)
- PR #1096 GPU: green at `af0a7c1d` (05-29 14:42, pre-#1106) → red at `e85ca1ad` (05-29 21:43, post-#1106)
- `git merge-base` confirms the green commit excludes #1106 and the red commit includes it.

`oke` carries the identical `driverInstallDir: "/"` bug but is not exercised in CI, so it never surfaced.

Fixes: #1087 (corrects the invariant that issue introduced via #1106)
Related: #1096, #1117 (both blocked by this on `kind`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Other: recipe overlays (`recipes/overlays/kind.yaml`, `recipes/components/gpu-operator/values-oke*.yaml`)

## Implementation Notes

- **Runtime fix:** remove the `driverInstallDir: "/"` override from `kind.yaml`, `values-oke.yaml`, and `values-oke-training.yaml`. They now inherit the gpu-operator base default `/run/nvidia/driver` — the value that ran green before #1106. `nvidiaDriverRoot: "/"` is left unchanged (it is legal for DRA and was proven green; changing it risks the CDI breakage #1087 guards against).
- **Test fix:** the `nvidiaDriverRoot == driverInstallDir` lockstep only holds when the operator *manages* the driver (`driver.enabled: true`). With host-installed drivers (`driver.enabled: false`, e.g. kind/oke/gke-cos) the two paths are independent: `nvidiaDriverRoot` may be `/`, but `driverInstallDir` must be a real subdirectory. `TestDriverRootLockstep` now gates the equality check on `driver.enabled` and adds a **hard invariant that `driverInstallDir` is never `/` for any overlay** — the direct guard for this regression class. Adds `boolAtPath` helper + `TestBoolAtPath`.

## Testing

```bash
make test    # full unit suite, -race — PASS (run unsandboxed)
make lint    # golangci-lint 0 issues + yamllint + license/docs-sync/chart-pins — PASS
go test ./pkg/recipe/ -run TestDriverRootLockstep -v   # 78/78 overlays verified
```

`pkg/recipe`: 88.8% coverage; `TestDriverRootLockstep` now skips kind/oke/gke-cos as `driver.enabled=false` (independent paths) and resolves their `driverInstallDir` to `/run/nvidia/driver`. No golden/bundle snapshots reference `driverInstallDir`, so bundle generation is unaffected.

`make qualify`'s local e2e/scan were not the deciding gate here: local e2e validates with `--no-cluster` and never launches the gpu-operator validator, so it cannot exercise the failing mount. The definitive proof is the H100 `nvkind` GPU CI jobs on this PR going green.

## Risk Assessment

- [x] **Low** — Removes three illegal config values (reverting to the proven-green default) and corrects a test invariant. Easy to revert.

**Rollout notes:** None. No user-facing surface; affects only `kind`/`oke` recipe resolution and a CI test.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — no user-facing change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
