### PR TITLE
docs(validator): document image tag mechanism (:edge vs :latest)

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -177,7 +177,7 @@ validators.Run(map[string]validators.CheckFunc{
 | `AICR_NAMESPACE` | Validation namespace (fallback) |
 | `AICR_CHECK_TIMEOUT` | Go-duration timeout for the check; honored by `ctx.Ctx`. Falls back to `defaults.CheckExecutionTimeout` if unset or malformed (logged WARN). |
 | `AICR_VALIDATOR_IMAGE_REGISTRY` | Override the image registry prefix (CLI passes through to inner workloads). |
-| `AICR_VALIDATOR_IMAGE_TAG` | Override resolved tag (e.g. `latest`) for feature-branch dev builds. Forwarded to inner workloads. |
+| `AICR_VALIDATOR_IMAGE_TAG` | Override the resolved tag when the binary's stamped commit has no published image (e.g. `edge` or `sha-<commit>`). See [Validator image tags](#validator-image-tags). Forwarded to inner workloads (including `aiperf-bench`). |
 | `AICR_NODE_SELECTOR` | Comma-separated `key=value`; read via `ctx.NodeSelector` |
 | `AICR_TOLERATIONS` | Comma-separated `key=value:effect`; read via `ctx.Tolerations` |
 
@@ -194,6 +194,74 @@ digest-pinned (`name@sha256:…`) → `IfNotPresent`;
 `AICR_VALIDATOR_IMAGE_TAG` set or `:latest` suffix → `Always`;
 otherwise → `IfNotPresent`. Both the outer validator Job and any
 inner workload Job share this helper so policy cannot drift.
+
+### Validator image tags
+
+The catalog declares every validator image as `…:latest`;
+`catalog.ResolveImage` (`pkg/validator/catalog/catalog.go`) rewrites that
+tag at runtime so the validators match the `aicr` binary that launched
+them:
+
+1. **Stamped build** — the binary's version + commit resolve the tag to
+   `:sha-<commit>`, the immutable per-commit image CI publishes on merge
+   to `main`.
+2. **`AICR_VALIDATOR_IMAGE_TAG` set** — overrides step 1 for *all* catalog
+   images uniformly, including the inner `aiperf-bench` runner the
+   `performance` validator launches (so both must exist at that tag).
+
+What CI publishes:
+
+| Trigger | Tags built (`on-push.yaml` / `on-tag.yaml`) |
+|---------|----------------------------------------------|
+| Merge to `main` | `:sha-<full-commit>` (immutable) **and** `:edge` (moving → always `main` HEAD) |
+| Release tag `vX.Y.Z` | `:vX.Y.Z` **and** `:latest` |
+
+**`:latest` is the last _release_, never `main`.** It is built only by the
+on-tag release pipeline, so a validator change merged to `main` after the
+last release is absent from `:latest` until the next release. Running
+`AICR_VALIDATOR_IMAGE_TAG=latest` against a `main`-tracking recipe can
+therefore silently run *older* validator behavior — e.g. a
+`performance.constraints` pin such as `inference-model` /
+`inference-concurrency-per-gpu` is only honored by a validator new enough
+to read it; an older `:latest` validator ignores the pin and runs its
+compiled default, which can surface as a misleading result rather than a
+clear version error.
+
+**To run the validator built on `main`** (e.g. testing a recipe whose pins
+are not yet in a release), point at `:edge` or the `main`-HEAD commit —
+*not* `:latest`:
+
+```shell
+# Moving tag — always main HEAD, no lookup:
+AICR_VALIDATOR_IMAGE_TAG=edge aicr validate -r recipe.yaml -s snapshot.yaml --phase performance
+
+# Immutable pin — reproducible:
+AICR_VALIDATOR_IMAGE_TAG=sha-$(git rev-parse origin/main) aicr validate -r recipe.yaml -s snapshot.yaml ...
+```
+
+A bare `go build` stamps `commit: unknown`, so step 1 cannot resolve a
+`:sha-<commit>` tag and the override is required; `make build` stamps the
+commit and resolves it automatically (no override needed). Only an
+un-pushed feature branch — whose commit has no published image — needs a
+moving tag, and even then `:edge` (current `main`) is closer than
+`:latest` (last release).
+
+Find or trace the `main` tag against GHCR (public read):
+
+```shell
+REPO=nvidia/aicr-validators/performance
+SHA=$(git rev-parse origin/main)
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:${REPO}:pull" | jq -r .token)
+
+# Does the image for this main commit exist? (200 = yes)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  "https://ghcr.io/v2/${REPO}/manifests/sha-${SHA}"
+```
+
+To go the other way — which commit built a given image — read the OCI
+labels baked in by CI: `org.opencontainers.image.revision=<commit>` and
+`org.opencontainers.image.version=main-<commit>`.
 
 ### `validators.Context` API
 


### PR DESCRIPTION
## Summary

Document the validator image tag mechanism in the validator development guide: how `catalog.ResolveImage` rewrites `:latest` to `:sha-<commit>` to match the launching binary, what CI publishes (`:sha-<commit>` + `:edge` on main; `:vX.Y.Z` + `:latest` on release), and the key gotcha that **`:latest` is the last release, never `main` HEAD**.

## Motivation / Context

The `:latest` validator tag is built only by the on-tag release pipeline, so a validator change merged to `main` after the last release is absent from `:latest` until the next release. A `main`-tracking recipe pin (e.g. `inference-model` / `inference-concurrency-per-gpu` in `performance.constraints`, added by #1133 after v0.14.0) is only honored by a validator new enough to read it — so running `AICR_VALIDATOR_IMAGE_TAG=latest` silently runs older validator behavior (small default model at low concurrency) and surfaces as a misleading throughput failure rather than a clear version error.

This bit us in practice (an inference-perf run reporting ~44K tok/s on H100/GKE instead of the documented ~108K, traced entirely to `:latest` predating #1133), and at least one other contributor hit the identical symptom on EKS GB200 (~20K vs ~66K). The note steers users to `:edge` / `:sha-<commit>` and documents how to find and trace the tag built on `main`.

Fixes: N/A
Related: #1133

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Validator (`pkg/validator`) — documentation only; no code change

## Implementation Notes

- Adds a `### Validator image tags` section to `docs/contributor/validator.md` covering the resolution precedence, the CI tag scheme (`on-push.yaml` vs `on-tag.yaml`), the `:latest` ≠ `main` gotcha with the concrete `inference-model` pin example, how to run the `main`-built validator (`:edge` or `sha-$(git rev-parse origin/main)`), why a bare `go build` (`commit: unknown`) forces the `AICR_VALIDATOR_IMAGE_TAG` override, and how to find/trace a `main` tag against GHCR (existence check + OCI `revision`/`version` labels).
- Corrects the env-var table entry for `AICR_VALIDATOR_IMAGE_TAG`, which previously suggested `:latest` as the go-to override.
- Docs-only; no behavior change. (A follow-up code hardening — fail closed when a validator can't prove it honored a pinned constraint — is noted separately and not part of this PR.)

## Testing

Documentation-only change (`docs/contributor/validator.md`):

```bash
# Verified the new intra-doc anchor resolves (heading "Validator image tags" -> #validator-image-tags)
# Verified all angle-brackets (<commit>, etc.) are inside backticks -> MDX-safe for Fern
```

Full `make qualify` was skipped intentionally: a Markdown-only change cannot regress unit tests, e2e, or Go lint. The relevant CI safety net for `docs/**` is the lychee link/anchor check (`fern-docs-ci.yaml`), which this satisfies.

## Risk Assessment

- [x] **Low** — Documentation-only, easy to revert.

**Rollout notes:** N/A — no behavior change; backwards compatible.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
- [ ] Tests pass locally (`make test` with `-race`) — N/A (docs-only)
- [ ] Linter passes (`make lint`) — N/A (no Go/YAML changed)
- [ ] I added/updated tests for new functionality — N/A (docs-only)
