### PR TITLE
docs(demos): add recipe-evidence slide deck and demo script

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -19,6 +19,8 @@ Runbooks for testing and demonstrating AICR end-to-end workflows on live cluster
 | [query.md](query.md) | Querying hydrated recipes with dot-path selectors |
 | [attestation.md](attestation.md) | Bundle attestation demo |
 | [evidence.md](evidence.md) | Recipe evidence demo (validate emit + verify) |
+| [evidence-demo-slides.html](evidence-demo-slides.html) | Recipe evidence demo — slide deck (talking point) |
+| [evidence-demo.sh](evidence-demo.sh) | Interactive split-leg evidence walkthrough (validate on VPN → publish off VPN → verify) |
 | [s3c.md](s3c.md) | Supply chain security demo |
 
 ## Recording Test Runs

--- a/demos/evidence-demo-slides.html
+++ b/demos/evidence-demo-slides.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>AICR · Recipe Evidence — slides</title>
+<style>
+  :root {
+    --bg: #0b0d10;
+    --panel: #14181d;
+    --panel-2: #1b2026;
+    --border: #2a313a;
+    --text: #e6edf3;
+    --dim: #9aa7b4;
+    --green: #76b900;
+    --green-bright: #93d22a;
+    --green-tint: rgba(118, 185, 0, 0.12);
+    --amber: #e3a008;
+    --amber-tint: rgba(227, 160, 8, 0.12);
+    --red: #e5534b;
+    --sans: "NVIDIA Sans", "NVIDIASans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --mono: "JetBrains Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, "Liberation Mono", monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; overflow: hidden;
+    background: var(--bg); color: var(--text);
+    font-family: var(--sans); font-size: 16px; line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--green-bright); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code.inl { font-family: var(--mono); font-size: 0.9em; background: var(--panel-2); border: 1px solid var(--border); padding: 1px 6px; border-radius: 5px; }
+  strong { color: var(--text); }
+  em { color: var(--dim); }
+
+  /* ---- chrome ---- */
+  .deck-top {
+    position: fixed; top: 0; left: 0; right: 0; height: 48px; z-index: 30;
+    display: flex; align-items: center; gap: 12px; padding: 0 22px;
+    background: rgba(11,13,16,0.9); border-bottom: 1px solid var(--border);
+  }
+  .deck-top .brand { font-weight: 700; letter-spacing: 0.02em; font-size: 14px; }
+  .deck-top .brand .sub { color: var(--dim); font-weight: 500; }
+  .deck-top .sect { margin-left: auto; color: var(--green-bright); font-family: var(--mono); font-size: 12.5px; }
+
+  .deck-bottom {
+    position: fixed; bottom: 3px; left: 0; right: 0; height: 50px; z-index: 30;
+    display: flex; align-items: center; gap: 16px; padding: 0 22px;
+    background: rgba(11,13,16,0.9); border-top: 1px solid var(--border);
+  }
+  .navbtn {
+    font-size: 22px; line-height: 1; color: var(--text); background: var(--panel-2);
+    border: 1px solid var(--border); border-radius: 8px; width: 40px; height: 32px;
+    cursor: pointer; user-select: none;
+  }
+  .navbtn:hover { color: var(--green-bright); border-color: var(--green); }
+  .deck-bottom .meter { margin: 0 auto; display: flex; align-items: center; gap: 16px; }
+  .deck-bottom #counter { font-family: var(--mono); font-size: 13px; color: var(--text); }
+  .deck-bottom .hint { font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .progress { position: fixed; bottom: 0; left: 0; right: 0; height: 3px; background: var(--border); z-index: 31; }
+  .progress > i { display: block; height: 100%; width: 0; background: var(--green); transition: width 0.2s ease; }
+
+  /* ---- slides ---- */
+  .slide {
+    position: fixed; inset: 0; z-index: 10;
+    display: none; flex-direction: column; justify-content: center; align-items: center;
+    padding: 70px 48px 80px;
+  }
+  .slide.active { display: flex; }
+  .slide-inner { width: 100%; max-width: 1000px; max-height: 86vh; overflow-y: auto; }
+  .slide.center .slide-inner { text-align: center; }
+
+  .label { font-family: var(--mono); font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--green); margin-bottom: 8px; }
+  .slide h1 { font-size: clamp(38px, 6vw, 62px); line-height: 1.08; margin: 0 0 18px; font-weight: 800; letter-spacing: -0.02em; }
+  .slide h2 { font-size: clamp(26px, 3.6vw, 40px); margin: 0 0 16px; font-weight: 750; letter-spacing: -0.01em; }
+  .slide p { color: #cdd6df; max-width: 74ch; }
+  .lede { font-size: clamp(17px, 2.2vw, 22px); color: var(--dim); margin: 0 auto 22px; max-width: 60ch; }
+  .hint { color: var(--dim); font-family: var(--mono); font-size: 12.5px; }
+
+  .chips { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; margin-top: 8px; }
+  .chip { font-size: 14px; color: var(--text); background: var(--panel-2); border: 1px solid var(--border); padding: 6px 13px; border-radius: 999px; }
+  .chip b { color: var(--green-bright); font-weight: 600; }
+
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 16px 0; }
+  @media (max-width: 820px) { .grid2 { grid-template-columns: 1fr; } }
+  .mini { background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; text-align: left; }
+  .mini h4 { margin: 0 0 6px; font-size: 15px; color: var(--green-bright); }
+  .mini p { font-size: 14px; color: var(--dim); margin: 0; }
+
+  .note { border-left: 3px solid var(--green); background: var(--green-tint); padding: 13px 18px; border-radius: 0 10px 10px 0; margin: 16px 0; text-align: left; }
+  .note.honest { border-left-color: var(--amber); background: var(--amber-tint); }
+  .note .t { font-weight: 700; display: block; margin-bottom: 4px; }
+  .note.honest .t { color: var(--amber); }
+  .note.honest .t::before { content: "⚖  "; }
+  .note .t.info { color: var(--green-bright); }
+
+  .code { position: relative; background: #0e1116; border: 1px solid var(--border); border-radius: 10px; margin: 14px 0; overflow: hidden; text-align: left; }
+  .code .bar { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border); background: var(--panel-2); }
+  .code .dot { width: 11px; height: 11px; border-radius: 50%; }
+  .code .bar .name { margin-left: 6px; font-family: var(--mono); font-size: 12px; color: var(--dim); }
+  .code .bar .copy { margin-left: auto; font-family: var(--mono); font-size: 11.5px; color: var(--dim); background: transparent; border: 1px solid var(--border); border-radius: 6px; padding: 3px 9px; cursor: pointer; }
+  .code .bar .copy:hover { color: var(--green-bright); border-color: var(--green); }
+  pre { margin: 0; padding: 15px; overflow-x: auto; font-family: var(--mono); font-size: 13.5px; line-height: 1.6; color: #d7dee6; }
+  pre .p { color: var(--green-bright); } pre .c { color: #6b7785; } pre .g { color: var(--green); }
+  pre .a { color: var(--amber); } pre .r { color: var(--red); } pre .d { color: var(--dim); }
+
+  table.r { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 15px; }
+  table.r th, table.r td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); }
+  table.r th { color: var(--dim); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+  table.r td code { font-family: var(--mono); font-size: 12.5px; }
+  .ok { color: var(--green-bright); } .warn { color: var(--amber); } .bad { color: var(--red); } .d { color: var(--dim); }
+
+  /* ---- diagrams ---- */
+  svg.diagram { display: block; margin: 4px auto; width: auto; height: auto; max-width: min(940px, 90vw); max-height: 52vh; }
+  figure.fig { margin: 0; }
+  .fig figcaption { color: var(--dim); font-size: 13.5px; text-align: center; padding: 8px 0 0; }
+  .diagram text { font-family: var(--sans); fill: var(--text); }
+  .diagram .nlabel { font-weight: 650; font-size: 14px; }
+  .diagram .nsub { fill: var(--dim); font-size: 11.5px; }
+  .diagram .mono { font-family: var(--mono); }
+  .diagram .edge { stroke: #46525f; stroke-width: 1.6; fill: none; }
+  .diagram .edge-g { stroke: var(--green); stroke-width: 2; fill: none; }
+  .diagram .elabel { fill: var(--dim); font-size: 11px; }
+  .diagram .node { fill: var(--panel-2); stroke: var(--border); }
+  .diagram .node-g { fill: rgba(118,185,0,0.10); stroke: var(--green); }
+  .diagram .node-a { fill: rgba(227,160,8,0.10); stroke: var(--amber); }
+  .diagram .node-r { fill: rgba(229,83,75,0.10); stroke: var(--red); }
+  .diagram .ttl-g { fill: var(--green-bright); }
+  .diagram .ttl-a { fill: var(--amber); }
+  .footlinks { margin-top: 18px; font-size: 14px; color: var(--dim); }
+  .footlinks a { margin: 0 8px; }
+</style>
+</head>
+<body>
+
+<div class="deck-top">
+  <span class="brand">NVIDIA AICR<span class="sub">&nbsp;· Recipe Evidence</span></span>
+  <span class="sect" id="sect"></span>
+</div>
+
+<!-- 1 · TITLE -->
+<section class="slide center" data-title="">
+  <div class="slide-inner">
+    <div class="label">NVIDIA AI Cluster Runtime</div>
+    <h1>Recipe evidence</h1>
+    <p class="lede">Signed, verifiable proof that a recipe passed <code class="inl">aicr validate</code> on real
+      hardware — reviewable without re-running it.</p>
+    <div class="chips">
+      <span class="chip"><b>Keyless</b> cosign + Fulcio</span>
+      <span class="chip"><b>Public</b> Rekor transparency log</span>
+      <span class="chip"><b>OCI-native</b> + in-tree pointer</span>
+      <span class="chip"><b>CI-gated</b> against recipe drift</span>
+    </div>
+    <p class="hint" style="margin-top:30px">←  →  or  Space  to navigate  ·  F for fullscreen</p>
+  </div>
+</section>
+
+<!-- 2 · WHY -->
+<section class="slide" data-title="Why">
+  <div class="slide-inner">
+    <div class="label">01 · The problem</div>
+    <h2>The reachability gap</h2>
+    <p>AICR ships recipes across a large matrix of services, accelerators, operating systems, intents, and
+      platforms. No single team can access every combination — contributions for unreachable hardware either
+      stall or merge on trust.</p>
+    <table class="r">
+      <thead><tr><th>Dimension</th><th>Values</th></tr></thead>
+      <tbody>
+        <tr><td>Services</td><td>AKS · BCM · EKS · GKE · Kind · LKE · OKE</td></tr>
+        <tr><td>Accelerators</td><td>A100 · B200 · GB200 · H100 · H200 · L40 · RTX&nbsp;PRO&nbsp;6000</td></tr>
+        <tr><td>Operating systems</td><td>Amazon Linux · COS · RHEL · Talos · Ubuntu</td></tr>
+        <tr><td>Workload intents</td><td>Inference · Training</td></tr>
+        <tr><td>Platforms</td><td>Dynamo · Kubeflow · NIM · Run:ai · Slurm (Slinky)</td></tr>
+      </tbody>
+    </table>
+    <div class="grid2">
+      <div class="mini"><h4>Stalls</h4><p>No maintainer has the cluster — or time to stand one up — to re-run the validation. The PR sits.</p></div>
+      <div class="mini"><h4>Merges on faith</h4><p><code class="inl">aicr validate</code> prints local output, but nothing a maintainer can cryptographically tie to who ran it.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- 3 · VALIDATE -->
+<section class="slide" data-title="Validate → evidence">
+  <div class="slide-inner">
+    <div class="label">02 · Produce</div>
+    <h2>Validate → evidence</h2>
+    <figure class="fig">
+      <svg class="diagram" viewBox="0 0 860 372" role="img" aria-label="Pipeline from Snapshot to Recipe to Validate to Evidence, with the emitted bundle anatomy">
+        <defs>
+          <marker id="aD1" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#46525f"/></marker>
+          <marker id="aD1g" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#76b900"/></marker>
+        </defs>
+        <g>
+          <rect class="node" x="14"  y="26" width="150" height="54" rx="9"/>
+          <text class="nlabel" x="89"  y="49" text-anchor="middle">Snapshot</text>
+          <text class="nsub"   x="89"  y="67" text-anchor="middle">cluster state</text>
+          <rect class="node" x="234" y="26" width="150" height="54" rx="9"/>
+          <text class="nlabel" x="309" y="49" text-anchor="middle">Recipe</text>
+          <text class="nsub"   x="309" y="67" text-anchor="middle">criteria + checks</text>
+          <rect class="node" x="454" y="26" width="150" height="54" rx="9"/>
+          <text class="nlabel" x="529" y="49" text-anchor="middle">Validate</text>
+          <text class="nsub"   x="529" y="67" text-anchor="middle">validator Jobs</text>
+          <rect class="node-g" x="674" y="26" width="172" height="54" rx="9"/>
+          <text class="nlabel ttl-g" x="760" y="49" text-anchor="middle">Evidence</text>
+          <text class="nsub"   x="760" y="67" text-anchor="middle">--emit-attestation</text>
+          <line class="edge" x1="164" y1="53" x2="228" y2="53" marker-end="url(#aD1)"/>
+          <line class="edge" x1="384" y1="53" x2="448" y2="53" marker-end="url(#aD1)"/>
+          <line class="edge-g" x1="604" y1="53" x2="668" y2="53" marker-end="url(#aD1g)"/>
+        </g>
+        <path class="edge-g" d="M760,80 L760,104 L430,104 L430,128" marker-end="url(#aD1g)"/>
+        <rect x="14" y="132" width="832" height="226" rx="11" fill="rgba(118,185,0,0.05)" stroke="#3a4754"/>
+        <text class="nlabel ttl-g mono" x="30" y="156">recipe-evidence bundle</text>
+        <rect class="node" x="30" y="170" width="470" height="172" rx="9"/>
+        <text class="nlabel mono" x="46" y="192">summary-bundle/</text>
+        <g class="mono nsub" font-size="12">
+          <text x="46" y="214">recipe.yaml &#183; snapshot.yaml</text>
+          <text x="46" y="234">bom.cdx.json &#183; ctrf/{phase}.json</text>
+          <text x="46" y="254">manifest.json &#8592; per-file sha256</text>
+          <text x="46" y="278" fill="#9aa7b4">statement.intoto.json</text>
+          <text x="46" y="294" fill="#6b7785" font-size="11">(unsigned, always written)</text>
+        </g>
+        <rect class="node-g" x="46" y="306" width="438" height="28" rx="6"/>
+        <text class="mono ttl-g" x="58" y="324" font-size="12.5">attestation.intoto.jsonl — SIGNED (DSSE)</text>
+        <rect class="node" x="516" y="170" width="314" height="62" rx="9"/>
+        <text class="nlabel mono" x="532" y="192">pointer.yaml</text>
+        <text class="nsub mono" x="532" y="212" font-size="11.5">tiny locator → commit to repo</text>
+        <rect class="node-g" x="516" y="244" width="314" height="98" rx="9"/>
+        <text class="ttl-g nlabel" x="532" y="268" font-size="13">Integrity chain</text>
+        <g class="nsub" font-size="11.5">
+          <text x="532" y="288">each file &#8594; sha256 in manifest.json</text>
+          <text x="532" y="306">manifest.json &#8594; predicate.manifest.digest</text>
+          <text x="532" y="324">predicate &#8594; the signature. Tamper-evident.</text>
+        </g>
+      </svg>
+    </figure>
+    <div class="code">
+      <div class="bar"><span class="dot" style="background:#e5534b"></span><span class="dot" style="background:#e3a008"></span><span class="dot" style="background:#76b900"></span><span class="name">producer</span><button class="copy">copy</button></div>
+<pre><span class="c"># on VPN — validate + emit an unsigned bundle</span>
+<span class="p">$</span> aicr validate --recipe recipe.yaml --snapshot snapshot.yaml --emit-attestation ./out
+
+<span class="c"># off VPN — sign (keyless OIDC), push, write the pointer</span>
+<span class="p">$</span> aicr evidence publish ./out --push ghcr.io/&lt;owner&gt;/aicr-evidence</pre>
+    </div>
+  </div>
+</section>
+
+<!-- 4 · SIGN -->
+<section class="slide" data-title="cosign → Rekor">
+  <div class="slide-inner">
+    <div class="label">03 · Sign</div>
+    <h2>cosign → Rekor, the keyless way</h2>
+    <figure class="fig">
+      <svg class="diagram" viewBox="0 0 860 318" role="img" aria-label="Keyless signing flow: aicr to Fulcio for a cert, sign the DSSE statement, record in Rekor, push to OCI">
+        <defs>
+          <marker id="aD2" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#46525f"/></marker>
+          <marker id="aD2g" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#76b900"/></marker>
+        </defs>
+        <rect class="node-g" x="20" y="92" width="150" height="120" rx="10"/>
+        <text class="nlabel ttl-g" x="95" y="142" text-anchor="middle">aicr</text>
+        <text class="nsub" x="95" y="162" text-anchor="middle">ephemeral key</text>
+        <text class="nsub" x="95" y="178" text-anchor="middle">(discarded after)</text>
+        <rect class="node" x="250" y="22" width="170" height="56" rx="9"/>
+        <text class="nlabel" x="335" y="45" text-anchor="middle">OIDC identity</text>
+        <text class="nsub" x="335" y="63" text-anchor="middle">GitHub / Google / you@</text>
+        <rect class="node" x="250" y="120" width="170" height="64" rx="9"/>
+        <text class="nlabel" x="335" y="146" text-anchor="middle">Fulcio CA</text>
+        <text class="nsub" x="335" y="166" text-anchor="middle">short-lived cert</text>
+        <rect class="node-g" x="500" y="120" width="170" height="64" rx="9"/>
+        <text class="nlabel ttl-g" x="585" y="146" text-anchor="middle">Rekor log</text>
+        <text class="nsub" x="585" y="166" text-anchor="middle">public · append-only</text>
+        <rect class="node" x="700" y="120" width="142" height="64" rx="9"/>
+        <text class="nlabel" x="771" y="146" text-anchor="middle">OCI registry</text>
+        <text class="nsub" x="771" y="166" text-anchor="middle">artifact + referrer</text>
+        <rect class="node-g" x="250" y="232" width="420" height="58" rx="9"/>
+        <text class="nlabel ttl-g mono" x="460" y="256" text-anchor="middle" font-size="13">DSSE( in-toto Statement )</text>
+        <text class="nsub mono" x="460" y="275" text-anchor="middle" font-size="11">predicateType: aicr.nvidia.com/recipe-evidence/v1</text>
+        <path class="edge" d="M170,120 C210,96 220,60 246,52" marker-end="url(#aD2)"/>
+        <text class="elabel" x="186" y="86">① id token</text>
+        <path class="edge" d="M335,78 L335,116" marker-end="url(#aD2)"/>
+        <text class="elabel" x="343" y="100">②</text>
+        <path class="edge" d="M250,152 C214,152 206,152 174,152" marker-end="url(#aD2)"/>
+        <text class="elabel" x="182" y="142">③ cert</text>
+        <path class="edge-g" d="M95,212 C95,262 240,262 246,262" marker-end="url(#aD2g)"/>
+        <text class="elabel" x="120" y="252">④ sign</text>
+        <path class="edge-g" d="M585,232 L585,188" marker-end="url(#aD2g)"/>
+        <text class="elabel" x="593" y="214">⑤ log</text>
+        <path class="edge-g" d="M670,262 C740,262 771,232 771,188" marker-end="url(#aD2g)"/>
+        <text class="elabel" x="700" y="250">⑥ push</text>
+      </svg>
+    </figure>
+    <div class="note honest">
+      <span class="t">The honest scope</span>
+      Evidence is <strong>signer-identity-bound, not cluster-physicality-bound</strong>. It proves <em>this identity
+      signed this (recipe, snapshot, results, BOM) tuple at this time</em> — tamper-evident and publicly logged — not
+      that the cluster physically existed. Closing that gap is a deferred follow-up. See ADR-007 §Trust model.
+    </div>
+  </div>
+</section>
+
+<!-- 5 · POINTER -->
+<section class="slide" data-title="Pointer files">
+  <div class="slide-inner">
+    <div class="label">04 · Submit</div>
+    <h2>Pointer files: locator, not payload</h2>
+    <figure class="fig">
+      <svg class="diagram" viewBox="0 0 860 250" role="img" aria-label="Pointer file in the repo points to the authoritative OCI bundle, which contains the signed predicate, recorded in Rekor">
+        <defs>
+          <marker id="aD3g" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#76b900"/></marker>
+          <marker id="aD3" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#46525f"/></marker>
+        </defs>
+        <rect x="16" y="40" width="236" height="170" rx="11" fill="rgba(118,185,0,0.05)" stroke="#3a4754"/>
+        <text class="nlabel ttl-g mono" x="34" y="64" font-size="12.5">git repo (NVIDIA/aicr)</text>
+        <rect class="node-g" x="34" y="78" width="200" height="116" rx="9"/>
+        <text class="nlabel mono" x="48" y="100" font-size="12.5">recipes/evidence/</text>
+        <text class="nlabel mono" x="48" y="118" font-size="12.5">&#160;&#160;&lt;recipe&gt;.yaml</text>
+        <g class="nsub mono" font-size="11">
+          <text x="48" y="142">bundle.oci + digest</text>
+          <text x="48" y="158">signer.identity</text>
+          <text x="48" y="174">signer.rekorLogIndex</text>
+        </g>
+        <rect class="node" x="330" y="64" width="226" height="122" rx="10"/>
+        <text class="nlabel" x="443" y="92" text-anchor="middle">OCI bundle</text>
+        <text class="nsub" x="443" y="112" text-anchor="middle">authoritative</text>
+        <text class="nsub" x="443" y="130" text-anchor="middle">content-addressed</text>
+        <text class="nsub mono" x="443" y="158" text-anchor="middle" font-size="11">@sha256:f0c1…</text>
+        <rect class="node" x="624" y="40" width="220" height="74" rx="10"/>
+        <text class="nlabel" x="734" y="68" text-anchor="middle">signed predicate</text>
+        <text class="nsub" x="734" y="88" text-anchor="middle">fingerprint · phases · BOM</text>
+        <rect class="node-g" x="624" y="136" width="220" height="62" rx="10"/>
+        <text class="nlabel ttl-g" x="734" y="162" text-anchor="middle">Rekor log</text>
+        <text class="nsub" x="734" y="182" text-anchor="middle">index 91234567</text>
+        <path class="edge-g" d="M252,128 C290,128 300,124 326,122" marker-end="url(#aD3g)"/>
+        <text class="elabel" x="262" y="116">points to</text>
+        <path class="edge" d="M556,108 C590,100 600,90 620,82" marker-end="url(#aD3)"/>
+        <text class="elabel" x="560" y="128">contains</text>
+        <path class="edge" d="M734,114 L734,132" marker-end="url(#aD3)"/>
+        <text class="elabel" x="742" y="128">in</text>
+      </svg>
+    </figure>
+    <p>Push auto-derives a per-recipe tag (<code class="inl">&lt;slug&gt;-&lt;fingerprint&gt;</code>); verification pulls
+      <strong>by digest</strong>, so the tag is only a label. <code class="inl">git log</code> on the pointer is the audit trail.</p>
+  </div>
+</section>
+
+<!-- 6 · GATE -->
+<section class="slide" data-title="CI gate">
+  <div class="slide-inner">
+    <div class="label">05 · Stay honest</div>
+    <h2>The CI gate</h2>
+    <figure class="fig">
+      <svg class="diagram" viewBox="0 0 860 300" role="img" aria-label="CI gate flow: a PR editing recipes triggers a material-digest comparison against the signed pointer digest, yielding matches, stale, or missing, posted as a sticky comment">
+        <defs>
+          <marker id="aD4" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#46525f"/></marker>
+        </defs>
+        <rect class="node" x="14" y="116" width="150" height="60" rx="9"/>
+        <text class="nlabel" x="89" y="142" text-anchor="middle">PR edits</text>
+        <text class="nsub mono" x="89" y="161" text-anchor="middle" font-size="11">recipes/**</text>
+        <rect class="node" x="208" y="78" width="186" height="56" rx="9"/>
+        <text class="nlabel" x="301" y="101" text-anchor="middle" font-size="13.5">material digest</text>
+        <text class="nsub" x="301" y="120" text-anchor="middle">resolve recipe @ HEAD</text>
+        <rect class="node-g" x="208" y="158" width="186" height="56" rx="9"/>
+        <text class="nlabel ttl-g" x="301" y="181" text-anchor="middle" font-size="13.5">signed digest</text>
+        <text class="nsub" x="301" y="200" text-anchor="middle">from committed pointer</text>
+        <path class="node" d="M470,146 L516,116 L562,146 L516,176 Z"/>
+        <text class="nlabel" x="516" y="151" text-anchor="middle" font-size="13">=?</text>
+        <rect class="node-g" x="636" y="20" width="208" height="48" rx="9"/>
+        <text class="ttl-g nlabel" x="652" y="49" font-size="13.5">✓ matches</text>
+        <text class="nsub" x="828" y="49" text-anchor="end" font-size="11">evidence current</text>
+        <rect class="node-a" x="636" y="122" width="208" height="48" rx="9"/>
+        <text class="ttl-a nlabel" x="652" y="151" font-size="13.5">⚠ stale</text>
+        <text class="nsub" x="828" y="151" text-anchor="end" font-size="11">recipe drifted</text>
+        <rect class="node-a" x="636" y="224" width="208" height="48" rx="9"/>
+        <text class="ttl-a nlabel" x="652" y="253" font-size="13.5">⚠ missing</text>
+        <text class="nsub" x="828" y="253" text-anchor="end" font-size="11">no pointer</text>
+        <line class="edge" x1="164" y1="140" x2="204" y2="106" marker-end="url(#aD4)"/>
+        <line class="edge" x1="164" y1="152" x2="204" y2="186" marker-end="url(#aD4)"/>
+        <line class="edge" x1="394" y1="106" x2="476" y2="140" marker-end="url(#aD4)"/>
+        <line class="edge" x1="394" y1="186" x2="476" y2="152" marker-end="url(#aD4)"/>
+        <line class="edge" x1="562" y1="140" x2="632" y2="46"  marker-end="url(#aD4)"/>
+        <line class="edge" x1="562" y1="146" x2="632" y2="146" marker-end="url(#aD4)"/>
+        <line class="edge" x1="562" y1="152" x2="632" y2="246" marker-end="url(#aD4)"/>
+      </svg>
+    </figure>
+    <div class="note">
+      <span class="t info">Advisory now, required later</span>
+      Warning-only today — a hard gate with an empty evidence corpus would block every recipe PR. The mechanism is
+      done; per ADR-007 it hardens to a required check once enough recipes carry evidence.
+    </div>
+  </div>
+</section>
+
+<!-- 7 · VERIFY -->
+<section class="slide" data-title="Verify">
+  <div class="slide-inner">
+    <div class="label">06 · The payoff</div>
+    <h2>Verify — offline, no re-run</h2>
+    <div class="code">
+      <div class="bar"><span class="dot" style="background:#e5534b"></span><span class="dot" style="background:#e3a008"></span><span class="dot" style="background:#76b900"></span><span class="name">clean pass</span><button class="copy">copy</button></div>
+<pre><span class="p">$</span> aicr evidence verify recipes/evidence/h100-eks-ubuntu-training.yaml
+
+<span class="d">## Evidence verification — h100-eks-ubuntu-training</span>
+<span class="g">Signer:</span> https://github.com/&lt;owner&gt;/…/validate.yaml@refs/heads/main  •  <span class="g">Rekor:</span> index 91234567
+<span class="g">AICR:</span> v0.13.0  •  <span class="g">Schema:</span> 1.0.0  •  <span class="g">Bundle digest:</span> sha256:f0c1…
+
+<span class="d">### Phase results</span>
+<span class="p">✓</span> deployment   passed=5  failed=0 skipped=0
+<span class="p">✓</span> performance  passed=3  failed=0 skipped=0
+<span class="p">✓</span> conformance  passed=12 failed=0 skipped=2
+
+<span class="d">### Verification steps</span>
+ 1 materialize-bundle    <span class="p">passed</span>
+ 2 signature-verify      <span class="p">passed</span>   signer … (issuer …)
+ 3 predicate-parse       <span class="p">passed</span>   from verified DSSE payload
+ 4 manifest-hash-check   <span class="p">passed</span>   all bundle files verified
+ 5 render-summary        informational
+
+<span class="g">Verdict: bundle valid — all checks passed (exit 0)</span></pre>
+    </div>
+  </div>
+</section>
+
+<!-- 8 · TAMPER -->
+<section class="slide" data-title="Tamper">
+  <div class="slide-inner">
+    <div class="label">06 · The payoff</div>
+    <h2>Tamper-evident</h2>
+    <div class="code">
+      <div class="bar"><span class="dot" style="background:#e5534b"></span><span class="dot" style="background:#e3a008"></span><span class="dot" style="background:#76b900"></span><span class="name">tampered bundle</span><button class="copy">copy</button></div>
+<pre><span class="p">$</span> sed -i 's/"failed"/"passed"/' summary-bundle/ctrf/deployment.json
+<span class="p">$</span> aicr evidence verify ./summary-bundle
+
+ 2 signature-verify      <span class="p">passed</span>   <span class="c"># the signed Statement is untouched…</span>
+ 4 manifest-hash-check   <span class="r">failed</span>   manifest inventory check failed for 1 file(s)
+
+<span class="d">### Failed check details</span>
+- manifest-hash-check
+  <span class="r">`ctrf/deployment.json` — sha256 mismatch (got 3f9a…, want 7b21…)</span>
+
+<span class="r">Verdict: bundle invalid — integrity check(s) failed (exit 2)</span></pre>
+    </div>
+    <p>The signature still verifies, but the file no longer matches its manifest hash — and the manifest is bound to
+      the signed predicate. Editing <code class="inl">manifest.json</code> to match instead breaks
+      <code class="inl">predicate.manifest.digest</code>, which is inside the signature.</p>
+  </div>
+</section>
+
+<!-- 9 · WHERE IT FITS -->
+<section class="slide" data-title="Where it fits">
+  <div class="slide-inner">
+    <div class="label">07 · Where it fits</div>
+    <h2>One trust model, three subjects</h2>
+    <div class="grid2">
+      <div class="mini"><h4>Images &amp; binaries</h4><p>SLSA provenance + SBOM on every published image and CLI binary, signed by NVIDIA CI. <code class="inl">demos/s3c.md</code></p></div>
+      <div class="mini"><h4>Deployment bundles</h4><p><code class="inl">aicr bundle --attest</code> signs the generated bundle with build provenance + trust levels. <code class="inl">demos/attestation.md</code></p></div>
+      <div class="mini"><h4>Recipe evidence</h4><p>The signed validation result for a recipe on real hardware, OCI-distributed with an in-tree pointer.</p></div>
+      <div class="mini"><h4>Next, demand-driven</h4><p>Gate hardening to required · multi-cluster evidence per recipe · identity tiers.</p></div>
+    </div>
+    <div class="note">
+      <span class="t info">Summary</span>
+      A signed, OCI-distributed validation result with an in-tree pointer and a CI gate — verifiable offline, no re-run.
+    </div>
+    <div class="footlinks">
+      <a href="../docs/design/007-recipe-evidence.md">ADR-007</a> ·
+      <a href="evidence.md">evidence.md</a> ·
+      <a href="evidence-demo.sh">demo script</a> ·
+      <a href="../SECURITY.md">SECURITY.md</a>
+    </div>
+  </div>
+</section>
+
+<div class="deck-bottom">
+  <button class="navbtn" id="prev" aria-label="Previous slide">‹</button>
+  <div class="meter">
+    <span id="counter">1 / 9</span>
+    <span class="hint">←  →  ·  Space  ·  F fullscreen</span>
+  </div>
+  <button class="navbtn" id="next" aria-label="Next slide">›</button>
+</div>
+<div class="progress"><i id="pfill"></i></div>
+
+<script>
+  var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+  var counter = document.getElementById('counter');
+  var pfill = document.getElementById('pfill');
+  var sect = document.getElementById('sect');
+  var i = 0;
+
+  function clamp(n) { return Math.max(0, Math.min(slides.length - 1, n)); }
+  function show(n) {
+    i = clamp(n);
+    slides.forEach(function (s, k) { s.classList.toggle('active', k === i); });
+    counter.textContent = (i + 1) + ' / ' + slides.length;
+    pfill.style.width = ((i + 1) / slides.length * 100) + '%';
+    sect.textContent = slides[i].getAttribute('data-title') || '';
+    var h = '#' + (i + 1);
+    if (location.hash !== h) history.replaceState(null, '', h);
+    slides[i].querySelector('.slide-inner').scrollTop = 0;
+  }
+  function next() { show(i + 1); }
+  function prev() { show(i - 1); }
+
+  document.getElementById('next').addEventListener('click', next);
+  document.getElementById('prev').addEventListener('click', prev);
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown' || e.key === 'n') { e.preventDefault(); next(); }
+    else if (e.key === 'ArrowLeft' || e.key === 'PageUp' || e.key === 'p') { e.preventDefault(); prev(); }
+    else if (e.key === 'Home') { e.preventDefault(); show(0); }
+    else if (e.key === 'End') { e.preventDefault(); show(slides.length - 1); }
+    else if (e.key === 'f' || e.key === 'F') {
+      if (!document.fullscreenElement) { (document.documentElement.requestFullscreen || function () {}).call(document.documentElement); }
+      else { (document.exitFullscreen || function () {}).call(document); }
+    }
+  });
+
+  // Copy buttons.
+  document.querySelectorAll('.code .copy').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var pre = btn.closest('.code').querySelector('pre');
+      navigator.clipboard.writeText(pre.innerText).then(function () {
+        var prev = btn.textContent; btn.textContent = 'copied';
+        setTimeout(function () { btn.textContent = prev; }, 1200);
+      });
+    });
+  });
+
+  var start = parseInt((location.hash || '').slice(1), 10);
+  show(isNaN(start) ? 0 : start - 1);
+  window.addEventListener('hashchange', function () {
+    var n = parseInt((location.hash || '').slice(1), 10);
+    if (!isNaN(n) && n - 1 !== i) show(n - 1);
+  });
+</script>
+</body>
+</html>

--- a/demos/evidence-demo.sh
+++ b/demos/evidence-demo.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# evidence-demo.sh — interactive walkthrough of the split-leg
+# recipe-evidence workflow:
+#
+#   Leg 1 (ON VPN, cluster-bound):   aicr validate --emit-attestation   (no --push)
+#   Leg 2 (OFF VPN, Sigstore-bound): aicr evidence publish --push <ref>
+#   Verify:                          aicr evidence verify <pointer>
+#
+# The two legs are decoupled so they can run on different networks: validate
+# where the cluster is reachable (often a corporate VPN), then publish from a
+# host with Fulcio/Rekor egress. See demos/evidence.md and ADR-007.
+#
+# Every step pauses first (unless DEMO_NO_PAUSE=1) and streams the FULL output
+# of each aicr command — nothing is suppressed or captured silently.
+#
+# Usage:  ./demos/evidence-demo.sh
+#
+# All configuration is via environment variables; every knob has a default, so
+# a future demo overrides only what differs for its cluster/recipe:
+#
+#   # which binary / where
+#   AICR=/path/to/aicr                        aicr binary (default: aicr on PATH)
+#   KUBECONFIG=/path/to/kubeconfig            cluster for snapshot + validate
+#   WORKDIR=/tmp/aicr-evidence-demo           scratch dir (recipe/snapshot/bundle)
+#
+#   # recipe criteria — what to attest. REQUIRED: SERVICE ACCELERATOR OS INTENT.
+#   # PLATFORM is optional (omitted when empty). e.g. eks gb200 ubuntu inference dynamo
+#   SERVICE=eks  ACCELERATOR=gb200  OS=ubuntu  INTENT=inference  PLATFORM=dynamo
+#
+#   # snapshot node targeting (heterogeneous clusters)
+#   NODE_SELECTOR=nvidia.com/gpu.present=true pin the snapshot Job to a GPU node
+#                                             (so nvidia-smi data is collected; "" = any node)
+#   RUNTIME_CLASS=nvidia                      nvidia-smi access without consuming a GPU ("" = none)
+#
+#   # where to publish
+#   PUSH_REF=ttl.sh/aicr-evidence-<uuid>:72h  OCI ref (default: fresh anonymous ttl.sh, 72h TTL)
+#
+#   # demo behavior
+#   AICR_VALIDATOR_IMAGE_TAG=edge   validator image tag for dev aicr builds
+#   SKIP_VALIDATE=1                 reuse the bundle at $WORKDIR/out; skip recipe + snapshot + validate
+#   DEMO_NO_PAUSE=1                 unattended: skip all the "Press Enter" prompts
+#   NO_COLOR=1                      disable ANSI color
+
+set -euo pipefail
+
+# --- configuration -----------------------------------------------------------
+
+AICR="${AICR:-aicr}"
+WORKDIR="${WORKDIR:-/tmp/aicr-evidence-demo}"
+
+# Recipe criteria: the (service, accelerator, os, intent) tuple the evidence
+# attests — REQUIRED, no defaults, so a demo never silently attests the wrong
+# recipe. PLATFORM is optional (omitted when empty; not every recipe has one).
+SERVICE="${SERVICE:-}"
+ACCELERATOR="${ACCELERATOR:-}"
+OS="${OS:-}"
+INTENT="${INTENT:-}"
+PLATFORM="${PLATFORM:-}"
+
+# Snapshot node targeting. On a mixed CPU+GPU cluster the snapshot Job must land
+# on a GPU node, or nvidia-smi finds nothing and the accelerator fingerprint is
+# empty (and won't match the recipe). Defaults pin to a GPU-Operator-labeled node
+# and grant nvidia-smi access without consuming a GPU. Set either to "" to
+# disable (homogeneous GPU cluster, or a CPU-only recipe).
+NODE_SELECTOR="${NODE_SELECTOR:-nvidia.com/gpu.present=true}"
+RUNTIME_CLASS="${RUNTIME_CLASS:-nvidia}"
+
+# Reuse the bundle already at $WORKDIR/out and skip the slow recipe + snapshot +
+# validate legs — for demoing publish + verify live after pre-staging validate.
+SKIP_VALIDATE="${SKIP_VALIDATE:-0}"
+
+# A fresh UUID keeps the public ttl.sh namespace collision-free; on ttl.sh the
+# tag IS the TTL, so :72h auto-expires the artifact (and its signature) in 72h.
+new_uuid() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  elif [ -r /proc/sys/kernel/random/uuid ]; then
+    cat /proc/sys/kernel/random/uuid
+  else
+    python3 -c 'import uuid; print(uuid.uuid4())'
+  fi
+}
+PUSH_REF="${PUSH_REF:-ttl.sh/aicr-evidence-$(new_uuid):72h}"
+
+# --- presentation helpers -----------------------------------------------------
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; CYAN=$'\033[36m'; GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'; RED=$'\033[31m'; RESET=$'\033[0m'
+else
+  BOLD=''; DIM=''; CYAN=''; GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+
+STEP=0
+
+# banner <title> — prints a numbered section header.
+banner() {
+  STEP=$((STEP + 1))
+  printf '\n%s========================================================================%s\n' "$CYAN" "$RESET"
+  printf '%sSTEP %s: %s%s\n' "$BOLD" "$STEP" "$1" "$RESET"
+  printf '%s========================================================================%s\n' "$CYAN" "$RESET"
+}
+
+# note <text> — prints an explanatory line.
+note() { printf '%s%s%s\n' "$DIM" "$1" "$RESET"; }
+
+# pause [prompt] — waits for Enter. Reads from the terminal directly so it works
+# even when the script's stdin is piped. Honors DEMO_NO_PAUSE=1 for unattended runs.
+pause() {
+  local prompt="${1:-Press Enter to continue...}"
+  if [ "${DEMO_NO_PAUSE:-0}" = "1" ]; then return 0; fi
+  printf '\n%s▶ %s%s ' "$YELLOW" "$prompt" "$RESET"
+  if [ -r /dev/tty ]; then read -r _ </dev/tty; else read -r _ || true; fi
+}
+
+# run <cmd...> — echoes the command, then runs it with output streaming straight
+# to the terminal (never suppressed, never silently captured). Aborts on failure.
+run() {
+  printf '\n%s$ %s%s\n' "$GREEN" "$*" "$RESET"
+  "$@"
+  local rc=$?
+  printf '%s[exit %s]%s\n' "$DIM" "$rc" "$RESET"
+  return "$rc"
+}
+
+# run_expect_fail <cmd...> — like run(), but a NON-zero exit is the expected,
+# successful outcome (e.g. demoing the verifier's safety refusals). Output is
+# still streamed in full. Kept as a reusable building block for future beats.
+run_expect_fail() {
+  printf '\n%s$ %s%s\n' "$GREEN" "$*" "$RESET"
+  local rc=0
+  "$@" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf '%s[exit %s — expected failure ✓]%s\n' "$GREEN" "$rc" "$RESET"
+  else
+    printf '%s[exit 0 — UNEXPECTED: command was supposed to fail]%s\n' "$RED" "$RESET"
+  fi
+}
+
+# --- preflight ----------------------------------------------------------------
+
+banner "Preflight — environment & aicr version"
+note "Binary:        $AICR"
+note "Workdir:       $WORKDIR"
+note "Push ref:      $PUSH_REF"
+note "Criteria:      service=$SERVICE accelerator=$ACCELERATOR os=$OS intent=$INTENT platform=$PLATFORM"
+note "Snapshot node: node-selector=${NODE_SELECTOR:-<any>}  runtime-class=${RUNTIME_CLASS:-<none>}"
+note "Kubeconfig:    ${KUBECONFIG:-<from default ~/.kube/config>}"
+note "Note: if a verify step reports a Sigstore trusted-root error, run"
+note "      'aicr trust update' once (OFF VPN) to bootstrap the root, then re-run."
+
+if ! command -v "$AICR" >/dev/null 2>&1 && [ ! -x "$AICR" ]; then
+  printf '%sERROR: aicr binary not found at %q. Set AICR=/path/to/aicr.%s\n' "$RED" "$AICR" "$RESET" >&2
+  exit 1
+fi
+
+mkdir -p "$WORKDIR"
+RECIPE="$WORKDIR/recipe.yaml"
+SNAPSHOT="$WORKDIR/snapshot.yaml"
+OUT="$WORKDIR/out"
+
+run "$AICR" --version
+pause
+
+# --- leg 1: generate inputs + validate (ON VPN) ------------------------------
+# Skipped entirely when SKIP_VALIDATE=1 (reuse the pre-staged bundle at $OUT).
+
+if [ "$SKIP_VALIDATE" = "1" ]; then
+  banner "Reuse pre-staged bundle (SKIP_VALIDATE=1)"
+  note "Skipping recipe + snapshot + validate; publishing the bundle already at $OUT."
+  if [ ! -d "$OUT/summary-bundle" ]; then
+    printf '%sERROR: SKIP_VALIDATE=1 but no bundle at %s — run once without it first.%s\n' "$RED" "$OUT/summary-bundle" "$RESET" >&2
+    exit 1
+  fi
+  pause
+else
+
+banner "Generate the recipe from criteria"
+note "Produces the recipe whose evidence we will sign. No cluster access yet."
+for _c in SERVICE ACCELERATOR OS INTENT; do
+  if [ -z "${!_c}" ]; then
+    printf '%sERROR: %s is required — set SERVICE, ACCELERATOR, OS, INTENT (and PLATFORM if the recipe has one).%s\n' "$RED" "$_c" "$RESET" >&2
+    exit 1
+  fi
+done
+recipe_args=(--service "$SERVICE" --accelerator "$ACCELERATOR" --os "$OS" --intent "$INTENT" --output "$RECIPE")
+[ -n "$PLATFORM" ] && recipe_args+=(--platform "$PLATFORM")
+pause "Press Enter to generate the recipe"
+run "$AICR" recipe "${recipe_args[@]}"
+
+banner "Snapshot the live cluster (ON VPN)"
+note "Captures cluster state the validators run against. Needs the cluster reachable."
+note "Targets a GPU node so nvidia-smi data is collected (NODE_SELECTOR / RUNTIME_CLASS)."
+# Build snapshot args so node targeting is opt-out: empty NODE_SELECTOR /
+# RUNTIME_CLASS simply omit the flag (homogeneous or CPU-only clusters).
+snapshot_args=(--output "$SNAPSHOT")
+[ -n "$NODE_SELECTOR" ] && snapshot_args+=(--node-selector "$NODE_SELECTOR")
+[ -n "$RUNTIME_CLASS" ] && snapshot_args+=(--runtime-class "$RUNTIME_CLASS")
+pause "Press Enter to snapshot the cluster"
+run "$AICR" snapshot "${snapshot_args[@]}"
+
+banner "LEG 1 (ON VPN): validate + emit attestation, WITHOUT --push"
+note "Runs the validators against the cluster and writes an UNSIGNED bundle to disk."
+note "No Fulcio/Rekor contact happens here — this leg only needs the cluster."
+rm -rf "$OUT"
+pause "Confirm you are ON VPN (cluster reachable), then press Enter to validate"
+run "$AICR" validate \
+  --recipe "$RECIPE" \
+  --snapshot "$SNAPSHOT" \
+  --emit-attestation "$OUT" \
+  --fail-on-error=false
+fi   # end SKIP_VALIDATE guard
+
+banner "Inspect the unsigned bundle on disk"
+note "The summary bundle + a pointer.yaml (its oci/digest stay empty until we sign)."
+run ls -R "$OUT"
+printf '\n%s--- pointer.yaml (pre-publish) ---%s\n' "$DIM" "$RESET"
+cat "$OUT/pointer.yaml"
+pause
+
+# --- leg 2: sign + push (OFF VPN) ---------------------------------------------
+
+banner "LEG 2 (OFF VPN): sign, push, and write the pointer"
+printf '%s%s' "$YELLOW" "$BOLD"
+cat <<'EOF'
+  ┌────────────────────────────────────────────────────────────────────┐
+  │  SWITCH OFF VPN NOW.                                                  │
+  │  This leg contacts Fulcio (signing cert) and Rekor (transparency     │
+  │  log), which are commonly blocked on corporate VPNs. A browser may   │
+  │  open for keyless OIDC authentication — complete it when it does.    │
+  └────────────────────────────────────────────────────────────────────┘
+EOF
+printf '%s' "$RESET"
+note "The predicate (incl. its baked-in attestedAt) is signed VERBATIM from the"
+note "on-disk bundle, so the result is identical regardless of which host signs."
+pause "Once you are OFF VPN, press Enter to sign + push"
+run "$AICR" evidence publish "$OUT" --push "$PUSH_REF"
+
+banner "Inspect the pointer after publish"
+note "oci, digest, signer identity, and the Rekor log index are now populated."
+printf '\n%s--- pointer.yaml (post-publish) ---%s\n' "$DIM" "$RESET"
+cat "$OUT/pointer.yaml"
+pause
+
+# --- verify -------------------------------------------------------------------
+
+banner "Verify from the pointer (maintainer path)"
+note "The pointer is the only input: it carries bundle.oci + digest, so the verifier"
+note "pulls the artifact BY DIGEST, then checks signature → DSSE predicate → manifest chain."
+pause "Press Enter to verify from pointer.yaml"
+run "$AICR" evidence verify "$OUT/pointer.yaml"
+
+# --- done ---------------------------------------------------------------------
+
+banner "Done"
+printf '%sBundle published and verified.%s\n' "$GREEN" "$RESET"
+note "OCI artifact:  $PUSH_REF  (ttl.sh default TTL: 72h)"
+note "Bundle digest: $(awk '/digest:/ {print $2; exit}' "$OUT/pointer.yaml")"
+note "Pointer:       $OUT/pointer.yaml"
+note "Rekor entry is permanent even after the ttl.sh artifact expires:"
+REKOR_INDEX="$(awk '/rekorLogIndex:/ {print $2; exit}' "$OUT/pointer.yaml" 2>/dev/null || true)"
+if [ -n "${REKOR_INDEX:-}" ]; then
+  note "  https://search.sigstore.dev/?logIndex=${REKOR_INDEX}"
+fi


### PR DESCRIPTION
## Summary

Add demo materials for the recipe-evidence workflow under `demos/`: a self-contained slide deck and an interactive split-leg publish/verify demo script.

## Motivation / Context

Supporting materials for presenting the recipe-evidence trust handoff —
`aicr validate --emit-attestation` → `aicr evidence publish` → `aicr evidence verify`
— to the broader org. Demo-only; no product code changes.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `demos/`

## Implementation Notes

- `demos/evidence-demo-slides.html` — self-contained (inline CSS + SVG) dark-theme slide deck covering the reachability gap, validate → evidence, cosign → Rekor, pointer files, the CI gate, verify/tamper, and where it fits. Keyboard/arrow nav, progress bar, fullscreen; opens standalone in a browser.
- `demos/evidence-demo.sh` — interactive walkthrough of the split-leg flow (validate on VPN, `aicr evidence publish` off VPN, verify from the pointer). Fully env-parameterized (binary, **required** recipe criteria, snapshot GPU-node targeting, push ref, `SKIP_VALIDATE`, `DEMO_NO_PAUSE`); streams full command output, nothing suppressed.
- `demos/README.md` — index rows for both.
- No changes to product code, recipes, or CI.

## Testing

Demo files only (HTML, shell, Markdown) — no Go or YAML touched.

```bash
bash -n demos/evidence-demo.sh   # clean
```

Slide deck inline SVG validated as well-formed; opens standalone. CI `make qualify` runs on the PR per repo policy.

## Risk Assessment

- [x] **Low** — Isolated, additive demo files; no product code; trivial to revert.

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A (no Go changes)
- [x] Linter passes (`make lint`) — `bash -n` clean; no Go/YAML to lint
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (demo material)
- [x] I updated docs if user-facing behavior changed — N/A (no behavior change)
- [x] Changes follow existing patterns in the codebase (the `demos/` collection)
- [x] Commits are cryptographically signed (`git commit -S`)
