### PR TITLE
fix(validator): run all phases by default; add --fail-fast opt-in

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -104,6 +104,11 @@ per run. Per-phase containers are built from
 `ParsePhaseSelection` collapses it to nil-meaning-everything. It is
 **exclusive** — combining `all` with any other phase is rejected.
 
+By default all phases run and produce results regardless of earlier failures —
+a performance threshold miss no longer silences conformance results. Pass
+`--fail-fast` (or set `spec.validate.execution.failFast: true` in config) to
+restore stop-on-first-failure behavior for cost-sensitive runs.
+
 `readiness` is also a field on `ValidationConfig` (see
 `pkg/recipe/validation.go`) and appears in overlay examples, but it
 is **not** a container-per-validator phase. Readiness runs as

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -630,6 +630,7 @@ aicr validate [flags]
 | `--config` | | string | | Path or HTTP/HTTPS URL to an AICRConfig file (YAML/JSON). CLI flags override values from this file. See [Validate Config File Mode](#validate-config-file-mode). |
 | `--phase` | | string[] | all | Validation phase to run: deployment, performance, conformance, all (repeatable) |
 | `--fail-on-error` | | bool | true | Exit with non-zero status if any constraint fails |
+| `--fail-fast` | | bool | false | Stop after the first phase that fails. By default all phases run and produce results. |
 | `--output` | `-o` | string | stdout | Output destination: file path, ConfigMap URI (`cm://namespace/name`), or stdout |
 | `--kubeconfig` | `-k` | string | ~/.kube/config | Path to kubeconfig file (used when `--recipe`, `--snapshot`, or `--output` is a ConfigMap URI) |
 | `--namespace` | `-n` | string | aicr-validation | Kubernetes namespace for validation Job deployment |
@@ -669,7 +670,7 @@ Validation can be run in different phases to validate different aspects of the d
 | `deployment` | Validates component deployment completeness plus post-install GPU readiness signals (see below) | After deploying components |
 | `performance` | Validates system performance and network fabric health | After components are running |
 | `conformance` | Validates workload-specific requirements and conformance | Before running production workloads |
-| `all` | Runs all phases sequentially with dependency logic | Complete end-to-end validation |
+| `all` | Runs all phases sequentially; results collected regardless of failures | Complete end-to-end validation |
 
 > **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs.
 
@@ -689,6 +690,7 @@ The `deployment` phase verifies that the cluster is actually ready for GPU workl
 
 **Phase Dependencies:**
 - Phases run sequentially when using `--phase all`
+- All phases run by default and produce results regardless of earlier failures. Use `--fail-fast` to stop after the first phase that fails (e.g., to skip a 65-minute inference-perf run when deployment already failed).
 - If a phase fails, subsequent phases are skipped
 - Use individual phases for targeted validation during specific deployment stages
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -691,7 +691,6 @@ The `deployment` phase verifies that the cluster is actually ready for GPU workl
 **Phase Dependencies:**
 - Phases run sequentially when using `--phase all`
 - All phases run by default and produce results regardless of earlier failures. Use `--fail-fast` to stop after the first phase that fails (e.g., to skip a 65-minute inference-perf run when deployment already failed).
-- If a phase fails, subsequent phases are skipped
 - Use individual phases for targeted validation during specific deployment stages
 
 #### Constraint Format

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -248,7 +248,10 @@ aicr validate --recipe recipe.yaml --snapshot snapshot.yaml
 # equivalent to: --phase deployment --phase performance --phase conformance
 ```
 
-Phases run sequentially. If any phase fails, subsequent phases are skipped.
+Phases run sequentially. By default all phases run and produce results
+regardless of earlier failures. Pass `--fail-fast` to stop after the first
+phase that fails (e.g., to skip a 65-minute inference-perf run when deployment
+already failed).
 
 ## Scoping CNCF submission evidence to specific features
 
@@ -487,7 +490,7 @@ Skips are always deliberate and always carry a reason, but the location of the
 reason in the CTRF entry depends on how the skip happened:
 
 - **Check-level skips** (the CheckFunc ran and returned `validators.Skip(reason)` — e.g., Guards A/B/C on inference, `--no-cluster` from inside a check): reason appears in `stdout` as `level=INFO msg=SKIP reason="…"`.
-- **Phase-level skips** (the CheckFunc never ran — e.g., a prior phase failed, so subsequent phases synthesize skip entries; also `--no-cluster` for checks that the runner marks skipped before dispatch): reason appears in `message`, not `stdout`.
+- **Phase-level skips** (the CheckFunc never ran — e.g., with `--fail-fast`, a prior phase failed so subsequent phases synthesize skip entries; also `--no-cluster` for checks that the runner marks skipped before dispatch): reason appears in `message`, not `stdout`.
 
 Common reasons and their cause:
 
@@ -497,7 +500,7 @@ Common reasons and their cause:
 | `dynamo-platform not in recipe components` | `stdout` | Inference check selected but `dynamo-platform` absent from `componentRefs` | Use `--platform dynamo` when generating the recipe |
 | `DynamoGraphDeployment CRD not installed` | `stdout` | Recipe declares `dynamo-platform` but the operator is not deployed | Run `aicr bundle` + `./deploy.sh` first, or wait for bootstrap to complete |
 | `skipped - no-cluster mode` | `message` | `--no-cluster` was passed — the runner short-circuits every phase before dispatching any Job | Remove the flag to run behavioral checks |
-| `skipped due to previous phase failure` | `message` | An earlier phase failed and subsequent phases are skipped | Fix the earlier phase first, then re-run |
+| `skipped due to previous phase failure` | `message` | `--fail-fast` was set and an earlier phase failed, so subsequent phases were skipped | Fix the earlier phase first, or drop `--fail-fast` to run all phases regardless |
 
 ### `ai-service-metrics` fails with "Prometheus unreachable"
 

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -221,6 +221,7 @@ type validationConfig struct {
 
 	// Behavior
 	failOnError bool
+	failFast    bool
 
 	// Evidence
 	evidenceDir string
@@ -302,6 +303,7 @@ func runValidation(
 		// above is always passed (even when resolved tolerations are nil) so
 		// the override always clears the validator's default tolerate-all.
 		aicr.WithValidationTimeout(0),
+		aicr.WithValidationFailFast(cfg.failFast),
 	}
 	// Pass phases only when explicitly selected. cfg.phases is nil when the
 	// user requested all phases (or used the "all" wildcard), and
@@ -441,6 +443,12 @@ func validateCmdFlags() []cli.Flag {
 			Name:     "fail-on-error",
 			Value:    true,
 			Usage:    "Exit with non-zero status if any check fails validation",
+			Category: catValidationControl,
+		},
+		&cli.BoolFlag{
+			Name:     "fail-fast",
+			Value:    false,
+			Usage:    "Stop validation after the first phase that fails. By default all phases run and produce results.",
 			Category: catValidationControl,
 		},
 		&cli.BoolFlag{
@@ -663,6 +671,7 @@ Run validation without failing on check errors (informational mode):
 			}
 
 			failOnError := boolFlagOrConfig(cmd, "fail-on-error", derefBoolOr(resolved.FailOnError, true))
+			failFast := boolFlagOrConfig(cmd, "fail-fast", derefBoolOr(resolved.FailFast, false))
 			noCluster := boolFlagOrConfig(cmd, "no-cluster", resolved.NoCluster)
 
 			// Resolve shared fields once, before the snapshot/agent split, so
@@ -776,6 +785,7 @@ Run validation without failing on check errors (informational mode):
 				output:                cmd.String("output"),
 				outFormat:             serializer.FormatJSON,
 				failOnError:           failOnError,
+				failFast:              failFast,
 				validationNamespace:   shared.namespace,
 				cleanup:               !shared.noCleanup,
 				imagePullSecrets:      shared.imagePullSecrets,

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -158,16 +158,17 @@ func TestValidateCmd_CNCFSubmissionFlagValidation(t *testing.T) {
 func TestValidateCmdFlags_FailFastDefault(t *testing.T) {
 	cmd := validateCmd()
 	for _, f := range cmd.Flags {
-		bf, ok := f.(*cli.BoolFlag)
-		if !ok {
+		if !hasFlag(f, "fail-fast") {
 			continue
 		}
-		if bf.Name == "fail-fast" {
-			if bf.Value {
-				t.Error("--fail-fast default should be false")
-			}
-			return
+		bf, ok := f.(*cli.BoolFlag)
+		if !ok {
+			t.Fatal("--fail-fast should be a *cli.BoolFlag")
 		}
+		if bf.Value {
+			t.Error("--fail-fast default should be false")
+		}
+		return
 	}
 	t.Error("--fail-fast flag not found in validateCmd flags")
 }

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -155,6 +155,23 @@ func TestValidateCmd_CNCFSubmissionFlagValidation(t *testing.T) {
 	}
 }
 
+func TestValidateCmdFlags_FailFastDefault(t *testing.T) {
+	cmd := validateCmd()
+	for _, f := range cmd.Flags {
+		bf, ok := f.(*cli.BoolFlag)
+		if !ok {
+			continue
+		}
+		if bf.Name == "fail-fast" {
+			if bf.Value {
+				t.Error("--fail-fast default should be false")
+			}
+			return
+		}
+	}
+	t.Error("--fail-fast flag not found in validateCmd flags")
+}
+
 func TestValidateCmd_RecipeKindHandling(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -1130,9 +1130,10 @@ func (c *Client) CollectSnapshot(ctx context.Context, cfg *AgentConfig) (*Snapsh
 //     failures surface as ErrCodeInvalidRequest, infrastructure
 //     failures as ErrCodeInternal.
 //
-// Phase-by-phase short-circuiting matches pkg/validator.ValidatePhases:
-// when one phase fails, subsequent phases are reported as skipped
-// rather than executed. Callers wanting per-phase control can
+// All phases run by default and produce results regardless of earlier
+// failures. Pass WithValidationFailFast(true) to stop after the first
+// failed phase (useful for skipping expensive checks like inference-perf
+// when deployment already failed). Callers wanting per-phase control can
 // reach into pkg/validator.ValidatePhase directly.
 func (c *Client) ValidateState(
 	ctx context.Context,

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -719,6 +719,17 @@ func TestWithValidationFailFast_RoundTrip(t *testing.T) {
 				if cfg.failFast != nil {
 					t.Fatalf("failFast = %v, want nil", *cfg.failFast)
 				}
+				// An unset failFast must emit NO validator option. Pre-seed a
+				// validator with FailFast=true, apply the translated options,
+				// and confirm none flipped it back: a regression that dropped
+				// the nil-guard and always emitted validator.WithFailFast(false)
+				// would fail here (the "set false" case alone can't catch it,
+				// since false is also the validator's zero value).
+				valOpts := validateOptionsFromConfig(cfg)
+				v := validator.New(append([]validator.Option{validator.WithFailFast(true)}, valOpts...)...)
+				if !v.FailFast {
+					t.Error("validateOptionsFromConfig emitted a WithFailFast option for unset failFast; want none")
+				}
 				return
 			}
 			if cfg.failFast == nil {

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -697,6 +697,47 @@ func TestWithValidationTimeout_OptIn(t *testing.T) {
 	}
 }
 
+// TestWithValidationFailFast_RoundTrip pins that WithValidationFailFast captures
+// the bool into validateConfig.failFast (nil when unset, non-nil when set) and
+// that validateOptionsFromConfig emits validator.WithFailFast when the field is
+// non-nil, landing the value on the Validator.
+func TestWithValidationFailFast_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ValidateOption
+		wantNil bool
+		wantVal bool
+	}{
+		{"unset", nil, true, false},
+		{"set true", []ValidateOption{WithValidationFailFast(true)}, false, true},
+		{"set false", []ValidateOption{WithValidationFailFast(false)}, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := buildValidateConfig(tt.opts)
+			if tt.wantNil {
+				if cfg.failFast != nil {
+					t.Fatalf("failFast = %v, want nil", *cfg.failFast)
+				}
+				return
+			}
+			if cfg.failFast == nil {
+				t.Fatal("failFast is nil, want set")
+			}
+			if *cfg.failFast != tt.wantVal {
+				t.Errorf("failFast = %v, want %v", *cfg.failFast, tt.wantVal)
+			}
+
+			// Verify validateOptionsFromConfig emits the validator option.
+			valOpts := validateOptionsFromConfig(cfg)
+			v := validator.New(valOpts...)
+			if v.FailFast != tt.wantVal {
+				t.Errorf("validator.FailFast = %v after options, want %v", v.FailFast, tt.wantVal)
+			}
+		})
+	}
+}
+
 // TestValidateState_ThreadsClientVersion pins FIX B: ValidateState threads
 // the Client's version into the validator (it rewrites :latest images and
 // populates AICR_CLI_VERSION). Run in no-cluster mode so no Kubernetes

--- a/pkg/client/v1/options.go
+++ b/pkg/client/v1/options.go
@@ -87,6 +87,10 @@ type validateConfig struct {
 	commit                string
 	imageRegistryOverride string
 	imageTagOverride      string
+
+	// failFast, when non-nil true, stops validation after the first phase that
+	// reports StatusFailed. nil means "unset; use validator default (false)".
+	failFast *bool
 }
 
 // buildValidateConfig replays each WithValidation* option into a fresh
@@ -146,6 +150,9 @@ func validateOptionsFromConfig(cfg *validateConfig) []validator.Option {
 	}
 	if cfg.imageTagOverride != "" {
 		out = append(out, validator.WithImageTagOverride(cfg.imageTagOverride))
+	}
+	if cfg.failFast != nil {
+		out = append(out, validator.WithFailFast(*cfg.failFast))
 	}
 	return out
 }
@@ -282,6 +289,13 @@ func WithValidationImageRegistryOverride(registry string) ValidateOption {
 // Empty means "no override" — the validator keeps its resolved tag.
 func WithValidationImageTagOverride(tag string) ValidateOption {
 	return func(c *validateConfig) { c.imageTagOverride = tag }
+}
+
+// WithValidationFailFast controls whether ValidateState stops after the
+// first phase that reports StatusFailed. Default: false (all phases run
+// and produce results). Set true to restore stop-on-first-failure behavior.
+func WithValidationFailFast(failFast bool) ValidateOption {
+	return func(c *validateConfig) { c.failFast = &failFast }
 }
 
 // cloneStringSlice returns a shallow copy of s, preserving the

--- a/pkg/client/v1/options.go
+++ b/pkg/client/v1/options.go
@@ -116,7 +116,7 @@ func buildValidateConfig(opts []ValidateOption) *validateConfig {
 // here and zero edits on the facade surface. phases is intentionally NOT
 // translated here — it is passed directly to ValidatePhases by the caller.
 func validateOptionsFromConfig(cfg *validateConfig) []validator.Option {
-	out := make([]validator.Option, 0, 10)
+	out := make([]validator.Option, 0, 11)
 	if cfg.namespace != nil {
 		out = append(out, validator.WithNamespace(*cfg.namespace))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -307,8 +307,8 @@ type ValidateExecutionSpec struct {
 	FailOnError *bool    `yaml:"failOnError,omitempty" json:"failOnError,omitempty"`
 	// FailFast, when true, stops validation after the first failed phase.
 	// Pointer so nil means "unset; inherit CLI default (false)".
-	FailFast  *bool `yaml:"failFast,omitempty" json:"failFast,omitempty"`
-	NoCluster bool  `yaml:"noCluster,omitempty" json:"noCluster,omitempty"`
-	NoCleanup   bool     `yaml:"noCleanup,omitempty" json:"noCleanup,omitempty"`
-	Timeout     string   `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	FailFast  *bool  `yaml:"failFast,omitempty" json:"failFast,omitempty"`
+	NoCluster bool   `yaml:"noCluster,omitempty" json:"noCluster,omitempty"`
+	NoCleanup bool   `yaml:"noCleanup,omitempty" json:"noCleanup,omitempty"`
+	Timeout   string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,7 +305,10 @@ type ValidateAgentSpec struct {
 type ValidateExecutionSpec struct {
 	Phases      []string `yaml:"phases,omitempty" json:"phases,omitempty"`
 	FailOnError *bool    `yaml:"failOnError,omitempty" json:"failOnError,omitempty"`
-	NoCluster   bool     `yaml:"noCluster,omitempty" json:"noCluster,omitempty"`
+	// FailFast, when true, stops validation after the first failed phase.
+	// Pointer so nil means "unset; inherit CLI default (false)".
+	FailFast  *bool `yaml:"failFast,omitempty" json:"failFast,omitempty"`
+	NoCluster bool  `yaml:"noCluster,omitempty" json:"noCluster,omitempty"`
 	NoCleanup   bool     `yaml:"noCleanup,omitempty" json:"noCleanup,omitempty"`
 	Timeout     string   `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -320,6 +320,10 @@ type ValidateResolved struct {
 	// the CLI flag's default.
 	FailOnError *bool
 
+	// FailFast is spec.validate.execution.failFast. Nil means "not set in
+	// config; fall back to CLI flag default (false)".
+	FailFast *bool
+
 	// NoCluster is spec.validate.execution.noCluster.
 	NoCluster bool
 
@@ -434,6 +438,10 @@ func (v *ValidateSpec) Resolve() (*ValidateResolved, error) {
 		if v.Execution.FailOnError != nil {
 			b := *v.Execution.FailOnError
 			out.FailOnError = &b
+		}
+		if v.Execution.FailFast != nil {
+			b := *v.Execution.FailFast
+			out.FailFast = &b
 		}
 		if v.Execution.Timeout != "" {
 			d, err := time.ParseDuration(v.Execution.Timeout)

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -602,7 +602,7 @@ func TestValidateResolve_EmptySpec(t *testing.T) {
 	}
 	if got.RecipePath != "" || got.SnapshotPath != "" || got.Namespace != "" ||
 		got.Timeout != nil || got.NoCluster || got.NoCleanup || got.RequireGPU ||
-		got.FailOnError != nil || got.Phases != nil ||
+		got.FailOnError != nil || got.FailFast != nil || got.Phases != nil ||
 		got.NodeSelector != nil || got.Tolerations != nil || got.ImagePullSecrets != nil {
 
 		t.Errorf("expected all zero, got %+v", got)
@@ -629,6 +629,7 @@ func TestValidateResolve_AllFieldsPopulated(t *testing.T) {
 		Execution: &config.ValidateExecutionSpec{
 			Phases:      []string{"deployment", "conformance"},
 			FailOnError: &tr,
+			FailFast:    &tr,
 			NoCluster:   true,
 			NoCleanup:   true,
 			Timeout:     "5m",
@@ -660,6 +661,9 @@ func TestValidateResolve_AllFieldsPopulated(t *testing.T) {
 	}
 	if got.FailOnError == nil || !*got.FailOnError {
 		t.Errorf("FailOnError = %v", got.FailOnError)
+	}
+	if got.FailFast == nil || !*got.FailFast {
+		t.Errorf("FailFast = %v, want true", got.FailFast)
 	}
 	if !got.NoCluster || !got.NoCleanup {
 		t.Errorf("flags = %+v", got)

--- a/pkg/validator/options.go
+++ b/pkg/validator/options.go
@@ -122,3 +122,12 @@ func WithDataProvider(dp recipe.DataProvider) Option {
 		v.dataProvider = dp
 	}
 }
+
+// WithFailFast controls whether ValidatePhases stops after the first phase
+// that reports StatusFailed. Default: false (all phases run regardless of
+// earlier failures). Set true to restore the historical fail-fast behavior.
+func WithFailFast(failFast bool) Option {
+	return func(v *Validator) {
+		v.FailFast = failFast
+	}
+}

--- a/pkg/validator/phases.go
+++ b/pkg/validator/phases.go
@@ -36,8 +36,9 @@ const (
 	PhaseConformance = v1.PhaseConformance
 )
 
-// PhaseOrder defines the mandatory execution order.
-// If a phase fails, subsequent phases are skipped.
+// PhaseOrder defines the execution order for ValidatePhases.
+// All phases run by default; set Validator.FailFast to stop after the
+// first phase that reports StatusFailed.
 //
 // Note: Readiness phase is NOT included. It remains in pkg/validator
 // and uses inline constraint evaluation (no containers).

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -73,6 +73,10 @@ type Validator struct {
 	// dev builds whose commit SHA has no published image; typical value: "latest".
 	ImageTagOverride string
 
+	// FailFast, when true, stops validation after the first phase that reports
+	// StatusFailed. By default (false) all phases run and produce results.
+	FailFast bool
+
 	// dataProvider supplies the recipe data files used to load the validator
 	// catalog. When nil, catalog.Load falls back to the package-global provider.
 	dataProvider recipe.DataProvider

--- a/pkg/validator/v1/job_plan_internal.go
+++ b/pkg/validator/v1/job_plan_internal.go
@@ -52,6 +52,10 @@ const (
 	requireScopedInferenceGatewayEnv = "AICR_REQUIRE_SCOPED_INFERENCE_GATEWAY"
 )
 
+// hfTokenEnvVar is the environment variable name used to forward the
+// Hugging Face API token to the inference performance validator.
+const hfTokenEnvVar = "HF_TOKEN"
+
 // buildEnv creates environment variables for the validator container.
 func buildEnv(
 	entry ValidatorEntry,
@@ -133,8 +137,8 @@ func buildEnv(
 	// low-sensitivity, easily-rotated rate-limit token and a per-run ephemeral
 	// namespace, the exposure does not justify the orchestrator-side Secret
 	// plumbing. Revisit if a higher-privilege credential ever flows this path.
-	if tok := os.Getenv("HF_TOKEN"); tok != "" && entry.Name == InferencePerfCheckName {
-		env = append(env, corev1.EnvVar{Name: "HF_TOKEN", Value: tok})
+	if tok := os.Getenv(hfTokenEnvVar); tok != "" && entry.Name == InferencePerfCheckName {
+		env = append(env, corev1.EnvVar{Name: hfTokenEnvVar, Value: tok})
 	}
 
 	// Forward the enforcement toggle for the inference-gateway exposure check
@@ -152,7 +156,7 @@ func buildEnv(
 	// forwarded value (k8s takes the last duplicate), breaking that trust
 	// boundary.
 	for _, e := range entry.Env {
-		if e.Name == "HF_TOKEN" || e.Name == requireScopedInferenceGatewayEnv {
+		if e.Name == hfTokenEnvVar || e.Name == requireScopedInferenceGatewayEnv {
 			continue
 		}
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})

--- a/pkg/validator/v1/job_plan_internal.go
+++ b/pkg/validator/v1/job_plan_internal.go
@@ -54,7 +54,7 @@ const (
 
 // hfTokenEnvVar is the environment variable name used to forward the
 // Hugging Face API token to the inference performance validator.
-const hfTokenEnvVar = "HF_TOKEN"
+const hfTokenEnvVar = "HF_TOKEN" //nolint:gosec // G101: env var name, not a hardcoded credential
 
 // buildEnv creates environment variables for the validator container.
 func buildEnv(

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -157,9 +157,10 @@ func (v *Validator) deferClusterCleanup(clientset kubernetes.Interface) {
 	}
 }
 
-// ValidatePhases runs the specified phases sequentially. If a phase fails,
-// subsequent phases are skipped. Returns one PhaseResult per phase.
-// Pass nil or empty phases to run all phases.
+// ValidatePhases runs the specified phases sequentially and returns one
+// PhaseResult per phase. Pass nil or empty phases to run all phases.
+// By default all phases run and produce results regardless of failures.
+// Set FailFast to stop after the first phase that reports StatusFailed.
 func (v *Validator) ValidatePhases(
 	ctx context.Context,
 	phases []Phase,
@@ -196,8 +197,29 @@ func (v *Validator) ValidatePhases(
 	defer close(cs.stopCh)
 	defer v.deferClusterCleanup(cs.clientset) //nolint:contextcheck // cleanup uses fresh context
 
+	results, err := v.runPhases(ctx, func(phase Phase) (*PhaseResult, error) {
+		return v.runPhase(ctx, cs.clientset, cs.factory, cat, phase, validationInput)
+	}, cat, phases)
+	if err != nil {
+		return results, err
+	}
+
+	slog.Info("all phases completed", "runID", v.RunID, "phases", len(results))
+	return results, nil
+}
+
+// runPhases drives the phase loop for ValidatePhases. It is extracted
+// as a separate method so the orchestration logic (fail-fast, skip
+// recording) can be unit-tested without a live cluster by injecting a
+// fake runner.
+func (v *Validator) runPhases(
+	ctx context.Context,
+	runner func(Phase) (*PhaseResult, error),
+	cat *catalog.ValidatorCatalog,
+	phases []Phase,
+) ([]*PhaseResult, error) {
 	results := make([]*PhaseResult, 0, len(phases))
-	overallFailed := false
+	anyFailed := false
 
 	for _, phase := range phases {
 		select {
@@ -206,26 +228,23 @@ func (v *Validator) ValidatePhases(
 		default:
 		}
 
-		if overallFailed {
-			// Skip with a CTRF report showing all validators as skipped
-			pr := v.phaseSkipped(cat, phase, "skipped due to previous phase failure")
+		if anyFailed && v.FailFast {
+			pr := v.phaseSkipped(cat, phase, "skipped due to previous phase failure (--fail-fast)")
 			results = append(results, pr)
-			slog.Info("skipping phase due to previous failure", "phase", phase)
+			slog.Info("skipping phase due to fail-fast", "phase", phase)
 			continue
 		}
 
-		pr, phaseErr := v.runPhase(ctx, cs.clientset, cs.factory, cat, phase, validationInput)
+		pr, phaseErr := runner(phase)
 		if phaseErr != nil {
 			return results, phaseErr
 		}
 		results = append(results, pr)
 
 		if pr.Status == ctrf.StatusFailed {
-			overallFailed = true
+			anyFailed = true
 		}
 	}
-
-	slog.Info("all phases completed", "runID", v.RunID, "phases", len(results))
 	return results, nil
 }
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -230,7 +230,7 @@ func (v *Validator) runPhases(
 		}
 
 		if anyFailed && v.FailFast {
-			pr := v.phaseSkipped(cat, phase, "skipped due to previous phase failure (--fail-fast)")
+			pr := v.phaseSkipped(cat, phase, "skipped due to previous phase failure")
 			results = append(results, pr)
 			slog.Info("skipping phase due to fail-fast", "phase", phase)
 			continue

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -218,6 +218,7 @@ func (v *Validator) runPhases(
 	cat *catalog.ValidatorCatalog,
 	phases []Phase,
 ) ([]*PhaseResult, error) {
+
 	results := make([]*PhaseResult, 0, len(phases))
 	anyFailed := false
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -50,6 +50,9 @@ func TestNewDefaults(t *testing.T) {
 	if len(v.Tolerations) != 1 || v.Tolerations[0].Operator != corev1.TolerationOpExists {
 		t.Errorf("Tolerations should default to tolerate-all, got %v", v.Tolerations)
 	}
+	if v.FailFast {
+		t.Error("FailFast should default to false")
+	}
 }
 
 func TestNewWithOptions(t *testing.T) {
@@ -408,5 +411,12 @@ func TestExtractResultSummaries(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWithFailFast_SetsField(t *testing.T) {
+	v := New(WithFailFast(true))
+	if !v.FailFast {
+		t.Error("WithFailFast(true): FailFast should be true")
 	}
 }

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -420,3 +420,98 @@ func TestWithFailFast_SetsField(t *testing.T) {
 		t.Error("WithFailFast(true): FailFast should be true")
 	}
 }
+
+// newFakeRunner returns a runner that returns the given status for every phase
+// and records how many times it was called.
+func newFakeRunner(status string, calls *int) func(Phase) (*PhaseResult, error) {
+	return func(phase Phase) (*PhaseResult, error) {
+		*calls++
+		return &PhaseResult{
+			Phase:  phase,
+			Status: status,
+			Report: ctrf.NewBuilder("aicr", "test", string(phase)).Build(),
+		}, nil
+	}
+}
+
+func TestRunPhases_Default_AllPhasesRun(t *testing.T) {
+	v := New(WithVersion("1.0.0")) // FailFast defaults to false
+	cat := loadEmbeddedCatalog(t)
+
+	calls := 0
+	results, err := v.runPhases(context.Background(), newFakeRunner(ctrf.StatusFailed, &calls), cat, PhaseOrder)
+	if err != nil {
+		t.Fatalf("runPhases() error = %v", err)
+	}
+	if calls != len(PhaseOrder) {
+		t.Errorf("runner called %d times, want %d (no fail-fast)", calls, len(PhaseOrder))
+	}
+	if len(results) != len(PhaseOrder) {
+		t.Fatalf("results len = %d, want %d", len(results), len(PhaseOrder))
+	}
+	for _, pr := range results {
+		if pr.Status != ctrf.StatusFailed {
+			t.Errorf("phase %q status = %q, want %q", pr.Phase, pr.Status, ctrf.StatusFailed)
+		}
+	}
+}
+
+func TestRunPhases_FailFast_StopsAfterFirstFailure(t *testing.T) {
+	v := New(WithVersion("1.0.0"), WithFailFast(true))
+	cat := loadEmbeddedCatalog(t)
+
+	calls := 0
+	results, err := v.runPhases(context.Background(), newFakeRunner(ctrf.StatusFailed, &calls), cat, PhaseOrder)
+	if err != nil {
+		t.Fatalf("runPhases() error = %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("runner called %d times, want 1 (fail-fast after first failure)", calls)
+	}
+	if len(results) != len(PhaseOrder) {
+		t.Fatalf("results len = %d, want %d", len(results), len(PhaseOrder))
+	}
+	if results[0].Status != ctrf.StatusFailed {
+		t.Errorf("results[0].Status = %q, want %q", results[0].Status, ctrf.StatusFailed)
+	}
+	for _, pr := range results[1:] {
+		if pr.Status != ctrf.StatusSkipped {
+			t.Errorf("phase %q status = %q, want %q (skipped by fail-fast)", pr.Phase, pr.Status, ctrf.StatusSkipped)
+		}
+	}
+}
+
+func TestRunPhases_FailFast_PassedPhaseDoesNotGate(t *testing.T) {
+	// Phase[0]=passed, Phase[1]=failed → Phase[2] skipped; runner called twice.
+	v := New(WithVersion("1.0.0"), WithFailFast(true))
+	cat := loadEmbeddedCatalog(t)
+
+	statuses := []string{ctrf.StatusPassed, ctrf.StatusFailed}
+	idx := 0
+	runner := func(phase Phase) (*PhaseResult, error) {
+		status := statuses[idx]
+		idx++
+		return &PhaseResult{
+			Phase:  phase,
+			Status: status,
+			Report: ctrf.NewBuilder("aicr", "test", string(phase)).Build(),
+		}, nil
+	}
+
+	results, err := v.runPhases(context.Background(), runner, cat, PhaseOrder)
+	if err != nil {
+		t.Fatalf("runPhases() error = %v", err)
+	}
+	if idx != 2 {
+		t.Errorf("runner called %d times, want 2", idx)
+	}
+	if results[0].Status != ctrf.StatusPassed {
+		t.Errorf("results[0].Status = %q, want passed", results[0].Status)
+	}
+	if results[1].Status != ctrf.StatusFailed {
+		t.Errorf("results[1].Status = %q, want failed", results[1].Status)
+	}
+	if results[2].Status != ctrf.StatusSkipped {
+		t.Errorf("results[2].Status = %q, want skipped", results[2].Status)
+	}
+}

--- a/validators/performance/model_cache.go
+++ b/validators/performance/model_cache.go
@@ -54,8 +54,9 @@ const (
 	// cluster has no default SC (which would otherwise leave the PVC Pending until
 	// the populate-Job timeout). The beta key is still emitted by older clusters /
 	// installers, so both are honored.
-	defaultStorageClassAnnotation     = "storageclass.kubernetes.io/is-default-class"
-	defaultStorageClassAnnotationBeta = "storageclass.beta.kubernetes.io/is-default-class"
+	defaultStorageClassAnnotation      = "storageclass.kubernetes.io/is-default-class"
+	defaultStorageClassAnnotationBeta  = "storageclass.beta.kubernetes.io/is-default-class"
+	defaultStorageClassAnnotationValue = "true"
 
 	// envModelCacheStorageClass sets the StorageClass for the cache PVC.
 	// Required on clusters without a default StorageClass — otherwise the PVC
@@ -164,7 +165,7 @@ func clusterHasDefaultStorageClass(ctx *validators.Context) (bool, error) {
 	}
 	for i := range scs.Items {
 		ann := scs.Items[i].Annotations
-		if ann[defaultStorageClassAnnotation] == "true" || ann[defaultStorageClassAnnotationBeta] == "true" {
+		if ann[defaultStorageClassAnnotation] == defaultStorageClassAnnotationValue || ann[defaultStorageClassAnnotationBeta] == defaultStorageClassAnnotationValue {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
## Summary

`aicr validate` now runs all requested phases by default instead of skipping every phase after the first failure. A new `--fail-fast` flag (and `spec.validate.execution.failFast` config field) restores the old stop-on-first-failure behavior as an opt-in.

## Motivation / Context

`ValidatePhases` latched a single `overallFailed` flag on the first failing phase and reported every *subsequent* phase as `skipped` — by execution order, not dependency. Because the order is `deployment → performance → conformance`, a `performance` threshold miss (e.g. an `inference-perf` throughput gate) skipped the **entire conformance suite**, even though conformance does not depend on performance. With `aicr validate --emit-attestation` this silently recorded conformance as `skipped` in the evidence bundle, losing all conformance signal. `--fail-on-error=false` did not help — it only changes the exit code, not phase orchestration.

This flips the default to "run all phases, collect every result" and makes fail-fast opt-in, which is the behavior the issue requested.

Fixes: #1178
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Recipe engine / data (`pkg/recipe`) — config schema (`pkg/config`)
- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/client/v1` facade

## Implementation Notes

- The phase loop in `ValidatePhases` was extracted into a `runPhases(ctx, runner, cat, phases)` helper that takes an injected per-phase runner, so the orchestration logic (fail-fast gating, skip recording) is unit-testable without a live cluster.
- The old unconditional latch `if overallFailed { skip }` became `if anyFailed && v.FailFast { skip }`. The skip-reason string stays mechanism-neutral (no CLI flag name) since it surfaces in the CTRF report consumed by non-CLI callers.
- `FailFast` is plumbed CLI flag → `pkg/config` (`*bool`, nil = inherit CLI default) → `pkg/client/v1` (`WithValidationFailFast`) → `validator.WithFailFast`. This mirrors the existing `FailOnError` plumbing. `FailOnError` (exit-code policy) stays CLI-only; `FailFast` (orchestration policy) lives on the `Validator` because `ValidatePhases` is the single drive point for both CLI and server callers.
- Rebased onto `main` to pick up the inference-gateway exposure feature (#1163). One conflict in `pkg/validator/v1/job_plan_internal.go`: that PR added `requireScopedInferenceGatewayEnv` to the orchestrator env-skip guard while this branch's lint commit replaced the `"HF_TOKEN"` literal with the `hfTokenEnvVar` constant. Resolved by keeping both — `if e.Name == hfTokenEnvVar || e.Name == requireScopedInferenceGatewayEnv`.

## Testing

```bash
# Affected-package unit suites:
GOFLAGS="-mod=vendor" go test ./pkg/validator/... ./pkg/client/v1/... ./pkg/config/... ./pkg/cli/...
```

All affected-package tests pass. New coverage: `runPhases` default-runs-all, fail-fast-stops, and passed-phase-does-not-gate cases; `WithValidationFailFast` round-trip through the facade; `--fail-fast` flag default; config resolution of `failFast`.

**Live verification — EKS GB200 inference-dynamo.** Validated the orchestration change end-to-end with a release-built binary (`make build`, `aicr_darwin_arm64_v8.0`) against a live EKS GB200 inference-dynamo cluster (`gb200-eks-ubuntu-inference-dynamo` recipe, 18 components, fresh cluster snapshot).

| Scenario | deployment | performance | conformance |
|---|---|---|---|
| default, all pass | passed (26s) | passed (10m29s) | **passed (1m39s) — all phases ran** |
| default, deployment forced to fail | failed (30s) | — (scoped out) | **passed — still ran** |
| `--fail-fast`, deployment forced to fail | failed (25s) | — | **skipped (0s)** — "skipped due to previous phase failure" |

Key confirmations:
- **Default runs all phases regardless of failure** — with deployment forced to fail (gpu-operator constraint `>= v99.0.0` on a throwaway recipe copy), conformance still executed and passed. Confirms the removed `overallFailed` latch.
- **`--fail-fast` short-circuits on first failure** — conformance reported `skipped` (0s); orchestrator logged `skipping phase due to fail-fast: phase=conformance`.
- **Flag wiring intact** CLI → config → `client/v1` → `runPhases`: binary exposes `--fail-fast`; CLI override logged (`flag=fail-fast config=false override=true`).
- **Full 3-phase happy path passed**: throughput 76,309 tok/s (constraint `>= 50000`), TTFT p99 1032 ms (constraint `<= 2000`), 4× GB200, driver 580.126.20.

Failure injection used only a throwaway recipe copy — production code and the real recipe were untouched. The validator cleaned up its `aicr-validation` namespace after each run.

## Risk Assessment

- [x] **Low** — Isolated to phase orchestration; default flip is well-tested (unit + live EKS GB200) and the old behavior is one flag away.

**Rollout notes:** Behavioral default change — clusters where a `performance` failure was previously skipping `conformance` will now run conformance and emit its results. Operators who relied on stop-on-first-failure must add `--fail-fast` or set `spec.validate.execution.failFast: true`. No API/wire breakage; the `failFast` config field is additive and optional.

## Checklist

- [x] Tests pass locally — full `make qualify` green (unit tests with `-race`, coverage 75.9% ≥ 75% threshold, 22/22 chainsaw e2e); also verified live on EKS GB200.
- [x] Linter passes (`make lint`) — golangci-lint reports `0 issues`; `go vet` clean; license headers + AGENTS sync OK.
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — all 8 commits show a good signature (`git log --show-signature`). [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

