### PR TITLE
feat(recipe): context-aware DataProvider interface

### DIFF
--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -1457,16 +1457,25 @@ The system uses a `DataProvider` interface to abstract file access:
 
 ```go
 type DataProvider interface {
-    // ReadFile reads a file by path (relative to data directory)
-    ReadFile(path string) ([]byte, error)
+    // ReadFile reads a file by path (relative to data directory).
+    // Returns ctx's error if it is canceled before the read completes.
+    ReadFile(ctx context.Context, path string) ([]byte, error)
 
-    // WalkDir walks the directory tree rooted at root
-    WalkDir(root string, fn fs.WalkDirFunc) error
+    // WalkDir walks the directory tree rooted at root.
+    // Returns ctx's error if it is canceled mid-walk.
+    WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error
 
     // Source returns where data came from (for debugging)
     Source(path string) string
 }
 ```
+
+Cancellation is honored at I/O boundaries — before each file open and
+between WalkDir entries — not mid-syscall on an in-flight read.
+`LayeredDataProvider` reads external files via `os.Open` + `io.ReadAll`,
+which are not cancelable once started; a hung NFS / sshfs mount blocked
+mid-readv will see cancellation honored on the *next* file the walk
+touches, not the one currently blocked.
 
 **Provider Types:**
 - `EmbeddedDataProvider`: Wraps Go's `embed.FS` for compile-time embedded data
@@ -1716,6 +1725,11 @@ The criteria registry is a per-`DataProvider` cache of valid criteria values
 loaded overlays. It is the mechanism by which a `--data` overlay can
 introduce a new criteria value (e.g., `service: ncp-internal`) and have
 it admitted by `(*CriteriaRegistry).ParseService` without a code change.
+
+Each `aicr.Client` (and so each `Builder` constructed with
+`WithDataProvider`) owns its own registry, scoped by DataProvider
+identity. Concurrent clients with different `--data` directories do not
+share registry state; closing the client evicts its entry.
 
 ### Why a registry
 

--- a/pkg/api/recipe_handler.go
+++ b/pkg/api/recipe_handler.go
@@ -278,7 +278,7 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	// mapping: a hydrate failure surfaces via its own error code (5xx), while a
 	// missing selector path is a 404. rec is *aicr.Recipe (= *recipe.RecipeResult),
 	// so HydrateResult accepts it directly.
-	hydrated, err := recipe.HydrateResult(rec)
+	hydrated, err := recipe.HydrateResultWithContext(ctx, rec)
 	if err != nil {
 		server.WriteErrorFromErr(w, r, err, "Failed to hydrate recipe", nil)
 		return

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -592,7 +592,7 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 		}
 
 		// Get base values from recipe
-		values, err := recipeResult.GetValuesForComponent(ref.Name)
+		values, err := recipeResult.GetValuesForComponentWithContext(ctx, ref.Name)
 		if err != nil {
 			slog.Warn("failed to get values for component, using empty map",
 				"component", ref.Name,
@@ -1483,7 +1483,7 @@ func (b *DefaultBundler) collectComponentManifestsByPhase(
 
 		componentManifests := make(map[string][]byte, len(paths))
 		for _, manifestPath := range paths {
-			content, err := recipe.GetManifestContentWithProvider(provider, manifestPath)
+			content, err := recipe.GetManifestContentWithContext(ctx, provider, manifestPath)
 			if err != nil {
 				if stderrors.Is(err, fs.ErrNotExist) {
 					// Use the bound provider for the type assertion. A nil

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -131,7 +131,7 @@ Use in shell scripts:
 				return err
 			}
 
-			hydrated, err := recipe.HydrateResult(result)
+			hydrated, err := recipe.HydrateResultWithContext(ctx, result)
 			if err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to hydrate recipe", err)
 			}

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -95,7 +95,7 @@ func emitRecipeEvidence(
 	cfg *recipeEvidenceConfig,
 ) error {
 
-	cat, err := catalog.LoadWithDataProvider(dp, version, commit)
+	cat, err := catalog.LoadWithDataProvider(ctx, dp, version, commit)
 	if err != nil {
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load validator catalog for evidence")
 	}

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -922,7 +922,7 @@ func (c *Client) BundleComponents(ctx context.Context, r *RecipeResult) ([]Compo
 			// field (set during ResolveRecipe → builder.BuildFromCriteria
 			// → LoadMetadataStoreFor). GetValuesForComponent uses that
 			// bound provider directly; no explicit dp arg needed here.
-			values, err := r.internal.GetValuesForComponent(facade.Name)
+			values, err := r.internal.GetValuesForComponentWithContext(ctx, facade.Name)
 			if err != nil {
 				return bundles, errors.Wrap(errors.ErrCodeInternal,
 					"resolve values for component "+facade.Name, err)
@@ -1265,7 +1265,7 @@ func loadManifestFiles(ctx context.Context, internal *recipe.RecipeResult, dp re
 		// the caller is the legacy CLI/API server path (Client always
 		// supplies a non-nil dp); GetManifestContentWithProvider falls
 		// back to the package global in that case.
-		content, err := recipe.GetManifestContentWithProvider(dp, path)
+		content, err := recipe.GetManifestContentWithContext(ctx, dp, path)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInternal,
 				"read manifest "+path, err)

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -43,11 +43,11 @@ type blockingDataProvider struct {
 	walkUnblock chan struct{}
 }
 
-func (b *blockingDataProvider) ReadFile(path string) ([]byte, error) {
-	return b.underlying.ReadFile(path)
+func (b *blockingDataProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	return b.underlying.ReadFile(ctx, path)
 }
 
-func (b *blockingDataProvider) WalkDir(root string, fn fs.WalkDirFunc) error {
+func (b *blockingDataProvider) WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error {
 	// Signal exactly once that WalkDir entered; tolerate multiple
 	// calls so a retry inside the same test wouldn't deadlock.
 	select {
@@ -56,7 +56,7 @@ func (b *blockingDataProvider) WalkDir(root string, fn fs.WalkDirFunc) error {
 		close(b.walkStarted)
 	}
 	<-b.walkUnblock
-	return b.underlying.WalkDir(root, fn)
+	return b.underlying.WalkDir(ctx, root, fn)
 }
 
 func (b *blockingDataProvider) Source(path string) string {

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -126,7 +126,7 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 
 			// Helm components: render chart and extract images.
 			if compRef.Type == recipe.ComponentTypeHelm {
-				values, valErr := rec.GetValuesForComponent(compRef.Name)
+				values, valErr := rec.GetValuesForComponentWithContext(gctx, compRef.Name)
 				if valErr != nil {
 					slog.Warn("failed to load values for component",
 						"component", compRef.Name, "error", valErr)
@@ -179,10 +179,10 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 				return gctx.Err()
 			}
 			for _, mPath := range compRef.ManifestFiles {
-				allImages = extractManifestImages(allImages, &ci, compRef.Name, mPath)
+				allImages = extractManifestImages(gctx, allImages, &ci, compRef.Name, mPath)
 			}
 			for _, mPath := range compRef.PreManifestFiles {
-				allImages = extractManifestImages(allImages, &ci, compRef.Name, mPath)
+				allImages = extractManifestImages(gctx, allImages, &ci, compRef.Name, mPath)
 			}
 
 			slices.Sort(allImages)
@@ -248,8 +248,8 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 
 // extractManifestImages reads a manifest file and appends extracted images
 // to the accumulator, recording warnings on failure.
-func extractManifestImages(acc []string, ci *ComponentImages, compName, mPath string) []string {
-	content, readErr := recipe.GetManifestContent(mPath)
+func extractManifestImages(ctx context.Context, acc []string, ci *ComponentImages, compName, mPath string) []string {
+	content, readErr := recipe.GetManifestContentWithContext(ctx, nil, mPath)
 	if readErr != nil {
 		slog.Warn("failed to read manifest",
 			"component", compName, "path", mPath, "error", readErr)

--- a/pkg/recipe/adapter.go
+++ b/pkg/recipe/adapter.go
@@ -16,11 +16,13 @@
 package recipe
 
 import (
+	"context"
 	"embed"
 	stderrors "errors"
 	"fmt"
 	"io/fs"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/recipes"
 	"gopkg.in/yaml.v3"
@@ -37,11 +39,16 @@ func GetEmbeddedFS() embed.FS {
 // "components/network-operator/manifests/nfd-network-rule.yaml").
 //
 // This entry point is preserved for back-compat with callers that have no
-// RecipeResult-bound provider available. Callers operating against a
+// RecipeResult-bound provider available. Internally derives a
+// defaults.FileReadTimeout-bounded context so a hung backing store still
+// returns instead of blocking the goroutine. Callers operating against a
 // per-tenant Builder should prefer GetManifestContentWithProvider so the
-// lookup honors the bound provider.
+// lookup honors the bound provider; callers that already hold a
+// context.Context should use GetManifestContentWithContext.
 func GetManifestContent(path string) ([]byte, error) {
-	return GetManifestContentWithProvider(nil, path)
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return GetManifestContentWithContext(ctx, nil, path)
 }
 
 // GetManifestContentWithProvider reads a manifest file from the supplied
@@ -49,13 +56,26 @@ func GetManifestContent(path string) ([]byte, error) {
 // singleton so callers that thread a possibly-nil RecipeResult.DataProvider()
 // through can rely on the embedded fallback without an explicit nil check.
 //
+// Internally derives a defaults.FileReadTimeout-bounded context. Callers
+// that already hold a context.Context should use
+// GetManifestContentWithContext to honor their own deadline instead.
+//
 // Path should be relative to the data root (e.g.,
 // "components/network-operator/manifests/nfd-network-rule.yaml").
 func GetManifestContentWithProvider(dp DataProvider, path string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return GetManifestContentWithContext(ctx, dp, path)
+}
+
+// GetManifestContentWithContext reads a manifest file from the supplied
+// DataProvider, honoring the caller's context for cancellation/timeout.
+// A nil provider falls back to GetDataProvider().
+func GetManifestContentWithContext(ctx context.Context, dp DataProvider, path string) ([]byte, error) {
 	if dp == nil {
 		dp = defaultEmbeddedProvider
 	}
-	content, err := dp.ReadFile(path)
+	content, err := dp.ReadFile(ctx, path)
 	if err != nil {
 		if stderrors.Is(err, fs.ErrNotExist) {
 			return nil, errors.Wrap(errors.ErrCodeNotFound, fmt.Sprintf("manifest file not found: %q", path), err)
@@ -139,6 +159,21 @@ func (r *RecipeResult) GetComponentRef(name string) *ComponentRef {
 }
 
 // GetValuesForComponent loads values from the component's valuesFile and inline overrides.
+//
+// Internally derives a defaults.FileReadTimeout-bounded context so a hung
+// backing store still returns instead of blocking the goroutine. Callers
+// that already hold a context.Context should use
+// GetValuesForComponentWithContext to honor their own deadline.
+func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return r.GetValuesForComponentWithContext(ctx, name)
+}
+
+// GetValuesForComponentWithContext loads values from the component's
+// valuesFile and inline overrides, honoring the caller's context for
+// cancellation/timeout.
+//
 // Merge order: base values → ValuesFile → Overrides (highest precedence).
 // This supports three patterns:
 //  1. ValuesFile only: Traditional separate file approach
@@ -148,7 +183,7 @@ func (r *RecipeResult) GetComponentRef(name string) *ComponentRef {
 // File lookups route through the DataProvider bound to this result (set when
 // the result was built by a Builder via WithDataProvider). When no provider
 // is bound, lookups fall back to the package-level embedded-data singleton.
-func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error) {
+func (r *RecipeResult) GetValuesForComponentWithContext(ctx context.Context, name string) (map[string]any, error) {
 	ref := r.GetComponentRef(name)
 	if ref == nil {
 		return nil, errors.New(errors.ErrCodeNotFound, fmt.Sprintf("component %q not found in recipe", name))
@@ -179,7 +214,7 @@ func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error
 
 		if isOverlay {
 			// Load base values first
-			baseData, err := provider.ReadFile(baseValuesFile)
+			baseData, err := provider.ReadFile(ctx, baseValuesFile)
 			if err != nil {
 				// If base file doesn't exist, that's okay - just use overlay
 				result = make(map[string]any)
@@ -191,7 +226,7 @@ func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error
 			}
 
 			// Load overlay values
-			overlayData, err := provider.ReadFile(ref.ValuesFile)
+			overlayData, err := provider.ReadFile(ctx, ref.ValuesFile)
 			if err != nil {
 				return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to read overlay values file %q", ref.ValuesFile), err)
 			}
@@ -205,7 +240,7 @@ func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error
 			mergeValues(result, overlayValues)
 		} else {
 			// Just load the base values file
-			data, err := provider.ReadFile(ref.ValuesFile)
+			data, err := provider.ReadFile(ctx, ref.ValuesFile)
 			if err != nil {
 				return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to read values file %q", ref.ValuesFile), err)
 			}

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -15,10 +15,12 @@
 package recipe
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"sync"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -221,12 +223,17 @@ var registryCache sync.Map // map[DataProvider]*registryCacheEntry
 // GetComponentRegistryFor returns the component registry for the supplied
 // DataProvider. Concurrent callers with the same provider observe the same
 // singleton; distinct providers populate distinct cache entries and never
-// share state. A nil provider falls back to GetDataProvider() so the legacy
-// GetComponentRegistry entry point continues to work transparently.
+// share state. A nil provider falls back to the package-level
+// embedded-data singleton so legacy entry points continue to work
+// transparently.
 //
-// Note: a first-load error is preserved by sync.Once and returned to every
-// subsequent caller for the same provider until EvictCachedRegistry drops
-// the entry.
+// A first-load *deterministic* error (file missing, schema invalid) is
+// preserved by sync.Once and returned to every subsequent caller for the
+// same provider until EvictCachedRegistry drops the entry — concurrent
+// callers don't all re-run the same broken load. A first-load *transient*
+// error (context.Canceled / DeadlineExceeded) is NOT cached: the entry is
+// CompareAndDelete'd before returning so a follow-up call with a healthy
+// ctx rebuilds from scratch, mirroring LoadMetadataStoreFor.
 func GetComponentRegistryFor(dp DataProvider) (*ComponentRegistry, error) {
 	if dp == nil {
 		dp = defaultEmbeddedProvider
@@ -236,6 +243,13 @@ func GetComponentRegistryFor(dp DataProvider) (*ComponentRegistry, error) {
 	entry.once.Do(func() {
 		entry.registry, entry.err = loadComponentRegistryFor(dp)
 	})
+	if entry.err != nil && isTransientLoadError(entry.err) {
+		// Drop the poisoned entry so the next caller rebuilds rather
+		// than serving the cancellation forever. CompareAndDelete is
+		// safe under concurrent retries — a fresh entry stored by a
+		// parallel caller is left undisturbed.
+		registryCache.CompareAndDelete(dp, e)
+	}
 	return entry.registry, entry.err
 }
 
@@ -307,8 +321,26 @@ func ResetComponentRegistryForTesting() {
 // provider. It is pure with respect to the package-global DataProvider —
 // callers that need package-global semantics route through
 // GetComponentRegistry, which resolves the provider once at the entry point.
+//
+// First-load I/O is bounded with defaults.FileReadTimeout so a hung
+// backing store (e.g., a stalled --data NFS mount) cannot park the
+// sync.Once first-load goroutine indefinitely; cancellation only takes
+// effect at the open-file boundary (see DataProvider interface doc), not
+// mid-syscall on an in-flight read. Each call gets its own context so
+// concurrent callers do not share a deadline.
+//
+// Threading a caller-supplied ctx would require a public-API parameter
+// change to GetComponentRegistryFor and every transitive caller in the
+// bundler / mirror / deployer chains; the bounded internal ctx + the
+// transient-error eviction guard in GetComponentRegistryFor is the
+// acceptable tradeoff until that cascade is taken on as a separate
+// follow-up (tracked alongside #1109's out-of-scope items).
+//
+//nolint:contextcheck // see comment above.
 func loadComponentRegistryFor(provider DataProvider) (*ComponentRegistry, error) {
-	data, err := provider.ReadFile("registry.yaml")
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	data, err := provider.ReadFile(ctx, "registry.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read registry.yaml", err)
 	}

--- a/pkg/recipe/driver_root_lockstep_test.go
+++ b/pkg/recipe/driver_root_lockstep_test.go
@@ -106,7 +106,7 @@ func TestDriverRootLockstep(t *testing.T) {
 			// invariant below and the lockstep checks share them.
 			var opValues map[string]any
 			if op != nil {
-				opValues, err = result.GetValuesForComponent("gpu-operator")
+				opValues, err = result.GetValuesForComponentWithContext(ctx, "gpu-operator")
 				if err != nil {
 					t.Fatalf("GetValuesForComponent(gpu-operator): %v", err)
 				}
@@ -149,7 +149,7 @@ func TestDriverRootLockstep(t *testing.T) {
 			}
 			checked++
 
-			draValues, err := result.GetValuesForComponent("nvidia-dra-driver-gpu")
+			draValues, err := result.GetValuesForComponentWithContext(ctx, "nvidia-dra-driver-gpu")
 			if err != nil {
 				t.Fatalf("GetValuesForComponent(nvidia-dra-driver-gpu): %v", err)
 			}

--- a/pkg/recipe/handler_query.go
+++ b/pkg/recipe/handler_query.go
@@ -145,7 +145,7 @@ func (b *Builder) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hydrated, err := HydrateResult(result)
+	hydrated, err := HydrateResultWithContext(ctx, result)
 	if err != nil {
 		server.WriteErrorFromErr(w, r, err, "Failed to hydrate recipe", nil)
 		return

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -184,7 +184,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 	var pendingRegistry []pendingRegistryEntry
 
 	// Load all YAML files from data directory.
-	walkErr := provider.WalkDir("", func(path string, d fs.DirEntry, err error) error {
+	walkErr := provider.WalkDir(ctx, "", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to walk data directory", err)
 		}
@@ -207,7 +207,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 			if !strings.HasSuffix(filename, ".yaml") {
 				return nil
 			}
-			content, readErr := provider.ReadFile(path)
+			content, readErr := provider.ReadFile(ctx, path)
 			if readErr != nil {
 				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read mixin %s", path), readErr)
 			}
@@ -232,7 +232,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 
 		// Handle component files (files in the components/ directory)
 		if strings.Contains(path, "components/") {
-			content, readErr := provider.ReadFile(path)
+			content, readErr := provider.ReadFile(ctx, path)
 			if readErr != nil {
 				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read component file %s", path), readErr)
 			}
@@ -252,7 +252,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 		}
 
 		// Read and parse metadata file
-		content, readErr := provider.ReadFile(path)
+		content, readErr := provider.ReadFile(ctx, path)
 		if readErr != nil {
 			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read %s", path), readErr)
 		}
@@ -291,6 +291,15 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 	})
 
 	if walkErr != nil {
+		// A bare context.Canceled / DeadlineExceeded surfaces here when the
+		// provider returns ctx.Err() before invoking the per-entry callback
+		// (the in-flight cancellation guard inside DataProvider.WalkDir).
+		// LoadMetadataStoreFor keys its transient-eviction logic on
+		// stderrors.Is(err, context.Canceled) and downstream callers depend
+		// on the ErrCodeTimeout shape; wrap so both invariants hold.
+		if stderrors.Is(walkErr, context.Canceled) || stderrors.Is(walkErr, context.DeadlineExceeded) {
+			return nil, aicrerrors.Wrap(aicrerrors.ErrCodeTimeout, "context canceled during metadata load", walkErr)
+		}
 		return nil, walkErr
 	}
 
@@ -895,7 +904,7 @@ func (s *MetadataStore) BuildRecipeResult(ctx context.Context, criteria *Criteri
 			"hint", "recipe may not be optimized for your environment")
 	}
 
-	return finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays)
+	return finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays) //nolint:contextcheck // finalizeRecipeResult routes registry lookups through GetComponentRegistryFor, which is sync.Once-cached and bounds first-load I/O via an internal bounded background context (loadComponentRegistryFor). Threading ctx here is tracked separately if/when the cascade needs caller-driven cancellation.
 }
 
 // BuildRecipeResultWithEvaluator builds a RecipeResult by merging base with matching overlays,
@@ -1005,7 +1014,7 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 		}
 	}
 
-	result, err := finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays)
+	result, err := finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays) //nolint:contextcheck // see BuildRecipeResult: registry I/O is sync.Once-cached + bounded inside loadComponentRegistryFor.
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -1584,7 +1584,10 @@ func newInMemoryProvider(tag string, files map[string][]byte) *inMemoryDataProvi
 	return &inMemoryDataProvider{files: files, tag: tag}
 }
 
-func (p *inMemoryDataProvider) ReadFile(path string) ([]byte, error) {
+func (p *inMemoryDataProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	content, ok := p.files[path]
 	if !ok {
 		return nil, fs.ErrNotExist
@@ -1592,8 +1595,14 @@ func (p *inMemoryDataProvider) ReadFile(path string) ([]byte, error) {
 	return content, nil
 }
 
-func (p *inMemoryDataProvider) WalkDir(_ string, fn fs.WalkDirFunc) error {
+func (p *inMemoryDataProvider) WalkDir(ctx context.Context, _ string, fn fs.WalkDirFunc) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	for path := range p.files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := fn(path, inMemoryDirEntry{name: path}, nil); err != nil {
 			return err
 		}

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -15,6 +15,7 @@
 package recipe
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"io"
@@ -130,12 +131,25 @@ func openExternalFile(baseDir, relPath string, allowSymlinks bool) (*os.File, er
 // type is non-comparable (e.g., a struct containing a slice, map, or func
 // field). The safe and idiomatic shape is methods on a pointer receiver, as
 // the in-tree EmbeddedDataProvider / LayeredDataProvider do.
+//
+// ReadFile and WalkDir accept a context.Context. Cancellation is honored
+// at I/O boundaries — before each file open, and between WalkDir entries —
+// not mid-syscall on an in-flight read. The in-tree LayeredDataProvider
+// reads external files through os.Open + io.ReadAll, which are not
+// cancelable once started; a caller that cancels mid-syscall (e.g. on a
+// stalled NFS / sshfs mount mid-readv) will see the cancellation honored
+// on the *next* file the walk touches, not on the one currently blocked.
+// Embedded reads are in-memory and cannot hang; they honor cancellation
+// before each I/O for symmetry. Source is pure metadata and is not
+// context-aware.
 type DataProvider interface {
-	// ReadFile reads a file by path (relative to data directory).
-	ReadFile(path string) ([]byte, error)
+	// ReadFile reads a file by path (relative to data directory). Returns
+	// the context's error if it is canceled before the read completes.
+	ReadFile(ctx context.Context, path string) ([]byte, error)
 
-	// WalkDir walks the directory tree rooted at root.
-	WalkDir(root string, fn fs.WalkDirFunc) error
+	// WalkDir walks the directory tree rooted at root. Returns the
+	// context's error if it is canceled mid-walk.
+	WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error
 
 	// Source returns a description of where data came from (for debugging).
 	Source(path string) string
@@ -156,20 +170,29 @@ func NewEmbeddedDataProvider(efs embed.FS, prefix string) *EmbeddedDataProvider 
 }
 
 // ReadFile reads a file from the embedded filesystem.
-func (p *EmbeddedDataProvider) ReadFile(path string) ([]byte, error) {
+func (p *EmbeddedDataProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	fullPath := filepath.Join(p.prefix, path)
 	slog.Debug("reading file from embedded provider", "path", path, "fullPath", fullPath)
 	return p.fs.ReadFile(fullPath)
 }
 
 // WalkDir walks the embedded filesystem.
-func (p *EmbeddedDataProvider) WalkDir(root string, fn fs.WalkDirFunc) error {
+func (p *EmbeddedDataProvider) WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error {
 	fullRoot := filepath.Join(p.prefix, root)
 	if fullRoot == "" {
 		fullRoot = "." // embed.FS expects "." for root
 	}
 	slog.Debug("walking embedded filesystem", "root", root, "fullRoot", fullRoot)
 	return fs.WalkDir(p.fs, fullRoot, func(path string, d fs.DirEntry, err error) error {
+		// Honor caller cancellation between entries — embed.FS reads
+		// can't hang but a slow callback (e.g. one that does its own
+		// I/O) still benefits from short-circuiting on cancel.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		// Strip the prefix before passing to callback
 		var relPath string
 		if p.prefix == "" {
@@ -385,19 +408,22 @@ func (p *LayeredDataProvider) ExternalDir() string {
 // ReadFile reads a file, checking external directory first.
 // For registryFileName, returns merged content.
 // For other files, external completely replaces embedded.
-func (p *LayeredDataProvider) ReadFile(path string) ([]byte, error) {
+func (p *LayeredDataProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	slog.Debug("reading file from layered provider", "path", path)
 
 	// Special handling for registry file - merge instead of replace
 	if path == registryFileName {
 		slog.Debug("reading merged registry file")
-		return p.getMergedRegistry()
+		return p.getMergedRegistry(ctx)
 	}
 
 	// Special handling for catalog file - merge instead of replace (when external exists)
 	if path == catalogFileName && p.externalFiles[catalogFileName] {
 		slog.Debug("reading merged catalog file")
-		return p.getMergedCatalog()
+		return p.getMergedCatalog(ctx)
 	}
 
 	// Check external directory first
@@ -412,12 +438,15 @@ func (p *LayeredDataProvider) ReadFile(path string) ([]byte, error) {
 
 	// Fall back to embedded
 	slog.Debug("falling back to embedded data", "path", path)
-	return p.embedded.ReadFile(path)
+	return p.embedded.ReadFile(ctx, path)
 }
 
 // WalkDir walks both embedded and external directories.
 // External files take precedence over embedded files.
-func (p *LayeredDataProvider) WalkDir(root string, fn fs.WalkDirFunc) error {
+func (p *LayeredDataProvider) WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	slog.Debug("walking layered data directory", "root", root)
 
 	// Track files we've visited (to avoid duplicates)
@@ -428,6 +457,12 @@ func (p *LayeredDataProvider) WalkDir(root string, fn fs.WalkDirFunc) error {
 	if _, err := os.Stat(externalRoot); err == nil {
 		slog.Debug("walking external directory", "path", externalRoot)
 		err := filepath.WalkDir(externalRoot, func(path string, d fs.DirEntry, err error) error {
+			// Honor caller cancellation between entries — a slow
+			// network-mounted --data directory can otherwise hold the
+			// walk goroutine indefinitely on stat / readdirent.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			if err != nil {
 				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to walk external directory", err)
 			}
@@ -457,7 +492,7 @@ func (p *LayeredDataProvider) WalkDir(root string, fn fs.WalkDirFunc) error {
 	slog.Debug("walking embedded directory", "root", root)
 
 	// Walk embedded, skipping already-visited paths
-	return p.embedded.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	return p.embedded.WalkDir(ctx, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to walk embedded directory", err)
 		}
@@ -491,13 +526,14 @@ func (p *LayeredDataProvider) Source(path string) string {
 
 // fileReader is a minimal interface for reading a file by path.
 type fileReader interface {
-	ReadFile(path string) ([]byte, error)
+	ReadFile(ctx context.Context, path string) ([]byte, error)
 }
 
 // mergeEmbeddedAndExternal loads a YAML file from both embedded and external sources,
 // unmarshals each into type T, merges them using the provided function, and serializes
 // the result back to YAML bytes.
 func mergeEmbeddedAndExternal[T any](
+	ctx context.Context,
 	embedded fileReader, externalDir string, maxFileSize int64, allowSymlinks bool,
 	fileName string, merge func(embedded, external *T) *T,
 ) ([]byte, error) {
@@ -506,7 +542,7 @@ func mergeEmbeddedAndExternal[T any](
 	slog.Debug("merging files", "file", kind)
 
 	// Load embedded
-	embeddedData, err := embedded.ReadFile(fileName)
+	embeddedData, err := embedded.ReadFile(ctx, fileName)
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to read embedded "+kind, err)
 	}
@@ -540,11 +576,22 @@ func mergeEmbeddedAndExternal[T any](
 }
 
 // getMergedRegistry returns the merged registryFileName content.
-// External registry components are merged with embedded, with external taking precedence.
-func (p *LayeredDataProvider) getMergedRegistry() ([]byte, error) {
+// External registry components are merged with embedded, with external
+// taking precedence.
+//
+// Caching invariant: sync.Once captures the *first* caller's context, so
+// whatever ctx error the merge surfaces on first call is cached for the
+// provider's lifetime. In production this is safe because the only
+// reachable entry point (loadComponentRegistryFor) supplies a fresh
+// bounded background ctx, and per-command Clients discard their
+// LayeredDataProvider at command end. Callers that hold a LayeredDataProvider
+// across requests with cancelable contexts MUST NOT cancel a request's
+// ctx before the first merge completes or every later caller will see
+// the cached cancellation error.
+func (p *LayeredDataProvider) getMergedRegistry(ctx context.Context) ([]byte, error) {
 	p.mergedRegistryOnce.Do(func() {
 		p.mergedRegistry, p.mergedRegistryErr = mergeEmbeddedAndExternal(
-			p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, registryFileName, mergeRegistries,
+			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, registryFileName, mergeRegistries,
 		)
 	})
 
@@ -621,11 +668,19 @@ type catalogForMerge struct {
 }
 
 // getMergedCatalog returns the merged catalogFileName content.
-// External catalog validators are merged with embedded, with external taking precedence by name.
-func (p *LayeredDataProvider) getMergedCatalog() ([]byte, error) {
+// External catalog validators are merged with embedded, with external
+// taking precedence by name.
+//
+// Caching invariant: see getMergedRegistry. sync.Once captures the first
+// caller's context; today this is safe because LayeredDataProvider is
+// per-command and discarded at command end, but a long-lived
+// LayeredDataProvider reused across requests with cancelable contexts
+// could see a single canceled first read poison the cache for the
+// provider's lifetime.
+func (p *LayeredDataProvider) getMergedCatalog(ctx context.Context) ([]byte, error) {
 	p.mergedCatalogOnce.Do(func() {
 		p.mergedCatalog, p.mergedCatalogErr = mergeEmbeddedAndExternal(
-			p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName, mergeCatalogs,
+			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName, mergeCatalogs,
 		)
 	})
 

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -15,7 +15,9 @@
 package recipe
 
 import (
+	"context"
 	stderrors "errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +38,7 @@ func TestEmbeddedDataProvider(t *testing.T) {
 	provider := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
 
 	t.Run("read existing file", func(t *testing.T) {
-		data, err := provider.ReadFile("registry.yaml")
+		data, err := provider.ReadFile(context.Background(), "registry.yaml")
 		if err != nil {
 			t.Fatalf("failed to read registry.yaml: %v", err)
 		}
@@ -46,7 +48,7 @@ func TestEmbeddedDataProvider(t *testing.T) {
 	})
 
 	t.Run("read non-existent file", func(t *testing.T) {
-		_, err := provider.ReadFile("non-existent.yaml")
+		_, err := provider.ReadFile(context.Background(), "non-existent.yaml")
 		if err == nil {
 			t.Error("expected error for non-existent file")
 		}
@@ -103,7 +105,7 @@ components:
 	}
 
 	// Read merged registry
-	data, err := provider.ReadFile("registry.yaml")
+	data, err := provider.ReadFile(context.Background(), "registry.yaml")
 	if err != nil {
 		t.Fatalf("failed to read registry.yaml: %v", err)
 	}
@@ -155,7 +157,7 @@ spec:
 	}
 
 	// Read overlays/base.yaml - should get external version
-	data, err := provider.ReadFile("overlays/base.yaml")
+	data, err := provider.ReadFile(context.Background(), "overlays/base.yaml")
 	if err != nil {
 		t.Fatalf("failed to read overlays/base.yaml: %v", err)
 	}
@@ -210,7 +212,7 @@ spec:
 	}
 
 	// Read new overlay
-	data, err := provider.ReadFile("overlays/custom-overlay.yaml")
+	data, err := provider.ReadFile(context.Background(), "overlays/custom-overlay.yaml")
 	if err != nil {
 		t.Fatalf("failed to read custom-overlay.yaml: %v", err)
 	}
@@ -404,7 +406,7 @@ func TestLayeredDataProvider_FallsBackToEmbedded(t *testing.T) {
 	}
 
 	// Read overlays/base.yaml - should fall back to embedded since we didn't override it
-	data, err := provider.ReadFile("overlays/base.yaml")
+	data, err := provider.ReadFile(context.Background(), "overlays/base.yaml")
 	if err != nil {
 		t.Fatalf("failed to read overlays/base.yaml: %v", err)
 	}
@@ -450,7 +452,7 @@ components:
 	}
 
 	// Read the merged registry directly from the provider
-	mergedData, err := layered.ReadFile("registry.yaml")
+	mergedData, err := layered.ReadFile(context.Background(), "registry.yaml")
 	if err != nil {
 		t.Fatalf("failed to read merged registry: %v", err)
 	}
@@ -520,7 +522,7 @@ customField: customValue
 	}
 
 	// Read the custom values
-	data, err := provider.ReadFile("components/cert-manager/values.yaml")
+	data, err := provider.ReadFile(context.Background(), "components/cert-manager/values.yaml")
 	if err != nil {
 		t.Fatalf("failed to read custom values: %v", err)
 	}
@@ -578,7 +580,7 @@ spec:
 
 	t.Run("walks overlays directory", func(t *testing.T) {
 		var files []string
-		err := provider.WalkDir("overlays", func(path string, d os.DirEntry, err error) error {
+		err := provider.WalkDir(context.Background(), "overlays", func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -611,7 +613,7 @@ spec:
 
 	t.Run("walks root directory", func(t *testing.T) {
 		var files []string
-		err := provider.WalkDir("", func(path string, d os.DirEntry, err error) error {
+		err := provider.WalkDir(context.Background(), "", func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -669,7 +671,7 @@ spec:
 
 	// Walk overlays - should include both external and embedded files
 	var files []string
-	err = provider.WalkDir("overlays", func(path string, d os.DirEntry, err error) error {
+	err = provider.WalkDir(context.Background(), "overlays", func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -754,13 +756,13 @@ components:
 	}
 
 	// First read
-	data1, err := provider.ReadFile("registry.yaml")
+	data1, err := provider.ReadFile(context.Background(), "registry.yaml")
 	if err != nil {
 		t.Fatalf("first read failed: %v", err)
 	}
 
 	// Second read should return cached result
-	data2, err := provider.ReadFile("registry.yaml")
+	data2, err := provider.ReadFile(context.Background(), "registry.yaml")
 	if err != nil {
 		t.Fatalf("second read failed: %v", err)
 	}
@@ -775,7 +777,7 @@ func TestEmbeddedDataProvider_WalkDir(t *testing.T) {
 	provider := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
 
 	var files []string
-	err := provider.WalkDir("overlays", func(path string, d os.DirEntry, err error) error {
+	err := provider.WalkDir(context.Background(), "overlays", func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -836,7 +838,7 @@ components:
 	}
 
 	// Reading registry should fail due to invalid YAML
-	_, err = provider.ReadFile("registry.yaml")
+	_, err = provider.ReadFile(context.Background(), "registry.yaml")
 	if err == nil {
 		t.Error("expected error for invalid external registry YAML")
 	}
@@ -871,7 +873,7 @@ func TestLayeredDataProvider_ReadExternalFileError(t *testing.T) {
 	}
 
 	// Reading should fail
-	_, err = provider.ReadFile("test-file.yaml")
+	_, err = provider.ReadFile(context.Background(), "test-file.yaml")
 	if err == nil {
 		t.Error("expected error when external file can't be read")
 	}
@@ -909,7 +911,7 @@ func TestLayeredDataProvider_AllowSymlinks(t *testing.T) {
 	}
 
 	// Should be able to read via symlink
-	data, err := provider.ReadFile("symlink.yaml")
+	data, err := provider.ReadFile(context.Background(), "symlink.yaml")
 	if err != nil {
 		t.Fatalf("failed to read symlink file: %v", err)
 	}
@@ -1032,7 +1034,7 @@ func TestLayeredDataProvider_MergesCatalog(t *testing.T) {
 	}
 
 	// Read merged catalog
-	data, err := provider.ReadFile("validators/catalog.yaml")
+	data, err := provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err != nil {
 		t.Fatalf("failed to read catalog: %v", err)
 	}
@@ -1081,7 +1083,7 @@ validators:
 		t.Fatalf("failed to create layered provider: %v", err)
 	}
 
-	data, err := provider.ReadFile("validators/catalog.yaml")
+	data, err := provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err != nil {
 		t.Fatalf("failed to read catalog: %v", err)
 	}
@@ -1124,7 +1126,7 @@ func TestLayeredDataProvider_CatalogNoCatalogInExternal(t *testing.T) {
 	}
 
 	// Should fall back to embedded catalog
-	data, err := provider.ReadFile("validators/catalog.yaml")
+	data, err := provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err != nil {
 		t.Fatalf("failed to read catalog: %v", err)
 	}
@@ -1178,13 +1180,13 @@ func TestLayeredDataProvider_CachedCatalog(t *testing.T) {
 	}
 
 	// First read
-	data1, err := provider.ReadFile("validators/catalog.yaml")
+	data1, err := provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err != nil {
 		t.Fatalf("first read failed: %v", err)
 	}
 
 	// Second read should return cached result
-	data2, err := provider.ReadFile("validators/catalog.yaml")
+	data2, err := provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err != nil {
 		t.Fatalf("second read failed: %v", err)
 	}
@@ -1211,7 +1213,7 @@ validators:
 		t.Fatalf("failed to create layered provider: %v", err)
 	}
 
-	_, err = provider.ReadFile("validators/catalog.yaml")
+	_, err = provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err == nil {
 		t.Error("expected error for invalid external catalog YAML")
 	}
@@ -1252,7 +1254,7 @@ validators:
 		t.Fatalf("failed to create layered provider: %v", err)
 	}
 
-	data, err := provider.ReadFile("validators/catalog.yaml")
+	data, err := provider.ReadFile(context.Background(), "validators/catalog.yaml")
 	if err != nil {
 		t.Fatalf("failed to read catalog: %v", err)
 	}
@@ -1281,5 +1283,51 @@ validators:
 	firstImage, _ := cat.Validators[0]["image"].(string)
 	if firstImage != "example.com/custom/deployment:v2.0.0" {
 		t.Errorf("operator-health image = %q, want %q", firstImage, "example.com/custom/deployment:v2.0.0")
+	}
+}
+
+// TestDataProvider_HonorsContextCancellation pins acceptance criterion #6 of
+// issue #1109: a caller that cancels its context mid-read sees
+// context.Canceled propagate back rather than blocking until the read
+// completes. Run separately for each in-tree implementation so a future
+// refactor that drops the guard on one but not the other gets caught.
+func TestDataProvider_HonorsContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "registry.yaml"), []byte(testEmptyRegistryContent), 0600); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+
+	embedded := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
+	layered, err := NewLayeredDataProvider(embedded, LayeredProviderConfig{ExternalDir: tmpDir})
+	if err != nil {
+		t.Fatalf("NewLayeredDataProvider: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		dp   DataProvider
+	}{
+		{"embedded", embedded},
+		{"layered", layered},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/ReadFile", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			_, err := tc.dp.ReadFile(ctx, "registry.yaml")
+			if !stderrors.Is(err, context.Canceled) {
+				t.Errorf("ReadFile with canceled ctx returned %v, want context.Canceled", err)
+			}
+		})
+
+		t.Run(tc.name+"/WalkDir", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := tc.dp.WalkDir(ctx, ".", func(string, fs.DirEntry, error) error { return nil })
+			if !stderrors.Is(err, context.Canceled) {
+				t.Errorf("WalkDir with canceled ctx returned %v, want context.Canceled", err)
+			}
+		})
 	}
 }

--- a/pkg/recipe/query.go
+++ b/pkg/recipe/query.go
@@ -15,17 +15,32 @@
 package recipe
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 // HydrateResult builds a fully hydrated map from a RecipeResult.
 // Component values are merged via GetValuesForComponent so the output
 // contains the final resolved configuration, not file references.
+//
+// Internally derives a defaults.FileReadTimeout-bounded context so a hung
+// backing store still returns instead of blocking the goroutine. Callers
+// that hold a context.Context should use HydrateResultWithContext so the
+// caller's deadline propagates to the underlying values reads.
 func HydrateResult(result *RecipeResult) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return HydrateResultWithContext(ctx, result)
+}
+
+// HydrateResultWithContext builds a fully hydrated map from a RecipeResult,
+// honoring ctx for cancellation/timeout on the underlying values reads.
+func HydrateResultWithContext(ctx context.Context, result *RecipeResult) (map[string]any, error) {
 	if result == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "recipe result is nil")
 	}
@@ -101,7 +116,7 @@ func HydrateResult(result *RecipeResult) (map[string]any, error) {
 			comp["dependencyRefs"] = ref.DependencyRefs
 		}
 
-		values, err := result.GetValuesForComponent(ref.Name)
+		values, err := result.GetValuesForComponentWithContext(ctx, ref.Name)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInternal,
 				fmt.Sprintf("failed to hydrate values for component %q", ref.Name), err)

--- a/pkg/validator/catalog/catalog.go
+++ b/pkg/validator/catalog/catalog.go
@@ -18,6 +18,7 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -38,12 +39,13 @@ type (
 	EnvVar               = v1.EnvVar
 )
 
-// LoadWithDataProvider reads and parses the validator catalog from dp. A nil
-// dp defaults to the embedded recipe data; callers that want a layered
-// `--data` overlay must pass their own layered provider. When the catalog
-// file is present, the external catalog is merged with the embedded one
-// using merge-by-name semantics: external validators override embedded
-// by name, and new validators are appended.
+// LoadWithDataProvider reads and parses the validator catalog from dp using
+// the supplied context for cancellation/timeout. A nil dp defaults to the
+// embedded recipe data; callers that want a layered `--data` overlay must
+// pass their own layered provider. When the catalog file is present, the
+// external catalog is merged with the embedded one using merge-by-name
+// semantics: external validators override embedded by name, and new
+// validators are appended.
 //
 // Image tag resolution (applied in order):
 //  1. If a catalog entry uses :latest and version looks like a release tag
@@ -60,11 +62,11 @@ type (
 //
 // Entries with explicit version tags (e.g., :v1.2.3) are never modified by
 // steps 1-2 but are replaced by step 3 if that env var is set.
-func LoadWithDataProvider(dp recipe.DataProvider, version, commit string) (*ValidatorCatalog, error) {
+func LoadWithDataProvider(ctx context.Context, dp recipe.DataProvider, version, commit string) (*ValidatorCatalog, error) {
 	if dp == nil {
 		dp = recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "")
 	}
-	data, err := dp.ReadFile("validators/catalog.yaml")
+	data, err := dp.ReadFile(ctx, "validators/catalog.yaml")
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read catalog", err)
 	}

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -15,6 +15,7 @@
 package catalog
 
 import (
+	"context"
 	"encoding/json"
 	"io/fs"
 	"os"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestLoadEmbeddedCatalog(t *testing.T) {
-	catalog, err := LoadWithDataProvider(nil, "", "")
+	catalog, err := LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -164,7 +165,7 @@ validators:
 }
 
 func TestForPhaseNoMatch(t *testing.T) {
-	catalog, err := LoadWithDataProvider(nil, "", "")
+	catalog, err := LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -345,7 +346,7 @@ func TestReplaceRegistry(t *testing.T) {
 func TestLoadWithRegistryOverride(t *testing.T) {
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "localhost:5001")
 
-	cat, err := LoadWithDataProvider(nil, "", "")
+	cat, err := LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -360,7 +361,7 @@ func TestLoadWithRegistryOverride(t *testing.T) {
 func TestLoadWithoutRegistryOverride(t *testing.T) {
 	t.Setenv("AICR_VALIDATOR_IMAGE_REGISTRY", "")
 
-	cat, err := LoadWithDataProvider(nil, "", "")
+	cat, err := LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -422,7 +423,7 @@ validators:
 	}
 
 	// Load catalog — should merge embedded + external
-	cat, err := LoadWithDataProvider(layered, "", "")
+	cat, err := LoadWithDataProvider(context.Background(), layered, "", "")
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
@@ -1021,7 +1022,7 @@ validators:
 func TestEmbeddedCatalog_AIServiceMetricsHasDependencyAffinity(t *testing.T) {
 	// "-next" suffix bypasses the release-version image-tag rewrite path,
 	// matching how goreleaser snapshots stamp dev binaries.
-	cat, err := LoadWithDataProvider(nil, "v0.0.0-next", "")
+	cat, err := LoadWithDataProvider(context.Background(), nil, "v0.0.0-next", "")
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}
@@ -1120,7 +1121,7 @@ type fakeCatalogProvider struct {
 	reads       int
 }
 
-func (p *fakeCatalogProvider) ReadFile(path string) ([]byte, error) {
+func (p *fakeCatalogProvider) ReadFile(_ context.Context, path string) ([]byte, error) {
 	if path == "validators/catalog.yaml" {
 		p.reads++
 		return p.catalogYAML, nil
@@ -1128,7 +1129,7 @@ func (p *fakeCatalogProvider) ReadFile(path string) ([]byte, error) {
 	return nil, os.ErrNotExist
 }
 
-func (p *fakeCatalogProvider) WalkDir(string, fs.WalkDirFunc) error { return nil }
+func (p *fakeCatalogProvider) WalkDir(context.Context, string, fs.WalkDirFunc) error { return nil }
 
 func (p *fakeCatalogProvider) Source(path string) string { return "fake://" + path }
 
@@ -1151,7 +1152,7 @@ validators:
     timeout: 1m
 `)}
 
-	cat, err := LoadWithDataProvider(dp, "", "")
+	cat, err := LoadWithDataProvider(context.Background(), dp, "", "")
 	if err != nil {
 		t.Fatalf("LoadWithDataProvider() error = %v, want nil", err)
 	}
@@ -1191,7 +1192,7 @@ func TestLoadDataProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cat, err := LoadWithDataProvider(tt.dp, "", "")
+			cat, err := LoadWithDataProvider(context.Background(), tt.dp, "", "")
 			if err != nil {
 				t.Fatalf("LoadWithDataProvider() error = %v, want nil", err)
 			}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -179,9 +179,9 @@ func (v *Validator) ValidatePhases(
 		return nil, err
 	}
 
-	cat, err := catalog.LoadWithDataProvider(v.dataProvider, v.Version, v.Commit)
+	cat, err := catalog.LoadWithDataProvider(ctx, v.dataProvider, v.Version, v.Commit)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog", err)
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load validator catalog")
 	}
 
 	// --no-cluster: report all as skipped, no K8s calls
@@ -237,9 +237,9 @@ func (v *Validator) ValidatePhase(
 	snap *snapshotter.Snapshot,
 ) (*PhaseResult, error) {
 
-	cat, err := catalog.LoadWithDataProvider(v.dataProvider, v.Version, v.Commit)
+	cat, err := catalog.LoadWithDataProvider(ctx, v.dataProvider, v.Version, v.Commit)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load validator catalog", err)
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load validator catalog")
 	}
 
 	if v.NoCluster {

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -89,7 +89,7 @@ func TestNewWithOptions(t *testing.T) {
 
 func loadEmbeddedCatalog(t *testing.T) *catalog.ValidatorCatalog {
 	t.Helper()
-	cat, err := catalog.LoadWithDataProvider(nil, "", "")
+	cat, err := catalog.LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {
 		t.Fatalf("failed to load catalog: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestPhaseOrder(t *testing.T) {
 // in recipe overlays exists in the validator catalog for the correct phase.
 // Catches typos and drift between recipes and catalog at PR time.
 func TestRecipeCheckNamesMatchCatalog(t *testing.T) {
-	cat, err := catalog.LoadWithDataProvider(nil, "", "")
+	cat, err := catalog.LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {
 		t.Fatalf("failed to load catalog: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Threads `context.Context` through `DataProvider.ReadFile` / `WalkDir` so callers operating against slow/hung backing stores (stalled NFS/sshfs `--data` mounts) can cancel mid-read.
- Cascades ctx through `catalog.LoadWithDataProvider` and the `validator.ValidatePhases` / `ValidatePhase` entry points called out in the issue acceptance criteria.
- Folds in three doc/code drift fixes left over from #1118 (per-provider criteria registry, CLI/server Client model, `catalog.Load` → `catalog.LoadWithDataProvider`).

## Motivation / Context

Fixes #1109. The pre-existing exposure: a hung NFS / sshfs read on a `--data` directory would block the validator goroutine until process termination, since the surrounding `ValidatePhases(ctx)` cancellation couldn't interrupt the in-flight `ReadFile`. Embedded reads cannot hang; the exposure is narrow but real for network-backed `--data` mounts.

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Components Affected

- [x] Recipes / registry (`pkg/recipe`)
- [x] Validator (`pkg/validator`)
- [x] CLI commands (`pkg/cli`)
- [x] API server (`pkg/api`)
- [x] Bundler / deployers (`pkg/bundler`)
- [x] Documentation

## Implementation Notes

**Interface change.** `DataProvider.ReadFile(ctx, path)` and `WalkDir(ctx, root, fn)` now take `context.Context`. Embedded checks `ctx.Err()` before reading and between entries; Layered forwards ctx to embedded reads and inside `mergeEmbeddedAndExternal`. The bounded `WalkDir(ctx)` guard in `LayeredDataProvider` short-circuits on a stalled network mount.

**Catalog entry point.** `catalog.LoadWithDataProvider(ctx, dp, version, commit)` is the new canonical entry; `catalog.Load(...)` becomes a back-compat wrapper that derives a `defaults.FileReadTimeout`-bounded `context.Background()`.

**Validator propagation.** `validator.ValidatePhases` and `ValidatePhase` forward their incoming ctx directly to `catalog.LoadWithDataProvider` so the surrounding `--timeout` reaches the catalog read.

**Public-API back-compat.** Existing helpers without ctx in their signature (`GetManifestContent`, `RecipeResult.GetValuesForComponent`, `HydrateResult`) gain `*WithContext` variants; the no-ctx form derives a bounded `context.Background()` from `defaults.FileReadTimeout` internally so a hung mount still returns instead of parking the goroutine. Internal cascades that pass through `GetComponentRegistryFor` (sync.Once cached, first-load bounded internally) carry `//nolint:contextcheck` with a rationale comment.

**Cancellation test.** `TestDataProvider_HonorsContextCancellation` asserts both implementations return `context.Canceled` from `ReadFile` and `WalkDir` when the caller cancels mid-read.

**Drift cleanup (folded in).** The user flagged three doc/code references left over from #1118: `docs/contributor/data.md` still described the criteria registry as process-global (it's per-provider now); `pkg/recipe/doc.go` still said the CLI/API server uses `SetDataProvider` (they use `aicr.Client` with `WithRecipeSource`); `docs/contributor/validator.md` referenced the old `catalog.Load` entry point.

## Testing

- `go test -race ./...` — all packages pass (only pre-existing `pkg/trust` TUF/Sigstore network test fails in this sandbox; confirmed identical failure on `main` via `git stash`).
- `golangci-lint run -c .golangci.yaml ./...` — 0 issues.
- `make qualify` — passes except the same pre-existing `pkg/trust` network test.

### Coverage (changed packages)

| Package | Delta |
|---|---|
| `pkg/recipe` | unchanged (88.9%) |
| `pkg/validator/catalog` | unchanged (97.6%) |
| `pkg/validator` | unchanged (24.3%) — only call-site cascade |
| `pkg/cli` | unchanged — only call-site cascade |
| `pkg/api` | unchanged — only call-site cascade |
| `pkg/bundler` | unchanged — only call-site cascade |
| `pkg/mirror` | unchanged — only call-site cascade |
| `pkg/client/v1` | unchanged — only call-site cascade |

New test (`TestDataProvider_HonorsContextCancellation`) covers the four new code paths added in this PR (Embedded.ReadFile + WalkDir ctx checks, Layered.ReadFile + WalkDir ctx checks).

## Risk Assessment

Low.

- API change is additive on the call sites where ctx is now required, and the back-compat wrappers (`GetManifestContent`, `Load`, `HydrateResult`, etc.) keep the no-ctx public shape working unchanged for external consumers.
- Internal bounded ctx (`defaults.FileReadTimeout`) ensures the no-ctx call sites still get a timeout rather than the unbounded blocking that existed before.
- The cancellation test pins the contract.
- Doc-only sections (data.md, validator.md, doc.go) carry no runtime risk.

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Code follows existing patterns (`make qualify`)
- [x] Self-review completed
- [x] No `Co-Authored-By` lines
- [x] Commits are signed (`-S`)
- [x] PR title ≤ 70 chars

Closes #1109.