### PR TITLE
feat(recipe): hydrate healthCheck.assertFile + suppression sentinel

### DIFF
--- a/pkg/recipe/hydrate_test.go
+++ b/pkg/recipe/hydrate_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	stderrors "errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestHydrateHealthCheckAsserts exercises the hydration step that loads
+// registry-declared healthCheck.assertFile content onto each ComponentRef
+// during recipe resolution. See issue #1219.
+func TestHydrateHealthCheckAsserts(t *testing.T) {
+	provider := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
+	registry, err := GetComponentRegistryFor(provider)
+	if err != nil {
+		t.Fatalf("GetComponentRegistryFor: %v", err)
+	}
+
+	// nfd is one of the components with a registry-declared assertFile.
+	if cfg := registry.Get("nfd"); cfg == nil || cfg.HealthCheck.AssertFile == "" {
+		t.Fatalf("test precondition: nfd must have healthCheck.assertFile in registry")
+	}
+
+	tests := []struct {
+		name        string
+		refs        []ComponentRef
+		wantContent func(string) bool
+		wantSkip    bool // expect HealthCheckAsserts to remain empty
+	}{
+		{
+			name: "hydrates from registry assertFile",
+			refs: []ComponentRef{{Name: "nfd"}},
+			wantContent: func(s string) bool {
+				return strings.Contains(s, "apiVersion:") && strings.Contains(s, "chainsaw")
+			},
+		},
+		{
+			name:     "skip sentinel suppresses hydration",
+			refs:     []ComponentRef{{Name: "nfd", HealthCheckSkip: true}},
+			wantSkip: true,
+		},
+		{
+			name: "inline HealthCheckAsserts is preserved (overlay wins)",
+			refs: []ComponentRef{{
+				Name:               "nfd",
+				HealthCheckAsserts: "inline-overlay-content",
+			}},
+			wantContent: func(s string) bool { return s == "inline-overlay-content" },
+		},
+		{
+			name:     "unknown component is a no-op",
+			refs:     []ComponentRef{{Name: "does-not-exist-in-registry"}},
+			wantSkip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs := tt.refs
+			if err := hydrateHealthCheckAsserts(provider, registry, refs); err != nil {
+				t.Fatalf("hydrateHealthCheckAsserts: %v", err)
+			}
+			got := refs[0].HealthCheckAsserts
+			if tt.wantSkip {
+				if got != "" {
+					t.Fatalf("expected empty HealthCheckAsserts, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("expected hydrated HealthCheckAsserts, got empty")
+			}
+			if !tt.wantContent(got) {
+				t.Fatalf("HealthCheckAsserts content did not satisfy predicate; got: %q", got)
+			}
+		})
+	}
+}
+
+// TestHydrateHealthCheckAsserts_NilProvider verifies hydration falls back
+// to the package-global embedded provider when nil is passed, matching the
+// nil-fallback contract documented on applyRegistryDefaults.
+func TestHydrateHealthCheckAsserts_NilProvider(t *testing.T) {
+	registry, err := GetComponentRegistry()
+	if err != nil {
+		t.Fatalf("GetComponentRegistry: %v", err)
+	}
+	refs := []ComponentRef{{Name: "nfd"}}
+	if err := hydrateHealthCheckAsserts(nil, registry, refs); err != nil {
+		t.Fatalf("hydrateHealthCheckAsserts(nil provider): %v", err)
+	}
+	if refs[0].HealthCheckAsserts == "" {
+		t.Fatalf("expected hydrated HealthCheckAsserts with nil provider fallback")
+	}
+}
+
+// TestMergeComponentRef_HealthCheckSkip verifies the suppression sentinel
+// propagates through overlay merge with set-if-true semantics (mirrors
+// Cleanup).
+func TestMergeComponentRef_HealthCheckSkip(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     ComponentRef
+		overlay  ComponentRef
+		wantSkip bool
+	}{
+		{
+			name:     "overlay sets skip",
+			base:     ComponentRef{Name: "x"},
+			overlay:  ComponentRef{Name: "x", HealthCheckSkip: true},
+			wantSkip: true,
+		},
+		{
+			name:     "base set, overlay unset preserves",
+			base:     ComponentRef{Name: "x", HealthCheckSkip: true},
+			overlay:  ComponentRef{Name: "x"},
+			wantSkip: true,
+		},
+		{
+			name:     "neither set",
+			base:     ComponentRef{Name: "x"},
+			overlay:  ComponentRef{Name: "x"},
+			wantSkip: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeComponentRef(tt.base, tt.overlay)
+			if got.HealthCheckSkip != tt.wantSkip {
+				t.Fatalf("HealthCheckSkip = %v, want %v", got.HealthCheckSkip, tt.wantSkip)
+			}
+		})
+	}
+}
+
+// fakeFailingProvider is a DataProvider stub whose ReadFile always fails.
+// Used to exercise the wrapped-error path in hydrateHealthCheckAsserts.
+type fakeFailingProvider struct {
+	delegate DataProvider // registry reads still need to work
+}
+
+func (f *fakeFailingProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	// Allow registry.yaml reads through the delegate so the test can build
+	// the registry; only fail when the hydrator tries to read the
+	// assertFile path.
+	if path == "registry.yaml" {
+		return f.delegate.ReadFile(ctx, path)
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (f *fakeFailingProvider) WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error {
+	return f.delegate.WalkDir(ctx, root, fn)
+}
+
+func (f *fakeFailingProvider) Source(path string) string { return f.delegate.Source(path) }
+
+// TestHydrateHealthCheckAsserts_ReadError verifies the function wraps
+// provider read errors with structured context (component name + path) so
+// operators can pinpoint the offending registry entry.
+func TestHydrateHealthCheckAsserts_ReadError(t *testing.T) {
+	embedded := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
+	registry, err := GetComponentRegistryFor(embedded)
+	if err != nil {
+		t.Fatalf("GetComponentRegistryFor: %v", err)
+	}
+
+	provider := &fakeFailingProvider{delegate: embedded}
+	refs := []ComponentRef{{Name: "nfd"}}
+	err = hydrateHealthCheckAsserts(provider, registry, refs)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("expected *errors.StructuredError, got %T: %v", err, err)
+	}
+	// fs.ErrNotExist is not structured, so PropagateOrWrap falls back to
+	// the supplied ErrCodeInternal fallback. A structured ReadFile error
+	// (e.g., ErrCodeTimeout from a bounded ctx) would surface its inner
+	// code instead — that path is exercised in the pkg/errors tests.
+	if se.Code != errors.ErrCodeInternal {
+		t.Fatalf("error code = %v, want ErrCodeInternal", se.Code)
+	}
+	// Component name + path are embedded in the message string so they
+	// survive both the propagate and wrap branches of PropagateOrWrap
+	// (the structured Context map is only populated by WrapWithContext,
+	// which we deliberately don't use here).
+	msg := se.Error()
+	if !strings.Contains(msg, "nfd") {
+		t.Fatalf("error message %q missing component name", msg)
+	}
+	if !strings.Contains(msg, "checks/nfd/health-check.yaml") {
+		t.Fatalf("error message %q missing assertFile path", msg)
+	}
+}
+
+// TestHydrateHealthCheckAsserts_NoAssertFile verifies the no-op branch when
+// a component is in the registry but has no healthCheck.assertFile declared.
+// Uses a synthetic ComponentRegistry to isolate the branch from in-tree
+// registry contents (every embedded component currently has an assertFile,
+// so this branch is otherwise unreachable from the embedded fixture).
+func TestHydrateHealthCheckAsserts_NoAssertFile(t *testing.T) {
+	registry := &ComponentRegistry{
+		Components: []ComponentConfig{{Name: "no-check-component"}},
+		byName: map[string]*ComponentConfig{
+			"no-check-component": {Name: "no-check-component"},
+		},
+	}
+	provider := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
+	refs := []ComponentRef{{Name: "no-check-component"}}
+	if err := hydrateHealthCheckAsserts(provider, registry, refs); err != nil {
+		t.Fatalf("hydrateHealthCheckAsserts: %v", err)
+	}
+	if refs[0].HealthCheckAsserts != "" {
+		t.Fatalf("HealthCheckAsserts should remain empty when registry has no assertFile, got %q",
+			refs[0].HealthCheckAsserts)
+	}
+}
+
+// TestMixinComponentRefSafeForMerge_RejectsHealthCheckSkip ensures a mixin
+// cannot silently suppress hydration of an inherited check. The merge
+// resolver must reject the offending field by name.
+func TestMixinComponentRefSafeForMerge_RejectsHealthCheckSkip(t *testing.T) {
+	ref := ComponentRef{Name: "x", HealthCheckSkip: true}
+	field, ok := mixinComponentRefSafeForMerge(ref)
+	if ok {
+		t.Fatalf("expected mixin with HealthCheckSkip to be rejected")
+	}
+	if field != "healthCheckSkip" {
+		t.Fatalf("expected offending field name 'healthCheckSkip', got %q", field)
+	}
+}

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -133,6 +133,16 @@ type ComponentRef struct {
 	// expected-resources check runs Chainsaw CLI to evaluate assertions instead of
 	// the default auto-discovery + typed replica checks.
 	HealthCheckAsserts string `json:"healthCheckAsserts,omitempty" yaml:"healthCheckAsserts,omitempty"`
+
+	// HealthCheckSkip suppresses hydration of the registry-declared
+	// healthCheck.assertFile for this component. Set by a leaf overlay (or an
+	// external --data overlay) as the rollback path for a regressing upstream
+	// check: when true, ApplyRegistryDefaults leaves HealthCheckAsserts empty
+	// even if the registry declares an assertFile for this component. Merge
+	// semantics mirror Cleanup — set-if-true; descendants can opt in but not
+	// opt out without re-declaring the assert content inline via
+	// HealthCheckAsserts.
+	HealthCheckSkip bool `json:"healthCheckSkip,omitempty" yaml:"healthCheckSkip,omitempty"`
 }
 
 // IsEnabled returns whether this component is enabled for deployment.
@@ -196,12 +206,13 @@ func (ref *ComponentRef) ApplyRegistryDefaults(config *ComponentConfig) {
 		}
 	}
 
-	// NOTE: healthCheck.assertFile content is intentionally NOT loaded here.
-	// The deployment validator image (distroless) does not include the chainsaw
-	// binary required to execute Chainsaw Test format assertions. Loading the
-	// content would activate chainsaw-based checks in expected-resources, causing
-	// runtime failures. Health check files are used by the conformance validator,
-	// which has its own chainsaw execution path.
+	// healthCheck.assertFile hydration is NOT performed in this method.
+	// ApplyRegistryDefaults runs per-ref against a registry config and has no
+	// DataProvider in scope, but assertFile content lives on disk (or in an
+	// external --data overlay) and must be loaded through the provider that
+	// produced this result. Hydration is performed by hydrateHealthCheckAsserts
+	// in metadata_store.go after the per-ref defaults pass, where the bound
+	// DataProvider is available. See issue #1219.
 }
 
 // ExpectedResource represents a Kubernetes resource that should exist after deployment.
@@ -829,6 +840,14 @@ func mergeComponentRef(base, overlay ComponentRef) ComponentRef {
 	// HealthCheckAsserts: overlay takes precedence if set
 	if overlay.HealthCheckAsserts != "" {
 		result.HealthCheckAsserts = overlay.HealthCheckAsserts
+	}
+
+	// HealthCheckSkip: overlay takes precedence if true (set-if-true,
+	// mirroring Cleanup). A descendant cannot opt back in to hydration
+	// once an ancestor has opted out; the explicit re-enable path is to
+	// declare HealthCheckAsserts inline in the descendant overlay.
+	if overlay.HealthCheckSkip {
+		result.HealthCheckSkip = true
 	}
 
 	return result

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -1129,20 +1130,27 @@ func mixinComponentRefSafeForMerge(c ComponentRef) (string, bool) {
 		return "expectedResources", false
 	case c.HealthCheckAsserts != "":
 		return "healthCheckAsserts", false
+	case c.HealthCheckSkip:
+		return "healthCheckSkip", false
 	}
 	return "", true
 }
 
-// applyRegistryDefaults fills in ComponentRef fields from ComponentConfig defaults.
-// This allows registry.yaml to specify default values that are applied to components
-// that don't explicitly set them in recipes. Returns an error if the registry
-// cannot be loaded — silently no-op'ing would emit partial ComponentRefs that
-// downstream bundlers would reject far from the root cause.
+// applyRegistryDefaults fills in ComponentRef fields from ComponentConfig
+// defaults AND hydrates healthCheck.assertFile content via the bound
+// DataProvider. Returns an error if the registry cannot be loaded or if
+// hydration cannot read a declared assertFile — silently no-op'ing would
+// emit partial ComponentRefs that downstream bundlers / validators would
+// reject far from the root cause.
 //
-// The provider parameter routes the registry lookup through a specific
-// DataProvider so per-provider isolation holds even when the package-global
-// provider has since been swapped. A nil provider falls back to the
-// package-global DataProvider via GetComponentRegistryFor.
+// The provider parameter routes both the registry lookup and assertFile
+// reads through a specific DataProvider so per-provider isolation holds
+// even when the package-global provider has since been swapped. A nil
+// provider falls back to the package-global DataProvider via
+// GetComponentRegistryFor.
+//
+// See hydrateHealthCheckAsserts for the skip / inline-wins / no-assertFile
+// rules and #1219 for the motivation.
 func applyRegistryDefaults(provider DataProvider, refs []ComponentRef) error {
 	registry, err := GetComponentRegistryFor(provider)
 	if err != nil {
@@ -1154,6 +1162,61 @@ func applyRegistryDefaults(provider DataProvider, refs []ComponentRef) error {
 		if config != nil {
 			refs[i].ApplyRegistryDefaults(config)
 		}
+	}
+
+	return hydrateHealthCheckAsserts(provider, registry, refs)
+}
+
+// hydrateHealthCheckAsserts loads each registry-declared healthCheck.assertFile
+// through the bound DataProvider and stamps the content onto the matching
+// ComponentRef.HealthCheckAsserts. Hydration is skipped when:
+//   - the overlay has set HealthCheckSkip (rollback / external-data override
+//     path — see ComponentRef field doc), or
+//   - the overlay already declared HealthCheckAsserts inline (the inline value
+//     wins; never silently overwrite caller intent), or
+//   - the registry has no assertFile entry for this component.
+//
+// Disabled components (overrides.enabled: false) ARE hydrated unconditionally
+// so the on-disk recipe.yaml artifact carries the same content regardless of
+// enablement; runtime execution is filtered separately by enabledComponentRefs.
+//
+// Read-bounded with defaults.FileReadTimeout per call to mirror
+// loadComponentRegistryFor — a hung backing store can't park recipe
+// resolution indefinitely. nil provider falls back to the embedded default,
+// matching applyRegistryDefaults / GetComponentRegistryFor.
+//
+//nolint:contextcheck // ctx is bounded internally; threading caller ctx would require a public-API change to applyRegistryDefaults and every transitive caller — same tradeoff as loadComponentRegistryFor.
+func hydrateHealthCheckAsserts(provider DataProvider, registry *ComponentRegistry, refs []ComponentRef) error {
+	if provider == nil {
+		provider = defaultEmbeddedProvider
+	}
+	for i := range refs {
+		ref := &refs[i]
+		if ref.HealthCheckSkip {
+			continue
+		}
+		if ref.HealthCheckAsserts != "" {
+			continue
+		}
+		config := registry.Get(ref.Name)
+		if config == nil || config.HealthCheck.AssertFile == "" {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+		data, err := provider.ReadFile(ctx, config.HealthCheck.AssertFile)
+		cancel()
+		if err != nil {
+			// PropagateOrWrap so a structured ReadFile error (e.g.,
+			// ErrCodeTimeout from the bounded ctx, or ErrCodeNotFound from
+			// the layered provider) preserves its inner code instead of
+			// being flattened to ErrCodeInternal. Falls back to Wrap for
+			// non-structured stdlib errors (e.g., fs.ErrNotExist), which
+			// is what the embedded provider surfaces today.
+			return aicrerrors.PropagateOrWrap(err, aicrerrors.ErrCodeInternal,
+				fmt.Sprintf("failed to read healthCheck.assertFile for component %q from %q",
+					ref.Name, config.HealthCheck.AssertFile))
+		}
+		ref.HealthCheckAsserts = string(data)
 	}
 	return nil
 }

--- a/validators/chainsaw/binary.go
+++ b/validators/chainsaw/binary.go
@@ -30,21 +30,36 @@ type ChainsawBinary interface {
 	// RunTest executes chainsaw test against the given test directory.
 	// Returns whether all tests passed, the combined output, and any execution error.
 	RunTest(ctx context.Context, testDir string) (passed bool, output string, err error)
+	// Available reports whether the chainsaw binary is callable from this
+	// process. Used by the deployment validator to skip Chainsaw Test-format
+	// dispatch when the binary is absent (e.g., the validator image has not
+	// shipped chainsaw yet), preserving today's no-op behavior while
+	// registry-declared HealthCheckAsserts content hydrates upstream in
+	// pkg/recipe.
+	Available() bool
 }
 
 type chainsawBinary struct {
-	binPath string
+	binPath   string
+	available bool
 }
 
 // NewChainsawBinary creates a ChainsawBinary that invokes the chainsaw CLI.
 // It resolves the binary path from PATH, falling back to /usr/local/bin/chainsaw.
+// Availability is recorded at construction time so callers can branch on it
+// without repeating the exec.LookPath probe.
 func NewChainsawBinary() ChainsawBinary {
 	binPath, err := exec.LookPath("chainsaw")
 	if err != nil {
-		binPath = "/usr/local/bin/chainsaw"
+		// Fall through with the canonical install path; RunTest will surface
+		// the missing-binary error if invoked, but Available() reports false
+		// so the deployment validator can short-circuit upstream.
+		return &chainsawBinary{binPath: "/usr/local/bin/chainsaw", available: false}
 	}
-	return &chainsawBinary{binPath: binPath}
+	return &chainsawBinary{binPath: binPath, available: true}
 }
+
+func (b *chainsawBinary) Available() bool { return b.available }
 
 func (b *chainsawBinary) RunTest(ctx context.Context, testDir string) (bool, string, error) {
 	slog.Debug("executing chainsaw binary", "binPath", b.binPath, "testDir", testDir)

--- a/validators/chainsaw/binary_test.go
+++ b/validators/chainsaw/binary_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsaw
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewChainsawBinary_Available exercises both branches of the
+// availability probe in NewChainsawBinary by manipulating PATH so the
+// chainsaw binary is found / not found. Required so the deployment
+// validator's runtime gate (which keeps issue #1219 runtime-neutral
+// until #1220 ships the binary) is itself covered.
+func TestNewChainsawBinary_Available(t *testing.T) {
+	t.Run("unavailable when not on PATH", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		bin := NewChainsawBinary()
+		if bin.Available() {
+			t.Fatal("Available() = true, want false when chainsaw is not on PATH")
+		}
+	})
+
+	t.Run("available when discoverable on PATH", func(t *testing.T) {
+		dir := t.TempDir()
+		stub := filepath.Join(dir, "chainsaw")
+		// 0o755: an exec.LookPath-discoverable executable is the whole
+		// point of this fixture.
+		if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // test fixture
+			t.Fatalf("write stub: %v", err)
+		}
+		t.Setenv("PATH", dir)
+		bin := NewChainsawBinary()
+		if !bin.Available() {
+			t.Fatal("Available() = false, want true when chainsaw is on PATH")
+		}
+	})
+}

--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -104,25 +104,40 @@ func checkExpectedResources(ctx *validators.Context) error {
 	failures = append(failures, verifyGPUReadinessSignals(ctx, enabledRefs)...)
 
 	if len(chainsawAsserts) > 0 {
-		slog.Info("running health check assertions", "components", len(chainsawAsserts))
-		fetcher, fetcherErr := buildResourceFetcher(ctx)
-		if fetcherErr != nil {
-			return fetcherErr
-		}
-		results := chainsaw.Run(ctx.Ctx, chainsawAsserts, defaults.ChainsawAssertTimeout, fetcher,
-			chainsaw.WithChainsawBinary(chainsaw.NewChainsawBinary()))
-		for _, r := range results {
-			if r.Passed {
-				fmt.Printf("  %s: chainsaw health check passed\n", r.Component)
-			} else {
-				msg := fmt.Sprintf("%s: chainsaw health check failed", r.Component)
-				if r.Output != "" {
-					msg += fmt.Sprintf(":\n%s", r.Output)
+		// Gate activation on chainsaw binary availability. Hydration of
+		// healthCheck.assertFile populates ref.HealthCheckAsserts upstream
+		// (pkg/recipe), but the deployment validator image does not ship the
+		// chainsaw binary yet — see issue #1220. Without this gate, every
+		// component with a registry-declared assertFile would trigger a
+		// failed binary invocation. When the binary is absent, log once and
+		// skip; this preserves the pre-hydration runtime behavior (these
+		// components had no validation path at all before).
+		bin := chainsaw.NewChainsawBinary()
+		if !bin.Available() {
+			slog.Warn("chainsaw binary not available; skipping registry-declared health check assertions",
+				"components", len(chainsawAsserts),
+				"hint", "ships in a later release; see https://github.com/NVIDIA/aicr/issues/1220")
+		} else {
+			slog.Info("running health check assertions", "components", len(chainsawAsserts))
+			fetcher, fetcherErr := buildResourceFetcher(ctx)
+			if fetcherErr != nil {
+				return fetcherErr
+			}
+			results := chainsaw.Run(ctx.Ctx, chainsawAsserts, defaults.ChainsawAssertTimeout, fetcher,
+				chainsaw.WithChainsawBinary(bin))
+			for _, r := range results {
+				if r.Passed {
+					fmt.Printf("  %s: chainsaw health check passed\n", r.Component)
+				} else {
+					msg := fmt.Sprintf("%s: chainsaw health check failed", r.Component)
+					if r.Output != "" {
+						msg += fmt.Sprintf(":\n%s", r.Output)
+					}
+					if r.Error != nil {
+						msg += fmt.Sprintf("\nerror: %v", r.Error)
+					}
+					failures = append(failures, msg)
 				}
-				if r.Error != nil {
-					msg += fmt.Sprintf("\nerror: %v", r.Error)
-				}
-				failures = append(failures, msg)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Hydrate registry-declared `healthCheck.assertFile` content onto
`ComponentRef.HealthCheckAsserts` during recipe resolution. Add an
overlay-driven suppression sentinel as the rollback path. PR 1 of 5
under epic #660.

## Motivation / Context

Today `recipes/checks/*` carries Chainsaw health checks for 22 registry
components, referenced by `healthCheck.assertFile` in
`recipes/registry.yaml`, but the content is never loaded:
`pkg/recipe/metadata.go` intentionally skipped hydration because the
deployment validator image does not ship the `chainsaw` binary, so
populating `ref.HealthCheckAsserts` would activate
`validators/deployment/expected_resources.go:86` and fail every
component invocation. The dormant content is the foundation for
deepening `aicr validate --phase deployment` — see epic #660 (
predecessor #622, ADR #631).

This PR introduces the hydration mechanism only. Runtime behavior is
preserved by gating activation on `ChainsawBinary.Available()`; the
binary ships in #1220.

Fixes: #1219
Related: #660, #1220, #622, #631

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`validators/deployment`, `validators/chainsaw`)

## Implementation Notes

- **Hydration** (`pkg/recipe/metadata_store.go`): `applyRegistryDefaults`
  now calls `hydrateHealthCheckAsserts`, which loads each
  registry-declared `assertFile` through the bound `DataProvider` and
  stamps the content onto the matching `ComponentRef`. Routing goes
  through the per-result provider so per-tenant isolation and external
  `--data` overlays continue to work.
- **Suppression sentinel**: new `HealthCheckSkip bool` field on
  `ComponentRef`. Leaf overlay or external `--data` overlay sets it to
  clear inherited hydration (rollback for a regressing upstream check).
  Merge semantics mirror `Cleanup` (set-if-true).
  `mixinComponentRefSafeForMerge` rejects mixins that set it so a mixin
  cannot silently suppress an inherited check.
- **Inline-wins**: when an overlay declares `HealthCheckAsserts` inline,
  hydration leaves it alone — never silently overwrite caller intent.
- **Disabled components**: hydrated unconditionally so the on-disk
  `recipe.yaml` artifact carries the same content regardless of
  enablement; runtime filtering by `enabledComponentRefs` strips them
  from execution.
- **Runtime gate** (`validators/chainsaw/binary.go`,
  `validators/deployment/expected_resources.go`): `ChainsawBinary` gains
  an `Available()` method (returns `false` when `exec.LookPath("chainsaw")`
  fails). The deployment validator checks it before dispatching
  hydrated assert content; absent binary logs once and skips, preserving
  today's behavior (these components had no validation path at all
  pre-hydration). PR #1220 ships the binary and the gate naturally
  lights up.
- **Stale NOTE rewrite**: the `// NOTE: healthCheck.assertFile content
  is intentionally NOT loaded here.` block in
  `pkg/recipe/metadata.go:199-205` now describes the new contract
  instead of the abandoned reason.

## Testing

```bash
go test -race -count=1 ./pkg/recipe/... ./validators/...
golangci-lint run -c .golangci.yaml ./pkg/recipe/... ./validators/deployment/... ./validators/chainsaw/...
```

- New `pkg/recipe/hydrate_test.go` covers:
  - hydration from registry assertFile
  - skip sentinel suppresses
  - inline `HealthCheckAsserts` is preserved (overlay wins)
  - unknown-component no-op
  - registered-but-no-assertFile no-op
  - provider read failure → wrapped `ErrCodeInternal` with `component` + `assertFile` context
  - nil-provider falls back to embedded
  - merge propagates `HealthCheckSkip` (set-if-true)
  - mixin merge rejects `HealthCheckSkip`
- New `validators/chainsaw/binary_test.go` covers both branches of
  `ChainsawBinary.Available()` (PATH miss → false, PATH hit → true).
- Coverage: `pkg/recipe` 86.0% → 86.2% (+0.2%); `validators/chainsaw`
  11.2% → 14.4% (+3.2%).
- All existing `pkg/recipe`, `validators/deployment`,
  `validators/chainsaw` tests pass under `-race`.
- `pkg/trust` `TestUpdate_Success` fails locally due to Sigstore CDN
  network restrictions in my sandbox — pre-existing, not from this PR.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Validation outcomes are unchanged — the chainsaw
dispatch path is skipped because `ChainsawBinary.Available()` returns
false until #1220 ships the binary, and components with a registry
`assertFile` had no validation path at all pre-hydration. One
user-visible delta: a single `slog.Warn("chainsaw binary not
available; skipping registry-declared health check assertions", ...)`
now fires per deployment-phase run when hydrated content is present
and the binary is missing. The resolved recipe + bundled `recipe.yaml`
now carry `healthCheckAsserts` content (previously empty); downstream
consumers tolerate the extra field since it was already in the
`ComponentRef` schema. To revert: drop the hydration call from
`applyRegistryDefaults` and remove `HealthCheckSkip` / the `Available()`
gate.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (changed paths)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] No user-facing CLI/API/recipe-field behavior changed (docs
      update follows in #1220 when the runtime path activates)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
