### PR TITLE
fix(docs): catch bare <word> tags in MDX safety check

### DIFF
--- a/docs/contributor/collector.md
+++ b/docs/contributor/collector.md
@@ -135,8 +135,8 @@ End-to-end, the smallest viable patch:
 4. **Extend the factory.** Add a `CreateXxxCollector() Collector`
    method on `Factory` and `DefaultFactory` in
    [`pkg/collector/factory.go`](https://github.com/NVIDIA/aicr/blob/main/pkg/collector/factory.go).
-5. **Wire into snapshotter.** Add one `g.Go(collectSafe(gctx, "<kind>",
-   n.Factory.CreateXxxCollector()))` line in
+5. **Wire into snapshotter.** Add one
+   `g.Go(collectSafe(gctx, "<kind>", n.Factory.CreateXxxCollector()))` line in
    [`pkg/snapshotter/snapshot.go`](https://github.com/NVIDIA/aicr/blob/main/pkg/snapshotter/snapshot.go).
 6. **Test.** `<kind>_test.go` with table-driven tests. Use
    `k8s.io/client-go/kubernetes/fake` for K8s collectors. Cover the

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -508,8 +508,8 @@ components:
       assertFile: checks/nfd/health-check.yaml
 ```
 
-The path is relative to `recipes/`. `make check-health
-COMPONENT=<name>` invokes Chainsaw against
+The path is relative to `recipes/`. `make check-health COMPONENT=<name>`
+invokes Chainsaw against
 `recipes/checks/<name>/health-check.yaml` (no-cluster flag has no
 effect here — chainsaw always needs a real cluster).
 

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -19,6 +19,9 @@
 #   3. HTML comments (<!-- -->) outside fenced code blocks
 #   4. Autolinks (<https://...> / <http://...>) outside fenced and inline code
 #      — MDX tries to parse them as JSX tags and chokes on the `://`.
+#   5. Bare angle-bracket placeholders (<word>) outside fenced and inline code
+#      — MDX interprets them as JSX component tags and fails on unexpected
+#      content that follows.
 
 set -euo pipefail
 
@@ -49,7 +52,7 @@ for dir in "${SEARCH_DIRS[@]}"; do
   done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) ! -name "${EXCLUDE}" 2>/dev/null)
 done
 
-# --- Checks 2, 3, 4: bare braces, HTML comments, and autolinks ---
+# --- Checks 2, 3, 4, 5: bare braces, HTML comments, autolinks, bare tags ---
 # All evaluated outside fenced code blocks; inline code spans are stripped
 # before the line is scanned so legitimate uses inside backticks don't trip.
 for dir in "${SEARCH_DIRS[@]}"; do
@@ -62,6 +65,9 @@ for dir in "${SEARCH_DIRS[@]}"; do
         # Strip inline code spans so backticked tokens don'\''t trigger.
         line = $0
         gsub(/`[^`]*`/, "", line)
+        # Strip backslash-escaped angle brackets (\<word\>) — these are
+        # valid markdown escapes and MDX-safe.
+        gsub(/\\<[^>]*\\>/, "", line)
       }
       # Bare { not preceded by backslash escape. The leading
       # (^|[^\\]) form catches { in column 1 as well.
@@ -77,6 +83,13 @@ for dir in "${SEARCH_DIRS[@]}"; do
       # JSX tag parser. Use markdown link syntax [text](url) instead.
       line ~ /<https?:\/\// {
         printf "MDX: autolink outside code fence: %s:%d: %s\n", FILENAME, NR, $0
+        errors++
+      }
+      # Bare angle-bracket placeholders: <word> that are not void HTML
+      # elements (check 1) or autolinks (check 4). MDX interprets these
+      # as JSX component tags.
+      line ~ /<[a-zA-Z]/ && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
+        printf "MDX: bare <word> tag outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }
       END { exit (errors > 0) ? 1 : 0 }
@@ -95,6 +108,7 @@ if [[ ${ERRORS} -gt 0 ]]; then
   echo "  <br>  → <br />          <img src=...>  → <img src=... />"
   echo "  {foo} → \\{foo\\}        <!-- ... -->   → remove or use {/* ... */}"
   echo "  <https://example.com>  → [example](https://example.com)"
+  echo "  <name>                 → \`<name>\`     or &lt;name&gt;"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Add a bare `<word>` angle-bracket check (check 5) to `tools/check-docs-mdx` and fix two cross-line inline code spans that escaped detection.

## Motivation / Context

Fern's MDX parser interprets bare `<word>` placeholders as JSX component tags and fails with parse errors. The existing MDX safety script had no check for this pattern class.

Fixes: #1147
Related: #1151

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/check-docs-mdx`

## Implementation Notes

- Check 5 matches `<[a-zA-Z]` after stripping inline code and backslash-escaped patterns (`\<word\>`), excluding void HTML elements (check 1) and autolinks (check 4).
- Two cross-line backtick spans in `validator.md` and `collector.md` were collapsed to single-line spans so the per-line `gsub` stripper correctly excludes them.

## Testing

```bash
bash tools/check-docs-mdx  # OK: all doc files are MDX-safe
```

- Script passes clean on all docs
- Deliberate bare `<placeholder>` correctly flagged
- Backtick-wrapped, code-fenced, and `\<escaped\>` patterns not flagged

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)