### PR TITLE
feat(agentgateway): scope inference-gateway LB to allowed source ranges

### DIFF
--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -63,6 +63,27 @@ aicr recipe --service eks --accelerator h100 --os ubuntu --intent training -o re
 
 The output lists every component with its pinned version and configuration values.
 
+## Inference Gateway Network Exposure
+
+Inference recipes include the **agentgateway** component, which deploys an `inference-gateway` Gateway. The agentgateway controller materializes that Gateway into a `Service` of type `LoadBalancer`, so on every cloud the platform provisions an internet-facing load balancer for the (plaintext HTTP, unauthenticated) inference endpoint. By default that load balancer accepts traffic from any source (`0.0.0.0/0`).
+
+To restrict it to trusted networks, set `agentgateway.allowedSourceRanges` to a list of CIDR (Classless Inter-Domain Routing) blocks. The values are rendered into the generated Service's `spec.loadBalancerSourceRanges`, which the AWS, GCP, Azure, and OCI cloud load balancers all honor — so one setting locks the gateway down on every platform.
+
+Do **not** use `--set` for this key. `--set agentgateway:allowedSourceRanges=<cidr>` exits 0 but renders `loadBalancerSourceRanges` as a bare string instead of a list, producing a type-invalid Service (the gateway may stay open to `0.0.0.0/0`, or the CR apply is rejected). Scope the gateway through a recipe overlay or `componentRef` override instead:
+
+```yaml
+componentRefs:
+  - name: agentgateway
+    type: Helm
+    overrides:
+      allowedSourceRanges:
+        - 216.228.127.128/30   # e.g. corporate egress
+```
+
+The default is intentionally empty rather than a fixed CIDR: a baked-in range would firewall every downstream deployment to one network and lock other operators out of their own gateway. Each operator should scope this to their own trusted networks. An empty list leaves the load balancer open to `0.0.0.0/0`.
+
+This setting filters by source IP only; it does not add TLS or authentication to the gateway listener.
+
 ## Adding Components
 
 New components are added declaratively in `recipes/registry.yaml` — no Go code required. See the [Contributing Guide](https://github.com/NVIDIA/aicr/blob/main/CONTRIBUTING.md) and [Bundler Development](../contributor/component.md) docs for details.

--- a/recipes/components/agentgateway/manifests/inference-gateway.yaml
+++ b/recipes/components/agentgateway/manifests/inference-gateway.yaml
@@ -33,6 +33,20 @@ metadata:
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  # Restrict the controller-generated LoadBalancer Service to trusted source
+  # CIDRs. Without this the agentgateway controller provisions an internet-facing
+  # load balancer open to 0.0.0.0/0, exposing the (plaintext, unauthenticated)
+  # inference endpoint to the entire internet. spec.service.spec is merged onto
+  # the generated Service, and loadBalancerSourceRanges is a portable Service
+  # field honored by the AWS, GCP, Azure, and OCI cloud load balancers — so this
+  # single setting locks the gateway down on every platform. An empty
+  # allowedSourceRanges list leaves the Service unrestricted (0.0.0.0/0).
+  {{- if $agw.allowedSourceRanges }}
+  service:
+    spec:
+      loadBalancerSourceRanges:
+        {{- toYaml $agw.allowedSourceRanges | nindent 8 }}
+  {{- end }}
   deployment:
     metadata:
       labels:

--- a/recipes/components/agentgateway/values.yaml
+++ b/recipes/components/agentgateway/values.yaml
@@ -33,3 +33,29 @@ resources:
 # Required for routing to InferencePool backends.
 inferenceExtension:
   enabled: true
+
+# Source IP CIDRs allowed to reach the inference-gateway's public LoadBalancer.
+# When non-empty, these CIDRs are rendered into the generated Service's
+# spec.loadBalancerSourceRanges, which is honored by the AWS, GCP, Azure, and
+# OCI cloud load balancers alike — so one setting locks the gateway down on
+# every platform.
+#
+# Default is EMPTY, which leaves the load balancer reachable from any source
+# (0.0.0.0/0) so deployments work out of the box regardless of network. This is
+# intentionally NOT defaulted to an NVIDIA-specific range: a baked-in CIDR would
+# firewall every downstream deployment to NVIDIA's network and lock external
+# operators out of their own gateway.
+#
+# Each operator should scope this to their trusted networks. Do NOT use `--set`
+# for this key: `--set agentgateway:allowedSourceRanges=<cidr>` exits 0 but
+# renders loadBalancerSourceRanges as a bare string instead of a list, producing
+# a type-invalid Service (the gateway may stay open at 0.0.0.0/0, or the CR apply
+# is rejected). Set it through a recipe overlay / componentRef override, e.g.:
+#
+#   componentRefs:
+#     - name: agentgateway
+#       type: Helm
+#       overrides:
+#         allowedSourceRanges:
+#           - 216.228.127.128/30   # e.g. NVIDIA HQ / Santa Clara egress
+allowedSourceRanges: []

--- a/tests/chainsaw/bundle-templates/agentgateway/chainsaw-test.yaml
+++ b/tests/chainsaw/bundle-templates/agentgateway/chainsaw-test.yaml
@@ -20,7 +20,8 @@ metadata:
 spec:
   description: |
     Validates that agentgateway manifest templates render correctly.
-    Tests inference-gateway AgentgatewayParameters scheduling (nodeSelector/tolerations).
+    Tests inference-gateway AgentgatewayParameters scheduling (nodeSelector/tolerations)
+    and the default LoadBalancer source-range restriction (loadBalancerSourceRanges).
     Run with: AICR_BIN=$(pwd)/dist/e2e/aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/agentgateway
   timeouts:
     exec: 30s
@@ -31,6 +32,7 @@ spec:
       try:
         - script:
             content: |
+              set -e
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-bundle-agentgateway-templates"
               rm -rf "${WORK}" && mkdir -p "${WORK}"
@@ -48,6 +50,7 @@ spec:
       try:
         - script:
             content: |
+              set -e
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-bundle-agentgateway-templates"
               rm -rf "${WORK}/bundle-defaults"
@@ -59,7 +62,12 @@ spec:
       description: Verify AgentgatewayParameters and Gateway resources exist.
       try:
         - script:
+            # set -e so EVERY assertion below is fail-closed: without it, /bin/sh -c
+            # only surfaces the last command's status, letting an earlier failed
+            # grep (e.g. a missing resource) pass silently when the final negative
+            # grep happens to succeed.
             content: |
+              set -e
               WORK="/tmp/chainsaw-bundle-agentgateway-templates"
               ## agentgateway is a mixed component (upstream Helm + raw manifests),
               ## so its raw manifests render into an injected NNN-agentgateway-post/
@@ -70,6 +78,47 @@ spec:
               ## Verify both are present.
               grep -q 'kind: AgentgatewayParameters' "${MANIFEST}"
               grep -q 'kind: Gateway' "${MANIFEST}"
+              ## allowedSourceRanges defaults to empty, so no LoadBalancer source
+              ## restriction is rendered out of the box (deployments stay reachable
+              ## regardless of network). Operators opt in via an overlay override;
+              ## see assert-gateway-source-ranges below for the configured path.
+              ! grep -q 'loadBalancerSourceRanges:' "${MANIFEST}"
+
+    ## ── With LoadBalancer source-range restriction ─────────────────────
+
+    - name: bundle-source-ranges
+      description: Override agentgateway.allowedSourceRanges via the recipe componentRef.
+      try:
+        - script:
+            content: |
+              set -e
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-agentgateway-templates"
+              rm -rf "${WORK}/bundle-source-ranges"
+              ## --set renders a type-invalid string for this key, so operators scope
+              ## the gateway through an overlay/componentRef override. Inject one here.
+              cp "${WORK}/recipe.yaml" "${WORK}/recipe-sr.yaml"
+              yq -i '(.componentRefs[] | select(.name == "agentgateway")).overrides.allowedSourceRanges = ["216.228.127.128/30"]' \
+                "${WORK}/recipe-sr.yaml"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe-sr.yaml" \
+                --output "${WORK}/bundle-source-ranges"
+
+    - name: assert-gateway-source-ranges
+      description: Verify the override renders loadBalancerSourceRanges onto the Service.
+      try:
+        - script:
+            # set -e so a failed first grep (e.g. the loadBalancerSourceRanges field
+            # name is wrong) cannot be masked by the trailing CIDR grep succeeding.
+            content: |
+              set -e
+              WORK="/tmp/chainsaw-bundle-agentgateway-templates"
+              MANIFEST=$(ls "${WORK}"/bundle-source-ranges/[0-9][0-9][0-9]-agentgateway-post/templates/inference-gateway.yaml 2>/dev/null | head -1)
+              [ -n "${MANIFEST}" ] || { echo "agentgateway inference-gateway.yaml not found in source-ranges bundle" >&2; exit 1; }
+              ## The configured CIDR must reach the generated Service's
+              ## spec.service.spec.loadBalancerSourceRanges.
+              grep -q 'loadBalancerSourceRanges:' "${MANIFEST}"
+              grep -q '216.228.127.128/30' "${MANIFEST}"
 
     ## ── With system node scheduling ────────────────────────────────────
 
@@ -78,6 +127,7 @@ spec:
       try:
         - script:
             content: |
+              set -e
               AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
               WORK="/tmp/chainsaw-bundle-agentgateway-templates"
               rm -rf "${WORK}/bundle-scheduling"
@@ -91,6 +141,7 @@ spec:
       try:
         - script:
             content: |
+              set -e
               WORK="/tmp/chainsaw-bundle-agentgateway-templates"
               MANIFEST=$(ls "${WORK}"/bundle-scheduling/[0-9][0-9][0-9]-agentgateway-post/templates/inference-gateway.yaml 2>/dev/null | head -1)
               [ -n "${MANIFEST}" ] || { echo "agentgateway inference-gateway.yaml not found in scheduling bundle" >&2; exit 1; }
@@ -100,4 +151,5 @@ spec:
       cleanup:
         - script:
             content: |
+              set -e
               rm -rf /tmp/chainsaw-bundle-agentgateway-templates


### PR DESCRIPTION
## Summary

Adds an `agentgateway.allowedSourceRanges` option that scopes the `inference-gateway` LoadBalancer to operator-supplied source CIDRs (rendered into the generated Service's `spec.loadBalancerSourceRanges`). One portable setting locks the gateway down on AWS, GCP, Azure, and OCI.

## Motivation / Context

The agentgateway controller materializes the `inference-gateway` Gateway into a `type: LoadBalancer` Service, which every cloud provisions as an internet-facing load balancer open to `0.0.0.0/0` — exposing the plaintext, unauthenticated inference endpoint to the public internet. A security scan flagged exactly this on an AICR-provisioned cluster. There was previously no first-class way to restrict that exposure from a recipe.

Fixes: N/A
Related: AICR inference-gateway public-exposure finding (internal security review)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`recipes/components/agentgateway`)
- [x] Docs/examples (`docs/`)
- [x] Other: `tests/chainsaw` (bundle-template test)

## Implementation Notes

- The CIDRs flow through the existing `AgentgatewayParameters` CR (`spec.service.spec.loadBalancerSourceRanges`), which the controller merges onto the generated Service — so no new mechanism is introduced.
- **Default is empty**, which is non-breaking (no source-range restriction is rendered; behavior is unchanged). It is intentionally **not** defaulted to an NVIDIA-specific CIDR: a baked-in range would firewall every downstream deployment to one network and lock other operators out of their own gateway. Operators scope it to their own trusted networks.
- Because list values cannot be passed via the scalar-only `--set`, the knob is set through a recipe overlay / `componentRef` override (documented in the component catalog).

### Alternative considered: ClusterIP-by-default

A stronger, secure-by-default alternative was prototyped: default the gateway Service to **`ClusterIP`** (no public load balancer at all — reach it in-cluster or via `kubectl port-forward`), with `LoadBalancer` + source ranges / internal-scheme annotations as an explicit opt-in. It removes the public surface entirely rather than narrowing it, and verified end-to-end (default ClusterIP, opt-in LoadBalancer+ranges, internal-LB-via-annotations all render correctly).

This PR takes the **less disruptive** path — keep the existing LoadBalancer behavior and add scoping — because ClusterIP-by-default changes out-of-the-box behavior (no external ingress unless explicitly enabled) and is a broader product decision. The ClusterIP-default variant can be adopted as a follow-up if the team prefers secure-by-default; the `allowedSourceRanges` knob composes with it.

## Testing

Recipes-YAML / docs / chainsaw-test only — no Go changes — so per the repo's infra-only verification guidance, scoped checks were run in place of full `make qualify` (Go unit tests, `-race`, e2e, and golangci-lint cannot regress from non-code changes):

```bash
# chainsaw bundle-template test (default renders no source ranges; override renders the scoped CIDR)
AICR_BIN=.../aicr chainsaw test --no-cluster --test-dir tests/chainsaw/bundle-templates/agentgateway   # PASS
yamllint recipes/components/agentgateway/{values.yaml,manifests/inference-gateway.yaml} \
         tests/chainsaw/bundle-templates/agentgateway/chainsaw-test.yaml                                # clean
make bom-docs   # docs/user/container-images.md unchanged (no image impact)
```

Also verified on a live EKS cluster: with `allowedSourceRanges` set, the generated ELB security group admitted only the configured CIDR (no `0.0.0.0/0`); requests from out-of-range sources were dropped at the ELB.

### CRD field-path validity (resolves the cross-review open question)

`AgentgatewayParameters.spec.service.spec.loadBalancerSourceRanges` is accepted by the installed CRD and is merged onto the generated Service:

```bash
# CRD accepts the field (server-side schema validation against the live CRD)
kubectl apply --dry-run=server -f - <<'YAML'
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayParameters
metadata: {name: dryrun-fieldcheck, namespace: agentgateway-system}
spec: {service: {spec: {loadBalancerSourceRanges: ["1.2.3.4/32"]}}}
YAML
# -> agentgatewayparameters.agentgateway.dev/dryrun-fieldcheck created (server dry run)

# Controller merge confirmed live: CR field is reflected on the Service
kubectl get agentgatewayparameters system-proxy -n agentgateway-system \
  -o jsonpath='{.spec.service.spec.loadBalancerSourceRanges}'   # ["216.228.127.128/30"]
kubectl get svc inference-gateway -n agentgateway-system \
  -o jsonpath='{.spec.loadBalancerSourceRanges}'                # ["216.228.127.128/30"]
```

### Review follow-up: `--set` wording hardened

CodeRabbit correctly flagged that the docs understated the `--set` risk. Confirmed empirically: `--set agentgateway:allowedSourceRanges=1.2.3.4/32` exits 0 but renders `loadBalancerSourceRanges: 1.2.3.4/32` (a bare **string**, not a list) — a type-invalid Service. The values.yaml comment and the component-catalog doc now **warn against `--set` for this key** and point to the overlay/`componentRef` override (which renders a correct list). Also hardened the chainsaw assertions with `set -e` so each check fails closed (without it, only the last command's status counted).

## Risk Assessment

- [x] **Low** — Isolated, additive change; empty default preserves current behavior; easy to revert.

**Rollout notes:** No migration needed. The default (empty) renders no source-range restriction, identical to prior behavior. Operators opt into scoping via an overlay/`componentRef` override.

## Checklist

- [x] Tests pass locally — chainsaw bundle-template test passes (`make test`/`-race` N/A: no Go changes)
- [x] Linter passes — `yamllint` clean (golangci-lint N/A: no Go changes)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (chainsaw default + override cases)
- [x] I updated docs (component catalog: "Inference Gateway Network Exposure")
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
