### PR TITLE
test(evidence): signed recipe-evidence pointers for h100 GKE + EKS inference

### DIFF
--- a/recipes/evidence/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/evidence/h100-eks-ubuntu-inference-dynamo.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+recipe: h100-eks-ubuntu-inference-dynamo
+attestations:
+  - bundle:
+      oci: ghcr.io/nvidia/aicr-evidence:v1
+      digest: sha256:da9d8838e1ce4032256b04d75e27dc7248a3fd230bd7fd0f112bd306bc367317
+      predicateType: https://aicr.nvidia.com/recipe-evidence/v1
+    signer:
+      identity: yuanchen97@gmail.com
+      issuer: https://github.com/login/oauth
+      rekorLogIndex: 1706788485
+    attestedAt: 2026-06-03T00:52:58Z

--- a/recipes/evidence/h100-gke-cos-inference-dynamo.yaml
+++ b/recipes/evidence/h100-gke-cos-inference-dynamo.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+recipe: h100-gke-cos-inference-dynamo
+attestations:
+  - bundle:
+      oci: ghcr.io/nvidia/aicr-evidence:v1
+      digest: sha256:6a59465f829489b5bf30eb56904817a573864f28afcce5022f2425f022ddb74d
+      predicateType: https://aicr.nvidia.com/recipe-evidence/v1
+    signer:
+      identity: yuanchen97@gmail.com
+      issuer: https://github.com/login/oauth
+      rekorLogIndex: 1706764289
+    attestedAt: 2026-06-03T00:42:43Z


### PR DESCRIPTION
## Summary

Adds two signed **recipe-evidence v1** pointers generated from live conformance validation on H100 inference clusters, to **exercise the warning-only recipe-evidence drift gate** (#1065, "Recipe Evidence: Verify").

| Recipe | Cluster | OCI digest | Rekor |
|--------|---------|-----------|-------|
| `h100-gke-cos-inference-dynamo` | GKE / COS (aicr-demo5) | `sha256:6a59465f…` | 1706764289 |
| `h100-eks-ubuntu-inference-dynamo` | EKS / Ubuntu (aicr3) | `sha256:da9d8838…` | 1706788485 |

Both bundles were built with `aicr validate --phase conformance --emit-attestation` against the live clusters (11/11 conformance checks passed on each), then signed + pushed to `ghcr.io/nvidia/aicr-evidence` via `aicr evidence publish` (Sigstore keyless OIDC).

## Motivation / Context

Validates the recipe-evidence verify pipeline end-to-end on real evidence: the gate should fetch each signed OCI artifact, verify its Sigstore signature, and compare the signed recipe digest against the current recipe.

Refs #1160

## Type of Change

- [x] CI / evidence (test of the recipe-evidence gate)

## Testing

- Conformance phase passed 11/11 on both clusters (GKE H100/COS, EKS H100/Ubuntu).
- Bundles signed (Sigstore keyless) and pushed to GHCR; pointers pin per-recipe digests.
- This PR's purpose is to trigger "Recipe Evidence: Verify" — observe its result.
