### PR TITLE
docs(recipe): refresh data/validator docs and godoc after #1118

### DIFF
--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1673,68 +1673,53 @@ provider only.
 
 ### CLI initialization
 
-The CLI installs a single process-global provider so legacy entry points
-that have no `Builder` in scope (e.g., the criteria registry pre-load,
-manifest helpers without a `RecipeResult`) keep working without threading
-a provider through every call site:
+Each CLI command owns a per-command `aicr.Client` whose own `DataProvider`
+backs recipe resolution and the per-provider criteria registry — no
+process-global provider is installed:
 
 ```go
 // pkg/cli/root.go
-func initDataProvider(cmd *cli.Command) error {
+func recipeClientFromCmd(cmd *cli.Command, cfg *config.AICRConfig) (*aicr.Client, error) {
     dataDir := cmd.String("data")
     if dataDir == "" {
-        return nil  // Use default embedded provider
+        dataDir = cfg.Recipe().DataDir()
     }
-
-    embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
-    layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
-        ExternalDir:   dataDir,
-        AllowSymlinks: false,
-    })
-    if err != nil {
-        return err
+    source := aicr.EmbeddedSource()
+    if dataDir != "" {
+        source = aicr.FilesystemSource(dataDir) // external dir layered over embedded
     }
-
-    recipe.SetDataProvider(layered)
-    return nil
+    return aicr.NewClient(
+        aicr.WithRecipeSource(source),
+        aicr.WithVersion(version),
+    )
+    // Caller MUST defer client.Close().
 }
 ```
 
-Single-tenant CLIs and the API server can stay on this pattern. Library
-callers and multi-tenant servers should prefer `WithDataProvider`.
+The Client binds its provider through `recipe.WithDataProvider` internally,
+so concurrent commands (and multi-tenant servers) stay isolated. Library
+callers construct their own `aicr.Client`, or call
+`recipe.NewBuilder(recipe.WithDataProvider(dp))` directly.
 
-### Back-compat: package-global accessors
-
-The following package-level accessors predate `WithDataProvider` and are
-retained for back-compat. New code should use `WithDataProvider`; see the
-godoc on each for the migration recommendation.
-
-- `SetDataProvider(dp)` — installs the process-global provider. Deprecated;
-  use `recipe.NewBuilder(recipe.WithDataProvider(dp))` instead.
-- `GetDataProvider()` — returns the current process-global provider
-  (embedded by default). Deprecated; recover the Builder-bound provider via
-  `(*RecipeResult).DataProvider()` or pass one explicitly.
-- `GetDataProviderGeneration()` — monotonic counter incremented by
-  `SetDataProvider` so caches keyed on the global can detect a swap.
-- `LoadMetadataStore(ctx)` — convenience wrapper around
-  `LoadMetadataStoreFor(ctx, GetDataProvider())`. Multi-tenant callers
-  should call `LoadMetadataStoreFor` directly with their bound provider.
-- `GetComponentRegistry()` — convenience wrapper around
-  `GetComponentRegistryFor(GetDataProvider())`. Same migration guidance.
+The former package-global accessors (`SetDataProvider`, `GetDataProvider`,
+`GetDataProviderGeneration`) have been removed — bind a provider via
+`WithDataProvider` and recover it with `(*RecipeResult).DataProvider()`.
+Provider-bound helpers that need a default fall back to a single shared
+embedded provider internally; callers no longer pass the global.
 
 ---
 
 ## Criteria Registry
 
-The criteria registry is a process-global cache of valid criteria values
+The criteria registry is a per-`DataProvider` cache of valid criteria values
 (`service`, `accelerator`, `intent`, `os`, `platform`) populated from
 loaded overlays. It is the mechanism by which a `--data` overlay can
 introduce a new criteria value (e.g., `service: ncp-internal`) and have
-it admitted by `ParseCriteriaServiceType` without a code change.
+it admitted by `(*CriteriaRegistry).ParseService` without a code change.
 
 ### Why a registry
 
-Before the registry existed, each `ParseCriteria*Type` had a hardcoded
+Before the registry existed, each criteria parser had a hardcoded
 `switch` of valid string values; an unknown value returned
 `ErrCodeInvalidRequest` before the overlay catalog was even consulted.
 That made it impossible to add a new criteria value via `--data` —
@@ -1768,7 +1753,8 @@ validate. Three sources can enable it (logical OR):
 
 1. `--criteria-strict` CLI flag (added on `aicr recipe`).
 2. `spec.recipe.criteriaStrict: true` in `--config`.
-3. `AICR_CRITERIA_STRICT=1` env var (read at `DefaultRegistry()` init).
+3. `AICR_CRITERIA_STRICT=1` env var (read at registry construction —
+   `NewCriteriaRegistry` / `GetCriteriaRegistryFor`).
 
 Strict mode is intended for **OSS CI gates** — `make qualify` exports
 `AICR_CRITERIA_STRICT=1` for the unit-test step so the upstream catalog
@@ -1794,26 +1780,28 @@ validation runs *before* the recipe build pulls the catalog, a fresh
 process with `--data` would otherwise reject a custom criteria value on
 the very first call — the registry would still be empty.
 
-`recipe.LoadCatalog(ctx)` forces an eager catalog parse, seeding the
-registry. The CLI `recipe` Action calls it right after
-`initDataProvider` so the registry is populated before any
-`ParseCriteria*Type` lookup. **Any future caller that wires its own
-`--data` (e.g., a new API server flag) must also call `LoadCatalog`
-right after `SetDataProvider` for the same reason.**
+`(*aicr.Client).LoadCatalog(ctx)` forces an eager catalog parse, seeding
+the Client's per-provider registry. The CLI `recipe` Action calls it right
+after constructing the Client so the registry is populated before any
+criteria lookup. **Any caller that wires its own `--data` provider must
+likewise call `LoadCatalog` before validating criteria for the same
+reason.** (The package-level `recipe.LoadCatalog(ctx)` seeds the default
+embedded provider's registry and is used by the embedded-only path.)
 
 ### API surface
 
 | Function | Purpose |
 |---|---|
-| `DefaultRegistry()` | Returns the process-wide singleton (lazy-init). |
+| `NewCriteriaRegistry()` | Constructs an empty ephemeral registry (OSS fast-path values only; honors `AICR_CRITERIA_STRICT`). |
+| `GetCriteriaRegistryFor(dp)` | Returns the per-`DataProvider` registry, seeded from that provider's overlays (the common case). |
 | `(*CriteriaRegistry).Register(field, value, origin)` | Records a value; embedded never downgrades. |
 | `(*CriteriaRegistry).Has(field, value)` | Lookup; respects strict mode (external hidden when strict). |
 | `(*CriteriaRegistry).HasEmbedded(field, value)` | Embedded-only lookup, regardless of strict. |
 | `(*CriteriaRegistry).Values(field)` | Sorted union of known values for help / autocomplete. |
 | `(*CriteriaRegistry).SetStrict(bool)` | Toggle strict mode. Composes with `AICR_CRITERIA_STRICT`. |
 | `(*CriteriaRegistry).Reset()` | Test helper; re-reads `AICR_CRITERIA_STRICT` from env. |
-| `LoadCatalog(ctx)` | Eager catalog load — call after `SetDataProvider`. |
-| `AllCriteria{Service,Accelerator,Intent,OS,Platform}Types()` | Union of static OSS list + currently-registered values. |
+| `(*aicr.Client).LoadCatalog(ctx)` | Eager catalog load — seeds the Client's per-provider registry. |
+| `(*CriteriaRegistry).All{Service,Accelerator,Intent,OS,Platform}Types()` | Union of static OSS list + values registered in this registry. |
 | `GetCriteria{Service,Accelerator,Intent,OS,Platform}Types()` | Static OSS list only (stable; not affected by `--data`). |
 
 ---

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -232,7 +232,7 @@ Each entry in `recipes/validators/catalog.yaml`:
     memory: "128Mi"
 ```
 
-**Image tag resolution** (applied by `catalog.Load`):
+**Image tag resolution** (applied by `catalog.LoadWithDataProvider`):
 
 1. `:latest` tags are replaced with the CLI version (e.g., `:v0.9.5`) for release builds
 2. On non-release dev builds with a valid commit, `:latest` becomes `:sha-<commit>` (matches the tags `on-push.yaml` pushes for merges to `main`)
@@ -242,7 +242,7 @@ Each entry in `recipes/validators/catalog.yaml`:
 
 **Digest-pinned references** (`name@sha256:…`) are not rewritten by step 4. A tag override is meaningless against a content-addressable pin, and naive rewriting would corrupt the digest. Step 5's registry override still applies — only the registry prefix changes, the digest is preserved verbatim.
 
-**Env-var forwarding to the validator pod:** `AICR_CLI_VERSION`, `AICR_CLI_COMMIT`, `AICR_VALIDATOR_IMAGE_REGISTRY`, and `AICR_VALIDATOR_IMAGE_TAG` are forwarded from the CLI invocation into the validator container so that validators resolving inner workload images at runtime (e.g. `inference-perf`'s AIPerf benchmark Job) apply the same semantics as `catalog.Load`. If you set `AICR_VALIDATOR_IMAGE_TAG=latest` on the CLI, the override reaches both the outer validator Job and the inner benchmark Job — they always travel together.
+**Env-var forwarding to the validator pod:** `AICR_CLI_VERSION`, `AICR_CLI_COMMIT`, `AICR_VALIDATOR_IMAGE_REGISTRY`, and `AICR_VALIDATOR_IMAGE_TAG` are forwarded from the CLI invocation into the validator container so that validators resolving inner workload images at runtime (e.g. `inference-perf`'s AIPerf benchmark Job) apply the same semantics as `catalog.LoadWithDataProvider`. If you set `AICR_VALIDATOR_IMAGE_TAG=latest` on the CLI, the override reaches both the outer validator Job and the inner benchmark Job — they always travel together.
 
 **Pull-policy behavior when the override is set:** both the outer validator Job and every inner workload Job it dispatches route through the shared `v1.ImagePullPolicy(image)` helper (`pkg/api/validator/v1/job_plan.go`). The rule, in precedence order, is:
 

--- a/pkg/recipe/doc.go
+++ b/pkg/recipe/doc.go
@@ -155,19 +155,23 @@
 //   - EvictCachedRegistry(dp) — drops the cached registry for dp; nil
 //     receiver is a no-op.
 //   - GetManifestContentWithProvider(dp, path) ([]byte, error) — reads a
-//     manifest file from dp; a nil provider falls back to GetDataProvider().
-//   - (*RecipeResult).DataProvider() DataProvider — recovers the bound
-//     provider that produced the result, or nil if the package-global was
-//     used. Nil-safe on the receiver.
+//     manifest file from dp; a nil provider falls back to the package's
+//     default embedded provider.
+//   - (*RecipeResult).DataProvider() DataProvider — recovers the provider
+//     that produced the result. A default/unbound build returns the package
+//     default embedded provider; nil is only returned for a nil receiver or
+//     a result constructed outside the normal builder path.
 //
-// Single-tenant entry points (the CLI, the API server) may continue to use
-// SetDataProvider / GetDataProvider; those package-global accessors are
-// deprecated in favor of WithDataProvider but remain functional for
-// back-compat.
+// Single-tenant entry points (the CLI, the API server) bind a provider
+// explicitly via WithDataProvider; the former package-global accessors
+// (SetDataProvider / GetDataProvider) have been removed. Recover a bound
+// provider with (*RecipeResult).DataProvider(), or pass one explicitly.
 //
-// Parse criteria from HTTP request:
+// Parse criteria from HTTP request (reg is a *CriteriaRegistry, typically
+// from GetCriteriaRegistryFor(dp); a nil reg validates against the OSS
+// fast-path values only):
 //
-//	criteria, err := recipe.ParseCriteriaFromRequest(r)
+//	criteria, err := recipe.ParseCriteriaFromRequest(r, reg)
 //	if err != nil {
 //	    http.Error(w, err.Error(), http.StatusBadRequest)
 //	    return
@@ -214,7 +218,7 @@
 //
 // Load criteria from a file:
 //
-//	criteria, err := recipe.LoadCriteriaFromFile("/path/to/criteria.yaml")
+//	criteria, err := recipe.LoadCriteriaFromFile("/path/to/criteria.yaml", reg)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -222,7 +226,7 @@
 //
 // Parse criteria from HTTP request body (POST):
 //
-//	criteria, err := recipe.ParseCriteriaFromBody(r.Body, r.Header.Get("Content-Type"))
+//	criteria, err := recipe.ParseCriteriaFromBody(r.Body, r.Header.Get("Content-Type"), reg)
 //	if err != nil {
 //	    http.Error(w, err.Error(), http.StatusBadRequest)
 //	    return


### PR DESCRIPTION
## Summary

Refresh three docs that still referenced the package-global data-provider and criteria-registry APIs removed by #1118.

## Motivation / Context

#1118 removed the back-compat shims (`SetDataProvider`, `GetDataProvider`, `GetDataProviderGeneration`, `DefaultRegistry`, `ParseCriteria*Type`, `AllCriteria*Types`, `catalog.Load`, …) but left documentation pointing at the deleted symbols. This was flagged during cross-review of #1118 as non-blocking follow-up; this PR clears it.

Fixes: N/A
Related: #1118, #983

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`) — godoc comments only
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- `docs/contributor/data.md` — rewrote the CLI-init example from the removed `initDataProvider`/`SetDataProvider` pattern to the current per-command `aicr.Client` (`recipeClientFromCmd`); dropped the "Back-compat: package-global accessors" subsection; refreshed the Criteria Registry prose and API-surface table to the per-`DataProvider` API (`GetCriteriaRegistryFor` / `NewCriteriaRegistry` / `(*CriteriaRegistry).Parse*` / `.All*Types`, `(*aicr.Client).LoadCatalog`).
- `pkg/recipe/doc.go` — removed the claim that `SetDataProvider`/`GetDataProvider` "remain functional for back-compat"; updated the `ParseCriteriaFromRequest`, `ParseCriteriaFromBody`, and `LoadCriteriaFromFile` examples to pass the new `*CriteriaRegistry` argument; corrected the nil-fallback note (now the package's default embedded provider).
- `docs/contributor/validator.md` — `catalog.Load` → `catalog.LoadWithDataProvider` (both occurrences).

No code behavior changes — comments and Markdown only.

## Testing

```bash
gofmt -l pkg/recipe/doc.go          # clean
go vet ./pkg/recipe/                 # clean
golangci-lint run -c .golangci.yaml ./pkg/recipe/...   # 0 issues
```

Doc/comment-only change: scoped checks run in place of full `make qualify` (no test/e2e surface can regress from comment and Markdown edits). Verified zero remaining references to the removed symbols across the three files, and that the removed `data.md` heading has no inbound anchor links. CI's lychee link-check covers `docs/**`; no links were added or repointed.

## Risk Assessment

- [x] **Low** — Documentation and godoc comments only, easy to revert.
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A; no code changes (comment/doc only). `go vet` + `golangci-lint` clean on `pkg/recipe`.
- [x] Linter passes (`make lint`) — `golangci-lint` on `pkg/recipe` reports 0 issues.
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (docs only)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
