### PR TITLE
fix(validator): honor tag override for main-container pull policy

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -187,8 +187,8 @@ prevents concurrent runs from clobbering each other's RBAC. External
 tooling selects by label `app.kubernetes.io/name=aicr-validator`, not
 literal name.
 
-**Image-pull policy** is computed by `v1.ImagePullPolicy(image)` in
-`pkg/validator/v1/job_plan.go`:
+**Image-pull policy** is computed by `v1.ImagePullPolicy(image,
+imageTagOverride)` in `pkg/validator/v1/job_plan.go`:
 side-loaded (`ko.local/*`, `kind.local/*`) → `Never`;
 digest-pinned (`name@sha256:…`) → `IfNotPresent`;
 `AICR_VALIDATOR_IMAGE_TAG` set or `:latest` suffix → `Always`;
@@ -202,9 +202,12 @@ The catalog declares every validator image as `…:latest`;
 tag at runtime so the validators match the `aicr` binary that launched
 them:
 
-1. **Stamped build** — the binary's version + commit resolve the tag to
-   `:sha-<commit>`, the immutable per-commit image CI publishes for
-   `main` pushes (only — see the caveat below the table).
+1. **Stamped build** — the binary's version + commit resolve the tag.
+   `ResolveImage` checks the version first: a **release** build → that
+   release's version tag (`:vX.Y.Z`, or `:vX.Y.Z-rc…` for a pre-release);
+   otherwise a dev/`main` build →
+   `:sha-<commit>`, the immutable per-commit image CI publishes for `main`
+   pushes (only — see the caveat below the table).
 2. **`AICR_VALIDATOR_IMAGE_TAG` set** — overrides step 1 for *all* catalog
    images uniformly, including the inner `aiperf-bench` runner the
    `performance` validator launches (so both must exist at that tag).

--- a/pkg/validator/v1/job_plan.go
+++ b/pkg/validator/v1/job_plan.go
@@ -51,6 +51,14 @@ type JobPlan struct {
 	// Image is the validator container image
 	Image string
 
+	// ImageTagOverride is the value of AICR_VALIDATOR_IMAGE_TAG when set
+	// (empty otherwise). The override is already applied to Image; this field
+	// preserves the "override in effect" signal so the renderers force
+	// PullAlways for a mutable override tag (e.g. :edge), matching the AIPerf
+	// sidecar. Without it a node silently reuses a cached older :edge image on
+	// the main validator container. See #1177.
+	ImageTagOverride string
+
 	// Args are container arguments
 	Args []string
 
@@ -256,6 +264,7 @@ func BuildJobPlan(
 		JobName:          generateJobName(entry.Name),
 		Namespace:        namespace,
 		Image:            entry.Image,
+		ImageTagOverride: imageTagOverride,
 		Args:             entry.Args,
 		Env:              env,
 		Volumes:          volumes,
@@ -279,9 +288,10 @@ func RenderPlan(plan JobPlan) *batchv1.Job {
 		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: secret})
 	}
 
-	// Determine image pull policy
-	// Note: imageTagOverride already applied to plan.Image during BuildJobPlan
-	pullPolicy := ImagePullPolicy(plan.Image, "")
+	// Determine image pull policy. Pass plan.ImageTagOverride (not "") so a
+	// mutable override tag like :edge forces PullAlways and the node does not
+	// silently reuse a cached older image on the main validator. See #1177.
+	pullPolicy := ImagePullPolicy(plan.Image, plan.ImageTagOverride)
 
 	jobObj := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -344,9 +354,10 @@ func RenderPlanToApplyConfig(plan JobPlan, jobName string) *applybatchv1.JobAppl
 			applycorev1.LocalObjectReference().WithName(secret))
 	}
 
-	// Determine image pull policy
-	// Note: imageTagOverride already applied to plan.Image during BuildJobPlan
-	pullPolicy := ImagePullPolicy(plan.Image, "")
+	// Determine image pull policy. Pass plan.ImageTagOverride (not "") so a
+	// mutable override tag like :edge forces PullAlways and the node does not
+	// silently reuse a cached older image on the main validator. See #1177.
+	pullPolicy := ImagePullPolicy(plan.Image, plan.ImageTagOverride)
 
 	// Build environment variables
 	envApply := buildEnvVarApply(plan.Env)

--- a/pkg/validator/v1/job_plan_test.go
+++ b/pkg/validator/v1/job_plan_test.go
@@ -472,6 +472,56 @@ func TestRenderPlan(t *testing.T) {
 	}
 }
 
+// TestRenderPlanTagOverridePullPolicy is the regression guard for #1177: a
+// mutable image tag override (e.g. :edge) must force PullAlways on the MAIN
+// validator container, not just the inner AIPerf sidecar — otherwise a node
+// that cached an older :edge silently reuses stale validator logic. Both
+// render paths (typed RenderPlan and the server-side-apply
+// RenderPlanToApplyConfig) must honor plan.ImageTagOverride.
+func TestRenderPlanTagOverridePullPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		override string
+		want     corev1.PullPolicy
+	}{
+		{name: "mutable :edge with override → Always", image: "ghcr.io/nvidia/aicr-validators/performance:edge", override: "edge", want: corev1.PullAlways},
+		{name: "mutable :edge without override → IfNotPresent", image: "ghcr.io/nvidia/aicr-validators/performance:edge", override: "", want: corev1.PullIfNotPresent},
+		{name: "immutable :sha pin, no override → IfNotPresent", image: "ghcr.io/nvidia/aicr-validators/performance:sha-abc1234", override: "", want: corev1.PullIfNotPresent},
+		// Digest pin + override → IfNotPresent: the @digest short-circuit wins
+		// over the override, so air-gap/disconnected behavior is preserved on
+		// the main container too (the explicit invariant this fix advertises).
+		{name: "digest pin with override → IfNotPresent (air-gap-safe; digest wins)", image: "ghcr.io/nvidia/aicr-validators/performance@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", override: "edge", want: corev1.PullIfNotPresent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := JobPlan{
+				JobName:          "j",
+				Namespace:        "ns",
+				Image:            tt.image,
+				ImageTagOverride: tt.override,
+				Timeout:          300,
+			}
+
+			// Typed render path (job_plan.go RenderPlan).
+			job := RenderPlan(plan)
+			if got := job.Spec.Template.Spec.Containers[0].ImagePullPolicy; got != tt.want {
+				t.Errorf("RenderPlan main container ImagePullPolicy = %q, want %q", got, tt.want)
+			}
+
+			// Server-side-apply render path (RenderPlanToApplyConfig).
+			jobApply := RenderPlanToApplyConfig(plan, "j")
+			gotApply := jobApply.Spec.Template.Spec.Containers[0].ImagePullPolicy
+			if gotApply == nil {
+				t.Fatal("RenderPlanToApplyConfig main container ImagePullPolicy is nil")
+			}
+			if *gotApply != tt.want {
+				t.Errorf("RenderPlanToApplyConfig main container ImagePullPolicy = %q, want %q", *gotApply, tt.want)
+			}
+		})
+	}
+}
+
 func TestRenderPlanToApplyConfig(t *testing.T) {
 	plan := JobPlan{
 		ValidatorName:    "test-validator",


### PR DESCRIPTION
## Summary

Force `PullAlways` on the **main validator container** when an image tag override (`AICR_VALIDATOR_IMAGE_TAG`) is in effect, so a node does not silently reuse a cached older image for a mutable tag like `:edge`. Previously only the inner AIPerf sidecar honored the override.

Also folds in two small doc corrections to `docs/contributor/validator.md` (the guide touched by #1176), since they describe this exact pull-policy helper and the tag-resolution flow.

## Motivation / Context

`ImagePullPolicy(image, imageTagOverride)` returns `PullAlways` when `imageTagOverride != ""` (or `:latest`), else `PullIfNotPresent`. The two render paths for the main validator container called it with `""`:

- `RenderPlan` (`pkg/validator/v1/job_plan.go`)
- `RenderPlanToApplyConfig` (same file)

So with `AICR_VALIDATOR_IMAGE_TAG=edge`, the tag was overridden but the pull policy stayed `IfNotPresent` for the main container — a node that had cached an older `:edge` ran **stale validator logic**. The inner AIPerf sidecar (`validators/performance/inference_perf_constraint.go`) already passed the override and pulled fresh, which masked the bug.

Concrete symptom (from #1177): a recipe pinning `inference-model: Qwen/Qwen3-8B` + `inference-concurrency-per-gpu: "256"` benchmarked `Qwen3-0.6B` at low concurrency from a stale cached `:edge` validator, while the (older) throughput-threshold path still applied the 8B-sized gate → guaranteed false failure. With `--emit-attestation`, the bundle would attest the wrong run.

Fixes: #1177
Related: #1176 (docs), #1133 (recipe-driven model/concurrency)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Added `JobPlan.ImageTagOverride`, set from `imageTagOverride` in `BuildJobPlan` (the override is already applied to `Image`; this preserves the "override in effect" signal for pull-policy computation).
- Both render sites now call `ImagePullPolicy(plan.Image, plan.ImageTagOverride)` instead of `ImagePullPolicy(plan.Image, "")`, mirroring the AIPerf sidecar.
- Net behavior: a mutable override tag (and `:latest`) forces `PullAlways` on **all** validator containers; digest-pinned refs stay `IfNotPresent` (air-gap-safe), and an immutable `:sha-<commit>` with no override stays `IfNotPresent` (safe — the tag is immutable).
- Docs (`docs/contributor/validator.md`): corrected the **Image-pull policy** prose to the real two-arg signature `ImagePullPolicy(image, imageTagOverride)`, and reworded step 1 of the tag-resolution list to note that `ResolveImage` checks the version first — a **release** build resolves to `:vX.Y.Z`, while `:sha-<commit>` is the dev/`main` case. (Follow-up nits from the #1176 cross-review, applied here since they describe this code.)

## Testing

```bash
gofmt -l pkg/validator/v1/...                       # clean
go test -race ./pkg/validator/v1/...                # ok
golangci-lint run -c .golangci.yaml ./pkg/validator/v1/...   # 0 issues
go test -cover ./pkg/validator/v1/...               # 75.0%
```

Added `TestRenderPlanTagOverridePullPolicy`: asserts `PullAlways` on the main container for `:edge` + override, and `IfNotPresent` for `:edge` without override and for an immutable `:sha` pin — across **both** render paths (`RenderPlan` and `RenderPlanToApplyConfig`).

The `docs/contributor/validator.md` change is Markdown-only (no Go behavior change); it is covered by the `docs/**` MDX/lychee CI gates — all added angle-brackets stay inside backticks and no headings/anchors changed.

## Risk Assessment

- [x] **Low** — Two call-site changes + one plan field, plus a docs-only correction; covered by a regression test. Only affects pull policy when an override is set; digest-pin and no-override behavior unchanged.

**Rollout notes:** Backwards compatible. Operators using `AICR_VALIDATOR_IMAGE_TAG=edge` will now correctly re-pull the main validator (one extra pull when the cached tag is stale).

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — `./pkg/validator/v1/...`
- [x] Linter passes (`make lint`) — `golangci-lint` 0 issues on the package
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
