### PR TITLE
fix(ci): unblock packaging dry-run and /ok-to-test startup failures

### DIFF
--- a/.github/workflows/ok-to-test.yaml
+++ b/.github/workflows/ok-to-test.yaml
@@ -14,14 +14,20 @@
 
 # Allows maintainers to run the full qualification suite on fork PRs
 # by commenting "/ok-to-test" on the PR. This runs in the base repo
-# context, but only grants the minimum permissions needed because the
-# called qualification workflow checks out and runs fork-controlled
-# local actions (`./.github/actions/*`). Privileged grants
-# (id-token: write, security-events: write) are deliberately withheld
-# here so a malicious fork cannot mint OIDC tokens or upload to code
-# scanning. Steps that need those tokens are either already gated to
-# non-fork PRs (e.g. SLSA predicate) or degrade gracefully on permission
-# denial (e.g. SARIF upload via continue-on-error).
+# context. The called qualification workflow checks out and runs
+# fork-controlled local actions (`./.github/actions/*`), so the
+# privileged jobs (cli-e2e with id-token: write, security-scan with
+# security-events: write) are gated by `if: inputs.privileged_ci` in
+# qualification.yaml and we pass `privileged_ci: false` below. Those
+# jobs are skipped before any step runs, so no fork-controlled code
+# ever executes with elevated tokens.
+#
+# We must still declare id-token: write and security-events: write on
+# the reusable-workflow call: GitHub validates the union of permissions
+# requested by every job in the called workflow at startup — before
+# `if:` conditions evaluate — and rejects the run with startup_failure
+# if any declared permission is missing here. The grants are declarative
+# only; the gated jobs never consume them on the fork path.
 
 name: OK to Test
 
@@ -82,6 +88,12 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # Declarative-only: required because qualification.yaml's cli-e2e and
+      # security-scan jobs declare these permissions and GitHub validates the
+      # union at startup. Those jobs are skipped via `if: inputs.privileged_ci`
+      # when privileged_ci=false (set below), so the grants are never consumed.
+      id-token: write
+      security-events: write
     with:
       privileged_ci: false
       ref: ${{ needs.authorize.outputs.ref }}

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -62,6 +62,10 @@ jobs:
         env:
           GORELEASER_CURRENT_TAG: v0.0.0
           GOFLAGS: -mod=vendor
+          # Empty placeholder so brews templates referencing .Env.HOMEBREW_DEPLOY_KEY
+          # evaluate cleanly in dry-run mode (publish is skipped). The real secret is
+          # provided by the release workflow in on-tag.yaml.
+          HOMEBREW_DEPLOY_KEY: ""
         run: |
           set -euo pipefail
           goreleaser release --snapshot --clean --skip=publish,sbom


### PR DESCRIPTION
## Summary

Two unrelated CI workflows have been failing on main and are fixed here together.

- **Packaging Check (`packaging.yaml`)** — failed after PR #1127 because the dry-run step did not set `HOMEBREW_DEPLOY_KEY`, so the brews template references to `.Env.HOMEBREW_DEPLOY_KEY` in `.goreleaser.yaml` blew up with `template: failed to apply "{{ .Env.HOMEBREW_DEPLOY_KEY }}": map has no entry for key "HOMEBREW_DEPLOY_KEY"`. Fixed by injecting an empty placeholder; publish is skipped so the value is never consumed. The real secret is still provided by the release workflow in `on-tag.yaml`.
- **OK to Test (`ok-to-test.yaml`)** — has been failing with `startup_failure` on every `issue_comment` trigger since PRs #1064 / #1067. Root cause: GitHub validates the **union** of permissions declared by every job in the called workflow at workflow startup, **before** `if:` conditions evaluate. `qualification.yaml`'s `cli-e2e` declares `id-token: write` and `security-scan` declares `security-events: write`, but the caller granted neither. Even though both jobs are gated by `if: inputs.privileged_ci=false`, the run never gets that far. Fixed by declaring those permissions on the reusable-workflow call; the gated jobs are still skipped on the fork path, so no fork-controlled code ever executes with elevated tokens.

## Motivation/Context

The Packaging Check failure was visible in https://github.com/NVIDIA/aicr/actions/runs/26692166497 right after PR #1127 merged (any push to main touching `.goreleaser.yaml` triggers it). The OK to Test failure is older — 100+ consecutive `startup_failure` runs going back to 2026-05-28 (see https://github.com/NVIDIA/aicr/actions/runs/26691845494). Both are pre-existing latent issues exposed by recent changes; this PR clears them.

## Type of Change

- [x] Bug fix (CI workflows)

## Components Affected

- CI (`.github/workflows/packaging.yaml`, `.github/workflows/ok-to-test.yaml`)

## Implementation Notes

- The `ok-to-test.yaml` change documents in-line why "deliberately withheld" permissions (per PR #1067) cannot actually be withheld at the workflow-call level once the reusable workflow declares them on any job. Security intent is preserved by the `if: inputs.privileged_ci` runtime gating, which keeps fork-controlled code from running with the declared tokens.
- The `packaging.yaml` change keeps the fix minimal and CI-local rather than complicating the goreleaser template for production releases.

## Testing

- `actionlint` and `yamllint` clean on both modified files.
- Verified locally that `HOMEBREW_DEPLOY_KEY=""` lets `goreleaser release --snapshot --clean --skip=publish,sbom` get past template evaluation and write the brew formula (final local-only failures were unrelated gcloud/docker sandbox issues, not present in CI).
- Post-merge, the next push to main that touches `.goreleaser.yaml` should keep Packaging Check green, and the next `/ok-to-test` comment on any PR should authorize and dispatch the qualification suite.

## Risk Assessment

Low. CI-only configuration changes. No application code or release artifacts affected.

## Checklist

- [x] Changes pass `actionlint` and `yamllint`
- [x] No application code changes
- [x] Commit is GPG-signed (`-S`)
