### PR TITLE
fix(validator): inference performance validation requires all worker services Ready

### DIFF
--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1120,15 +1120,21 @@ func waitForDynamoDeploymentReady(ctx *validators.Context, config *inferenceWork
 	}
 }
 
-// isDynamoDeploymentReady returns true when the object's status.state equals "successful".
-// isDynamoDeploymentReady reports whether every service in the
+// isDynamoDeploymentReady reports whether *every desired* service in the
 // DynamoGraphDeployment has all of its replicas Ready — not just that the
 // operator reported a top-level state of "successful". The benchmark pins one
 // data-parallel worker per GPU; if it starts while some workers are still
 // loading (common when model-cache reads stagger, e.g. 8 workers reading an 8B
 // model concurrently from one RWO EBS cache), it measures an under-provisioned
-// deployment and reports falsely low throughput / high TTFT. Gating on
-// per-service replica readiness prevents that. See #1181.
+// deployment and reports falsely low throughput / high TTFT. See #1181.
+//
+// Readiness is keyed off spec.services (the desired set), and each service's
+// status.readyReplicas is compared against its spec replica count. This guards
+// two failure modes that checking status.services alone misses: (1) the
+// operator may populate status.services incrementally, so a desired service
+// (e.g. the worker) can be entirely absent while the frontend already reports
+// ready; (2) during scale-up status.replicas lags the spec count, so comparing
+// ready against status.replicas can pass at, say, 6/8.
 func isDynamoDeploymentReady(obj *unstructured.Unstructured) bool {
 	if obj == nil {
 		return false
@@ -1138,30 +1144,55 @@ func isDynamoDeploymentReady(obj *unstructured.Unstructured) bool {
 		return false
 	}
 
-	// status.services maps each component (Frontend, VllmDecodeWorker, ...) to
-	// its replica counts. Require every service to have all replicas Ready;
-	// "successful" alone can be reported before the worker pods finish loading.
-	services, found, err := unstructured.NestedMap(obj.Object, "status", "services")
-	if err != nil || !found || len(services) == 0 {
+	desired, found, err := unstructured.NestedMap(obj.Object, "spec", "services")
+	if err != nil || !found || len(desired) == 0 {
 		return false
 	}
-	for _, raw := range services {
-		svc, ok := raw.(map[string]interface{})
+	statusServices, found, err := unstructured.NestedMap(obj.Object, "status", "services")
+	if err != nil || !found {
+		return false
+	}
+
+	for name, draw := range desired {
+		dsvc, ok := draw.(map[string]interface{})
 		if !ok {
 			return false
 		}
-		replicas, found, err := unstructured.NestedInt64(svc, "replicas")
-		if err != nil || !found || replicas < 1 {
+		// Desired replica count from the spec. DGD services default to 1
+		// replica when unset; a 0-replica service has nothing to await.
+		want, wfound, werr := unstructured.NestedInt64(dsvc, "replicas")
+		if werr != nil {
+			// Present but wrong-typed replicas: fail closed rather than
+			// silently defaulting to 1, which could pass the gate early in
+			// the same under-provisioned class this guards against.
+			return false
+		}
+		if !wfound {
+			want = 1
+		}
+		if want < 1 {
+			continue
+		}
+
+		// The desired service must be represented in status — not just the
+		// subset the operator has populated so far.
+		sraw, ok := statusServices[name]
+		if !ok {
+			return false
+		}
+		ssvc, ok := sraw.(map[string]interface{})
+		if !ok {
 			return false
 		}
 		// readyReplicas is populated for Deployment/PodClique/LeaderWorkerSet;
-		// PodCliqueScalingGroup reports availableReplicas instead. Accept
-		// whichever the operator set for this component kind.
-		ready, found, err := unstructured.NestedInt64(svc, "readyReplicas")
-		if err != nil || !found {
-			ready, found, err = unstructured.NestedInt64(svc, "availableReplicas")
+		// PodCliqueScalingGroup reports availableReplicas instead. Compare
+		// against the desired (spec) count so a scale-up window does not read
+		// as ready.
+		ready, rfound, err := unstructured.NestedInt64(ssvc, "readyReplicas")
+		if err != nil || !rfound {
+			ready, rfound, err = unstructured.NestedInt64(ssvc, "availableReplicas")
 		}
-		if err != nil || !found || ready < replicas {
+		if err != nil || !rfound || ready < want {
 			return false
 		}
 	}

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -326,72 +326,108 @@ func TestParseAIPerfOutput(t *testing.T) {
 }
 
 func TestIsDynamoDeploymentReady(t *testing.T) {
+	// dgd builds a DynamoGraphDeployment with the given spec replica counts and
+	// status.services entries (each entry is a field->count map, e.g.
+	// {"replicas": 8, "readyReplicas": 8}).
+	dgd := func(state string, spec map[string]int64, status map[string]map[string]int64) *unstructured.Unstructured {
+		specSvc := map[string]interface{}{}
+		for name, r := range spec {
+			specSvc[name] = map[string]interface{}{"replicas": r}
+		}
+		statSvc := map[string]interface{}{}
+		for name, fields := range status {
+			m := map[string]interface{}{}
+			for k, v := range fields {
+				m[k] = v
+			}
+			statSvc[name] = m
+		}
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec":   map[string]interface{}{"services": specSvc},
+			"status": map[string]interface{}{"state": state, "services": statSvc},
+		}}
+	}
 	tests := []struct {
 		name  string
 		input *unstructured.Unstructured
 		want  bool
 	}{
-		{
-			name:  "nil object",
-			input: nil,
-			want:  false,
-		},
+		{name: "nil object", input: nil, want: false},
 		{
 			name:  "no status",
 			input: &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{}}},
 			want:  false,
 		},
 		{
-			name: "state != successful",
-			input: &unstructured.Unstructured{Object: map[string]interface{}{
-				"status": map[string]interface{}{"state": "pending"},
-			}},
-			want: false,
+			name:  "state != successful",
+			input: dgd("pending", map[string]int64{"VllmDecodeWorker": 8}, map[string]map[string]int64{"VllmDecodeWorker": {"replicas": 8, "readyReplicas": 8}}),
+			want:  false,
 		},
 		{
-			name: "successful but per-service status not yet populated",
-			input: &unstructured.Unstructured{Object: map[string]interface{}{
-				"status": map[string]interface{}{"state": "successful"},
-			}},
-			want: false,
+			name:  "successful but status.services empty",
+			input: dgd("successful", map[string]int64{"Frontend": 1, "VllmDecodeWorker": 8}, map[string]map[string]int64{}),
+			want:  false,
 		},
 		{
-			name: "successful but a worker replica not ready",
+			// Codex review gap: operator populates status.services
+			// incrementally; the worker service is not represented yet.
+			name:  "successful but worker absent from status",
+			input: dgd("successful", map[string]int64{"Frontend": 1, "VllmDecodeWorker": 8}, map[string]map[string]int64{"Frontend": {"replicas": 1, "readyReplicas": 1}}),
+			want:  false,
+		},
+		{
+			name:  "successful but worker not all ready (5/8)",
+			input: dgd("successful", map[string]int64{"Frontend": 1, "VllmDecodeWorker": 8}, map[string]map[string]int64{"Frontend": {"replicas": 1, "readyReplicas": 1}, "VllmDecodeWorker": {"replicas": 8, "readyReplicas": 5}}),
+			want:  false,
+		},
+		{
+			// Scale-up window: status.replicas lags spec (6 of 8 created), all
+			// 6 ready. Comparing against spec (8) must still report not-ready.
+			name:  "successful but worker still scaling up (6/8 desired)",
+			input: dgd("successful", map[string]int64{"Frontend": 1, "VllmDecodeWorker": 8}, map[string]map[string]int64{"Frontend": {"replicas": 1, "readyReplicas": 1}, "VllmDecodeWorker": {"replicas": 6, "readyReplicas": 6}}),
+			want:  false,
+		},
+		{
+			name:  "successful and all desired services ready (readyReplicas)",
+			input: dgd("successful", map[string]int64{"Frontend": 1, "VllmDecodeWorker": 8}, map[string]map[string]int64{"Frontend": {"replicas": 1, "readyReplicas": 1}, "VllmDecodeWorker": {"replicas": 8, "readyReplicas": 8}}),
+			want:  true,
+		},
+		{
+			name:  "successful with scaling-group availableReplicas fallback",
+			input: dgd("successful", map[string]int64{"VllmDecodeWorker": 8}, map[string]map[string]int64{"VllmDecodeWorker": {"replicas": 8, "availableReplicas": 8}}),
+			want:  true,
+		},
+		{
+			// spec replicas omitted → defaults to 1; one ready replica satisfies it.
+			name: "spec replicas omitted defaults to 1",
 			input: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"services": map[string]interface{}{
+					"VllmDecodeWorker": map[string]interface{}{}, // no replicas field
+				}},
 				"status": map[string]interface{}{
 					"state": "successful",
 					"services": map[string]interface{}{
-						"Frontend":         map[string]interface{}{"replicas": int64(1), "readyReplicas": int64(1)},
-						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(8), "readyReplicas": int64(5)},
+						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(1), "readyReplicas": int64(1)},
 					},
 				},
 			}},
-			want: false,
+			want: true,
 		},
 		{
-			name: "successful and all replicas ready (readyReplicas)",
+			// Present-but-wrong-typed spec replicas must fail closed, not default to 1.
+			name: "spec replicas wrong type fails closed",
 			input: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"services": map[string]interface{}{
+					"VllmDecodeWorker": map[string]interface{}{"replicas": "eight"},
+				}},
 				"status": map[string]interface{}{
 					"state": "successful",
 					"services": map[string]interface{}{
-						"Frontend":         map[string]interface{}{"replicas": int64(1), "readyReplicas": int64(1)},
 						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(8), "readyReplicas": int64(8)},
 					},
 				},
 			}},
-			want: true,
-		},
-		{
-			name: "successful with scaling-group availableReplicas fallback",
-			input: &unstructured.Unstructured{Object: map[string]interface{}{
-				"status": map[string]interface{}{
-					"state": "successful",
-					"services": map[string]interface{}{
-						"VllmDecodeWorker": map[string]interface{}{"replicas": int64(8), "availableReplicas": int64(8)},
-					},
-				},
-			}},
-			want: true,
+			want: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #1182. Require **every desired** DynamoGraphDeployment service (from `spec.services`) to be present in `status.services` and have all replicas Ready — comparing `status.readyReplicas` against the **spec** replica count — before `inference-perf` starts the benchmark.

## Motivation / Context

#1182's gate iterated only the services *present* in `status.services` and compared `readyReplicas` against `status.replicas`. Two gaps remained:

1. **Incremental status population** — the operator can populate `status.services` one component at a time, so a desired service (the worker) can be entirely absent while the frontend already reports ready → the loop validates only what's present and returns ready.
2. **Scale-up window** — `status.replicas` lags the spec count while pods are still being created, so `readyReplicas == status.replicas` can pass at, e.g., 6 of 8.

Both let AIPerf measure an under-provisioned deployment. Confirmed on a live EKS run with the #1182 image: **85,637 tok/s / TTFT 5,361 ms** (≈6-7/8 workers) vs the **108,455 / 657 ms** baseline. Codex review flagged the same gap independently.

This fix keys readiness off `spec.services` (desired set) and compares each service's `status.readyReplicas` (or `availableReplicas` for `PodCliqueScalingGroup`) against its **spec** replica count, so the benchmark waits for all desired workers.

Refs: #1181, #1182

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — performance validator image (`validators/performance`)

## Implementation Notes

- `isDynamoDeploymentReady`: after `state == "successful"`, iterate `spec.services`; for each desired service with `replicas >= 1`, require it present in `status.services` with `readyReplicas` (or `availableReplicas`) `>= spec replicas`. 0-replica services are skipped; default desired = 1 when unset.

## Testing

```bash
go test -race ./validators/performance/...      # ok
golangci-lint run -c .golangci.yaml ./validators/performance/...   # 0 issues
```

`TestIsDynamoDeploymentReady` rewritten (9 cases): adds **worker-absent-from-status** (incremental population) and **worker-scaling-up 6/8 desired** (lags spec) → both `false`, plus the all-ready and `availableReplicas`-fallback `true` paths.

> Validated against the merged #1182 image on EKS `aicr3` (which still failed at ~6/8). Live confirmation of the refined gate is pending a rebuilt validator image — hence **draft/WIP**.

## Risk Assessment

- [x] **Low** — Tightens an existing readiness gate; unit-tested. Worst case is waiting up to the existing `WORKLOAD_READY_TIMEOUT` for all desired workers (intended).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
