### PR TITLE
fix(evidence): emit recipe-evidence pointer.yaml at 2-space indent

### DIFF
--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -19,9 +19,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // PointerInputs carries the pointer-file fields that are not derived
@@ -58,13 +57,20 @@ func BuildPointer(in PointerInputs) (*Pointer, error) {
 	}, nil
 }
 
-// MarshalPointer renders a pointer as YAML with deterministic output
-// (sorted keys via yaml.v3 default behavior, trailing newline).
+// MarshalPointer renders a pointer as deterministic YAML (recursively
+// sorted keys, 2-space indent) via serializer.MarshalYAMLDeterministic —
+// the same serializer emit.go uses for the recipe/snapshot, keeping the
+// evidence outputs consistent.
+//
+// The 2-space indent is load-bearing: the pointer is committed to
+// recipes/evidence/<recipe>.yaml, where the repo's .yamllint (spaces: 2)
+// lints it. yaml.v3's default 4-space sequence indent would fail
+// `make lint` and break the documented publish -> commit -> PR workflow.
 func MarshalPointer(p *Pointer) ([]byte, error) {
 	if p == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "pointer is required")
 	}
-	body, err := yaml.Marshal(p)
+	body, err := serializer.MarshalYAMLDeterministic(p)
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to marshal pointer", err)
 	}

--- a/pkg/evidence/attestation/pointer_test.go
+++ b/pkg/evidence/attestation/pointer_test.go
@@ -15,6 +15,7 @@
 package attestation
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,58 @@ import (
 )
 
 func ptrInt64(v int64) *int64 { return &v }
+
+// TestMarshalPointer_TwoSpaceIndent guards the indentation contract: the
+// pointer is committed to recipes/evidence/<recipe>.yaml, where the repo's
+// .yamllint (spaces: 2) lints it. yaml.v3's default 4-space sequence indent
+// would fail `make lint`, so MarshalPointer must emit 2-space indentation.
+func TestMarshalPointer_TwoSpaceIndent(t *testing.T) {
+	bundle := &Bundle{
+		RecipeName: "h100-eks-ubuntu-inference-dynamo",
+		Predicate: &Predicate{
+			SchemaVersion: PredicateSchemaVersion,
+			AttestedAt:    time.Date(2026, 6, 3, 0, 52, 58, 0, time.UTC),
+		},
+	}
+	rekorIdx := int64(1706788485)
+	p, err := BuildPointer(PointerInputs{
+		Bundle:     bundle,
+		BundleOCI:  "ghcr.io/nvidia/aicr-evidence:v1",
+		BundleHash: "sha256:da9d8838",
+		Signer:     &PointerSigner{Identity: "test@example.com", Issuer: "https://oauth.example.com", RekorLogIndex: &rekorIdx},
+	})
+	if err != nil {
+		t.Fatalf("BuildPointer: %v", err)
+	}
+	out, err := MarshalPointer(p)
+	if err != nil {
+		t.Fatalf("MarshalPointer: %v", err)
+	}
+	got := string(out)
+
+	// The attestations sequence item must sit at 2-space indent, not 4.
+	// (Keys are sorted, so attestations may be the first top-level key.)
+	if !strings.Contains(got, "attestations:\n  - ") {
+		t.Errorf("attestations sequence not at 2-space indent:\n%s", got)
+	}
+	if strings.Contains(got, "\n    - ") {
+		t.Errorf("found 4-space sequence indent (would fail yamllint spaces:2):\n%s", got)
+	}
+	// Every indented line must use an even number of leading spaces.
+	for _, line := range strings.Split(got, "\n") {
+		if n := len(line) - len(strings.TrimLeft(line, " ")); n%2 != 0 {
+			t.Errorf("odd leading-space count (%d) on line %q", n, line)
+		}
+	}
+	// Round-trips to an equivalent pointer (re-indentation preserves content).
+	var rt Pointer
+	if err := yaml.Unmarshal(out, &rt); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if rt.Recipe != p.Recipe || len(rt.Attestations) != 1 || rt.Attestations[0].Bundle.OCI != p.Attestations[0].Bundle.OCI {
+		t.Errorf("round-trip mismatch: %+v", rt)
+	}
+}
 
 func TestBuildPointer_RequiresBundle(t *testing.T) {
 	if _, err := BuildPointer(PointerInputs{}); err == nil {


### PR DESCRIPTION
## Summary

`aicr evidence publish` / `aicr validate --emit-attestation` wrote the recipe-evidence `pointer.yaml` with **4-space** sequence indentation (yaml.v3 default). Since the pointer is committed to `recipes/evidence/<recipe>.yaml` — where the repo's `.yamllint` (`spaces: 2`) lints it — the documented **publish → commit → PR** flow failed `make lint` on every generated pointer:

```
recipes/evidence/*.yaml  4:5 [indentation] wrong indentation: expected 2 but found 4
```

## Fix

`pkg/evidence/attestation/pointer.go` `MarshalPointer` now uses a `yaml.v3` encoder with `SetIndent(2)` instead of plain `yaml.Marshal`. Content/field order unchanged — only indentation. Fixes both code paths that emit a pointer (`validate --emit-attestation` and `evidence publish`, both via `WritePointer → MarshalPointer`).

(`emit.go` already serializes the recipe/snapshot via `serializer.MarshalYAMLDeterministic`; the pointer writer was the lone holdout on plain `yaml.Marshal`.)

## Type of Change

- [x] Bug fix (non-breaking)

## Testing

- New `TestMarshalPointer_TwoSpaceIndent`: asserts 2-space sequence indent, no 4-space, even leading-space on every line, and content round-trips.
- `go test ./pkg/evidence/attestation/...` pass; `golangci-lint` 0 issues; `gofmt` clean.
- Discovered while committing real signed evidence pointers (#1164), which failed `tests / Lint` until hand-reformatted; this removes the need for that manual step.

Refs #1164
