### PR TITLE
chore(scan): per-CVE OpenVEX evidence for aiperf-bench suppressions

### DIFF
--- a/.github/workflows/vuln-scan-images.yaml
+++ b/.github/workflows/vuln-scan-images.yaml
@@ -232,6 +232,11 @@ jobs:
           only-fixed: true
           fail-build: false
           config: .grype.yaml
+          # OpenVEX statements with per-CVE reachability evidence for
+          # aiperf-bench suppressions. Grype applies statements only to
+          # products whose PURL matches, so this is a no-op for the other
+          # images in the matrix.
+          vex: .openvex.json
 
       - name: Extract severity counts
         shell: bash

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -26,26 +26,50 @@ exclude:
 # Reviewed: 2026-05-06
 ignore:
   - vulnerability: CVE-2026-6100
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "python upstream — no fix available (Critical)"
   - vulnerability: CVE-2026-3298
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "python upstream — no fix available (High)"
   - vulnerability: CVE-2026-4786
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "python upstream — no fix available (High)"
   - vulnerability: CVE-2026-5450
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (Critical)"
   - vulnerability: CVE-2026-4437
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-4046
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-5435
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-5928
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-4878
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libcap2 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2025-69720
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "ncurses 6.5 — won't fix in Debian trixie (High)"
   - vulnerability: GHSA-whj4-6x5x-4v2j
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "pillow — fix in 12.2.0, pinned by aiperf (High)"
   - vulnerability: GHSA-pwv6-vv43-88gr
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
     reason: "pillow — pinned by aiperf (High)"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -21,28 +21,16 @@ exclude:
   - './aicrd'
   - './dist/**'
 
-# High/Critical CVE suppressions for the aiperf-bench base image
-# (python:3.13-slim, Debian trixie). Status + justification + per-CVE
-# reachability evidence live in `.openvex.json`, consumed by
+# CVE suppressions for the aiperf-bench base image (python:3.13-slim,
+# Debian trixie) are managed in `.openvex.json` and consumed by
 # scan-action via the `vex:` input in
-# `.github/workflows/vuln-scan-images.yaml`.
+# `.github/workflows/vuln-scan-images.yaml`. The OpenVEX document
+# carries the structured status + justification + per-CVE
+# reachability evidence and is self-sufficient for suppression.
 #
-# `vex-status` / `vex-justification` are intentionally NOT set on
-# these inline rules. In Grype v0.112 those fields act as matchers
-# against incoming external VEX statements; setting them here would
-# break suppression. The OpenVEX document is the canonical source of
-# the structured claim.
+# When scanning the aiperf-bench image locally, pass `--vex
+# .openvex.json` alongside `-c .grype.yaml`. Scans of the AICR Go
+# source tree (`make scan` → `grype dir:.`) don't need VEX since the
+# suppressed CVEs are all in Python / glibc / libcap2 / ncurses /
+# pillow and never surface against Go source.
 # Reviewed: 2026-06-01
-ignore:
-  - vulnerability: CVE-2026-6100
-  - vulnerability: CVE-2026-3298
-  - vulnerability: CVE-2026-4786
-  - vulnerability: CVE-2026-5450
-  - vulnerability: CVE-2026-4437
-  - vulnerability: CVE-2026-4046
-  - vulnerability: CVE-2026-5435
-  - vulnerability: CVE-2026-5928
-  - vulnerability: CVE-2026-4878
-  - vulnerability: CVE-2025-69720
-  - vulnerability: GHSA-whj4-6x5x-4v2j
-  - vulnerability: GHSA-pwv6-vv43-88gr

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -26,50 +26,26 @@ exclude:
 # Reviewed: 2026-05-06
 ignore:
   - vulnerability: CVE-2026-6100
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "python upstream — no fix available (Critical)"
   - vulnerability: CVE-2026-3298
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "python upstream — no fix available (High)"
   - vulnerability: CVE-2026-4786
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "python upstream — no fix available (High)"
   - vulnerability: CVE-2026-5450
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (Critical)"
   - vulnerability: CVE-2026-4437
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-4046
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-5435
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-5928
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libc 2.41 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2026-4878
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "libcap2 — won't fix in Debian trixie (High)"
   - vulnerability: CVE-2025-69720
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "ncurses 6.5 — won't fix in Debian trixie (High)"
   - vulnerability: GHSA-whj4-6x5x-4v2j
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "pillow — fix in 12.2.0, pinned by aiperf (High)"
   - vulnerability: GHSA-pwv6-vv43-88gr
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
     reason: "pillow — pinned by aiperf (High)"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -21,55 +21,46 @@ exclude:
   - './aicrd'
   - './dist/**'
 
-# CVE suppressions for aiperf-bench base image (python:3.13-slim, Debian trixie).
-# All are either unfixed upstream or won't-fix in Debian.
-# Reviewed: 2026-05-06
+# High/Critical CVE suppressions for the aiperf-bench base image
+# (python:3.13-slim, Debian trixie). All entries are upstream residuals
+# with no fix available — Debian trixie marks them won't-fix, upstream
+# Python has not released a patched 3.13 yet, and the pillow CVEs are
+# fixed in 12.2.0 but pinned by aiperf to 12.1.x.
+#
+# Structured VEX statements (status + justification + per-CVE
+# reachability evidence) live in `.openvex.json` and are consumed by
+# scan-action via the `vex:` input in
+# `.github/workflows/vuln-scan-images.yaml`. The reason strings below
+# are short audit hints; see `.openvex.json` for the full rationale.
+#
+# Note: `vex-status` / `vex-justification` are intentionally NOT set on
+# these inline rules. In Grype v0.112 those fields act as matchers
+# against incoming external VEX statements; setting them here would
+# break suppression. The OpenVEX document is the canonical source of
+# the structured claim.
+# Reviewed: 2026-06-01
 ignore:
   - vulnerability: CVE-2026-6100
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "python upstream — no fix available (Critical)"
+    reason: "cpython UAF in lzma/bz2/gzip decompressor reuse; aiperf has no such imports (Critical) — see .openvex.json"
   - vulnerability: CVE-2026-3298
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "python upstream — no fix available (High)"
+    reason: "asyncio.ProactorEventLoop OOB write; Windows-only, Linux build does not ship the class (High) — see .openvex.json"
   - vulnerability: CVE-2026-4786
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "python upstream — no fix available (High)"
+    reason: "webbrowser.open command injection; only on `aiperf plot` path, image runs `aiperf profile` (High) — see .openvex.json"
   - vulnerability: CVE-2026-5450
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "libc 2.41 — won't fix in Debian trixie (Critical)"
+    reason: "glibc scanf %mc heap overflow; specifier unused by CPython and aiperf deps (Critical) — see .openvex.json"
   - vulnerability: CVE-2026-4437
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+    reason: "glibc gethostbyaddr OOB read; aiohttp uses getaddrinfo, not the legacy path (High) — see .openvex.json"
   - vulnerability: CVE-2026-4046
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+    reason: "glibc iconv() DoS on IBM1390/IBM1399; aiperf transports UTF-8 JSON (High) — see .openvex.json"
   - vulnerability: CVE-2026-5435
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+    reason: "glibc ns_printrrf/ns_printrr/fp_nquery OOB write; deprecated, not exposed to Python (High) — see .openvex.json"
   - vulnerability: CVE-2026-5928
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+    reason: "glibc ungetwc under-read; requires non-Unicode wide-char encoding, aiperf is UTF-8 (High) — see .openvex.json"
   - vulnerability: CVE-2026-4878
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "libcap2 — won't fix in Debian trixie (High)"
+    reason: "libcap2 cap_set_file TOCTOU; aiperf-bench runs as uid 10001 and never calls libcap (High) — see .openvex.json"
   - vulnerability: CVE-2025-69720
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "ncurses 6.5 — won't fix in Debian trixie (High)"
+    reason: "ncurses analyze_string lives in infocmp utility; aiperf-bench never invokes infocmp (High) — see .openvex.json"
   - vulnerability: GHSA-whj4-6x5x-4v2j
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "pillow — fix in 12.2.0, pinned by aiperf (High)"
+    reason: "pillow FITS decompression bomb; text-LLM benchmark never loads images (High) — see .openvex.json"
   - vulnerability: GHSA-pwv6-vv43-88gr
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_in_execute_path
-    reason: "pillow — pinned by aiperf (High)"
+    reason: "pillow PSD OOB write; text-LLM benchmark never loads images (High) — see .openvex.json"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -25,20 +25,51 @@ exclude:
 # All are either unfixed upstream or won't-fix in Debian.
 # Reviewed: 2026-05-06
 ignore:
-  # python — no fix available
-  - vulnerability: CVE-2026-6100   # Critical
-  - vulnerability: CVE-2026-3298   # High
-  - vulnerability: CVE-2026-4786   # High
-  # libc 2.41 — won't fix in Debian trixie
-  - vulnerability: CVE-2026-5450   # Critical
-  - vulnerability: CVE-2026-4437   # High
-  - vulnerability: CVE-2026-4046   # High
-  - vulnerability: CVE-2026-5435   # High
-  - vulnerability: CVE-2026-5928   # High
-  # libcap2 — won't fix in Debian trixie
-  - vulnerability: CVE-2026-4878   # High
-  # ncurses 6.5 — won't fix in Debian trixie
-  - vulnerability: CVE-2025-69720  # High
-  # aiperf pip dependencies
-  - vulnerability: GHSA-whj4-6x5x-4v2j  # High, pillow (fix in 12.2.0, pinned by aiperf)
-  - vulnerability: GHSA-pwv6-vv43-88gr  # High, pillow (pinned by aiperf)
+  - vulnerability: CVE-2026-6100
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "python upstream — no fix available (Critical)"
+  - vulnerability: CVE-2026-3298
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "python upstream — no fix available (High)"
+  - vulnerability: CVE-2026-4786
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "python upstream — no fix available (High)"
+  - vulnerability: CVE-2026-5450
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "libc 2.41 — won't fix in Debian trixie (Critical)"
+  - vulnerability: CVE-2026-4437
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+  - vulnerability: CVE-2026-4046
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+  - vulnerability: CVE-2026-5435
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+  - vulnerability: CVE-2026-5928
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "libc 2.41 — won't fix in Debian trixie (High)"
+  - vulnerability: CVE-2026-4878
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "libcap2 — won't fix in Debian trixie (High)"
+  - vulnerability: CVE-2025-69720
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "ncurses 6.5 — won't fix in Debian trixie (High)"
+  - vulnerability: GHSA-whj4-6x5x-4v2j
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "pillow — fix in 12.2.0, pinned by aiperf (High)"
+  - vulnerability: GHSA-pwv6-vv43-88gr
+    vex-status: not_affected
+    vex-justification: vulnerable_code_not_in_execute_path
+    reason: "pillow — pinned by aiperf (High)"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -22,18 +22,12 @@ exclude:
   - './dist/**'
 
 # High/Critical CVE suppressions for the aiperf-bench base image
-# (python:3.13-slim, Debian trixie). All entries are upstream residuals
-# with no fix available — Debian trixie marks them won't-fix, upstream
-# Python has not released a patched 3.13 yet, and the pillow CVEs are
-# fixed in 12.2.0 but pinned by aiperf to 12.1.x.
-#
-# Structured VEX statements (status + justification + per-CVE
-# reachability evidence) live in `.openvex.json` and are consumed by
+# (python:3.13-slim, Debian trixie). Status + justification + per-CVE
+# reachability evidence live in `.openvex.json`, consumed by
 # scan-action via the `vex:` input in
-# `.github/workflows/vuln-scan-images.yaml`. The reason strings below
-# are short audit hints; see `.openvex.json` for the full rationale.
+# `.github/workflows/vuln-scan-images.yaml`.
 #
-# Note: `vex-status` / `vex-justification` are intentionally NOT set on
+# `vex-status` / `vex-justification` are intentionally NOT set on
 # these inline rules. In Grype v0.112 those fields act as matchers
 # against incoming external VEX statements; setting them here would
 # break suppression. The OpenVEX document is the canonical source of
@@ -41,26 +35,14 @@ exclude:
 # Reviewed: 2026-06-01
 ignore:
   - vulnerability: CVE-2026-6100
-    reason: "cpython UAF in lzma/bz2/gzip decompressor reuse; aiperf has no such imports (Critical) — see .openvex.json"
   - vulnerability: CVE-2026-3298
-    reason: "asyncio.ProactorEventLoop OOB write; Windows-only, Linux build does not ship the class (High) — see .openvex.json"
   - vulnerability: CVE-2026-4786
-    reason: "webbrowser.open command injection; only on `aiperf plot` path, image runs `aiperf profile` (High) — see .openvex.json"
   - vulnerability: CVE-2026-5450
-    reason: "glibc scanf %mc heap overflow; specifier unused by CPython and aiperf deps (Critical) — see .openvex.json"
   - vulnerability: CVE-2026-4437
-    reason: "glibc gethostbyaddr OOB read; aiohttp uses getaddrinfo, not the legacy path (High) — see .openvex.json"
   - vulnerability: CVE-2026-4046
-    reason: "glibc iconv() DoS on IBM1390/IBM1399; aiperf transports UTF-8 JSON (High) — see .openvex.json"
   - vulnerability: CVE-2026-5435
-    reason: "glibc ns_printrrf/ns_printrr/fp_nquery OOB write; deprecated, not exposed to Python (High) — see .openvex.json"
   - vulnerability: CVE-2026-5928
-    reason: "glibc ungetwc under-read; requires non-Unicode wide-char encoding, aiperf is UTF-8 (High) — see .openvex.json"
   - vulnerability: CVE-2026-4878
-    reason: "libcap2 cap_set_file TOCTOU; aiperf-bench runs as uid 10001 and never calls libcap (High) — see .openvex.json"
   - vulnerability: CVE-2025-69720
-    reason: "ncurses analyze_string lives in infocmp utility; aiperf-bench never invokes infocmp (High) — see .openvex.json"
   - vulnerability: GHSA-whj4-6x5x-4v2j
-    reason: "pillow FITS decompression bomb; text-LLM benchmark never loads images (High) — see .openvex.json"
   - vulnerability: GHSA-pwv6-vv43-88gr
-    reason: "pillow PSD OOB write; text-LLM benchmark never loads images (High) — see .openvex.json"

--- a/.openvex.json
+++ b/.openvex.json
@@ -1,0 +1,215 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/NVIDIA/aicr/.openvex.json",
+  "author": "NVIDIA AICR maintainers",
+  "role": "document creator",
+  "timestamp": "2026-06-01T00:00:00Z",
+  "version": 1,
+  "tooling": "manual; reachability verified against aiperf v0.7.0 source",
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6100",
+        "description": "cpython use-after-free in lzma.LZMADecompressor / bz2.BZ2Decompressor / gzip.GzipFile when a decompressor instance is reused after a MemoryError (CWE-416, Critical)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "aiperf v0.7.0 source contains zero imports or references to the gzip, lzma, or bz2 stdlib modules (verified with `grep -rn -E '^(import|from) (gzip|lzma|bz2)'`). The vulnerable decompressor classes are never instantiated. The vulnerability requires not just calling these classes but also reusing the same instance after a MemoryError; one-shot helpers (lzma.decompress(), bz2.decompress(), gzip.decompress(), zlib.decompress()) are not affected per the upstream Python advisory."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3298",
+        "description": "cpython out-of-bounds write in asyncio.ProactorEventLoop.sock_recvfrom_into() on Windows (CWE-787, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The vulnerable class is asyncio.ProactorEventLoop, defined in asyncio.windows_events and conditionally compiled out of non-Windows CPython builds. The aiperf-bench image is based on python:3.13-slim (Debian trixie, Linux/glibc); the ProactorEventLoop class is not present in the shipped CPython binary."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-4786",
+        "description": "cpython command injection in webbrowser.open() via crafted URL (CWE-77, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "aiperf imports webbrowser exclusively in aiperf/plot/dashboard/server.py and invokes webbrowser.open(url) only when launching the local plot dashboard server. That code path is reached from the `aiperf plot` subcommand. The aiperf-bench image's benchmark workload runs `aiperf profile` (validators/performance/inference_perf_constraint.go), which never imports the plot or dashboard modules. Additionally, the URL passed to webbrowser.open is the internally-constructed dashboard server URL, not attacker-supplied."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-5450",
+        "description": "glibc heap overflow in _vfscanf_internal via the %mc scanf format specifier (CWE-787, Critical)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Trigger requires calling glibc's scanf family with the %mc (malloc'd character match) format specifier. CPython does not expose the C scanf family to Python code. aiperf's declared runtime dependencies (aiohttp, cyclopts, fastapi, jinja2, jmespath, kaleido, matplotlib, msgspec, numpy, pillow, transformers, uvicorn, uvloop, zstandard) parse user input via Python-native parsers, not scanf. Upstream advisory notes %mc is not used by major Linux distros."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-4437",
+        "description": "glibc out-of-bounds read in gethostbyaddr / gethostbyaddr_r legacy POSIX reverse DNS lookup (CWE-125, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Upstream advisory explicitly states getaddrinfo() is not affected. aiperf's HTTP client is aiohttp, which uses asyncio's resolver (getaddrinfo) for name resolution; aiperf source contains no gethostbyaddr references. The legacy gethostbyaddr() and gethostbyaddr_r() reverse-DNS functions are not on aiperf-bench's execution path."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-4046",
+        "description": "glibc iconv() assertion failure DoS when converting IBM1390 / IBM1399 EBCDIC variant character sets (CWE-617, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Trigger requires iconv() conversion specifically to/from IBM1390 or IBM1399. aiperf transports UTF-8 JSON over HTTP between the benchmark and the inference endpoint; Python's defaults are UTF-8 throughout. No code in aiperf or its declared dependencies references IBM1390/IBM1399, codepage 1390, or codepage 1399."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-5435",
+        "description": "glibc out-of-bounds write in the deprecated DNS resolver-printing functions ns_printrrf / ns_printrr / fp_nquery when processing TSIG records (CWE-787, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable functions are deprecated libresolv internals (ns_printrrf, ns_printrr, fp_nquery) used for formatting DNS records as text. CPython does not expose these symbols; aiperf and its declared dependencies do not link libresolv or print DNS packets. The benchmark performs only outbound HTTP and name resolution via getaddrinfo."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-5928",
+        "description": "glibc buffer under-read in ungetwc / _IO_wdefault_pbackfail on wide-char streams using non-Unicode encodings with byte/multibyte overlaps (CWE-127, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Upstream advisory: the spurious-match condition that triggers the under-read 'is not possible in the standard Unicode character sets.' aiperf runs with Python's default UTF-8 locale; no LC_ALL / LANG override pins the process to a non-Unicode wide-char encoding. The trigger condition cannot occur."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-4878",
+        "description": "libcap TOCTOU race in cap_set_file() allowing local privilege escalation when an attacker controls the target's parent directory (CWE-367, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The aiperf-bench image drops root after pip install and runs as the non-root user `aiperf` (uid 10001, no shell, no home write privileges; see validators/performance/aiperf-bench.Dockerfile). The workload never calls cap_set_file or any other libcap API; libcap2 is present only as a transitive dependency of base-image utilities. The benchmark process has no capabilities to set and no parent-directory-control vector."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-69720",
+        "description": "ncurses stack-based buffer overflow in analyze_string() in progs/infocmp.c, triggered by `infocmp -i` on crafted terminfo input (CWE-121, High)."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable analyze_string() function lives in the infocmp utility binary (ncurses-bin package), not in the shared libraries (libncursesw6, libtinfo6). Trigger requires executing `infocmp -i <crafted-terminfo>`. The aiperf-bench image runs `aiperf profile` and never invokes infocmp; no shell wrapper or aiperf subcommand exec's it."
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-whj4-6x5x-4v2j",
+        "description": "pillow FITS image format decoder GZIP decompression bomb leading to unbounded memory consumption (CVE-2026-40192, CWE-400, High). Fixed in pillow 12.2.0; pinned by aiperf to 12.1.x."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "AICR invokes aiperf-bench as `aiperf profile <text-LLM> --url <endpoint>` against text-only models (Qwen/Qwen3-0.6B per validators/performance/inference_perf_constraint.go) with synthetic text tokens (aiperfInputTokensMean=128, aiperfOutputTokensMean=128). The benchmark transports only JSON over HTTP and never loads image files. aiperf's image-loading code paths in dataset_manager.py / generator/image.py / utils.py are gated to multimodal benchmark configurations that the AICR validator does not exercise. Even when image mode is enabled, aiperf's ImageFormat enum (aiperf/common/enums/enums.py) restricts inputs to PNG/JPEG; FITS is not in the allowlist."
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-pwv6-vv43-88gr",
+        "description": "pillow PSD image codec integer overflow leading to out-of-bounds write in src/decode.c / src/encode.c (CVE-2026-25990, CWE-787, High). Fixed in pillow 12.2.0; pinned by aiperf to 12.1.x."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Same reachability argument as GHSA-whj4-6x5x-4v2j: the AICR text-LLM benchmark workload never enters pillow's image-loading paths, and aiperf's ImageFormat allowlist restricts inputs to PNG/JPEG. PSD is not in the allowlist."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Make the `.grype.yaml` suppressions for the `aiperf-bench` base image carry honest, advisory-grounded VEX claims. Split the work across `.grype.yaml` (plain ignores for actual suppression), `.openvex.json` (structured OpenVEX statements with per-CVE reachability evidence), and the daily image-scan workflow (which now passes `vex:` to scan-action).

## Motivation / Context

The first iteration of this PR set `vex-status: not_affected` + `vex-justification: vulnerable_code_not_in_execute_path` on every entry. CodeRabbit flagged that as semantically wrong — the justification is an OpenVEX/CISA-defined attestation about reachability, not a stand-in for "no fix available" / "won't fix in Debian". The follow-up work here:

1. **Validates the suppression list against current scans.** All 12 entries still match against the current `aicr-aiperf-bench:local-py313` build (verified with `grype dir:image -c <empty>`). No stale entries.
2. **Pulls each advisory and identifies the vulnerable function / module + trigger condition.** Recorded per-CVE in `.openvex.json`'s `impact_statement` field.
3. **Cross-references aiperf v0.7.0 source** (`github.com/ai-dynamo/aiperf @ v0.7.0`, the pinned `AIPERF_VERSION` in `validators/performance/aiperf-bench.Dockerfile`) and AICR's invocation pattern (`validators/performance/inference_perf_constraint.go` — `aiperf profile <text-LLM> --url <endpoint>` against `Qwen/Qwen3-0.6B` with synthetic text tokens).
4. **Picks the honest OpenVEX justification per CVE.** All 12 land on `not_affected`; 11 with `vulnerable_code_not_in_execute_path`, 1 (CVE-2026-3298, asyncio.ProactorEventLoop) with `vulnerable_code_not_present` because Windows-only code is not compiled into the Linux CPython build.

### Why two files

Grype v0.112.0 (the pinned version, `.settings.yaml`) treats `vex-status` in an *inline* ignore rule as a **matcher** for incoming external VEX statements, not as an inline declaration. Verified locally:

| Rule shape | Suppressed? |
|---|---|
| `vulnerability` + `reason` | ✅ |
| `vulnerability` + `reason` + `vex-status: not_affected` + `vex-justification: …` | ❌ |

So the structured VEX claim has to live in an external OpenVEX document referenced via `--vex`. `.grype.yaml` keeps plain ignores (suppression), `.openvex.json` carries the structured VEX (claim).

### Findings per CVE

Full evidence is in each statement's `impact_statement` in `.openvex.json`. Summary:

| CVE / GHSA | Component | Vulnerable code | Reachability call |
|---|---|---|---|
| CVE-2026-6100 | python | lzma/bz2/gzip decompressor UAF on instance reuse after `MemoryError` | aiperf source has 0 imports of `gzip` / `lzma` / `bz2`; classes never instantiated |
| CVE-2026-3298 | python | `asyncio.ProactorEventLoop.sock_recvfrom_into()` OOB write (Windows-only) | `vulnerable_code_not_present` — Linux build does not ship the class |
| CVE-2026-4786 | python | `webbrowser.open()` command injection via crafted URL | only called by `aiperf plot` dashboard; image runs `aiperf profile` |
| CVE-2026-5450 | glibc | `_vfscanf_internal` heap overflow via `%mc` specifier | CPython does not expose C scanf; `%mc` unused by aiperf deps |
| CVE-2026-4437 | glibc | `gethostbyaddr` / `gethostbyaddr_r` OOB read | upstream: `getaddrinfo` unaffected; aiohttp uses `getaddrinfo` |
| CVE-2026-4046 | glibc | `iconv()` DoS on IBM1390 / IBM1399 EBCDIC codecs | aiperf transports UTF-8 JSON; no EBCDIC codec referenced |
| CVE-2026-5435 | glibc | `ns_printrrf` / `ns_printrr` / `fp_nquery` OOB write (TSIG records) | deprecated libresolv internals; not exposed to Python |
| CVE-2026-5928 | glibc | `ungetwc` / `_IO_wdefault_pbackfail` buffer under-read | advisory: spurious match impossible in standard Unicode; aiperf is UTF-8 |
| CVE-2026-4878 | libcap2 | `cap_set_file()` TOCTOU privilege escalation | aiperf-bench runs as uid 10001; never calls libcap |
| CVE-2025-69720 | ncurses | `analyze_string()` in `progs/infocmp.c` | vulnerable code is in the `infocmp` utility, not libncursesw; aiperf-bench never exec's `infocmp` |
| GHSA-whj4-6x5x-4v2j | pillow | FITS image format decompression bomb | AICR runs text-LLM benchmark; image-loading paths gated to multimodal; ImageFormat allowlist is PNG/JPEG |
| GHSA-pwv6-vv43-88gr | pillow | PSD codec integer overflow → OOB write | same reachability argument as the FITS CVE |

Fixes: N/A
Related: CodeRabbit review on this PR

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: scan config (`.grype.yaml`, `.openvex.json`, `.github/workflows/vuln-scan-images.yaml`)

## Implementation Notes

- `.grype.yaml`: plain ignore rules with short `reason` strings pointing readers to `.openvex.json` for the full claim. Header notes why VEX fields are intentionally not set inline.
- `.openvex.json`: canonical OpenVEX v0.2.0 document, 12 statements. Each has `vulnerability.name`, `vulnerability.description`, `products[]` (PURL: `pkg:oci/aicr-aiperf-bench`), `status`, `justification`, and a detailed `impact_statement` carrying the per-CVE reachability evidence.
- `.github/workflows/vuln-scan-images.yaml`: adds `vex: .openvex.json` to the scan-action `with:` block. The other images in the scan matrix (`aicr`, `aicrd`, deployment, performance, conformance) have different product PURLs, so the statements are a no-op for them.

## Testing

```bash
# yamllint
yamllint .grype.yaml                                  # clean
yamllint .github/workflows/vuln-scan-images.yaml      # clean
python3 -c "import json; json.load(open('.openvex.json'))"   # valid

# Grype suppression — both layers contribute
grype aicr-aiperf-bench:local-py313 -c .grype.yaml --vex .openvex.json --show-suppressed
# → all 12 entries marked `(suppressed)` or `(suppressed by VEX)`

# OpenVEX doc is self-sufficient
grype aicr-aiperf-bench:local-py313 -c <empty.yaml> --vex .openvex.json --show-suppressed
# → all 12 entries marked `(suppressed by VEX)`

make qualify
# → tests pass, lint clean, 22 chainsaw e2e pass,
#   scan reports `No vulnerabilities found`, license check passes.
```

## Risk Assessment

- [x] **Low** — Suppression scope is byte-identical to the previous state (same 12 CVE / GHSA IDs). The added file is a structured VEX document; the workflow change is a single new `vex:` input on the existing scan-action invocation. Easy to revert per file.

**Rollout notes:** the next run of the daily `Daily Image Vulnerability Scan` workflow will consume `.openvex.json`; suppression behavior in the aiperf-bench scan report should be equivalent or stricter than before. No runtime / consumer impact.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — covered by `make qualify`
- [x] Linter passes (`make lint`) — yamllint clean
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, config + workflow only
- [x] I updated docs if user-facing behavior changed — N/A, scan-internal
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)