### PR TITLE
feat(evidence): add `aicr evidence publish` for off-network signing

### DIFF
--- a/demos/evidence.md
+++ b/demos/evidence.md
@@ -77,6 +77,29 @@ it finishes:
     └── attestation.intoto.jsonl # SIGNED Sigstore Bundle (DSSE + Fulcio + Rekor)
 ```
 
+### Alternative: split validate and publish across networks
+
+Validation needs the cluster (often behind a corporate VPN); keyless signing
+needs `fulcio.sigstore.dev` + `rekor.sigstore.dev`, which corporate networks
+frequently block. Drop `--push` to emit an *unsigned* bundle on the VPN, then
+sign + push + write the pointer from a host with Sigstore egress:
+
+```shell
+# On the VPN — validates and emits an unsigned bundle (no signing network).
+aicr validate \
+  --recipe recipe.yaml \
+  --snapshot snapshot.yaml \
+  --emit-attestation ./out
+
+# Off the VPN (CI runner, jump box, hotspot) — sign, push, write pointer.
+aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence
+```
+
+The bundle is content-addressable and `evidence publish` signs the predicate
+(with its emit-time `attestedAt`) verbatim from disk, so `./out` ends up
+identical to the one-shot output above — including the signed
+`attestation.intoto.jsonl` and a populated `pointer.yaml`.
+
 ## 2. Commit the pointer
 
 ```shell

--- a/docs/design/007-recipe-evidence.md
+++ b/docs/design/007-recipe-evidence.md
@@ -195,6 +195,17 @@ surface item 1 below for the full schema).
    `--emit-attestation`, not a separate command — generation, OCI push,
    signing, and pointer population happen in one invocation.
 
+   **Decoupled publish (post-V1 addition).** `aicr validate
+   --emit-attestation` *without* `--push` leaves an unsigned bundle on
+   disk; `aicr evidence publish <dir> --push <ref>` then runs the
+   sign+push+pointer leg against that pre-built bundle. This lets the
+   cluster-bound validate step (corporate VPN) and the
+   Fulcio/Rekor-bound signing step (Sigstore egress) run on different
+   hosts. Because the bundle is content-addressable and the predicate
+   (with its baked-in `attestedAt`) is signed verbatim from disk, the
+   signed artifact is identical to the one-shot path. See the CLI
+   reference for `aicr evidence publish`.
+
    **Canonical invocation: `--config aicr.yaml`.** PR-A extends
    `pkg/config.AICRConfig` with a `ValidateSpec` sibling of
    `RecipeSpec`/`BundleSpec`, reusing `AttestationSpec` and

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2208,6 +2208,51 @@ current=$(aicr evidence digest -r recipes/overlays/<file>.yaml)
 
 ---
 
+### aicr evidence publish
+
+Sign, push, and write the pointer for a recipe-evidence v1 bundle that was produced earlier by `aicr validate --emit-attestation` **without** `--push` (which leaves an unsigned bundle on disk).
+
+This decouples the cluster-bound validate step from the Fulcio/Rekor-bound signing step so they can run on different networks: validation must run where the cluster is reachable (often a corporate VPN), but keyless signing must reach `fulcio.sigstore.dev` + `rekor.sigstore.dev`, which corporate networks frequently block. Run `validate --emit-attestation` on the VPN, then `evidence publish` from a host with Sigstore egress (CI runner, jump box, hotspot).
+
+The signed artifact is content-addressable, so the result is byte-for-byte identical to the one-shot `validate --emit-attestation --push` output regardless of which host ran which leg — the predicate (including its baked-in `attestedAt` timestamp) is signed verbatim from the bundle on disk.
+
+**Synopsis:**
+
+```shell
+aicr evidence publish <bundle-dir> --push <ref> [flags]
+```
+
+The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote (holds `summary-bundle/` and receives `pointer.yaml`) or the `summary-bundle/` directory itself.
+
+**Flags:**
+
+| Flag | Alias | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--push` | | string | | OCI registry reference (e.g. `ghcr.io/myorg/aicr-evidence`) to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. |
+| `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
+| `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
+| `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
+| `--insecure-tls` | | bool | `false` | Skip TLS verification when pushing the OCI artifact (self-signed registries). |
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Bundle signed, pushed, and `pointer.yaml` written. |
+| non-zero | Bundle could not be loaded, signed, or pushed. |
+
+**Examples:**
+
+```shell
+# On VPN: produce an unsigned bundle from a passing validation.
+aicr validate -r recipe.yaml -s snapshot.yaml --emit-attestation ./out
+
+# Off VPN: sign, push, and write the pointer.
+aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence
+```
+
+---
+
 ### aicr evidence verify
 
 Verify a recipe-evidence v1 bundle produced by `aicr validate --emit-attestation`. When the bundle carries a signature, verifies it against the Sigstore trusted root and extracts the cryptographically anchored predicate. Recomputes every file's sha256 against `manifest.json` (which the predicate's `manifest.digest` field anchors), and surfaces the predicate's fingerprint, phase counts, and BOM info.

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -124,10 +124,10 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		attest:                    boolFlagOrConfig(cmd, "attest", resolved.Attest),
 		vendorCharts:              boolFlagOrConfig(cmd, "vendor-charts", resolved.VendorCharts),
 		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", resolved.CertIDRegexp),
-		identityToken:             cmd.String("identity-token"),
-		oidcDeviceFlow:            boolFlagOrConfig(cmd, "oidc-device-flow", resolved.OIDCDeviceFlow),
-		insecureTLS:               boolFlagOrConfig(cmd, "insecure-tls", resolved.InsecureTLS),
-		plainHTTP:                 boolFlagOrConfig(cmd, "plain-http", resolved.PlainHTTP),
+		identityToken:             cmd.String(flagIdentityToken),
+		oidcDeviceFlow:            boolFlagOrConfig(cmd, flagOIDCDeviceFlow, resolved.OIDCDeviceFlow),
+		insecureTLS:               boolFlagOrConfig(cmd, flagInsecureTLS, resolved.InsecureTLS),
+		plainHTTP:                 boolFlagOrConfig(cmd, flagPlainHTTP, resolved.PlainHTTP),
 		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", resolved.ImageRefs),
 	}
 
@@ -556,13 +556,13 @@ Package with explicit tag (overrides CLI version):
 				Category: catDeployment,
 			},
 			&cli.StringFlag{
-				Name:     "identity-token",
+				Name:     flagIdentityToken,
 				Usage:    "Pre-fetched OIDC identity token for --attest keyless signing. Skips ambient/browser/device-code flows. Prefer COSIGN_IDENTITY_TOKEN on shared hosts; flag values are visible in process listings (ps, /proc/<pid>/cmdline).",
 				Sources:  cli.EnvVars("COSIGN_IDENTITY_TOKEN"),
 				Category: catDeployment,
 			},
 			&cli.BoolFlag{
-				Name:     "oidc-device-flow",
+				Name:     flagOIDCDeviceFlow,
 				Usage:    "Use the OAuth 2.0 device authorization grant for --attest OIDC instead of opening a browser callback. Useful on headless hosts (bastions, remote build boxes) when --identity-token / COSIGN_IDENTITY_TOKEN and ambient GitHub Actions OIDC are both unavailable.",
 				Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
 				Category: catDeployment,
@@ -571,12 +571,12 @@ Package with explicit tag (overrides CLI version):
 			dataFlag(),
 			// OCI registry connection flags (used when --output is oci://...)
 			&cli.BoolFlag{
-				Name:     "insecure-tls",
+				Name:     flagInsecureTLS,
 				Usage:    "Skip TLS certificate verification for OCI registry",
 				Category: catOCIRegistry,
 			},
 			&cli.BoolFlag{
-				Name:     "plain-http",
+				Name:     flagPlainHTTP,
 				Usage:    "Use HTTP instead of HTTPS for OCI registry (for local development)",
 				Category: catOCIRegistry,
 			},

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -40,6 +40,7 @@ const (
 	flagOIDCDeviceFlow = "oidc-device-flow"
 	flagInsecureTLS    = "insecure-tls"
 	flagPlainHTTP      = "plain-http"
+	flagPush           = "push"
 )
 
 // Category labels (urfave/cli flag.Category values, grouping flags in help output).

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -31,6 +31,17 @@ const (
 	flagFormat = "format"
 )
 
+// Keyless-signing / OCI-push flag names shared by `validate`, `bundle`,
+// and `evidence publish`. Extracted so the same literal is declared once
+// (goconst flags a string repeated ≥3 times across the package) and the
+// flag wiring stays consistent across the commands that sign+push.
+const (
+	flagIdentityToken  = "identity-token"
+	flagOIDCDeviceFlow = "oidc-device-flow"
+	flagInsecureTLS    = "insecure-tls"
+	flagPlainHTTP      = "plain-http"
+)
+
 // Category labels (urfave/cli flag.Category values, grouping flags in help output).
 const (
 	catInput             = "Input"

--- a/pkg/cli/evidence.go
+++ b/pkg/cli/evidence.go
@@ -33,12 +33,14 @@ the validators against hardware they may not have access to.
 
 Subcommands:
 
-  digest  Print the canonical digest of a resolved recipe.
-  verify  Verify a bundle's integrity claims.
+  digest   Print the canonical digest of a resolved recipe.
+  publish  Sign and push an already-emitted bundle, then write its pointer.
+  verify   Verify a bundle's integrity claims.
 
 See docs/design/007-recipe-evidence.md for the trust model.`,
 		Commands: []*cli.Command{
 			evidenceDigestCmd(),
+			evidencePublishCmd(),
 			evidenceVerifyCmd(),
 		},
 	}

--- a/pkg/cli/evidence.go
+++ b/pkg/cli/evidence.go
@@ -18,18 +18,20 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// evidenceCmd is the parent verb-group for offline operations on
-// recipe-evidence bundles produced by `aicr validate --emit-attestation`.
+// evidenceCmd is the parent verb-group for operations on recipe-evidence
+// bundles produced by `aicr validate --emit-attestation`. Most subcommands
+// are offline; `publish` reaches the registry and Sigstore.
 func evidenceCmd() *cli.Command {
 	return &cli.Command{
 		Name:     "evidence",
 		Category: functionalCategoryName,
-		Usage:    "Inspect and verify recipe evidence bundles.",
-		Description: `Offline operations on recipe-evidence v1 bundles.
+		Usage:    "Manage recipe evidence bundles: digest, publish, verify.",
+		Description: `Operations on recipe-evidence v1 bundles.
 
 Bundles are produced by ` + "`aicr validate --emit-attestation`" + ` and consumed
 by maintainers and CI to verify a recipe contribution without re-running
-the validators against hardware they may not have access to.
+the validators against hardware they may not have access to. Most
+subcommands are offline; ` + "`publish`" + ` reaches the OCI registry and Sigstore.
 
 Subcommands:
 

--- a/pkg/cli/evidence_publish.go
+++ b/pkg/cli/evidence_publish.go
@@ -110,7 +110,7 @@ func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
 		return errors.New(errors.ErrCodeInvalidRequest, "--push <oci-ref> is required")
 	}
 
-	_, err := attestation.Publish(ctx, attestation.PublishOptions{
+	err := attestation.Publish(ctx, attestation.PublishOptions{
 		BundleDir:   dir,
 		Push:        push,
 		PlainHTTP:   cmd.Bool(flagPlainHTTP),

--- a/pkg/cli/evidence_publish.go
+++ b/pkg/cli/evidence_publish.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+)
+
+// evidencePublishCmd implements `aicr evidence publish <bundle-dir> --push <ref>`.
+// It signs and pushes an already-emitted on-disk evidence bundle, then
+// writes pointer.yaml — the off-network second leg of the workflow whose
+// first leg is `aicr validate --emit-attestation` (no --push).
+func evidencePublishCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "publish",
+		Category:  functionalCategoryName,
+		Usage:     "Sign and push an already-emitted evidence bundle.",
+		ArgsUsage: "<bundle-dir>",
+		Description: `Sign, push, and write the pointer for a recipe-evidence v1 bundle
+that was produced earlier by ` + "`aicr validate --emit-attestation`" + ` (without
+--push), leaving an unsigned bundle on disk.
+
+This decouples the cluster-bound validate step from the
+Fulcio/Rekor-bound signing step so they can run on different networks:
+validate where the cluster is reachable (often a corporate VPN), then
+publish from a host with Sigstore egress (CI runner, jump box, hotspot).
+
+The signed artifact is content-addressable, so the result is identical
+to the one-shot ` + "`validate --emit-attestation --push`" + ` output regardless of
+which host ran which leg — the predicate (including its baked-in
+attestedAt timestamp) is signed verbatim from the bundle on disk.
+
+<bundle-dir> is either the directory ` + "`--emit-attestation`" + ` wrote (holds
+summary-bundle/ and receives pointer.yaml) or the summary-bundle/
+directory itself.
+
+Keyless OIDC signing uses the same precedence chain as ` + "`aicr validate --push`" + `:
+--identity-token > COSIGN_IDENTITY_TOKEN env > GitHub Actions ambient OIDC >
+--oidc-device-flow > interactive browser flow.
+
+Example:
+
+  # On VPN: produce an unsigned bundle from a passing validation.
+  aicr validate -r recipe.yaml -s snapshot.yaml --emit-attestation ./out
+
+  # Off VPN: sign, push, and write the pointer.
+  aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "push",
+				Usage:    "OCI registry reference (e.g. ghcr.io/myorg/aicr-evidence) to push the signed summary bundle to. Required.",
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagPlainHTTP,
+				Usage:    "Use HTTP instead of HTTPS when pushing the evidence OCI artifact (local registry tests).",
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagInsecureTLS,
+				Usage:    "Skip TLS verification when pushing the evidence OCI artifact (self-signed registries).",
+				Category: catEvidence,
+			},
+			&cli.StringFlag{
+				Name:     flagIdentityToken,
+				Usage:    "Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Prefer COSIGN_IDENTITY_TOKEN on shared hosts; flag values are visible in process listings (ps, /proc/<pid>/cmdline).",
+				Sources:  cli.EnvVars("COSIGN_IDENTITY_TOKEN"),
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagOIDCDeviceFlow,
+				Usage:    "Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Useful on headless hosts when --identity-token / COSIGN_IDENTITY_TOKEN and ambient GitHub Actions OIDC are both unavailable.",
+				Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
+				Category: catEvidence,
+			},
+		},
+		Action: runEvidencePublishCmd,
+	}
+}
+
+func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
+	if err := validateSingleValueFlags(cmd, "push", flagIdentityToken); err != nil {
+		return err
+	}
+
+	dir := cmd.Args().First()
+	if dir == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"bundle directory is required: aicr evidence publish <bundle-dir> --push <ref>")
+	}
+	push := cmd.String("push")
+	if push == "" {
+		return errors.New(errors.ErrCodeInvalidRequest, "--push <oci-ref> is required")
+	}
+
+	_, err := attestation.Publish(ctx, attestation.PublishOptions{
+		BundleDir:   dir,
+		Push:        push,
+		PlainHTTP:   cmd.Bool(flagPlainHTTP),
+		InsecureTLS: cmd.Bool(flagInsecureTLS),
+		AICRVersion: version,
+		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
+	})
+	return err
+}

--- a/pkg/cli/evidence_publish.go
+++ b/pkg/cli/evidence_publish.go
@@ -64,7 +64,7 @@ Example:
   aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "push",
+				Name:     flagPush,
 				Usage:    "OCI registry reference (e.g. ghcr.io/myorg/aicr-evidence) to push the signed summary bundle to. Required.",
 				Category: catEvidence,
 			},
@@ -96,7 +96,7 @@ Example:
 }
 
 func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
-	if err := validateSingleValueFlags(cmd, "push", flagIdentityToken); err != nil {
+	if err := validateSingleValueFlags(cmd, flagPush, flagIdentityToken); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			"bundle directory is required: aicr evidence publish <bundle-dir> --push <ref>")
 	}
-	push := cmd.String("push")
+	push := cmd.String(flagPush)
 	if push == "" {
 		return errors.New(errors.ErrCodeInvalidRequest, "--push <oci-ref> is required")
 	}
@@ -118,5 +118,7 @@ func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
 		AICRVersion: version,
 		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
 	})
-	return err
+	// Publish already returns coded pkg/errors; PropagateOrWrap preserves
+	// those and only classifies any uncoded error that slips through.
+	return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to publish evidence bundle")
 }

--- a/pkg/cli/evidence_publish_test.go
+++ b/pkg/cli/evidence_publish_test.go
@@ -17,7 +17,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
+	"strings"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 func TestEvidenceCmd_RegistersPublishSubcommand(t *testing.T) {
@@ -53,26 +57,26 @@ func TestEvidencePublishCmd_HasExpectedFlags(t *testing.T) {
 
 func TestEvidencePublishCmd_RejectsInvalidInvocations(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		why  string
+		name       string
+		args       []string
+		wantSubstr string // case-specific reason embedded in the error
 	}{
 		{
-			name: "missing bundle dir",
-			args: []string{"--push", "ghcr.io/example/aicr-evidence"},
-			why:  "missing positional <bundle-dir> arg",
+			name:       "missing bundle dir",
+			args:       []string{"--push", "ghcr.io/example/aicr-evidence"},
+			wantSubstr: "bundle directory is required",
 		},
 		{
-			name: "missing push",
-			args: []string{t.TempDir()},
-			why:  "missing --push",
+			name:       "missing push",
+			args:       []string{t.TempDir()},
+			wantSubstr: "--push <oci-ref> is required",
 		},
 		{
 			// Valid arg + push, but the directory has no bundle markers:
 			// the command must fail at bundle load, before any network work.
-			name: "directory is not a bundle",
-			args: []string{t.TempDir(), "--push", "ghcr.io/example/aicr-evidence"},
-			why:  "directory that is not an evidence bundle",
+			name:       "directory is not a bundle",
+			args:       []string{t.TempDir(), "--push", "ghcr.io/example/aicr-evidence"},
+			wantSubstr: "does not look like an evidence bundle",
 		},
 	}
 	for _, tt := range tests {
@@ -82,8 +86,16 @@ func TestEvidencePublishCmd_RejectsInvalidInvocations(t *testing.T) {
 			root.Writer = &out
 			root.ErrWriter = &out
 			argv := append([]string{"aicr", "evidence", "publish"}, tt.args...)
-			if err := root.Run(context.Background(), argv); err == nil {
-				t.Errorf("expected error for %s", tt.why)
+			err := root.Run(context.Background(), argv)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			// Every rejection here is a malformed invocation → invalid-request.
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSubstr)
 			}
 		})
 	}

--- a/pkg/cli/evidence_publish_test.go
+++ b/pkg/cli/evidence_publish_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestEvidenceCmd_RegistersPublishSubcommand(t *testing.T) {
+	cmd := evidenceCmd()
+	found := false
+	for _, sub := range cmd.Commands {
+		if sub.Name == "publish" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("evidence publish subcommand not registered")
+	}
+}
+
+func TestEvidencePublishCmd_HasExpectedFlags(t *testing.T) {
+	cmd := evidencePublishCmd()
+	wanted := []string{
+		"push", "plain-http", "insecure-tls", "identity-token", "oidc-device-flow",
+	}
+	for _, name := range wanted {
+		found := false
+		for _, f := range cmd.Flags {
+			if f.Names()[0] == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing expected flag: --%s", name)
+		}
+	}
+}
+
+func TestEvidencePublishCmd_RejectsInvalidInvocations(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		why  string
+	}{
+		{
+			name: "missing bundle dir",
+			args: []string{"--push", "ghcr.io/example/aicr-evidence"},
+			why:  "missing positional <bundle-dir> arg",
+		},
+		{
+			name: "missing push",
+			args: []string{t.TempDir()},
+			why:  "missing --push",
+		},
+		{
+			// Valid arg + push, but the directory has no bundle markers:
+			// the command must fail at bundle load, before any network work.
+			name: "directory is not a bundle",
+			args: []string{t.TempDir(), "--push", "ghcr.io/example/aicr-evidence"},
+			why:  "directory that is not an evidence bundle",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newRootCmd()
+			var out bytes.Buffer
+			root.Writer = &out
+			root.ErrWriter = &out
+			argv := append([]string{"aicr", "evidence", "publish"}, tt.args...)
+			if err := root.Run(context.Background(), argv); err == nil {
+				t.Errorf("expected error for %s", tt.why)
+			}
+		})
+	}
+}

--- a/pkg/cli/evidence_publish_test.go
+++ b/pkg/cli/evidence_publish_test.go
@@ -76,7 +76,7 @@ func TestEvidencePublishCmd_RejectsInvalidInvocations(t *testing.T) {
 			// the command must fail at bundle load, before any network work.
 			name:       "directory is not a bundle",
 			args:       []string{t.TempDir(), "--push", "ghcr.io/example/aicr-evidence"},
-			wantSubstr: "does not look like an evidence bundle",
+			wantSubstr: "does not look like a summary bundle",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -542,7 +542,7 @@ func validateCmdFlags() []cli.Flag {
 			Category: catEvidence,
 		},
 		&cli.StringFlag{
-			Name: "push",
+			Name: flagPush,
 			Usage: `OCI registry reference (e.g. ghcr.io/myorg/aicr-evidence) to push the signed summary bundle to.
 	Sigstore keyless OIDC signing uses the same precedence chain as ` + "`aicr bundle --attest`" + `:
 	--identity-token > COSIGN_IDENTITY_TOKEN env > GitHub Actions ambient OIDC >
@@ -613,7 +613,7 @@ Run validation without failing on check errors (informational mode):
 `,
 		Flags: validateCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, "recipe", "snapshot", "output", "config", "namespace", "image", "job-name", "service-account-name", "timeout", "data", "evidence-dir", "emit-attestation", "bom", "push", flagIdentityToken); err != nil {
+			if err := validateSingleValueFlags(cmd, "recipe", "snapshot", "output", "config", "namespace", "image", "job-name", "service-account-name", "timeout", "data", "evidence-dir", "emit-attestation", "bom", flagPush, flagIdentityToken); err != nil {
 				return err
 			}
 

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -550,23 +550,23 @@ func validateCmdFlags() []cli.Flag {
 			Category: catEvidence,
 		},
 		&cli.BoolFlag{
-			Name:     "plain-http",
+			Name:     flagPlainHTTP,
 			Usage:    "Use HTTP instead of HTTPS when pushing the evidence OCI artifact (local registry tests).",
 			Category: catEvidence,
 		},
 		&cli.BoolFlag{
-			Name:     "insecure-tls",
+			Name:     flagInsecureTLS,
 			Usage:    "Skip TLS verification when pushing the evidence OCI artifact (self-signed registries).",
 			Category: catEvidence,
 		},
 		&cli.StringFlag{
-			Name:     "identity-token",
+			Name:     flagIdentityToken,
 			Usage:    "Pre-fetched OIDC identity token for --push keyless signing. Skips ambient/browser/device-code flows. Prefer COSIGN_IDENTITY_TOKEN on shared hosts; flag values are visible in process listings (ps, /proc/<pid>/cmdline).",
 			Sources:  cli.EnvVars("COSIGN_IDENTITY_TOKEN"),
 			Category: catEvidence,
 		},
 		&cli.BoolFlag{
-			Name:     "oidc-device-flow",
+			Name:     flagOIDCDeviceFlow,
 			Usage:    "Use the OAuth 2.0 device authorization grant for --push OIDC instead of opening a browser callback. Useful on headless hosts when --identity-token / COSIGN_IDENTITY_TOKEN and ambient GitHub Actions OIDC are both unavailable.",
 			Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
 			Category: catEvidence,
@@ -613,7 +613,7 @@ Run validation without failing on check errors (informational mode):
 `,
 		Flags: validateCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, "recipe", "snapshot", "output", "config", "namespace", "image", "job-name", "service-account-name", "timeout", "data", "evidence-dir", "emit-attestation", "bom", "push", "identity-token"); err != nil {
+			if err := validateSingleValueFlags(cmd, "recipe", "snapshot", "output", "config", "namespace", "image", "job-name", "service-account-name", "timeout", "data", "evidence-dir", "emit-attestation", "bom", "push", flagIdentityToken); err != nil {
 				return err
 			}
 

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -62,15 +62,24 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 		OutDir:      out,
 		BOMPath:     stringFlagOrConfig(cmd, "bom", att.BOM),
 		Push:        stringFlagOrConfig(cmd, "push", att.Push),
-		PlainHTTP:   boolFlagOrConfig(cmd, "plain-http", att.PlainHTTP),
-		InsecureTLS: boolFlagOrConfig(cmd, "insecure-tls", att.InsecureTLS),
-		OIDCResolve: bundleattest.ResolveOptions{
-			IdentityToken: cmd.String("identity-token"),
-			AmbientURL:    os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
-			AmbientToken:  os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
-			DeviceFlow:    cmd.Bool("oidc-device-flow"),
-			PromptWriter:  os.Stderr,
-		},
+		PlainHTTP:   boolFlagOrConfig(cmd, flagPlainHTTP, att.PlainHTTP),
+		InsecureTLS: boolFlagOrConfig(cmd, flagInsecureTLS, att.InsecureTLS),
+		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
+	}
+}
+
+// oidcResolveOptionsFromFlags builds the keyless-signing OIDC resolution
+// options from the shared --identity-token / --oidc-device-flow flag pair
+// plus the GitHub Actions ambient-OIDC env vars. Shared by every command
+// that signs an evidence bundle (`validate --push`, `evidence publish`) so
+// the source-precedence wiring stays in one place.
+func oidcResolveOptionsFromFlags(cmd *cli.Command) bundleattest.ResolveOptions {
+	return bundleattest.ResolveOptions{
+		IdentityToken: cmd.String(flagIdentityToken),
+		AmbientURL:    os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
+		AmbientToken:  os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+		DeviceFlow:    cmd.Bool(flagOIDCDeviceFlow),
+		PromptWriter:  os.Stderr,
 	}
 }
 

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -61,7 +61,7 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 	return &recipeEvidenceConfig{
 		OutDir:      out,
 		BOMPath:     stringFlagOrConfig(cmd, "bom", att.BOM),
-		Push:        stringFlagOrConfig(cmd, "push", att.Push),
+		Push:        stringFlagOrConfig(cmd, flagPush, att.Push),
 		PlainHTTP:   boolFlagOrConfig(cmd, flagPlainHTTP, att.PlainHTTP),
 		InsecureTLS: boolFlagOrConfig(cmd, flagInsecureTLS, att.InsecureTLS),
 		OIDCResolve: oidcResolveOptionsFromFlags(cmd),

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -141,7 +141,13 @@ func Emit(ctx context.Context, opts EmitOptions) (*EmitResult, error) {
 		"recipe", bundle.RecipeName,
 		"subjectDigest", bundle.SubjectDigest)
 
-	out, err := signAndPush(ctx, bundle, opts)
+	out, err := signAndPush(ctx, bundle, signPushOptions{
+		Push:        opts.Push,
+		PlainHTTP:   opts.PlainHTTP,
+		InsecureTLS: opts.InsecureTLS,
+		AICRVersion: opts.AICRVersion,
+		OIDCResolve: opts.OIDCResolve,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +186,19 @@ type emitOutcome struct {
 	PushSummary *PushResult
 }
 
+// signPushOptions is the subset of EmitOptions the sign+push leg
+// consumes. Pulling it out of EmitOptions lets both Emit (which builds
+// the bundle in-memory) and Publish (which loads a pre-built bundle from
+// disk) drive the identical pipeline without sharing the build-only
+// fields (Recipe, Snapshot, PhaseResults, …).
+type signPushOptions struct {
+	Push        string
+	PlainHTTP   bool
+	InsecureTLS bool
+	AICRVersion string
+	OIDCResolve bundleattest.ResolveOptions
+}
+
 // signAndPush handles the optional sign+push pipeline. Returns a
 // zero-valued outcome when Push is absent.
 //
@@ -187,11 +206,11 @@ type emitOutcome struct {
 //  1. Push the bundle directory as an OCI artifact → artifactDigest.
 //  2. Build an artifact-subject Statement (subject.digest = artifactDigest)
 //     carrying the same predicate body.
-//  3. Resolve the OIDC token (deferred until here — see EmitOptions.OIDCResolve).
+//  3. Resolve the OIDC token (deferred until here — see signPushOptions.OIDCResolve).
 //  4. Sign the Statement → Sigstore Bundle JSON.
 //  5. Attach the Sigstore Bundle as an OCI Referrer so cosign's
 //     /v2/<name>/referrers/<digest> discovery finds the signature.
-func signAndPush(ctx context.Context, bundle *Bundle, opts EmitOptions) (emitOutcome, error) {
+func signAndPush(ctx context.Context, bundle *Bundle, opts signPushOptions) (emitOutcome, error) {
 	if opts.Push == "" {
 		return emitOutcome{}, nil
 	}

--- a/pkg/evidence/attestation/emit_test.go
+++ b/pkg/evidence/attestation/emit_test.go
@@ -130,7 +130,7 @@ func TestBuildPointerInputsFromOutcome_SignedWithoutRekorLeavesIndexNil(t *testi
 
 func TestSignAndPush_NoPushReturnsZeroOutcome(t *testing.T) {
 	bundle := &Bundle{SummaryDir: "/tmp/x"}
-	out, err := signAndPush(context.Background(), bundle, EmitOptions{})
+	out, err := signAndPush(context.Background(), bundle, signPushOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/evidence/attestation/publish.go
+++ b/pkg/evidence/attestation/publish.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/oci"
+)
+
+// PublishOptions controls a single Publish run. Publish operates on an
+// already-emitted on-disk bundle so the cluster-bound validate step and
+// the Fulcio/Rekor-bound signing step can run on different networks (see
+// ADR-007 and issue #1130).
+type PublishOptions struct {
+	// BundleDir is the on-disk evidence directory. It may be either the
+	// OutDir that `validate --emit-attestation` wrote (holds
+	// summary-bundle/ and is where pointer.yaml is written) or the
+	// summary-bundle/ directory itself.
+	BundleDir string
+
+	// Push is the OCI reference the summary bundle is pushed to. Unlike
+	// Emit, Push is required: a publish with nothing to push is a no-op.
+	Push        string
+	PlainHTTP   bool
+	InsecureTLS bool
+
+	// AICRVersion is stamped into the pushed OCI manifest's annotations.
+	// It does not alter the signed predicate, which is read verbatim from
+	// the bundle's statement.intoto.json — the bundle bytes (and their
+	// baked-in attestedAt timestamp) are signed as-is.
+	AICRVersion string
+
+	// OIDCResolve configures keyless-signing token resolution. Resolution
+	// is deferred until adjacent to SignStatement so Fulcio's
+	// nonce-binding window is respected.
+	OIDCResolve bundleattest.ResolveOptions
+}
+
+// Publish signs and pushes an already-emitted recipe-evidence v1 bundle,
+// then writes pointer.yaml beside it. It is the off-network second leg of
+// the workflow whose first leg is `aicr validate --emit-attestation`
+// (no --push): that step produces the unsigned on-disk bundle this one
+// consumes.
+//
+// The output is identical to the one-shot `validate --emit-attestation
+// --push` path: the predicate signed here is read verbatim from the
+// bundle's statement.intoto.json, so the timestamp baked at emit time is
+// preserved and the resulting signed artifact is content-identical
+// regardless of which host ran which leg.
+//
+// The *EmitResult return mirrors Emit for the future API surface: it carries
+// PushSummary's ref+digest and the Sign/Rekor info an API handler would
+// serialize. The success path that populates it requires a live push + Fulcio
+// sign, which unit tests can't exercise, so no in-repo caller consumes it yet.
+//
+//nolint:unparam // result is returned for the future API surface; see above.
+func Publish(ctx context.Context, opts PublishOptions) (*EmitResult, error) {
+	if opts.Push == "" {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "push reference is required for publish")
+	}
+	// Validate the ref up front so a malformed reference doesn't waste a
+	// Fulcio cert + Rekor inclusion proof on a sign the push would reject.
+	if _, err := oci.ParseOutputTarget(opts.Push); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid push reference", err)
+	}
+
+	bundle, outDir, err := loadOnDiskBundle(opts.BundleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("publishing evidence bundle",
+		"summaryDir", bundle.SummaryDir,
+		"recipe", bundle.RecipeName,
+		"push", opts.Push)
+
+	out, err := signAndPush(ctx, bundle, signPushOptions{
+		Push:        opts.Push,
+		PlainHTTP:   opts.PlainHTTP,
+		InsecureTLS: opts.InsecureTLS,
+		AICRVersion: opts.AICRVersion,
+		OIDCResolve: opts.OIDCResolve,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pointer, err := BuildPointer(buildPointerInputsFromOutcome(bundle, out))
+	if err != nil {
+		return nil, err
+	}
+	pointerPath, err := WritePointer(outDir, pointer)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("evidence pointer written",
+		"path", pointerPath,
+		"copyTo", "recipes/evidence/"+bundle.RecipeName+".yaml")
+
+	if out.PushSummary != nil {
+		slog.Info("evidence bundle pushed",
+			"reference", out.PushSummary.Reference,
+			"digest", out.PushSummary.Digest)
+	}
+
+	return &EmitResult{
+		Bundle:      bundle,
+		PointerPath: pointerPath,
+		Sign:        out.Sign,
+		PushSummary: out.PushSummary,
+	}, nil
+}
+
+// loadOnDiskBundle resolves the summary-bundle directory and the
+// pointer-output directory from a user-supplied path, then reconstructs
+// the minimal *Bundle the sign+push leg needs by reading the bundle's
+// unsigned in-toto Statement. The predicate is trusted as-is — Publish
+// signs the pre-built bundle bytes verbatim; integrity auditing is the
+// job of `aicr evidence verify`.
+func loadOnDiskBundle(dir string) (*Bundle, string, error) {
+	if dir == "" {
+		return nil, "", errors.New(errors.ErrCodeInvalidRequest, "bundle directory is required")
+	}
+	summaryDir, outDir, err := resolveSummaryDir(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	pred, stmt, err := readBundlePredicate(summaryDir)
+	if err != nil {
+		return nil, "", err
+	}
+	if pred.Recipe.Name == "" || pred.Recipe.Digest == "" {
+		return nil, "", errors.New(errors.ErrCodeInvalidRequest,
+			"bundle statement predicate is missing recipe.{name,digest}")
+	}
+	return &Bundle{
+		SummaryDir:    summaryDir,
+		RecipeName:    pred.Recipe.Name,
+		SubjectDigest: pred.Recipe.Digest,
+		Predicate:     pred,
+		StatementJSON: stmt,
+	}, outDir, nil
+}
+
+// resolveSummaryDir accepts either the summary-bundle root or a parent
+// containing it (mirroring `aicr evidence verify`'s directory handling).
+// It returns the summary directory to push and the directory pointer.yaml
+// should be written to. When dir is the summary bundle itself, the
+// pointer lands in its parent so the on-disk layout matches the one-shot
+// `validate --emit-attestation --push` output (pointer.yaml beside
+// summary-bundle/).
+func resolveSummaryDir(dir string) (summaryDir, outDir string, err error) {
+	clean := filepath.Clean(dir)
+	if HasBundleMarkers(clean) {
+		return clean, filepath.Dir(clean), nil
+	}
+	candidate := filepath.Join(clean, SummaryBundleDirName)
+	if HasBundleMarkers(candidate) {
+		return candidate, clean, nil
+	}
+	return "", "", errors.New(errors.ErrCodeInvalidRequest,
+		"directory "+dir+" does not look like an evidence bundle "+
+			"(no recipe.yaml / manifest.json at root or under summary-bundle/)")
+}
+
+// HasBundleMarkers reports whether dir holds the two files every summary
+// bundle carries at its root. recipe.yaml + manifest.json together are a
+// reliable discriminator: the unsigned Statement and BOM share names with
+// other artifacts, but this pair only co-occurs in a summary bundle. It is
+// the single source of truth for "is this directory a summary bundle?",
+// shared by the publish path here and the verifier's materialization.
+func HasBundleMarkers(dir string) bool {
+	for _, f := range []string{RecipeFilename, ManifestFilename} {
+		info, statErr := os.Stat(filepath.Join(dir, f))
+		if statErr != nil || info.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+// readBundlePredicate reads the bundle's unsigned in-toto Statement and
+// returns the predicate body plus the raw statement bytes. Mirrors the
+// verifier's loadUnsignedPredicate: the predicate is trusted as-is.
+func readBundlePredicate(summaryDir string) (*Predicate, []byte, error) {
+	path := filepath.Join(summaryDir, StatementFilename)
+	body, err := os.ReadFile(path) //nolint:gosec // bundle-local path
+	if err != nil {
+		return nil, nil, errors.Wrap(errors.ErrCodeNotFound, "failed to read in-toto Statement", err)
+	}
+	var envelope struct {
+		PredicateType string    `json:"predicateType"`
+		Predicate     Predicate `json:"predicate"`
+	}
+	if uErr := json.Unmarshal(body, &envelope); uErr != nil {
+		return nil, nil, errors.Wrap(errors.ErrCodeInvalidRequest, "statement is not valid JSON", uErr)
+	}
+	if envelope.PredicateType != PredicateTypeV1 {
+		return nil, nil, errors.New(errors.ErrCodeInvalidRequest,
+			"unexpected predicateType "+envelope.PredicateType)
+	}
+	return &envelope.Predicate, body, nil
+}

--- a/pkg/evidence/attestation/publish.go
+++ b/pkg/evidence/attestation/publish.go
@@ -17,11 +17,14 @@ package attestation
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/oci"
 )
@@ -204,9 +207,23 @@ func HasBundleMarkers(dir string) bool {
 // verifier's loadUnsignedPredicate: the predicate is trusted as-is.
 func readBundlePredicate(summaryDir string) (*Predicate, []byte, error) {
 	path := filepath.Join(summaryDir, StatementFilename)
-	body, err := os.ReadFile(path) //nolint:gosec // bundle-local path
+	// Bound the read: a publish target may be an attacker-influenced bundle
+	// root (extracted archive, symlinked path) where os.ReadFile would
+	// allocate the whole file before any size check. Mirrors the verifier's
+	// readBoundedFile against the same defaults cap.
+	f, err := os.Open(path) //nolint:gosec // bundle-local path resolved by resolveSummaryDir
 	if err != nil {
 		return nil, nil, errors.Wrap(errors.ErrCodeNotFound, "failed to read in-toto Statement", err)
+	}
+	defer func() { _ = f.Close() }()
+	body, err := io.ReadAll(io.LimitReader(f, defaults.MaxAttestationFileBytes+1))
+	if err != nil {
+		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to read in-toto Statement", err)
+	}
+	if int64(len(body)) > defaults.MaxAttestationFileBytes {
+		return nil, nil, errors.New(errors.ErrCodeInvalidRequest,
+			"in-toto Statement exceeds maximum size of "+
+				strconv.FormatInt(defaults.MaxAttestationFileBytes, 10)+" bytes")
 	}
 	var envelope struct {
 		PredicateType string    `json:"predicateType"`

--- a/pkg/evidence/attestation/publish.go
+++ b/pkg/evidence/attestation/publish.go
@@ -70,25 +70,24 @@ type PublishOptions struct {
 // preserved and the resulting signed artifact is content-identical
 // regardless of which host ran which leg.
 //
-// The *EmitResult return mirrors Emit for the future API surface: it carries
-// PushSummary's ref+digest and the Sign/Rekor info an API handler would
-// serialize. The success path that populates it requires a live push + Fulcio
-// sign, which unit tests can't exercise, so no in-repo caller consumes it yet.
-//
-//nolint:unparam // result is returned for the future API surface; see above.
-func Publish(ctx context.Context, opts PublishOptions) (*EmitResult, error) {
+// Publish returns only an error: unlike Emit (whose EmitResult is exercised by
+// tests), no in-repo caller consumes Publish's artifacts, and the populated
+// success path needs a live push + Fulcio sign that unit tests can't reach. A
+// future API handler that needs PushSummary/Sign can reintroduce the richer
+// return when a real caller exists.
+func Publish(ctx context.Context, opts PublishOptions) error {
 	if opts.Push == "" {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "push reference is required for publish")
+		return errors.New(errors.ErrCodeInvalidRequest, "push reference is required for publish")
 	}
 	// Validate the ref up front so a malformed reference doesn't waste a
 	// Fulcio cert + Rekor inclusion proof on a sign the push would reject.
 	if _, err := oci.ParseOutputTarget(opts.Push); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid push reference", err)
+		return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid push reference", err)
 	}
 
 	bundle, outDir, err := loadOnDiskBundle(opts.BundleDir)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	slog.Info("publishing evidence bundle",
@@ -104,16 +103,16 @@ func Publish(ctx context.Context, opts PublishOptions) (*EmitResult, error) {
 		OIDCResolve: opts.OIDCResolve,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	pointer, err := BuildPointer(buildPointerInputsFromOutcome(bundle, out))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	pointerPath, err := WritePointer(outDir, pointer)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	slog.Info("evidence pointer written",
@@ -126,12 +125,7 @@ func Publish(ctx context.Context, opts PublishOptions) (*EmitResult, error) {
 			"digest", out.PushSummary.Digest)
 	}
 
-	return &EmitResult{
-		Bundle:      bundle,
-		PointerPath: pointerPath,
-		Sign:        out.Sign,
-		PushSummary: out.PushSummary,
-	}, nil
+	return nil
 }
 
 // loadOnDiskBundle resolves the summary-bundle directory and the
@@ -182,7 +176,7 @@ func resolveSummaryDir(dir string) (summaryDir, outDir string, err error) {
 		return candidate, clean, nil
 	}
 	return "", "", errors.New(errors.ErrCodeInvalidRequest,
-		"directory "+dir+" does not look like an evidence bundle "+
+		"directory "+dir+" does not look like a summary bundle "+
 			"(no recipe.yaml / manifest.json at root or under summary-bundle/)")
 }
 

--- a/pkg/evidence/attestation/publish_test.go
+++ b/pkg/evidence/attestation/publish_test.go
@@ -64,13 +64,13 @@ func wantInvalidRequest(t *testing.T, err error) {
 }
 
 func TestPublish_RequiresPush(t *testing.T) {
-	_, err := Publish(context.Background(), PublishOptions{BundleDir: t.TempDir()})
+	err := Publish(context.Background(), PublishOptions{BundleDir: t.TempDir()})
 	wantInvalidRequest(t, err)
 }
 
 func TestPublish_InvalidPushReference(t *testing.T) {
 	dir := emitUnsignedBundle(t)
-	_, err := Publish(context.Background(), PublishOptions{
+	err := Publish(context.Background(), PublishOptions{
 		BundleDir: dir,
 		Push:      "oci://not a valid ref",
 	})
@@ -80,7 +80,7 @@ func TestPublish_InvalidPushReference(t *testing.T) {
 func TestPublish_MissingBundleDir(t *testing.T) {
 	// A valid push ref but a directory with no bundle markers must fail
 	// before any network work.
-	_, err := Publish(context.Background(), PublishOptions{
+	err := Publish(context.Background(), PublishOptions{
 		BundleDir: t.TempDir(),
 		Push:      "ghcr.io/example/aicr-evidence",
 	})

--- a/pkg/evidence/attestation/publish_test.go
+++ b/pkg/evidence/attestation/publish_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+)
+
+// emitUnsignedBundle produces a real on-disk, unsigned bundle (the
+// artifact `validate --emit-attestation` without --push leaves behind)
+// and returns the OutDir that holds summary-bundle/ + pointer.yaml.
+func emitUnsignedBundle(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	rec := &recipe.RecipeResult{
+		Kind:       "RecipeResult",
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Criteria: &recipe.Criteria{
+			Service:     recipe.CriteriaServiceEKS,
+			Accelerator: recipe.CriteriaAcceleratorH100,
+			Intent:      recipe.CriteriaIntentTraining,
+		},
+	}
+	_, err := Emit(context.Background(), EmitOptions{
+		OutDir:      dir,
+		Recipe:      rec,
+		Snapshot:    &snapshotter.Snapshot{},
+		AICRVersion: "v0.0.0-test",
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	return dir
+}
+
+func wantInvalidRequest(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+	}
+}
+
+func TestPublish_RequiresPush(t *testing.T) {
+	_, err := Publish(context.Background(), PublishOptions{BundleDir: t.TempDir()})
+	wantInvalidRequest(t, err)
+}
+
+func TestPublish_InvalidPushReference(t *testing.T) {
+	dir := emitUnsignedBundle(t)
+	_, err := Publish(context.Background(), PublishOptions{
+		BundleDir: dir,
+		Push:      "oci://not a valid ref",
+	})
+	wantInvalidRequest(t, err)
+}
+
+func TestPublish_MissingBundleDir(t *testing.T) {
+	// A valid push ref but a directory with no bundle markers must fail
+	// before any network work.
+	_, err := Publish(context.Background(), PublishOptions{
+		BundleDir: t.TempDir(),
+		Push:      "ghcr.io/example/aicr-evidence",
+	})
+	wantInvalidRequest(t, err)
+}
+
+func TestLoadOnDiskBundle_ParentDir(t *testing.T) {
+	dir := emitUnsignedBundle(t)
+
+	bundle, outDir, err := loadOnDiskBundle(dir)
+	if err != nil {
+		t.Fatalf("loadOnDiskBundle: %v", err)
+	}
+	if outDir != filepath.Clean(dir) {
+		t.Errorf("outDir = %q, want %q (pointer beside summary-bundle/)", outDir, dir)
+	}
+	if bundle.SummaryDir != filepath.Join(dir, SummaryBundleDirName) {
+		t.Errorf("SummaryDir = %q, want %q", bundle.SummaryDir, filepath.Join(dir, SummaryBundleDirName))
+	}
+	if bundle.RecipeName != "h100-eks-training" {
+		t.Errorf("RecipeName = %q, want h100-eks-training", bundle.RecipeName)
+	}
+	if bundle.Predicate == nil || bundle.SubjectDigest == "" {
+		t.Fatalf("expected populated Predicate + SubjectDigest, got %+v", bundle)
+	}
+	if bundle.SubjectDigest != bundle.Predicate.Recipe.Digest {
+		t.Errorf("SubjectDigest %q != predicate.recipe.digest %q",
+			bundle.SubjectDigest, bundle.Predicate.Recipe.Digest)
+	}
+}
+
+func TestLoadOnDiskBundle_SummaryDirItself(t *testing.T) {
+	dir := emitUnsignedBundle(t)
+	summaryDir := filepath.Join(dir, SummaryBundleDirName)
+
+	bundle, outDir, err := loadOnDiskBundle(summaryDir)
+	if err != nil {
+		t.Fatalf("loadOnDiskBundle: %v", err)
+	}
+	// Pointing at summary-bundle/ directly puts the pointer in its parent,
+	// matching the one-shot output layout.
+	if outDir != filepath.Clean(dir) {
+		t.Errorf("outDir = %q, want parent %q", outDir, dir)
+	}
+	if bundle.SummaryDir != filepath.Clean(summaryDir) {
+		t.Errorf("SummaryDir = %q, want %q", bundle.SummaryDir, summaryDir)
+	}
+}
+
+func TestLoadOnDiskBundle_EmptyArg(t *testing.T) {
+	_, _, err := loadOnDiskBundle("")
+	wantInvalidRequest(t, err)
+}
+
+func TestResolveSummaryDir_NotABundle(t *testing.T) {
+	_, _, err := resolveSummaryDir(t.TempDir())
+	wantInvalidRequest(t, err)
+}
+
+func TestReadBundlePredicate_MissingStatement(t *testing.T) {
+	_, _, err := readBundlePredicate(t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error for missing statement")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("expected ErrCodeNotFound, got %v", err)
+	}
+}
+
+func TestReadBundlePredicate_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, StatementFilename), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := readBundlePredicate(dir)
+	wantInvalidRequest(t, err)
+}
+
+func TestReadBundlePredicate_WrongPredicateType(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`{"predicateType":"https://example.com/other/v1","predicate":{}}`)
+	if err := os.WriteFile(filepath.Join(dir, StatementFilename), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := readBundlePredicate(dir)
+	wantInvalidRequest(t, err)
+}
+
+func TestLoadOnDiskBundle_MissingRecipeIdentity(t *testing.T) {
+	// A V1 statement whose predicate lacks recipe.{name,digest} must be
+	// rejected — BuildArtifactStatement requires both downstream.
+	dir := t.TempDir()
+	summaryDir := filepath.Join(dir, SummaryBundleDirName)
+	if err := os.MkdirAll(summaryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{RecipeFilename, ManifestFilename} {
+		if err := os.WriteFile(filepath.Join(summaryDir, f), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	body := []byte(`{"predicateType":"` + PredicateTypeV1 + `","predicate":{"recipe":{}}}`)
+	if err := os.WriteFile(filepath.Join(summaryDir, StatementFilename), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := loadOnDiskBundle(dir)
+	wantInvalidRequest(t, err)
+}

--- a/pkg/evidence/verifier/fetch.go
+++ b/pkg/evidence/verifier/fetch.go
@@ -106,26 +106,16 @@ func MaterializeBundle(
 // containing it. Bundles are recognized by recipe.yaml + manifest.json
 // at the candidate root.
 func materializeDir(input string) (*MaterializedBundle, error) {
-	if hasBundleMarkers(input) {
+	if attestation.HasBundleMarkers(input) {
 		return &MaterializedBundle{BundleDir: filepath.Clean(input)}, nil
 	}
 	candidate := filepath.Join(input, attestation.SummaryBundleDirName)
-	if hasBundleMarkers(candidate) {
+	if attestation.HasBundleMarkers(candidate) {
 		return &MaterializedBundle{BundleDir: filepath.Clean(candidate)}, nil
 	}
 	return nil, errors.New(errors.ErrCodeInvalidRequest,
 		"directory "+input+" does not look like a summary bundle "+
 			"(no recipe.yaml / manifest.json at root or under summary-bundle/)")
-}
-
-func hasBundleMarkers(dir string) bool {
-	for _, f := range []string{attestation.RecipeFilename, attestation.ManifestFilename} {
-		info, err := os.Stat(filepath.Join(dir, f))
-		if err != nil || info.IsDir() {
-			return false
-		}
-	}
-	return true
 }
 
 // materializeFromPointer pulls the OCI artifact named in the pointer's
@@ -367,11 +357,11 @@ func fetchAndWriteReferrerLayer(ctx context.Context, repo referrerFetcher, refer
 // resolveBundleDir picks the bundle root from a temp dir holding the
 // pulled or extracted layer contents.
 func resolveBundleDir(dir string) (string, error) {
-	if hasBundleMarkers(dir) {
+	if attestation.HasBundleMarkers(dir) {
 		return dir, nil
 	}
 	candidate := filepath.Join(dir, attestation.SummaryBundleDirName)
-	if hasBundleMarkers(candidate) {
+	if attestation.HasBundleMarkers(candidate) {
 		return candidate, nil
 	}
 	return "", errors.New(errors.ErrCodeInvalidRequest,


### PR DESCRIPTION
## Summary

Add `aicr evidence publish <bundle-dir> --push <ref>`, which signs, pushes, and writes the pointer for an evidence bundle that `aicr validate --emit-attestation` (without `--push`) left on disk — splitting the one-shot path into a cluster-bound leg and a Sigstore-bound leg.

## Motivation / Context

The one-shot `validate --emit-attestation --push` requires one host to reach **both** the target cluster *and* Fulcio/Rekor. In practice those live on different networks: validation needs the cluster (often behind a corporate VPN), while keyless signing needs public Sigstore egress (frequently blocked on that same VPN). This change lets the two legs run on different hosts/networks without changing the signed artifact.

Because the predicate — including its baked-in `attestedAt` timestamp — is read verbatim from the bundle's `statement.intoto.json`, the published result is byte-for-byte identical to the one-shot output regardless of which host ran which leg.

Fixes: #1130
Related: ADR-007 (`docs/design/007-recipe-evidence.md`)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: evidence (`pkg/evidence/attestation`, `pkg/evidence/verifier`)

## Implementation Notes

- **New command** `aicr evidence publish` and **new `attestation.Publish`** entry point. Publish loads a pre-built on-disk bundle, validates the `--push` ref up front (so a malformed ref doesn't waste a Fulcio cert + Rekor inclusion proof), signs the unsigned `statement.intoto.json` verbatim, pushes as an OCI artifact, attaches the Sigstore bundle as an OCI referrer, and writes `pointer.yaml`.
- **Shared sign+push pipeline.** Refactored the sign+push leg out of `EmitOptions` into a `signPushOptions` struct so both `Emit` (in-memory bundle) and `Publish` (on-disk bundle) drive the identical pipeline without sharing build-only fields (Recipe/Snapshot/PhaseResults).
- **Shared OIDC resolution.** `oidcResolveOptionsFromFlags` centralizes the `--identity-token` / `COSIGN_IDENTITY_TOKEN` / ambient-GHA / `--oidc-device-flow` precedence chain across `validate --push` and `evidence publish`. Token resolution stays deferred until adjacent to signing so Fulcio's nonce-binding window is respected.
- **Bundle discrimination** via `HasBundleMarkers` (recipe.yaml + manifest.json co-occurrence), accepting either the parent dir or `summary-bundle/` itself, mirroring the verifier's directory handling.

## Testing

```bash
# Targeted gate on affected packages (race + lint + gofmt)
go test -race ./pkg/cli/... ./pkg/evidence/...      # all ok
golangci-lint run -c .golangci.yaml ./pkg/cli/... ./pkg/evidence/...   # 0 issues
```

Plus a full **live end-to-end run** against a real EKS GB200 (Ubuntu, Dynamo) cluster:

1. `validate --emit-attestation ./out` (no `--push`) — all phases passed (deployment / performance / conformance), unsigned bundle written.
2. `evidence publish ./out --push ttl.sh/…:72h` — pushed, Fulcio keyless-signed (Rekor log index recorded), Sigstore bundle attached as referrer, `pointer.yaml` populated.
3. `evidence verify` confirmed **exit 0** across all three input modes (OCI digest ref, pointer file); the tag-only ref was correctly rejected.

Verified the cross-host content-addressability guarantee held: `attestedAt` from leg 1 was preserved verbatim in the signed output from leg 2.

> Note: `make qualify`'s cluster-bound e2e was exercised manually against live hardware rather than via the KWOK path; unit/lint gates run clean.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Purely additive — new subcommand + new exported `Publish`. The existing one-shot `validate --emit-attestation --push` path is unchanged (the refactor is internal and output-preserving). No migration required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
