### PR TITLE
feat(client/v1): wrap remaining facade alias types

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -204,8 +204,8 @@ client, err := aicr.NewClient(
 ```
 
 - **`WithVersion(version string)`** stamps the given version string into
-  resolved recipe metadata (`Recipe.Metadata.Version`). Typically the
-  consuming binary's build version.
+  resolved recipe metadata (accessible via `result.Resolved().Metadata.Version`).
+  Typically the consuming binary's build version.
 - **`WithAllowLists(al *AllowLists)`** fences which criteria values the
   Client's resolve path accepts. A resolve whose criteria fall outside
   the allowlist is rejected before the recipe is built. Pass `nil` (or
@@ -217,47 +217,63 @@ client, err := aicr.NewClient(
   `AllowLists` as allow-all, so the result is always safe to pass straight
   to `WithAllowLists`.
 
-`AllowLists` is a transparent alias of `pkg/recipe.AllowLists`; you can
-also construct one directly when you don't want to read from the
-environment.
+`AllowLists` is a facade-owned struct whose `Accelerators`, `Services`,
+`Intents`, and `OSTypes` fields are plain `[]string` slices, so callers
+can construct one directly without depending on `pkg/recipe`'s enum
+identifiers. When you already hold a `pkg/recipe.AllowLists`, use
+`aicr.WrapAllowLists` to project it onto the facade shape.
 
 ## Resolving from criteria
 
 `ResolveRecipe` takes the stable `RecipeRequest` shape and returns the
 facade `RecipeResult` — a deliberately small struct exposing the
 `Name`, `Version`, and `Components` of the resolved recipe. When you
-already hold a `pkg/recipe.Criteria` value — for example, a REST handler
-that parsed criteria from an incoming HTTP request — use
-`ResolveRecipeFromCriteria`, which returns the full `Recipe` (the
-complete underlying `pkg/recipe.RecipeResult`, including constraints,
-deployment order, and metadata that the facade `RecipeResult` omits):
+already hold an `*aicr.Criteria` value — for example, a REST handler
+that parsed criteria from an incoming HTTP request and wrapped them with
+`aicr.WrapCriteria` — use `ResolveRecipeFromCriteria`. It returns the
+same facade `*RecipeResult`; call `result.Resolved()` when you need the
+complete underlying `*pkg/recipe.RecipeResult` (constraints, deployment
+order, validation config, metadata):
 
 ```go
-rec, err := client.ResolveRecipeFromCriteria(ctx, criteria)
+rec, err := client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
 if err != nil {
 	log.Fatalf("resolve recipe: %v", err)
 }
+
+// Facade surface — Name, Version, Components.
+log.Printf("recipe %s components: %d", rec.Name, len(rec.Components))
+
+// Full upstream shape, when needed.
+resolved := rec.Resolved()
+log.Printf("recipe constraints: %d", len(resolved.Constraints))
 ```
 
-`Recipe` is a transparent alias of `pkg/recipe.RecipeResult` and carries
-the complete resolved recipe, including:
+The returned `*RecipeResult` carries:
 
-- component references
-- constraints
-- deployment order
-- metadata
+- `Name`, `Version`, `TranslatedAt` — stable identity
+- `Components` — `[]ComponentRef` (Name, Kind, Version, Source, Chart, Namespace)
+- `Resolved()` — the upstream `*pkg/recipe.RecipeResult` for callers that
+  need constraints, deployment order, validation config, or metadata
+  (e.g., evidence emission). Do not mutate; do not retain past the
+  facade `RecipeResult`'s lifetime — marshal first if persistence is
+  needed.
 
-`Criteria` is a transparent alias of
-`pkg/recipe.Criteria`. Allowlist enforcement (`WithAllowLists`) applies
-here just as it does on `ResolveRecipe`; a `nil` Client, `nil` context,
-or `nil` criteria each return `ErrCodeInvalidRequest`, and the same
-facade-level timeout bounds the resolve.
+`Criteria` is a facade-owned struct whose enum-typed fields project to
+plain strings, decoupling the public surface from `pkg/recipe`'s enum
+identifiers. Construct one directly or wrap an upstream
+`*pkg/recipe.Criteria` via `aicr.WrapCriteria`. Allowlist enforcement
+(`WithAllowLists`) applies here just as it does on `ResolveRecipe`; a
+`nil` Client, `nil` context, or `nil` criteria each return
+`ErrCodeInvalidRequest`, and the same facade-level timeout bounds the
+resolve.
 
-To extract a single value from a resolved `Recipe`, use
+To extract a single value from a resolved recipe, use
 `SelectFromRecipe` with a dot-path selector. It hydrates the recipe's
 component values and returns the value at the path; an empty selector
-returns the entire hydrated structure, and a `nil` `Recipe` returns
-`ErrCodeInvalidRequest`. This mirrors the `aicr query` CLI command:
+returns the entire hydrated structure, and a `nil` `*RecipeResult`
+returns `ErrCodeInvalidRequest`. This mirrors the `aicr query` CLI
+command:
 
 ```go
 v, err := aicr.SelectFromRecipe(rec, "components.gpu-operator.values.driver.version")

--- a/docs/integrator/public-api.md
+++ b/docs/integrator/public-api.md
@@ -56,10 +56,10 @@ aliases — the table below documents which.
 | `aicr.Phase`, `aicr.PhaseDeployment` / `PhasePerformance` / `PhaseConformance` | string consts | **Facade-owned**. Values match `pkg/api/validator/v1` constants verbatim for byte-identical wire round-trip. |
 | `aicr.ReportSummary` | `pkg/validator/ctrf.Summary` | **Facade-owned struct** with the CTRF count fields. |
 | `aicr.ValidateOption` | `pkg/validator.Option` | **Facade-owned** functional-option type that captures into an internal struct and translates at call time. |
-| `aicr.Recipe` | `pkg/recipe.RecipeResult` | Transparent alias added by #1077. Future wrapping tracked separately. |
-| `aicr.AllowLists` | `pkg/recipe.AllowLists` | Transparent alias added by #1077. |
-| `aicr.Criteria` | `pkg/recipe.Criteria` | Transparent alias added by #1077. |
-| `aicr.CriteriaRegistry` | `pkg/recipe.CriteriaRegistry` | Transparent alias added by #1077. |
+| `aicr.RecipeResult` | `pkg/recipe.RecipeResult` | **Facade-owned struct** exposing `Name`, `Version`, `TranslatedAt`, and `Components`. Call `Resolved()` for the full upstream `*pkg/recipe.RecipeResult` (constraints, deployment order, validation config, metadata). The previous `aicr.Recipe` alias was removed in #1115; `ResolveRecipeFromCriteria` and `ResolveRecipeFromSnapshot` now return `*RecipeResult`. |
+| `aicr.AllowLists` | `pkg/recipe.AllowLists` | **Facade-owned struct** with `[]string` fields (Accelerators / Services / Intents / OSTypes). Use `aicr.WrapAllowLists` to lift a `*pkg/recipe.AllowLists`. |
+| `aicr.Criteria` | `pkg/recipe.Criteria` | **Facade-owned struct** whose enum-typed fields project to plain strings (Service / Accelerator / Intent / OS / Platform / Nodes). Use `aicr.WrapCriteria` to lift a `*pkg/recipe.Criteria`. |
+| `aicr.CriteriaRegistry` | `pkg/recipe.CriteriaRegistry` | Documented transparent alias. Kept as an alias intentionally because the registry is behavior-rich (`ParseService`, `SetStrict`, `Values`, ...) and carries mutable per-`DataProvider` state — wrapping would either break the per-Client identity coupling (copy) or add no isolation win over the alias (pointer). |
 
 ## Recommended consumption pattern
 

--- a/docs/integrator/public-api.md
+++ b/docs/integrator/public-api.md
@@ -58,7 +58,7 @@ aliases — the table below documents which.
 | `aicr.ValidateOption` | `pkg/validator.Option` | **Facade-owned** functional-option type that captures into an internal struct and translates at call time. |
 | `aicr.RecipeResult` | `pkg/recipe.RecipeResult` | **Facade-owned struct** exposing `Name`, `Version`, `TranslatedAt`, and `Components`. Call `Resolved()` for the full upstream `*pkg/recipe.RecipeResult` (constraints, deployment order, validation config, metadata). The previous `aicr.Recipe` alias was removed in #1115; `ResolveRecipeFromCriteria` and `ResolveRecipeFromSnapshot` now return `*RecipeResult`. |
 | `aicr.AllowLists` | `pkg/recipe.AllowLists` | **Facade-owned struct** with `[]string` fields (Accelerators / Services / Intents / OSTypes). Use `aicr.WrapAllowLists` to lift a `*pkg/recipe.AllowLists`. |
-| `aicr.Criteria` | `pkg/recipe.Criteria` | **Facade-owned struct** whose enum-typed fields project to plain strings (Service / Accelerator / Intent / OS / Platform / Nodes). Use `aicr.WrapCriteria` to lift a `*pkg/recipe.Criteria`. |
+| `aicr.Criteria` | `pkg/recipe.Criteria` | **Facade-owned struct** whose enum-typed fields (Service / Accelerator / Intent / OS / Platform) project to plain strings; Nodes stays an `int` per the facade's string/int contract. Use `aicr.WrapCriteria` to lift a `*pkg/recipe.Criteria`. |
 | `aicr.CriteriaRegistry` | `pkg/recipe.CriteriaRegistry` | Documented transparent alias. Kept as an alias intentionally because the registry is behavior-rich (`ParseService`, `SetStrict`, `Values`, ...) and carries mutable per-`DataProvider` state — wrapping would either break the per-Client identity coupling (copy) or add no isolation win over the alias (pointer). |
 
 ## Recommended consumption pattern

--- a/pkg/api/allowlist.go
+++ b/pkg/api/allowlist.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// validateAgainstAllowLists runs the upstream pkg/recipe.AllowLists check
+// for an in-tree handler holding both a facade *aicr.AllowLists and a
+// freshly-parsed *recipe.Criteria. The handler runs this explicit pre-check
+// so the user-facing error message stays exactly the one the legacy handler
+// emitted; the Client's internal enforcement on Resolve/MakeBundle remains a
+// backstop for callers that go straight to the facade methods.
+//
+// The translation is a thin string-slice → enum-slice projection; it is not
+// in the hot path (handlers run it once per request).
+func validateAgainstAllowLists(al *aicr.AllowLists, c *recipe.Criteria) error {
+	if al == nil {
+		return nil
+	}
+	internal := &recipe.AllowLists{
+		Accelerators: convertToTypes[recipe.CriteriaAcceleratorType](al.Accelerators),
+		Services:     convertToTypes[recipe.CriteriaServiceType](al.Services),
+		Intents:      convertToTypes[recipe.CriteriaIntentType](al.Intents),
+		OSTypes:      convertToTypes[recipe.CriteriaOSType](al.OSTypes),
+	}
+	return internal.ValidateCriteria(c)
+}
+
+func convertToTypes[T ~string](in []string) []T {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]T, len(in))
+	for i, v := range in {
+		out[i] = T(v)
+	}
+	return out
+}

--- a/pkg/api/allowlist.go
+++ b/pkg/api/allowlist.go
@@ -26,28 +26,13 @@ import (
 // emitted; the Client's internal enforcement on Resolve/MakeBundle remains a
 // backstop for callers that go straight to the facade methods.
 //
-// The translation is a thin string-slice → enum-slice projection; it is not
-// in the hot path (handlers run it once per request).
+// Delegates the facade→internal AllowLists projection to
+// aicr.ToInternalAllowLists so this pre-check and the Client's backstop
+// share a single translator — a field added to AllowLists is wired in one
+// place rather than mapped twice.
 func validateAgainstAllowLists(al *aicr.AllowLists, c *recipe.Criteria) error {
 	if al == nil {
 		return nil
 	}
-	internal := &recipe.AllowLists{
-		Accelerators: convertToTypes[recipe.CriteriaAcceleratorType](al.Accelerators),
-		Services:     convertToTypes[recipe.CriteriaServiceType](al.Services),
-		Intents:      convertToTypes[recipe.CriteriaIntentType](al.Intents),
-		OSTypes:      convertToTypes[recipe.CriteriaOSType](al.OSTypes),
-	}
-	return internal.ValidateCriteria(c)
-}
-
-func convertToTypes[T ~string](in []string) []T {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]T, len(in))
-	for i, v := range in {
-		out[i] = T(v)
-	}
-	return out
+	return aicr.ToInternalAllowLists(al).ValidateCriteria(c)
 }

--- a/pkg/api/bundle_handler.go
+++ b/pkg/api/bundle_handler.go
@@ -115,7 +115,7 @@ func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 	// pre-check preserves the legacy user-facing message; the Client's
 	// MakeBundle enforcement remains a backstop.
 	if h.allowLists != nil && recipeResult.Criteria != nil {
-		if validateErr := h.allowLists.ValidateCriteria(recipeResult.Criteria); validateErr != nil {
+		if validateErr := validateAgainstAllowLists(h.allowLists, recipeResult.Criteria); validateErr != nil {
 			server.WriteErrorFromErr(w, r, validateErr, "Recipe criteria value not allowed", nil)
 			return
 		}

--- a/pkg/api/recipe_handler.go
+++ b/pkg/api/recipe_handler.go
@@ -145,13 +145,13 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 	// pre-check preserves the exact user-facing message; the Client's internal
 	// enforcement remains a backstop.
 	if h.allowLists != nil {
-		if validateErr := h.allowLists.ValidateCriteria(criteria); validateErr != nil {
+		if validateErr := validateAgainstAllowLists(h.allowLists, criteria); validateErr != nil {
 			server.WriteErrorFromErr(w, r, validateErr, "Criteria value not allowed", nil)
 			return
 		}
 	}
 
-	result, err := h.client.ResolveRecipeFromCriteria(ctx, criteria)
+	result, err := h.client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
 	if err != nil {
 		server.WriteErrorFromErr(w, r, err, "Failed to build recipe", nil)
 		return
@@ -160,7 +160,12 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 	// Set caching headers
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(recipeCacheTTL.Seconds())))
 
-	serializer.RespondJSON(w, http.StatusOK, result)
+	// Wire format must remain the upstream pkg/recipe.RecipeResult JSON so
+	// CLI/library consumers parse the same shape they always have. Resolved()
+	// returns the borrowed upstream pointer the facade wraps; nil would mean
+	// the result lacks internal state (only possible from a hand-constructed
+	// RecipeResult, which ResolveRecipeFromCriteria never returns).
+	serializer.RespondJSON(w, http.StatusOK, result.Resolved())
 }
 
 // HandleQuery processes query requests. It resolves a recipe from criteria,
@@ -261,13 +266,13 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	// pre-check preserves the exact user-facing message; the Client's internal
 	// enforcement remains a backstop.
 	if h.allowLists != nil {
-		if validateErr := h.allowLists.ValidateCriteria(criteria); validateErr != nil {
+		if validateErr := validateAgainstAllowLists(h.allowLists, criteria); validateErr != nil {
 			server.WriteErrorFromErr(w, r, validateErr, "Criteria value not allowed", nil)
 			return
 		}
 	}
 
-	rec, err := h.client.ResolveRecipeFromCriteria(ctx, criteria)
+	rec, err := h.client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
 	if err != nil {
 		server.WriteErrorFromErr(w, r, err, "Failed to build recipe", nil)
 		return
@@ -276,9 +281,9 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	// Hydrate and select as two steps (rather than the combined
 	// aicr.SelectFromRecipe) to preserve the legacy handler's distinct error
 	// mapping: a hydrate failure surfaces via its own error code (5xx), while a
-	// missing selector path is a 404. rec is *aicr.Recipe (= *recipe.RecipeResult),
-	// so HydrateResult accepts it directly.
-	hydrated, err := recipe.HydrateResultWithContext(ctx, rec)
+	// missing selector path is a 404. rec.Resolved() returns the upstream
+	// pkg/recipe.RecipeResult that HydrateResult accepts.
+	hydrated, err := recipe.HydrateResultWithContext(ctx, rec.Resolved())
 	if err != nil {
 		server.WriteErrorFromErr(w, r, err, "Failed to hydrate recipe", nil)
 		return

--- a/pkg/api/recipe_handler_test.go
+++ b/pkg/api/recipe_handler_test.go
@@ -129,15 +129,20 @@ func TestHandleRecipes_MethodNotAllowed(t *testing.T) {
 // the legacy pkg/recipe Builder handler for the same rejection.
 func TestHandleRecipes_AllowListRejection(t *testing.T) {
 	// Allow only a100; h100 falls outside and must be rejected.
-	allowLists := &aicr.AllowLists{
-		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorA100},
+	facadeAllow := &aicr.AllowLists{
+		Accelerators: []string{string(recipe.CriteriaAcceleratorA100)},
 	}
-	h := newTestHandler(t, allowLists)
+	h := newTestHandler(t, facadeAllow)
 
-	// Reference: the legacy Builder handler, same allowlists.
+	// Reference: the legacy Builder handler, same allowlists. The facade
+	// AllowLists carries plain strings (semver-stable surface); the upstream
+	// pkg/recipe.AllowLists carries enum-typed slices — so the test
+	// constructs both shapes here for the two consumers.
 	rb := recipe.NewBuilder(
 		recipe.WithVersion("test"),
-		recipe.WithAllowLists(allowLists),
+		recipe.WithAllowLists(&recipe.AllowLists{
+			Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorA100},
+		}),
 	)
 
 	const target = "/v1/recipe?accelerator=h100&intent=training"
@@ -333,13 +338,15 @@ func TestHandleQuery_MethodNotAllowed(t *testing.T) {
 // TestHandleQuery_AllowListRejection verifies query enforces allowlists with the
 // same message as the legacy handler.
 func TestHandleQuery_AllowListRejection(t *testing.T) {
-	allowLists := &aicr.AllowLists{
-		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorA100},
+	facadeAllow := &aicr.AllowLists{
+		Accelerators: []string{string(recipe.CriteriaAcceleratorA100)},
 	}
-	h := newTestHandler(t, allowLists)
+	h := newTestHandler(t, facadeAllow)
 	rb := recipe.NewBuilder(
 		recipe.WithVersion("test"),
-		recipe.WithAllowLists(allowLists),
+		recipe.WithAllowLists(&recipe.AllowLists{
+			Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorA100},
+		}),
 	)
 
 	const target = "/v1/query?accelerator=h100&intent=training&selector=components.gpu-operator"

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -73,10 +73,10 @@ func Serve() error {
 			"os_types", len(allowLists.OSTypes),
 		)
 		slog.Debug("criteria allowlists loaded",
-			"accelerators", allowLists.AcceleratorStrings(),
-			"services", allowLists.ServiceStrings(),
-			"intents", allowLists.IntentStrings(),
-			"os_types", allowLists.OSTypeStrings(),
+			"accelerators", allowLists.Accelerators,
+			"services", allowLists.Services,
+			"intents", allowLists.Intents,
+			"os_types", allowLists.OSTypes,
 		)
 	}
 

--- a/pkg/cli/mirror.go
+++ b/pkg/cli/mirror.go
@@ -247,7 +247,11 @@ func resolveRecipeForMirror(ctx context.Context, cmd *cli.Command, cfg *appcfg.A
 	if err := client.LoadCatalog(ctx); err != nil {
 		return nil, err
 	}
-	return buildRecipeFromCmdWithConfig(ctx, cmd, cfg, client)
+	resolved, err := buildRecipeFromCmdWithConfig(ctx, cmd, cfg, client)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.Resolved(), nil
 }
 
 // resolveOutputWriter returns a writer for the mirror list output. When

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -131,7 +131,7 @@ Use in shell scripts:
 				return err
 			}
 
-			hydrated, err := recipe.HydrateResultWithContext(ctx, result)
+			hydrated, err := recipe.HydrateResultWithContext(ctx, result.Resolved())
 			if err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to hydrate recipe", err)
 			}
@@ -164,7 +164,7 @@ Use in shell scripts:
 // overlay validates against the same DataProvider the Client resolves with.
 // The Client's catalog must already be loaded (LoadCatalog) so that registry
 // is seeded.
-func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*recipe.RecipeResult, error) {
+func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*aicr.RecipeResult, error) {
 	reg := client.CriteriaRegistry()
 
 	snapFilePath := stringFlagOrConfig(cmd, "snapshot", cfg.Recipe().SnapshotPath())
@@ -188,7 +188,7 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 		// ResolveRecipeFromSnapshot builds the constraint evaluator
 		// internally (constraints.Evaluate against snap), mirroring the
 		// pre-facade BuildFromCriteriaWithEvaluator path.
-		return client.ResolveRecipeFromSnapshot(ctx, criteria, aicr.WrapSnapshot(snap))
+		return client.ResolveRecipeFromSnapshot(ctx, aicr.WrapCriteria(criteria), aicr.WrapSnapshot(snap))
 	}
 
 	criteria, err := mergeCriteriaFromCmdAndConfig(cmd, cfg, reg)
@@ -202,7 +202,7 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 	}
 
 	slog.Info("building recipe from criteria", "criteria", criteria.String())
-	return client.ResolveRecipeFromCriteria(ctx, criteria)
+	return client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
 }
 
 // writeQueryResult formats and writes the selected value to w.

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -187,9 +187,15 @@ Override snapshot-detected criteria:
 				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "error building recipe")
 			}
 
+			// Operate on the upstream pkg/recipe.RecipeResult for the remainder
+			// of this command — the facade RecipeResult exposes only the
+			// stable projection, but the CLI emits the full YAML and reports
+			// metadata that lives on the upstream shape.
+			resolved := result.Resolved()
+
 			// Log constraint warnings for visibility
-			if result != nil && len(result.Metadata.ConstraintWarnings) > 0 {
-				for _, w := range result.Metadata.ConstraintWarnings {
+			if resolved != nil && len(resolved.Metadata.ConstraintWarnings) > 0 {
+				for _, w := range resolved.Metadata.ConstraintWarnings {
 					slog.Warn("overlay excluded due to constraint failure",
 						"overlay", w.Overlay,
 						"constraint", w.Constraint,
@@ -212,14 +218,14 @@ Override snapshot-detected criteria:
 				}
 			}()
 
-			if err := ser.Serialize(ctx, result); err != nil {
+			if err := ser.Serialize(ctx, resolved); err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to serialize recipe", err)
 			}
 
 			slog.Info("recipe generation completed",
 				"output", output,
-				"components", len(result.ComponentRefs),
-				"overlays", len(result.Metadata.AppliedOverlays))
+				"components", len(resolved.ComponentRefs),
+				"overlays", len(resolved.Metadata.AppliedOverlays))
 
 			return nil
 		},

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -359,7 +359,7 @@ func (c *Client) enforceAllowLists(criteria *recipe.Criteria) error {
 	if c.allowLists == nil {
 		return nil
 	}
-	return toInternalAllowLists(c.allowLists).ValidateCriteria(criteria)
+	return ToInternalAllowLists(c.allowLists).ValidateCriteria(criteria)
 }
 
 // ResolveRecipe maps a RecipeRequest to a concrete validated recipe.

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -350,11 +350,16 @@ func (c *Client) assertOwns(r *RecipeResult) error {
 // it is a no-op. The underlying AllowLists.ValidateCriteria already
 // returns a pkg/errors-coded error, so the result is returned as-is
 // rather than re-wrapped.
-func (c *Client) enforceAllowLists(criteria *Criteria) error {
+//
+// Accepts the upstream pkg/recipe.Criteria because all in-tree callers
+// (resolveCriteria, ResolveRecipeFromSnapshot) already hold the internal
+// shape post-translation; routing back through the facade would force a
+// pointless round-trip.
+func (c *Client) enforceAllowLists(criteria *recipe.Criteria) error {
 	if c.allowLists == nil {
 		return nil
 	}
-	return c.allowLists.ValidateCriteria(criteria)
+	return toInternalAllowLists(c.allowLists).ValidateCriteria(criteria)
 }
 
 // ResolveRecipe maps a RecipeRequest to a concrete validated recipe.
@@ -445,21 +450,24 @@ func (c *Client) ResolveRecipe(ctx context.Context, req RecipeRequest) (*RecipeR
 
 // resolveCriteria is the shared path: allowlist enforcement + build. Callers
 // snapshot the builder under the read lock and pass it in; they own the lossy-
-// vs-lossless projection and owner stamping.
-func (c *Client) resolveCriteria(ctx context.Context, builder *recipe.Builder, criteria *Criteria) (*recipe.RecipeResult, error) {
+// vs-lossless projection and owner stamping. The criteria parameter is the
+// upstream pkg/recipe.Criteria shape — facade entry points translate via
+// toInternalCriteria before reaching here.
+func (c *Client) resolveCriteria(ctx context.Context, builder *recipe.Builder, criteria *recipe.Criteria) (*recipe.RecipeResult, error) {
 	if err := c.enforceAllowLists(criteria); err != nil {
 		return nil, err
 	}
 	return builder.BuildFromCriteria(ctx, criteria)
 }
 
-// ResolveRecipeFromCriteria resolves a pre-built recipe.Criteria into the
-// FULL pkg/recipe.RecipeResult (the Recipe alias), losslessly — unlike
-// ResolveRecipe, which projects into the lossy facade RecipeResult shape.
-// Use this when the caller already speaks the internal Criteria type (e.g.,
-// a REST handler that parsed criteria from an HTTP request) and needs the
-// complete resolved recipe, including constraints, deployment order, and
-// metadata.
+// ResolveRecipeFromCriteria resolves a facade Criteria into a facade
+// RecipeResult. The Components projection mirrors ResolveRecipe; callers
+// needing the full upstream recipe (constraints, deployment order, metadata)
+// access it via the returned result's Resolved() helper.
+//
+// Use this when the caller already speaks the facade Criteria type (e.g.,
+// a REST handler that parsed criteria from an HTTP request and translated
+// via WrapCriteria) rather than the RecipeRequest shape ResolveRecipe takes.
 //
 // Allowlist enforcement (WithAllowLists) applies here just as it does on the
 // shared resolve path: criteria outside the configured allowlist are rejected
@@ -468,7 +476,7 @@ func (c *Client) resolveCriteria(ctx context.Context, builder *recipe.Builder, c
 // The same guards and synchronization as ResolveRecipe apply: nil receiver,
 // nil context, and nil criteria are rejected with ErrCodeInvalidRequest; a
 // closed Client is rejected; a facade-level timeout bounds the resolve.
-func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criteria) (*Recipe, error) {
+func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criteria) (*RecipeResult, error) {
 	if c == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
 	}
@@ -495,14 +503,23 @@ func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criter
 	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
 	defer cancel()
 
-	return c.resolveCriteria(ctx, builder, criteria)
+	internal, err := c.resolveCriteria(ctx, builder, toInternalCriteria(criteria))
+	if err != nil {
+		return nil, err
+	}
+	result, err := recipeResultFromInternal(internal)
+	if err != nil {
+		return nil, err
+	}
+	result.owner = c
+	return result, nil
 }
 
 // ResolveRecipeFromSnapshot resolves a recipe from explicit Criteria and
 // evaluates its constraints against an observed cluster Snapshot, mirroring
-// `aicr recipe --snapshot`. It returns the full lossless *Recipe (the
-// pkg/recipe.RecipeResult alias), so callers see ComponentRefs, deployment
-// order, and per-constraint evaluation results directly.
+// `aicr recipe --snapshot`. It returns the facade RecipeResult; callers
+// needing the upstream recipe (ComponentRefs, deployment order, per-
+// constraint evaluation results) access it via Resolved().
 //
 // Unlike ResolveRecipeFromCriteria — which builds the recipe without
 // observing the cluster — this variant threads a constraint evaluator that
@@ -521,7 +538,7 @@ func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criter
 // ErrCodeInvalidRequest; a closed Client is rejected; a facade-level timeout
 // bounds the resolve. Builder errors propagate as-is (they already carry the
 // appropriate pkg/errors code) rather than being re-wrapped.
-func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criteria, snap *Snapshot) (*Recipe, error) {
+func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criteria, snap *Snapshot) (*RecipeResult, error) {
 	if c == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
 	}
@@ -551,10 +568,14 @@ func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criter
 	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
 	defer cancel()
 
+	// Translate facade Criteria once; remaining steps operate on the
+	// upstream shape.
+	internalCriteria := toInternalCriteria(criteria)
+
 	// Enforce allowlists before building — same fence resolveCriteria applies
 	// on the criteria-only path. AllowLists.ValidateCriteria returns a
 	// pkg/errors-coded error, so enforceAllowLists propagates it as-is.
-	if err := c.enforceAllowLists(criteria); err != nil {
+	if err := c.enforceAllowLists(internalCriteria); err != nil {
 		return nil, err
 	}
 
@@ -575,7 +596,16 @@ func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criter
 	// Don't re-wrap the builder's error — it already returns a structured
 	// error with the appropriate code (ErrCodeInvalidRequest for bad
 	// criteria, ErrCodeTimeout for context expiry, etc.).
-	return builder.BuildFromCriteriaWithEvaluator(ctx, criteria, evaluator)
+	internal, err := builder.BuildFromCriteriaWithEvaluator(ctx, internalCriteria, evaluator)
+	if err != nil {
+		return nil, err
+	}
+	result, err := recipeResultFromInternal(internal)
+	if err != nil {
+		return nil, err
+	}
+	result.owner = c
+	return result, nil
 }
 
 // buildDataProvider constructs an isolated DataProvider for a single

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -146,19 +146,19 @@ func TestEnforceAllowLists(t *testing.T) {
 	tests := []struct {
 		name       string
 		allowLists *AllowLists
-		criteria   *Criteria
+		criteria   *recipe.Criteria
 		wantErr    bool
 	}{
 		{"nil allowlist allows anything", nil, b200, false},
 		{
 			"in-list accelerator passes",
-			&AllowLists{Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100}},
+			&AllowLists{Accelerators: []string{string(recipe.CriteriaAcceleratorH100)}},
 			h100,
 			false,
 		},
 		{
 			"out-of-list accelerator rejected",
-			&AllowLists{Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100}},
+			&AllowLists{Accelerators: []string{string(recipe.CriteriaAcceleratorH100)}},
 			b200,
 			true,
 		},
@@ -738,10 +738,10 @@ func TestValidateState_ThreadsClientVersion(t *testing.T) {
 }
 
 // TestAdoptRecipe_DeepCopiesForClientIsolation pins FIX A: adopting the
-// SAME caller-owned *Recipe into two different Clients must not let the
-// second adopt overwrite the first's provider binding, and must not mutate
-// the caller's original recipe pointer. adoptRecipe deep-copies before
-// BindDataProvider, so each adopted result carries its own Client's
+// SAME caller-owned pkg/recipe.RecipeResult into two different Clients must
+// not let the second adopt overwrite the first's provider binding, and must
+// not mutate the caller's original recipe pointer. adoptRecipe deep-copies
+// before BindDataProvider, so each adopted result carries its own Client's
 // DataProvider and the input recipe's provider stays nil.
 func TestAdoptRecipe_DeepCopiesForClientIsolation(t *testing.T) {
 	t.Parallel()

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -760,9 +760,9 @@ spec:
 }
 
 // TestResolveRecipeFromCriteriaLossless proves the lossless resolve path:
-// ResolveRecipeFromCriteria returns the full pkg/recipe.RecipeResult
-// (not the lossy facade RecipeResult), so callers see ComponentRefs and
-// the threaded Metadata.Version directly.
+// ResolveRecipeFromCriteria returns a facade RecipeResult whose Resolved()
+// surfaces the full pkg/recipe.RecipeResult, so callers see ComponentRefs
+// and the threaded Metadata.Version directly.
 func TestResolveRecipeFromCriteriaLossless(t *testing.T) {
 	t.Parallel()
 
@@ -776,15 +776,19 @@ func TestResolveRecipeFromCriteriaLossless(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildCriteria: %v", err)
 	}
-	rec, err := c.ResolveRecipeFromCriteria(t.Context(), crit)
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), aicr.WrapCriteria(crit))
 	if err != nil {
 		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
 	}
-	if len(rec.ComponentRefs) == 0 {
+	resolved := rec.Resolved()
+	if resolved == nil {
+		t.Fatal("expected non-nil Resolved()")
+	}
+	if len(resolved.ComponentRefs) == 0 {
 		t.Fatal("expected component refs")
 	}
-	if rec.Metadata.Version != "v1.2.3" {
-		t.Fatalf("version not threaded: %q", rec.Metadata.Version)
+	if resolved.Metadata.Version != "v1.2.3" {
+		t.Fatalf("version not threaded: %q", resolved.Metadata.Version)
 	}
 }
 
@@ -818,19 +822,23 @@ func TestResolveRecipeFromSnapshot(t *testing.T) {
 	// h100-eks-training chain's strictest readiness constraint (">= 1.32.4").
 	snap := k8sVersionSnapshot()
 
-	rec, err := c.ResolveRecipeFromSnapshot(t.Context(), crit, snap)
+	rec, err := c.ResolveRecipeFromSnapshot(t.Context(), aicr.WrapCriteria(crit), snap)
 	if err != nil {
 		t.Fatalf("ResolveRecipeFromSnapshot: %v", err)
 	}
 	if rec == nil {
-		t.Fatal("expected non-nil *Recipe")
+		t.Fatal("expected non-nil *RecipeResult")
 	}
-	if len(rec.ComponentRefs) == 0 {
+	resolved := rec.Resolved()
+	if resolved == nil {
+		t.Fatal("expected non-nil Resolved()")
+	}
+	if len(resolved.ComponentRefs) == 0 {
 		t.Fatal("expected component refs (snapshot satisfies the chain's constraints, so overlays must not be excluded)")
 	}
 	// Version is threaded through the builder just as on the criteria path.
-	if rec.Metadata.Version != "v1.2.3" {
-		t.Fatalf("version not threaded: %q", rec.Metadata.Version)
+	if resolved.Metadata.Version != "v1.2.3" {
+		t.Fatalf("version not threaded: %q", resolved.Metadata.Version)
 	}
 }
 
@@ -855,11 +863,13 @@ func TestResolveRecipeFromSnapshot_NilArgs(t *testing.T) {
 	}
 	snap := k8sVersionSnapshot()
 
+	facadeCrit := aicr.WrapCriteria(crit)
+
 	// Nil receiver: must not panic; returns an error.
 	t.Run("nil receiver", func(t *testing.T) {
 		t.Parallel()
 		var nilClient *aicr.Client
-		if _, err := nilClient.ResolveRecipeFromSnapshot(context.Background(), crit, snap); err == nil {
+		if _, err := nilClient.ResolveRecipeFromSnapshot(context.Background(), facadeCrit, snap); err == nil {
 			t.Fatal("expected error from nil receiver, got nil")
 		}
 	})
@@ -868,12 +878,12 @@ func TestResolveRecipeFromSnapshot_NilArgs(t *testing.T) {
 	tests := []struct {
 		name string
 		ctx  context.Context
-		crit *recipe.Criteria
+		crit *aicr.Criteria
 		snap *aicr.Snapshot
 	}{
-		{name: "nil context", ctx: nil, crit: crit, snap: snap},
+		{name: "nil context", ctx: nil, crit: facadeCrit, snap: snap},
 		{name: "nil criteria", ctx: context.Background(), crit: nil, snap: snap},
-		{name: "nil snapshot", ctx: context.Background(), crit: crit, snap: nil},
+		{name: "nil snapshot", ctx: context.Background(), crit: facadeCrit, snap: nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -901,7 +911,7 @@ func TestResolveRecipeFromSnapshotRejectsOutOfAllowList(t *testing.T) {
 	t.Parallel()
 
 	al := &aicr.AllowLists{
-		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100},
+		Accelerators: []string{string(recipe.CriteriaAcceleratorH100)},
 	}
 	c, err := aicr.NewClient(
 		aicr.WithRecipeSource(aicr.EmbeddedSource()),
@@ -920,7 +930,7 @@ func TestResolveRecipeFromSnapshotRejectsOutOfAllowList(t *testing.T) {
 		t.Fatalf("BuildCriteria: %v", err)
 	}
 
-	_, err = c.ResolveRecipeFromSnapshot(t.Context(), crit, k8sVersionSnapshot())
+	_, err = c.ResolveRecipeFromSnapshot(t.Context(), aicr.WrapCriteria(crit), k8sVersionSnapshot())
 	if err == nil {
 		t.Fatal("expected allowlist rejection for b200, got nil error")
 	}
@@ -942,7 +952,7 @@ func TestResolveRecipeFromCriteriaRejectsOutOfAllowList(t *testing.T) {
 	t.Parallel()
 
 	al := &aicr.AllowLists{
-		Accelerators: []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100},
+		Accelerators: []string{string(recipe.CriteriaAcceleratorH100)},
 	}
 	c, err := aicr.NewClient(
 		aicr.WithRecipeSource(aicr.EmbeddedSource()),
@@ -961,7 +971,7 @@ func TestResolveRecipeFromCriteriaRejectsOutOfAllowList(t *testing.T) {
 		t.Fatalf("BuildCriteria: %v", err)
 	}
 
-	_, err = c.ResolveRecipeFromCriteria(t.Context(), crit)
+	_, err = c.ResolveRecipeFromCriteria(t.Context(), aicr.WrapCriteria(crit))
 	if err == nil {
 		t.Fatal("expected allowlist rejection for b200, got nil error")
 	}
@@ -992,7 +1002,7 @@ func TestSelectFromRecipe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildCriteria: %v", err)
 	}
-	rec, err := c.ResolveRecipeFromCriteria(t.Context(), crit)
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), aicr.WrapCriteria(crit))
 	if err != nil {
 		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
 	}

--- a/pkg/client/v1/bundle.go
+++ b/pkg/client/v1/bundle.go
@@ -23,15 +23,16 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 // BundleConfig is the bundler configuration — deployer mode, value
 // overrides, node selectors, tolerations, vendoring, app/chart names,
 // etc. Transparent alias of pkg/bundler/config.Config (the alias is
-// tracked by #1078, matching the Recipe / AllowLists pattern). Construct
-// one with config.NewConfig(config.WithDeployer(...), ...) — the same
-// builder the CLI bundle command and the REST /v1/bundle handler use, so
-// MakeBundle reproduces their exact output byte-for-byte.
+// tracked by #1078). Construct one with
+// config.NewConfig(config.WithDeployer(...), ...) — the same builder the
+// CLI bundle command and the REST /v1/bundle handler use, so MakeBundle
+// reproduces their exact output byte-for-byte.
 type BundleConfig = config.Config
 
 // BundleAttester signs bundle content. Transparent alias of
@@ -82,9 +83,9 @@ type BundleOptions struct {
 	Timeout time.Duration
 }
 
-// adoptRecipe wraps a raw, externally-supplied *Recipe (the full
-// pkg/recipe.RecipeResult, e.g. decoded from a /v1/bundle POST body) into a
-// Client-owned *RecipeResult ready for MakeBundle. It binds the Client's own
+// adoptRecipe wraps a raw, externally-supplied pkg/recipe.RecipeResult (e.g.
+// decoded from a /v1/bundle POST body) into a Client-owned facade
+// *RecipeResult ready for MakeBundle. It binds the Client's own
 // DataProvider onto the recipe so provider-scoped lookups (values files,
 // manifest files, external data files) resolve against the Client's recipe
 // source rather than the package global, and stamps the owner token so the
@@ -101,15 +102,15 @@ type BundleOptions struct {
 // Errors:
 //   - ErrCodeInvalidRequest when the Client, ctx, or recipe is nil, or when
 //     the Client has been Closed.
-func (c *Client) adoptRecipe(ctx context.Context, recipe *Recipe) (*RecipeResult, error) {
+func (c *Client) adoptRecipe(ctx context.Context, rec *recipe.RecipeResult) (*RecipeResult, error) {
 	if c == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
 	}
 	if ctx == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
 	}
-	if recipe == nil {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil Recipe")
+	if rec == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil RecipeResult")
 	}
 
 	c.mu.RLock()
@@ -122,11 +123,12 @@ func (c *Client) adoptRecipe(ctx context.Context, recipe *Recipe) (*RecipeResult
 
 	// Deep-copy the caller-supplied recipe BEFORE binding the provider.
 	// BindDataProvider mutates the receiver's unexported provider field, and
-	// the input *Recipe is caller-owned: a caller reusing one *Recipe across
-	// two Clients would otherwise have the second adopt overwrite the first's
-	// binding, breaking per-Client isolation. DeepCopy leaves the copy's
-	// provider nil for BindDataProvider to set, so the original is untouched.
-	cp := recipe.DeepCopy()
+	// the input is caller-owned: a caller reusing one recipe.RecipeResult
+	// across two Clients would otherwise have the second adopt overwrite
+	// the first's binding, breaking per-Client isolation. DeepCopy leaves
+	// the copy's provider nil for BindDataProvider to set, so the original
+	// is untouched.
+	cp := rec.DeepCopy()
 	cp.BindDataProvider(dp)
 
 	result, err := loadedResultFromInternal(cp)
@@ -147,8 +149,8 @@ func (c *Client) adoptRecipe(ctx context.Context, recipe *Recipe) (*RecipeResult
 // criteria request or a file path) and needs to bundle it through the facade.
 // In-process consumers that resolve via ResolveRecipe / LoadRecipe should use
 // those results directly; AdoptRecipe is for the decode-then-bundle boundary.
-func (c *Client) AdoptRecipe(ctx context.Context, recipe *Recipe) (*RecipeResult, error) {
-	return c.adoptRecipe(ctx, recipe)
+func (c *Client) AdoptRecipe(ctx context.Context, rec *recipe.RecipeResult) (*RecipeResult, error) {
+	return c.adoptRecipe(ctx, rec)
 }
 
 // MakeBundle generates the full deployer-mode bundle for a previously

--- a/pkg/client/v1/options.go
+++ b/pkg/client/v1/options.go
@@ -361,7 +361,11 @@ func WithAllowLists(al *AllowLists) Option {
 // WithAllowLists treats a nil AllowLists as allow-all. Pass the result to
 // WithAllowLists.
 func ParseAllowListsFromEnv() (*AllowLists, error) {
-	return recipe.ParseAllowListsFromEnv()
+	internal, err := recipe.ParseAllowListsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return WrapAllowLists(internal), nil
 }
 
 // OCISource describes an OCI registry containing AICR recipes.

--- a/pkg/client/v1/query.go
+++ b/pkg/client/v1/query.go
@@ -38,7 +38,7 @@ func SelectFromRecipe(r *RecipeResult, selector string) (any, error) {
 	}
 	hydrated, err := recipe.HydrateResult(internal)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "hydrate recipe", err)
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "hydrate recipe")
 	}
 	return recipe.Select(hydrated, selector)
 }

--- a/pkg/client/v1/query.go
+++ b/pkg/client/v1/query.go
@@ -22,11 +22,21 @@ import (
 // SelectFromRecipe hydrates a resolved recipe and extracts a dot-path selector
 // (e.g. "components.gpu-operator.values.driver.version"). An empty selector
 // returns the entire hydrated structure. Mirrors `aicr query`.
-func SelectFromRecipe(r *Recipe, selector string) (any, error) {
+//
+// The recipe must have been produced by a Client (so its internal
+// pkg/recipe.RecipeResult is populated). A facade RecipeResult constructed
+// outside ResolveRecipe / LoadRecipe / AdoptRecipe is rejected with
+// ErrCodeInvalidRequest.
+func SelectFromRecipe(r *RecipeResult, selector string) (any, error) {
 	if r == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil recipe")
 	}
-	hydrated, err := recipe.HydrateResult(r)
+	internal := r.Resolved()
+	if internal == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"RecipeResult has no internal recipe state — call Client.ResolveRecipe, LoadRecipe, or AdoptRecipe to obtain a queryable RecipeResult")
+	}
+	hydrated, err := recipe.HydrateResult(internal)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "hydrate recipe", err)
 	}

--- a/pkg/client/v1/translate.go
+++ b/pkg/client/v1/translate.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/header"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 	"github.com/NVIDIA/aicr/pkg/validator"
 )
@@ -156,3 +157,109 @@ func fromInternalPhaseResult(p *validator.PhaseResult) *PhaseResult {
 
 // fromInternalPhase is the typed lift from validator.Phase to facade Phase.
 func fromInternalPhase(p validator.Phase) Phase { return Phase(p) }
+
+// WrapCriteria projects a pkg/recipe.Criteria into the facade Criteria
+// shape. Use this at the boundary where in-tree callers (CLI/API
+// handlers) hand a parsed criteria — produced by recipe.ParseCriteriaFromRequest
+// or recipe.BuildCriteriaWithRegistry — to facade methods such as
+// Client.ResolveRecipeFromCriteria. Returns nil for nil input.
+//
+// Round-trip: WrapCriteria(c) then toInternalCriteria projects back to the
+// pkg/recipe.Criteria enum-typed shape; the round-trip is lossless because
+// the facade carries plain strings for the same set of named enum fields
+// (Service/Accelerator/Intent/OS/Platform) plus Nodes.
+func WrapCriteria(c *recipe.Criteria) *Criteria {
+	if c == nil {
+		return nil
+	}
+	return &Criteria{
+		Service:     string(c.Service),
+		Accelerator: string(c.Accelerator),
+		Intent:      string(c.Intent),
+		OS:          string(c.OS),
+		Platform:    string(c.Platform),
+		Nodes:       c.Nodes,
+	}
+}
+
+// toInternalCriteria translates a facade Criteria back into the
+// pkg/recipe.Criteria enum-typed shape the resolver consumes. The string
+// values are wrapped in the corresponding pkg/recipe enum types without
+// validation — registry-strict mode at resolve time is the gate that
+// rejects unknown values (with ErrCodeInvalidRequest).
+func toInternalCriteria(c *Criteria) *recipe.Criteria {
+	if c == nil {
+		return nil
+	}
+	return &recipe.Criteria{
+		Service:     recipe.CriteriaServiceType(c.Service),
+		Accelerator: recipe.CriteriaAcceleratorType(c.Accelerator),
+		Intent:      recipe.CriteriaIntentType(c.Intent),
+		OS:          recipe.CriteriaOSType(c.OS),
+		Platform:    recipe.CriteriaPlatformType(c.Platform),
+		Nodes:       c.Nodes,
+	}
+}
+
+// WrapAllowLists projects a pkg/recipe.AllowLists into the facade
+// AllowLists shape. Use at the boundary where in-tree callers parse
+// allowlists from configuration (e.g., recipe.ParseAllowListsFromEnv)
+// and hand them to the facade. Returns nil for nil input.
+//
+// The facade slices are independent copies; mutating either side after
+// wrap does not affect the other.
+func WrapAllowLists(al *recipe.AllowLists) *AllowLists {
+	if al == nil {
+		return nil
+	}
+	return &AllowLists{
+		Accelerators: stringsFromTypes(al.Accelerators),
+		Services:     stringsFromTypes(al.Services),
+		Intents:      stringsFromTypes(al.Intents),
+		OSTypes:      stringsFromTypes(al.OSTypes),
+	}
+}
+
+// toInternalAllowLists translates a facade AllowLists into the
+// pkg/recipe.AllowLists enum-typed shape the resolver consumes. The
+// string values are wrapped in the corresponding pkg/recipe enum types
+// without validation; registry-strict mode at resolve time rejects
+// unknown values.
+func toInternalAllowLists(al *AllowLists) *recipe.AllowLists {
+	if al == nil {
+		return nil
+	}
+	return &recipe.AllowLists{
+		Accelerators: typesFromStrings[recipe.CriteriaAcceleratorType](al.Accelerators),
+		Services:     typesFromStrings[recipe.CriteriaServiceType](al.Services),
+		Intents:      typesFromStrings[recipe.CriteriaIntentType](al.Intents),
+		OSTypes:      typesFromStrings[recipe.CriteriaOSType](al.OSTypes),
+	}
+}
+
+// stringsFromTypes converts a slice of pkg/recipe enum-typed strings to
+// a plain []string. Returns nil for nil/empty input so the facade can
+// retain the upstream IsEmpty semantics (nil = "accept all").
+func stringsFromTypes[T ~string](in []T) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = string(v)
+	}
+	return out
+}
+
+// typesFromStrings converts a plain []string to a slice of pkg/recipe
+// enum-typed strings. Returns nil for nil/empty input.
+func typesFromStrings[T ~string](in []string) []T {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]T, len(in))
+	for i, v := range in {
+		out[i] = T(v)
+	}
+	return out
+}

--- a/pkg/client/v1/translate.go
+++ b/pkg/client/v1/translate.go
@@ -220,12 +220,17 @@ func WrapAllowLists(al *recipe.AllowLists) *AllowLists {
 	}
 }
 
-// toInternalAllowLists translates a facade AllowLists into the
+// ToInternalAllowLists translates a facade AllowLists into the
 // pkg/recipe.AllowLists enum-typed shape the resolver consumes. The
 // string values are wrapped in the corresponding pkg/recipe enum types
 // without validation; registry-strict mode at resolve time rejects
 // unknown values.
-func toInternalAllowLists(al *AllowLists) *recipe.AllowLists {
+//
+// Exposed so in-tree adapters (e.g., the REST handler's pre-check)
+// share the same facade→internal projection as the Client's internal
+// backstop, instead of inlining a parallel mapping that can drift if
+// AllowLists gains a field.
+func ToInternalAllowLists(al *AllowLists) *recipe.AllowLists {
 	if al == nil {
 		return nil
 	}

--- a/pkg/client/v1/translate_test.go
+++ b/pkg/client/v1/translate_test.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// TestWrapCriteria_Nil verifies that wrapping a nil upstream criteria
+// returns nil — the facade preserves the "unspecified" sentinel.
+func TestWrapCriteria_Nil(t *testing.T) {
+	if got := WrapCriteria(nil); got != nil {
+		t.Fatalf("WrapCriteria(nil) = %+v, want nil", got)
+	}
+}
+
+// TestToInternalCriteria_Nil verifies the inverse: a nil facade criteria
+// translates to a nil upstream pointer (so resolve-path nil checks fire).
+func TestToInternalCriteria_Nil(t *testing.T) {
+	if got := toInternalCriteria(nil); got != nil {
+		t.Fatalf("toInternalCriteria(nil) = %+v, want nil", got)
+	}
+}
+
+// TestWrapCriteria_AllFieldsProjected confirms every enum-typed field
+// on pkg/recipe.Criteria projects to its plain-string counterpart on
+// the facade, and that Nodes is carried through unchanged.
+func TestWrapCriteria_AllFieldsProjected(t *testing.T) {
+	src := &recipe.Criteria{
+		Service:     recipe.CriteriaServiceEKS,
+		Accelerator: recipe.CriteriaAcceleratorH100,
+		Intent:      recipe.CriteriaIntentTraining,
+		OS:          recipe.CriteriaOSUbuntu,
+		Platform:    recipe.CriteriaPlatformKubeflow,
+		Nodes:       8,
+	}
+	got := WrapCriteria(src)
+	if got == nil {
+		t.Fatal("WrapCriteria returned nil for non-nil input")
+	}
+	want := &Criteria{
+		Service:     "eks",
+		Accelerator: "h100",
+		Intent:      "training",
+		OS:          "ubuntu",
+		Platform:    "kubeflow",
+		Nodes:       8,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("WrapCriteria mismatch\n  got:  %+v\n  want: %+v", got, want)
+	}
+}
+
+// TestCriteriaRoundTrip verifies WrapCriteria followed by
+// toInternalCriteria reconstructs the original upstream criteria
+// byte-for-byte — the projection is lossless.
+func TestCriteriaRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *recipe.Criteria
+	}{
+		{
+			name: "fully populated",
+			in: &recipe.Criteria{
+				Service:     recipe.CriteriaServiceGKE,
+				Accelerator: recipe.CriteriaAcceleratorB200,
+				Intent:      recipe.CriteriaIntentInference,
+				OS:          recipe.CriteriaOSCOS,
+				Platform:    recipe.CriteriaPlatformNIM,
+				Nodes:       16,
+			},
+		},
+		{
+			name: "zero-valued",
+			in:   &recipe.Criteria{},
+		},
+		{
+			name: "any sentinel",
+			in: &recipe.Criteria{
+				Service:     recipe.CriteriaServiceAny,
+				Accelerator: recipe.CriteriaAcceleratorAny,
+				Intent:      recipe.CriteriaIntentAny,
+				OS:          recipe.CriteriaOSAny,
+				Platform:    recipe.CriteriaPlatformAny,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := toInternalCriteria(WrapCriteria(tc.in))
+			if !reflect.DeepEqual(got, tc.in) {
+				t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", got, tc.in)
+			}
+		})
+	}
+}
+
+// TestWrapAllowLists_Nil confirms a nil upstream AllowLists wraps to
+// nil — preserves "no fencing" semantics across the boundary.
+func TestWrapAllowLists_Nil(t *testing.T) {
+	if got := WrapAllowLists(nil); got != nil {
+		t.Fatalf("WrapAllowLists(nil) = %+v, want nil", got)
+	}
+}
+
+// TestToInternalAllowLists_Nil confirms the inverse direction.
+func TestToInternalAllowLists_Nil(t *testing.T) {
+	if got := toInternalAllowLists(nil); got != nil {
+		t.Fatalf("toInternalAllowLists(nil) = %+v, want nil", got)
+	}
+}
+
+// TestWrapAllowLists_AllSlicesProjected confirms every typed enum slice
+// projects to the corresponding plain-string slice on the facade.
+func TestWrapAllowLists_AllSlicesProjected(t *testing.T) {
+	src := &recipe.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{
+			recipe.CriteriaAcceleratorH100,
+			recipe.CriteriaAcceleratorB200,
+		},
+		Services: []recipe.CriteriaServiceType{
+			recipe.CriteriaServiceEKS,
+			recipe.CriteriaServiceGKE,
+		},
+		Intents: []recipe.CriteriaIntentType{
+			recipe.CriteriaIntentTraining,
+		},
+		OSTypes: []recipe.CriteriaOSType{
+			recipe.CriteriaOSUbuntu,
+			recipe.CriteriaOSRHEL,
+		},
+	}
+	got := WrapAllowLists(src)
+	if got == nil {
+		t.Fatal("WrapAllowLists returned nil for non-nil input")
+	}
+	want := &AllowLists{
+		Accelerators: []string{"h100", "b200"},
+		Services:     []string{"eks", "gke"},
+		Intents:      []string{"training"},
+		OSTypes:      []string{"ubuntu", "rhel"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("WrapAllowLists mismatch\n  got:  %+v\n  want: %+v", got, want)
+	}
+}
+
+// TestAllowListsRoundTrip confirms WrapAllowLists followed by
+// toInternalAllowLists reconstructs the upstream AllowLists.
+func TestAllowListsRoundTrip(t *testing.T) {
+	src := &recipe.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{
+			recipe.CriteriaAcceleratorH100,
+			recipe.CriteriaAcceleratorL40,
+		},
+		Services: []recipe.CriteriaServiceType{recipe.CriteriaServiceEKS},
+		Intents:  []recipe.CriteriaIntentType{recipe.CriteriaIntentInference},
+		OSTypes:  []recipe.CriteriaOSType{recipe.CriteriaOSUbuntu},
+	}
+	got := toInternalAllowLists(WrapAllowLists(src))
+	if !reflect.DeepEqual(got, src) {
+		t.Errorf("AllowLists round-trip mismatch\n  got:  %+v\n  want: %+v", got, src)
+	}
+}
+
+// TestWrapAllowLists_EmptySlicesBecomeNil verifies the facade preserves
+// IsEmpty semantics by mapping empty slices to nil (so a nil-receiver
+// or all-nil-slices AllowLists still reports "no fencing").
+func TestWrapAllowLists_EmptySlicesBecomeNil(t *testing.T) {
+	src := &recipe.AllowLists{
+		Accelerators: []recipe.CriteriaAcceleratorType{},
+		Services:     nil,
+		Intents:      []recipe.CriteriaIntentType{},
+		OSTypes:      nil,
+	}
+	got := WrapAllowLists(src)
+	if got == nil {
+		t.Fatal("WrapAllowLists returned nil for non-nil input")
+	}
+	if got.Accelerators != nil || got.Services != nil || got.Intents != nil || got.OSTypes != nil {
+		t.Errorf("expected all slices to project to nil; got %+v", got)
+	}
+	// Round-trip the empty-but-non-nil facade through toInternal and
+	// confirm the upstream AllowLists.IsEmpty returns true so the
+	// resolve-path "no fencing" branch is taken.
+	rt := toInternalAllowLists(got)
+	if rt == nil {
+		t.Fatal("toInternalAllowLists returned nil for non-nil empty input")
+	}
+	if !rt.IsEmpty() {
+		t.Errorf("round-tripped AllowLists.IsEmpty() = false, want true")
+	}
+}
+
+// TestStringsFromTypes_NilAndEmpty confirms the generic helper treats
+// nil and empty input identically (returns nil) — critical so the
+// facade preserves IsEmpty semantics.
+func TestStringsFromTypes_NilAndEmpty(t *testing.T) {
+	if got := stringsFromTypes[recipe.CriteriaServiceType](nil); got != nil {
+		t.Errorf("stringsFromTypes(nil) = %v, want nil", got)
+	}
+	if got := stringsFromTypes([]recipe.CriteriaServiceType{}); got != nil {
+		t.Errorf("stringsFromTypes(empty) = %v, want nil", got)
+	}
+}
+
+// TestTypesFromStrings_NilAndEmpty mirrors the prior test for the
+// reverse generic helper.
+func TestTypesFromStrings_NilAndEmpty(t *testing.T) {
+	if got := typesFromStrings[recipe.CriteriaServiceType](nil); got != nil {
+		t.Errorf("typesFromStrings(nil) = %v, want nil", got)
+	}
+	if got := typesFromStrings[recipe.CriteriaServiceType]([]string{}); got != nil {
+		t.Errorf("typesFromStrings(empty) = %v, want nil", got)
+	}
+}
+
+// TestStringsFromTypes_PreservesOrder confirms the generic helper does
+// not reorder elements — ordering is observable in error messages and
+// must be stable across the boundary.
+func TestStringsFromTypes_PreservesOrder(t *testing.T) {
+	in := []recipe.CriteriaAcceleratorType{
+		recipe.CriteriaAcceleratorB200,
+		recipe.CriteriaAcceleratorH100,
+		recipe.CriteriaAcceleratorL40,
+	}
+	got := stringsFromTypes(in)
+	want := []string{"b200", "h100", "l40"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ordering mismatch\n  got:  %v\n  want: %v", got, want)
+	}
+}

--- a/pkg/client/v1/translate_test.go
+++ b/pkg/client/v1/translate_test.go
@@ -120,8 +120,8 @@ func TestWrapAllowLists_Nil(t *testing.T) {
 
 // TestToInternalAllowLists_Nil confirms the inverse direction.
 func TestToInternalAllowLists_Nil(t *testing.T) {
-	if got := toInternalAllowLists(nil); got != nil {
-		t.Fatalf("toInternalAllowLists(nil) = %+v, want nil", got)
+	if got := ToInternalAllowLists(nil); got != nil {
+		t.Fatalf("ToInternalAllowLists(nil) = %+v, want nil", got)
 	}
 }
 
@@ -161,7 +161,7 @@ func TestWrapAllowLists_AllSlicesProjected(t *testing.T) {
 }
 
 // TestAllowListsRoundTrip confirms WrapAllowLists followed by
-// toInternalAllowLists reconstructs the upstream AllowLists.
+// ToInternalAllowLists reconstructs the upstream AllowLists.
 func TestAllowListsRoundTrip(t *testing.T) {
 	src := &recipe.AllowLists{
 		Accelerators: []recipe.CriteriaAcceleratorType{
@@ -172,7 +172,7 @@ func TestAllowListsRoundTrip(t *testing.T) {
 		Intents:  []recipe.CriteriaIntentType{recipe.CriteriaIntentInference},
 		OSTypes:  []recipe.CriteriaOSType{recipe.CriteriaOSUbuntu},
 	}
-	got := toInternalAllowLists(WrapAllowLists(src))
+	got := ToInternalAllowLists(WrapAllowLists(src))
 	if !reflect.DeepEqual(got, src) {
 		t.Errorf("AllowLists round-trip mismatch\n  got:  %+v\n  want: %+v", got, src)
 	}
@@ -198,9 +198,9 @@ func TestWrapAllowLists_EmptySlicesBecomeNil(t *testing.T) {
 	// Round-trip the empty-but-non-nil facade through toInternal and
 	// confirm the upstream AllowLists.IsEmpty returns true so the
 	// resolve-path "no fencing" branch is taken.
-	rt := toInternalAllowLists(got)
+	rt := ToInternalAllowLists(got)
 	if rt == nil {
-		t.Fatal("toInternalAllowLists returned nil for non-nil empty input")
+		t.Fatal("ToInternalAllowLists returned nil for non-nil empty input")
 	}
 	if !rt.IsEmpty() {
 		t.Errorf("round-tripped AllowLists.IsEmpty() = false, want true")

--- a/pkg/client/v1/types.go
+++ b/pkg/client/v1/types.go
@@ -113,20 +113,80 @@ type AgentConfig struct {
 	Limits             corev1.ResourceList
 }
 
-// Recipe is the full resolved recipe, returned losslessly by the resolve
-// methods. Transparent alias of recipe.RecipeResult; future wrapping tracked
-// separately.
-type Recipe = recipe.RecipeResult
+// Criteria is the facade-owned, semver-stable shape of a recipe-resolution
+// query. Mirrors pkg/recipe.Criteria field-for-field with the enum-typed
+// pkg/recipe values projected to plain strings so the facade contract does
+// not pin consumers to pkg/recipe's enum identifiers (an internal enum
+// rename or addition stays internal). Construct one directly or wrap an
+// upstream pkg/recipe.Criteria via WrapCriteria.
+//
+// Field meanings match the pkg/recipe.Criteria documentation:
+//   - Service: Kubernetes service flavor (eks/gke/aks/oke/kind/lke/bcm).
+//   - Accelerator: GPU model identifier (h100/h200/b200/gb200/a100/l40/rtx-pro-6000).
+//   - Intent: workload intent (training/inference).
+//   - OS: worker-node OS (ubuntu/rhel/cos/amazonlinux/talos).
+//   - Platform: framework overlay (dynamo/kubeflow/nim/runai/slurm).
+//   - Nodes: worker-node count hint (0 = unspecified).
+//
+// Empty string is the "unspecified" sentinel for every field except Nodes,
+// where 0 plays that role. A non-empty string that the registry does not
+// recognize is rejected at resolve time with ErrCodeInvalidRequest.
+type Criteria struct {
+	Service     string
+	Accelerator string
+	Intent      string
+	OS          string
+	Platform    string
+	Nodes       int
+}
 
-// AllowLists fences which criteria values the resolve path accepts.
-type AllowLists = recipe.AllowLists
+// AllowLists fences which criteria values the resolve path accepts on a
+// Client constructed via WithAllowLists. Facade-owned; the typed-enum
+// fields on pkg/recipe.AllowLists project to plain string slices so the
+// facade does not propagate pkg/recipe's enum identifiers across the
+// semver boundary. A nil receiver, or an AllowLists whose slices are all
+// empty, accepts every value (the documented "no fencing" mode). An "any"
+// value on a Criteria field is always accepted regardless of the
+// allowlist, matching the pkg/recipe behavior.
+type AllowLists struct {
+	// Accelerators is the set of accepted accelerator identifiers
+	// (e.g., "h100", "b200"). Empty = accept all.
+	Accelerators []string
 
-// Criteria lets REST keep its exact existing HTTP->Criteria parser.
-type Criteria = recipe.Criteria
+	// Services is the set of accepted service identifiers
+	// (e.g., "eks", "gke"). Empty = accept all.
+	Services []string
+
+	// Intents is the set of accepted intent identifiers
+	// (e.g., "training", "inference"). Empty = accept all.
+	Intents []string
+
+	// OSTypes is the set of accepted OS identifiers
+	// (e.g., "ubuntu", "rhel"). Empty = accept all.
+	OSTypes []string
+}
 
 // CriteriaRegistry is the per-DataProvider set of valid criteria values,
 // returned by Client.CriteriaRegistry so CLI/library callers parse and
 // validate criteria against the SAME provider the Client resolves with.
+//
+// Intentionally kept as a transparent alias of pkg/recipe.CriteriaRegistry
+// rather than wrapped into a facade-owned type, for two reasons:
+//
+//  1. The registry is behavior-rich (ParseService/ParseAccelerator/...,
+//     SetStrict, Values, AllAcceleratorTypes, etc.) — wrapping it would
+//     require translating every method through, with no semver win because
+//     these methods are already used to construct pkg/recipe.Criteria
+//     instances in CLI / API call paths.
+//  2. The registry carries mutable shared state (strict mode, registered
+//     values) keyed by per-Client DataProvider identity. A facade wrapper
+//     would either copy state (breaking the per-Client identity coupling)
+//     or hold a pointer (no isolation win over the alias).
+//
+// External callers receive the same pkg/recipe.CriteriaRegistry the
+// Client's resolve path uses. If the underlying API evolves, this alias
+// is the single canary; the facade can absorb it by hand-writing a wrapper
+// then.
 type CriteriaRegistry = recipe.CriteriaRegistry
 
 // RecipeRequest is the stable external request shape. The Client
@@ -237,7 +297,11 @@ type RecipeResult struct {
 // exposes only Name/Version/Components; callers that need constraints,
 // validation config, deployment order, or metadata (e.g. evidence emission)
 // use this. Returns nil if the result was not produced by the Client.
-func (r *RecipeResult) Resolved() *Recipe {
+//
+// Lifetime: the returned pointer is borrowed from the facade RecipeResult.
+// Do not mutate; do not retain past the facade RecipeResult's lifetime.
+// Marshal/serialize first if persistence is needed.
+func (r *RecipeResult) Resolved() *recipe.RecipeResult {
 	if r == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Replaces the transparent type aliases in `pkg/client/v1/types.go` with facade-owned structs and translation funcs at the boundary, completing the facade-ownership story started by #1078.

## Motivation / Context

Per #1115, four facade types were transparent aliases into `pkg/recipe` (Public (evolving)). Any field-shape change in `pkg/recipe` would propagate to external Go importers without a minor-version signal. This PR addresses each, resolves the dual-surface `Recipe` vs `RecipeResult` problem, and updates docs.

Fixes: #1115
Related: #1077 (introduced these aliases), #1078 (wrapped the snapshotter/validator-tier aliases via the same pattern)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Build/CI/tooling

The breaking-change marker covers external Go importers of `pkg/client/v1`. The HTTP wire surface and CLI behavior are unchanged.

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/client/v1`

## Implementation Notes

**Dual-surface resolution: consolidate on `RecipeResult`.**
The `Recipe` alias is removed. `ResolveRecipeFromCriteria` and `ResolveRecipeFromSnapshot` now return `*RecipeResult` (the existing facade-owned wrapper). Callers needing the full upstream `*pkg/recipe.RecipeResult` (constraints, deployment order, validation config, metadata) use `result.Resolved()`. This preserves the owner-token / DataProvider isolation guarantees `RecipeResult` already provides.

**`AllowLists` → facade-owned struct.**
Fields are plain `[]string` (Accelerators / Services / Intents / OSTypes). `WrapAllowLists` lifts an upstream value; `toInternalAllowLists` translates back at the resolve boundary. `ParseAllowListsFromEnv` now returns the facade shape directly.

**`Criteria` → facade-owned struct.**
Enum-typed `pkg/recipe` fields project to plain strings (Service / Accelerator / Intent / OS / Platform / Nodes). `WrapCriteria` and `toInternalCriteria` handle translation; in-tree REST and CLI callers wrap at parse sites.

**`CriteriaRegistry` → documented transparent alias.**
The registry is behavior-rich (`ParseService`, `SetStrict`, `Values`, `AllAcceleratorTypes`, ...) and carries mutable per-`DataProvider` state. Wrapping would either copy state (breaking the per-Client identity coupling) or hold a pointer (no isolation win over the alias). Reasoning recorded inline in `types.go`.

**Cross-type validation helper.**
A new `pkg/api/allowlist.go` provides `validateAgainstAllowLists` so REST handlers preserve their pre-check error message ("Criteria value not allowed") without forcing every callsite to inline the facade → internal translation.

**HTTP wire format preserved.**
`/v1/recipe` continues to serialize `result.Resolved()` (the upstream JSON), so external CLI/library consumers parse byte-identical responses. The change is Go-API only.

## Testing

```bash
make qualify
```

- `make test` passes (75.9% project-wide coverage, well above the 70% floor).
- `make lint` (`golangci-lint` + `yamllint`) reports `0 issues`.
- Dedicated unit tests for `WrapCriteria` / `toInternalCriteria`, `WrapAllowLists` / `toInternalAllowLists`, and the generic `stringsFromTypes` / `typesFromStrings` helpers — covering nil, empty, fully-populated, and round-trip cases (`pkg/client/v1/translate_test.go`).
- `pkg/client/v1` coverage: 76.8% → 77.4% (+0.6%).

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Breaking for external Go importers of `pkg/client/v1`. Migration is mechanical:
- `aicr.Recipe` → `*aicr.RecipeResult` (use `.Resolved()` for upstream fields)
- `aicr.AllowLists` field types change from `[]recipe.CriteriaXxxType` to `[]string`
- `aicr.Criteria` field types change from typed enums to plain strings
- `aicr.WrapCriteria` / `aicr.WrapAllowLists` available for callers holding upstream values

HTTP wire surface, CLI output, and recipe data semantics are unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (`docs/integrator/public-api.md`, `docs/integrator/go-library.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)