### PR TITLE
fix(validator): gate inference-perf on all workers Ready

### DIFF
--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1121,12 +1121,51 @@ func waitForDynamoDeploymentReady(ctx *validators.Context, config *inferenceWork
 }
 
 // isDynamoDeploymentReady returns true when the object's status.state equals "successful".
+// isDynamoDeploymentReady reports whether every service in the
+// DynamoGraphDeployment has all of its replicas Ready — not just that the
+// operator reported a top-level state of "successful". The benchmark pins one
+// data-parallel worker per GPU; if it starts while some workers are still
+// loading (common when model-cache reads stagger, e.g. 8 workers reading an 8B
+// model concurrently from one RWO EBS cache), it measures an under-provisioned
+// deployment and reports falsely low throughput / high TTFT. Gating on
+// per-service replica readiness prevents that. See #1181.
 func isDynamoDeploymentReady(obj *unstructured.Unstructured) bool {
 	if obj == nil {
 		return false
 	}
 	state, found, _ := unstructured.NestedString(obj.Object, "status", "state")
-	return found && state == "successful"
+	if !found || state != "successful" {
+		return false
+	}
+
+	// status.services maps each component (Frontend, VllmDecodeWorker, ...) to
+	// its replica counts. Require every service to have all replicas Ready;
+	// "successful" alone can be reported before the worker pods finish loading.
+	services, found, err := unstructured.NestedMap(obj.Object, "status", "services")
+	if err != nil || !found || len(services) == 0 {
+		return false
+	}
+	for _, raw := range services {
+		svc, ok := raw.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		replicas, found, err := unstructured.NestedInt64(svc, "replicas")
+		if err != nil || !found || replicas < 1 {
+			return false
+		}
+		// readyReplicas is populated for Deployment/PodClique/LeaderWorkerSet;
+		// PodCliqueScalingGroup reports availableReplicas instead. Accept
+		// whichever the operator set for this component kind.
+		ready, found, err := unstructured.NestedInt64(svc, "readyReplicas")
+		if err != nil || !found {
+			ready, found, err = unstructured.NestedInt64(svc, "availableReplicas")
+		}
+		if err != nil || !found || ready < replicas {
+			return false
+		}
+	}
+	return true
 }
 
 // existingResourceVersion returns the ResourceVersion from an Unstructured

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -349,9 +349,47 @@ func TestIsDynamoDeploymentReady(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "state == successful",
+			name: "successful but per-service status not yet populated",
 			input: &unstructured.Unstructured{Object: map[string]interface{}{
 				"status": map[string]interface{}{"state": "successful"},
+			}},
+			want: false,
+		},
+		{
+			name: "successful but a worker replica not ready",
+			input: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"state": "successful",
+					"services": map[string]interface{}{
+						"Frontend":         map[string]interface{}{"replicas": int64(1), "readyReplicas": int64(1)},
+						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(8), "readyReplicas": int64(5)},
+					},
+				},
+			}},
+			want: false,
+		},
+		{
+			name: "successful and all replicas ready (readyReplicas)",
+			input: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"state": "successful",
+					"services": map[string]interface{}{
+						"Frontend":         map[string]interface{}{"replicas": int64(1), "readyReplicas": int64(1)},
+						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(8), "readyReplicas": int64(8)},
+					},
+				},
+			}},
+			want: true,
+		},
+		{
+			name: "successful with scaling-group availableReplicas fallback",
+			input: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"state": "successful",
+					"services": map[string]interface{}{
+						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(8), "availableReplicas": int64(8)},
+					},
+				},
 			}},
 			want: true,
 		},


### PR DESCRIPTION
## Summary

Gate the `inference-perf` benchmark on **all data-parallel workers being Ready**, not just the DynamoGraphDeployment's top-level `status.state == "successful"` + a single endpoint probe. Prevents AIPerf from measuring an under-provisioned deployment.

## Motivation / Context

`isDynamoDeploymentReady` only checked `status.state == "successful"`, and `waitForEndpointReady` only requires one `/v1/chat/completions` 200 (the dynamo router serves it from whichever worker is up). Neither counts ready workers — so the benchmark could start while only a subset of the 8 data-parallel workers were serving.

On clusters where worker readiness staggers — notably EKS, where the `ReadWriteOnce` EBS model-cache PVC serializes 8 concurrent Qwen3-8B loads — this recurringly measured an under-provisioned deployment: abnormally low throughput **and** very high TTFT p99.

Same cluster (`aicr3`, `h100-eks-ubuntu-inference-dynamo`), same harness, evidence:

| Run | Workers serving at measure time | Throughput | TTFT p99 | Result |
|-----|---------------------------------|-----------:|---------:|--------|
| cold | ~5/8 (staggered EBS load) | 64,538 tok/s | 16,328 ms | FAIL |
| warm | 8/8 (converged together) | 108,455 tok/s | 657 ms | PASS (baseline ~108,790 / ~688 ms) |

`64,538 / 108,455 ≈ 5/8`; concurrency 2048 split across 5 instead of 8 workers pushes each past the saturation knee → nonlinear TTFT. The warm run only passed because its workers happened to converge simultaneously.

With `--emit-attestation`, an under-provisioned run would also be signed into the evidence predicate — so this also protects evidence integrity.

Fixes: #1181

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — performance validator image (`validators/performance`)

## Implementation Notes

- `isDynamoDeploymentReady` now, after `state == "successful"`, requires **every** entry in `status.services` to have all replicas Ready: `readyReplicas == replicas` (Deployment/PodClique/LeaderWorkerSet) or `availableReplicas == replicas` (PodCliqueScalingGroup, which doesn't populate `readyReplicas`). Self-contained — uses the DGD's own status, no pod-label assumptions or extra API calls.
- Empty/absent `status.services` (operator reported "successful" before per-service status populated) is treated as not-ready, so the existing `waitForDynamoDeploymentReady` watch keeps waiting until the readiness timeout.

## Testing

```bash
go test -race ./validators/performance/...      # ok
golangci-lint run -c .golangci.yaml ./validators/performance/...   # 0 issues
```

`TestIsDynamoDeploymentReady` extended to 7 cases: nil, no status, non-successful, successful-but-no-services, successful-but-worker-not-ready (5/8), successful-all-ready (`readyReplicas`), and the `availableReplicas` scaling-group fallback.

## Risk Assessment

- [x] **Low** — Tightens an existing readiness gate; covered by unit tests. Worst case is waiting longer (up to the existing `WORKLOAD_READY_TIMEOUT`) for all workers, which is the intended behavior.

**Rollout notes:** Affects the `performance` validator image; CI publishes the fixed image (`:sha-<commit>` / `:edge`) on merge to `main`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — `./validators/performance/...`
- [x] Linter passes (`make lint`) — `golangci-lint` 0 issues
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
