### PR TITLE
feat(recipe): add aicr recipe list subcommand for catalog enumeration

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -537,6 +537,82 @@ constraints:
 
 ---
 
+### aicr recipe list
+
+Enumerate overlay recipes in the catalog. Useful for discovering which criteria
+combinations have a dedicated leaf overlay versus an intermediate shared recipe.
+
+**Synopsis:**
+
+```shell
+aicr recipe list [flags]
+```
+
+**Flags:**
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--service` | | string | | Filter by Kubernetes service type (e.g. eks, gke, aks) |
+| `--accelerator` | `--gpu` | string | | Filter by accelerator/GPU type (e.g. h100, gb200) |
+| `--intent` | | string | | Filter by workload intent (e.g. training, inference) |
+| `--os` | | string | | Filter by worker-node OS (e.g. ubuntu, rhel, cos) |
+| `--platform` | | string | | Filter by platform/framework type (e.g. dynamo, kubeflow, nim) |
+| `--format` | `-t` | string | table | Output format: json, yaml, table |
+| `--data` | | string | | External data directory to include alongside embedded overlays |
+
+Filter flags narrow the output to overlays whose criteria carry that exact value.
+Unspecified flags match all overlays for that dimension. Multiple filters are combined
+with AND.
+
+**Output fields:**
+
+| Field | Description |
+|-------|-------------|
+| `name` | Overlay name (e.g. `h100-eks-ubuntu-training`) |
+| `criteria` | The full criteria dimensions the overlay targets |
+| `is_leaf` | `true` when the overlay is a leaf — no other overlay inherits from it |
+| `source` | Data provenance: `embedded` (built-in) or `external` (from `--data`) |
+
+**Examples:**
+
+```shell
+# List all overlays as a table (default)
+aicr recipe list
+
+# List all overlays as JSON
+aicr recipe list --format json
+
+# Filter to EKS training overlays
+aicr recipe list --service eks --intent training
+
+# Filter to H100 overlays and emit JSON
+aicr recipe list --accelerator h100 --format json
+
+# Include external overlays from a custom data directory
+aicr recipe list --data /etc/aicr/custom-recipes --format yaml
+```
+
+**Example JSON output:**
+
+```json
+[
+  {
+    "name": "gb200-eks-ubuntu-training",
+    "criteria": {"service": "eks", "accelerator": "gb200", "os": "ubuntu", "intent": "training"},
+    "is_leaf": true,
+    "source": "embedded"
+  },
+  {
+    "name": "h100-eks-ubuntu-training",
+    "criteria": {"service": "eks", "accelerator": "h100", "os": "ubuntu", "intent": "training"},
+    "is_leaf": true,
+    "source": "embedded"
+  }
+]
+```
+
+---
+
 ### aicr query
 
 Query a specific value from the fully hydrated recipe configuration. Resolves a recipe

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -21,15 +21,24 @@ package cli
 
 // Command names (urfave/cli command.Name values).
 const (
-	cmdNameSnapshot = "snapshot"
-	cmdNameRecipe   = "recipe"
+	cmdNameSnapshot   = "snapshot"
+	cmdNameRecipe     = "recipe"
+	cmdNameRecipeList = "list"
 )
 
 // Flag names (urfave/cli flag.Name values).
 const (
-	flagOutput = "output"
-	flagFormat = "format"
+	flagOutput      = "output"
+	flagFormat      = "format"
+	flagService     = "service"
+	flagAccelerator = "accelerator"
+	flagIntent      = "intent"
+	flagOS          = "os"
+	flagPlatform    = "platform"
 )
+
+// criteriaAny is the wildcard value for any criteria dimension.
+const criteriaAny = "any"
 
 // Keyless-signing / OCI-push flag names shared by `validate`, `bundle`,
 // and `evidence publish`. Extracted so the same literal is declared once

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -40,28 +40,28 @@ func recipeCmdFlags() []cli.Flag {
 	// validation still works regardless.
 	return []cli.Flag{
 		withCompletions(&cli.StringFlag{
-			Name:     "service",
+			Name:     flagService,
 			Usage:    fmt.Sprintf("Kubernetes service type (e.g. %s)", strings.Join(recipe.GetCriteriaServiceTypes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.GetCriteriaServiceTypes),
 		withCompletions(&cli.StringFlag{
-			Name:     "accelerator",
+			Name:     flagAccelerator,
 			Aliases:  []string{"gpu"},
 			Usage:    fmt.Sprintf("Accelerator/GPU type (e.g. %s)", strings.Join(recipe.GetCriteriaAcceleratorTypes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.GetCriteriaAcceleratorTypes),
 		withCompletions(&cli.StringFlag{
-			Name:     "intent",
+			Name:     flagIntent,
 			Usage:    fmt.Sprintf("Workload intent (e.g. %s)", strings.Join(recipe.GetCriteriaIntentTypes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.GetCriteriaIntentTypes),
 		withCompletions(&cli.StringFlag{
-			Name:     "os",
+			Name:     flagOS,
 			Usage:    fmt.Sprintf("Operating system type of the GPU node (e.g. %s)", strings.Join(recipe.GetCriteriaOSTypes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.GetCriteriaOSTypes),
 		withCompletions(&cli.StringFlag{
-			Name:     "platform",
+			Name:     flagPlatform,
 			Usage:    fmt.Sprintf("Platform/framework type to include in the runtime (e.g. %s)", strings.Join(recipe.GetCriteriaPlatformTypes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.GetCriteriaPlatformTypes),
@@ -98,6 +98,9 @@ func recipeCmd() *cli.Command {
 		Name:     cmdNameRecipe,
 		Category: functionalCategoryName,
 		Usage:    "Create optimized recipe for given intent and environment parameters.",
+		Commands: []*cli.Command{
+			recipeListCmd(),
+		},
 		Description: `Generate configuration recipe based on specified environment parameters including:
   - Kubernetes service type (e.g. eks, gke, aks, oke, kind, lke, bcm)
   - Accelerator type (e.g. h100, h200, gb200, b200, a100, l40, rtx-pro-6000)
@@ -132,7 +135,7 @@ Override snapshot-detected criteria:
   aicr recipe --snapshot cm://gpu-operator/aicr-snapshot --service gke`,
 		Flags: recipeCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", "snapshot", "config", "output", "format"); err != nil {
+			if err := validateSingleValueFlags(cmd, flagService, flagAccelerator, flagIntent, flagOS, flagPlatform, "snapshot", "config", flagOutput, flagFormat); err != nil {
 				return err
 			}
 
@@ -272,23 +275,23 @@ func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig, 
 		return err
 	}
 	if resolved.Service != "" {
-		logCriteriaOverride("service", string(criteria.Service), string(resolved.Service))
+		logCriteriaOverride(flagService, string(criteria.Service), string(resolved.Service))
 		criteria.Service = resolved.Service
 	}
 	if resolved.Accelerator != "" {
-		logCriteriaOverride("accelerator", string(criteria.Accelerator), string(resolved.Accelerator))
+		logCriteriaOverride(flagAccelerator, string(criteria.Accelerator), string(resolved.Accelerator))
 		criteria.Accelerator = resolved.Accelerator
 	}
 	if resolved.Intent != "" {
-		logCriteriaOverride("intent", string(criteria.Intent), string(resolved.Intent))
+		logCriteriaOverride(flagIntent, string(criteria.Intent), string(resolved.Intent))
 		criteria.Intent = resolved.Intent
 	}
 	if resolved.OS != "" {
-		logCriteriaOverride("os", string(criteria.OS), string(resolved.OS))
+		logCriteriaOverride(flagOS, string(criteria.OS), string(resolved.OS))
 		criteria.OS = resolved.OS
 	}
 	if resolved.Platform != "" {
-		logCriteriaOverride("platform", string(criteria.Platform), string(resolved.Platform))
+		logCriteriaOverride(flagPlatform, string(criteria.Platform), string(resolved.Platform))
 		criteria.Platform = resolved.Platform
 	}
 	if resolved.Nodes > 0 {
@@ -305,7 +308,7 @@ func applyCriteriaFromConfig(criteria *recipe.Criteria, cfg *appcfg.AICRConfig, 
 // snapshot-extracted value with a different one. Empty/wildcard prior values
 // are not interesting (the field was effectively unset).
 func logCriteriaOverride(field, prior, override string) {
-	if prior == "" || prior == "any" || prior == override {
+	if prior == "" || prior == criteriaAny || prior == override {
 		return
 	}
 	slog.Info("config overriding snapshot-detected value",
@@ -331,66 +334,66 @@ func mergeCriteriaFromCmdAndConfig(cmd *cli.Command, cfg *appcfg.AICRConfig, reg
 // enum value against the supplied per-provider registry. Logs a warning when a
 // flag overrides a value detected from the snapshot.
 func applyCriteriaOverrides(cmd *cli.Command, criteria *recipe.Criteria, reg *recipe.CriteriaRegistry) error {
-	if s := cmd.String("service"); s != "" {
+	if s := cmd.String(flagService); s != "" {
 		parsed, err := reg.ParseService(s)
 		if err != nil {
 			return err
 		}
 		if criteria.Service != "" && criteria.Service != parsed {
 			slog.Info("CLI flag overriding snapshot-detected value",
-				"field", "service",
+				"field", flagService,
 				"detected", criteria.Service,
 				"override", parsed)
 		}
 		criteria.Service = parsed
 	}
-	if s := cmd.String("accelerator"); s != "" {
+	if s := cmd.String(flagAccelerator); s != "" {
 		parsed, err := reg.ParseAccelerator(s)
 		if err != nil {
 			return err
 		}
 		if criteria.Accelerator != "" && criteria.Accelerator != parsed {
 			slog.Info("CLI flag overriding snapshot-detected value",
-				"field", "accelerator",
+				"field", flagAccelerator,
 				"detected", criteria.Accelerator,
 				"override", parsed)
 		}
 		criteria.Accelerator = parsed
 	}
-	if s := cmd.String("intent"); s != "" {
+	if s := cmd.String(flagIntent); s != "" {
 		parsed, err := reg.ParseIntent(s)
 		if err != nil {
 			return err
 		}
 		if criteria.Intent != "" && criteria.Intent != parsed {
 			slog.Info("CLI flag overriding snapshot-detected value",
-				"field", "intent",
+				"field", flagIntent,
 				"detected", criteria.Intent,
 				"override", parsed)
 		}
 		criteria.Intent = parsed
 	}
-	if s := cmd.String("os"); s != "" {
+	if s := cmd.String(flagOS); s != "" {
 		parsed, err := reg.ParseOS(s)
 		if err != nil {
 			return err
 		}
 		if criteria.OS != "" && criteria.OS != parsed {
 			slog.Info("CLI flag overriding snapshot-detected value",
-				"field", "os",
+				"field", flagOS,
 				"detected", criteria.OS,
 				"override", parsed)
 		}
 		criteria.OS = parsed
 	}
-	if s := cmd.String("platform"); s != "" {
+	if s := cmd.String(flagPlatform); s != "" {
 		parsed, err := reg.ParsePlatform(s)
 		if err != nil {
 			return err
 		}
 		if criteria.Platform != "" && criteria.Platform != parsed {
 			slog.Info("CLI flag overriding snapshot-detected value",
-				"field", "platform",
+				"field", flagPlatform,
 				"detected", criteria.Platform,
 				"override", parsed)
 		}

--- a/pkg/cli/recipe_list.go
+++ b/pkg/cli/recipe_list.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/urfave/cli/v3"
+
+	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+func recipeListCmd() *cli.Command {
+	return &cli.Command{
+		Name:  cmdNameRecipeList,
+		Usage: "List recipe overlays in the catalog.",
+		Description: `Enumerate all overlay recipes in the catalog and their criteria.
+
+Each entry shows the overlay name, its criteria dimensions, whether it is a
+leaf overlay (no other overlay inherits from it), and its data source
+(embedded or external).
+
+Filter flags narrow the output to overlays that carry the specified criteria
+value. Unspecified flags match all overlays for that dimension.
+
+Examples:
+
+List all overlays (table format):
+  aicr recipe list
+
+List all overlays as JSON:
+  aicr recipe list --format json
+
+Filter to EKS training overlays:
+  aicr recipe list --service eks --intent training
+
+Filter to H100 overlays as JSON:
+  aicr recipe list --accelerator h100 --format json
+
+Include overlays from an external data directory:
+  aicr recipe list --data /path/to/custom-recipes`,
+		Flags: []cli.Flag{
+			withCompletions(&cli.StringFlag{
+				Name:     flagService,
+				Usage:    fmt.Sprintf("Filter by service type (e.g. %s)", strings.Join(recipe.GetCriteriaServiceTypes(), ", ")),
+				Category: catQueryParameters,
+			}, recipe.GetCriteriaServiceTypes),
+			withCompletions(&cli.StringFlag{
+				Name:     flagAccelerator,
+				Aliases:  []string{"gpu"},
+				Usage:    fmt.Sprintf("Filter by accelerator type (e.g. %s)", strings.Join(recipe.GetCriteriaAcceleratorTypes(), ", ")),
+				Category: catQueryParameters,
+			}, recipe.GetCriteriaAcceleratorTypes),
+			withCompletions(&cli.StringFlag{
+				Name:     flagIntent,
+				Usage:    fmt.Sprintf("Filter by workload intent (e.g. %s)", strings.Join(recipe.GetCriteriaIntentTypes(), ", ")),
+				Category: catQueryParameters,
+			}, recipe.GetCriteriaIntentTypes),
+			withCompletions(&cli.StringFlag{
+				Name:     flagOS,
+				Usage:    fmt.Sprintf("Filter by OS type (e.g. %s)", strings.Join(recipe.GetCriteriaOSTypes(), ", ")),
+				Category: catQueryParameters,
+			}, recipe.GetCriteriaOSTypes),
+			withCompletions(&cli.StringFlag{
+				Name:     flagPlatform,
+				Usage:    fmt.Sprintf("Filter by platform type (e.g. %s)", strings.Join(recipe.GetCriteriaPlatformTypes(), ", ")),
+				Category: catQueryParameters,
+			}, recipe.GetCriteriaPlatformTypes),
+			dataFlag(),
+			withCompletions(&cli.StringFlag{
+				Name:     flagFormat,
+				Aliases:  []string{"t"},
+				Value:    string(serializer.FormatTable),
+				Usage:    "Output format (json, yaml, table)",
+				Category: catOutput,
+			}, func() []string { return []string{"json", "yaml", "table"} }),
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			if err := validateSingleValueFlags(cmd, flagService, flagAccelerator, flagIntent, flagOS, flagPlatform, flagFormat); err != nil {
+				return err
+			}
+
+			client, err := recipeClientFromCmd(cmd, nil)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			if err = client.LoadCatalog(ctx); err != nil {
+				return err
+			}
+
+			var filter *aicr.Criteria
+			if hasAnyCriteriaFlag(cmd) {
+				var err error
+				filter, err = buildCatalogFilter(cmd, client)
+				if err != nil {
+					return err
+				}
+			}
+
+			entries, err := client.ListCatalog(ctx, filter)
+			if err != nil {
+				return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to list catalog")
+			}
+
+			format := serializer.Format(cmd.String(flagFormat))
+			if format.IsUnknown() {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("unknown output format %q, valid formats are: json, yaml, table", cmd.String(flagFormat)))
+			}
+
+			return writeCatalogEntries(ctx, cmd, entries, format)
+		},
+	}
+}
+
+// hasAnyCriteriaFlag reports whether the user provided at least one filter flag.
+func hasAnyCriteriaFlag(cmd *cli.Command) bool {
+	for _, name := range []string{flagService, flagAccelerator, flagIntent, flagOS, flagPlatform} {
+		if cmd.IsSet(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildCatalogFilter constructs a Criteria filter from the CLI flags.
+// Each flag value is parsed through the client's criteria registry so
+// --data overlay values are accepted. Returns an error for unrecognized values.
+func buildCatalogFilter(cmd *cli.Command, client *aicr.Client) (*aicr.Criteria, error) {
+	reg := client.CriteriaRegistry()
+	filter := &aicr.Criteria{}
+
+	if s := cmd.String(flagService); s != "" {
+		parsed, err := reg.ParseService(s)
+		if err != nil {
+			return nil, err
+		}
+		filter.Service = string(parsed)
+	}
+	if s := cmd.String(flagAccelerator); s != "" {
+		parsed, err := reg.ParseAccelerator(s)
+		if err != nil {
+			return nil, err
+		}
+		filter.Accelerator = string(parsed)
+	}
+	if s := cmd.String(flagIntent); s != "" {
+		parsed, err := reg.ParseIntent(s)
+		if err != nil {
+			return nil, err
+		}
+		filter.Intent = string(parsed)
+	}
+	if s := cmd.String(flagOS); s != "" {
+		parsed, err := reg.ParseOS(s)
+		if err != nil {
+			return nil, err
+		}
+		filter.OS = string(parsed)
+	}
+	if s := cmd.String(flagPlatform); s != "" {
+		parsed, err := reg.ParsePlatform(s)
+		if err != nil {
+			return nil, err
+		}
+		filter.Platform = string(parsed)
+	}
+	return filter, nil
+}
+
+// writeCatalogEntries writes catalog entries to the command's writer in the
+// requested format.
+func writeCatalogEntries(ctx context.Context, cmd *cli.Command, entries []aicr.CatalogEntry, format serializer.Format) error {
+	w := cmd.Root().Writer
+
+	switch format {
+	case serializer.FormatJSON:
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to marshal catalog entries as JSON", err)
+		}
+		if _, err := fmt.Fprintln(w, string(data)); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write JSON output", err)
+		}
+
+	case serializer.FormatYAML:
+		data, err := serializer.MarshalYAMLDeterministic(entries)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to marshal catalog entries as YAML", err)
+		}
+		if _, err := fmt.Fprint(w, string(data)); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write YAML output", err)
+		}
+
+	case serializer.FormatTable:
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		if _, err := fmt.Fprintln(tw, "NAME\tSERVICE\tACCELERATOR\tINTENT\tOS\tPLATFORM\tIS_LEAF\tSOURCE"); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write table header", err)
+		}
+		for _, e := range entries {
+			if err := ctx.Err(); err != nil {
+				return errors.Wrap(errors.ErrCodeTimeout, "write canceled", err)
+			}
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%v\t%s\n",
+				e.Name,
+				orAny(e.Criteria.Service),
+				orAny(e.Criteria.Accelerator),
+				orAny(e.Criteria.Intent),
+				orAny(e.Criteria.OS),
+				orAny(e.Criteria.Platform),
+				e.IsLeaf,
+				e.Source,
+			); err != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed to write table row", err)
+			}
+		}
+		if err := tw.Flush(); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to flush table output", err)
+		}
+		if len(entries) == 0 {
+			if _, err := fmt.Fprintln(w, "(no matching overlays)"); err != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed to write empty message", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// orAny returns s if non-empty, otherwise the wildcard placeholder.
+func orAny(s string) string {
+	if s == "" || s == criteriaAny {
+		return criteriaAny
+	}
+	return s
+}

--- a/pkg/cli/recipe_list.go
+++ b/pkg/cli/recipe_list.go
@@ -111,7 +111,6 @@ Include overlays from an external data directory:
 
 			var filter *aicr.Criteria
 			if hasAnyCriteriaFlag(cmd) {
-				var err error
 				filter, err = buildCatalogFilter(cmd, client)
 				if err != nil {
 					return err

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -316,6 +316,64 @@ func (c *Client) LoadCatalog(ctx context.Context) error {
 	return nil
 }
 
+// ListCatalog returns catalog entries for all overlays known to this Client,
+// optionally narrowed by the filter criteria. Call LoadCatalog first so the
+// catalog is fully populated before calling this.
+//
+// Each entry carries the overlay name, its criteria, whether it is a leaf
+// (IsLeaf=true means no other overlay inherits from it), and its data
+// provenance ("embedded" or "external"). Entries are returned in ascending
+// name order for deterministic output.
+//
+// When filter is non-nil, only overlays whose criteria carry the exact values
+// specified in each non-empty/non-"any" filter dimension are returned. Setting
+// a filter dimension to "" or "any" places no constraint on that dimension.
+//
+// Returns ErrCodeInvalidRequest on a nil or closed Client, and propagates
+// ErrCodeInternal if the underlying metadata store cannot be loaded.
+func (c *Client) ListCatalog(ctx context.Context, filter *Criteria) ([]CatalogEntry, error) {
+	if c == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+
+	c.mu.RLock()
+	if c.builder == nil {
+		c.mu.RUnlock()
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	dp := c.dp
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+
+	store, err := recipe.LoadMetadataStoreFor(ctx, dp)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load recipe catalog")
+	}
+
+	raw := store.ListCatalog(toInternalCriteria(filter))
+	entries := make([]CatalogEntry, len(raw))
+	for i, e := range raw {
+		var crit Criteria
+		if wrapped := WrapCriteria(e.Criteria); wrapped != nil {
+			crit = *wrapped
+		}
+		entries[i] = CatalogEntry{
+			Name:     e.Name,
+			Criteria: crit,
+			IsLeaf:   e.IsLeaf,
+			Source:   e.Source,
+		}
+	}
+	return entries, nil
+}
+
 // CriteriaRegistry returns the per-DataProvider criteria registry for THIS
 // Client. CLI/library callers use it to parse criteria values (so --data
 // overlay contributions validate) and to apply strict mode against the same

--- a/pkg/client/v1/types.go
+++ b/pkg/client/v1/types.go
@@ -351,6 +351,38 @@ type ComponentBundle struct {
 	Manifests []byte
 }
 
+// CatalogSource constants for CatalogEntry.Source comparisons.
+const (
+	// CatalogSourceEmbedded is the Source value for built-in OSS overlays.
+	CatalogSourceEmbedded = recipe.CatalogSourceEmbedded
+
+	// CatalogSourceExternal is the Source value for overlays loaded via --data.
+	CatalogSourceExternal = recipe.CatalogSourceExternal
+)
+
+// CatalogEntry describes one overlay in the recipe catalog, returned by
+// Client.ListCatalog.
+//
+// IsLeaf is true when the overlay is a leaf — no other overlay in the
+// catalog lists this one as its spec.base. Leaf overlays are the most
+// specific recipes for a given criteria combination.
+//
+// Source is one of CatalogSourceEmbedded or CatalogSourceExternal.
+type CatalogEntry struct {
+	// Name is the overlay name, e.g. "h100-eks-ubuntu-training".
+	Name string `json:"name" yaml:"name"`
+
+	// Criteria is the set of dimensions this overlay targets.
+	Criteria Criteria `json:"criteria" yaml:"criteria"`
+
+	// IsLeaf is true when this overlay is a catalog leaf (no other
+	// overlay inherits from it).
+	IsLeaf bool `json:"is_leaf" yaml:"is_leaf"`
+
+	// Source is the data provenance: "embedded" or "external".
+	Source string `json:"source" yaml:"source"`
+}
+
 // ComponentRef identifies a deployable recipe component.
 //
 // The Name/Chart distinction matters: Name is AICR's identifier

--- a/pkg/recipe/catalog.go
+++ b/pkg/recipe/catalog.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import "sort"
+
+// CatalogEntry describes a single overlay entry in the recipe catalog.
+//
+// IsLeaf is true when the overlay is a leaf — no other overlay in the
+// catalog lists this one as its spec.base. Leaf overlays are the most
+// specific recipes for a given criteria combination; intermediate overlays
+// (which exist to share constraints across multiple leaves) are not leaves.
+//
+// Source reflects where the overlay data came from: "embedded" for the
+// built-in OSS overlays, "external" for overlays loaded via --data.
+type CatalogEntry struct {
+	Name     string    `json:"name"     yaml:"name"`
+	Criteria *Criteria `json:"criteria" yaml:"criteria"`
+	IsLeaf   bool      `json:"is_leaf"  yaml:"is_leaf"`
+	Source   string    `json:"source"   yaml:"source"`
+}
+
+// ListCatalog returns catalog entries for overlays in the store that have
+// non-nil Criteria, optionally narrowed by filter. Overlays without a
+// Criteria block (e.g. the base recipe) are silently excluded.
+//
+// IsLeaf is set to true for leaf overlays — those that are not the
+// base of any other overlay in the catalog.
+//
+// When filter is non-nil, only overlays whose criteria satisfy every
+// explicitly-set filter dimension are returned. The filter uses simple
+// equality: a filter dimension set to "any" or "" places no constraint
+// on that dimension, while a specific value (e.g., "eks") restricts
+// results to overlays whose criteria carry exactly that value.
+//
+// Entries are returned in ascending name order for deterministic output.
+func (s *MetadataStore) ListCatalog(filter *Criteria) []CatalogEntry {
+	// Identify ancestor overlays: any overlay listed as spec.base of
+	// another overlay is not a leaf.
+	ancestors := make(map[string]bool, len(s.Overlays))
+	for _, overlay := range s.Overlays {
+		if overlay.Spec.Base != "" && overlay.Spec.Base != baseRecipeName {
+			ancestors[overlay.Spec.Base] = true
+		}
+	}
+
+	entries := make([]CatalogEntry, 0, len(s.Overlays))
+	for name, overlay := range s.Overlays {
+		if overlay.Spec.Criteria == nil {
+			continue
+		}
+		if filter != nil && !matchesCatalogFilter(overlay.Spec.Criteria, filter) {
+			continue
+		}
+
+		source := sourceEmbedded
+		if src, ok := s.OverlaySources[name]; ok {
+			source = src
+		}
+
+		critCopy := *overlay.Spec.Criteria
+		entries = append(entries, CatalogEntry{
+			Name:     name,
+			Criteria: &critCopy,
+			IsLeaf:   !ancestors[name],
+			Source:   source,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+
+	return entries
+}
+
+// matchesCatalogFilter reports whether overlayCriteria satisfies every
+// explicitly-set dimension of filter. A filter dimension that is empty or
+// "any" places no constraint. This is a simple equality check — unlike the
+// asymmetric Criteria.Matches used for recipe resolution, this predicate
+// asks "does this overlay carry the values I asked for?" without wildcard
+// promotion, so --accelerator h100 returns overlays explicitly specifying
+// h100, not overlays where accelerator=any.
+func matchesCatalogFilter(overlayCriteria *Criteria, filter *Criteria) bool {
+	if filter == nil {
+		return true
+	}
+	if filter.Service != "" && filter.Service != CriteriaServiceAny {
+		if overlayCriteria.Service != filter.Service {
+			return false
+		}
+	}
+	if filter.Accelerator != "" && filter.Accelerator != CriteriaAcceleratorAny {
+		if overlayCriteria.Accelerator != filter.Accelerator {
+			return false
+		}
+	}
+	if filter.Intent != "" && filter.Intent != CriteriaIntentAny {
+		if overlayCriteria.Intent != filter.Intent {
+			return false
+		}
+	}
+	if filter.OS != "" && filter.OS != CriteriaOSAny {
+		if overlayCriteria.OS != filter.OS {
+			return false
+		}
+	}
+	if filter.Platform != "" && filter.Platform != CriteriaPlatformAny {
+		if overlayCriteria.Platform != filter.Platform {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/recipe/catalog_test.go
+++ b/pkg/recipe/catalog_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// catalogStore builds a MetadataStore from an in-memory provider that has:
+//   - base.yaml (required)
+//   - overlays/eks-training.yaml           criteria: service=eks, intent=training
+//   - overlays/h100-eks-training.yaml      criteria: service=eks, accel=h100, intent=training  base: eks-training
+//   - overlays/h100-eks-ubuntu-training.yaml criteria: service=eks, accel=h100, os=ubuntu, intent=training  base: h100-eks-training
+//   - overlays/gb200-eks-ubuntu-training.yaml criteria: service=eks, accel=gb200, os=ubuntu, intent=training  base: eks-training
+func catalogStore(t *testing.T) *MetadataStore {
+	t.Helper()
+
+	files := map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/eks-training.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: eks-training
+spec:
+  criteria:
+    service: eks
+    intent: training
+  componentRefs: []
+`),
+		"overlays/h100-eks-training.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-eks-training
+spec:
+  base: eks-training
+  criteria:
+    service: eks
+    accelerator: h100
+    intent: training
+  componentRefs: []
+`),
+		"overlays/h100-eks-ubuntu-training.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: h100-eks-ubuntu-training
+spec:
+  base: h100-eks-training
+  criteria:
+    service: eks
+    accelerator: h100
+    os: ubuntu
+    intent: training
+  componentRefs: []
+`),
+		"overlays/gb200-eks-ubuntu-training.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: gb200-eks-ubuntu-training
+spec:
+  base: eks-training
+  criteria:
+    service: eks
+    accelerator: gb200
+    os: ubuntu
+    intent: training
+  componentRefs: []
+`),
+	}
+
+	dp := newInMemoryProvider("catalog-test", files)
+	t.Cleanup(func() { EvictCachedStore(dp) })
+
+	store, err := LoadMetadataStoreFor(context.Background(), dp)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor: %v", err)
+	}
+	return store
+}
+
+func TestListCatalog_AllOverlays(t *testing.T) {
+	store := catalogStore(t)
+
+	entries := store.ListCatalog(nil)
+
+	// We have 4 overlays (base is not in Overlays).
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d: %v", len(entries), entryNames(entries))
+	}
+
+	// Entries must be sorted by name.
+	if !isSortedByName(entries) {
+		t.Errorf("entries not sorted by name: %v", entryNames(entries))
+	}
+
+	// IsLeaf: leaves are those whose name does not appear as any overlay's spec.base.
+	//   ancestors: eks-training (base of h100-eks-training and gb200-eks-ubuntu-training)
+	//              h100-eks-training (base of h100-eks-ubuntu-training)
+	// IsLeaf=true:  gb200-eks-ubuntu-training, h100-eks-ubuntu-training
+	// IsLeaf=false: eks-training, h100-eks-training
+	wantLeaf := map[string]bool{
+		"eks-training":              false,
+		"h100-eks-training":         false,
+		"h100-eks-ubuntu-training":  true,
+		"gb200-eks-ubuntu-training": true,
+	}
+	for _, e := range entries {
+		want, ok := wantLeaf[e.Name]
+		if !ok {
+			t.Errorf("unexpected entry %q", e.Name)
+			continue
+		}
+		if e.IsLeaf != want {
+			t.Errorf("entry %q: IsLeaf=%v want %v", e.Name, e.IsLeaf, want)
+		}
+	}
+}
+
+func TestListCatalog_SourcePropagated(t *testing.T) {
+	store := catalogStore(t)
+
+	entries := store.ListCatalog(nil)
+	for _, e := range entries {
+		// The inMemoryDataProvider returns "catalog-test:<path>" for every file.
+		if !strings.HasPrefix(e.Source, "catalog-test:") {
+			t.Errorf("entry %q: Source = %q, want prefix %q", e.Name, e.Source, "catalog-test:")
+		}
+	}
+}
+
+func TestListCatalog_Filter(t *testing.T) {
+	store := catalogStore(t)
+
+	tests := []struct {
+		name      string
+		filter    *Criteria
+		wantNames []string // nil means "expect all 4"
+		wantLen   int
+	}{
+		{
+			name:    "nil filter returns all",
+			filter:  nil,
+			wantLen: 4,
+		},
+		{
+			name:    "sorted by name",
+			filter:  nil,
+			wantLen: 4,
+		},
+		{
+			name:    "service=eks matches all",
+			filter:  &Criteria{Service: CriteriaServiceEKS},
+			wantLen: 4,
+		},
+		{
+			name:      "accelerator=h100",
+			filter:    &Criteria{Accelerator: CriteriaAcceleratorH100},
+			wantNames: []string{"h100-eks-training", "h100-eks-ubuntu-training"},
+		},
+		{
+			name:    "service=eks and intent=training matches all",
+			filter:  &Criteria{Service: CriteriaServiceEKS, Intent: CriteriaIntentTraining},
+			wantLen: 4,
+		},
+		{
+			name:      "os=ubuntu",
+			filter:    &Criteria{OS: CriteriaOSUbuntu},
+			wantNames: []string{"gb200-eks-ubuntu-training", "h100-eks-ubuntu-training"},
+		},
+		{
+			name:    "service=gke no match",
+			filter:  &Criteria{Service: CriteriaServiceGKE},
+			wantLen: 0,
+		},
+		{
+			name: "all-any filter same as nil",
+			filter: &Criteria{
+				Service:     CriteriaServiceAny,
+				Accelerator: CriteriaAcceleratorAny,
+				Intent:      CriteriaIntentAny,
+				OS:          CriteriaOSAny,
+				Platform:    CriteriaPlatformAny,
+			},
+			wantLen: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := store.ListCatalog(tt.filter)
+			if tt.wantNames != nil {
+				if !namesMatch(entries, tt.wantNames) {
+					t.Errorf("got %v, want %v", entryNames(entries), tt.wantNames)
+				}
+			} else if len(entries) != tt.wantLen {
+				t.Errorf("got %d entries, want %d: %v", len(entries), tt.wantLen, entryNames(entries))
+			}
+			if !isSortedByName(entries) {
+				t.Errorf("entries not sorted: %v", entryNames(entries))
+			}
+		})
+	}
+}
+
+func TestMatchesCatalogFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		overlay *Criteria
+		filter  *Criteria
+		want    bool
+	}{
+		{
+			name:    "nil filter matches everything",
+			overlay: &Criteria{Service: CriteriaServiceEKS},
+			filter:  nil,
+			want:    true,
+		},
+		{
+			name: "exact match on subset of dimensions",
+			overlay: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorH100,
+				Intent:      CriteriaIntentTraining,
+				OS:          CriteriaOSUbuntu,
+			},
+			filter: &Criteria{Service: CriteriaServiceEKS, Accelerator: CriteriaAcceleratorH100},
+			want:   true,
+		},
+		{
+			name:    "mismatched dimension",
+			overlay: &Criteria{Service: CriteriaServiceGKE},
+			filter:  &Criteria{Service: CriteriaServiceEKS},
+			want:    false,
+		},
+		{
+			// Unlike Criteria.Matches for recipe resolution, catalog filter with
+			// accelerator=h100 must NOT match an overlay whose accelerator is unset/any.
+			name:    "wildcard overlay does not match specific filter",
+			overlay: &Criteria{Service: CriteriaServiceEKS},
+			filter:  &Criteria{Accelerator: CriteriaAcceleratorH100},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesCatalogFilter(tt.overlay, tt.filter)
+			if got != tt.want {
+				t.Errorf("matchesCatalogFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// entryNames extracts the names from a slice for readable error messages.
+func entryNames(entries []CatalogEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names
+}
+
+// isSortedByName checks that entries are in ascending name order.
+func isSortedByName(entries []CatalogEntry) bool {
+	for i := 1; i < len(entries); i++ {
+		if entries[i].Name < entries[i-1].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// namesMatch checks that the entry names match wantNames exactly (order-insensitive).
+func namesMatch(entries []CatalogEntry, wantNames []string) bool {
+	if len(entries) != len(wantNames) {
+		return false
+	}
+	got := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		got[e.Name] = true
+	}
+	for _, n := range wantNames {
+		if !got[n] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -59,6 +59,11 @@ type MetadataStore struct {
 	// Overlays is a list of overlay recipes indexed by name.
 	Overlays map[string]*RecipeMetadata
 
+	// OverlaySources maps overlay name to its data provenance string
+	// (e.g., "embedded", "external"). Populated during buildMetadataStore
+	// by calling provider.Source(path) for each overlay file.
+	OverlaySources map[string]string
+
 	// Mixins is a map of composable mixin fragments indexed by name.
 	Mixins map[string]*RecipeMixin
 
@@ -170,10 +175,11 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 	recipeCacheMisses.Inc()
 
 	store := &MetadataStore{
-		Overlays:    make(map[string]*RecipeMetadata),
-		Mixins:      make(map[string]*RecipeMixin),
-		ValuesFiles: make(map[string][]byte),
-		provider:    provider,
+		Overlays:       make(map[string]*RecipeMetadata),
+		OverlaySources: make(map[string]string),
+		Mixins:         make(map[string]*RecipeMixin),
+		ValuesFiles:    make(map[string][]byte),
+		provider:       provider,
 	}
 
 	// Staged criteria registry entries. Each overlay's criteria are
@@ -274,6 +280,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 			store.Base = &metadata
 		} else {
 			store.Overlays[metadata.Metadata.Name] = &metadata
+			store.OverlaySources[metadata.Metadata.Name] = provider.Source(path)
 			// Stage this overlay's criteria for registration; the
 			// actual call to seedCriteriaRegistry is deferred until
 			// after every overlay parses cleanly, the base recipe is

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -256,11 +256,21 @@ type LayeredProviderConfig struct {
 }
 
 const (
-	// sourceEmbedded is the source name for embedded files.
-	sourceEmbedded = "embedded"
+	// CatalogSourceEmbedded is the Source value for overlays shipped with the
+	// binary (built-in OSS recipes).
+	CatalogSourceEmbedded = "embedded"
 
-	// sourceExternal is the source name for external files.
-	sourceExternal = "external"
+	// CatalogSourceExternal is the Source value for overlays loaded from an
+	// external --data directory.
+	CatalogSourceExternal = "external"
+
+	// sourceEmbedded is the internal alias kept for backward compatibility
+	// within this package.
+	sourceEmbedded = CatalogSourceEmbedded
+
+	// sourceExternal is the internal alias kept for backward compatibility
+	// within this package.
+	sourceExternal = CatalogSourceExternal
 
 	// sourceMerged is the source name for files merged from both embedded and external.
 	sourceMerged = "merged (" + sourceEmbedded + " + " + sourceExternal + ")"


### PR DESCRIPTION
## Summary

Adds a read-only `aicr recipe list` subcommand that enumerates overlay recipes in the catalog with machine-readable output (JSON, YAML, table), solving the catalog discoverability gap in #1207.

## Motivation / Context

Tools consuming AICR as a library or CLI with external `--data` had no programmatic way to discover which criteria combinations resolve to a curated leaf overlay versus a generic fallback. The only workarounds were parsing `--help` hint text (not a complete API) or probing every `service × accelerator × intent × os` combination and inspecting `appliedOverlays` — both fragile and expensive.

Fixes: N/A
Related: #1207

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

**Source tracking (`pkg/recipe/metadata_store.go`):** Added `OverlaySources map[string]string` to `MetadataStore`, populated with `provider.Source(path)` during the catalog walk alongside the existing criteria-registry staging. This avoids re-walking the provider at list time.

**Curated definition (`pkg/recipe/catalog.go`):** An overlay has `IsLeaf: true` when no other overlay in the catalog lists it as `spec.base` — i.e., it is a maximal leaf. Intermediate overlays (e.g., `eks-training`, which is the base of `h100-eks-training`) get `IsLeaf: false`. This matches the issue's intent of distinguishing dedicated leaf recipes from generic shared layers.

**Filter semantics (`matchesCatalogFilter`):** Uses simple equality rather than the asymmetric `Criteria.Matches` logic used for recipe resolution. `--accelerator h100` returns only overlays explicitly specifying `h100`; it does not match overlays whose accelerator is `any`. This is the correct semantic for a discovery query: "show me what targets h100", not "show me what a query for h100 would pick up via wildcard".

**CLI output (`pkg/cli/recipe_list.go`):** Default format is `table` (human-friendly with tabwriter); `--format json` and `--format yaml` are available for machine consumption. Writes to `cmd.Root().Writer` per project conventions. Filter flags are validated through the client's criteria registry so `--data` overlay values are accepted.

**Facade (`pkg/client/v1`):** `Client.ListCatalog` follows the same inflight/lock protocol as `LoadCatalog` and reuses the existing `toInternalCriteria`/`WrapCriteria` translation helpers to avoid parallel projection logic.

## Testing

```bash
make qualify
```

All tests pass, linter clean. New unit tests in `pkg/recipe/catalog_test.go` cover:
- Full enumeration (no filter)
- Source field propagation
- Per-dimension filters: service, accelerator, OS, service+intent combined
- Empty result when no overlays match
- All-`any` filter behaves identically to no filter
- Ascending name sort
- `matchesCatalogFilter` nil filter, exact match, mismatched dimension, wildcard-overlay vs specific-filter

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Purely additive. No existing commands or API endpoints are modified. The only change to `MetadataStore` is a new field populated during the existing catalog walk; no behavior changes to recipe resolution or bundling.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)