### PR TITLE
fix(evidence): pull by digest and auto-tag pushes instead of :v1

### DIFF
--- a/demos/evidence.md
+++ b/demos/evidence.md
@@ -59,14 +59,14 @@ aicr validate \
 ```
 
 `--push` opens a browser for OIDC sign-in (or uses ambient GitHub Actions
-OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). **Tag the ref with the
-recipe slug** (`:h100-eks-ubuntu-training` here) so each recipe's evidence
-lands on its own tag. The OCI digest is always the canonical address — but
-if you omit the tag, aicr applies `:v1` as a placeholder, and *every*
-untagged push overwrites that same `:v1` tag. Evidence for unrelated
-recipes then collides under one human-readable ref, even though each
-bundle is still independently pinned by digest. The pointer file (below)
-records both the tag and the digest. After it finishes:
+OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). The OCI digest is always
+the canonical address, so the tag is just a human-readable label — tag
+choice never affects verification. The example tags with the recipe slug
+(`:h100-eks-ubuntu-training`), but that's a suggestion, not a requirement.
+Omit the tag and aicr applies `:v1` as a placeholder; every untagged push
+then shares that one tag — harmless for pulls (the pointer pins by digest),
+just ambiguous to read once several recipes pile onto `:v1`. The pointer
+file (below) records both the tag and the digest. After it finishes:
 
 ```text
 ./out
@@ -96,7 +96,7 @@ aicr validate \
   --emit-attestation ./out
 
 # Off the VPN (CI runner, jump box, hotspot) — sign, push, write pointer.
-# Same recipe-slug tag as the one-shot path above.
+# Same tag as the one-shot path above (optional convention; else :v1).
 aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
 ```
 

--- a/demos/evidence.md
+++ b/demos/evidence.md
@@ -55,18 +55,20 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
+  --push ghcr.io/<owner>/aicr-evidence
 ```
 
 `--push` opens a browser for OIDC sign-in (or uses ambient GitHub Actions
 OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). The OCI digest is always
 the canonical address, so the tag is just a human-readable label — tag
-choice never affects verification. The example tags with the recipe slug
-(`:h100-eks-ubuntu-training`), but that's a suggestion, not a requirement.
-Omit the tag and aicr applies `:v1` as a placeholder; every untagged push
-then shares that one tag — harmless for pulls (the pointer pins by digest),
-just ambiguous to read once several recipes pile onto `:v1`. The pointer
-file (below) records both the tag and the digest. After it finishes:
+choice never affects verification. We omit the tag above, so aicr derives a
+unique per-recipe one, `<recipe-slug>-<short-fingerprint>` (e.g.
+`h100-eks-ubuntu-training-3f9a1c2b4d5e`). The fingerprint is the first 12 hex
+of the bundle's manifest digest — deterministic, not random, so re-emitting
+the same bundle yields the same tag while a different attestation yields a
+different one. This keeps distinct attestations on distinct tags instead of
+piling onto a shared one. Pass an explicit tag to override. The pointer file
+(below) records both the tag and the digest. After it finishes:
 
 ```text
 ./out
@@ -96,8 +98,8 @@ aicr validate \
   --emit-attestation ./out
 
 # Off the VPN (CI runner, jump box, hotspot) — sign, push, write pointer.
-# Same tag as the one-shot path above (optional convention; else :v1).
-aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
+# Tag optional; aicr derives <recipe-slug>-<fingerprint> when omitted.
+aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence
 ```
 
 The bundle is content-addressable and `evidence publish` signs the predicate
@@ -122,8 +124,8 @@ schemaVersion: 1.0.0
 recipe: h100-eks-ubuntu-training
 attestations:
 - bundle:
-    oci: ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training  # human-readable locator
-    digest: sha256:f0c1...                                       # canonical pin — verify uses this
+    oci: ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training-3f9a1c2b4d5e  # human-readable locator
+    digest: sha256:f0c1...                                                    # canonical pin — verify uses this
     predicateType: https://aicr.nvidia.com/recipe-evidence/v1
   signer:
     identity: https://github.com/<owner>/<repo>/.github/workflows/validate.yaml@refs/heads/main
@@ -136,12 +138,14 @@ It's a locator, not a cache — every other field (fingerprint, phase counts,
 BOM info) lives in the predicate inside the pulled artifact.
 
 `bundle.oci` is the human-readable ref; `bundle.digest` is the
-content-addressable pin. Verification (next section) keys off
-`bundle.digest`, so the floating tag never affects what gets pulled.
+content-addressable pin. Verification (next section) pulls **by digest** —
+`registry/repo@<bundle.digest>`, taking only the registry/repo from
+`bundle.oci` — so the tag never affects what gets fetched, and the pointer
+stays verifiable even if that tag is later moved to another artifact.
 **Don't copy `bundle.oci` out of the pointer and feed it to `aicr evidence
-verify`** — pass the pointer file itself (or a digest-pinned ref). The tag
-ref is refused by default because tags are registry-rewritable; see
-§4 and `--allow-unpinned-tag`.
+verify`** — pass the pointer file itself (or a digest-pinned ref). As a raw
+OCI argument a tag-only ref is refused because tags are registry-rewritable;
+see §4 and `--allow-unpinned-tag`.
 
 ## 3. Verify from the pointer (maintainer path)
 
@@ -202,7 +206,7 @@ digest from the pointer's `bundle.digest` (or the push output), **not** the
 `:tag` from `bundle.oci`. A tag-only ref is refused:
 
 ```text
-OCI reference ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training is
+OCI reference ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training-3f9a1c2b4d5e is
 tag-only — refusing to pull an unpinned reference. Use a digest-bound
 reference (registry/repo@sha256:<hex>), supply a pointer with bundle.digest
 set, or pass --allow-unpinned-tag for one-off debugging.

--- a/demos/evidence.md
+++ b/demos/evidence.md
@@ -55,14 +55,18 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence
+  --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
 ```
 
 `--push` opens a browser for OIDC sign-in (or uses ambient GitHub Actions
-OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). The tag may be omitted as
-shown — the emitter applies `:v1` as a placeholder since the OCI digest
-is the canonical address; the pointer file (below) records both. After
-it finishes:
+OIDC if `ACTIONS_ID_TOKEN_REQUEST_URL` is set). **Tag the ref with the
+recipe slug** (`:h100-eks-ubuntu-training` here) so each recipe's evidence
+lands on its own tag. The OCI digest is always the canonical address — but
+if you omit the tag, aicr applies `:v1` as a placeholder, and *every*
+untagged push overwrites that same `:v1` tag. Evidence for unrelated
+recipes then collides under one human-readable ref, even though each
+bundle is still independently pinned by digest. The pointer file (below)
+records both the tag and the digest. After it finishes:
 
 ```text
 ./out
@@ -92,7 +96,8 @@ aicr validate \
   --emit-attestation ./out
 
 # Off the VPN (CI runner, jump box, hotspot) — sign, push, write pointer.
-aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence
+# Same recipe-slug tag as the one-shot path above.
+aicr evidence publish ./out --push ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training
 ```
 
 The bundle is content-addressable and `evidence publish` signs the predicate
@@ -117,8 +122,8 @@ schemaVersion: 1.0.0
 recipe: h100-eks-ubuntu-training
 attestations:
 - bundle:
-    oci: ghcr.io/<owner>/aicr-evidence:v1
-    digest: sha256:f0c1...
+    oci: ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training  # human-readable locator
+    digest: sha256:f0c1...                                       # canonical pin — verify uses this
     predicateType: https://aicr.nvidia.com/recipe-evidence/v1
   signer:
     identity: https://github.com/<owner>/<repo>/.github/workflows/validate.yaml@refs/heads/main
@@ -129,6 +134,14 @@ attestations:
 
 It's a locator, not a cache — every other field (fingerprint, phase counts,
 BOM info) lives in the predicate inside the pulled artifact.
+
+`bundle.oci` is the human-readable ref; `bundle.digest` is the
+content-addressable pin. Verification (next section) keys off
+`bundle.digest`, so the floating tag never affects what gets pulled.
+**Don't copy `bundle.oci` out of the pointer and feed it to `aicr evidence
+verify`** — pass the pointer file itself (or a digest-pinned ref). The tag
+ref is refused by default because tags are registry-rewritable; see
+§4 and `--allow-unpinned-tag`.
 
 ## 3. Verify from the pointer (maintainer path)
 
@@ -184,7 +197,19 @@ aicr evidence verify ghcr.io/<owner>/aicr-evidence@sha256:f0c1...
 ```
 
 Same five checks, no repo checkout required. Useful for auditing a
-contribution before merge.
+contribution before merge. Note the `@sha256:...` digest form — take the
+digest from the pointer's `bundle.digest` (or the push output), **not** the
+`:tag` from `bundle.oci`. A tag-only ref is refused:
+
+```text
+OCI reference ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training is
+tag-only — refusing to pull an unpinned reference. Use a digest-bound
+reference (registry/repo@sha256:<hex>), supply a pointer with bundle.digest
+set, or pass --allow-unpinned-tag for one-off debugging.
+```
+
+In practice, prefer verifying from the pointer file (§3) — it carries the
+digest, so you never handle the ref by hand.
 
 ## 5. Verify locally without push (contributor self-debug, no signature)
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -620,7 +620,7 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence
+  --push ghcr.io/<owner>/aicr-evidence:gb200-eks-ubuntu-training
 
 # 3. Commit the pointer. The bundle bytes live in OCI; the repo
 #    only stores the locator.
@@ -628,6 +628,14 @@ mkdir -p recipes/evidence
 cp ./out/pointer.yaml recipes/evidence/<recipe-name>.yaml
 git add recipes/evidence/<recipe-name>.yaml
 ```
+
+Tag the `--push` ref with the recipe slug (`:gb200-eks-ubuntu-training`
+above) so each recipe's evidence gets its own tag. If you omit the tag,
+aicr applies `:v1`, and every untagged push overwrites that single tag —
+collapsing unrelated recipes' evidence onto one human-readable ref. The
+bundle is always pinned by its `sha256:` digest (what `evidence verify`
+and the pointer use), so a colliding tag doesn't corrupt verification, but
+it does make the registry ref ambiguous.
 
 `--push` triggers cosign keyless signing through Sigstore's
 public-good infrastructure. The CLI resolves an OIDC token through

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -620,7 +620,7 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence:gb200-eks-ubuntu-training
+  --push ghcr.io/<owner>/aicr-evidence
 
 # 3. Commit the pointer. The bundle bytes live in OCI; the repo
 #    only stores the locator.
@@ -629,13 +629,13 @@ cp ./out/pointer.yaml recipes/evidence/<recipe-name>.yaml
 git add recipes/evidence/<recipe-name>.yaml
 ```
 
-The example tags the `--push` ref with the recipe slug
-(`:gb200-eks-ubuntu-training`) — a suggested convention, not a requirement.
-The bundle is always pinned by its `sha256:` digest (what `evidence verify`
-and the pointer use), so the tag is only a human-readable label and tag
-choice never affects verification. Omit it and aicr applies `:v1`; that's
-harmless, it just leaves unrelated recipes sharing one ref, so a per-recipe
-tag like the slug simply keeps the registry readable.
+The `--push` example omits the tag, so aicr derives a unique per-recipe one,
+`<recipe-slug>-<short-fingerprint>` (e.g.
+`gb200-eks-ubuntu-training-3f9a1c2b4d5e`). The bundle is always pinned by its
+`sha256:` digest (what `evidence verify` and the pointer use, pulling by
+digest), so the tag is only a human-readable label and tag choice never
+affects verification. The derived tag keeps distinct attestations on
+distinct refs; pass an explicit tag to override.
 
 `--push` triggers cosign keyless signing through Sigstore's
 public-good infrastructure. The CLI resolves an OIDC token through

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -629,13 +629,13 @@ cp ./out/pointer.yaml recipes/evidence/<recipe-name>.yaml
 git add recipes/evidence/<recipe-name>.yaml
 ```
 
-Tag the `--push` ref with the recipe slug (`:gb200-eks-ubuntu-training`
-above) so each recipe's evidence gets its own tag. If you omit the tag,
-aicr applies `:v1`, and every untagged push overwrites that single tag —
-collapsing unrelated recipes' evidence onto one human-readable ref. The
-bundle is always pinned by its `sha256:` digest (what `evidence verify`
-and the pointer use), so a colliding tag doesn't corrupt verification, but
-it does make the registry ref ambiguous.
+The example tags the `--push` ref with the recipe slug
+(`:gb200-eks-ubuntu-training`) — a suggested convention, not a requirement.
+The bundle is always pinned by its `sha256:` digest (what `evidence verify`
+and the pointer use), so the tag is only a human-readable label and tag
+choice never affects verification. Omit it and aicr applies `:v1`; that's
+harmless, it just leaves unrelated recipes sharing one ref, so a per-recipe
+tag like the slug simply keeps the registry readable.
 
 `--push` triggers cosign keyless signing through Sigstore's
 public-good infrastructure. The CLI resolves an OIDC token through

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -648,7 +648,7 @@ aicr validate [flags]
 | `--feature` | `-f` | string[] | | CNCF evidence-collection feature(s) to scope (repeatable). Valid names: `dra-support`, `gang-scheduling`, `secure-access`, `accelerator-metrics`, `ai-service-metrics`, `inference-gateway`, `robust-operator`, `pod-autoscaling`, `cluster-autoscaling`. Empty selects all features. |
 | `--emit-attestation` | | string | | Directory to write a recipe-evidence v1 attestation bundle (signed when `--push` is set). See [ADR-007](../design/007-recipe-evidence.md). |
 | `--bom` | | string | | Path to a CycloneDX BOM (`bom.cdx.json`) to embed. Optional with `--emit-attestation`; when omitted, aicr synthesizes a recipe-bound BOM from the recipe's component refs + validator catalog images. Pass `make bom`'s output for an exhaustive BOM. |
-| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. The `sha256:` digest is the canonical address, so the tag is only a human-readable label — tag choice never affects verification. If you omit the tag, aicr applies `:v1` as a placeholder; every untagged push then shares that one tag, which is harmless for pulls (the pointer pins by digest) but ambiguous to read once several recipes pile onto `:v1`. A simple convention to keep refs distinct is the recipe slug (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`), but any scheme works. |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. The `sha256:` digest is the canonical address, so the tag is only a human-readable label — tag choice never affects verification. Omit the tag and aicr derives a unique per-recipe one, `<recipe-slug>-<short-fingerprint>` (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training-3f9a1c2b4d5e`), so distinct attestations never collide on a shared tag. Pass an explicit tag to override. |
 | `--plain-http` | | bool | false | Use HTTP instead of HTTPS for evidence push (local registry tests). |
 | `--insecure-tls` | | bool | false | Skip TLS verification for evidence push (self-signed registries). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for `--push` keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr bundle --attest`. |
@@ -782,7 +782,7 @@ aicr validate \
 aicr validate \
   --recipe recipe.yaml --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # optional tag; slug keeps refs distinct (else :v1)
+  --push ghcr.io/myorg/aicr-evidence  # tag optional; aicr derives :<recipe-slug>-<fingerprint>
 # After this, copy ./out/pointer.yaml to recipes/evidence/<recipe>.yaml
 
 # Validate on a cluster with custom GPU node labels (non-standard labels that AICR doesn't
@@ -845,7 +845,7 @@ spec:
       attestation:                       # --emit-attestation / --bom / --push / ...
         out: ./out/attestation
         bom: dist/bom/bom.cdx.json       # optional; auto-generated from recipe + validators when absent
-        push: ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # optional tag; slug keeps refs distinct (else :v1)
+        push: ghcr.io/myorg/aicr-evidence  # tag optional; aicr derives :<recipe-slug>-<fingerprint>
         plainHTTP: false
         insecureTLS: false
 ```
@@ -2228,7 +2228,7 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Omitting the tag defaults to `:v1` — harmless, since the pointer pins by digest, but several recipes then share one ref. A recipe-slug tag like `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training` is an optional convention to keep refs distinct; see [`aicr validate --push`](#aicr-validate). |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Omit the tag and aicr derives a unique per-recipe one (`<recipe-slug>-<short-fingerprint>`); pass an explicit tag to override. See [`aicr validate --push`](#aicr-validate). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
 | `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
@@ -2247,9 +2247,9 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 # On VPN: produce an unsigned bundle from a passing validation.
 aicr validate -r recipe.yaml -s snapshot.yaml --emit-attestation ./out
 
-# Off VPN: sign, push, and write the pointer. The tag is optional — a
-# recipe-slug tag just keeps this recipe's evidence on its own ref (else :v1).
-aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training
+# Off VPN: sign, push, and write the pointer. Omit the tag and aicr derives
+# a unique per-recipe one (<recipe-slug>-<fingerprint>).
+aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence
 ```
 
 ---
@@ -2267,13 +2267,14 @@ aicr evidence verify <input> [flags]
 
 The positional argument is auto-detected as one of:
 
-* `recipes/evidence/<recipe>.yaml` — **pointer file (preferred)**. The verifier pulls the bundle by the pointer's `bundle.digest` (a content-addressable `sha256:` pin), not by the human-readable `bundle.oci` tag. This is the input to use in nearly all cases.
-* `ghcr.io/<owner>/aicr-evidence@sha256:...` or `oci://...@sha256:...` — a **digest-pinned** OCI reference. A tag-only ref (such as the `bundle.oci` value from a pointer, e.g. `...aicr-evidence:h100-eks-ubuntu-training`) is refused by default because tags are registry-rewritable; see `--allow-unpinned-tag`.
+* `recipes/evidence/<recipe>.yaml` — **pointer file (preferred)**. The verifier pulls **by digest** — `registry/repo@<bundle.digest>`, with the registry/repo taken from `bundle.oci` and the digest as the pin — so it fetches the exact attested bytes even if the `bundle.oci` tag has since been moved to a different artifact. This is the input to use in nearly all cases.
+* `ghcr.io/<owner>/aicr-evidence@sha256:...` or `oci://...@sha256:...` — a **digest-pinned** OCI reference. A tag-only ref (such as the `bundle.oci` value copied from a pointer, e.g. `...aicr-evidence:h100-eks-ubuntu-training-3f9a1c2b4d5e`) is refused by default because tags are registry-rewritable; see `--allow-unpinned-tag`.
 * `./out/summary-bundle/` (or a parent containing it) — unpacked directory.
 
-> **Do not extract `bundle.oci` from a pointer and pass it to `verify`.** That field is a human-readable locator (a tag ref), not the verification input. Pass the pointer file itself — the verifier reads `bundle.digest` from it and pins the pull by digest. If you must verify a raw OCI ref, use the digest form (`...@sha256:<hex>`), not the tag.
+> **Do not extract `bundle.oci` from a pointer and pass it to `verify` as a raw OCI argument.** As a raw ref it carries no companion `bundle.digest`, so a tag-only ref is refused (tags are registry-rewritable). Pass the pointer file itself — the verifier reads `bundle.digest` from it and pulls `registry/repo@<digest>`, ignoring the tag. If you must verify a raw OCI ref, use the digest form (`...@sha256:<hex>`), not the tag.
 
 **Flags:**
+
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--output` | `-o` | string | | Write output to this file. When empty, output goes to stdout. |

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -648,7 +648,7 @@ aicr validate [flags]
 | `--feature` | `-f` | string[] | | CNCF evidence-collection feature(s) to scope (repeatable). Valid names: `dra-support`, `gang-scheduling`, `secure-access`, `accelerator-metrics`, `ai-service-metrics`, `inference-gateway`, `robust-operator`, `pod-autoscaling`, `cluster-autoscaling`. Empty selects all features. |
 | `--emit-attestation` | | string | | Directory to write a recipe-evidence v1 attestation bundle (signed when `--push` is set). See [ADR-007](../design/007-recipe-evidence.md). |
 | `--bom` | | string | | Path to a CycloneDX BOM (`bom.cdx.json`) to embed. Optional with `--emit-attestation`; when omitted, aicr synthesizes a recipe-bound BOM from the recipe's component refs + validator catalog images. Pass `make bom`'s output for an exhaustive BOM. |
-| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Tag the ref with the recipe slug so each recipe's evidence lands on a distinct tag (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`). If you omit the tag, aicr applies `:v1` as a placeholder — every untagged push then overwrites the same `:v1` tag, so evidence for different recipes collides under one human-readable ref. The bundle is still pinned by its `sha256:` digest (the canonical address) regardless of tag, but a colliding tag makes the registry ref ambiguous to humans. |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. The `sha256:` digest is the canonical address, so the tag is only a human-readable label — tag choice never affects verification. If you omit the tag, aicr applies `:v1` as a placeholder; every untagged push then shares that one tag, which is harmless for pulls (the pointer pins by digest) but ambiguous to read once several recipes pile onto `:v1`. A simple convention to keep refs distinct is the recipe slug (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`), but any scheme works. |
 | `--plain-http` | | bool | false | Use HTTP instead of HTTPS for evidence push (local registry tests). |
 | `--insecure-tls` | | bool | false | Skip TLS verification for evidence push (self-signed registries). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for `--push` keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr bundle --attest`. |
@@ -782,7 +782,7 @@ aicr validate \
 aicr validate \
   --recipe recipe.yaml --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # tag = recipe slug; omitting defaults to a shared :v1
+  --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # optional tag; slug keeps refs distinct (else :v1)
 # After this, copy ./out/pointer.yaml to recipes/evidence/<recipe>.yaml
 
 # Validate on a cluster with custom GPU node labels (non-standard labels that AICR doesn't
@@ -845,7 +845,7 @@ spec:
       attestation:                       # --emit-attestation / --bom / --push / ...
         out: ./out/attestation
         bom: dist/bom/bom.cdx.json       # optional; auto-generated from recipe + validators when absent
-        push: ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # tag with the recipe slug; omitting defaults to a shared :v1
+        push: ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # optional tag; slug keeps refs distinct (else :v1)
         plainHTTP: false
         insecureTLS: false
 ```
@@ -2228,7 +2228,7 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Tag the ref with the recipe slug (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`) so evidence for different recipes does not collide. Omitting the tag defaults to `:v1`, which every untagged push overwrites — see [`aicr validate --push`](#aicr-validate). |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Omitting the tag defaults to `:v1` — harmless, since the pointer pins by digest, but several recipes then share one ref. A recipe-slug tag like `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training` is an optional convention to keep refs distinct; see [`aicr validate --push`](#aicr-validate). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
 | `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
@@ -2247,8 +2247,8 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 # On VPN: produce an unsigned bundle from a passing validation.
 aicr validate -r recipe.yaml -s snapshot.yaml --emit-attestation ./out
 
-# Off VPN: sign, push, and write the pointer. Tag with the recipe slug
-# so this recipe's evidence gets its own tag instead of the shared :v1.
+# Off VPN: sign, push, and write the pointer. The tag is optional — a
+# recipe-slug tag just keeps this recipe's evidence on its own ref (else :v1).
 aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training
 ```
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -648,7 +648,7 @@ aicr validate [flags]
 | `--feature` | `-f` | string[] | | CNCF evidence-collection feature(s) to scope (repeatable). Valid names: `dra-support`, `gang-scheduling`, `secure-access`, `accelerator-metrics`, `ai-service-metrics`, `inference-gateway`, `robust-operator`, `pod-autoscaling`, `cluster-autoscaling`. Empty selects all features. |
 | `--emit-attestation` | | string | | Directory to write a recipe-evidence v1 attestation bundle (signed when `--push` is set). See [ADR-007](../design/007-recipe-evidence.md). |
 | `--bom` | | string | | Path to a CycloneDX BOM (`bom.cdx.json`) to embed. Optional with `--emit-attestation`; when omitted, aicr synthesizes a recipe-bound BOM from the recipe's component refs + validator catalog images. Pass `make bom`'s output for an exhaustive BOM. |
-| `--push` | | string | | OCI registry reference (e.g. `ghcr.io/myorg/aicr-evidence`) to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Tag the ref with the recipe slug so each recipe's evidence lands on a distinct tag (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`). If you omit the tag, aicr applies `:v1` as a placeholder — every untagged push then overwrites the same `:v1` tag, so evidence for different recipes collides under one human-readable ref. The bundle is still pinned by its `sha256:` digest (the canonical address) regardless of tag, but a colliding tag makes the registry ref ambiguous to humans. |
 | `--plain-http` | | bool | false | Use HTTP instead of HTTPS for evidence push (local registry tests). |
 | `--insecure-tls` | | bool | false | Skip TLS verification for evidence push (self-signed registries). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for `--push` keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr bundle --attest`. |
@@ -782,7 +782,7 @@ aicr validate \
 aicr validate \
   --recipe recipe.yaml --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/myorg/aicr-evidence
+  --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # tag = recipe slug; omitting defaults to a shared :v1
 # After this, copy ./out/pointer.yaml to recipes/evidence/<recipe>.yaml
 
 # Validate on a cluster with custom GPU node labels (non-standard labels that AICR doesn't
@@ -845,7 +845,7 @@ spec:
       attestation:                       # --emit-attestation / --bom / --push / ...
         out: ./out/attestation
         bom: dist/bom/bom.cdx.json       # optional; auto-generated from recipe + validators when absent
-        push: ghcr.io/myorg/aicr-evidence
+        push: ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training  # tag with the recipe slug; omitting defaults to a shared :v1
         plainHTTP: false
         insecureTLS: false
 ```
@@ -2228,7 +2228,7 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--push` | | string | | OCI registry reference (e.g. `ghcr.io/myorg/aicr-evidence`) to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. |
+| `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Tag the ref with the recipe slug (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training`) so evidence for different recipes does not collide. Omitting the tag defaults to `:v1`, which every untagged push overwrites — see [`aicr validate --push`](#aicr-validate). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
 | `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
@@ -2247,8 +2247,9 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 # On VPN: produce an unsigned bundle from a passing validation.
 aicr validate -r recipe.yaml -s snapshot.yaml --emit-attestation ./out
 
-# Off VPN: sign, push, and write the pointer.
-aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence
+# Off VPN: sign, push, and write the pointer. Tag with the recipe slug
+# so this recipe's evidence gets its own tag instead of the shared :v1.
+aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training
 ```
 
 ---
@@ -2266,9 +2267,11 @@ aicr evidence verify <input> [flags]
 
 The positional argument is auto-detected as one of:
 
-* `recipes/evidence/<recipe>.yaml` — pointer file (verifier fetches the OCI artifact named inside).
-* `ghcr.io/<owner>/aicr-evidence@sha256:...` or `oci://...` — OCI reference.
+* `recipes/evidence/<recipe>.yaml` — **pointer file (preferred)**. The verifier pulls the bundle by the pointer's `bundle.digest` (a content-addressable `sha256:` pin), not by the human-readable `bundle.oci` tag. This is the input to use in nearly all cases.
+* `ghcr.io/<owner>/aicr-evidence@sha256:...` or `oci://...@sha256:...` — a **digest-pinned** OCI reference. A tag-only ref (such as the `bundle.oci` value from a pointer, e.g. `...aicr-evidence:h100-eks-ubuntu-training`) is refused by default because tags are registry-rewritable; see `--allow-unpinned-tag`.
 * `./out/summary-bundle/` (or a parent containing it) — unpacked directory.
+
+> **Do not extract `bundle.oci` from a pointer and pass it to `verify`.** That field is a human-readable locator (a tag ref), not the verification input. Pass the pointer file itself — the verifier reads `bundle.digest` from it and pins the pull by digest. If you must verify a raw OCI ref, use the digest form (`...@sha256:<hex>`), not the tag.
 
 **Flags:**
 | Flag | Alias | Type | Default | Description |
@@ -2277,7 +2280,7 @@ The positional argument is auto-detected as one of:
 | `--format` | `-t` | string | `text` | Output format: `text` (Markdown) or `json`. Applies regardless of destination. |
 | `--expected-issuer` | | string | | Pin the OIDC issuer URL on the signing certificate. Empty allows any issuer. |
 | `--expected-identity-regexp` | | string | | Pin the signer's `SubjectAlternativeName` via regex. Empty allows any identity. |
-| `--bundle` | | string | | OCI reference override when the pointer carries no `bundle.oci`. |
+| `--bundle` | | string | | OCI reference override for a local-only pointer that carries no `bundle.oci`. Use a digest-pinned ref (`...@sha256:<hex>`); a tag-only ref is refused unless `--allow-unpinned-tag` is set. |
 | `--registry-plain-http` | | bool | `false` | Use HTTP for registry traffic (local-registry tests only). |
 | `--registry-insecure-tls` | | bool | `false` | Skip TLS verification for the registry (self-signed certificates). |
 | `--allow-unpinned-tag` | | bool | `false` | Accept tag-only OCI references. By default the verifier refuses unpinned refs because tags are registry-rewritable; opt in only for one-off debugging. Pointer-driven flows ignore this flag when the pointer carries a `sha256:` digest. |

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -299,8 +299,15 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence
+  --push ghcr.io/<owner>/aicr-evidence:<recipe-slug>
 ```
+
+Tag the `--push` ref with the recipe slug (e.g.
+`ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training`). Omitting the tag
+defaults to `:v1`, and every untagged push overwrites that one tag — so
+evidence for different recipes collides under a single human-readable ref.
+The bundle is pinned by its `sha256:` digest either way, but a distinct tag
+keeps the registry ref meaningful.
 
 After the command finishes:
 
@@ -333,7 +340,7 @@ aicr evidence verify recipes/evidence/<recipe>.yaml
 | Flag | What it does |
 |------|--------------|
 | `--emit-attestation <dir>` | Write the bundle to `<dir>`. Required to produce evidence. |
-| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. Without it, the bundle is unsigned (development/self-debug only). |
+| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. Tag the ref with the recipe slug so evidence for different recipes doesn't collide on the default `:v1` tag. Without it, the bundle is unsigned (development/self-debug only). |
 | `--bom <path>` | Embed an existing CycloneDX BOM instead of the auto-generated one. Pass `make bom` output for an exhaustive BOM that includes chart-default sub-images. |
 | `--identity-token <token>` | Pre-fetched OIDC identity token, skipping the browser flow. Reads `COSIGN_IDENTITY_TOKEN`. |
 | `--oidc-device-flow` | Use OAuth device-code flow instead of opening a browser. Reads `AICR_OIDC_DEVICE_FLOW`. |

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -302,12 +302,12 @@ aicr validate \
   --push ghcr.io/<owner>/aicr-evidence:<recipe-slug>
 ```
 
-Tag the `--push` ref with the recipe slug (e.g.
-`ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training`). Omitting the tag
-defaults to `:v1`, and every untagged push overwrites that one tag — so
-evidence for different recipes collides under a single human-readable ref.
-The bundle is pinned by its `sha256:` digest either way, but a distinct tag
-keeps the registry ref meaningful.
+The `--push` tag is just a human-readable label — the `sha256:` digest is
+what pins the bundle, so tag choice never affects verification. Omit the tag
+and it defaults to `:v1`; that's harmless (the pointer pins by digest), it
+just leaves several recipes sharing one ref. Tagging with the recipe slug
+(e.g. `ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training`) is a simple
+convention to keep refs distinct — any scheme works.
 
 After the command finishes:
 
@@ -340,7 +340,7 @@ aicr evidence verify recipes/evidence/<recipe>.yaml
 | Flag | What it does |
 |------|--------------|
 | `--emit-attestation <dir>` | Write the bundle to `<dir>`. Required to produce evidence. |
-| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. Tag the ref with the recipe slug so evidence for different recipes doesn't collide on the default `:v1` tag. Without it, the bundle is unsigned (development/self-debug only). |
+| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. The digest pins the bundle, so the tag is just a label; omit it and it defaults to `:v1`. A recipe-slug tag is an optional way to keep refs distinct. Without `--push`, the bundle is unsigned (development/self-debug only). |
 | `--bom <path>` | Embed an existing CycloneDX BOM instead of the auto-generated one. Pass `make bom` output for an exhaustive BOM that includes chart-default sub-images. |
 | `--identity-token <token>` | Pre-fetched OIDC identity token, skipping the browser flow. Reads `COSIGN_IDENTITY_TOKEN`. |
 | `--oidc-device-flow` | Use OAuth device-code flow instead of opening a browser. Reads `AICR_OIDC_DEVICE_FLOW`. |

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -299,15 +299,16 @@ aicr validate \
   --recipe recipe.yaml \
   --snapshot snapshot.yaml \
   --emit-attestation ./out \
-  --push ghcr.io/<owner>/aicr-evidence:<recipe-slug>
+  --push ghcr.io/<owner>/aicr-evidence
 ```
 
 The `--push` tag is just a human-readable label — the `sha256:` digest is
-what pins the bundle, so tag choice never affects verification. Omit the tag
-and it defaults to `:v1`; that's harmless (the pointer pins by digest), it
-just leaves several recipes sharing one ref. Tagging with the recipe slug
-(e.g. `ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training`) is a simple
-convention to keep refs distinct — any scheme works.
+what pins the bundle, so tag choice never affects verification (the verifier
+pulls by digest). Omit the tag, as above, and aicr derives a unique
+per-recipe one, `<recipe-slug>-<short-fingerprint>` (e.g.
+`ghcr.io/<owner>/aicr-evidence:h100-eks-ubuntu-training-3f9a1c2b4d5e`), so
+distinct attestations never collide on a shared tag. Pass an explicit tag to
+override.
 
 After the command finishes:
 
@@ -340,7 +341,7 @@ aicr evidence verify recipes/evidence/<recipe>.yaml
 | Flag | What it does |
 |------|--------------|
 | `--emit-attestation <dir>` | Write the bundle to `<dir>`. Required to produce evidence. |
-| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. The digest pins the bundle, so the tag is just a label; omit it and it defaults to `:v1`. A recipe-slug tag is an optional way to keep refs distinct. Without `--push`, the bundle is unsigned (development/self-debug only). |
+| `--push <oci-ref>` | Sign via cosign keyless OIDC and push to the registry. The digest pins the bundle, so the tag is just a label; omit it and aicr derives a unique per-recipe tag (`<recipe-slug>-<short-fingerprint>`). Pass an explicit tag to override. Without `--push`, the bundle is unsigned (development/self-debug only). |
 | `--bom <path>` | Embed an existing CycloneDX BOM instead of the auto-generated one. Pass `make bom` output for an exhaustive BOM that includes chart-default sub-images. |
 | `--identity-token <token>` | Pre-fetched OIDC identity token, skipping the browser flow. Reads `COSIGN_IDENTITY_TOKEN`. |
 | `--oidc-device-flow` | Use OAuth device-code flow instead of opening a browser. Reads `AICR_OIDC_DEVICE_FLOW`. |

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -215,11 +215,19 @@ func signAndPush(ctx context.Context, bundle *Bundle, opts signPushOptions) (emi
 		return emitOutcome{}, nil
 	}
 
+	// Resolve the push target. When the operator omits a tag, derive a
+	// per-recipe one from the bundle rather than defaulting to a shared
+	// constant, so distinct attestations never collide on one tag.
+	pushRef, err := effectiveEvidenceRef(opts.Push, bundle)
+	if err != nil {
+		return emitOutcome{}, err
+	}
+
 	pushCtx, pushCancel := context.WithTimeout(ctx, defaults.EvidenceBundlePushTimeout)
 	defer pushCancel()
 	summary, err := Push(pushCtx, PushOptions{
 		SourceDir:   bundle.SummaryDir,
-		Reference:   opts.Push,
+		Reference:   pushRef,
 		AICRVersion: opts.AICRVersion,
 		PlainHTTP:   opts.PlainHTTP,
 		InsecureTLS: opts.InsecureTLS,
@@ -272,7 +280,7 @@ func signAndPush(ctx context.Context, bundle *Bundle, opts signPushOptions) (emi
 	attachCtx, attachCancel := context.WithTimeout(ctx, defaults.EvidenceBundlePushTimeout)
 	defer attachCancel()
 	referrer, attachErr := AttachSigstoreBundleAsReferrer(attachCtx, AttachReferrerOptions{
-		Reference:  opts.Push,
+		Reference:  pushRef,
 		BundleJSON: signRes.BundleJSON,
 		MainArtifact: MainArtifactDescriptor{
 			Digest:    summary.Digest,

--- a/pkg/evidence/attestation/oci.go
+++ b/pkg/evidence/attestation/oci.go
@@ -17,6 +17,7 @@ package attestation
 import (
 	"context"
 	"os"
+	"strings"
 
 	digestpkg "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -37,9 +38,11 @@ type PushOptions struct {
 	// SourceDir is the bundle directory to package (summary or logs).
 	SourceDir string
 
-	// Reference is an OCI URI like "oci://ghcr.io/myorg/aicr-evidence"
-	// (or a non-prefixed equivalent). When the reference omits a tag,
-	// the bundle's content digest is used as the tag.
+	// Reference is an OCI URI like
+	// "oci://ghcr.io/myorg/aicr-evidence:<tag>" (or a non-prefixed
+	// equivalent). A tag is required at this level; the emit/publish
+	// orchestration derives a per-recipe tag from the bundle when the
+	// operator's --push omits one (see effectiveEvidenceRef).
 	Reference string
 
 	// AICRVersion is recorded in the OCI manifest's
@@ -86,8 +89,11 @@ func Push(ctx context.Context, opts PushOptions) (*PushResult, error) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "Reference must be an OCI registry reference")
 	}
 	if ref.Tag == "" {
-		// Placeholder tag; the OCI digest is the canonical address.
-		ref = ref.WithTag(defaultEvidenceTag)
+		// The emit/publish orchestration derives a per-recipe tag from the
+		// bundle before calling Push (see effectiveEvidenceRef); a tag is
+		// required here so we never silently fall back to a shared constant.
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"evidence reference must include a tag")
 	}
 
 	tmpOut, err := os.MkdirTemp("", "aicr-evidence-oci-")
@@ -130,6 +136,82 @@ func Push(ctx context.Context, opts PushOptions) (*PushResult, error) {
 		MediaType: res.MediaType,
 		Size:      res.Size,
 	}, nil
+}
+
+// maxEvidenceTagSlug caps the recipe-slug portion of a derived tag so the
+// slug plus "-" plus the 12-char fingerprint stays well under the 128-char
+// OCI tag limit.
+const maxEvidenceTagSlug = 80
+
+// effectiveEvidenceRef resolves the OCI reference to push a bundle to. When
+// the operator's reference omits a tag, a per-attestation tag derived from
+// the bundle (see deriveEvidenceTag) is applied, so distinct attestations
+// never collide on a shared tag. Verification pins on the content digest
+// regardless, so the tag is a human-readable label, not the trust anchor.
+func effectiveEvidenceRef(userRef string, bundle *Bundle) (string, error) {
+	ref, err := oci.ParseOutputTarget(oci.EnsureScheme(userRef))
+	if err != nil {
+		return "", errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "invalid reference")
+	}
+	if !ref.IsOCI {
+		return "", errors.New(errors.ErrCodeInvalidRequest, "Reference must be an OCI registry reference")
+	}
+	if ref.Tag == "" {
+		ref = ref.WithTag(deriveEvidenceTag(bundle))
+	}
+	return ref.String(), nil
+}
+
+// deriveEvidenceTag builds a human-readable, per-attestation OCI tag for a
+// bundle pushed without one: "<recipe-slug>-<fingerprint>", where the
+// fingerprint is the first 12 hex chars of the bundle's manifest digest.
+// The slug keeps the tag readable; the fingerprint keeps it unique per
+// attestation so a later push never silently floats an existing tag.
+func deriveEvidenceTag(bundle *Bundle) string {
+	slug := sanitizeOCITag(bundle.RecipeName)
+	fp := manifestFingerprint(bundle)
+	if fp == "" {
+		return slug
+	}
+	return slug + "-" + fp
+}
+
+// sanitizeOCITag coerces s into a valid OCI tag: lowercased, with any
+// character outside [a-z0-9_.-] replaced by '-', leading/trailing '-' and
+// '.' trimmed, and the result capped at maxEvidenceTagSlug. Falls back to
+// defaultRecipeName when nothing usable remains.
+func sanitizeOCITag(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_', r == '.', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if len(out) > maxEvidenceTagSlug {
+		out = strings.Trim(out[:maxEvidenceTagSlug], "-.")
+	}
+	if out == "" {
+		return defaultRecipeName
+	}
+	return out
+}
+
+// manifestFingerprint returns the first 12 hex chars of the bundle's
+// manifest digest, identifying this attestation's content. Empty when the
+// digest is unavailable.
+func manifestFingerprint(bundle *Bundle) string {
+	if bundle == nil || bundle.Predicate == nil {
+		return ""
+	}
+	hexDigest := strings.TrimPrefix(bundle.Predicate.Manifest.Digest, "sha256:")
+	if len(hexDigest) < 12 {
+		return hexDigest
+	}
+	return hexDigest[:12]
 }
 
 // AttachSigstoreBundleAsReferrer pushes a Sigstore Bundle blob as an OCI

--- a/pkg/evidence/attestation/tag_test.go
+++ b/pkg/evidence/attestation/tag_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeOCITag(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"already a slug", "h100-eks-ubuntu-training", "h100-eks-ubuntu-training"},
+		{"uppercase and spaces", "Foo Bar Baz", "foo-bar-baz"},
+		{"slashes and colons", "ghcr.io/owner:tag", "ghcr.io-owner-tag"},
+		{"leading and trailing junk trimmed", "--weird.name--", "weird.name"},
+		{"empty falls back to recipe", "", defaultRecipeName},
+		{"all-invalid falls back to recipe", "///", defaultRecipeName},
+		{"length capped", strings.Repeat("a", 200), strings.Repeat("a", maxEvidenceTagSlug)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeOCITag(tt.in); got != tt.want {
+				t.Errorf("sanitizeOCITag(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManifestFingerprint(t *testing.T) {
+	tests := []struct {
+		name   string
+		bundle *Bundle
+		want   string
+	}{
+		{
+			name:   "first 12 hex of manifest digest",
+			bundle: &Bundle{Predicate: &Predicate{Manifest: ManifestRef{Digest: "sha256:" + strings.Repeat("a", 64)}}},
+			want:   strings.Repeat("a", 12),
+		},
+		{
+			name:   "nil predicate yields empty",
+			bundle: &Bundle{},
+			want:   "",
+		},
+		{
+			name:   "missing digest yields empty",
+			bundle: &Bundle{Predicate: &Predicate{}},
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := manifestFingerprint(tt.bundle); got != tt.want {
+				t.Errorf("manifestFingerprint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveEvidenceTag(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("b", 64)
+	tests := []struct {
+		name   string
+		bundle *Bundle
+		want   string
+	}{
+		{
+			name:   "slug plus fingerprint",
+			bundle: &Bundle{RecipeName: "h100-eks-ubuntu-training", Predicate: &Predicate{Manifest: ManifestRef{Digest: digest}}},
+			want:   "h100-eks-ubuntu-training-" + strings.Repeat("b", 12),
+		},
+		{
+			name:   "no fingerprint falls back to slug only",
+			bundle: &Bundle{RecipeName: "h100-eks-ubuntu-training"},
+			want:   "h100-eks-ubuntu-training",
+		},
+		{
+			name:   "empty recipe name uses default slug",
+			bundle: &Bundle{Predicate: &Predicate{Manifest: ManifestRef{Digest: digest}}},
+			want:   defaultRecipeName + "-" + strings.Repeat("b", 12),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveEvidenceTag(tt.bundle); got != tt.want {
+				t.Errorf("deriveEvidenceTag() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveEvidenceRef(t *testing.T) {
+	bundle := &Bundle{
+		RecipeName: "h100-eks-ubuntu-training",
+		Predicate:  &Predicate{Manifest: ManifestRef{Digest: "sha256:" + strings.Repeat("c", 64)}},
+	}
+	wantTag := "h100-eks-ubuntu-training-" + strings.Repeat("c", 12)
+
+	t.Run("operator tag preserved (no derivation)", func(t *testing.T) {
+		got, err := effectiveEvidenceRef("ghcr.io/owner/aicr-evidence:my-tag", bundle)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The ref is returned canonicalized, but the operator's tag is kept
+		// as-is — no derived fingerprint tag is substituted.
+		if !strings.HasSuffix(got, ":my-tag") {
+			t.Errorf("got %q, want it to keep the operator tag :my-tag", got)
+		}
+		if strings.Contains(got, wantTag) {
+			t.Errorf("got %q, should not derive a tag when one is supplied", got)
+		}
+	})
+
+	t.Run("missing tag gets derived per-recipe tag", func(t *testing.T) {
+		got, err := effectiveEvidenceRef("ghcr.io/owner/aicr-evidence", bundle)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasSuffix(got, ":"+wantTag) {
+			t.Errorf("got %q, want suffix %q", got, ":"+wantTag)
+		}
+		if !strings.Contains(got, "ghcr.io/owner/aicr-evidence") {
+			t.Errorf("got %q, want it to retain the repository", got)
+		}
+	})
+
+	t.Run("non-OCI reference rejected", func(t *testing.T) {
+		if _, err := effectiveEvidenceRef("/local/path", bundle); err == nil {
+			t.Error("expected error for non-OCI reference, got nil")
+		}
+	})
+}
+
+func TestPush_RequiresTag(t *testing.T) {
+	_, err := Push(context.Background(), PushOptions{
+		SourceDir: t.TempDir(),
+		Reference: "oci://ghcr.io/owner/aicr-evidence",
+	})
+	if err == nil {
+		t.Fatal("expected error for tag-less reference, got nil")
+	}
+	if !strings.Contains(err.Error(), "must include a tag") {
+		t.Errorf("error = %v, want it to mention a missing tag", err)
+	}
+}

--- a/pkg/evidence/attestation/types.go
+++ b/pkg/evidence/attestation/types.go
@@ -76,11 +76,6 @@ const (
 	// DefaultCycloneDXVersion is the BOM spec version we record when callers
 	// don't override it. Mirrors what `make bom` produces today.
 	DefaultCycloneDXVersion = "1.6"
-
-	// defaultEvidenceTag is the OCI tag used when the operator gives a
-	// reference without one. The OCI digest is the canonical address;
-	// the tag exists to satisfy registries that require one.
-	defaultEvidenceTag = "v1"
 )
 
 // Phase enumerates the validation phases that may appear in the bundle.

--- a/pkg/evidence/verifier/fetch.go
+++ b/pkg/evidence/verifier/fetch.go
@@ -118,13 +118,15 @@ func materializeDir(input string) (*MaterializedBundle, error) {
 			"(no recipe.yaml / manifest.json at root or under summary-bundle/)")
 }
 
-// materializeFromPointer pulls the OCI artifact named in the pointer's
-// first attestation, or falls back to opts.BundleRef when the pointer
-// has no OCI ref. The pointer's digest claim is cross-checked against
-// the actual pulled digest. A tag-only ref is allowed only when the
-// pointer carries a sha256-prefixed bundle.digest (the validator in
-// pointer.go rejects any other shape when bundle.oci is set) — that
-// digest is the pin.
+// materializeFromPointer pulls the OCI artifact for the pointer's first
+// attestation. When the pointer carries a content digest (bundle.digest),
+// it pulls by digest — registry/repo@sha256:... derived from bundle.oci —
+// rather than by the rewritable tag in bundle.oci, so the exact attested
+// bytes are fetched even if that tag has since been re-pushed to a
+// different artifact. The bundle.oci value then supplies only the
+// registry/repo; the digest is the pin. Without a digest (a local-only
+// pointer plus an --bundle override), it falls back to pulling the ref
+// directly and refusing a tag-only ref unless --allow-unpinned-tag.
 func materializeFromPointer(
 	ctx context.Context,
 	pointer *attestation.Pointer,
@@ -143,20 +145,43 @@ func materializeFromPointer(
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			"pointer carries no bundle.oci — re-run with --bundle <oci-ref> or point at the unpacked directory")
 	}
-	// Pointer-driven path: pointer.bundle.digest is the pin. When it
-	// is empty (e.g., a local-only pointer plus --bundle override),
-	// fall through to the direct-OCI digest-pinning rule.
-	requirePin := !opts.AllowUnpinnedTag && att.Bundle.Digest == ""
-	mat, err := materializeOCIRefRequireDigest(ctx, ref, opts, requirePin)
+	// Pull by digest when the pointer pins one; the tag in bundle.oci is
+	// only a human-readable label and may have floated to another artifact.
+	pullRef, err := pointerPullRef(ref, att.Bundle.Digest)
 	if err != nil {
 		return nil, err
 	}
+	// pullRef is digest-pinned whenever bundle.digest is set, so a tag-only
+	// bundle.oci is fine there. Only the no-digest fallback must refuse an
+	// unpinned ref.
+	requirePin := !opts.AllowUnpinnedTag && att.Bundle.Digest == ""
+	mat, err := materializeOCIRefRequireDigest(ctx, pullRef, opts, requirePin)
+	if err != nil {
+		return nil, err
+	}
+	// Defense in depth: when we pulled by digest this always holds, but a
+	// misbehaving registry that returned other content is caught here.
 	if att.Bundle.Digest != "" && mat.Digest != "" && att.Bundle.Digest != mat.Digest {
 		mat.Cleanup()
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			"pointer digest "+att.Bundle.Digest+" does not match pulled digest "+mat.Digest)
 	}
 	return mat, nil
+}
+
+// pointerPullRef returns the OCI reference to pull for a pointer-driven
+// verification. With a sha256 digest it returns registry/repo@digest
+// (derived from ref, any tag dropped) so the pull is content-addressed and
+// immune to tag drift; with an empty digest it returns ref unchanged.
+func pointerPullRef(ref, digest string) (string, error) {
+	if digest == "" {
+		return ref, nil
+	}
+	registry, repo, _, err := parseOCIReference(ref)
+	if err != nil {
+		return "", err
+	}
+	return formatOCIReference(registry, repo, digest), nil
 }
 
 // materializeOCIRefRequireDigest pulls an OCI artifact into a temp

--- a/pkg/evidence/verifier/fetch_test.go
+++ b/pkg/evidence/verifier/fetch_test.go
@@ -100,3 +100,59 @@ func TestParseOCIReference(t *testing.T) {
 		})
 	}
 }
+
+func TestPointerPullRef(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	tests := []struct {
+		name    string
+		ref     string
+		digest  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "tag ref with digest pins by digest",
+			ref:    "ghcr.io/owner/aicr-evidence:h100-eks-ubuntu-training",
+			digest: digest,
+			want:   "ghcr.io/owner/aicr-evidence@" + digest,
+		},
+		{
+			name:   "scheme-prefixed tag ref with digest",
+			ref:    "oci://ghcr.io/owner/aicr-evidence:v1",
+			digest: digest,
+			want:   "ghcr.io/owner/aicr-evidence@" + digest,
+		},
+		{
+			name:   "already digest ref with digest re-pins to same digest",
+			ref:    "ghcr.io/owner/aicr-evidence@" + digest,
+			digest: digest,
+			want:   "ghcr.io/owner/aicr-evidence@" + digest,
+		},
+		{
+			name:   "empty digest returns ref unchanged",
+			ref:    "ghcr.io/owner/aicr-evidence:v1",
+			digest: "",
+			want:   "ghcr.io/owner/aicr-evidence:v1",
+		},
+		{
+			name:    "invalid ref with digest errors",
+			ref:     "::not-a-ref",
+			digest:  digest,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pointerPullRef(tt.ref, tt.digest)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("pointerPullRef(%q, %q) = %q, want %q", tt.ref, tt.digest, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Make recipe-evidence verification pin on the content digest and stop defaulting
evidence pushes to a shared `:v1` tag — so a committed pointer stays verifiable
regardless of registry tag drift, and distinct attestations never collide on one
tag. Includes the doc clarifications that motivated the change.

## Motivation / Context

`aicr evidence verify` pulled the OCI artifact by the pointer's `bundle.oci`
**tag**, then checked the pulled digest against `bundle.digest`. Because tags are
registry-rewritable, a later push to the same tag floated it to a different
artifact and **broke re-verification of any already-committed pointer** (the pull
returned the new artifact; the digest check then failed). The push side made this
worse: every tag-less `--push` defaulted to a shared `:v1`, so unrelated recipes
collided on one tag immediately. Users and agents also tended to copy the
human-readable `bundle.oci` tag into `verify`, which refuses tag-only refs.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence` (recipe-evidence emit + verify)

## Implementation Notes

- **Verifier (`pkg/evidence/verifier/fetch.go`):** when the pointer carries a
  content digest, `materializeFromPointer` now pulls by digest
  (`registry/repo@sha256:…` derived from `bundle.oci` via the new
  `pointerPullRef`), not by the tag — so the exact attested bytes are fetched even
  if the tag has since moved. The post-pull digest cross-check stays as
  defense-in-depth. The no-digest path (local pointer + `--bundle`) is unchanged.
- **Emitter (`pkg/evidence/attestation`):** dropped the `:v1` default. When
  `--push` omits a tag, the emit/publish orchestration derives a unique per-recipe
  tag, `<recipe-slug>-<fingerprint>`, where the fingerprint is the first 12 hex of
  the bundle's manifest digest (deterministic, not random). An operator-supplied
  tag is still honored.
- **Behavior change to note:** the exported `attestation.Push` now returns
  `ErrCodeInvalidRequest` if handed a tag-less reference instead of silently
  defaulting — tag derivation is the orchestration layer's responsibility
  (`effectiveEvidenceRef`). Both real flows (`validate --emit-attestation` and
  `evidence publish`) derive a tag first, so this only affects direct API callers.
- **Docs:** the CLI reference, demo, validation, and recipe-development guides now
  explain that the `sha256:` digest is the canonical pin (verify pulls by digest),
  the tag is a human-readable label, and aicr auto-derives a unique one.

## Testing

```bash
go test ./pkg/evidence/... ./pkg/cli/...      # pass
go vet ./pkg/evidence/...                     # clean
golangci-lint -c .golangci.yaml run ./pkg/evidence/attestation/... ./pkg/evidence/verifier/...  # 0 issues
./tools/check-docs-mdx                        # OK
```

New tests: `pointerPullRef` (digest-pinning, tag drop, passthrough, invalid ref);
`deriveEvidenceTag` / `sanitizeOCITag` / `manifestFingerprint`; `Push` tag-required
error. Per-package coverage: `pkg/evidence/attestation` 72.8%, `pkg/evidence/verifier`
64.7% (new functions covered).

## Risk Assessment

- [x] **Medium** — Touches the evidence trust path (verify fetch + push tag) and
  changes an exported function's contract (`Push` now requires a tag).

**Rollout notes:** Backward-compatible for existing committed pointers — they carry
`bundle.digest`, so verification now pulls by digest (and can even re-verify
pointers whose tag had drifted, as long as the digest still resolves). No pointer
schema change.

## Checklist

- [x] Tests pass locally (`make test` equivalent on affected packages, with `-race` via `go test`)
- [x] Linter passes (`golangci-lint`, 0 issues)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs for the user-facing behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
