### PR TITLE
fix(bundler): scope helmfile disableValidation to primary release

### DIFF
--- a/pkg/bundler/deployer/helmfile/helmfile_test.go
+++ b/pkg/bundler/deployer/helmfile/helmfile_test.go
@@ -501,6 +501,47 @@ func TestBuildHelmfile_CreateNamespaceFromFolder(t *testing.T) {
 	}
 }
 
+// TestBuildHelmfile_DisableValidationPrimaryOnly asserts that the
+// registry flag HasSelfRefCRDs emits `disableValidation: true` only on
+// the primary release of a component, not on the injected -pre / -post
+// local-helm wrappers. The wrappers ship raw manifests (no `crds/`, no
+// self-reference of their own); cascading the flag would silently drop
+// helm-diff's REST-mapper sanity check on those wrappers — a typo in a
+// resource Kind would render at diff time and fail at apply. See issue
+// #929.
+func TestBuildHelmfile_DisableValidationPrimaryOnly(t *testing.T) {
+	folders := []localformat.Folder{
+		{Index: 1, Dir: "001-gpu-operator-pre", Kind: localformat.KindLocalHelm,
+			Name: "gpu-operator-pre", Parent: "gpu-operator"},
+		{Index: 2, Dir: "002-gpu-operator", Kind: localformat.KindUpstreamHelm,
+			Name: "gpu-operator", Parent: "gpu-operator",
+			Upstream: &localformat.Upstream{Chart: "gpu-operator", Repo: "https://helm.ngc.nvidia.com/nvidia", Version: "v25.3.3"}},
+		{Index: 3, Dir: "003-gpu-operator-post", Kind: localformat.KindLocalHelm,
+			Name: "gpu-operator-post", Parent: "gpu-operator"},
+	}
+	ns := map[string]string{"gpu-operator": "gpu-operator"}
+	flags := map[string]componentFlags{"gpu-operator": {HasSelfRefCRDs: true}}
+	doc, err := buildHelmfile(folders, ns, nil, flags)
+	if err != nil {
+		t.Fatalf("buildHelmfile() error = %v", err)
+	}
+	if len(doc.Releases) != 3 {
+		t.Fatalf("expected 3 releases (pre + primary + post), got %d", len(doc.Releases))
+	}
+	if doc.Releases[0].DisableValidation {
+		t.Error("release[0] (gpu-operator-pre) DisableValidation = true, want false — " +
+			"the wrapper ships raw manifests, not the self-ref chart's crds/")
+	}
+	if !doc.Releases[1].DisableValidation {
+		t.Error("release[1] (gpu-operator) DisableValidation = false, want true — " +
+			"primary release carries the self-ref CRDs and needs the helm-diff bypass")
+	}
+	if doc.Releases[2].DisableValidation {
+		t.Error("release[2] (gpu-operator-post) DisableValidation = true, want false — " +
+			"the wrapper ships raw manifests, not the self-ref chart's crds/")
+	}
+}
+
 // TestGenerate_NamespaceOwningPreManifest is the integration counterpart:
 // a pre-manifest containing a Namespace resource flows end-to-end through
 // localformat.Write → buildHelmfile and surfaces as `createNamespace: false`

--- a/pkg/bundler/deployer/helmfile/releases.go
+++ b/pkg/bundler/deployer/helmfile/releases.go
@@ -100,8 +100,10 @@ type Release struct {
 	// will skip the live-cluster REST-mapper check for this release,
 	// letting render succeed when a template creates a CR whose CRD
 	// is shipped under `crds/` in the same chart and not yet present
-	// in the cluster. Scoped per-release so other releases keep the
-	// safety check. Issue #914.
+	// in the cluster. Scoped to the primary release only — injected
+	// -pre / -post wrapper folders carry raw manifests, not the
+	// self-ref chart, so they keep the safety check. Issues #914,
+	// #929.
 	DisableValidation bool `yaml:"disableValidation,omitempty"`
 }
 
@@ -210,9 +212,14 @@ func buildHelmfile(folders []localformat.Folder, namespaceByComponent map[string
 		// disableValidation: true so helm-diff skips the live-cluster
 		// mapper check for charts whose own templates reference CRDs
 		// they ship in `crds/` (e.g., gpu-operator's clusterpolicy
-		// template). Keyed by f.Parent so injected -pre / -post
-		// folders inherit the same flag.
-		if flags[f.Parent].HasSelfRefCRDs {
+		// template). Scoped to the primary release (f.Name == f.Parent):
+		// injected -pre / -post wrapper folders are local-helm charts
+		// containing only raw manifests, so they have no `crds/` and
+		// no self-reference of their own. Letting them inherit the
+		// flag would silently drop helm-diff's mapper sanity check on
+		// the wrapper's manifests — a typo in a resource Kind would
+		// render at diff time and fail at apply. See issue #929.
+		if f.Name == f.Parent && flags[f.Parent].HasSelfRefCRDs {
 			rel.DisableValidation = true
 		}
 

--- a/pkg/bundler/deployer/helmfile/testdata/mixed_gpu_operator/helmfile.yaml
+++ b/pkg/bundler/deployer/helmfile/testdata/mixed_gpu_operator/helmfile.yaml
@@ -20,4 +20,3 @@ releases:
       - ./002-gpu-operator-post/values.yaml
     needs:
       - gpu-operator
-    disableValidation: true


### PR DESCRIPTION
## Summary

Scope helmfile `disableValidation: true` to the primary release in a folder group; do not propagate it to the local-helm `-pre`/`-post` wrappers.

## Motivation / Context

The `HasSelfRefCRDs` registry flag (added in #914 for charts whose templates reference CRDs the chart itself installs) was being applied to every release sharing a parent component. The wrappers are local-helm raw-manifest charts with no `crds/` directory and no self-references, so inheriting the flag silently suppressed helm-diff's mapper sanity check on resources where it is still valuable.

Fixes: #929
Related: #914

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)

## Implementation Notes

- In `pkg/bundler/deployer/helmfile/releases.go`, the gate is now `if f.Name == f.Parent && flags[f.Parent].HasSelfRefCRDs` — the `f.Name == f.Parent` predicate is the canonical "is this the primary release for this component" check in the localformat folder model. Wrappers append `-pre`/`-post` to `Name` while keeping `Parent` as the component name.
- Comment on the `DisableValidation` field on `Release` was updated to record the scoping and reference both issues.

## Testing

```bash
go test ./pkg/bundler/deployer/helmfile/
golangci-lint run -c .golangci.yaml ./pkg/bundler/deployer/helmfile/...
```

- Added `TestBuildHelmfile_DisableValidationPrimaryOnly` with a pre + primary (KindUpstreamHelm) + post layout. Asserts `DisableValidation` is `false` on the wrappers and `true` only on the primary.
- Regenerated the `mixed_gpu_operator` golden via `go test ./pkg/bundler/deployer/helmfile/ -run TestGenerate_Scenarios -update`. Diff: one line removed (`disableValidation: true` on `gpu-operator-post`).
- Full package suite passes; lint reports 0 issues.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Behavioral change is limited to bundles whose primary component has `HasSelfRefCRDs: true` AND ships wrappers — today this is gpu-operator only. Operators previously saw `disableValidation: true` on the post wrapper for gpu-operator; the new output removes it, restoring the mapper check on the wrapper's plain manifests. No registry / values / docs change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — internal field comment only)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
