### PR TITLE
feat(mirror): thread recipe-bound DataProvider through manifest reads

### DIFF
--- a/docs/user/air-gap-mirror.md
+++ b/docs/user/air-gap-mirror.md
@@ -9,9 +9,12 @@ the static image inventory across all registered components, see
 ## Overview
 
 `aicr mirror list` renders each component's Helm chart with recipe-resolved
-values, scans embedded manifests, and produces a deduplicated list of container
-images and chart references. The output is available in four formats — two
-general-purpose (YAML, JSON) and two tool-specific (Hauler, Zarf).
+values, scans referenced manifests, and produces a deduplicated list of
+container images and chart references. Manifest reads honor the recipe's
+data source — when the recipe was built with `--data <dir>`, an overlay
+manifest shadowing an embedded path is used in place of the embedded copy.
+The output is available in four formats — two general-purpose (YAML, JSON)
+and two tool-specific (Hauler, Zarf).
 
 > **Trust boundary:** Discovery shells out to `helm template`, which executes
 > the full Go template engine (`tpl`, `include`, `lookup`). AICR recipes

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2063,7 +2063,9 @@ for flags and behavior.
 
 Discover container images and Helm charts referenced by a recipe for air-gapped
 mirroring. Renders each component's Helm chart with recipe-resolved values and
-scans embedded manifests to produce a deduplicated image and chart list.
+scans referenced manifests to produce a deduplicated image and chart list. When
+the recipe was resolved with `--data <dir>`, both values and manifests are read
+through the overlay so overlay-shadowed paths take precedence over embedded.
 
 For an end-to-end walkthrough covering Hauler and Zarf workflows, see
 [Air-Gapped Mirroring](air-gap-mirror.md).
@@ -2083,6 +2085,7 @@ aicr mirror list [flags]
 | `--os` | | string | | Operating system (e.g., `ubuntu`). Alternative to `--recipe`. |
 | `--platform` | | string | | Optional platform specialization (e.g., `kubeflow`). |
 | `--set` | | string[] | | Override values that affect image discovery (format: `component:path.to.field=value`). Repeatable. |
+| `--data` | | string | | External data directory to overlay on embedded data. Overlay-provided component values and manifests both feed image discovery (see [External Data](#external-data-directory)). |
 | `--format` | `-f` | string | `yaml` | Output format: `yaml`, `json`, `hauler`, `zarf` |
 | `--output` | `-o` | string | stdout | Output file path |
 

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -91,6 +91,12 @@ type componentResult struct {
 
 // Discover takes a loaded RecipeResult and returns a MirrorList by
 // rendering each component's chart and extracting images.
+//
+// Manifest and component-values reads both route through the recipe's bound
+// DataProvider (rec.DataProvider()), so a recipe built against a `--data`
+// overlay sees overlay-provided manifests and values consistently. When the
+// recipe carries no bound provider, reads fall back to the package-global
+// embedded provider inside recipe.GetManifestContentWithContext.
 func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*MirrorList, error) {
 	if rec == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "recipe is required")
@@ -174,15 +180,20 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 				}
 			}
 
-			// Both types: scan ManifestFiles and PreManifestFiles.
+			// Both types: scan ManifestFiles and PreManifestFiles. Use the
+			// recipe-bound DataProvider so `--data` overlays that shadow an
+			// embedded manifest path are honored, matching the values-loading
+			// path above. A nil provider falls back to embedded inside
+			// GetManifestContentWithContext.
 			if gctx.Err() != nil {
 				return gctx.Err()
 			}
+			dp := rec.DataProvider()
 			for _, mPath := range compRef.ManifestFiles {
-				allImages = extractManifestImages(gctx, allImages, &ci, compRef.Name, mPath)
+				allImages = extractManifestImages(gctx, dp, allImages, &ci, compRef.Name, mPath)
 			}
 			for _, mPath := range compRef.PreManifestFiles {
-				allImages = extractManifestImages(gctx, allImages, &ci, compRef.Name, mPath)
+				allImages = extractManifestImages(gctx, dp, allImages, &ci, compRef.Name, mPath)
 			}
 
 			slices.Sort(allImages)
@@ -246,10 +257,12 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 	return ml, nil
 }
 
-// extractManifestImages reads a manifest file and appends extracted images
-// to the accumulator, recording warnings on failure.
-func extractManifestImages(ctx context.Context, acc []string, ci *ComponentImages, compName, mPath string) []string {
-	content, readErr := recipe.GetManifestContentWithContext(ctx, nil, mPath)
+// extractManifestImages reads a manifest file from the supplied DataProvider
+// and appends extracted images to the accumulator, recording warnings on
+// failure. A nil provider falls back to the package-global embedded provider
+// inside recipe.GetManifestContentWithContext.
+func extractManifestImages(ctx context.Context, dp recipe.DataProvider, acc []string, ci *ComponentImages, compName, mPath string) []string {
+	content, readErr := recipe.GetManifestContentWithContext(ctx, dp, mPath)
 	if readErr != nil {
 		slog.Warn("failed to read manifest",
 			"component", compName, "path", mPath, "error", readErr)

--- a/pkg/mirror/discover_test.go
+++ b/pkg/mirror/discover_test.go
@@ -16,6 +16,8 @@ package mirror
 
 import (
 	"context"
+	"io/fs"
+	"slices"
 	"testing"
 	"time"
 
@@ -368,4 +370,109 @@ func splitPath(path string) []string {
 		}
 	}
 	return parts
+}
+
+// inMemoryDataProvider is a minimal recipe.DataProvider backed by an
+// in-memory map[path]content. Only ReadFile is exercised by extractManifestImages;
+// WalkDir and Source are implemented to satisfy the interface.
+type inMemoryDataProvider struct {
+	files map[string][]byte
+}
+
+func (p *inMemoryDataProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	content, ok := p.files[path]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return content, nil
+}
+
+func (p *inMemoryDataProvider) WalkDir(ctx context.Context, _ string, _ fs.WalkDirFunc) error {
+	return ctx.Err()
+}
+
+func (p *inMemoryDataProvider) Source(path string) string { return "inmem:" + path }
+
+// TestDiscover_HonorsRecipeBoundDataProviderForManifests pins the invariant
+// that extractManifestImages reads ManifestFiles through the recipe-bound
+// DataProvider. Without the binding, mirror would silently fall back to the
+// package-global embedded provider — making `aicr mirror --data <dir>`
+// inconsistent with `aicr bundle --data <dir>` for overlay-shadowed manifests.
+func TestDiscover_HonorsRecipeBoundDataProviderForManifests(t *testing.T) {
+	const manifestPath = "components/network-operator/manifests/overlay-only.yaml"
+	overlayManifest := []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: overlay-only
+spec:
+  containers:
+    - name: c
+      image: overlay/from-provider:v9.9.9
+`)
+
+	dp := &inMemoryDataProvider{files: map[string][]byte{
+		manifestPath: overlayManifest,
+	}}
+
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:          "network-operator",
+				Type:          recipe.ComponentTypeKustomize,
+				ManifestFiles: []string{manifestPath},
+			},
+		},
+	}
+	rec.BindDataProvider(dp)
+
+	lister := NewLister(WithHelmRenderer(&helmtest.MockRenderer{}))
+	result, err := lister.Discover(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	if !slices.Contains(result.Images, "overlay/from-provider:v9.9.9") {
+		t.Errorf("overlay manifest image not extracted: images=%v", result.Images)
+	}
+	for _, c := range result.Components {
+		if c.Component == "network-operator" && len(c.Warnings) > 0 {
+			t.Errorf("unexpected warnings on overlay-bound read: %v", c.Warnings)
+		}
+	}
+}
+
+// TestDiscover_NilDataProviderFallsBackToEmbedded confirms the back-compat
+// path: when a RecipeResult has no bound provider, extractManifestImages must
+// still resolve manifest paths via the package-global embedded provider
+// (recipe.GetManifestContentWithContext treats a nil dp as embedded fallback).
+// We use a real embedded manifest path to keep the test hermetic.
+func TestDiscover_NilDataProviderFallsBackToEmbedded(t *testing.T) {
+	const embeddedManifest = "components/network-operator/manifests/nfd-network-rule.yaml"
+
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:          "network-operator",
+				Type:          recipe.ComponentTypeKustomize,
+				ManifestFiles: []string{embeddedManifest},
+			},
+		},
+	}
+	// Intentionally do NOT call BindDataProvider — rec.DataProvider() returns nil.
+
+	lister := NewLister(WithHelmRenderer(&helmtest.MockRenderer{}))
+	result, err := lister.Discover(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	for _, c := range result.Components {
+		if c.Component == "network-operator" && len(c.Warnings) > 0 {
+			t.Errorf("unexpected warnings reading embedded manifest: %v", c.Warnings)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`pkg/mirror.extractManifestImages` now reads ManifestFiles / PreManifestFiles through the recipe's bound `DataProvider`, so `aicr mirror --data <dir>` honors overlay-provided manifests the same way it already honors overlay-provided component values.

## Motivation / Context

`extractManifestImages` was calling `recipe.GetManifestContentWithContext(ctx, nil, mPath)` — the `nil` falls back to the package-global embedded provider. The sibling component-values call (`rec.GetValuesForComponentWithContext`) already uses the recipe-bound provider, so mirror was reading values from `--data` but manifests from embedded. That inconsistency was flagged by @yuanchen8911 during PR #1121 review and predates #1121.

Fixes: #1122
Related: #1109, #1121

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/mirror`

## Implementation Notes

- `Lister.Discover` reads `rec.DataProvider()` once per component and passes it down to `extractManifestImages` for both `ManifestFiles` and `PreManifestFiles` loops.
- `extractManifestImages` gained a `dp recipe.DataProvider` parameter. A nil provider keeps the embedded fallback inside `recipe.GetManifestContentWithContext`, so recipes loaded outside the Builder path (no bound provider) still resolve embedded manifests unchanged.
- No new behavior surface for callers of `Discover` — overlay-aware manifest reading happens automatically when the recipe was built via a `Builder` bound with `WithDataProvider`, which is what `aicr mirror --data` already does.

## Testing

```bash
go test -race ./pkg/mirror/... ./pkg/recipe/...
golangci-lint run -c .golangci.yaml ./pkg/mirror/...
```

- New `TestDiscover_HonorsRecipeBoundDataProviderForManifests` proves a recipe-bound in-memory provider supplying a manifest at `components/network-operator/manifests/overlay-only.yaml` is what mirror actually reads (image extracted, no warnings).
- New `TestDiscover_NilDataProviderFallsBackToEmbedded` pins the back-compat path: no bound provider, embedded `nfd-network-rule.yaml` still resolves.
- `pkg/mirror` package coverage: **68.1% → 71.2%** (+3.1%).
- All `pkg/recipe` tests pass (no API change required there — `RecipeResult.DataProvider()` already existed).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Pure bug fix. `Lister.Discover` signature unchanged; `extractManifestImages` is package-private. Recipes loaded outside the Builder path keep the embedded fallback through `GetManifestContentWithContext`'s nil-provider handling.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (mirror godoc, `docs/user/air-gap-mirror.md`, `docs/user/cli-reference.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)