### PR TITLE
feat(bundle): private Sigstore via --fulcio-url and --rekor-url

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1087,6 +1087,8 @@ aicr bundle [flags]
 | `--certificate-identity-regexp` | | string | Override the certificate identity pattern for binary attestation verification. Must contain `"NVIDIA/aicr"`. For testing only. |
 | `--identity-token` | | string | Pre-fetched OIDC identity token for `--attest` keyless signing. Skips ambient/browser/device-code flows. Prefer `COSIGN_IDENTITY_TOKEN` on shared hosts — flag values are visible in `ps` and `/proc/<pid>/cmdline`. |
 | `--oidc-device-flow` | | bool | Use the OAuth 2.0 device authorization grant for `--attest` instead of opening a browser callback. Useful on headless hosts that can still reach Sigstore (`--identity-token` and CI ambient OIDC are alternatives). Also reads `AICR_OIDC_DEVICE_FLOW`. |
+| `--fulcio-url` | | string | Override the Fulcio CA URL for `--attest` keyless signing, pointing at a private Sigstore instance. Must be an absolute `https://` URL with no embedded credentials. Defaults to the public-good Fulcio when omitted. Also reads `AICR_FULCIO_URL`. |
+| `--rekor-url` | | string | Override the Rekor transparency-log URL for `--attest` keyless signing, pointing at a private Sigstore instance. Must be an absolute `https://` URL with no embedded credentials. Defaults to the public-good Rekor when omitted. Also reads `AICR_REKOR_URL`. The two URLs are independent — a private Fulcio can pair with the public Rekor or vice versa. |
 
 #### Bundle Config File Mode
 
@@ -1117,6 +1119,11 @@ spec:
       storageClass: gp3
     attestation:
       enabled: false
+      # Optional: target a private Sigstore instead of the public-good
+      # endpoints. Each defaults to public Sigstore when omitted; both must
+      # be absolute https:// URLs with no embedded credentials.
+      fulcioURL: https://fulcio.internal.example.com
+      rekorURL: https://rekor.internal.example.com
     registry:
       insecureTLS: false
       plainHTTP: false
@@ -1830,6 +1837,10 @@ When `--attest` is passed, the bundle command performs five steps:
 5. **Writes attestation files** — `attestation/bundle-attestation.sigstore.json` and `attestation/aicr-attestation.sigstore.json` are added to the bundle output.
 
 Attestation is opt-in; bundles are unsigned by default. Signing uses Sigstore keyless signing (Fulcio CA + Rekor transparency log). For verification, see [`aicr verify`](#aicr-verify).
+
+**Private Sigstore infrastructure:** organizations running their own Fulcio CA or Rekor log can redirect signing with `--fulcio-url` and `--rekor-url` (both must be absolute `https://` URLs with no embedded credentials). The two are independent, so a private Fulcio can pair with the public Rekor or vice versa. Public Sigstore remains the default when the flags are omitted.
+
+> **Verification caveat:** these flags redirect **signing** only. `aicr verify` does not yet support a custom Sigstore trust root, so bundles signed against private Fulcio/Rekor **cannot be verified with `aicr verify` today** — public Sigstore is currently the only supported verification root. Verifier support for private trust roots is tracked under [#1149](https://github.com/NVIDIA/aicr/issues/1149) / [#1153](https://github.com/NVIDIA/aicr/issues/1153).
 
 ##### OIDC Token Sources
 

--- a/pkg/bundler/attestation/keyless.go
+++ b/pkg/bundler/attestation/keyless.go
@@ -18,13 +18,8 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
-)
-
-// Sigstore public-good instance URLs.
-const (
-	DefaultFulcioURL = "https://fulcio.sigstore.dev"
-	DefaultRekorURL  = "https://rekor.sigstore.dev"
 )
 
 // KeylessAttester signs bundle content using Sigstore keyless OIDC signing
@@ -36,13 +31,22 @@ type KeylessAttester struct {
 	identity  string
 }
 
-// NewKeylessAttester returns a new KeylessAttester configured for Sigstore
-// public-good infrastructure.
-func NewKeylessAttester(oidcToken string) *KeylessAttester {
+// NewKeylessAttester returns a new KeylessAttester targeting the given Fulcio
+// and Rekor endpoints. Empty fulcioURL or rekorURL falls back to the Sigstore
+// public-good default, so callers that do not run private infrastructure pass
+// "" for both. Non-empty values point signing at a private Sigstore instance
+// (issue #408).
+func NewKeylessAttester(oidcToken, fulcioURL, rekorURL string) *KeylessAttester {
+	if fulcioURL == "" {
+		fulcioURL = defaults.SigstoreFulcioURL
+	}
+	if rekorURL == "" {
+		rekorURL = defaults.SigstoreRekorURL
+	}
 	return &KeylessAttester{
 		oidcToken: oidcToken,
-		fulcioURL: DefaultFulcioURL,
-		rekorURL:  DefaultRekorURL,
+		fulcioURL: fulcioURL,
+		rekorURL:  rekorURL,
 	}
 }
 

--- a/pkg/bundler/attestation/keyless_test.go
+++ b/pkg/bundler/attestation/keyless_test.go
@@ -27,18 +27,54 @@ import (
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
 )
 
 func TestNewKeylessAttester(t *testing.T) {
-	attester := NewKeylessAttester("test-oidc-token")
+	attester := NewKeylessAttester("test-oidc-token", "", "")
 
 	if attester == nil {
 		t.Fatal("NewKeylessAttester() returned nil")
 	}
 }
 
+// TestNewKeylessAttester_SigstoreURLs covers the private-Sigstore override:
+// non-empty Fulcio/Rekor URLs are honored verbatim, and empty strings fall
+// back to the public-good defaults so existing callers keep their behavior.
+// See issue #408.
+func TestNewKeylessAttester_SigstoreURLs(t *testing.T) {
+	const (
+		privFulcio = "https://fulcio.internal.example.com"
+		privRekor  = "https://rekor.internal.example.com"
+	)
+	tests := []struct {
+		name       string
+		fulcio     string
+		rekor      string
+		wantFulcio string
+		wantRekor  string
+	}{
+		{"both empty fall back to public defaults", "", "", defaults.SigstoreFulcioURL, defaults.SigstoreRekorURL},
+		{"both overridden are honored", privFulcio, privRekor, privFulcio, privRekor},
+		{"private Fulcio with public Rekor", privFulcio, "", privFulcio, defaults.SigstoreRekorURL},
+		{"public Fulcio with private Rekor", "", privRekor, defaults.SigstoreFulcioURL, privRekor},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewKeylessAttester("test-oidc-token", tt.fulcio, tt.rekor)
+			if a.fulcioURL != tt.wantFulcio {
+				t.Errorf("fulcioURL = %q, want %q", a.fulcioURL, tt.wantFulcio)
+			}
+			if a.rekorURL != tt.wantRekor {
+				t.Errorf("rekorURL = %q, want %q", a.rekorURL, tt.wantRekor)
+			}
+		})
+	}
+}
+
 func TestKeylessAttester_Identity(t *testing.T) {
-	attester := NewKeylessAttester("test-oidc-token")
+	attester := NewKeylessAttester("test-oidc-token", "", "")
 
 	// Identity is not known until after Attest() succeeds (Fulcio returns it).
 	// Before signing, identity should be empty.
@@ -48,7 +84,7 @@ func TestKeylessAttester_Identity(t *testing.T) {
 }
 
 func TestKeylessAttester_HasRekorEntry(t *testing.T) {
-	attester := NewKeylessAttester("test-oidc-token")
+	attester := NewKeylessAttester("test-oidc-token", "", "")
 
 	if !attester.HasRekorEntry() {
 		t.Error("HasRekorEntry() = false, want true (keyless always uses Rekor)")

--- a/pkg/bundler/attestation/resolver.go
+++ b/pkg/bundler/attestation/resolver.go
@@ -47,6 +47,14 @@ type ResolveOptions struct {
 	// (RFC 8628) for headless hosts where a browser callback is unavailable.
 	DeviceFlow bool
 
+	// FulcioURL and RekorURL point keyless signing at a private Sigstore
+	// instance (a self-hosted Fulcio CA and/or Rekor transparency log).
+	// Empty falls back to the public-good defaults (defaults.SigstoreFulcioURL
+	// / defaults.SigstoreRekorURL); the two are independent, so an org can run
+	// private Fulcio with public Rekor or vice versa. See issue #408.
+	FulcioURL string
+	RekorURL  string
+
 	// PromptWriter receives user-facing prompts emitted by the interactive
 	// and device-code flows (verification URL + short code). Pass os.Stderr
 	// for typical CLI behavior, io.Discard to suppress, or nil (treated as
@@ -102,7 +110,7 @@ func ResolveAttester(ctx context.Context, opts ResolveOptions) (Attester, error)
 	if err != nil {
 		return nil, err
 	}
-	return NewKeylessAttester(token), nil
+	return NewKeylessAttester(token, opts.FulcioURL, opts.RekorURL), nil
 }
 
 // ResolveAttesterLazy is the deferred-token variant of ResolveAttester.
@@ -161,7 +169,7 @@ func (l *LazyKeylessAttester) Attest(ctx context.Context, subject AttestSubject)
 			l.mu.Unlock()
 			return nil, err
 		}
-		l.inner = NewKeylessAttester(token)
+		l.inner = NewKeylessAttester(token, l.opts.FulcioURL, l.opts.RekorURL)
 	}
 	inner := l.inner
 	l.mu.Unlock()

--- a/pkg/bundler/attestation/resolver_test.go
+++ b/pkg/bundler/attestation/resolver_test.go
@@ -188,3 +188,55 @@ func TestResolveAttesterLazy_DisabledShortCircuits(t *testing.T) {
 		t.Errorf("expected *NoOpAttester, got %T", att)
 	}
 }
+
+// TestResolveAttester_ThreadsSigstoreURLs verifies the eager resolver carries
+// private Fulcio/Rekor endpoints from ResolveOptions onto the constructed
+// KeylessAttester. The identity-token branch resolves synchronously (no
+// network), so the returned attester can be inspected directly. See #408.
+func TestResolveAttester_ThreadsSigstoreURLs(t *testing.T) {
+	const (
+		privFulcio = "https://fulcio.internal.example.com"
+		privRekor  = "https://rekor.internal.example.com"
+	)
+	att, err := ResolveAttester(context.Background(), ResolveOptions{
+		Attest:        true,
+		IdentityToken: "pre-fetched-token",
+		FulcioURL:     privFulcio,
+		RekorURL:      privRekor,
+	})
+	if err != nil {
+		t.Fatalf("ResolveAttester returned error: %v", err)
+	}
+	keyless, ok := att.(*KeylessAttester)
+	if !ok {
+		t.Fatalf("expected *KeylessAttester, got %T", att)
+	}
+	if keyless.fulcioURL != privFulcio {
+		t.Errorf("fulcioURL = %q, want %q", keyless.fulcioURL, privFulcio)
+	}
+	if keyless.rekorURL != privRekor {
+		t.Errorf("rekorURL = %q, want %q", keyless.rekorURL, privRekor)
+	}
+}
+
+// TestNewLazyKeylessAttester_RetainsSigstoreURLs verifies the lazy attester
+// retains the private-Sigstore endpoints in its deferred options so the
+// KeylessAttester it builds on first Attest() targets the same infrastructure
+// as the eager path. See #408.
+func TestNewLazyKeylessAttester_RetainsSigstoreURLs(t *testing.T) {
+	const (
+		privFulcio = "https://fulcio.internal.example.com"
+		privRekor  = "https://rekor.internal.example.com"
+	)
+	lazy := NewLazyKeylessAttester(ResolveOptions{
+		Attest:    true,
+		FulcioURL: privFulcio,
+		RekorURL:  privRekor,
+	})
+	if lazy.opts.FulcioURL != privFulcio {
+		t.Errorf("opts.FulcioURL = %q, want %q", lazy.opts.FulcioURL, privFulcio)
+	}
+	if lazy.opts.RekorURL != privRekor {
+		t.Errorf("opts.RekorURL = %q, want %q", lazy.opts.RekorURL, privRekor)
+	}
+}

--- a/pkg/bundler/attestation/signing.go
+++ b/pkg/bundler/attestation/signing.go
@@ -38,11 +38,11 @@ type SignOptions struct {
 	OIDCToken string
 
 	// FulcioURL is the Fulcio certificate authority URL. Empty falls
-	// back to DefaultFulcioURL.
+	// back to defaults.SigstoreFulcioURL.
 	FulcioURL string
 
 	// RekorURL is the Rekor transparency log URL. Empty falls back to
-	// DefaultRekorURL.
+	// defaults.SigstoreRekorURL.
 	RekorURL string
 }
 
@@ -98,11 +98,11 @@ func SignStatement(ctx context.Context, statementJSON []byte, opts SignOptions) 
 
 	fulcioURL := opts.FulcioURL
 	if fulcioURL == "" {
-		fulcioURL = DefaultFulcioURL
+		fulcioURL = defaults.SigstoreFulcioURL
 	}
 	rekorURL := opts.RekorURL
 	if rekorURL == "" {
-		rekorURL = DefaultRekorURL
+		rekorURL = defaults.SigstoreRekorURL
 	}
 
 	content := &sign.DSSEData{

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -103,6 +104,32 @@ func ValidateAppName(name string) error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid app name %q: must be a DNS-1123 subdomain (%s)",
 				name, strings.Join(errs, "; ")))
+	}
+	return nil
+}
+
+// ValidateHTTPSURL reports whether raw is a usable absolute https:// endpoint.
+// The empty string is allowed (callers treat it as "use the default"); any
+// non-empty value must parse as an absolute URL with an https scheme and a
+// host, and must not embed credentials. label names the field for the error
+// message (e.g. "fulcio URL"). Used to fail malformed signing endpoints at
+// bundle/parse time rather than at sign time. See #408.
+func ValidateHTTPSURL(label, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s %q", label, raw), err)
+	}
+	// Reject embedded credentials: url.Parse stashes "user:pass@" in u.User
+	// while leaving Scheme/Host intact, so a scheme+host-only check would
+	// otherwise accept "https://user:pass@host". Credentials have no place in
+	// a signing endpoint and would leak via config/flags/process listings.
+	if u.Scheme != "https" || u.Host == "" || u.User != nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s %q: must be an absolute https:// URL without embedded credentials", label, raw))
 	}
 	return nil
 }

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -720,6 +720,32 @@ func TestValidateAppName(t *testing.T) {
 	}
 }
 
+func TestValidateHTTPSURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty is allowed (means use default)", "", false},
+		{"valid https URL", "https://fulcio.internal.example.com", false},
+		{"valid https URL with port and path", "https://rekor.example.com:8443/api", false},
+		{"http scheme rejected", "http://fulcio.internal.example.com", true},
+		{"embedded credentials rejected", "https://user:pass@fulcio.internal.example.com", true},
+		{"missing scheme rejected", "fulcio.internal.example.com", true},
+		{"relative path rejected", "not-a-url", true},
+		{"scheme without host rejected", "https://", true},
+		{"non-http scheme rejected", "ftp://example.com", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHTTPSURL("fulcio URL", tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateHTTPSURL(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestWithBundleChartName verifies the override flows to BundleChartName,
 // that the default is empty (so the argocd-helm deployer falls back to
 // its own "aicr-bundle" default), and that the most-recent option wins

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -86,6 +86,12 @@ type bundleCmdOptions struct {
 	// (RFC 8628) for headless hosts where a browser callback is unavailable.
 	oidcDeviceFlow bool
 
+	// fulcioURL and rekorURL override the public-good Sigstore endpoints so
+	// keyless signing targets a private Fulcio CA and/or Rekor transparency
+	// log. Empty leaves the public defaults in place. See #408.
+	fulcioURL string
+	rekorURL  string
+
 	// OCI output reference (nil if outputting to local directory)
 	ociRef        *oci.Reference
 	plainHTTP     bool
@@ -110,7 +116,7 @@ type bundleCmdOptions struct {
 // config-supplied fields happens at the conversion boundary in Resolve;
 // errors from that boundary carry "spec.bundle.<path>" attribution.
 //
-//nolint:gocyclo // option resolution is inherently long but linear
+//nolint:gocyclo,funlen // option resolution is inherently long but linear
 func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmdOptions, error) {
 	resolved, err := cfg.Bundle().Resolve()
 	if err != nil {
@@ -126,6 +132,8 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", resolved.CertIDRegexp),
 		identityToken:             cmd.String(flagIdentityToken),
 		oidcDeviceFlow:            boolFlagOrConfig(cmd, flagOIDCDeviceFlow, resolved.OIDCDeviceFlow),
+		fulcioURL:                 stringFlagOrConfig(cmd, flagFulcioURL, resolved.FulcioURL),
+		rekorURL:                  stringFlagOrConfig(cmd, flagRekorURL, resolved.RekorURL),
 		insecureTLS:               boolFlagOrConfig(cmd, flagInsecureTLS, resolved.InsecureTLS),
 		plainHTTP:                 boolFlagOrConfig(cmd, flagPlainHTTP, resolved.PlainHTTP),
 		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", resolved.ImageRefs),
@@ -299,7 +307,25 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		opts.storageClass = resolved.StorageClass
 	}
 
+	// Validate any private Sigstore endpoints up front so a malformed
+	// --fulcio-url / --rekor-url fails before bundling instead of at sign
+	// time. Both must be HTTPS (#408): keyless signing exchanges OIDC
+	// credentials with these endpoints, so plaintext transport is rejected.
+	if err := validateSigstoreEndpoints(opts); err != nil {
+		return nil, err
+	}
+
 	return opts, nil
+}
+
+// validateSigstoreEndpoints rejects malformed --fulcio-url / --rekor-url
+// values (non-empty endpoints that are not absolute https:// URLs). The
+// HTTPS check is shared with the config layer via config.ValidateHTTPSURL.
+func validateSigstoreEndpoints(opts *bundleCmdOptions) error {
+	if err := config.ValidateHTTPSURL("fulcio URL", opts.fulcioURL); err != nil {
+		return err
+	}
+	return config.ValidateHTTPSURL("rekor URL", opts.rekorURL)
 }
 
 // resolveOutputTarget returns the parsed *oci.Reference for --output,
@@ -567,6 +593,18 @@ Package with explicit tag (overrides CLI version):
 				Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
 				Category: catDeployment,
 			},
+			&cli.StringFlag{
+				Name:     flagFulcioURL,
+				Usage:    "Override the Fulcio CA URL for --attest keyless signing (e.g. a private Sigstore instance). Must be an absolute https:// URL with no embedded credentials. Defaults to the public-good Fulcio. Also reads AICR_FULCIO_URL.",
+				Sources:  cli.EnvVars("AICR_FULCIO_URL"),
+				Category: catDeployment,
+			},
+			&cli.StringFlag{
+				Name:     flagRekorURL,
+				Usage:    "Override the Rekor transparency-log URL for --attest keyless signing (e.g. a private Sigstore instance). Must be an absolute https:// URL with no embedded credentials. Defaults to the public-good Rekor. Also reads AICR_REKOR_URL.",
+				Sources:  cli.EnvVars("AICR_REKOR_URL"),
+				Category: catDeployment,
+			},
 			kubeconfigFlag(),
 			dataFlag(),
 			// OCI registry connection flags (used when --output is oci://...)
@@ -593,7 +631,7 @@ Package with explicit tag (overrides CLI version):
 // runBundleCmd is the Action handler for the bundle command.
 func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 	// Validate single-value flags are not duplicated
-	if err := validateSingleValueFlags(cmd, "recipe", "config", "output", "deployer", "repo", "storage-class", "app-name"); err != nil {
+	if err := validateSingleValueFlags(cmd, "recipe", "config", "output", "deployer", "repo", "storage-class", "app-name", flagFulcioURL, flagRekorURL); err != nil {
 		return err
 	}
 
@@ -755,6 +793,8 @@ func selectAttester(ctx context.Context, opts *bundleCmdOptions) (attestation.At
 		AmbientURL:    os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
 		AmbientToken:  os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
 		DeviceFlow:    opts.oidcDeviceFlow,
+		FulcioURL:     opts.fulcioURL,
+		RekorURL:      opts.rekorURL,
 		// Prompts (verification URL + user code) go to stderr so they don't
 		// pollute stdout when callers redirect bundle output.
 		PromptWriter: os.Stderr,

--- a/pkg/cli/bundle_test.go
+++ b/pkg/cli/bundle_test.go
@@ -314,6 +314,84 @@ func TestParseBundleCmdOptions_AppName(t *testing.T) {
 	})
 }
 
+// TestParseBundleCmdOptions_SigstoreURLs covers the --fulcio-url / --rekor-url
+// flags: valid HTTPS endpoints land on the parsed options, unset leaves them
+// empty (public-good defaults apply downstream), and a non-HTTPS endpoint is
+// rejected at parse time. See issue #408.
+func TestParseBundleCmdOptions_SigstoreURLs(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	out := filepath.Join(tmp, "out")
+	base := []string{"--recipe", recipePath, "--output", out}
+
+	t.Run("unset leaves both empty", func(t *testing.T) {
+		opts := captureBundleOpts(t, base)
+		if opts.fulcioURL != "" || opts.rekorURL != "" {
+			t.Errorf("expected empty URLs, got fulcio=%q rekor=%q", opts.fulcioURL, opts.rekorURL)
+		}
+	})
+
+	t.Run("env vars populate the endpoints", func(t *testing.T) {
+		t.Setenv("AICR_FULCIO_URL", "https://fulcio.env.example.com")
+		t.Setenv("AICR_REKOR_URL", "https://rekor.env.example.com")
+		opts := captureBundleOpts(t, base)
+		if opts.fulcioURL != "https://fulcio.env.example.com" {
+			t.Errorf("fulcioURL from env = %q", opts.fulcioURL)
+		}
+		if opts.rekorURL != "https://rekor.env.example.com" {
+			t.Errorf("rekorURL from env = %q", opts.rekorURL)
+		}
+	})
+
+	t.Run("explicit flags override env vars", func(t *testing.T) {
+		t.Setenv("AICR_FULCIO_URL", "https://fulcio.env.example.com")
+		t.Setenv("AICR_REKOR_URL", "https://rekor.env.example.com")
+		opts := captureBundleOpts(t, append(append([]string{}, base...),
+			"--fulcio-url", "https://fulcio.flag.example.com",
+			"--rekor-url", "https://rekor.flag.example.com"))
+		if opts.fulcioURL != "https://fulcio.flag.example.com" {
+			t.Errorf("fulcioURL = %q, want the flag value to win over AICR_FULCIO_URL", opts.fulcioURL)
+		}
+		if opts.rekorURL != "https://rekor.flag.example.com" {
+			t.Errorf("rekorURL = %q, want the flag value to win over AICR_REKOR_URL", opts.rekorURL)
+		}
+	})
+
+	t.Run("valid HTTPS endpoints flow to opts", func(t *testing.T) {
+		opts := captureBundleOpts(t, append(append([]string{}, base...),
+			"--fulcio-url", "https://fulcio.internal.example.com",
+			"--rekor-url", "https://rekor.internal.example.com"))
+		if opts.fulcioURL != "https://fulcio.internal.example.com" {
+			t.Errorf("fulcioURL = %q", opts.fulcioURL)
+		}
+		if opts.rekorURL != "https://rekor.internal.example.com" {
+			t.Errorf("rekorURL = %q", opts.rekorURL)
+		}
+	})
+
+	t.Run("non-HTTPS fulcio-url is rejected", func(t *testing.T) {
+		_, err := tryCaptureBundleOpts(t, append(append([]string{}, base...),
+			"--fulcio-url", "http://fulcio.internal.example.com"))
+		if err == nil {
+			t.Fatal("expected error rejecting non-HTTPS --fulcio-url")
+		}
+		if !strings.Contains(err.Error(), "https") {
+			t.Errorf("error should mention https requirement, got: %v", err)
+		}
+	})
+
+	t.Run("malformed rekor-url is rejected", func(t *testing.T) {
+		_, err := tryCaptureBundleOpts(t, append(append([]string{}, base...),
+			"--rekor-url", "not-a-url"))
+		if err == nil {
+			t.Fatal("expected error rejecting malformed --rekor-url")
+		}
+	})
+}
+
 // TestPrintArgoCDHelmOCIInstructions exercises the post-#1051 install-hint
 // contract: `helm install` against the full OCI artifact reference, and
 // `--set repoURL` carrying only the parent namespace (chart name omitted

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -38,6 +38,8 @@ const (
 const (
 	flagIdentityToken  = "identity-token"
 	flagOIDCDeviceFlow = "oidc-device-flow"
+	flagFulcioURL      = "fulcio-url"
+	flagRekorURL       = "rekor-url"
 	flagInsecureTLS    = "insecure-tls"
 	flagPlainHTTP      = "plain-http"
 	flagPush           = "push"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -201,6 +201,12 @@ type AttestationSpec struct {
 	Enabled                   bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	CertificateIdentityRegexp string `yaml:"certificateIdentityRegexp,omitempty" json:"certificateIdentityRegexp,omitempty"`
 	OIDCDeviceFlow            bool   `yaml:"oidcDeviceFlow,omitempty" json:"oidcDeviceFlow,omitempty"`
+
+	// FulcioURL and RekorURL override the public-good Sigstore endpoints so
+	// keyless signing targets a private Fulcio CA and/or Rekor transparency
+	// log. Empty leaves the public defaults in place. See issue #408.
+	FulcioURL string `yaml:"fulcioURL,omitempty" json:"fulcioURL,omitempty"`
+	RekorURL  string `yaml:"rekorURL,omitempty" json:"rekorURL,omitempty"`
 }
 
 // RegistrySpec captures OCI-registry transport options for bundle push.

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -105,6 +105,14 @@ type BundleResolved struct {
 	// OIDCDeviceFlow is spec.bundle.attestation.oidcDeviceFlow.
 	OIDCDeviceFlow bool
 
+	// FulcioURL is spec.bundle.attestation.fulcioURL; empty leaves the
+	// public-good Sigstore default in place.
+	FulcioURL string
+
+	// RekorURL is spec.bundle.attestation.rekorURL; empty leaves the
+	// public-good Sigstore default in place.
+	RekorURL string
+
 	// InsecureTLS is spec.bundle.registry.insecureTLS.
 	InsecureTLS bool
 
@@ -232,6 +240,15 @@ func (b *BundleSpec) Resolve() (*BundleResolved, error) {
 		out.Attest = b.Attestation.Enabled
 		out.CertIDRegexp = b.Attestation.CertificateIdentityRegexp
 		out.OIDCDeviceFlow = b.Attestation.OIDCDeviceFlow
+		// Validate the signing endpoints at the conversion boundary so a
+		// malformed config value fails here with spec-path attribution
+		// (and is caught for non-CLI callers of Resolve too), rather than
+		// only later in CLI flag parsing.
+		if err := validateAttestationEndpoints(b.Attestation); err != nil {
+			return nil, err
+		}
+		out.FulcioURL = b.Attestation.FulcioURL
+		out.RekorURL = b.Attestation.RekorURL
 	}
 
 	if b.Registry != nil {
@@ -240,6 +257,16 @@ func (b *BundleSpec) Resolve() (*BundleResolved, error) {
 	}
 
 	return out, nil
+}
+
+// validateAttestationEndpoints rejects malformed private Sigstore endpoints in
+// the bundle attestation spec. ValidateHTTPSURL returns a pkg/errors
+// StructuredError with the right code, so its result is returned as-is.
+func validateAttestationEndpoints(a *AttestationSpec) error {
+	if err := bundlercfg.ValidateHTTPSURL("spec.bundle.attestation.fulcioURL", a.FulcioURL); err != nil {
+		return err
+	}
+	return bundlercfg.ValidateHTTPSURL("spec.bundle.attestation.rekorURL", a.RekorURL)
 }
 
 // ValidateResolved is the typed-domain projection of ValidateSpec produced

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -192,6 +192,37 @@ func TestBundleResolve_EmptySpec(t *testing.T) {
 	}
 }
 
+func TestBundleResolve_RejectsMalformedSigstoreURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		attest  *config.AttestationSpec
+		wantSub string
+	}{
+		{
+			name:    "non-https fulcioURL fails with spec-path attribution",
+			attest:  &config.AttestationSpec{FulcioURL: "http://fulcio.internal.example.com"},
+			wantSub: "spec.bundle.attestation.fulcioURL",
+		},
+		{
+			name:    "malformed rekorURL fails with spec-path attribution",
+			attest:  &config.AttestationSpec{RekorURL: "https://user:pass@rekor.internal.example.com"},
+			wantSub: "spec.bundle.attestation.rekorURL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &config.BundleSpec{Attestation: tt.attest}
+			_, err := b.Resolve()
+			if err == nil {
+				t.Fatal("expected error for malformed Sigstore URL, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q must contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
 func TestBundleResolve_AllFieldsPopulated(t *testing.T) {
 	b := &config.BundleSpec{
 		Input:  &config.BundleInputSpec{Recipe: "recipe.yaml"},
@@ -216,6 +247,8 @@ func TestBundleResolve_AllFieldsPopulated(t *testing.T) {
 			Enabled:                   true,
 			CertificateIdentityRegexp: ".+",
 			OIDCDeviceFlow:            true,
+			FulcioURL:                 "https://fulcio.internal.example.com",
+			RekorURL:                  "https://rekor.internal.example.com",
 		},
 		Registry: &config.RegistrySpec{InsecureTLS: true, PlainHTTP: true},
 	}
@@ -271,6 +304,9 @@ func TestBundleResolve_AllFieldsPopulated(t *testing.T) {
 	if !got.Attest || got.CertIDRegexp != ".+" || !got.OIDCDeviceFlow {
 		t.Errorf("Attestation fields: got attest=%v cert=%q oidc=%v",
 			got.Attest, got.CertIDRegexp, got.OIDCDeviceFlow)
+	}
+	if got.FulcioURL != "https://fulcio.internal.example.com" || got.RekorURL != "https://rekor.internal.example.com" {
+		t.Errorf("Sigstore URLs: got fulcio=%q rekor=%q", got.FulcioURL, got.RekorURL)
 	}
 	if !got.InsecureTLS || !got.PlainHTTP {
 		t.Errorf("Registry: got insecure=%v plain=%v", got.InsecureTLS, got.PlainHTTP)

--- a/pkg/defaults/sigstore.go
+++ b/pkg/defaults/sigstore.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+// Sigstore public-good ("the commons") infrastructure endpoints used for
+// keyless signing when no private instance is configured. Callers override
+// these via --fulcio-url / --rekor-url (and the equivalent config fields) to
+// target a private Sigstore deployment. See issue #408.
+const (
+	// SigstoreFulcioURL is the default Fulcio certificate-authority URL.
+	SigstoreFulcioURL = "https://fulcio.sigstore.dev"
+
+	// SigstoreRekorURL is the default Rekor transparency-log URL.
+	SigstoreRekorURL = "https://rekor.sigstore.dev"
+)

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -253,10 +253,15 @@ func signAndPush(ctx context.Context, bundle *Bundle, opts signPushOptions) (emi
 
 	signCtx, signCancel := context.WithTimeout(ctx, defaults.EvidenceBundleSignTimeout)
 	defer signCancel()
+	// Honor any configured private Sigstore endpoints rather than forcing
+	// public Sigstore. Empty values fall back to the public-good defaults
+	// inside SignStatement. (The validate-emit path does not yet expose
+	// --fulcio-url/--rekor-url, so these are empty today; this keeps the
+	// signer from overriding a configured endpoint once it does.)
 	signRes, err := bundleattest.SignStatement(signCtx, artifactStmt, bundleattest.SignOptions{
 		OIDCToken: token,
-		FulcioURL: bundleattest.DefaultFulcioURL,
-		RekorURL:  bundleattest.DefaultRekorURL,
+		FulcioURL: opts.OIDCResolve.FulcioURL,
+		RekorURL:  opts.OIDCResolve.RekorURL,
 	})
 	if err != nil {
 		return emitOutcome{}, err


### PR DESCRIPTION
## Summary

Adds `--fulcio-url` / `--rekor-url` flags (and matching config fields) to `aicr bundle` so `--attest` keyless signing can target a private Sigstore instance instead of the public-good endpoints.

## Motivation / Context

Organizations running their own Fulcio CA and/or Rekor transparency log could not point AICR at them — all signing hit public Sigstore. The signing library already accepted custom endpoints (`SignOptions.FulcioURL`/`RekorURL` with default fallback); this PR connects the CLI and config layers so the capability is actually reachable.

Fixes: #408
Related: #1149

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/defaults`
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `ResolveOptions` carries `FulcioURL`/`RekorURL`; `NewKeylessAttester(token, fulcio, rekor)` applies the public-good default on empty, so existing callers are unaffected. Both the eager and lazy resolver paths thread the URLs to `SignStatement`.
- Config: `spec.bundle.attestation.fulcioURL`/`rekorURL` → `BundleResolved`.
- CLI validates both flags at parse time as absolute `https://` URLs (fail fast, before bundling), via a shared `config.ValidateHTTPSURL(label, raw)` helper that lives next to the sibling `ValidateAppName`.
- Moved the Sigstore default endpoints out of `pkg/bundler/attestation` into `pkg/defaults` as `SigstoreFulcioURL` / `SigstoreRekorURL` (matching the existing `SigstoreSignTimeout` convention) and updated all call sites, including `pkg/evidence/attestation/emit.go`.
- The two URLs are independent (private Fulcio + public Rekor, or vice versa); public Sigstore is the default when omitted.
- Verifier support for privately-signed bundles is intentionally out of scope here and tracked under epic #1149 (#1153).

## Testing

```bash
make qualify
```

`make qualify` passes end-to-end: unit tests (`-race`), golangci-lint (0 issues), chainsaw e2e (22 passed / 0 failed), vulnerability scan (no vulnerabilities), license-header and repo checks. New table-driven tests cover `NewKeylessAttester` URL defaulting, resolver URL propagation (eager + lazy), config resolution, CLI flag parsing + HTTPS-validation rejection, and the shared `ValidateHTTPSURL`.

## Risk Assessment

- [x] **Low** — Additive flags; default behavior (public Sigstore) is unchanged when the flags are omitted. The constant move is mechanical with all call sites updated and covered by the full gate.

**Rollout notes:** Backwards compatible. No migration. `--fulcio-url`/`--rekor-url` are opt-in and only take effect with `--attest`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
