### PR TITLE
fix(docs): cover contributor docs in MDX check; catch autolinks

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -457,8 +457,9 @@ spec:
 Use Chainsaw's `assert` (expected match), `error` (unexpected match
 must not exist), and `script` (shell). Always include an existence
 guard before phase assertions so an empty namespace can't yield a
-vacuous pass. Full Chainsaw operator reference:
-<https://kyverno.github.io/chainsaw/latest/operations/check/assert/>.
+vacuous pass. See the
+[Chainsaw assert reference](https://kyverno.github.io/chainsaw/latest/operations/check/assert/)
+for the full operator list.
 
 **Running:**
 

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -63,12 +63,13 @@ for dir in "${SEARCH_DIRS[@]}"; do
         line = $0
         gsub(/`[^`]*`/, "", line)
       }
-      # Bare { not preceded by backslash escape
-      line ~ /[^\\]{/ {
+      # Bare { not preceded by backslash escape. The leading
+      # (^|[^\\]) form catches { in column 1 as well.
+      line ~ /(^|[^\\])\{/ {
         printf "MDX: bare { outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }
-      /<!--/ {
+      line ~ /<!--/ {
         printf "MDX: HTML comment outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -8,9 +8,8 @@
 # are valid in plain markdown but invalid in JSX. This script catches the
 # common violations before they reach CI or break versioned doc snapshots.
 #
-# Scope: docs/user/ and docs/integrator/ (published to Fern).
-# Contributor and design docs are code-heavy and excluded from brace/comment
-# checks. container-images.md is auto-generated with HTML comment markers
+# Scope: docs/user/, docs/integrator/, and docs/contributor/ (all published
+# to Fern). container-images.md is auto-generated with HTML comment markers
 # that VitePress still needs; excluded until VitePress is removed.
 # Override with positional args for frozen version content.
 #
@@ -18,11 +17,13 @@
 #   1. Non-self-closing void HTML elements (<br>, <hr>, <img>, etc.)
 #   2. Bare { } outside fenced code blocks (MDX interprets as JSX expressions)
 #   3. HTML comments (<!-- -->) outside fenced code blocks
+#   4. Autolinks (<https://...> / <http://...>) outside fenced and inline code
+#      — MDX tries to parse them as JSX tags and chokes on the `://`.
 
 set -euo pipefail
 
 ERRORS=0
-SEARCH_DIRS=("docs/user/" "docs/integrator/")
+SEARCH_DIRS=("docs/user/" "docs/integrator/" "docs/contributor/")
 EXCLUDE="container-images.md"
 
 # Allow overriding the search path (e.g., for frozen version content)
@@ -48,27 +49,33 @@ for dir in "${SEARCH_DIRS[@]}"; do
   done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) ! -name "${EXCLUDE}" 2>/dev/null)
 done
 
-# --- Check 2 & 3: bare braces and HTML comments outside fenced code blocks ---
+# --- Checks 2, 3, 4: bare braces, HTML comments, and autolinks ---
+# All evaluated outside fenced code blocks; inline code spans are stripped
+# before the line is scanned so legitimate uses inside backticks don't trip.
 for dir in "${SEARCH_DIRS[@]}"; do
   while IFS= read -r file; do
     [[ -z "${file}" ]] && continue
-    # awk tracks fenced-block state and reports violations with line numbers
     awk '
       /^```/ { in_fence = !in_fence; next }
       in_fence { next }
-      # Bare { not preceded by backslash escape
-      /[^\\]{/ {
-        # Skip lines that are pure inline code (single backtick-wrapped)
+      {
+        # Strip inline code spans so backticked tokens don'\''t trigger.
         line = $0
-        # Strip all inline code spans before checking
         gsub(/`[^`]*`/, "", line)
-        if (line ~ /[^\\]{/) {
-          printf "MDX: bare { outside code fence: %s:%d: %s\n", FILENAME, NR, $0
-          errors++
-        }
+      }
+      # Bare { not preceded by backslash escape
+      line ~ /[^\\]{/ {
+        printf "MDX: bare { outside code fence: %s:%d: %s\n", FILENAME, NR, $0
+        errors++
       }
       /<!--/ {
         printf "MDX: HTML comment outside code fence: %s:%d: %s\n", FILENAME, NR, $0
+        errors++
+      }
+      # Autolinks: <https://...> or <http://...>. The `://` breaks MDX'\''s
+      # JSX tag parser. Use markdown link syntax [text](url) instead.
+      line ~ /<https?:\/\// {
+        printf "MDX: autolink outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }
       END { exit (errors > 0) ? 1 : 0 }
@@ -84,8 +91,9 @@ if [[ ${ERRORS} -gt 0 ]]; then
   echo "ERROR: MDX safety violations found."
   echo ""
   echo "Common fixes:"
-  echo "  <br>  → <br />        <img src=...>  → <img src=... />"
-  echo "  {foo} → \\{foo\\}      <!-- ... -->   → remove or use {/* ... */}"
+  echo "  <br>  → <br />          <img src=...>  → <img src=... />"
+  echo "  {foo} → \\{foo\\}        <!-- ... -->   → remove or use {/* ... */}"
+  echo "  <https://example.com>  → [example](https://example.com)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Closes #1148.

Expand \`tools/check-docs-mdx\` to scope \`docs/contributor/\` and add a new check for markdown autolinks (\`<https://...>\` / \`<http://...>\`) that break the MDX parser on the \`://\`. Fix the one offending autolink in \`docs/contributor/validator.md:461\` that slipped through when \#1143 added contributor docs to the Fern sidebar.

## Motivation/Context

PR \#1143 added \`docs/contributor/\` to the Fern sidebar, so contributor docs are now MDX-rendered. But the safety check in \`tools/check-docs-mdx\` only scoped \`docs/user/\` and \`docs/integrator/\`. \`validator.md:461\` had a \`<https://kyverno.github.io/...>\` autolink that broke MDX parsing with:

\`\`\`
Failed to parse ../docs/contributor/validator.md: Unexpected character \`/\` (U+002F) before local name
\`\`\`

Fixes: \#1148

## Type of Change

Bug fix (tooling + docs).

## Implementation Notes

**Three changes:**

1. \`SEARCH_DIRS\` in \`tools/check-docs-mdx\` now includes \`docs/contributor/\`.
2. New **Check 4** flags autolinks outside fenced code and inline code. The actual MDX-breaker class — once that fires, the \`://\` confuses the JSX tag parser.
3. \`docs/contributor/validator.md:461\` autolink rewritten as a markdown link.

**On the issue's listed 14 \`<word>\` patterns:** the other 13 (\`<phase>\`, \`<name>\`, \`<runID>\`, \`<component>\`) are all inside inline code spans (\`\` \` \`\`), which MDX treats as literal \`<code>\` content. They are not parser-breakers — the same placeholder convention is used in \`docs/user/cli-reference.md\` and \`docs/integrator/automation.md\`, both of which are MDX-rendered and pass. The new check follows the issue's own criterion — "outside code fences/inline code" — so it strips inline code spans before scanning, matching the existing braces/comments checks.

## Testing

- \`bash tools/check-docs-mdx\` — green
- \`make lint\` — green
- Synthetic test: dropped \`Visit <https://example.com> for details\` into a temp file under \`docs/contributor/\` → check flagged it as expected, then file removed.

## Risk Assessment

Low. Tightens a CI check and fixes one doc line; no runtime impact.

## Checklist

- [x] \`make lint\` passes
- [x] New check verified to catch the target pattern
- [x] Existing checks still pass on user/integrator docs
- [x] Commit signed