### PR TITLE
feat(cli): add --set-json/--set-file for list and object bundle overrides

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1064,7 +1064,9 @@ aicr bundle [flags]
 | `--output` | `-o` | string | Output directory (default: current dir) |
 | `--deployer` | `-d` | string | Deployment method: `helm` (default), `argocd`, `argocd-helm`, `flux`, or `helmfile` |
 | `--repo` | | string | Git/OCI repository URL baked into Argo CD Application sources. Used with `--deployer argocd`. Ignored with `--deployer argocd-helm` (that bundle is URL-portable — the URL is supplied at `helm install` time via `--set repoURL=...`); a warning is logged if passed. |
-| `--set` | | string[] | Override values in bundle files (repeatable). Use `enabled` key to include/exclude components (e.g., `--set awsebscsidriver:enabled=false`) |
+| `--set` | | string[] | Override **scalar** values in bundle files (repeatable, format: `component:path=value`). Use `enabled` key to include/exclude components (e.g., `--set awsebscsidriver:enabled=false`). Scalar-only — for list/object values use `--set-json` / `--set-file`. |
+| `--set-json` | | string[] | Override values with a JSON-encoded **list or object** (repeatable, format: `component:path=<json>`, e.g. `--set-json agentgateway:allowedSourceRanges='["216.228.127.128/30"]'`). Object values deep-merge into existing maps; lists and scalars replace. Takes precedence over `--set` on the same path. See [List and Object Value Overrides](#list-and-object-value-overrides). |
+| `--set-file` | | string[] | Override a value by reading JSON/YAML from a file (repeatable, format: `component:path=<filepath>`). For larger structures than `--set-json`; same merge semantics. |
 | `--dynamic` | | string[] | Declare value paths as install-time parameters (repeatable, format: `component:path`). Supported with `helm`, `argocd-helm`, `flux`, and `helmfile` deployers. See [Dynamic Install-Time Values](#dynamic-install-time-values). |
 | `--data` | | string | External data directory to overlay on embedded data (see [External Data](#external-data-directory)) |
 | `--system-node-selector` | | string[] | Node selector for system components (format: key=value, repeatable) |
@@ -1243,9 +1245,11 @@ Override any value in the generated bundle files using dot notation:
 
 **Behavior:**
 - **Duplicate keys**: When the same `bundler:path` is specified multiple times, the **last value wins**
-- **Array values**: Individual array elements cannot be overridden (no `[0]` index syntax). Arrays can only be replaced entirely via recipe overrides, not via `--set` flags. Use recipe-level overrides in `componentRefs[].overrides` if you need to replace an entire array.
+- **Array values**: Individual array elements cannot be overridden (no `[0]` index syntax). `--set` is **scalar-only** — pointing it at a list/object field writes a bare string and produces type-invalid output. To replace an entire array or object from the CLI, use [`--set-json` / `--set-file`](#list-and-object-value-overrides); recipe-level overrides in `componentRefs[].overrides` are the alternative.
 - **Type conversion**: String values are automatically converted to appropriate types (`true`/`false` → bool, numeric strings → numbers)
 - **Component enable/disable**: The special `enabled` key controls whether a component is included in the bundle. `--set <component>:enabled=false` excludes the component; `--set <component>:enabled=true` re-enables a recipe-disabled component. The `enabled` key is consumed by the bundler and not passed to Helm chart values.
+- **Aliases merge**: overrides supplied under both a component's canonical name and a registered alias (e.g. `gpu-operator` and `gpuoperator`) are **combined, not dropped**; the canonical name wins on any shared path. (Same alias-merge behavior as [`--set-json` / `--set-file`](#list-and-object-value-overrides).)
+- **Repeat to add; commas are literal**: To supply multiple overrides, repeat the flag (`--set a:x=1 --set b:y=2`). On the `bundle` command, commas inside a single slice-flag value are taken **literally** (not treated as a value separator), so a value containing a comma — and the comma-heavy JSON passed to `--set-json` — is preserved intact. This applies to all repeatable `bundle` flags (`--set`, `--set-json`, `--set-file`, `--dynamic`, `--*-node-selector`, `--*-node-toleration`, `--workload-selector`).
 
 **Examples:**
 ```shell
@@ -1281,7 +1285,89 @@ aicr bundle -r recipe.yaml \
 aicr bundle -r recipe.yaml \
   --set awsebscsidriver:enabled=false \
   -o ./bundles
+```
 
+#### List and Object Value Overrides
+
+`--set` is scalar-only: it cannot express a list or object value. Pointing it
+at a list field such as `agentgateway.allowedSourceRanges` exits 0 but writes a
+**bare string** at that path, producing a type-invalid manifest — the value may
+be dropped or rejected at apply time. Use `--set-json` (inline) or `--set-file`
+(from a file) for any list or object override.
+
+**Format:** `component:path=<value>` where:
+- `component` / `path` — same component name and dot-separated path as `--set`
+- `<value>` — for `--set-json`, a JSON-encoded value; for `--set-file`, a path
+  to a **regular file** containing a **single** JSON or YAML value (one
+  document — in a multi-document YAML file only the first document is read). A
+  non-regular path (directory, FIFO/named pipe, device, socket) is rejected
+  with a fast validation error rather than hanging or failing later.
+
+**Behavior:**
+- **Object values deep-merge** into any existing map at the path (partial
+  object overrides compose with recipe/base values), matching how inline recipe
+  `componentRefs[].overrides` merge. Within a merged object, a JSON `null`
+  **deletes** that key from the result (same explicit-null semantics as recipe
+  overrides).
+- **Lists and scalars replace** the value at the path.
+- **Precedence**: applied after `--set`, so a `--set-json` / `--set-file` entry
+  wins over a scalar `--set` on the same path. Between the two typed flags, an
+  inline `--set-json` wins over a `--set-file` on the same `component:path`
+  (mirroring Helm's `--set` taking precedence over `-f` value files). Within a
+  single flag, the last entry for a given `component:path` wins.
+- **Overlapping nested paths**: when one override targets a parent object and
+  another targets a key beneath it (e.g. `comp:driver.env=<object>` plus
+  `comp:driver.env.HTTPS_PROXY=<value>`), the deeper, more-specific path wins
+  on the keys they share — regardless of the order the flags are given. The
+  parent object's other keys are preserved.
+- **Aliases merge**: overrides supplied under both a component's canonical name
+  and a registered alias (e.g. `gpu-operator` and `gpuoperator`) are combined,
+  not dropped; the canonical name wins on any shared path.
+- **Node-scheduling paths deep-merge with CLI injection (asymmetric with
+  `--set`)**: a typed override on a node-scheduling path (e.g. `--set-json
+  gpu-operator:nodeSelector=<object>`) **deep-merges into** the selectors and
+  tolerations injected by `--accelerated-node-selector` /
+  `--system-node-selector` / `--*-node-toleration`, rather than suppressing that
+  injection. This is intentional — deep-merge is the point of the typed path —
+  but it differs from scalar `--set`: `--set comp:nodeSelector.x=y` marks that
+  path as user-populated and suppresses CLI injection on it, whereas a typed
+  override composes with the injected keys (so system-injected selector keys
+  remain present alongside it). Use scalar `--set`, or omit the node-scheduling
+  flags, when you need to fully replace an injected selector instead of merging
+  into it.
+- **CLI-only**: `--set-json` / `--set-file` have no `AICRConfig`
+  (`spec.bundle.deployment.set`) or HTTP API (`?set=`) equivalent — those
+  surfaces remain scalar-only. To set a list or object value outside the CLI,
+  use a recipe overlay or `componentRefs[].overrides`.
+- **Not for `enabled`**: the special `enabled` component toggle is honored only
+  via scalar `--set`; passing it through `--set-json` / `--set-file` is rejected
+  with an error (it would not toggle the component and would leak a stray
+  `enabled:` value into the chart).
+
+**Examples:**
+
+```shell
+# Scope the agentgateway inference-gateway to trusted CIDRs (inline JSON list)
+aicr bundle -r recipe.yaml \
+  --set-json agentgateway:allowedSourceRanges='["216.228.127.128/30","10.0.0.0/8"]' \
+  -o ./bundles
+
+# Same override, read from a file (JSON or YAML)
+cat > ranges.yaml <<'EOF'
+- 216.228.127.128/30
+- 10.0.0.0/8
+EOF
+aicr bundle -r recipe.yaml \
+  --set-file agentgateway:allowedSourceRanges=ranges.yaml \
+  -o ./bundles
+
+# Override object keys (deep-merges into the existing map)
+aicr bundle -r recipe.yaml \
+  --set-json gpuoperator:driver.env='{"HTTPS_PROXY":"http://proxy:3128"}' \
+  -o ./bundles
+```
+
+```shell
 # Schedule system components on specific node pool
 aicr bundle -r recipe.yaml \
   --system-node-selector nodeGroup=system-pool \

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -69,7 +69,14 @@ Inference recipes include the **agentgateway** component, which deploys an `infe
 
 To restrict it to trusted networks, set `agentgateway.allowedSourceRanges` to a list of CIDR (Classless Inter-Domain Routing) blocks. The values are rendered into the generated Service's `spec.loadBalancerSourceRanges`, which the AWS, GCP, Azure, and OCI cloud load balancers all honor — so one setting locks the gateway down on every platform.
 
-Do **not** use `--set` for this key. `--set agentgateway:allowedSourceRanges=<cidr>` exits 0 but renders `loadBalancerSourceRanges` as a bare string instead of a list, producing a type-invalid Service (the gateway may stay open to `0.0.0.0/0`, or the CR apply is rejected). Scope the gateway through a recipe overlay or `componentRef` override instead:
+Do **not** use plain `--set` for this key. `--set agentgateway:allowedSourceRanges=<cidr>` exits 0 but renders `loadBalancerSourceRanges` as a bare string instead of a list, producing a type-invalid Service (the gateway may stay open to `0.0.0.0/0`, or the CR apply is rejected). Use the list-aware [`--set-json` / `--set-file`](cli-reference.md#list-and-object-value-overrides) flags from the CLI:
+
+```shell
+aicr bundle -r recipe.yaml \
+  --set-json agentgateway:allowedSourceRanges='["216.228.127.128/30"]'
+```
+
+or scope the gateway through a recipe overlay or `componentRef` override:
 
 ```yaml
 componentRefs:

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -71,6 +71,10 @@ func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
 // digestAlgoSHA256 is the algorithm key used in attestation digest maps.
 const digestAlgoSHA256 = "sha256"
 
+// errCtxKeyComponent is the structured-error context key carrying the
+// component name in bundle value-override failures.
+const errCtxKeyComponent = "component"
+
 // DefaultBundler generates Helm per-component bundles from recipes.
 //
 // The per-component approach produces a directory per component, each with its
@@ -620,7 +624,7 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 				return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
 					"failed to apply --set value overrides",
 					applyErr,
-					map[string]any{"component": ref.Name})
+					map[string]any{errCtxKeyComponent: ref.Name})
 			}
 		}
 
@@ -634,16 +638,97 @@ func (b *DefaultBundler) extractComponentValues(ctx context.Context, recipeResul
 		// Apply node selectors, tolerations, workload selector, and taints based on component type
 		b.applyNodeSchedulingOverrides(ref.Name, values, provider, policy)
 
+		// Apply structured --set-json / --set-file overrides last so they take
+		// precedence over base values, scalar --set, and scheduling injection.
+		// Unlike --set, these carry lists/objects: object values deep-merge into
+		// any existing map at the path, while lists and scalars replace it. This
+		// is the type-safe path for list/object fields like
+		// agentgateway.allowedSourceRanges that --set cannot express. See #1161.
+		if typedOverrides := b.getTypedValueOverridesForComponent(ref.Name, provider); len(typedOverrides) > 0 {
+			// Reject the "enabled" toggle on the typed path here — below the CLI
+			// boundary — so non-CLI/SDK callers that build TypedComponentPath
+			// values directly are guarded too, not just the CLI flag parser.
+			// Routing it through --set-json/--set-file would write a stray
+			// literal `enabled:` into chart values rather than toggle the
+			// component; it is honored only via scalar --set.
+			if _, hasEnabled := typedOverrides[config.ComponentEnabledKey]; hasEnabled {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("component %q: %q is the enable/disable toggle and must be set with --set "+
+						"(e.g. --set %s:%s=false), not --set-json/--set-file",
+						ref.Name, config.ComponentEnabledKey, ref.Name, config.ComponentEnabledKey))
+			}
+			if applyErr := component.ApplyTypedOverrides(values, typedOverrides); applyErr != nil {
+				return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+					"failed to apply --set-json/--set-file value overrides",
+					applyErr,
+					map[string]any{errCtxKeyComponent: ref.Name})
+			}
+		}
+
 		componentValues[ref.Name] = values
 	}
 
 	return componentValues, nil
 }
 
-// getValueOverridesForComponent returns value overrides for a specific component.
-// Uses the component registry to match both exact names and alternative override keys.
-// The provider argument scopes the registry lookup to the recipe's bound DataProvider;
-// a nil provider falls back to the package-global registry via GetComponentRegistryFor.
+// componentOverrideKeys returns the candidate override-map keys for
+// componentName, in priority order: the exact name first, then either its
+// non-hyphenated form (when the registry is unavailable) or the registry's
+// ValueOverrideKeys aliases. Shared by the string (--set) and typed
+// (--set-json / --set-file) override lookups so both resolve component
+// aliases identically. The provider argument scopes the registry lookup to
+// the recipe's bound DataProvider; a nil provider falls back to the
+// package-global registry via GetComponentRegistryFor.
+func (b *DefaultBundler) componentOverrideKeys(componentName string, provider recipe.DataProvider) []string {
+	keys := []string{componentName}
+
+	registry, err := recipe.GetComponentRegistryFor(provider)
+	if err != nil {
+		// Registry unavailable: fall back to the non-hyphenated form only.
+		if nonHyphenated := removeHyphens(componentName); nonHyphenated != componentName {
+			keys = append(keys, nonHyphenated)
+		}
+		return keys
+	}
+
+	if comp := registry.Get(componentName); comp != nil {
+		keys = append(keys, comp.ValueOverrideKeys...)
+	}
+
+	return keys
+}
+
+// mergeOverridesAcrossKeys merges the per-path override maps stored under every
+// candidate key (the exact component name plus its registry aliases) into a
+// single map, so overrides supplied under a mix of canonical and alias names —
+// e.g. both gpu-operator and gpuoperator — are all honored rather than the
+// first-matching key silently dropping the rest. When the same path appears
+// under more than one key, the higher-priority key (earlier in keys: the exact
+// name before its aliases) wins. Returns nil when no candidate key has
+// overrides, preserving the callers' "no overrides" contract.
+func mergeOverridesAcrossKeys[V any](allOverrides map[string]map[string]V, keys []string) map[string]V {
+	var merged map[string]V
+	// Apply in reverse priority order so earlier (higher-priority) keys
+	// overwrite later ones on a path collision.
+	for i := len(keys) - 1; i >= 0; i-- {
+		overrides, ok := allOverrides[keys[i]]
+		if !ok {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string]V, len(overrides))
+		}
+		for path, value := range overrides {
+			merged[path] = value
+		}
+	}
+	return merged
+}
+
+// getValueOverridesForComponent returns scalar (--set) value overrides for a
+// specific component, merging overrides supplied under both the exact name and
+// any registry override-key aliases via componentOverrideKeys. Returns nil when
+// none apply.
 func (b *DefaultBundler) getValueOverridesForComponent(componentName string, provider recipe.DataProvider) map[string]string {
 	if b.Config == nil {
 		return nil
@@ -654,38 +739,24 @@ func (b *DefaultBundler) getValueOverridesForComponent(componentName string, pro
 		return nil
 	}
 
-	// Check exact name first
-	if overrides, ok := allOverrides[componentName]; ok {
-		return overrides
-	}
+	return mergeOverridesAcrossKeys(allOverrides, b.componentOverrideKeys(componentName, provider))
+}
 
-	// Use component registry to find component by any override key
-	registry, err := recipe.GetComponentRegistryFor(provider)
-	if err != nil {
-		// Fall back to non-hyphenated check if registry fails
-		nonHyphenated := removeHyphens(componentName)
-		if nonHyphenated != componentName {
-			if overrides, ok := allOverrides[nonHyphenated]; ok {
-				return overrides
-			}
-		}
+// getTypedValueOverridesForComponent returns structured (--set-json /
+// --set-file) value overrides for a specific component, resolving and merging
+// component aliases the same way getValueOverridesForComponent does. Returns
+// nil when none apply.
+func (b *DefaultBundler) getTypedValueOverridesForComponent(componentName string, provider recipe.DataProvider) map[string]any {
+	if b.Config == nil {
 		return nil
 	}
 
-	// Get the component config to access its value override keys
-	comp := registry.Get(componentName)
-	if comp == nil {
+	allOverrides := b.Config.ValueOverridesTyped()
+	if allOverrides == nil {
 		return nil
 	}
 
-	// Check each alternative override key
-	for _, key := range comp.ValueOverrideKeys {
-		if overrides, ok := allOverrides[key]; ok {
-			return overrides
-		}
-	}
-
-	return nil
+	return mergeOverridesAcrossKeys(allOverrides, b.componentOverrideKeys(componentName, provider))
 }
 
 // getSetEnabledOverride checks if --set overrides contain an "enabled" key
@@ -709,7 +780,7 @@ func (b *DefaultBundler) getSetEnabledOverride(componentName string, provider re
 	if parseErr != nil {
 		return false, false, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
 			"invalid --set enabled value", parseErr,
-			map[string]any{"component": componentName, "value": val})
+			map[string]any{errCtxKeyComponent: componentName, "value": val})
 	}
 	return parsed, true, nil
 }

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -28,6 +28,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -544,6 +546,114 @@ func TestMake_WithValueOverrides(t *testing.T) {
 	}
 }
 
+// TestMake_WithTypedValueOverrides verifies that a --set-json / --set-file list
+// override is rendered into the generated values.yaml as a real YAML sequence
+// (not the bare string scalar --set would produce). This is the regression
+// guard for the agentgateway.allowedSourceRanges trap described in #1161.
+func TestMake_WithTypedValueOverrides(t *testing.T) {
+	cfg := config.NewConfig(
+		config.WithValueOverridesTypedPaths([]config.TypedComponentPath{
+			{
+				Component: "gpu-operator",
+				Path:      "allowedSourceRanges",
+				Value:     []any{"216.228.127.128/30", "10.0.0.0/8"},
+			},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "gpu-operator",
+				Version: "v25.3.3",
+				Type:    "helm",
+				Source:  "https://helm.ngc.nvidia.com/nvidia",
+			},
+		},
+	}
+
+	if _, makeErr := bundler.Make(ctx, recipeResult, tmpDir); makeErr != nil {
+		t.Fatalf("Make() error = %v", makeErr)
+	}
+
+	valuesPath := filepath.Join(tmpDir, "001-gpu-operator", "values.yaml")
+	data, err := os.ReadFile(valuesPath)
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+
+	var values map[string]any
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("unmarshal values.yaml: %v", err)
+	}
+
+	got, ok := values["allowedSourceRanges"].([]any)
+	if !ok {
+		t.Fatalf("allowedSourceRanges is %T, want a YAML list ([]any); raw:\n%s", values["allowedSourceRanges"], data)
+	}
+	want := []any{"216.228.127.128/30", "10.0.0.0/8"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("allowedSourceRanges = %#v, want %#v", got, want)
+	}
+}
+
+// TestMake_TypedOverrideWinsOverSet locks in the precedence contract: when
+// scalar --set and structured --set-json/--set-file target the same path, the
+// typed override wins (it is applied last in buildComponentValues). Guards
+// against a future reordering silently flipping precedence.
+func TestMake_TypedOverrideWinsOverSet(t *testing.T) {
+	const path = "driver.version"
+
+	cfg := config.NewConfig(
+		config.WithValueOverrides(map[string]map[string]string{
+			"gpu-operator": {path: "from-set"},
+		}),
+		config.WithValueOverridesTypedPaths([]config.TypedComponentPath{
+			{Component: "gpu-operator", Path: path, Value: "from-json"},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	if _, makeErr := bundler.Make(context.Background(), recipeResult, tmpDir); makeErr != nil {
+		t.Fatalf("Make() error = %v", makeErr)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "001-gpu-operator", "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	var values map[string]any
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("unmarshal values.yaml: %v", err)
+	}
+
+	got, _ := component.GetValueByPath(values, path)
+	if got != "from-json" {
+		t.Errorf("%s = %#v, want \"from-json\" (typed --set-json must win over scalar --set)", path, got)
+	}
+}
+
 func TestMake_WithNodeSelectors(t *testing.T) {
 	cfg := config.NewConfig(
 		config.WithSystemNodeSelector(map[string]string{
@@ -949,6 +1059,143 @@ func TestGetValueOverridesForComponent(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGetTypedValueOverridesForComponent verifies that --set-json / --set-file
+// overrides resolve component aliases the same way scalar --set overrides do.
+func TestGetTypedValueOverridesForComponent(t *testing.T) {
+	tests := []struct {
+		name          string
+		paths         []config.TypedComponentPath
+		componentName string
+		wantOverrides bool
+		wantKey       string
+		wantValue     any
+	}{
+		{
+			name:          "no overrides returns nil",
+			componentName: "agentgateway",
+			wantOverrides: false,
+		},
+		{
+			name: "exact name match with list value",
+			paths: []config.TypedComponentPath{
+				{Component: "agentgateway", Path: "allowedSourceRanges", Value: []any{"10.0.0.0/8"}},
+			},
+			componentName: "agentgateway",
+			wantOverrides: true,
+			wantKey:       "allowedSourceRanges",
+			wantValue:     []any{"10.0.0.0/8"},
+		},
+		{
+			name: "override key match via registry alias",
+			paths: []config.TypedComponentPath{
+				{Component: "gpuoperator", Path: "driver.env", Value: map[string]any{"A": "b"}},
+			},
+			componentName: "gpu-operator",
+			wantOverrides: true,
+			wantKey:       "driver.env",
+			wantValue:     map[string]any{"A": "b"},
+		},
+		{
+			name: "no match returns nil",
+			paths: []config.TypedComponentPath{
+				{Component: "network-operator", Path: "list", Value: []any{"x"}},
+			},
+			componentName: "gpu-operator",
+			wantOverrides: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfig(config.WithValueOverridesTypedPaths(tt.paths))
+			b, err := New(WithConfig(cfg))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			result := b.getTypedValueOverridesForComponent(tt.componentName, nil)
+			if tt.wantOverrides && result == nil {
+				t.Fatal("expected overrides, got nil")
+			}
+			if !tt.wantOverrides && result != nil {
+				t.Errorf("expected nil overrides, got %v", result)
+			}
+			if tt.wantOverrides {
+				if !reflect.DeepEqual(result[tt.wantKey], tt.wantValue) {
+					t.Errorf("override[%q] = %#v, want %#v", tt.wantKey, result[tt.wantKey], tt.wantValue)
+				}
+			}
+		})
+	}
+}
+
+// TestGetTypedValueOverridesForComponent_MergesAcrossAliases verifies that when
+// typed overrides are supplied under BOTH the canonical name and a registry
+// alias for the same component, all of them are honored — none are silently
+// dropped — and that the canonical (higher-priority) key wins on a path that
+// collides across keys.
+func TestGetTypedValueOverridesForComponent_MergesAcrossAliases(t *testing.T) {
+	cfg := config.NewConfig(config.WithValueOverridesTypedPaths([]config.TypedComponentPath{
+		{Component: "gpu-operator", Path: "driver.env", Value: map[string]any{"A": "b"}},
+		{Component: "gpuoperator", Path: "allowedSourceRanges", Value: []any{"10.0.0.0/8"}},
+		// Collision: both the exact name and the alias set the same path.
+		{Component: "gpu-operator", Path: "shared", Value: "from-exact"},
+		{Component: "gpuoperator", Path: "shared", Value: "from-alias"},
+	}))
+	b, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result := b.getTypedValueOverridesForComponent("gpu-operator", nil)
+	if result == nil {
+		t.Fatal("expected merged overrides, got nil")
+	}
+	if !reflect.DeepEqual(result["driver.env"], map[string]any{"A": "b"}) {
+		t.Errorf("driver.env (exact-name override) = %#v, want {A:b}", result["driver.env"])
+	}
+	if !reflect.DeepEqual(result["allowedSourceRanges"], []any{"10.0.0.0/8"}) {
+		t.Errorf("allowedSourceRanges (alias override) = %#v, want [10.0.0.0/8] — alias override was dropped", result["allowedSourceRanges"])
+	}
+	if result["shared"] != "from-exact" {
+		t.Errorf("shared = %#v, want \"from-exact\" (canonical name must win on collision)", result["shared"])
+	}
+}
+
+// TestMake_TypedEnabledToggleRejectedBelowCLI verifies the bundler rejects an
+// "enabled" toggle supplied on the typed path even when it reaches the config
+// directly (i.e. not through the CLI flag parser) — guarding non-CLI/SDK
+// callers, not just the CLI. Routing the toggle through --set-json/--set-file
+// would write a stray literal `enabled:` into chart values instead of toggling
+// the component.
+func TestMake_TypedEnabledToggleRejectedBelowCLI(t *testing.T) {
+	cfg := config.NewConfig(
+		config.WithValueOverridesTypedPaths([]config.TypedComponentPath{
+			{Component: "gpu-operator", Path: config.ComponentEnabledKey, Value: false},
+		}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.nvidia.com/v1alpha1",
+		Kind:       "Recipe",
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia"},
+		},
+	}
+
+	_, makeErr := bundler.Make(context.Background(), recipeResult, t.TempDir())
+	if makeErr == nil {
+		t.Fatal("expected error: typed 'enabled' override must be rejected below the CLI boundary")
+	}
+	if !strings.Contains(makeErr.Error(), config.ComponentEnabledKey) || !strings.Contains(makeErr.Error(), "--set") {
+		t.Errorf("error %q must name the enabled toggle and point to --set", makeErr.Error())
 	}
 }
 

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -154,6 +155,13 @@ type Config struct {
 	// Map structure: bundler_name -> (path -> value)
 	valueOverrides map[string]map[string]string
 
+	// valueOverridesTyped holds structured (--set-json / --set-file) value
+	// overrides per component. Map structure: component_name -> (path ->
+	// decoded value). Unlike valueOverrides, the values are already-decoded
+	// lists/objects/scalars so list and object fields render as real YAML
+	// structures instead of the bare string `--set` would produce. See #1161.
+	valueOverridesTyped map[string]map[string]any
+
 	// systemNodeSelector contains node selector labels for system components.
 	systemNodeSelector map[string]string
 
@@ -274,6 +282,24 @@ func (c *Config) ValueOverrides() map[string]map[string]string {
 		for path, value := range paths {
 			overrides[bundler][path] = value
 		}
+	}
+	return overrides
+}
+
+// ValueOverridesTyped returns a deep copy of the structured (--set-json /
+// --set-file) value overrides to prevent callers from mutating the Config's
+// backing maps/slices. Returns nil when no typed overrides were supplied.
+func (c *Config) ValueOverridesTyped() map[string]map[string]any {
+	if len(c.valueOverridesTyped) == 0 {
+		return nil
+	}
+	overrides := make(map[string]map[string]any, len(c.valueOverridesTyped))
+	for component, paths := range c.valueOverridesTyped {
+		copied := make(map[string]any, len(paths))
+		for path, value := range paths {
+			copied[path] = serializer.DeepCopyAny(value)
+		}
+		overrides[component] = copied
 	}
 	return overrides
 }
@@ -700,13 +726,14 @@ func WithAppName(name string) Option {
 // NewConfig returns a Config with default values.
 func NewConfig(options ...Option) *Config {
 	c := &Config{
-		deployer:         DeployerHelm,
-		includeChecksums: true,
-		includeReadme:    true,
-		valueOverrides:   make(map[string]map[string]string),
-		dynamicValues:    make(map[string][]string),
-		verbose:          false,
-		version:          "dev",
+		deployer:            DeployerHelm,
+		includeChecksums:    true,
+		includeReadme:       true,
+		valueOverrides:      make(map[string]map[string]string),
+		valueOverridesTyped: make(map[string]map[string]any),
+		dynamicValues:       make(map[string][]string),
+		verbose:             false,
+		version:             "dev",
 	}
 	for _, opt := range options {
 		opt(c)

--- a/pkg/bundler/config/typed_override.go
+++ b/pkg/bundler/config/typed_override.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+// ComponentEnabledKey is the special value-override path that toggles whether a
+// component is included in the bundle. It is consumed by the bundler's
+// enable/disable handling and is valid only on scalar --set — never on the
+// typed --set-json / --set-file overrides, which would write a stray literal
+// `enabled:` into chart values and ship a component the operator believed
+// disabled. The bundler rejects it on the typed path regardless of caller (CLI
+// or SDK); the CLI also rejects it early for a friendlier message. See #1161.
+const ComponentEnabledKey = "enabled"
+
+// TypedComponentPath is a structured value override supplied via
+// `--set-json` / `--set-file`. Unlike ComponentPath (whose Value is always a
+// string), Value here is an already-decoded list, object, or scalar so that
+// list/object fields — e.g. agentgateway.allowedSourceRanges — render as real
+// YAML structures instead of the bare string `--set` would produce. See #1161.
+type TypedComponentPath struct {
+	Component string
+	Path      string
+	Value     any
+}
+
+// ParseValueOverridesJSON parses `--set-json` specs in the format
+// "component:path=<json>". The portion after the first '=' is decoded as a
+// JSON value (object, array, string, number, bool, or null), so list and
+// object overrides survive as structured values. The component:path prefix is
+// validated by ComponentPath.Parse (same path-segment safety rules as --set),
+// guarding against template injection and traversal.
+func ParseValueOverridesJSON(specs []string) ([]TypedComponentPath, error) {
+	return ParseTypedOverrides(specs, "--set-json", func(raw string) (any, error) {
+		var v any
+		// Return the raw decode error so ParseTypedOverrides attributes it to
+		// the offending spec; it carries no pkg/errors code, so PropagateOrWrap
+		// wraps it as ErrCodeInvalidRequest rather than propagating.
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	})
+}
+
+// ParseTypedOverrides is the shared parser behind ParseValueOverridesJSON and
+// the CLI's --set-file handling. It reuses ComponentPath.Parse to validate and
+// split "component:path=raw", then hands the raw value to decode. flagName is
+// used only for error attribution. The decode callback owns value
+// interpretation: --set-json supplies a JSON decoder, while --set-file supplies
+// a file-reading + YAML decoder from the CLI layer (so no filesystem access
+// leaks into this shared, server-reachable package).
+func ParseTypedOverrides(specs []string, flagName string, decode func(raw string) (any, error)) ([]TypedComponentPath, error) {
+	result := make([]TypedComponentPath, 0, len(specs))
+	for _, spec := range specs {
+		var cp ComponentPath
+		if err := cp.Parse(spec); err != nil {
+			return nil, err
+		}
+		if cp.Value == nil {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid format %q: %s requires 'component:path=value'", spec, flagName))
+		}
+		v, err := decode(*cp.Value)
+		if err != nil {
+			return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid %s %q", flagName, spec))
+		}
+		result = append(result, TypedComponentPath{Component: cp.Component, Path: cp.Path, Value: v})
+	}
+	return result, nil
+}
+
+// WithValueOverridesTypedPaths wires parsed --set-json / --set-file entries
+// into the config. Later entries for the same component+path win, mirroring
+// the last-one-wins semantics of repeated --set flags. Pass the combined
+// result of ParseValueOverridesJSON and the CLI's --set-file parsing.
+//
+// Each value is deep-copied on insertion so a caller (e.g. an SDK consumer
+// constructing TypedComponentPath values directly) that retains and later
+// mutates the source map/slice cannot reach into the Config's backing store.
+// This matches the copy-on-insert convention of the other With* options.
+func WithValueOverridesTypedPaths(paths []TypedComponentPath) Option {
+	return func(c *Config) {
+		for _, tp := range paths {
+			if c.valueOverridesTyped[tp.Component] == nil {
+				c.valueOverridesTyped[tp.Component] = make(map[string]any)
+			}
+			c.valueOverridesTyped[tp.Component][tp.Path] = serializer.DeepCopyAny(tp.Value)
+		}
+	}
+}

--- a/pkg/bundler/config/typed_override_test.go
+++ b/pkg/bundler/config/typed_override_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseValueOverridesJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		specs     []string
+		wantErr   bool
+		component string
+		path      string
+		wantValue any
+	}{
+		{
+			name:      "list value",
+			specs:     []string{`agentgateway:allowedSourceRanges=["216.228.127.128/30"]`},
+			component: "agentgateway",
+			path:      "allowedSourceRanges",
+			wantValue: []any{"216.228.127.128/30"},
+		},
+		{
+			name:      "object value",
+			specs:     []string{`gpuoperator:driver.env={"FOO":"bar"}`},
+			component: "gpuoperator",
+			path:      "driver.env",
+			wantValue: map[string]any{"FOO": "bar"},
+		},
+		{
+			name:      "scalar string value (quoted JSON)",
+			specs:     []string{`comp:field="hello"`},
+			component: "comp",
+			path:      "field",
+			wantValue: "hello",
+		},
+		{
+			name:      "bool value",
+			specs:     []string{`comp:field=true`},
+			component: "comp",
+			path:      "field",
+			wantValue: true,
+		},
+		{
+			name:    "invalid JSON",
+			specs:   []string{`comp:field=[not json`},
+			wantErr: true,
+		},
+		{
+			name:    "missing colon",
+			specs:   []string{`no-colon`},
+			wantErr: true,
+		},
+		{
+			name:    "missing equals",
+			specs:   []string{`comp:path-no-equals`},
+			wantErr: true,
+		},
+		{
+			name:    "template injection in path rejected",
+			specs:   []string{`comp:{{evil}}=[]`},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseValueOverridesJSON(tt.specs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseValueOverridesJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d entries, want 1", len(got))
+			}
+			if got[0].Component != tt.component || got[0].Path != tt.path {
+				t.Errorf("got component=%q path=%q, want %q/%q", got[0].Component, got[0].Path, tt.component, tt.path)
+			}
+			if !reflect.DeepEqual(got[0].Value, tt.wantValue) {
+				t.Errorf("value = %#v, want %#v", got[0].Value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestParseTypedOverrides_DecoderError(t *testing.T) {
+	_, err := ParseTypedOverrides([]string{"comp:field=x"}, "--set-file", func(string) (any, error) {
+		return nil, errInvalidTestValue
+	})
+	if err == nil {
+		t.Fatal("expected error when decoder fails, got nil")
+	}
+}
+
+var errInvalidTestValue = &decoderTestError{}
+
+type decoderTestError struct{}
+
+func (*decoderTestError) Error() string { return "decode failed" }
+
+func TestWithValueOverridesTypedPaths(t *testing.T) {
+	t.Run("applies and last-wins per path", func(t *testing.T) {
+		c := NewConfig(WithValueOverridesTypedPaths([]TypedComponentPath{
+			{Component: "agentgateway", Path: "allowedSourceRanges", Value: []any{"1.0.0.0/8"}},
+			{Component: "agentgateway", Path: "allowedSourceRanges", Value: []any{"2.0.0.0/8"}},
+			{Component: "gpuoperator", Path: "driver.env", Value: map[string]any{"A": "b"}},
+		}))
+
+		got := c.ValueOverridesTyped()
+		if !reflect.DeepEqual(got["agentgateway"]["allowedSourceRanges"], []any{"2.0.0.0/8"}) {
+			t.Errorf("allowedSourceRanges = %#v, want last value [2.0.0.0/8]", got["agentgateway"]["allowedSourceRanges"])
+		}
+		if !reflect.DeepEqual(got["gpuoperator"]["driver.env"], map[string]any{"A": "b"}) {
+			t.Errorf("driver.env = %#v", got["gpuoperator"]["driver.env"])
+		}
+	})
+
+	t.Run("getter returns a deep copy", func(t *testing.T) {
+		c := NewConfig(WithValueOverridesTypedPaths([]TypedComponentPath{
+			{Component: "comp", Path: "list", Value: []any{"a"}},
+		}))
+		got := c.ValueOverridesTyped()
+		// Mutate the returned copy; the config must not observe the change.
+		got["comp"]["list"] = []any{"mutated"}
+		got["comp"]["new"] = "x"
+
+		fresh := c.ValueOverridesTyped()
+		if !reflect.DeepEqual(fresh["comp"]["list"], []any{"a"}) {
+			t.Errorf("config backing map was mutated through getter: %#v", fresh["comp"]["list"])
+		}
+		if _, ok := fresh["comp"]["new"]; ok {
+			t.Error("added key leaked back into config backing map")
+		}
+	})
+
+	t.Run("no typed overrides returns nil", func(t *testing.T) {
+		c := NewConfig()
+		if got := c.ValueOverridesTyped(); got != nil {
+			t.Errorf("ValueOverridesTyped() = %#v, want nil", got)
+		}
+	})
+
+	t.Run("deep-copies value on insertion", func(t *testing.T) {
+		// A caller that retains and mutates the source value after NewConfig
+		// must not be able to reach into the Config's backing store.
+		srcList := []any{"a"}
+		srcMap := map[string]any{"k": "v"}
+		c := NewConfig(WithValueOverridesTypedPaths([]TypedComponentPath{
+			{Component: "comp", Path: "list", Value: srcList},
+			{Component: "comp", Path: "obj", Value: srcMap},
+		}))
+
+		// Mutate the originals; the Config must be unaffected.
+		srcList[0] = "MUTATED"
+		srcMap["k"] = "MUTATED"
+
+		got := c.ValueOverridesTyped()
+		if !reflect.DeepEqual(got["comp"]["list"], []any{"a"}) {
+			t.Errorf("list aliased source on insertion: %#v", got["comp"]["list"])
+		}
+		if !reflect.DeepEqual(got["comp"]["obj"], map[string]any{"k": "v"}) {
+			t.Errorf("obj aliased source on insertion: %#v", got["comp"]["obj"])
+		}
+	})
+}

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -46,6 +46,7 @@ type bundleCmdOptions struct {
 	deployer                   config.DeployerType
 	repoURL                    string
 	valueOverrides             []config.ComponentPath
+	valueOverridesTyped        []config.TypedComponentPath
 	systemNodeSelector         map[string]string
 	systemNodeTolerations      []corev1.Toleration
 	acceleratedNodeSelector    map[string]string
@@ -264,6 +265,9 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 	if opts.valueOverrides, err = resolveComponentPaths(cmd, "set", resolved.ValueOverrides, config.ParseValueOverrides); err != nil {
 		return nil, err
 	}
+	if opts.valueOverridesTyped, err = resolveTypedOverrides(cmd); err != nil {
+		return nil, err
+	}
 	if opts.dynamicValues, err = resolveComponentPaths(cmd, "dynamic", resolved.DynamicValues, config.ParseDynamicValues); err != nil {
 		return nil, err
 	}
@@ -364,9 +368,21 @@ func resolveOutputTarget(cmd *cli.Command, resolved *appcfg.BundleResolved) (*oc
 //nolint:funlen // bundle command is inherently large (flags + description + action)
 func bundleCmd() *cli.Command {
 	return &cli.Command{
-		Name:     "bundle",
-		Category: functionalCategoryName,
-		Usage:    "Generate deployment bundle from a given recipe.",
+		Name: "bundle",
+		// Treat commas literally in repeatable slice flags rather than as
+		// value separators. Required so --set-json / --set-file can carry
+		// JSON lists/objects (which are comma-heavy) in a single flag, and it
+		// removes a latent footgun where a --set string value containing a
+		// comma would be silently split. urfave/cli splits slice-flag values
+		// on commas by default, and this disables that for EVERY slice flag on
+		// the command (--set, --dynamic, --*-node-selector/-toleration,
+		// --workload-selector) — not just the typed ones. Repeat-to-add is the
+		// only documented form in AICR; comma-packing multiple values into one
+		// flag was never part of AICR's documented contract, so the only
+		// affected usage is a CI script that relied on the framework default.
+		DisableSliceFlagSeparator: true,
+		Category:                  functionalCategoryName,
+		Usage:                     "Generate deployment bundle from a given recipe.",
 		Description: `Generates a deployment bundle from a given recipe.
 Use --deployer argocd to generate Argo CD Applications.
 Use --deployer flux to generate Flux HelmRelease and Kustomization manifests.
@@ -428,6 +444,10 @@ Generate Helmfile release graph:
 Override values in generated bundle:
   aicr bundle --recipe recipe.yaml --set gpuoperator:driver.version=570.133.20
 
+Override a list/object value (--set cannot express these):
+  aicr bundle --recipe recipe.yaml \
+    --set-json agentgateway:allowedSourceRanges='["216.228.127.128/30"]'
+
 Set node selectors for GPU workloads:
   aicr bundle --recipe recipe.yaml \
     --accelerated-node-selector nodeGroup=gpu-nodes \
@@ -464,7 +484,26 @@ Package with explicit tag (overrides CLI version):
 				Usage: `Override values in generated bundle files
 	(format: component:path.to.field=value, e.g., --set gpuoperator:gds.enabled=true).
 	Use the special 'enabled' key to include/exclude components at bundle time
-	(e.g., --set awsebscsidriver:enabled=false to skip aws-ebs-csi-driver)`,
+	(e.g., --set awsebscsidriver:enabled=false to skip aws-ebs-csi-driver).
+	--set is scalar-only; use --set-json / --set-file for list or object values.`,
+				Category: catDeployment,
+			},
+			&cli.StringSliceFlag{
+				Name: "set-json",
+				Usage: `Override values with a JSON-encoded scalar, list, or object
+	(format: component:path.to.field=<json>, can be repeated). Use this for
+	typed fields that --set cannot express, e.g.
+	--set-json agentgateway:allowedSourceRanges='["216.228.127.128/30"]'.
+	Object values deep-merge into existing maps; lists and scalars replace.
+	Takes precedence over --set on the same path.`,
+				Category: catDeployment,
+			},
+			&cli.StringSliceFlag{
+				Name: "set-file",
+				Usage: `Override values by reading a JSON/YAML value from a file
+	(format: component:path.to.field=<filepath>, can be repeated). The file
+	holds a single value (list, object, or scalar) for larger structures than
+	--set-json. Merge semantics match --set-json.`,
 				Category: catDeployment,
 			},
 			&cli.StringSliceFlag{
@@ -701,6 +740,7 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		config.WithAttest(opts.attest),
 		config.WithCertificateIdentityRegexp(opts.certificateIdentityRegexp),
 		config.WithValueOverridePaths(opts.valueOverrides),
+		config.WithValueOverridesTypedPaths(opts.valueOverridesTyped),
 		config.WithDynamicValuePaths(opts.dynamicValues),
 		config.WithSystemNodeSelector(opts.systemNodeSelector),
 		config.WithSystemNodeTolerations(opts.systemNodeTolerations),

--- a/pkg/cli/bundle_config.go
+++ b/pkg/cli/bundle_config.go
@@ -15,16 +15,21 @@
 package cli
 
 import (
+	stderrors "errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
+	"os"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
 
 	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
@@ -107,6 +112,131 @@ func resolveTolerations(cmd *cli.Command, flagName string, fallback []corev1.Tol
 		return snapshotter.DefaultTolerations(), nil
 	}
 	return fallback, nil
+}
+
+// resolveTypedOverrides parses the --set-json and --set-file flags into
+// structured component-path overrides for list/object values that scalar
+// --set cannot express (see #1161). --set-json decodes the value as JSON;
+// --set-file reads the value from a file and decodes it as YAML (a JSON
+// superset). Both reuse --set's "component:path" validation.
+//
+// The two flags are additive. When both target the same component:path,
+// --set-file is collected first so an inline --set-json wins on that path,
+// mirroring Helm's precedence of --set over -f value files. (urfave/cli does
+// not expose the interleaved command-line order across two distinct flags, so
+// this fixed precedence is the deterministic contract rather than raw argument
+// order.) Within a single flag, the last entry for a given component:path
+// wins. Returns nil when neither flag is set.
+func resolveTypedOverrides(cmd *cli.Command) ([]bundlercfg.TypedComponentPath, error) {
+	var out []bundlercfg.TypedComponentPath
+
+	// Collect --set-file first so a later-applied --set-json on the same
+	// component:path takes precedence (Helm-like: --set beats -f).
+	//
+	// ParseTypedOverrides / ParseValueOverridesJSON already return structured
+	// ErrCodeInvalidRequest errors that name the offending spec (and, for value
+	// decode/format failures, the flag), so propagate them as-is rather than
+	// re-wrapping with the same code.
+	if cmd.IsSet("set-file") {
+		parsed, err := bundlercfg.ParseTypedOverrides(cmd.StringSlice("set-file"), "--set-file", decodeSetFileValue)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, parsed...)
+	}
+
+	if cmd.IsSet("set-json") {
+		parsed, err := bundlercfg.ParseValueOverridesJSON(cmd.StringSlice("set-json"))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, parsed...)
+	}
+
+	// The top-level "enabled" key is the bundler's component include/exclude
+	// toggle, not a Helm chart value — it is honored only via scalar --set
+	// (getSetEnabledOverride) and stripped before reaching chart values.
+	// Routing it through the typed flags would neither toggle the component nor
+	// strip the key: it would silently write a stray literal `enabled:` into the
+	// component's values and ship a component the operator believed disabled.
+	// Reject it loudly with a pointer to --set rather than emit a misconfigured
+	// bundle. A nested chart value such as `gds.enabled` is unaffected — only
+	// the exact toggle path is blocked.
+	for _, tp := range out {
+		if tp.Path == componentEnabledKey {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("%q is the component enable/disable toggle and must be set with --set "+
+					"(e.g. --set %s:%s=false), not --set-json/--set-file",
+					componentEnabledKey, tp.Component, componentEnabledKey))
+		}
+	}
+
+	return out, nil
+}
+
+// componentEnabledKey is the special value-override path that toggles whether a
+// component is included in the bundle. It is consumed by the bundler's
+// getSetEnabledOverride and is valid only on scalar --set (see #1161). Aliased
+// to the bundler config's canonical constant so the CLI early-reject and the
+// bundler's below-the-boundary guard never drift.
+const componentEnabledKey = bundlercfg.ComponentEnabledKey
+
+// decodeSetFileValue reads the value file at path (bounded to
+// defaults.MaxSetFileBytes) and decodes it as YAML, a superset of JSON, for
+// the --set-file flag. os.Open + io.LimitReader is used instead of
+// os.ReadFile so an attacker-influenced path (e.g. a /proc symlink or a
+// network mount) cannot OOM the process before the size check.
+func decodeSetFileValue(path string) (any, error) {
+	// Stat before Open so a non-regular path fails fast with a clear error
+	// instead of hanging or being misreported. Opening a FIFO/named pipe blocks
+	// in os.Open until a writer appears, which would hang the CLI/CI job; a
+	// directory opens fine on Unix and only fails later in io.ReadAll with
+	// EISDIR (misreported as an internal error). Rejecting every non-regular
+	// mode (pipe, device, socket, directory) up front covers all of these.
+	// os.Stat follows symlinks, so a symlink to a regular file is still
+	// accepted.
+	info, err := os.Stat(path)
+	if err != nil {
+		// Only a genuine "does not exist" is NOT_FOUND; permission denied or
+		// transient I/O are bad operator input, not a missing resource — report
+		// them as invalid request.
+		if stderrors.Is(err, os.ErrNotExist) {
+			return nil, errors.Wrap(errors.ErrCodeNotFound, "cannot open --set-file value file: "+path, err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "cannot open --set-file value file: "+path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"--set-file value path must be a regular file: "+path)
+	}
+
+	f, err := os.Open(path) //nolint:gosec // operator-supplied --set-file path, read bounded below
+	if err != nil {
+		// The file passed the regular-file check above; a failure here is a
+		// race (removed/replaced) or permission/I/O issue. Keep the same
+		// NOT_FOUND vs invalid-request split as the stat above.
+		if stderrors.Is(err, os.ErrNotExist) {
+			return nil, errors.Wrap(errors.ErrCodeNotFound, "cannot open --set-file value file: "+path, err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "cannot open --set-file value file: "+path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	limited := io.LimitReader(f, defaults.MaxSetFileBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read --set-file value file: "+path, err)
+	}
+	if int64(len(data)) > defaults.MaxSetFileBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("--set-file value file %q exceeds %d bytes", path, defaults.MaxSetFileBytes))
+	}
+
+	var v any
+	if err := yaml.Unmarshal(data, &v); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid YAML/JSON in --set-file value file: "+path, err)
+	}
+	return v, nil
 }
 
 // resolveComponentPaths returns the final component-path slice for a

--- a/pkg/cli/bundle_typed_overrides_test.go
+++ b/pkg/cli/bundle_typed_overrides_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func typedOverrideFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringSliceFlag{Name: "set-json"},
+		&cli.StringSliceFlag{Name: "set-file"},
+	}
+}
+
+func TestResolveTypedOverrides_SetJSON(t *testing.T) {
+	runWith(t, typedOverrideFlags(),
+		[]string{"--set-json", `agentgateway:allowedSourceRanges=["216.228.127.128/30"]`},
+		func(c *cli.Command) {
+			got, err := resolveTypedOverrides(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d entries, want 1", len(got))
+			}
+			if got[0].Component != "agentgateway" || got[0].Path != "allowedSourceRanges" {
+				t.Errorf("got %q/%q", got[0].Component, got[0].Path)
+			}
+			if !reflect.DeepEqual(got[0].Value, []any{"216.228.127.128/30"}) {
+				t.Errorf("value = %#v", got[0].Value)
+			}
+		})
+}
+
+// TestResolveTypedOverrides_SetJSONWithCommas verifies that a multi-element
+// JSON list (comma-heavy) survives flag parsing when the command disables the
+// slice-flag separator, as the real bundle command does. Without
+// DisableSliceFlagSeparator the value would be split on commas and fail to
+// parse — this is the regression guard for that wiring.
+func TestResolveTypedOverrides_SetJSONWithCommas(t *testing.T) {
+	cmd := &cli.Command{
+		Name:                      "t",
+		DisableSliceFlagSeparator: true,
+		Flags:                     typedOverrideFlags(),
+		Action: func(_ context.Context, c *cli.Command) error {
+			got, err := resolveTypedOverrides(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d entries, want 1", len(got))
+			}
+			want := []any{"216.228.127.128/30", "10.0.0.0/8"}
+			if !reflect.DeepEqual(got[0].Value, want) {
+				t.Errorf("value = %#v, want %#v", got[0].Value, want)
+			}
+			return nil
+		},
+	}
+	args := []string{"t", "--set-json", `agentgateway:allowedSourceRanges=["216.228.127.128/30","10.0.0.0/8"]`}
+	if err := cmd.Run(context.Background(), args); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestResolveTypedOverrides_NeitherFlagReturnsNil(t *testing.T) {
+	runWith(t, typedOverrideFlags(), []string{}, func(c *cli.Command) {
+		got, err := resolveTypedOverrides(c)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("got %#v, want nil", got)
+		}
+	})
+}
+
+func TestResolveTypedOverrides_InvalidJSON(t *testing.T) {
+	runWith(t, typedOverrideFlags(), []string{"--set-json", "comp:field=[bad"}, func(c *cli.Command) {
+		_, err := resolveTypedOverrides(c)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+		if !strings.Contains(err.Error(), "--set-json") {
+			t.Errorf("error %q must mention --set-json", err.Error())
+		}
+	})
+}
+
+func TestResolveTypedOverrides_SetFile(t *testing.T) {
+	dir := t.TempDir()
+	valFile := filepath.Join(dir, "ranges.yaml")
+	if err := os.WriteFile(valFile, []byte("- 10.0.0.0/8\n- 192.168.0.0/16\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runWith(t, typedOverrideFlags(),
+		[]string{"--set-file", "agentgateway:allowedSourceRanges=" + valFile},
+		func(c *cli.Command) {
+			got, err := resolveTypedOverrides(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d entries, want 1", len(got))
+			}
+			want := []any{"10.0.0.0/8", "192.168.0.0/16"}
+			if !reflect.DeepEqual(got[0].Value, want) {
+				t.Errorf("value = %#v, want %#v", got[0].Value, want)
+			}
+		})
+}
+
+func TestResolveTypedOverrides_BothFlagsCombine(t *testing.T) {
+	dir := t.TempDir()
+	valFile := filepath.Join(dir, "v.json")
+	if err := os.WriteFile(valFile, []byte(`{"k":"v"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runWith(t, typedOverrideFlags(),
+		[]string{
+			"--set-json", `a:list=[1]`,
+			"--set-file", "b:obj=" + valFile,
+		},
+		func(c *cli.Command) {
+			got, err := resolveTypedOverrides(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 2 {
+				t.Fatalf("got %d entries, want 2 (set-json + set-file)", len(got))
+			}
+		})
+}
+
+// TestResolveTypedOverrides_SetJSONWinsOverSetFile locks in the precedence
+// contract between the two typed flags: when --set-json and --set-file target
+// the same component:path, the inline --set-json must win (mirroring Helm's
+// --set over -f). resolveTypedOverrides collects --set-file first so the
+// --set-json entry is applied last by WithValueOverridesTypedPaths. The
+// command-line order is deliberately --set-json before --set-file to prove the
+// outcome is governed by the fixed precedence, not raw argument order.
+func TestResolveTypedOverrides_SetJSONWinsOverSetFile(t *testing.T) {
+	dir := t.TempDir()
+	valFile := filepath.Join(dir, "ranges.yaml")
+	if err := os.WriteFile(valFile, []byte("- from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runWith(t, typedOverrideFlags(),
+		[]string{
+			"--set-json", `agentgateway:allowedSourceRanges=["from-json"]`,
+			"--set-file", "agentgateway:allowedSourceRanges=" + valFile,
+		},
+		func(c *cli.Command) {
+			got, err := resolveTypedOverrides(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 2 {
+				t.Fatalf("got %d entries, want 2", len(got))
+			}
+			// The last entry for a given component:path wins when applied; the
+			// --set-json entry must be ordered after the --set-file entry.
+			last := got[len(got)-1]
+			if last.Component != "agentgateway" || last.Path != "allowedSourceRanges" {
+				t.Fatalf("last entry = %q/%q, want agentgateway/allowedSourceRanges", last.Component, last.Path)
+			}
+			if !reflect.DeepEqual(last.Value, []any{"from-json"}) {
+				t.Errorf("last (winning) value = %#v, want [from-json] (--set-json must win over --set-file)", last.Value)
+			}
+		})
+}
+
+// TestResolveTypedOverrides_RejectsEnabledToggle verifies the top-level
+// "enabled" component toggle is rejected on the typed flags — it is honored
+// only via scalar --set, so routing it through --set-json/--set-file would
+// silently ship a component the operator believed disabled.
+func TestResolveTypedOverrides_RejectsEnabledToggle(t *testing.T) {
+	runWith(t, typedOverrideFlags(),
+		[]string{"--set-json", "gpuoperator:enabled=false"},
+		func(c *cli.Command) {
+			_, err := resolveTypedOverrides(c)
+			if err == nil {
+				t.Fatal("expected error: 'enabled' toggle must use --set")
+			}
+			if !strings.Contains(err.Error(), "enabled") || !strings.Contains(err.Error(), "--set") {
+				t.Errorf("error %q must name the enabled toggle and point to --set", err.Error())
+			}
+		})
+}
+
+// TestResolveTypedOverrides_AllowsNestedEnabledValue verifies that only the
+// exact top-level toggle key is blocked; a nested chart value such as
+// gds.enabled is a legitimate boolean override.
+func TestResolveTypedOverrides_AllowsNestedEnabledValue(t *testing.T) {
+	runWith(t, typedOverrideFlags(),
+		[]string{"--set-json", "gpuoperator:gds.enabled=true"},
+		func(c *cli.Command) {
+			got, err := resolveTypedOverrides(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 || got[0].Path != "gds.enabled" || got[0].Value != true {
+				t.Errorf("got %#v, want gds.enabled=true allowed", got)
+			}
+		})
+}
+
+func TestDecodeSetFileValue_MissingFile(t *testing.T) {
+	_, err := decodeSetFileValue(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestDecodeSetFileValue_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(bad, []byte("key: [unterminated\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := decodeSetFileValue(bad)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestDecodeSetFileValue_ExceedsSizeLimit(t *testing.T) {
+	dir := t.TempDir()
+	big := filepath.Join(dir, "big.yaml")
+	// Write a valid-ish YAML scalar larger than the 1 MiB cap.
+	payload := make([]byte, 1*1024*1024+10)
+	for i := range payload {
+		payload[i] = 'a'
+	}
+	if err := os.WriteFile(big, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := decodeSetFileValue(big)
+	if err == nil {
+		t.Fatal("expected error for oversized file")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error %q must mention size limit", err.Error())
+	}
+}
+
+// TestDecodeSetFileValue_MissingFileIsNotFound verifies a genuinely absent file
+// maps to ErrCodeNotFound.
+func TestDecodeSetFileValue_MissingFileIsNotFound(t *testing.T) {
+	_, err := decodeSetFileValue(filepath.Join(t.TempDir(), "absent.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("missing file: got code != NOT_FOUND for %v", err)
+	}
+}
+
+// TestDecodeSetFileValue_NonNotExistOpenErrorIsInvalidRequest verifies an
+// os.Open failure that is NOT "does not exist" (here ENOTDIR: a path component
+// is a regular file, not a directory) is reported as ErrCodeInvalidRequest
+// rather than masquerading as NOT_FOUND.
+func TestDecodeSetFileValue_NonNotExistOpenErrorIsInvalidRequest(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "regular.yaml")
+	if err := os.WriteFile(file, []byte("[]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Treating the regular file as a directory triggers ENOTDIR on open.
+	notADir := filepath.Join(file, "child.yaml")
+
+	_, err := decodeSetFileValue(notADir)
+	if err == nil {
+		t.Fatal("expected error opening a path under a non-directory")
+	}
+	if stderrors.Is(err, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("ENOTDIR open error must not be NOT_FOUND: %v", err)
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("ENOTDIR open error should be INVALID_REQUEST: %v", err)
+	}
+}
+
+// TestDecodeSetFileValue_DirectoryIsInvalidRequest verifies that pointing
+// --set-file at a directory is reported as ErrCodeInvalidRequest (bad operator
+// input), not ErrCodeInternal. os.Open succeeds on a directory on Unix; the
+// read would otherwise fail later with EISDIR and be wrapped as internal.
+func TestDecodeSetFileValue_DirectoryIsInvalidRequest(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := decodeSetFileValue(dir)
+	if err == nil {
+		t.Fatal("expected error when --set-file points at a directory")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("directory path should be INVALID_REQUEST, got %v", err)
+	}
+	if stderrors.Is(err, errors.New(errors.ErrCodeInternal, "")) {
+		t.Errorf("directory path must not be INTERNAL: %v", err)
+	}
+}
+
+// TestDecodeSetFileValue_NonRegularFileIsInvalidRequest verifies that a
+// non-regular --set-file path (here a FIFO) is rejected as
+// ErrCodeInvalidRequest by the up-front stat, rather than blocking in os.Open
+// until a writer appears (which would hang the CLI/CI job).
+func TestDecodeSetFileValue_NonRegularFileIsInvalidRequest(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "set-file.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported on this platform: %v", err)
+	}
+
+	// decodeSetFileValue must return promptly with an invalid-request error;
+	// because the stat happens before os.Open, no writer is needed and the
+	// call does not block.
+	_, err := decodeSetFileValue(fifo)
+	if err == nil {
+		t.Fatal("expected error when --set-file points at a FIFO")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("non-regular path should be INVALID_REQUEST, got %v", err)
+	}
+	if stderrors.Is(err, errors.New(errors.ErrCodeInternal, "")) {
+		t.Errorf("non-regular path must not be INTERNAL: %v", err)
+	}
+}

--- a/pkg/component/overrides.go
+++ b/pkg/component/overrides.go
@@ -16,12 +16,14 @@ package component
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // ApplyMapOverrides applies overrides to a map[string]any using dot-notation paths.
@@ -48,6 +50,125 @@ func ApplyMapOverrides(target map[string]any, overrides map[string]string) error
 	}
 
 	return nil
+}
+
+// ApplyTypedOverrides applies structured (--set-json / --set-file) overrides
+// to target using dot-notation paths. For each path, a map value is
+// deep-merged into any existing map at that path (so partial object overrides
+// compose with recipe/base values); every other value kind — scalar or list —
+// replaces what is at the path. Values are deep-copied so the override source
+// is never aliased into target. Intermediate path segments that exist but are
+// not maps are an error (strict mode), matching ApplyMapOverrides.
+//
+// Paths are applied shallowest-first (by segment count, then lexicographically)
+// rather than in Go's randomized map-iteration order. This makes the result
+// deterministic when two paths overlap by prefix — e.g. "driver.env" (an
+// object) and "driver.env.HTTPS_PROXY" (a scalar): the parent object is merged
+// first, then the deeper, more-specific override lands last and wins. Without
+// the sort, the apply order — and thus the bundle output — would vary run to
+// run, violating the project's "same inputs -> same outputs" guarantee.
+func ApplyTypedOverrides(target map[string]any, overrides map[string]any) error {
+	if target == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "target map cannot be nil")
+	}
+
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	var errs []string
+	for _, path := range sortedOverridePaths(overrides) {
+		if err := mergeTypedValueByPath(target, path, overrides[path]); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", path, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("failed to apply typed overrides: %s", strings.Join(errs, "; ")))
+	}
+
+	return nil
+}
+
+// sortedOverridePaths returns the override paths ordered shallowest-first by
+// dot-separated segment count, breaking ties lexicographically. A path that is
+// a strict dot-prefix of another always has fewer segments, so it is always
+// applied before the path that extends it — making overlapping-path merges
+// deterministic and letting the deeper override win.
+func sortedOverridePaths(overrides map[string]any) []string {
+	paths := make([]string, 0, len(overrides))
+	for path := range overrides {
+		paths = append(paths, path)
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		di, dj := strings.Count(paths[i], "."), strings.Count(paths[j], ".")
+		if di != dj {
+			return di < dj
+		}
+		return paths[i] < paths[j]
+	})
+	return paths
+}
+
+// mergeTypedValueByPath resolves the parent map for a dot-notation path
+// (creating intermediate maps as needed) and merges value at the final key:
+// map-into-map deep-merges, everything else replaces (deep-copied).
+//
+// A map value is always routed through mergeAnyMap — even when there is no
+// existing map at the key — so its explicit-null delete semantics apply
+// uniformly. A bare DeepCopyAny would instead store a `null` child verbatim
+// (rendering `key: null` rather than dropping it) when the destination is
+// absent, contradicting the documented "null deletes the key" behavior.
+func mergeTypedValueByPath(target map[string]any, path string, value any) error {
+	parent, key, err := getOrCreateNestedMap(target, path, true)
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to resolve override path", err)
+	}
+
+	if srcMap, srcIsMap := value.(map[string]any); srcIsMap {
+		if dstMap, dstIsMap := parent[key].(map[string]any); dstIsMap {
+			mergeAnyMap(dstMap, srcMap)
+			return nil
+		}
+		// No existing map at the key: merge into a fresh map so null-valued
+		// keys are dropped rather than stored as literal nulls.
+		clean := make(map[string]any, len(srcMap))
+		mergeAnyMap(clean, srcMap)
+		parent[key] = clean
+		return nil
+	}
+
+	parent[key] = serializer.DeepCopyAny(value)
+	return nil
+}
+
+// mergeAnyMap recursively merges src into dst: nested maps merge key-by-key,
+// all other values (scalars, slices) replace and are deep-copied, and a nil
+// src value deletes the key. Mirrors the recipe overlay merge semantics so
+// --set-json object overrides compose the same way inline recipe overrides do.
+func mergeAnyMap(dst, src map[string]any) {
+	for k, sv := range src {
+		if sv == nil {
+			delete(dst, k)
+			continue
+		}
+		if svMap, ok := sv.(map[string]any); ok {
+			if dvMap, ok := dst[k].(map[string]any); ok {
+				mergeAnyMap(dvMap, svMap)
+				continue
+			}
+			// No existing map at the key: merge into a fresh map (rather than
+			// deep-copying verbatim) so nested null-valued keys are dropped
+			// instead of stored as literal nulls — matching the top-level
+			// behavior in mergeTypedValueByPath and the documented "null
+			// deletes the key" semantics at every depth.
+			clean := make(map[string]any, len(svMap))
+			mergeAnyMap(clean, svMap)
+			dst[k] = clean
+			continue
+		}
+		dst[k] = serializer.DeepCopyAny(sv)
+	}
 }
 
 // getOrCreateNestedMap traverses a dot-separated path in a nested map,

--- a/pkg/component/typed_overrides_test.go
+++ b/pkg/component/typed_overrides_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyTypedOverrides(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    map[string]any
+		overrides map[string]any
+		wantErr   bool
+		verify    func(t *testing.T, got map[string]any)
+	}{
+		{
+			name:      "list value replaces and renders as slice",
+			target:    map[string]any{"allowedSourceRanges": []any{}},
+			overrides: map[string]any{"allowedSourceRanges": []any{"216.228.127.128/30"}},
+			verify: func(t *testing.T, got map[string]any) {
+				if !reflect.DeepEqual(got["allowedSourceRanges"], []any{"216.228.127.128/30"}) {
+					t.Errorf("allowedSourceRanges = %#v", got["allowedSourceRanges"])
+				}
+			},
+		},
+		{
+			name:      "creates intermediate maps for nested list",
+			target:    map[string]any{},
+			overrides: map[string]any{"a.b.list": []any{int64(1), int64(2)}},
+			verify: func(t *testing.T, got map[string]any) {
+				a := got["a"].(map[string]any)
+				b := a["b"].(map[string]any)
+				if !reflect.DeepEqual(b["list"], []any{int64(1), int64(2)}) {
+					t.Errorf("a.b.list = %#v", b["list"])
+				}
+			},
+		},
+		{
+			name: "object value deep-merges into existing map",
+			target: map[string]any{
+				"driver": map[string]any{
+					"env":     map[string]any{"KEEP": "yes", "OVER": "old"},
+					"version": "1.0",
+				},
+			},
+			overrides: map[string]any{"driver": map[string]any{"env": map[string]any{"OVER": "new", "ADD": "x"}}},
+			verify: func(t *testing.T, got map[string]any) {
+				driver := got["driver"].(map[string]any)
+				if driver["version"] != "1.0" {
+					t.Errorf("version lost in merge: %#v", driver["version"])
+				}
+				env := driver["env"].(map[string]any)
+				want := map[string]any{"KEEP": "yes", "OVER": "new", "ADD": "x"}
+				if !reflect.DeepEqual(env, want) {
+					t.Errorf("driver.env = %#v, want %#v", env, want)
+				}
+			},
+		},
+		{
+			name:      "list replaces existing map (no merge for non-map)",
+			target:    map[string]any{"field": map[string]any{"a": "b"}},
+			overrides: map[string]any{"field": []any{"x"}},
+			verify: func(t *testing.T, got map[string]any) {
+				if !reflect.DeepEqual(got["field"], []any{"x"}) {
+					t.Errorf("field = %#v, want [x]", got["field"])
+				}
+			},
+		},
+		{
+			name:      "nil value in merged map deletes key",
+			target:    map[string]any{"m": map[string]any{"keep": "1", "drop": "2"}},
+			overrides: map[string]any{"m": map[string]any{"drop": nil}},
+			verify: func(t *testing.T, got map[string]any) {
+				m := got["m"].(map[string]any)
+				if _, ok := m["drop"]; ok {
+					t.Error("drop key should have been deleted")
+				}
+				if m["keep"] != "1" {
+					t.Errorf("keep = %#v, want 1", m["keep"])
+				}
+			},
+		},
+		{
+			// Regression: when no map pre-exists at the path, a null-valued key
+			// in the override object must still be dropped (not stored as a
+			// literal null), matching the documented delete semantics.
+			name:      "nil value dropped when destination map is absent",
+			target:    map[string]any{},
+			overrides: map[string]any{"env": map[string]any{"DROP": nil, "KEEP": "v"}},
+			verify: func(t *testing.T, got map[string]any) {
+				env := got["env"].(map[string]any)
+				if _, ok := env["DROP"]; ok {
+					t.Errorf("DROP must be absent, got %#v", env["DROP"])
+				}
+				if env["KEEP"] != "v" {
+					t.Errorf("KEEP = %#v, want v", env["KEEP"])
+				}
+			},
+		},
+		{
+			// Regression: the destination-absent null-drop must also hold for a
+			// NESTED map, not just the top-level path key. Here driver exists
+			// but driver.env does not; a null inside the freshly-created env map
+			// must be dropped, not stored as a literal null.
+			name:      "nil value dropped in nested map when inner destination is absent",
+			target:    map[string]any{"driver": map[string]any{"version": "1.0"}},
+			overrides: map[string]any{"driver": map[string]any{"env": map[string]any{"DROP": nil, "KEEP": "v"}}},
+			verify: func(t *testing.T, got map[string]any) {
+				driver := got["driver"].(map[string]any)
+				if driver["version"] != "1.0" {
+					t.Errorf("version lost in merge: %#v", driver["version"])
+				}
+				env := driver["env"].(map[string]any)
+				if _, ok := env["DROP"]; ok {
+					t.Errorf("nested DROP must be absent, got %#v", env["DROP"])
+				}
+				if env["KEEP"] != "v" {
+					t.Errorf("nested KEEP = %#v, want v", env["KEEP"])
+				}
+			},
+		},
+		{
+			name:      "intermediate non-map segment is an error",
+			target:    map[string]any{"a": "scalar"},
+			overrides: map[string]any{"a.b": []any{"x"}},
+			wantErr:   true,
+		},
+		{
+			name:      "empty overrides is a no-op",
+			target:    map[string]any{"x": "y"},
+			overrides: map[string]any{},
+			verify: func(t *testing.T, got map[string]any) {
+				if got["x"] != "y" {
+					t.Errorf("target mutated: %#v", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ApplyTypedOverrides(tt.target, tt.overrides)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ApplyTypedOverrides() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			tt.verify(t, tt.target)
+		})
+	}
+}
+
+func TestApplyTypedOverrides_NilTarget(t *testing.T) {
+	if err := ApplyTypedOverrides(nil, map[string]any{"a": "b"}); err == nil {
+		t.Error("expected error for nil target, got nil")
+	}
+}
+
+// TestApplyTypedOverrides_NoAliasing verifies the override source is not
+// aliased into the target — mutating the applied value must not reach back
+// into the override map (and vice versa).
+func TestApplyTypedOverrides_NoAliasing(t *testing.T) {
+	src := []any{"a", "b"}
+	overrides := map[string]any{"list": src}
+	target := map[string]any{}
+
+	if err := ApplyTypedOverrides(target, overrides); err != nil {
+		t.Fatalf("ApplyTypedOverrides() error = %v", err)
+	}
+
+	// Mutate the source slice; target must be unaffected.
+	src[0] = "MUTATED"
+	got := target["list"].([]any)
+	if got[0] != "a" {
+		t.Errorf("target aliased override source: got[0] = %v, want a", got[0])
+	}
+}
+
+// TestApplyTypedOverrides_OverlappingPathsDeterministic guards against the
+// nondeterministic apply order that map-iteration produced before paths were
+// sorted shallowest-first. When a parent-object path ("driver.env") and a
+// deeper scalar path ("driver.env.HTTPS_PROXY") collide on a leaf, the deeper,
+// more-specific override must always win — and the result must be identical
+// across many runs (Go randomizes map iteration). Run repeatedly to make a
+// regression flaky-fail loudly rather than pass intermittently.
+func TestApplyTypedOverrides_OverlappingPathsDeterministic(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		target := map[string]any{}
+		overrides := map[string]any{
+			// Parent object also carries HTTPS_PROXY, colliding with the deeper path.
+			"driver.env":             map[string]any{"HTTPS_PROXY": "from-object", "NO_PROXY": "keep"},
+			"driver.env.HTTPS_PROXY": "from-scalar",
+		}
+		if err := ApplyTypedOverrides(target, overrides); err != nil {
+			t.Fatalf("ApplyTypedOverrides() error = %v", err)
+		}
+		env := target["driver"].(map[string]any)["env"].(map[string]any)
+		if env["HTTPS_PROXY"] != "from-scalar" {
+			t.Fatalf("run %d: HTTPS_PROXY = %#v, want \"from-scalar\" (deeper path must win deterministically)", i, env["HTTPS_PROXY"])
+		}
+		if env["NO_PROXY"] != "keep" {
+			t.Fatalf("run %d: NO_PROXY = %#v, want \"keep\" (non-colliding object key must survive)", i, env["NO_PROXY"])
+		}
+	}
+}

--- a/pkg/defaults/spec.go
+++ b/pkg/defaults/spec.go
@@ -29,4 +29,10 @@ const (
 	// from a corrupted or hostile file. A typical spec is well under 64KiB;
 	// 1 MiB provides generous headroom for embedded status payloads.
 	MaxSpecFileBytes = 1 * 1024 * 1024 // 1 MiB
+
+	// MaxSetFileBytes is the maximum size in bytes for a value file referenced
+	// by `aicr bundle --set-file component:path=<file>`. The file holds a
+	// single JSON/YAML value override; 1 MiB is far above any legitimate
+	// value snippet and bounds the read against a corrupted or hostile path.
+	MaxSetFileBytes int64 = 1 * 1024 * 1024 // 1 MiB
 )

--- a/recipes/components/agentgateway/values.yaml
+++ b/recipes/components/agentgateway/values.yaml
@@ -46,11 +46,17 @@ inferenceExtension:
 # firewall every downstream deployment to NVIDIA's network and lock external
 # operators out of their own gateway.
 #
-# Each operator should scope this to their trusted networks. Do NOT use `--set`
-# for this key: `--set agentgateway:allowedSourceRanges=<cidr>` exits 0 but
-# renders loadBalancerSourceRanges as a bare string instead of a list, producing
-# a type-invalid Service (the gateway may stay open at 0.0.0.0/0, or the CR apply
-# is rejected). Set it through a recipe overlay / componentRef override, e.g.:
+# Each operator should scope this to their trusted networks. Do NOT use plain
+# `--set` for this key: `--set agentgateway:allowedSourceRanges=<cidr>` exits 0
+# but renders loadBalancerSourceRanges as a bare string instead of a list,
+# producing a type-invalid Service (the gateway may stay open at 0.0.0.0/0, or
+# the CR apply is rejected). Use the list-aware CLI flag `--set-json` (or
+# `--set-file` for a file), e.g.:
+#
+#   aicr bundle -r recipe.yaml \
+#     --set-json agentgateway:allowedSourceRanges='["216.228.127.128/30"]'
+#
+# or set it through a recipe overlay / componentRef override:
 #
 #   componentRefs:
 #     - name: agentgateway


### PR DESCRIPTION
## Summary

Adds `--set-json` and `--set-file` to `aicr bundle` so list and object value overrides (e.g. `agentgateway.allowedSourceRanges`) can be set from the CLI. `--set` is scalar-only and silently mangles such fields.

## Motivation / Context

`aicr bundle --set component:path=value` writes a bare string, so a list field like `agentgateway.allowedSourceRanges` (rendered into the Service's `spec.loadBalancerSourceRanges`) becomes a type-invalid scalar — the gateway can silently stay open at `0.0.0.0/0`. The docs even warn "Do NOT use `--set` for this key." This adds the list-aware flags that mirror Helm, giving operators a clean CLI lockdown workflow without hand-editing the recipe.

Fixes: #1161
Related: #1160 (agentgateway open-exposure guardrails) and its PR #1163 — `--set-json` is the CLI mechanism operators use to scope `allowedSourceRanges` after that warning/check fires.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- **Flags** (both repeatable, reuse `--set`'s `component:path` validation):
  - `--set-json component:path=<json>` — inline JSON list/object/scalar
  - `--set-file component:path=<file>` — same value read from a JSON/YAML file
- **Merge semantics** (`pkg/component.ApplyTypedOverrides`): object values deep-merge into any existing map at the path (matching inline `componentRefs[].overrides`), while lists and scalars replace. Applied **last** in `buildComponentValues`, so a typed override wins over scalar `--set` on the same path. Paths are applied **shallowest-first** (by segment count, then lexicographically), so when one override targets a parent object and another a key beneath it (e.g. `comp:driver.env=<object>` and `comp:driver.env.HTTPS_PROXY=<value>`), the deeper, more-specific path deterministically wins on shared keys regardless of flag order — Go's randomized map iteration is no longer observable.
- **Layering**: typed overrides live in a parallel `map[string]map[string]any` on the bundler `Config`; the registry alias resolution (`gpuoperator` → `gpu-operator`) is shared with scalar `--set` via a new `componentOverrideKeys` helper. Overrides supplied under both a component's canonical name and a registered alias are **merged** (via `mergeOverridesAcrossKeys`), not first-match-wins, so mixed canonical/alias inputs no longer silently drop entries; the canonical name wins on a shared path. The scalar `--set` lookup was switched to the same merge for consistency.
- **File reads** are bounded (`os.Open` + `io.LimitReader` against `defaults.MaxSetFileBytes`, 1 MiB), and the `--set-file` path is `os.Stat`-validated as a **regular file** before opening (rejecting directories, FIFOs, devices, and sockets up front so a special file fails fast instead of blocking in `os.Open`), and stay in the CLI layer — the shared config parser takes a decode callback, so no filesystem access leaks into the server-reachable `pkg/bundler/config`. The API server surface is intentionally unchanged.
- **Comma handling**: set `DisableSliceFlagSeparator: true` on the `bundle` command so commas in slice-flag values are literal (required for comma-heavy JSON, and removes a latent footgun where a `--set` value containing a comma was silently split). Repeat-the-flag remains the documented way to add multiple values; comma-packing was never documented.

## Testing

```bash
make test-coverage   # 76.5% total (threshold 75%); pkg/bundler/config 96.8%, pkg/component 80.0%
make lint            # golangci-lint 0 issues, yamllint, license headers, agents-sync, MDX-safe
make e2e             # 22/22 chainsaw tests pass (incl. cli-bundle-agentgateway-templates, cli-bundle-scheduling)
```

Also verified end-to-end with a locally built binary against a generated EKS/H100/dynamo recipe:

```
aicr bundle -r recipe.yaml --set-json 'agentgateway:allowedSourceRanges=["216.228.127.128/30","10.0.0.0/8"]'
# → agentgateway/values.yaml renders a real YAML list (not a bare string)
aicr bundle -r recipe.yaml --set-file 'agentgateway:allowedSourceRanges=ranges.yaml'   # same, from a file
aicr bundle -r recipe.yaml --set-json 'agentgateway:allowedSourceRanges=[bad json'      # clear, attributed error
```

New tests: `pkg/bundler/config` (JSON parse, deep-copy getter, last-wins), `pkg/component` (deep-merge / replace / no-aliasing / null-deletes-key, plus a 200-iteration determinism guard for overlapping parent/child paths), `pkg/cli` (flag wiring, `--set-file` read + size cap, non-regular-path rejection (FIFO/directory), comma-containing JSON), `pkg/bundler` (alias resolution, a regression test asserting mixed canonical+alias overrides are merged rather than dropped, end-to-end list rendering, and a precedence regression test asserting `--set-json` wins over `--set` on the same path through `Make()`).

`make scan` (grype) was not run: no new dependencies were introduced (uses stdlib `encoding/json` and the already-vendored `gopkg.in/yaml.v3`), so the vulnerability surface is unchanged.

## Risk Assessment

- [x] **Low** — Additive flags; well-covered by unit + e2e + manual end-to-end.

⚠️ **Maintainer sign-off needed on one behavior change:** `DisableSliceFlagSeparator: true` is set on the **whole `bundle` command**, not just the new flags. It makes commas **literal** for *all* repeatable `bundle` slice flags (`--set`, `--set-json`, `--set-file`, `--dynamic`, `--*-node-selector`, `--*-node-toleration`, `--workload-selector`). This is required because urfave/cli v3's per-flag separator config is not exposed (the disable is command-scoped). The documented way to supply multiple values has always been to **repeat the flag** — comma-packing into one flag (e.g. `--set a=1,b=2`) was never documented as supported in AICR — but urfave/cli **does** split slice values on commas by default, so any existing CI script relying on that framework default (rather than AICR docs) to pack multiple values into one flag must switch to repeating the flag. That is the only usage affected; the change also removes a latent footgun where a `--set` value containing a comma was silently split. The selector/toleration parsers (`ParseNodeSelectors`, `ParseTolerations`) do not split on comma themselves, so repeat-the-flag is unaffected. e2e (22/22) is green.

**Rollout notes:** Backwards compatible for documented usage. The API server bundle endpoint is unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)




