### PR TITLE
refactor: clarify evidence push tags, enhance push/pull semantics

### DIFF
--- a/demos/evidence.md
+++ b/demos/evidence.md
@@ -55,14 +55,18 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence
+  --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
 ```
 
 `--push` opens a browser for OIDC sign-in (or uses ambient GitHub Actions
-OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). The tag may be omitted as
-shown — the emitter applies `:v1` as a placeholder since the OCI digest
-is the canonical address; the pointer file (below) records both. After
-it finishes:
+OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). **Tag the ref with the
+recipe slug** (`:h100-eks-ubuntu-training` here) so each recipe's evidence
+lands on its own tag. The OCI digest is always the canonical address — but
+if you omit the tag, aicr applies `:v1` as a placeholder, and *every*
+untagged push overwrites that same `:v1` tag. Evidence for unrelated
+recipes then collides under one human-readable ref, even though each
+bundle is still independently pinned by digest. The pointer file (below)
+records both the tag and the digest. After it finishes:
 
 ```text
 ./out
@@ -92,7 +96,8 @@ aicr validate \
   --emit-attestation ./out
 
 # Off the VPN (CI runner, jump box, hotspot) — sign, push, write pointer.
-aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence
+# Same recipe-slug tag as the one-shot path above.
+aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
 ```
 
 The bundle is content-addressable and `evidence publish` signs the predicate
@@ -117,8 +122,8 @@ schemaVersion: 1.0.0
 recipe: h100-eks-ubuntu-training
 attestations:
 - bundle:
-    oci: ghcr.io/<owner>/aicr-evidence:v1
-    digest: sha256:f0c1...
+    oci: ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training  # human-readable locator
+    digest: sha256:f0c1...                                       # canonical pin — verify uses this
     predicateType: https://aicr.nvidia.com/recipe-evidence/v1
   signer:
     identity: https://github.com/<owner>/<repo>/.github/workflows/validate.yaml@refs/heads/main
@@ -129,6 +134,14 @@ attestations:
 
 It's a locator, not a cache — every other field (fingerprint, phase counts,
 BOM info) lives in the predicate inside the pulled artifact.
+
+`bundle.oci` is the human-readable ref; `bundle.digest` is the
+content-addressable pin. Verification (next section) keys off
+`bundle.digest`, so the floating tag never affects what gets pulled.
+**Don't copy `bundle.oci` out of the pointer and feed it to `aicr evidence
+verify`** — pass the pointer file itself (or a digest-pinned ref). The tag
+ref is refused by default because tags are registry-rewritable; see
+§4 and `--allow-unpinned-tag`.
 
 ## 3. Verify from the pointer (maintainer path)
 
@@ -184,7 +197,19 @@ aicr evidence verify ghcr.io/<owner>/aicr-evidence@sha256:f0c1...
 ```
 
 Same five checks, no repo checkout required. Useful for auditing a
-contribution before merge.
+contribution before merge. Note the `@sha256:...` digest form — take the
+digest from the pointer's `bundle.digest` (or the push output), **not** the
+`:tag` from `bundle.oci`. A tag-only ref is refused:
+
+```text
+OCI reference ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training is
+tag-only — refusing to pull an unpinned reference. Use a digest-bound
+reference (registry/repo@sha256:<hex>), supply a pointer with bundle.digest
+set, or pass --allow-unpinned-tag for one-off debugging.
+```
+
+In practice, prefer verifying from the pointer file (§3) — it carries the
+digest, so you never handle the ref by hand.
 
 ## 5. Verify locally without push (contributor self-debug, no signature)
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -620,7 +620,7 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence
+  --push ghcr.io/<owner>/aicr-evidence:gb200-eks-ubuntu-training
 
 # 3. Commit the pointer. The bundle bytes live in OCI; the repo
 #    only stores the locator.
@@ -628,6 +628,14 @@ mkdir -p recipes/evidence
 cp ./out/pointer.yaml recipes/evidence/<recipe-name>.yaml
 git add recipes/evidence/<recipe-name>.yaml
 ```
+
+Tag the `--push` ref with the recipe slug (`:gb200-eks-ubuntu-training`
+above) so each recipe's evidence gets its own tag. If you omit the tag,
+aicr applies `:v1`, and every untagged push overwrites that single tag —
+collapsing unrelated recipes' evidence onto one human-readable ref. The
+bundle is always pinned by its `sha256:` digest (what `evidence verify`
+and the pointer use), so a colliding tag doesn't corrupt verification, but
+it does make the registry ref ambiguous.
 
 `--push` triggers cosign keyless signing through Sigstore's
 public-good infrastructure. The CLI resolves an OIDC token through

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -648,7 +648,7 @@ aicr validate [flags]
 | `--feature` | `-f` | string[] | | CNCF evidence-collection feature(s) to scope (repeatable). Valid names: `dra-support`, `gang-scheduling`, `secure-access`, `accelerator-metrics`, `ai-service-metrics`, `inference-gateway`, `robust-operator`, `pod-autoscaling`, `cluster-autoscaling`. Empty selects all features. |
 | `--emit-attestation` | | string | | Directory to write a recipe-evidence v1 attestation bundle (signed when `--push` is set). See [ADR-007](../design/007-recipe-evidence.md). |
 | `--bom` | | string | | Path to a CycloneDX BOM (`bom.cdx.json`) to embed. Optional with `--emit-attestation`; when omitted, aicr synthesizes a recipe-bound BOM from the recipe's component refs + validator catalog images. Pass `make bom`'s output for an exhaustive BOM. |
-| `--push` | | string | | OCI registry reference (e.g. `ghcr.io/myorg/aicr-evidence`) to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Tag the ref with the recipe slug so each recipe's evidence lands on a distinct tag (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`). If you omit the tag, aicr applies `:v1` as a placeholder — every untagged push then overwrites the same `:v1` tag, so evidence for different recipes collides under one human-readable ref. The bundle is still pinned by its `sha256:` digest (the canonical address) regardless of tag, but a colliding tag makes the registry ref ambiguous to humans. |
 | `--plain-http` | | bool | false | Use HTTP instead of HTTPS for evidence push (local registry tests). |
 | `--insecure-tls` | | bool | false | Skip TLS verification for evidence push (self-signed registries). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for `--push` keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr bundle --attest`. |
@@ -782,7 +782,7 @@ aicr validate \
 aicr validate \
   --recipe recipe.yaml --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/myorg/aicr-evidence
+  --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # tag = recipe slug; omitting defaults to a shared :v1
 # After this, copy ./out/pointer.yaml to recipes/evidence/<recipe>.yaml
 
 # Validate on a cluster with custom GPU node labels (non-standard labels that AICR doesn't
@@ -845,7 +845,7 @@ spec:
       attestation:                       # --emit-attestation / --bom / --push / ...
         out: ./out/attestation
         bom: dist/bom/bom.cdx.json       # optional; auto-generated from recipe + validators when absent
-        push: ghcr.io/myorg/aicr-evidence
+        push: ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # tag with the recipe slug; omitting defaults to a shared :v1
         plainHTTP: false
         insecureTLS: false
 ```
@@ -2228,7 +2228,7 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--push` | | string | | OCI registry reference (e.g. `ghcr.io/myorg/aicr-evidence`) to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Tag the ref with the recipe slug (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`) so evidence for different recipes does not collide. Omitting the tag defaults to `:v1`, which every untagged push overwrites — see [`aicr validate --push`](#aicr-validate). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
 | `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
@@ -2247,8 +2247,9 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 # On VPN: produce an unsigned bundle from a passing validation.
 aicr validate -r recipe.yaml -s snapshot.yaml --emit-attestation ./out
 
-# Off VPN: sign, push, and write the pointer.
-aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence
+# Off VPN: sign, push, and write the pointer. Tag with the recipe slug
+# so this recipe's evidence gets its own tag instead of the shared :v1.
+aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training
 ```
 
 ---
@@ -2266,9 +2267,11 @@ aicr evidence verify <input> [flags]
 
 The positional argument is auto-detected as one of:
 
-* `recipes/evidence/<recipe>.yaml` — pointer file (verifier fetches the OCI artifact named inside).
-* `ghcr.io/<owner>/aicr-evidence@sha256:...` or `oci://...` — OCI reference.
+* `recipes/evidence/<recipe>.yaml` — **pointer file (preferred)**. The verifier pulls the bundle by the pointer's `bundle.digest` (a content-addressable `sha256:` pin), not by the human-readable `bundle.oci` tag. This is the input to use in nearly all cases.
+* `ghcr.io/<owner>/aicr-evidence@sha256:...` or `oci://...@sha256:...` — a **digest-pinned** OCI reference. A tag-only ref (such as the `bundle.oci` value from a pointer, e.g. `...aicr-evidence:h100-eks-ubuntu-training`) is refused by default because tags are registry-rewritable; see `--allow-unpinned-tag`.
 * `./out/summary-bundle/` (or a parent containing it) — unpacked directory.
+
+> **Do not extract `bundle.oci` from a pointer and pass it to `verify`.** That field is a human-readable locator (a tag ref), not the verification input. Pass the pointer file itself — the verifier reads `bundle.digest` from it and pins the pull by digest. If you must verify a raw OCI ref, use the digest form (`...@sha256:<hex>`), not the tag.
 
 **Flags:**
 | Flag | Alias | Type | Default | Description |
@@ -2277,7 +2280,7 @@ The positional argument is auto-detected as one of:
 | `--format` | `-t` | string | `text` | Output format: `text` (Markdown) or `json`. Applies regardless of destination. |
 | `--expected-issuer` | | string | | Pin the OIDC issuer URL on the signing certificate. Empty allows any issuer. |
 | `--expected-identity-regexp` | | string | | Pin the signer's `SubjectAlternativeName` via regex. Empty allows any identity. |
-| `--bundle` | | string | | OCI reference override when the pointer carries no `bundle.oci`. |
+| `--bundle` | | string | | OCI reference override for a local-only pointer that carries no `bundle.oci`. Use a digest-pinned ref (`...@sha256:<hex>`); a tag-only ref is refused unless `--allow-unpinned-tag` is set. |
 | `--registry-plain-http` | | bool | `false` | Use HTTP for registry traffic (local-registry tests only). |
 | `--registry-insecure-tls` | | bool | `false` | Skip TLS verification for the registry (self-signed certificates). |
 | `--allow-unpinned-tag` | | bool | `false` | Accept tag-only OCI references. By default the verifier refuses unpinned refs because tags are registry-rewritable; opt in only for one-off debugging. Pointer-driven flows ignore this flag when the pointer carries a `sha256:` digest. |

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -299,8 +299,15 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence
+  --push ghcr.io/<owner>/aicr-evidence:<recipe-slug>
 ```
+
+Tag the `--push` ref with the recipe slug (e.g.
+`ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training`). Omitting the tag
+defaults to `:v1`, and every untagged push overwrites that one tag — so
+evidence for different recipes collides under a single human-readable ref.
+The bundle is pinned by its `sha256:` digest either way, but a distinct tag
+keeps the registry ref meaningful.
 
 After the command finishes:
 
@@ -333,7 +340,7 @@ aicr evidence verify recipes/evidence/<recipe>.yaml
 | Flag | What it does |
 |------|--------------|
 | `--emit-attestation <dir>` | Write the bundle to `<dir>`. Required to produce evidence. |
-| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. Without it, the bundle is unsigned (development/self-debug only). |
+| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. Tag the ref with the recipe slug so evidence for different recipes doesn't collide on the default `:v1` tag. Without it, the bundle is unsigned (development/self-debug only). |
 | `--bom <path>` | Embed an existing CycloneDX BOM instead of the auto-generated one. Pass `make bom` output for an exhaustive BOM that includes chart-default sub-images. |
 | `--identity-token <token>` | Pre-fetched OIDC identity token, skipping the browser flow. Reads `COSIGN_IDENTITY_TOKEN`. |
 | `--oidc-device-flow` | Use OAuth device-code flow instead of opening a browser. Reads `AICR_OIDC_DEVICE_FLOW`. |


### PR DESCRIPTION
## Summary

Clarify the recipe-evidence docs so users tag `aicr validate/evidence publish --push` with the recipe slug instead of relying on the default `:v1` placeholder, and verify from the pointer file (or a digest-pinned ref) rather than the pointer's human-readable `bundle.oci` tag.

## Motivation / Context

Two recurring habits caused friction:

1. **Default-tag reliance → tag collisions.** Every `--push` example omitted the tag, and `demos/evidence.md` actively taught that omitting it is fine because the emitter applies `:v1`. Result: evidence for unrelated recipes all lands on the same `:v1` tag and overwrites each other's human-readable ref (the digest still pins, but the registry ref becomes ambiguous).
2. **Passing `bundle.oci` to `verify`.** The pointer's `bundle.oci` is a tag ref; `evidence verify` keys off `bundle.digest`. Users and AI agents extract `bundle.oci` and pass it to `verify`, which refuses tag-only refs by default (`--allow-unpinned-tag`).

The docs now recommend the recipe slug as the tag and explicitly steer verification to the pointer/digest, with a warning not to copy `bundle.oci` into `verify`.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Tag convention recommended: `ghcr.io/<owner>/aicr-evidence:<recipe-slug>` (matches the per-recipe pointer naming, so different recipes never collide; re-certs of the same recipe float the tag, which is fine because the digest pins).
- Files touched: `docs/user/cli-reference.md` (validate/publish `--push`, verify input list + `--bundle`, examples, config-file schema), `docs/user/validation.md`, `docs/integrator/recipe-development.md`, `demos/evidence.md`.
- ADR-007 design docs under `docs/design/007-recipe-evidence/` use a different `aicr-evidence:<digest>` placeholder notation and are design records, so they were left untouched.

## Testing

```bash
./tools/check-docs-mdx   # OK: all doc files are MDX-safe
```

Docs-only change; no Go sources touched (test-coverage / lint gates not applicable). Internal anchor links (`#aicr-validate`, `#aicr-evidence-verify`) verified to resolve. lychee anchor checking runs in CI.

## Risk Assessment

- [x] **Low** — Documentation-only, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
