### PR TITLE
chore(deps): bump GPU Operator chart to v26.3.2

### DIFF
--- a/demos/cuj2-demo.md
+++ b/demos/cuj2-demo.md
@@ -126,7 +126,7 @@
 │  h100-eks-ubuntu-training.yaml      │  (Ubuntu constraints)               │
 │  (Ubuntu constraints)               │      │                              │
 │      │                              │  h100-eks-ubuntu-inference-dynamo   │
-│  h100-eks-ubuntu-training-kubeflow  │  ├── gpu-operator (v26.3.1, CDI)    │
+│  h100-eks-ubuntu-training-kubeflow  │  ├── gpu-operator (v26.3.2, CDI)    │
 │  └── kubeflow-trainer       ◀── NEW │  ├── nvidia-dra-driver (gpuRes)◀─NEW│
 │                                     │  ├── dynamo-crds             ◀─ NEW │
 │                                     │  └── dynamo-platform         ◀─ NEW │

--- a/docs/integrator/automation.md
+++ b/docs/integrator/automation.md
@@ -328,7 +328,7 @@ spec:
     # Helm chart from upstream
     - repoURL: https://helm.ngc.nvidia.com/nvidia
       chart: gpu-operator
-      targetRevision: v26.3.1
+      targetRevision: v26.3.2
       helm:
         valueFiles:
           - $values/gpu-operator/values.yaml

--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -719,7 +719,7 @@ spec:
   sources:
     # Helm chart from upstream
     - repoURL: https://helm.ngc.nvidia.com/nvidia
-      targetRevision: v26.3.1
+      targetRevision: v26.3.2
       chart: gpu-operator
       helm:
         valueFiles:

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -23,7 +23,7 @@ spec:
     intent: training
   componentRefs:
     - name: gpu-operator
-      version: v26.3.1
+      version: v26.3.2
       valuesFile: components/gpu-operator/eks-gb200-training.yaml
       overrides:
         driver:
@@ -197,7 +197,7 @@ together in an overlay rather than relying on the global defaults for the inputs
 componentRefs:
   - name: gpu-operator
     type: Helm
-    version: v26.3.1
+    version: v26.3.2
     valuesFile: components/gpu-operator/values.yaml
     overrides:
       driver:
@@ -381,7 +381,7 @@ spec:
     intent: training
   componentRefs:
     - name: gpu-operator
-      version: v26.3.1
+      version: v26.3.2
       valuesFile: components/gpu-operator/eks-gb200-training.yaml
 ```
 
@@ -392,7 +392,7 @@ spec:
 # Update component version
 componentRefs:
   - name: gpu-operator
-    version: v26.3.1  # Changed from v26.3.0
+    version: v26.3.2  # Changed from v26.3.1
 ```
 
 **Adding components:**

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -37,7 +37,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | dynamo-platform | helm | dynamo-platform | 1.0.2 | 1 |
 | gatekeeper | helm | gatekeeper/gatekeeper | 3.22.2 | 3 |
 | gke-nccl-tcpxo | manifest | — | — | 4 |
-| gpu-operator | helm | nvidia/gpu-operator | v26.3.1 | 14 |
+| gpu-operator | helm | nvidia/gpu-operator | v26.3.2 | 14 |
 | grove | helm | grove-charts | v0.1.0-alpha.6 | 1 |
 | k8s-ephemeral-storage-metrics | helm | k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics | 1.19.2 | 1 |
 | k8s-nim-operator | helm | k8s-nim-operator | 3.1.0 | 1 |
@@ -101,7 +101,7 @@ _No images extracted._
 
 - `gcr.io/gke-release/nri-device-injector:1.0.25-gke.6@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c`
 - `gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830`
-- `ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b`
+- `ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54`
 - `us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3f39455a2ea35e844e0fc92564ca5629f6b03250fde40e8160719dae4`
 
 ### gpu-operator
@@ -109,16 +109,16 @@ _No images extracted._
 - `nvcr.io/nvidia/cloud-native/dcgm:4.5.2-1-ubuntu22.04`
 - `nvcr.io/nvidia/cloud-native/gdrdrv:v2.5.2`
 - `nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.4.0`
-- `nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.10.0`
-- `nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.0`
+- `nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.11.0`
+- `nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.2`
 - `nvcr.io/nvidia/cloud-native/nvidia-fs:2.27.3`
 - `nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin:v0.0.3`
 - `nvcr.io/nvidia/cloud-native/vgpu-device-manager:v0.4.2`
 - `nvcr.io/nvidia/driver:580.126.20`
-- `nvcr.io/nvidia/gpu-operator:v26.3.1`
-- `nvcr.io/nvidia/k8s-device-plugin:v0.19.0`
-- `nvcr.io/nvidia/k8s/container-toolkit:v1.19.0`
-- `nvcr.io/nvidia/k8s/dcgm-exporter:4.5.1-4.8.0-distroless`
+- `nvcr.io/nvidia/gpu-operator:v26.3.2`
+- `nvcr.io/nvidia/k8s-device-plugin:v0.19.2`
+- `nvcr.io/nvidia/k8s/container-toolkit:v1.19.1`
+- `nvcr.io/nvidia/k8s/dcgm-exporter:4.5.3-4.8.2-distroless`
 - `nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0`
 
 ### grove

--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -61,9 +61,9 @@ validation:
   deployment:
     constraints:
       - name: gpu-operator.version
-        value: "== v26.3.1"
+        value: "== v26.3.2"
         severity: warning
-        remediation: "Update GPU Operator to v26.3.1"
+        remediation: "Update GPU Operator to v26.3.2"
     checks:
       - expected-resources
 
@@ -100,7 +100,7 @@ componentRefs:
     chart: gpu-operator
     type: Helm
     source: https://helm.ngc.nvidia.com/nvidia
-    version: v26.3.1
+    version: v26.3.2
     valuesFile: components/gpu-operator/values-eks-training.yaml
     expectedResources:
       - kind: Deployment

--- a/pkg/recipe/driver_root_lockstep_test.go
+++ b/pkg/recipe/driver_root_lockstep_test.go
@@ -73,7 +73,7 @@ import (
 // **Why "explicitly set" matters for the lockstep case.** An empty value
 // falls through to the upstream chart's bundled default, which the test
 // cannot read — and per-component defaults differ (GPU Operator chart
-// 26.3.1 defaults driverInstallDir to /run/nvidia/driver, but DRA chart
+// 26.3.2 defaults driverInstallDir to /run/nvidia/driver, but DRA chart
 // 25.12.0 defaults nvidiaDriverRoot to /). Relying on chart defaults is
 // itself drift waiting to happen on the next chart bump, so when the
 // lockstep applies the test treats "not explicitly set on both" as a
@@ -173,7 +173,7 @@ func TestDriverRootLockstep(t *testing.T) {
 				t.Errorf(
 					"overlay %q: both nvidia-dra-driver-gpu.nvidiaDriverRoot and gpu-operator.hostPaths.driverInstallDir are unset.\n"+
 						"  Both must be set explicitly to the same path. Chart defaults differ across components\n"+
-						"  (gpu-operator chart 26.3.1: /run/nvidia/driver; dra chart 25.12.0: /), so an unset value\n"+
+						"  (gpu-operator chart 26.3.2: /run/nvidia/driver; dra chart 25.12.0: /), so an unset value\n"+
 						"  is drift waiting to happen on the next chart bump.\n"+
 						"  See issue #1087.",
 					name)

--- a/recipes/components/gpu-operator/values-aks.yaml
+++ b/recipes/components/gpu-operator/values-aks.yaml
@@ -35,7 +35,7 @@ nfd:
 # building its own bundled MOFED — required for the network-operator
 # integration to actually work end-to-end. The global default in
 # components/gpu-operator/values.yaml is off because EFA / non-MOFED
-# fabrics trip v26.3.1's driver-validation gate.
+# fabrics trip v26.3.2's driver-validation gate.
 driver:
   rdma:
     enabled: true

--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -152,7 +152,7 @@ gfd:
   enabled: true
 
 driver:
-  # NVIDIA's recommended driver for the v26.3.1 chart; matches the
+  # NVIDIA's recommended driver for the v26.3.2 chart; matches the
   # GB200+EFA floor so a single global pin covers H100/B200/GB200 EKS.
   version: 580.126.20
   enabled: true
@@ -161,7 +161,7 @@ driver:
   rdma:
     # Default off: nvidia_peermem only loads against Mellanox MOFED
     # symbols. AWS EFA (EKS p4d/p5/p5e) and Linode have no MOFED, so
-    # peermem fails to load and v26.3.1's stricter driver-validation
+    # peermem fails to load and v26.3.2's stricter driver-validation
     # init container blocks the rest of the GPU stack. Overlays that
     # ship MOFED (AKS via network-operator) explicitly re-enable this.
     enabled: false

--- a/recipes/overlays/aks.yaml
+++ b/recipes/overlays/aks.yaml
@@ -42,7 +42,7 @@ spec:
     # AKS pre-installs NVIDIA container toolkit; disable toolkit installation
     - name: gpu-operator
       type: Helm
-      version: "v26.3.1"
+      version: "v26.3.2"
       valuesFile: components/gpu-operator/values-aks.yaml
       dependencyRefs:
         - network-operator

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -40,7 +40,7 @@ spec:
     - name: gpu-operator
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia
-      version: v26.3.1
+      version: v26.3.2
       valuesFile: components/gpu-operator/values.yaml
       dependencyRefs:
         - nfd

--- a/recipes/overlays/oke.yaml
+++ b/recipes/overlays/oke.yaml
@@ -40,7 +40,7 @@ spec:
     # (BM.GPU.B200, BM.GPU.H100, etc.). Disable both to avoid conflicts.
     - name: gpu-operator
       type: Helm
-      version: v26.3.1
+      version: v26.3.2
       valuesFile: components/gpu-operator/values-oke.yaml
 
     # Prometheus persistent storage (provide --storage-class at bundle time, e.g. oci-bv)

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -100,7 +100,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia
       defaultChart: nvidia/gpu-operator
-      defaultVersion: v26.3.1
+      defaultVersion: v26.3.2
       defaultNamespace: gpu-operator
     nodeScheduling:
       system:

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml
@@ -39,7 +39,7 @@ daemonsets:
 
 # ── Driver: nvidia_peermem off on EKS (AWS EFA path uses aws-ofi-nccl)
 # nvidia_peermem only loads against Mellanox MOFED symbols; on AWS EFA
-# (p4d/p5/p5e) it fails to load and v26.3.1's strict driver-validation
+# (p4d/p5/p5e) it fails to load and v26.3.2's strict driver-validation
 # init container blocks the rest of the GPU stack. NCCL multi-node on
 # EFA uses libfabric via aws-ofi-nccl, not nvidia_peermem.
 driver:


### PR DESCRIPTION
## Summary

Bump the pinned NVIDIA GPU Operator Helm chart from **v26.3.1 → v26.3.2** (released 2026-05-28), a patch on the same 26.3.x line. v26.3.2 is validated with Kubernetes v1.36.

## Motivation / Context

Stay current on the 26.3.x patch line. The chart's recommended `driver.version` (580.126.20) and `driverInstallDir` (`/run/nvidia/driver`) defaults are **byte-identical** between v26.3.1 and v26.3.2 (verified via `helm show values` against both chart versions), so no recipe values or scheduling logic change — this is a clean version-string bump plus the regenerated BOM.

Fixes: #1174
Related: N/A

## Type of Change

- [x] Build/CI/tooling
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Authoritative pin and all hardcoded references updated:

- `recipes/overlays/base.yaml` — authoritative `version` pin
- `recipes/registry.yaml` — `defaultVersion`
- `recipes/overlays/aks.yaml`, `recipes/overlays/oke.yaml` — overlay pins
- `examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml` — constraint `== v26.3.2`, remediation text, component `version`
- Version-referencing comments in `recipes/components/gpu-operator/values.yaml`, `values-aks.yaml`, `tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling.yaml`, and `pkg/recipe/driver_root_lockstep_test.go` (driver/`driverInstallDir` defaults re-verified unchanged)
- Docs/demos: `docs/integrator/recipe-development.md`, `automation.md`, `data-flow.md`, `demos/cuj2-demo.md`

`make bom-docs` regenerated `docs/user/container-images.md`, which picks up upstream operand image drift on the same chart line: container-toolkit v1.19.0→v1.19.1, k8s-driver-manager v0.10.0→v0.11.0, k8s-mig-manager v0.14.0→v0.14.2, k8s-device-plugin v0.19.0→v0.19.2, dcgm-exporter 4.5.1→4.5.3. The `nvcr.io/nvidia/driver:580.126.20` ref is unchanged.

## Testing

```bash
make bom-docs   # regenerated docs/user/container-images.md (passed)
make qualify    # see note below
```

`make bom-docs` succeeded and the regenerated BOM is committed. **`make qualify` was not run to completion locally** (filed at request to not wait); the full CI gate runs the complete test + lint + e2e + scan suite on this PR. Given the change is a chart version-string bump with verified-identical chart defaults (no Go logic change beyond a comment), risk of a qualify regression is low. Recommend a single post-merge smoke test on a representative recipe (e.g. gb200-eks-training) to confirm the new operand images come up, rather than a full re-validation sweep.

## Risk Assessment

- [x] **Low** — Patch bump within 26.3.x; chart driver/`driverInstallDir` defaults verified unchanged; easy to revert.

**Rollout notes:** No migration. Recommend one post-merge smoke test on a representative recipe to confirm the bumped operand images deploy cleanly.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — deferred to CI (see Testing)
- [ ] Linter passes (`make lint`) — deferred to CI
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
