### PR TITLE
fix(validators): update and tune inference performance validation

### DIFF
--- a/docs/contributor/inference-perf-fluctuation.md
+++ b/docs/contributor/inference-perf-fluctuation.md
@@ -1,0 +1,400 @@
+# Inference-Perf Validation — TTFT Fluctuation & Worker-Stall Investigation
+
+**Date:** 2026-06-04
+**Author:** Yuan Chen (with Claude Code)
+**Related:** NVIDIA/aicr #1192, #1193, #1194, #1196
+**Status:** root cause characterized; mitigations shipped/in-PR; long-term fix proposed
+
+---
+
+## 1. Executive summary
+
+The `inference-perf` validator intermittently **failed healthy GPU clusters** at
+2048 concurrency — sometimes with a catastrophic time-to-first-token (TTFT) p99
+of 9–45 s, sometimes just over the 1000 ms gate. Extensive testing across three
+H100/RTX clusters showed:
+
+- **No genuine deployment or hardware failure** was ever found. GPUs were healthy
+  throughout; clusters delivered ~108–140k tok/s.
+- The failures were the **validator/benchmark/gate mis-firing**: a fixed-but-real
+  version-skew panic, a transient/stochastic worker stall, and a too-tight
+  latency gate at the saturation knee producing **false negatives**.
+- An early hypothesis (aiperf↔worker **CPU contention**) was **refuted by direct
+  measurement** — the GPU node's CPU is never contended.
+
+**Mitigations shipped/in-PR:** dynamo runtime image bump 0.9.0→1.0.2 (#1193, the
+panic fix); reproducible gate — TTFT `<= 2000` ms + pinned AIPerf inputs (#1196);
+centralized dynamo image reference + drift guard (#1194).
+**Long-term:** load-aware routing (`least-loaded`, dynamo 1.2.x) + a sub-knee,
+throughput-primary gate.
+
+---
+
+## 2. Symptom / problem statement
+
+- On **EKS H100** (`p5.48xlarge`, 8× H100), the `inference-perf` check at
+  2048 in-flight (256/GPU) **failed intermittently** on a cluster that had passed
+  cleanly two days earlier (§9). TTFT p99 swung **664 ms → 45 s** run-to-run;
+  throughput 25k–127k.
+- User report: *"we used to get consistently good performance on EKS H100 until
+  today."* Historical EKS H100 baseline: **108,790 tok/s / 688 ms**, on par with GKE.
+- Two visible failure shapes:
+  1. **Severe stall** — one worker's in-flight queue backs up to the
+     `max_num_seqs` cap (1022) or partway (643) while its GPU sits at low util;
+     TTFT 9–45 s.
+  2. **Knee jitter** — balanced, full-throughput runs whose TTFT p99 lands just
+     over the 1000 ms gate (1358 / 1670 ms) → false negative.
+
+---
+
+## 3. Environment & setup
+
+### Clusters
+
+| Cluster | Platform | GPU node | GPUs | Region |
+|---|---|---|---|---|
+| EKS H100 | EKS | `p5.48xlarge` (192 vCPU) | 8× H100-SXM | us-east-1 |
+| GKE H100 | GKE | `a3-megagpu-8g` (208 vCPU) | 8× H100-SXM | us-central1 |
+| EKS RTX Pro 6000 | EKS | RTX PRO 6000 | 8 | us-west-2 |
+
+Non-GPU nodes were small on both EKS H100 paths: EKS H100 system nodes =
+`m7i.xlarge` (4 vCPU); GKE = `n2-standard-8` cpu-worker (8 vCPU) + `e2-standard-4`
+system nodes (4 vCPU).
+
+### Workload / gate
+
+- Model **Qwen/Qwen3-8B** (BF16), PVC weights cache.
+- **256 concurrency/GPU → 2048 in-flight** (the per-GPU "knee").
+- Recipe gate (original): throughput `>= 50000`, TTFT p99 `<= 1000` (gb200 already 2000).
+- Validator deployed a `DynamoGraphDeployment` (Dynamo frontend + 8 vLLM decode
+  workers, 1 GPU/worker via DRA) + an **AIPerf** benchmark Job.
+
+### Tooling built for the investigation
+
+- Locally-built `performance` validator images pushed to each cluster's registry
+  (ECR / GCP Artifact Registry), invoked via `AICR_VALIDATOR_IMAGE_REGISTRY` +
+  `AICR_VALIDATOR_IMAGE_TAG` overrides. Tags used: `dynamo102` (1.0.2 bump),
+  `dynamo102b` (+CPU req +aiperf nodeAffinity), `dynamo102c` (+CPU req only),
+  `dynamo102d` (+CPU req +aiperf CPU req), `dynamo102e` (+`kv` routing).
+- Live cluster-state watchers capturing per-worker `Running`/`Waiting`/KV-cache,
+  per-GPU `nvidia-smi` (util/clocks/power/throttle/ECC via the gpu-operator
+  driver pod), worker→GPU-UUID mapping, frontend serve/panic signals, AIPerf
+  pod node, and **node CPU PSI + loadavg** (`/proc/pressure/cpu`, `/proc/loadavg`
+  via the hostPID driver pod — `kubectl top`/metrics-server was unavailable).
+
+### Operational caveat: a GPU driver restart requires a DRA plugin restart
+
+Restarting the GPU driver pod (`nvidia-driver-daemonset-*` in `gpu-operator`) on a
+node **also requires restarting the NVIDIA DRA kubelet-plugin** pod
+(`nvidia-dra-driver-gpu-kubelet-plugin-*` in `nvidia-dra-driver`) on that same
+node. The plugin caches device state from before the driver reload, so a
+driver-only restart leaves it emitting invalid CDI specs — every GPU
+`ResourceClaim` then fails kubelet `NodePrepareResources` with
+`FailedPrepareDynamicResources: … invalid device, empty device edits`, the vLLM
+decode workers hang in `ContainerCreating`, and the validator times out at its
+phase deadline with no benchmark run. Restart order: **driver pod → DRA
+kubelet-plugin → confirm node `nvidia.com/gpu` allocatable is restored → launch
+workloads.**
+
+---
+
+## 4. Investigation — tests run, in order
+
+### 4.1 Dynamo frontend panic (version skew) — a real, fixed bug
+
+- **Symptom:** on EKS RTX Pro 6000, the frontend reached 1/1 but never served; logs showed
+  `thread 'tokio-runtime-worker' panicked … Unfold must not be polled after it
+  returned Poll::Ready(None)` (24×) and `KVStoreDiscovery … bucket missing for
+  query=AllEndpoints` (97×) — worker discovery died, `/v1/chat/completions` hung.
+- **Root cause:** upstream `futures-util 0.3.31` bug ([ai-dynamo/dynamo#7328]),
+  fixed in `futures-util 0.3.32`, first shipped in **dynamo v1.0.0**, never
+  backported to 0.9.x. AICR ran a **version skew**: the `dynamo-platform`
+  operator chart was `1.0.2` but the runtime **image tags were still `0.9.0`**
+  (hardcoded literals the chart bump never touched).
+- **Fix & confirmation:** bump runtime images 0.9.0→1.0.2 (#1193). Rebuilt the
+  validator, ran on EKS RTX Pro 6000 @2048: **73,993 tok/s / 537 ms PASS, zero panics**
+  (vs 24 on 0.9.0). Verified `futures-util` pin per `Cargo.lock` at each tag.
+
+### 4.2 The worker-stall pattern (EKS H100)
+
+Instrumented runs captured the stall directly. Representative (run "r1",
+`dynamo102`, round-robin, 2048):
+
+```text
+worker        Running  Waiting  GPU-util  clock     throttle  power
+<stalled>      1022      151      ~1–27%   1980MHz   0x0       ~130W   ← backed up, GPU starved
+the other 7    16–366     0       86–100%  1980MHz   0/pcap    520–700W
+```
+
+- The stalled worker's **GPU is healthy and *under*-driven** (full clock, no
+  throttle, low util) yet holds a huge queue → bottleneck is **upstream of GPU
+  compute**. Under **round-robin** (dynamo default), the router keeps feeding the
+  slow worker its 1/8 share, so its queue backs up to the cap.
+- **Stochastic & device-independent:** across runs the stalled worker was a
+  *different* physical GPU (idx 2 then idx 6) → not a bad GPU.
+- GPU health verified clean every time: full 1980 MHz clocks, power cap 700 W,
+  **0 ECC / 0 row-remap / 0 XID**, no thermal/SW throttle (idle or under load).
+
+### 4.3 Fix attempts (config variants, EKS H100, 2048, dynamo 1.0.2)
+
+| Config | router | worker CPU req | aiperf node | result | finding |
+|---|---|---|---|---|---|
+| baseline `dynamo102` | round-robin | none | GPU node | r1 **9.2 s** FAIL (peak 1022); r2 1030 ms PASS | stall intermittent |
+| `dynamo102b` +CPU req +aiperf nodeAffinity | round-robin | 16/32Gi | forced → 4-vCPU sys node | r3 50k / **1265 ms** FAIL | aiperf under-drives (sys node too small) — **backfired** |
+| `dynamo102c` +CPU req only | round-robin | 16/32Gi | GPU node | r4 **122k / 741 ms** PASS | clean |
+| `dynamo102d` +CPU req +aiperf CPU req | round-robin | 16/32Gi | GPU node (forced by req) | r5–r8: **1/4 pass** (708 P; 1358/1670/**9020** F, peak 643) | still intermittent |
+| `dynamo102e` `kv` routing | **kv** | 16/32Gi | GPU node | k1 **13.9 s** FAIL (skew 303↔1); k2 114k/897 ms PASS | kv concentrates on low-diversity prompts — **worse** |
+
+Key learnings from the variants:
+- **Fix B (banish aiperf off the GPU node) backfired:** EKS H100's only non-GPU
+  nodes are 4-vCPU; aiperf couldn't drive 2048 there (~446 in-flight) → 50k.
+- **An aiperf CPU request forces co-location** on the GPU node (16 vCPU can't fit
+  a 4-vCPU node) — deterministic placement, but co-located with the workers.
+- **`kv` routing is worse** here: its prefix-affinity term concentrates AIPerf's
+  ~94%-prefix-hit synthetic prompts onto one worker.
+
+### 4.4 CPU-contention hypothesis — REFUTED by measurement
+
+The stall looked like CPU starvation, so we measured node CPU during runs:
+
+```text
+Node CPU PSI (some avg10):  0.00 – 1.54   ≈ 0   (no CPU stall)
+Node load1:                 3 – 24  of 192 vCPU  (<13%; ~170 idle vCPUs)
+Per-worker CPU:             ~2 cores each
+```
+
+`some avg10 ≈ 0` means tasks were essentially never stalled waiting for CPU.
+**There is no node CPU contention.** AIPerf *does* co-locate on the GPU node, but
+co-location ≠ contention. The "aiperf steals worker CPU → stall" hypothesis is
+**not supported by the data**, and worker CPU/memory requests are therefore *not*
+justified as a stall fix.
+
+### 4.5 Stall-reproduction hunt — the stall is transient
+
+Re-ran the exact stalling config (round-robin, no CPU req, `dynamo102`) the next
+morning, 6 times back-to-back with the CPU sampler:
+
+| run | throughput | TTFT p99 | peak Running | result |
+|---|---|---|---|---|
+| stall1 | 127,036 | 722 ms | 256 | passed |
+| stall2 | 118,376 | 939 ms | 256 | passed |
+| stall3 | 108,739 | 973 ms | 256 | passed |
+| stall4 | 122,189 | 765 ms | 256 | passed |
+| stall5 | 116,678 | 664 ms | 256 | passed |
+| stall6 | 114,380 | 943 ms | 256 | passed |
+
+**6/6 passed, all balanced (peak 256 = fair share, no backup).** The severe stall
+(r1 1022/9.2 s; r8 9.0 s) did **not** reproduce. It was happening the night before
+and **cleared overnight** → transient/stochastic, not a stable property.
+
+### 4.6 GKE deconfounding — the 1.0.2 bump is safe
+
+GKE H100 with the **same** validator/config:
+
+| config | throughput | TTFT p99 | result |
+|---|---|---|---|
+| GKE 0.9.0 | 108,164 | 586 ms | PASS |
+| GKE 1.0.2 (g1) | 137,105 | 474 ms | PASS |
+| GKE 1.0.2 (g2) | 140,641 | 227 ms | PASS |
+| GKE 1.0.2 (g3) | 138,700 | 365 ms | PASS |
+
+GKE 1.0.2 ≥ its own 0.9.0 baseline and 4/4 clean → **the 1.0.2 bump is not a
+regression** (it's an improvement). The earlier worry that 1.0.2 caused the
+fluctuation is cleared; the difference is environmental/gate-design, not the bump.
+(Note: 4 GKE runs is a small sample — GKE was *never observed* to stall, but that
+does not prove immunity.)
+
+### 4.7 Same-window tweak vs. no-tweak, and a driver/DRA restart (2026-06-04)
+
+A later afternoon window — when the fluctuation had returned — was used to
+isolate whether the gate-hardening changes (relaxed TTFT + pinned AIPerf inputs)
+themselves affect the fluctuation, by running **both** configs back-to-back on
+EKS H100.
+
+**No-tweak** (image `dynamo102`, original AIPerf script, recipe TTFT 1000) —
+byte-identical to the 4.5 morning setup, same `diag-cpu` collector:
+
+| run | throughput | TTFT p99 | peak | result |
+|---|---|---|---|---|
+| s1 | 123,043 | 729 ms | 256 | passed |
+| s2 | 84,049 | **4,155 ms** | 256 | failed (degraded) |
+| s3 | 122,151 | 935 ms | 256 | passed |
+
+**Tweak** (image `combo` = 1.0.2 + pinned AIPerf inputs, recipe TTFT 2000):
+
+| run | throughput | TTFT p99 | peak | result |
+|---|---|---|---|---|
+| t1 | 48,920 | **30,743 ms** | 291 | failed (severe stall) |
+| t2 | 111,472 | 1,183 ms | 256 | passed |
+| t3 | 92,865 | 1,056 ms | 257 | passed |
+| t4 | 124,479 | 603 ms | 256 | passed |
+| t5 | 112,637 | 910 ms | 296 | passed |
+| t6 | 92,590 | **4,844 ms** | 256 | failed (degraded) |
+
+**No-tweak 2/3, tweak 4/6 — an identical ≈ 1/3 fluctuation rate in the same
+window.** This confirms the fluctuation is **environmental/time-varying, not
+introduced by the tweaks**. The tweaks' value shows in the passing runs: t2
+(1,183 ms) and t3 (1,056 ms) would *fail* the old `<= 1000 ms` gate but pass at
+`<= 2000 ms` — exactly the knee-jitter false-negative the relaxed ceiling
+removes. Neither config prevents the severe stall (t1 30.7 s, s2 4.2 s); those
+exceed even 2,000 ms and fail correctly. The recurring degraded signature is
+**≈ 84–93 k tok/s at balanced peak Running 256** — degradation *without* an
+obvious single-worker queue backup (s2, t6, and combo-c3 all share it).
+
+**Driver + DRA restart probe.** To test whether stale GPU-driver state drives the
+stall, the GPU driver pod was restarted (see the operational caveat in §3 — it
+required a DRA kubelet-plugin restart too; the first attempt, `t7`, timed out in
+`ContainerCreating` until the DRA plugin was also restarted). After a clean
+driver + DRA restart, the single confirming run **`t8` passed** (110,847 tok/s,
+1,274 ms, peak 229). One pass is **not** proof the restart fixes anything — at a
+≈ 1/3 stall rate a single run has ≈ 2/3 odds of passing regardless — so a small
+post-restart batch was run to look for a durable effect: **`t9` failed**
+(77,537 tok/s, **12,295 ms**, peak 256 — the same balanced degradation) on the
+freshly-restarted node, after which the batch was stopped. Post-restart **1 pass
+/ 1 fail** is indistinguishable from the background ≈ 1/3 rate, so **the driver +
+DRA restart does not fix the stall** — evidence the stall is *not* GPU-driver
+state, consistent with a routing / vLLM-scheduler origin (see §7).
+
+### 4.8 Serve-readiness cold-start timeout — a separate RTX PRO 6000 false-negative
+
+A distinct failure surfaced on EKS RTX PRO 6000 (and *only* there): the phase
+failed with `[TIMEOUT] timed out waiting for inference endpoint to serve
+requests` even though the DGD was `successful`, all 8 workers `1/1`, and the
+frontend `1/1`. This is the **same outer symptom as the dynamo 0.9.0 frontend
+discovery panic (#1192)** but a **different root cause** — and #1192's panic is
+already fixed in 1.0.2 (futures-util `0.3.31` → `0.3.32`; upstream
+[ai-dynamo/dynamo#7328](https://github.com/ai-dynamo/dynamo/issues/7328) /
+[#7346](https://github.com/ai-dynamo/dynamo/pull/7346), shipped in dynamo v1.0).
+Verified the running frontend was genuine 1.0.2 by image digest, with
+`/v1/models` populated, 24 discovery instances, and **no `Unfold` panic / no
+`bucket missing`** in its logs.
+
+Live probing of the wedged endpoint isolated it:
+
+| Probe | Result |
+|---|---|
+| `/health`, `/v1/models` | 200 — model + 24 endpoints registered (discovery healthy) |
+| `/v1/chat/completions` (first ever) | **200 in ~42 s** for 8 tokens |
+| `/v1/chat/completions` (warm) | fast |
+
+So the model serves — the **first inference is just slow** (~42 s: CUDA-graph
+capture / JIT kernel warm on a fresh worker). The readiness probe
+(`waitForEndpointReady`) polled with the generic **30 s** `HTTPClientTimeout`,
+which **cancelled that legitimate first request mid-warmup**; each retry
+restarts it, so no poll ever succeeded and the 5-minute window expired —
+**before AIPerf (which has its own warmup phase) ever started**. It is
+intermittent because RTX's cold first-token straddles the 30 s line (morning
+runs landed <30 s and passed; afternoon landed ~42 s and failed); H100/GB200
+cold-start stays under 30 s, so they never tripped it. Independent of the AIPerf
+determinism flags (the same tweaked image both passed and failed across runs)
+and of concurrency.
+
+**Fix:** a dedicated **120 s** serve-readiness probe timeout
+(`InferenceEndpointProbeTimeout`) — clears observed cold-start with margin while
+still fitting several polls inside the 5-minute window; AIPerf's own warmup then
+absorbs steady-state. Validated on EKS RTX PRO 6000: **74,833 tok/s / 459 ms /
+PASS** with the fix, vs repeated serve-timeouts before. A debug escape hatch,
+`AICR_INFERENCE_PERF_NO_CLEANUP=1`, was added to leave the namespace / DGD /
+workers / frontend / AIPerf Job in place for exactly this kind of post-mortem.
+
+---
+
+## 5. Key findings & insights
+
+> These are also recorded as the consolidated findings comment on the
+> investigation issue:
+> [#1192 findings comment](https://github.com/NVIDIA/aicr/issues/1192#issuecomment-4623706346)
+
+1. **Outlier-driven.** TTFT-p99 swings come from a small subset of requests
+   queuing behind a transiently-backed-up worker, not uniform slowdown.
+   **Throughput is the stable, discriminating signal; tail latency is the noise.**
+2. **AIPerf co-locates with workers, but it is NOT resource contention.** The
+   CPU-only generator runs on the GPU node, yet node CPU is idle (PSI ≈ 0, ~170
+   idle vCPUs). *Measure, don't infer* — this corrected an earlier wrong call.
+3. **Routing strategy + workload-generation config materially change the result.**
+   round-robin is capacity-blind (force-feeds a slow worker → backup); `kv`
+   prefix-affinity concentrates on low-diversity synthetic prompts; non-pinned
+   AIPerf inputs add RNG variance. The gate measures the *test setup* unless pinned.
+4. **The validation is a baseline / conformance floor, not optimal/peak.** Gating
+   at the saturation knee (2048) — where the p99 curve is steepest — guarantees
+   volatility. Gate **sub-knee, throughput-primary, with a generous TTFT ceiling.**
+5. **The severe stall was stochastic / transient** — not reproducible the next
+   day. A single run is an unreliable verdict.
+6. **GPU hardware was healthy throughout** (clocks, ECC, throttle, XID all clean)
+   — the fluctuation is software/routing/methodology, not hardware.
+7. **`nvidia-smi` "GPU utilization" is a duty-cycle metric, not compute
+   saturation** — a worker can read 100% util while under-fed; cross-check **power
+   draw + achieved throughput**.
+8. **Distinct, compounding failure modes** — the dynamo 0.9.0 discovery panic
+   (version skew) is *separate* from the routing/knee fluctuation. Don't conflate.
+9. **Cross-cluster variance (GKE consistent, EKS marginal at 2048) is
+   unexplained** — same H100 GPU, near-same host CPU (208 vs 192 vCPU). Could be
+   sampling, NUMA/pinning, or env. **Honest unknown.**
+10. **Guiding principle:** the verdict must be `f(deployment health)`, not
+    `f(RNG / knee jitter / benchmark config)`.
+11. **Readiness gates must tolerate cold-start first-token latency.** A fresh
+    worker's first inference (CUDA-graph capture / JIT warm) took ~42 s on RTX
+    PRO 6000; the 30 s per-request probe timeout cancelled it and failed a
+    healthy deployment (§4.8). Same *outer* symptom as the #1192 discovery panic,
+    *different* root cause — discovery was healthy. Fixed with a 120 s probe
+    timeout (`InferenceEndpointProbeTimeout`).
+
+---
+
+## 6. Mitigations & workarounds applied
+
+| Change | What | Status | Notes |
+|---|---|---|---|
+| **#1193** | Bump dynamo runtime image 0.9.0 → 1.0.2 (all 5 manifest pins) | PR ready | The real fix for the discovery panic; aligns runtime with the 1.0.2 operator. Confirmed on EKS RTX Pro 6000 (panic gone) & GKE (improved). |
+| **#1196** | Reproducible gate: TTFT `<= 2000` across overlays + pinned AIPerf inputs (`--random-seed`, token stddev 0, `--num-dataset-entries`, `--extra-inputs temperature:0`) + methodology docs | PR draft | 2000 ms passes healthy 708–1670 ms runs, still catches 9–45 s stalls 5–20×. Pending one confirming run. |
+| **#1194** | Centralize the dynamo runtime image reference (single source of truth + registry-override parity + tag-vs-operator-chart drift guard) | issue | Absorbs former #1159. Prevents the version skew that caused #1193. |
+| Operational | Run at **1024 concurrency** (`AICR_INFERENCE_PERF_CONCURRENCY_PER_GPU=128`) | env-only workaround | Sub-knee → stable everywhere (292–533 ms observed), zero rebuild. |
+| **#1196** | Serve-readiness probe timeout 30 s → **120 s** (`InferenceEndpointProbeTimeout`) | PR draft | Fixes the §4.8 RTX cold-start false-negative; 42 s first-token no longer cancelled. Validated RTX PRO 6000: 74,833 / 459 ms PASS. |
+| **#1196** | `AICR_INFERENCE_PERF_NO_CLEANUP=1` debug env var | PR draft | Leaves namespace/DGD/workers/AIPerf in place for post-mortem of a failed run. |
+| **Rejected** | Worker CPU/memory requests as a "stall fix" | not adopted | Refuted: no CPU contention measured. Would be an unsupported change. |
+| **Rejected** | aiperf nodeAffinity off GPU nodes (Fix B) | not adopted | Backfired — EKS H100's non-GPU nodes (4 vCPU) are too small to drive the load. |
+| **Rejected** | `kv` routing on 1.0.2 | not adopted | Worse — prefix-affinity concentrates synthetic load (13.9 s). |
+
+---
+
+## 7. Proposed long-term solution
+
+1. **Reproducible, baseline-shaped gate (#1196):** throughput-primary pass
+   condition at a **sub-knee operating point** (e.g. 1024) with a **generous TTFT
+   ceiling** (≥2000 ms) as a guardrail; deterministic AIPerf inputs. The verdict
+   then reflects deployment health, not RNG or knee jitter.
+2. **Load-aware routing (`least-loaded`)** — the proper fix for a transiently-slow
+   worker (routes around it instead of force-feeding). Requires a **dynamo 1.2.x**
+   runtime + operator bump (least-loaded is a 1.2.x feature; 1.0.2 has only
+   round-robin / random / kv). Bump operator chart **and** runtime images together
+   to avoid re-introducing version skew, then switch `DYN_ROUTER_MODE=least-loaded`.
+3. **Version-drift guard (#1194):** single source of truth for the dynamo runtime
+   image (repo+tag) + a `make` check tying the tag to the operator chart version,
+   so the 0.9.0/1.0.2 skew can't recur.
+4. **(Optional) isolate the load generator** on an adequately-sized non-GPU node —
+   only worth it where such a node exists (GKE/EKS H100 here do not; their non-GPU
+   nodes are ≤8 vCPU). Otherwise co-location on the big GPU node is fine.
+
+---
+
+## 8. Open questions
+
+- **Exact stall mechanism** (when it occurs) is not pinned down — node CPU is not
+  contended, so the leading remaining hypothesis is an *intra-worker* single-thread
+  / GIL bottleneck (invisible to node-level load/PSI), or a transient
+  software/discovery hiccup. Not confirmed.
+- **Why EKS H100 fluctuated and GKE didn't** — same H100, near-same host CPU.
+  Unexplained; candidates are NUMA/CPU-pinning differences, background-pod load,
+  or simply small-sample luck (only 4 GKE runs).
+- **What triggered the severe stalls the night of 2026-06-04 and cleared them by
+  morning** — transient, root trigger unidentified.
+
+---
+
+## 9. References
+
+- NVIDIA/aicr **#1192** — investigation issue (false-negative timeout); consolidated findings comment: [issuecomment-4623706346](https://github.com/NVIDIA/aicr/issues/1192#issuecomment-4623706346)
+- NVIDIA/aicr **#1193** — dynamo runtime image bump 0.9.0 → 1.0.2 (panic fix)
+- NVIDIA/aicr **#1194** — centralize dynamo image reference (SSOT + registry parity + drift guard)
+- NVIDIA/aicr **#1196** — reproducible inference-perf gate (TTFT ≤ 2000 + pinned AIPerf inputs)
+- ai-dynamo/dynamo **#7328** — `Unfold` / `futures-util 0.3.31` frontend panic (fixed in v1.0.0)

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -399,7 +399,7 @@ validation:
       - name: inference-throughput
         value: ">= 50000"
       - name: inference-ttft-p99
-        value: "<= 1000"
+        value: "<= 2000"
 ```
 
 Resolution precedence is **recipe constraint > catalog env knob > compiled
@@ -452,6 +452,65 @@ ModelExpress server is the alternative (see #1116).
 > per-GPU concurrency) so a healthy per-GPU result on a partially occupied node
 > is not failed against a full-node number. TTFT is a per-request latency and
 > is **not** scaled.
+
+#### Methodology: a baseline gate, and reading run-to-run fluctuation
+
+`inference-perf` is a **conformance baseline**, not a tuned peak-throughput
+benchmark — pass/fail answers *"is this deployment serving acceptably,"* not
+*"what is the maximum."* Read the numbers as a health floor, not a leaderboard.
+Design choices follow from that, and from what we measured debugging
+run-to-run TTFT fluctuation (see NVIDIA/aicr#1192):
+
+- **Throughput is the stable, discriminating signal; TTFT p99 is noisy at high
+  concurrency.** Near the saturation knee the p99 curve is steep, so batching /
+  scheduling timing produces large run-to-run swings on an otherwise healthy
+  deployment. That is why the `inference-ttft-p99` constraint is a **generous
+  ceiling** (catches gross stalls — real ones ran 9–45 s — while tolerating
+  normal knee jitter), not a tight target.
+- **The verdict should reflect the deployment, not RNG.** The AIPerf workload is
+  pinned for reproducibility — fixed random seed, fixed input/output token
+  counts (stddev 0), a pinned prompt pool, and greedy decoding
+  (`temperature: 0`). Input determinism stabilizes *throughput*; it does not
+  remove system-side p99 jitter at the knee.
+- **Routing matters.** Dynamo defaults to **round-robin**, which is
+  capacity-blind — if one worker transiently slows, round-robin keeps feeding it
+  its share and its queue backs up (observed as one worker pinned near
+  `max_num_seqs` while peers idle). A load-aware mode (`least-loaded`, dynamo
+  1.2.x) routes around a slow worker; until then, prefer round-robin over `kv`
+  (whose prefix-affinity *concentrates* load on AIPerf's low-diversity synthetic
+  prompts).
+- **The AIPerf load generator co-locates with the GPU workers, but that is not
+  resource contention.** It is CPU-only and the GPU node has ample CPU headroom
+  (measured node CPU pressure ≈ 0 across runs); co-location does not starve the
+  workers. Do not add worker CPU/memory requests to "fix" contention that the
+  data does not show.
+- **Triaging an anomalous run:** the severe stalls we saw were **stochastic and
+  often not reproducible** — re-run before concluding. Verify GPU health
+  (clocks, ECC, throttle reasons, XID) to rule out hardware. And note
+  `nvidia-smi` *utilization* is a duty-cycle metric (kernel-present time), **not**
+  compute saturation — a worker can read 100% util while under-fed; cross-check
+  **power draw and achieved throughput**, not utilization alone.
+- **A GPU driver restart needs a DRA plugin restart.** If you restart the GPU
+  driver pod (`nvidia-driver-daemonset-*`) on a node — e.g. to clear suspected
+  driver state between runs — also restart the NVIDIA DRA kubelet-plugin
+  (`nvidia-dra-driver-gpu-kubelet-plugin-*`) on that node. Otherwise it serves
+  stale CDI specs and every worker `ResourceClaim` fails with
+  `FailedPrepareDynamicResources: … empty device edits`, leaving the decode
+  workers stuck in `ContainerCreating` until the phase times out.
+- **The serve-readiness probe tolerates cold-start first-token latency.** A fresh
+  worker's first inference captures CUDA graphs / JIT-warms kernels — measured at
+  ~42 s on RTX PRO 6000. The readiness probe (`waitForEndpointReady`) therefore
+  uses a generous **120 s** per-request timeout (`InferenceEndpointProbeTimeout`),
+  not the generic 30 s `HTTPClientTimeout`; the latter cancelled the legitimate
+  first request mid-warmup and failed healthy deployments with
+  `timed out waiting for inference endpoint to serve requests` — the *same* outer
+  symptom as the (fixed) #1192 discovery panic but a different root cause. AIPerf's
+  own warmup absorbs steady-state once the probe passes.
+- **Inspecting a failed run.** `AICR_INFERENCE_PERF_NO_CLEANUP=1` leaves the
+  namespace, DGD, workers, frontend, and AIPerf Job in place after the run so a
+  serve-wait / generate hang can be examined live (`kubectl logs` the frontend,
+  ping `/v1/models` and `/v1/chat/completions`). Debug-only — delete the namespace
+  manually afterward.
 
 ### Code walkthrough
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -72,6 +72,8 @@ navigation:
         path: contributor/collector.md
       - page: Validators
         path: contributor/validator.md
+      - page: Inference-Perf Fluctuation (investigation)
+        path: contributor/inference-perf-fluctuation.md
       - page: CLI
         path: contributor/cli.md
       - page: API Server

--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -468,7 +468,7 @@ Results are output in [CTRF](https://ctrf.io/) (Common Test Report Format) JSON:
           "RESULT: Inference throughput: 108789.87 tokens/sec",
           "RESULT: Inference TTFT p99: 687.50 ms",
           "Throughput constraint: >= 50000 → PASS",
-          "TTFT p99 constraint: <= 1000 → PASS"
+          "TTFT p99 constraint: <= 2000 → PASS"
         ]
       }
     ]

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -175,7 +175,7 @@ validation:
       - name: inference-throughput          # >= only; output tokens/sec
         value: ">= 50000"
       - name: inference-ttft-p99            # <= only; TTFT p99 in ms
-        value: "<= 1000"
+        value: "<= 2000"
       - name: inference-model               # optional; HF model ID
         value: Qwen/Qwen3-8B
       - name: inference-concurrency-per-gpu # optional; positive integer

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -991,7 +991,7 @@ Results are output in CTRF (Common Test Report Format) — an industry-standard 
           "RESULT: Inference throughput: 108789.87 tokens/sec",
           "RESULT: Inference TTFT p99: 687.50 ms",
           "Throughput constraint: >= 50000 → PASS",
-          "TTFT p99 constraint: <= 1000 → PASS"
+          "TTFT p99 constraint: <= 2000 → PASS"
         ]
       },
       {

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -118,6 +118,14 @@ reflect steady state, not cold start. Warm-up scales with concurrency and is
 tunable via `AICR_INFERENCE_PERF_WARMUP_PER_CONCURRENCY` (see the
 [validator reference](../contributor/validator.md#inference-perf-benchmark-tuning)).
 
+**Determinism:** the benchmark is driven reproducibly so the verdict reflects the
+deployment, not run-to-run RNG — a fixed random seed, fixed input/output token
+counts (stddev 0), a pinned synthetic-prompt pool, and greedy decoding
+(`temperature: 0`). Note that throughput (not the latency tail) is the stable,
+discriminating signal at high concurrency; TTFT p99 near the saturation knee can
+still vary with batching/scheduling, which is why the TTFT constraint is a
+generous ceiling rather than a tight target.
+
 ```bash
 # Capture snapshot, generate inference recipe, validate the performance phase.
 aicr snapshot --output snapshot.yaml
@@ -143,7 +151,7 @@ validation:
       - name: inference-throughput   # output tokens/sec
         value: ">= 50000"
       - name: inference-ttft-p99     # time-to-first-token p99 in ms
-        value: "<= 1000"
+        value: "<= 2000"
       # Optional per-accelerator inputs (bare value, no comparator).
       # Precedence: recipe > AICR_INFERENCE_PERF_* env > compiled default.
       - name: inference-model                # HF model ID; default Qwen/Qwen3-8B
@@ -173,6 +181,18 @@ catalog overlay in the `aicr validate --data <dir>` directory), or disable the c
 **not** read from the shell environment of the process running `aicr validate`
 (only `HF_TOKEN` is). AICR-deployed EKS clusters get a default `gp3` StorageClass
 from the `aws-ebs-csi-driver` component, so the cache works there with no knob.
+
+**Debugging a failed run with `AICR_INFERENCE_PERF_NO_CLEANUP`.** By default the
+validator deletes the per-run namespace (DGD, workers, frontend, AIPerf Job) on
+both success and failure. To investigate a failure — e.g. a `timed out waiting
+for inference endpoint to serve requests` — set `AICR_INFERENCE_PERF_NO_CLEANUP=1`
+and the validator leaves everything in place so you can `kubectl logs` the
+frontend/workers and curl `/v1/models` and `/v1/chat/completions` live. Unlike the
+other `AICR_INFERENCE_PERF_*` knobs, this one is read from the **shell
+environment** of the process running `aicr validate` (forwarded to the
+inference-perf pod, like `HF_TOKEN`), not from the catalog. Debug-only: you must
+delete the `aicr-inference-perf-<suffix>` namespace manually afterward, or it
+keeps GPU workers running.
 
 Expected flow (~5–7 min on H100): readiness pre-flight → deploy
 `ResourceClaimTemplate` + `DynamoGraphDeployment` in a per-run namespace
@@ -205,7 +225,7 @@ A passing CTRF entry (measured on EKS H100, 8 × H100 GPUs, Qwen/Qwen3-8B at 256
     "RESULT: Inference throughput: 108789.87 tokens/sec",
     "RESULT: Inference TTFT p99: 687.50 ms",
     "Throughput constraint: >= 50000 → PASS",
-    "TTFT p99 constraint: <= 1000 → PASS"
+    "TTFT p99 constraint: <= 2000 → PASS"
   ]
 }
 ```

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -384,6 +384,17 @@ const (
 	// probe described on InferenceHealthTimeout.
 	InferenceHealthPollInterval = 10 * time.Second
 
+	// InferenceEndpointProbeTimeout is the per-request timeout for the readiness
+	// probe's chat-completion against the inference endpoint. It must exceed the
+	// cold-start first-token latency: a fresh worker captures CUDA graphs / JIT-
+	// warms kernels on its first inference, which was measured at ~40s and can
+	// reach 60-90s on some GPUs (e.g. RTX PRO 6000). The generic 30s
+	// HTTPClientTimeout canceled that legitimate first request, so the probe
+	// never saw a success and the phase failed before AIPerf (which has its own
+	// warmup) could start. 120s clears observed cold-start with margin while
+	// still fitting several polls inside InferenceHealthTimeout.
+	InferenceEndpointProbeTimeout = 120 * time.Second
+
 	// InferencePerfJobTimeout is the maximum time for the AIPerf benchmark Job
 	// to complete. AIPerf with 100 requests at concurrency 16 typically finishes
 	// in a few minutes; this provides headroom for model loading and warmup.

--- a/pkg/validator/v1/job_plan_internal.go
+++ b/pkg/validator/v1/job_plan_internal.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,6 +51,11 @@ const (
 	InferenceGatewayCheckName = "inference-gateway"
 
 	requireScopedInferenceGatewayEnv = "AICR_REQUIRE_SCOPED_INFERENCE_GATEWAY"
+
+	// inferencePerfNoCleanupEnv, when truthy, makes the inference-perf validator
+	// leave its namespace/DGD/workers/frontend/AIPerf Job in place after the run
+	// for post-mortem inspection. Forwarded only to the inference-perf pod.
+	inferencePerfNoCleanupEnv = "AICR_INFERENCE_PERF_NO_CLEANUP"
 )
 
 // hfTokenEnvVar is the environment variable name used to forward the
@@ -149,6 +155,19 @@ func buildEnv(
 		env = append(env, corev1.EnvVar{Name: requireScopedInferenceGatewayEnv, Value: v})
 	}
 
+	// Forward the inference-perf no-cleanup debug toggle into that validator pod.
+	// Cleanup runs inside the Job, so it can't see the CLI process environment
+	// unless the orchestrator carries the value across. Scoped to the
+	// inference-perf entry. Gated on strconv.ParseBool — the same truthiness the
+	// runtime cleanup gate uses — so a value like "yes"/"2" can't be forwarded
+	// here yet parsed false there (half-enabling the toggle). Forwards a
+	// canonical "1" so the pod-side check is unambiguous. When set, a
+	// failed/anomalous run leaves the namespace, DGD, workers, frontend, and
+	// AIPerf Job in place for inspection.
+	if on, _ := strconv.ParseBool(os.Getenv(inferencePerfNoCleanupEnv)); on && entry.Name == InferencePerfCheckName {
+		env = append(env, corev1.EnvVar{Name: inferencePerfNoCleanupEnv, Value: "1"})
+	}
+
 	// Add catalog entry's custom env vars. Orchestrator-controlled env vars are
 	// deliberately skipped here: they must come only from the process
 	// environment (forwarded above), never from the in-repo catalog. Appending
@@ -156,7 +175,7 @@ func buildEnv(
 	// forwarded value (k8s takes the last duplicate), breaking that trust
 	// boundary.
 	for _, e := range entry.Env {
-		if e.Name == hfTokenEnvVar || e.Name == requireScopedInferenceGatewayEnv {
+		if e.Name == hfTokenEnvVar || e.Name == requireScopedInferenceGatewayEnv || e.Name == inferencePerfNoCleanupEnv {
 			continue
 		}
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})

--- a/pkg/validator/v1/job_plan_test.go
+++ b/pkg/validator/v1/job_plan_test.go
@@ -429,6 +429,99 @@ func TestBuildJobPlan_ForwardsScopedInferenceGatewayEnv(t *testing.T) {
 	})
 }
 
+// TestBuildJobPlan_ForwardsInferencePerfNoCleanupEnv verifies the no-cleanup
+// debug toggle is carried from the CLI process into the inference-perf validator
+// Job (where cleanupInferenceWorkload reads it), and only that validator.
+func TestBuildJobPlan_ForwardsInferencePerfNoCleanupEnv(t *testing.T) {
+	build := func(entry ValidatorEntry) map[string]string {
+		plan, err := BuildJobPlan(entry, "run-1", "ns", "1.0.0", "abc123", "sa", nil, nil, nil, "", "", nil)
+		if err != nil {
+			t.Fatalf("BuildJobPlan error: %v", err)
+		}
+		m := make(map[string]string)
+		for _, e := range plan.Env {
+			m[e.Name] = e.Value
+		}
+		return m
+	}
+
+	perfEntry := ValidatorEntry{Name: InferencePerfCheckName, Phase: "performance", Image: "img:v1", Timeout: time.Minute}
+
+	t.Run("forwarded to inference-perf", func(t *testing.T) {
+		t.Setenv(inferencePerfNoCleanupEnv, "1")
+		if got := build(perfEntry)[inferencePerfNoCleanupEnv]; got != "1" {
+			t.Errorf("%s env = %q, want 1", inferencePerfNoCleanupEnv, got)
+		}
+	})
+	t.Run("empty value omitted", func(t *testing.T) {
+		t.Setenv(inferencePerfNoCleanupEnv, "")
+		if _, present := build(perfEntry)[inferencePerfNoCleanupEnv]; present {
+			t.Errorf("%s should not be in Job env when empty", inferencePerfNoCleanupEnv)
+		}
+	})
+	t.Run("not forwarded to other validators", func(t *testing.T) {
+		t.Setenv(inferencePerfNoCleanupEnv, "1")
+		other := ValidatorEntry{Name: InferenceGatewayCheckName, Phase: "conformance", Image: "img:v1", Timeout: time.Minute}
+		if _, present := build(other)[inferencePerfNoCleanupEnv]; present {
+			t.Errorf("%s must not be forwarded to a non-inference-perf validator", inferencePerfNoCleanupEnv)
+		}
+	})
+	t.Run("truthy forwarded as canonical 1", func(t *testing.T) {
+		t.Setenv(inferencePerfNoCleanupEnv, "true")
+		if got := build(perfEntry)[inferencePerfNoCleanupEnv]; got != "1" {
+			t.Errorf("%s env = %q, want 1 (normalized)", inferencePerfNoCleanupEnv, got)
+		}
+	})
+	t.Run("non-bool value not forwarded", func(t *testing.T) {
+		// Aligns the forwarding gate with the runtime ParseBool gate: a value
+		// that parses false there must not be forwarded here.
+		for _, v := range []string{"yes", "2", "on", "garbage"} {
+			t.Setenv(inferencePerfNoCleanupEnv, v)
+			if _, present := build(perfEntry)[inferencePerfNoCleanupEnv]; present {
+				t.Errorf("%s=%q should not be forwarded (not ParseBool-truthy)", inferencePerfNoCleanupEnv, v)
+			}
+		}
+	})
+
+	// values is a helper that collects every occurrence of the env var (not just
+	// the last) so we can assert the catalog value is dropped, not merely shadowed.
+	values := func(entry ValidatorEntry) []string {
+		plan, err := BuildJobPlan(entry, "run-1", "ns", "1.0.0", "abc123", "sa", nil, nil, nil, "", "", nil)
+		if err != nil {
+			t.Fatalf("BuildJobPlan error: %v", err)
+		}
+		var got []string
+		for _, e := range plan.Env {
+			if e.Name == inferencePerfNoCleanupEnv {
+				got = append(got, e.Value)
+			}
+		}
+		return got
+	}
+
+	t.Run("catalog value cannot override forwarded value", func(t *testing.T) {
+		t.Setenv(inferencePerfNoCleanupEnv, "1")
+		entry := ValidatorEntry{
+			Name: InferencePerfCheckName, Phase: "performance", Image: "img:v1", Timeout: time.Minute,
+			Env: []EnvVar{{Name: inferencePerfNoCleanupEnv, Value: "0"}},
+		}
+		if got := values(entry); len(got) != 1 || got[0] != "1" {
+			t.Errorf("%s env = %v, want exactly [1] (catalog value must be dropped)", inferencePerfNoCleanupEnv, got)
+		}
+	})
+
+	t.Run("catalog value alone cannot enable", func(t *testing.T) {
+		t.Setenv(inferencePerfNoCleanupEnv, "")
+		entry := ValidatorEntry{
+			Name: InferencePerfCheckName, Phase: "performance", Image: "img:v1", Timeout: time.Minute,
+			Env: []EnvVar{{Name: inferencePerfNoCleanupEnv, Value: "1"}},
+		}
+		if got := values(entry); len(got) != 0 {
+			t.Errorf("%s env = %v, want none (catalog must not enable no-cleanup without shell env)", inferencePerfNoCleanupEnv, got)
+		}
+	})
+}
+
 func TestBuildJobPlanWithDefaults(t *testing.T) {
 	// Test with minimal entry (no custom resources, no tolerations, no node selector)
 	entry := ValidatorEntry{

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -90,7 +90,7 @@ spec:
         - name: inference-throughput
           value: ">= 50000"
         - name: inference-ttft-p99
-          value: "<= 1000"
+          value: "<= 2000"
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
+++ b/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
@@ -90,7 +90,7 @@ spec:
         - name: inference-throughput
           value: ">= 50000"
         - name: inference-ttft-p99
-          value: "<= 1000"
+          value: "<= 2000"
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
@@ -89,7 +89,7 @@ spec:
         - name: inference-throughput
           value: ">= 50000"
         - name: inference-ttft-p99
-          value: "<= 1000"
+          value: "<= 2000"
     conformance:
       checks:
         - platform-health

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -119,6 +119,17 @@ const (
 	// aiperfOutputTokensMean is the mean number of output tokens per request.
 	aiperfOutputTokensMean = 128
 
+	// Determinism knobs — make the benchmark reproducible run-to-run so the
+	// verdict reflects the deployment, not RNG. The benchmark is driven with a
+	// fixed random seed, fixed input/output token counts (stddev 0), a fixed
+	// dataset-entry pool, and greedy decoding (temperature 0 via --extra-inputs,
+	// AIPerf's recommended way to get deterministic output without ignore_eos).
+	// aiperfRandomSeed seeds prompt selection, ordering, and sampling.
+	aiperfRandomSeed = 100
+	// aiperfNumDatasetEntries pins the synthetic-prompt pool size (AIPerf's
+	// default is 100; pinned here so it's explicit and reproducible).
+	aiperfNumDatasetEntries = 100
+
 	// aiperfArtifactDir is where AIPerf writes benchmark result files.
 	aiperfArtifactDir = "/tmp/aiperf"
 
@@ -1228,10 +1239,30 @@ func resolveFrontendEndpoint(ctx *validators.Context, namespace string) string {
 	return fmt.Sprintf("http://%s.%s.svc:%d", svc.Name, svc.Namespace, port)
 }
 
+// inferencePerfNoCleanup reports whether AICR_INFERENCE_PERF_NO_CLEANUP is set
+// to a truthy value. When set, the inference-perf validator leaves the
+// namespace, DGD, workers, frontend, and AIPerf Job in place after the run so a
+// failed/anomalous run (e.g. serve-wait or generate hang) can be inspected
+// post-mortem. Debug-only; the operator must clean up the namespace manually.
+func inferencePerfNoCleanup() bool {
+	b, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv("AICR_INFERENCE_PERF_NO_CLEANUP")))
+	return b
+}
+
 // cleanupInferenceWorkload removes the deployed benchmark workload and its namespace.
 // Safe to call even on partial failure — skips if deployedByUs is false.
 func cleanupInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadConfig) {
 	if !config.deployedByUs {
+		return
+	}
+
+	// Debug escape hatch: leave the namespace, DGD, workers, frontend, and
+	// AIPerf Job in place for post-mortem inspection (e.g. serve-wait / generate
+	// hangs). Set AICR_INFERENCE_PERF_NO_CLEANUP=1. Operator must delete the
+	// namespace manually afterward.
+	if inferencePerfNoCleanup() {
+		slog.Warn("AICR_INFERENCE_PERF_NO_CLEANUP set — leaving workload in place for inspection",
+			"namespace", config.namespace, "deployment", inferenceDeploymentName)
 		return
 	}
 
@@ -1317,7 +1348,7 @@ func waitForEndpointReadyWithInterval(ctx context.Context, endpoint, model strin
 	chatURL := endpoint + "/v1/chat/completions"
 	slog.Info("Waiting for inference endpoint to serve requests", "url", chatURL, "model", model, "timeout", timeout)
 
-	client := &http.Client{Timeout: defaults.HTTPClientTimeout}
+	client := &http.Client{Timeout: defaults.InferenceEndpointProbeTimeout}
 
 	pollCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -1684,7 +1715,12 @@ aiperf profile "$AICR_MODEL" \
   --request-count %d \
   --warmup-request-count %d \
   --prompt-input-tokens-mean %d \
+  --prompt-input-tokens-stddev 0 \
   --prompt-output-tokens-mean %d \
+  --prompt-output-tokens-stddev 0 \
+  --num-dataset-entries %d \
+  --random-seed %d \
+  --extra-inputs temperature:0 \
   --output-artifact-dir %s \
   --export-level summary
 echo '%s'
@@ -1693,6 +1729,7 @@ echo '%s'`,
 		endpoint,
 		concurrency, requestCount, warmupCount,
 		inputTokensMean, outputTokensMean,
+		aiperfNumDatasetEntries, aiperfRandomSeed,
 		aiperfArtifactDir,
 		aiperfResultSentinel,
 		aiperfArtifactDir,
@@ -1753,6 +1790,10 @@ echo '%s'`,
 // actual deletion. Synchronous wait prevents subsequent Create calls from
 // racing against an in-flight foreground deletion and hitting AlreadyExists.
 func cleanupAIPerfJob(ctx *validators.Context, jobName string) {
+	if inferencePerfNoCleanup() {
+		slog.Warn("AICR_INFERENCE_PERF_NO_CLEANUP set — leaving AIPerf Job in place", "job", jobName)
+		return
+	}
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## Summary

Make the `inference-perf` validation gate **reproducible** and **robust to cold start**, and document the investigation behind it. Three changes remove distinct false-negatives, plus a debug aid and a contributor report.

## Motivation / Context

The gate failed on healthy clusters from two unrelated causes:

1. **TTFT-p99 knee jitter.** At the 2048 saturation knee, TTFT p99 is inherently noisy (708–1670 ms run-to-run on H100-EKS) and the `1000 ms` target left almost no margin (baseline ≈688 ms) → healthy deployments failed on latency jitter. Inputs were also non-deterministic (no seed, variable output length), so the verdict partly reflected RNG.
2. **Serve-readiness cold-start timeout.** A fresh worker's first inference captures CUDA graphs / JIT-warms kernels — **~42 s measured on RTX PRO 6000**. The readiness probe used the generic **30 s** `HTTPClientTimeout`, which cancelled that legitimate first request mid-warmup, so the probe never succeeded and the phase failed with `timed out waiting for inference endpoint to serve requests`. This is the **same outer symptom as the (fixed) #1192 discovery panic but a different root cause** — discovery was healthy (verified: genuine 1.0.2 frontend by image digest, `/v1/models` populated, 24 discovery instances, no `Unfold` panic). It's intermittent because RTX cold-start straddles 30 s; H100/GB200 stay under it.

Related: #1192 (discovery panic, fixed by #1193), #1193 (dynamo 0.9.0→1.0.2 runtime bump), #1194 (image-reference SSOT).

## Changes

**Gate / benchmark:**
1. **Relax TTFT p99 → `<= 2000 ms`** on `h100-eks`, `h100-gke`, `rtx-pro-6000-eks` (`gb200-eks` already 2000). 2000 ms passes the healthy 708–1670 ms range and still catches genuine stalls (9–45 s) by 5–20×.
2. **Pin AIPerf workload generation:** `--random-seed`, `--prompt-input-tokens-stddev 0`, `--prompt-output-tokens-stddev 0`, `--num-dataset-entries`, `--extra-inputs temperature:0` (greedy — AIPerf's documented determinism path).
3. **Serve-readiness probe timeout 30 s → 120 s** (`InferenceEndpointProbeTimeout`). Clears observed cold-start (~42 s) with margin while fitting several polls inside the 5-min window; AIPerf's own warmup then absorbs steady-state. **Validated on RTX PRO 6000: 74,833 tok/s / 459 ms PASS** (vs repeated serve-timeouts before).

**Debug aid:**
4. **`AICR_INFERENCE_PERF_NO_CLEANUP=1`** — shell-env forwarded to the inference-perf pod (like `HF_TOKEN`); leaves the namespace/DGD/workers/frontend/AIPerf Job in place for post-mortem of a failed run.

**Documentation:**
5. **New contributor investigation report** `docs/contributor/inference-perf-fluctuation.md` (wired into `docs/index.yml`): symptom, full test setup + per-experiment results, the worker-stall capture, the CPU-contention measurement that **refuted** the contention hypothesis, the GKE/GB200/RTX cross-cluster runs, **§4.8 the serve-wait cold-start finding**, 11 key findings, mitigations (incl. rejected), and the proposed long-term solution.
6. `validator.md` methodology subsection + cold-start probe-timeout + no-cleanup notes; `validation.md` determinism note + `AICR_INFERENCE_PERF_NO_CLEANUP` doc; TTFT-example consistency across `recipe-development.md` / `data-flow.md` / `cli-reference.md`.

## Type of Change

- [x] Bug fix (gate false-negatives: knee jitter + cold-start timeout)
- [x] Documentation (investigation report + methodology)
- [x] Build/CI/tooling (benchmark determinism)

## Component(s) Affected

- [x] Validator (`pkg/validator`, `validators/performance`) — AIPerf flags, probe timeout, no-cleanup
- [x] Recipe engine / data — `recipes/overlays/*-inference-dynamo.yaml` (TTFT target)
- [x] Docs/examples — new report + 5 existing pages

## Implementation Notes

- The serve-wait probe timeout is a **dedicated** constant (`InferenceEndpointProbeTimeout = 120s`), not the shared `HTTPClientTimeout`, so other bounded HTTP ops keep their 30 s cap.
- `AICR_INFERENCE_PERF_NO_CLEANUP` is forwarded in `buildEnv` scoped to the inference-perf entry (mirrors `HF_TOKEN`/gateway-toggle); read via `strconv.ParseBool`. Unit-tested (`TestBuildJobPlan_ForwardsInferencePerfNoCleanupEnv`).
- **Root-cause confirmed by live probing** (RTX): `/health` + `/v1/models` 200 with 24 registered endpoints, first `/v1/chat/completions` 200 in ~42 s, warm requests fast → model healthy, first-token warmup is the cost. Distinct from #1192 (no `Unfold` panic / `bucket missing`).
- **Deliberately NOT included:** worker CPU/memory requests (CPU PSI ≈ 0, no contention measured); AIPerf node-pinning (a test-only instrument, not product behavior).

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/defaults/... ./pkg/validator/v1/... ./validators/performance/...  # 0 issues
go test ./pkg/defaults/... ./pkg/validator/v1/... ./validators/performance/...                              # ok
```

**End-to-end, per GPU platform (combined #1193 + this PR image):**
- **GKE H100** 3/3 PASS (304–420 ms, balanced)
- **GB200** (4-GPU node, 1024) PASS — 79,400 tok/s / 902 ms; consistent with prior runs
- **EKS RTX PRO 6000** PASS — **74,833 tok/s / 459 ms** after the 120 s probe fix (previously serve-timed-out 2× on genuine 1.0.2)
- **EKS H100** clean when balanced (~119 k); the residual stochastic stall at 2048 is tracked separately (#1197), not this PR's scope

## Risk Assessment

- [x] **Low** — constraint-value + benchmark-flag + timeout-constant + debug-env changes; no change to validator control flow or deployment topology. Probe timeout only lengthens a wait; no-cleanup is opt-in.

## Checklist

- [x] Tests pass locally (`pkg/defaults`, `pkg/validator/v1`, `validators/performance`) + new forwarding test
- [x] Linter passes (`golangci-lint`, 0 issues)
- [x] I did not skip/disable tests to make CI green
- [x] Docs updated (new report + methodology + determinism + cold-start + no-cleanup)
- [x] Internal cluster names / account IDs scrubbed from repo docs (EKS H100 / GKE H100 / RTX PRO 6000 / GB200)
- [x] Commit cryptographically signed (`-S`)
