### PR TITLE
chore: align go.mod go directive with .go-version (1.26.4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/aicr
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.11.0


### PR DESCRIPTION
## Summary

Bump the `go` directive in `go.mod` from `1.26.3` to `1.26.4` so it matches `.go-version`, the documented single source of truth for the Go toolchain.

## Motivation / Context

`.go-version` was bumped to `1.26.4` during a toolchain upgrade, but `go.mod` line 3 was left at `1.26.3`. This is pre-existing drift on `main`. `.github/workflows/on-push-comment.yaml` resolves its toolchain via `go-version-file: go.mod`, so the two should agree to avoid the coverage job running on a different patch release than the rest of CI.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: repo tooling (`go.mod` Go directive)

## Implementation Notes

Generated with `go mod edit -go=1.26.4` rather than hand-editing, keeping the directive canonical. `go 1.26.x` patch versions are valid in the directive (Go 1.21+). No dependency graph change: `go.sum` is untouched and `go mod tidy`/vendoring were not needed.

## Testing

```bash
go build ./...   # passes, exit 0
```

## Risk Assessment

- [x] **Low** — Single-line directive bump, no dependency or source changes, trivially revertible.

**Rollout notes:** N/A

## Checklist

- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
