### PR TITLE
docs(contributor): address PR #1143 review feedback

### DIFF
--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -49,7 +49,7 @@ All server code lives in [`pkg/server`](https://github.com/NVIDIA/aicr/tree/main
 ## Middleware Chain
 
 Composition lives in `withMiddleware` in
-[`middleware.go`](https://github.com/NVIDIA/aicr/blob/main/pkg/server/middleware.go#L45-L61).
+[`pkg/server/middleware.go`](https://github.com/NVIDIA/aicr/blob/main/pkg/server/middleware.go).
 Order is **outermost first**:
 
 | # | Layer | Purpose |
@@ -113,7 +113,7 @@ if err := json.NewDecoder(bounded).Decode(&recipeResult); err != nil {
 ### Error responses and the 5xx cause-leak rule
 
 All errors flow through
-[`WriteErrorFromErr`](https://github.com/NVIDIA/aicr/blob/main/pkg/server/errors.go#L127).
+[`WriteErrorFromErr`](https://github.com/NVIDIA/aicr/blob/main/pkg/server/errors.go).
 It maps a `*errors.StructuredError` to an HTTP status via `httpStatusFromCode`
 and serializes the `ErrorResponse` shape (`code`, `message`, `details`,
 `requestId`, `timestamp`, `retryable`).

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -179,6 +179,7 @@ both entry points share it. Adding business logic to `pkg/cli` or
 | `pkg/client/v1` | `aicr.Client` facade — shared SDK used by CLI, server, and external Go callers |
 | **Recipe and data** | |
 | `pkg/recipe` | Recipe resolution, overlay/mixin composition, registry. [recipe.md](recipe.md) |
+| `pkg/recipe/oskind` | Single source of truth for OS criterion string values (`ubuntu`, `rhel`, `cos`, `amazonlinux`, `talos`). Imported by `pkg/recipe`, `pkg/collector`, `pkg/snapshotter`, and the CLI. |
 | `pkg/constraints` | Declarative constraint operators (`>=`, `<=`, tolerance) and evaluation |
 | `pkg/measurement` | Schema for collector output and validator input |
 | `pkg/serializer` | Deterministic YAML/JSON for evidence and bundles |

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -59,7 +59,7 @@ A recipe PR touches `recipes/overlays/`, `recipes/mixins/`,
 2. **The BOM stays in sync.** `make bom-docs` must have been run; the
    `docs/user/container-images.md` change must be present in the PR
    when a chart pin or values file changed. See
-   [recipe.md](recipe.md#bom-regeneration-rule).
+   [recipe.md](recipe.md#bom-regeneration).
 3. **The configuration is correct on the target hardware.** This is
    the hard one — maintainers cannot run a contributor's GB200 recipe
    on an H100. ADR-007 closes that gap with bundled evidence.

--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -292,7 +292,12 @@ proceeds in fixed precedence (low → high):
 
 ```text
 registry defaults → mixin → base chain → overlay leaf → CLI/API --set
+(lowest priority)                                       (highest priority)
 ```
+
+Each step wins over everything to its left — `--set` overrides the
+overlay leaf, the leaf overrides the base chain, and so on. Read as
+priority, not as temporal order.
 
 Implementation notes:
 

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -104,6 +104,14 @@ per run. Per-phase containers are built from
 `ParsePhaseSelection` collapses it to nil-meaning-everything. It is
 **exclusive** — combining `all` with any other phase is rejected.
 
+`readiness` is also a field on `ValidationConfig` (see
+`pkg/recipe/validation.go`) and appears in overlay examples, but it
+is **not** a container-per-validator phase. Readiness runs as
+inline constraint evaluation in
+`pkg/validator/validator.go::checkReadiness` before any phase
+container is scheduled — see [Constraints](#constraints-declarative)
+above for how the evaluator works.
+
 ### Quick start
 
 Three steps to add a check to an existing validator container.


### PR DESCRIPTION
## Summary

Five follow-up fixes against @pdmack's [review](https://github.com/NVIDIA/aicr/pull/1143#pullrequestreview-4411351315) of #1143 (already merged):

| # | File | Fix |
|---|------|-----|
| 1 | `docs/contributor/maintaining.md:62` | Broken anchor: `recipe.md#bom-regeneration-rule` → `recipe.md#bom-regeneration` (heading has no \`-rule\` suffix) |
| 2 | `docs/contributor/validator.md` | Add a note that \`readiness\` is a \`ValidationConfig\` field evaluated inline by \`checkReadiness\`, not a container-per-validator phase |
| 3 | `docs/contributor/index.md` package table | Add \`pkg/recipe/oskind\` row (it's imported by pkg/recipe, pkg/collector, pkg/snapshotter, and the CLI) |
| 4 | `docs/contributor/recipe.md` merge-precedence arrow | Annotate with \`(lowest priority)\` / \`(highest priority)\` and note that the arrow is priority, not temporal order |
| 5 | `docs/contributor/api-server.md` | Drop fragile line-range links (\`middleware.go#L45-L61\`, \`errors.go#L127\`) — they go stale silently on file edits |

## Motivation/Context

Follow-up to the contributor docs rewrite (#1143). The five items above were raised in review but the PR had already been merged. This PR resolves the residual feedback.

Fixes: #1143 (review follow-up)

## Type of Change

Documentation only.

## Components Affected

- \`area/docs\` — five files in \`docs/contributor/\`

## Testing

- \`make lint\` green
- Anchor target verified by inspecting \`recipe.md\` heading (\`## BOM Regeneration\` on line 416)
- All relative links and anchors validated

## Risk Assessment

Low. Doc-only.

## Checklist

- [x] \`make lint\` passes locally
- [x] Anchors verified
- [x] Commit signed