### PR TITLE
docs(skills): add creating-guided-demos skill

### DIFF
--- a/.claude/skills/creating-guided-demos/SKILL.md
+++ b/.claude/skills/creating-guided-demos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-guided-demos
-description: Use when building an interactive, self-paced walkthrough of a CLI or workflow (e.g. a demos/*.sh) — for driving a live demo to an audience, or for a user stepping through the flow themselves to learn or reproduce it.
+description: Scaffolds an interactive guided demo script (demos/*.sh), live or self-paced, with the Frame → Tell → Show → Close pattern. Triggers on "demo script", "guided walkthrough", "demos/*.sh", "live demo".
 ---
 
 # Creating Guided Demos

--- a/.claude/skills/creating-guided-demos/SKILL.md
+++ b/.claude/skills/creating-guided-demos/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: creating-guided-demos
+description: Use when building an interactive, self-paced walkthrough of a CLI or workflow (e.g. a demos/*.sh) — for driving a live demo to an audience, or for a user stepping through the flow themselves to learn or reproduce it.
+---
+
+# Creating Guided Demos
+
+## Overview
+
+A guided demo is a **narrative, not a command dump** — and it serves two readers equally: a presenter driving it live for a room, and a lone user stepping through it to learn or reproduce the flow. Either way, at every step they know *why* they're here, *what's* about to happen, and *what just happened*.
+
+Four beats: **Frame → Tell → Show → Close.** The script is the guide — it paces itself, explains each step, and streams the real tool output so what's watched is the actual thing working.
+
+## When to use
+
+- Building a `demos/*.sh` to present a CLI/workflow live **or** to let a user self-walk it (onboarding, learning, reproducing a result).
+- Turning a bare sequence of commands into a self-paced, narrated walkthrough.
+- **Not for:** non-interactive CI scripts, one-off scratch scripts, or pure reference docs.
+
+## The four beats
+
+1. **Frame** — the *why*, for whoever's following (a room, or one reader). One or two sentences: what's missing/broken and why it matters. No commands.
+2. **Tell** — name the steps before running them, so they have a map. Flag what's slow, what needs the network/VPN, what to watch for.
+3. **Show** — run the real commands one at a time, pausing before each, streaming their **full** output. Pre-stage the slow/fragile parts; keep a fallback for anything that can fail.
+4. **Close** — one line on what just happened, plus pointers: docs/ADR, related demos, the source of truth.
+
+## Mechanics
+
+Copy [`skeleton.sh`](skeleton.sh). It gives you:
+
+- **`banner` / `note` / `pause` / `run` helpers** — numbered sections, dim explanations, an Enter-gated pause per step, and a `run` that echoes then streams output verbatim. Plus an optional `run_expect_fail` for steps where a non-zero exit is the expected result (uses `|| rc=$?` so `set -euo pipefail` doesn't abort).
+- **One env config block at the top** — every input is an env var; *required* ones fail fast (validate producer-only inputs inside the producer branch so the skip flag still works), the rest default. Each runner overrides only what differs.
+- **Re-runnability** — `DEMO_NO_PAUSE=1` runs unattended; a skip flag (e.g. `SKIP_SETUP=1`) reuses pre-staged state. Skip contract: **guard the producer, assert the artifact exists (fail loudly), then run the fast steps either way.**
+
+## Rules
+
+- **Show real output.** Never `>/dev/null`, never fabricate. Watching the real tool *is* the point.
+- **Don't fake success.** Never weaken a gate/threshold to force green — an honest failure is a valid beat.
+- **Respect time.** Anything multi-minute (deploys, benchmarks, sign-in) is pre-staged; live steps are seconds.
+- **Commit-ready by default.** No home paths, kubeconfig paths, or private refs; generic defaults. (A throwaway personal demo can relax this.)
+
+## Worked example
+
+`demos/evidence-demo.sh` — the split-leg recipe-evidence walkthrough: Frame (the reachability gap) → Tell (validate → publish → verify) → Show (each leg, streamed, pre-staged with fallbacks) → Close (ADR-007 + related demos). Reads the same whether presented live or run solo.
+
+## Common mistakes
+
+- Command dump, no Frame/Close → the runner never learns *why*, or what they saw.
+- Slow producer step run live → blows the time budget; pre-stage it and add a skip flag.
+- Hardcoded paths/criteria → not reusable; use env vars and fail fast on required ones.
+- Faked/suppressed output or a weakened gate → destroys the trust the demo exists to build.

--- a/.claude/skills/creating-guided-demos/skeleton.sh
+++ b/.claude/skills/creating-guided-demos/skeleton.sh
@@ -21,6 +21,7 @@
 # Usage:  ./demos/<name>.sh
 #
 # Config (env vars; required ones fail fast, the rest default):
+#   BIN=/path/to/mycli     the binary the demo drives (default: mycli on PATH)
 #   REQUIRED_INPUT=...     required — <what it is>
 #   OPTIONAL_INPUT=foo     optional — <what it is> (default: foo)
 #   DEMO_NO_PAUSE=1        unattended: skip the "Press Enter" prompts
@@ -29,6 +30,7 @@
 set -euo pipefail
 
 # --- configuration (one block; override only what differs) --------------------
+BIN="${BIN:-mycli}"                 # the binary the demo drives (override: BIN=/path/to/mycli)
 REQUIRED_INPUT="${REQUIRED_INPUT:-}"
 OPTIONAL_INPUT="${OPTIONAL_INPUT:-foo}"
 WORKDIR="${WORKDIR:-/tmp/demo}"   # scratch for the pre-staged artifact
@@ -70,8 +72,13 @@ run_expect_fail() {
 }
 
 # --- preflight: validate inputs needed in ALL modes, fail fast ----------------
+# The binary is needed by every mode (setup AND the skip path), so check it here.
 # Inputs only the producer step needs are validated inside the producer branch
 # below — so a SKIP_SETUP=1 run doesn't demand inputs it won't use.
+if ! command -v "$BIN" >/dev/null 2>&1 && [ ! -x "$BIN" ]; then
+  printf '%sERROR: %q not found. Set BIN=/path/to/mycli.%s\n' "$RED" "$BIN" "$RESET" >&2
+  exit 1
+fi
 
 # === 1. FRAME — why this matters (no commands) ================================
 banner "Why this matters"
@@ -99,13 +106,13 @@ else
   banner "<slow setup step>"
   note "<what this produces — the multi-minute part>"
   pause "Press Enter to run <slow setup>"
-  run echo "replace with the producer command that writes $OUT, using $REQUIRED_INPUT"
+  run echo "replace with the producer command (e.g. \"$BIN\" ...) that writes $OUT, using $REQUIRED_INPUT"
 fi
 
 banner "<live step — fast>"
 note "<what this step proves>"
 pause "Press Enter to run <live step>"
-run echo "replace with the fast/consumer command that reads $OUT / $OPTIONAL_INPUT"
+run echo "replace with the fast/consumer command (e.g. \"$BIN\" ...) that reads $OUT / $OPTIONAL_INPUT"
 # A step whose failure IS the point (e.g. a safety refusal) uses run_expect_fail.
 
 # === 4. CLOSE — recap + pointers ==============================================

--- a/.claude/skills/creating-guided-demos/skeleton.sh
+++ b/.claude/skills/creating-guided-demos/skeleton.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# <name>.sh — guided walkthrough of <thing> (live demo or self-paced).  Frame → Tell → Show → Close.
+#
+# Copy this skeleton and fill in the four beats below. See the
+# creating-guided-demos skill and demos/evidence-demo.sh for the full pattern.
+#
+# Usage:  ./demos/<name>.sh
+#
+# Config (env vars; required ones fail fast, the rest default):
+#   REQUIRED_INPUT=...     required — <what it is>
+#   OPTIONAL_INPUT=foo     optional — <what it is> (default: foo)
+#   DEMO_NO_PAUSE=1        unattended: skip the "Press Enter" prompts
+#   NO_COLOR=1             disable ANSI color
+
+set -euo pipefail
+
+# --- configuration (one block; override only what differs) --------------------
+REQUIRED_INPUT="${REQUIRED_INPUT:-}"
+OPTIONAL_INPUT="${OPTIONAL_INPUT:-foo}"
+WORKDIR="${WORKDIR:-/tmp/demo}"   # scratch for the pre-staged artifact
+OUT="$WORKDIR/out"                # the expensive-to-produce artifact
+SKIP_SETUP="${SKIP_SETUP:-0}"     # reuse a pre-staged $OUT; skip the slow producer step
+
+# --- presentation helpers -----------------------------------------------------
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; CYAN=$'\033[36m'; GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'; RED=$'\033[31m'; RESET=$'\033[0m'
+else
+  BOLD=''; DIM=''; CYAN=''; GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+STEP=0
+banner() { STEP=$((STEP + 1)); printf '\n%s== STEP %s: %s ==%s\n' "$CYAN" "$STEP" "$1" "$RESET"; }
+note()   { printf '%s%s%s\n' "$DIM" "$1" "$RESET"; }
+# pause reads from the terminal directly so it works even when stdin is piped.
+pause()  {
+  [ "${DEMO_NO_PAUSE:-0}" = "1" ] && return 0
+  printf '\n%s▶ %s%s ' "$YELLOW" "${1:-Press Enter to continue...}" "$RESET"
+  if [ -r /dev/tty ]; then read -r _ </dev/tty; else read -r _ || true; fi
+}
+# run echoes the command, then runs it with output streaming straight to the
+# terminal — never suppressed, never captured silently, never faked.
+run() {
+  printf '\n%s$ %s%s\n' "$GREEN" "$*" "$RESET"
+  "$@"; local rc=$?
+  printf '%s[exit %s]%s\n' "$DIM" "$rc" "$RESET"
+  return "$rc"
+}
+# run_expect_fail: a NON-zero exit is the expected, successful outcome (e.g. a
+# safety refusal you want to demo). The `|| rc=$?` keeps `set -euo pipefail`
+# from aborting the demo on that intended failure.
+run_expect_fail() {
+  printf '\n%s$ %s%s\n' "$GREEN" "$*" "$RESET"
+  local rc=0; "$@" || rc=$?
+  if [ "$rc" -ne 0 ]; then printf '%s[exit %s — expected failure ✓]%s\n' "$GREEN" "$rc" "$RESET"
+  else printf '%s[exit 0 — UNEXPECTED: was supposed to fail]%s\n' "$RED" "$RESET"; fi
+}
+
+# --- preflight: validate inputs needed in ALL modes, fail fast ----------------
+# Inputs only the producer step needs are validated inside the producer branch
+# below — so a SKIP_SETUP=1 run doesn't demand inputs it won't use.
+
+# === 1. FRAME — why this matters (no commands) ================================
+banner "Why this matters"
+note "<one or two sentences framing the problem for the whole room>"
+pause
+
+# === 2. TELL — name the steps before running them =============================
+banner "What we'll do"
+note "1) <step one>   2) <step two>   3) <step three>"
+note "Heads-up: <what's slow / needs network / has been pre-staged ahead of time>"
+pause
+
+# === 3. SHOW — run the real thing, stream real output =========================
+# Pre-stage anything multi-minute ahead of time; SKIP_SETUP=1 reuses it so the
+# live run is only the fast steps. Contract: guard the producer, assert the
+# artifact exists (fail loudly), then run the fast/consumer steps either way.
+if [ "$SKIP_SETUP" = "1" ]; then
+  banner "Reuse pre-staged state (SKIP_SETUP=1)"
+  [ -e "$OUT" ] || { printf '%sERROR: SKIP_SETUP=1 but %s missing — run once without it first.%s\n' "$RED" "$OUT" "$RESET" >&2; exit 1; }
+  pause
+else
+  [ -n "$REQUIRED_INPUT" ] || {
+    printf '%sERROR: REQUIRED_INPUT is required for the setup step.%s\n' "$RED" "$RESET" >&2; exit 1; }
+  mkdir -p "$WORKDIR"
+  banner "<slow setup step>"
+  note "<what this produces — the multi-minute part>"
+  pause "Press Enter to run <slow setup>"
+  run echo "replace with the producer command that writes $OUT, using $REQUIRED_INPUT"
+fi
+
+banner "<live step — fast>"
+note "<what this step proves>"
+pause "Press Enter to run <live step>"
+run echo "replace with the fast/consumer command that reads $OUT / $OPTIONAL_INPUT"
+# A step whose failure IS the point (e.g. a safety refusal) uses run_expect_fail.
+
+# === 4. CLOSE — recap + pointers ==============================================
+banner "Done"
+note "<one-line recap of what they just saw>"
+note "Docs: <link/ADR>   ·   Related: <other demo>"


### PR DESCRIPTION
## Summary

Add a `creating-guided-demos` Claude skill (plus a copy-paste `skeleton.sh`) so contributors can author interactive, self-paced guided walkthrough scripts — for driving a live demo to an audience, or for a user stepping through a flow themselves to learn or reproduce it.

## Motivation / Context

Generalizes the pattern behind `demos/evidence-demo.sh` (#1188) into a reusable skill: the Frame → Tell → Show → Close narrative plus the helper/config mechanics that make those scripts work. Demo-tooling only; no product code.

Fixes: N/A
Related: #1188

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Other: `.claude/skills/` (agent skills / tooling)

## Implementation Notes

- `.claude/skills/creating-guided-demos/SKILL.md` — the guide: the four beats, the helper + env-parameterization mechanics, the "show real output / don't fake success" rules, common mistakes, anchored to `demos/evidence-demo.sh`.
- `.claude/skills/creating-guided-demos/skeleton.sh` — copy-paste template: `banner`/`note`/`pause`/`run` (+ optional `run_expect_fail`) helpers, one env config block (required inputs fail fast, the rest default), the four-beat scaffold, and a skip-flag pre-stage pattern.
- Framed for dual use — a live presented demo and a self-paced walkthrough read the same.

## Testing

Docs + shell only — no Go or YAML.

```bash
bash -n .claude/skills/creating-guided-demos/skeleton.sh   # clean
```

Validated by a subagent that produced a correct Frame/Tell/Show/Close demo for a different AICR workflow using the skill, plus a fidelity review cross-referencing it against `demos/evidence-demo.sh`.

## Risk Assessment

- [x] **Low** — additive agent-tooling docs; no product code; trivial to revert.

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A (no Go changes)
- [x] Linter passes (`make lint`) — `bash -n` clean; no Go/YAML to lint
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (skill docs)
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns (sits alongside the aicr-release-notes / managing-openvex skills)
- [x] Commits are cryptographically signed (`git commit -S`)
