### PR TITLE
feat(recipe): add AKS H100 Dynamo perf check

### DIFF
--- a/docs/integrator/aks-gpu-setup.md
+++ b/docs/integrator/aks-gpu-setup.md
@@ -108,12 +108,21 @@ az aks nodepool add \
   --cluster-name <cluster> \
   --resource-group <rg> \
   --name gpupool \
-  --node-vm-size Standard_NC80adis_H100_v5 \
+  --node-vm-size Standard_ND96isr_H100_v5 \
   --gpu-driver none \
   --node-count 1
 ```
 
 No changes to AICR recipes are needed — this is the default configuration.
+
+`Standard_ND96isr_H100_v5` is the 8-GPU ND H100 v5 SKU. The AKS Dynamo
+inference throughput gate (`inference-throughput`) is a fixed absolute
+**full-node** floor calibrated on an 8-GPU H100 node, so this SKU is the
+supported happy path for that gate. Smaller NCads H100 SKUs
+(`Standard_NC80adis_H100_v5` = 2 GPUs, `Standard_NC40ads_H100_v5` = 1 GPU) run
+fine for deployment but will false-fail the throughput floor; gate on
+`inference-ttft-p99` only on those until the per-GPU normalization in
+[#1254](https://github.com/NVIDIA/aicr/issues/1254) lands.
 
 ### Alternative: Use the AKS-Managed Driver
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -76,6 +76,13 @@ The generated recipe lists the selected variant(s) under
 (example: `>= 300 GB/s` for H100 + EFA; `>= 40 GB/s` NET and `>= 500 GB/s`
 NVLS for GB200 + EFA, each sized for a 2-node pair).
 
+**Node-shape assumption.** These bus-bandwidth floors are fixed absolute
+values calibrated on full, high-bandwidth nodes (8-GPU H100 NVLink/SXM with
+multi-NIC transport). They are *not* normalized for node fabric or GPU count,
+so a smaller or different-fabric H100 SKU (e.g. a single-GPU-per-node shape)
+can false-fail a healthy run. Making the NCCL gate fabric/transport-class
+aware is tracked in [#1256](https://github.com/NVIDIA/aicr/issues/1256).
+
 Expected flow (~5–10 min per variant): readiness pre-flight → deploy
 `TrainingRuntime` + `TrainJob` in `aicr-validation` → worker pods reach
 `Running` → run `all_reduce_perf` → parse peak bus bandwidth → verify the
@@ -163,6 +170,16 @@ validation:
       - name: inference-concurrency-per-gpu  # positive integer; default 256
         value: "256"
 ```
+
+**Node-shape assumption.** The `inference-throughput` floor is a fixed
+absolute full-node value calibrated on a full node (the shared `>= 50000`
+gate was measured on 8-GPU H100; GB200 on a 4-GPU node). It is *not*
+normalized for GPU count, and the evaluator only scales it down for partial
+occupancy — not across node sizes — so a smaller H100 SKU (e.g. 1-/2-GPU
+shapes such as `p5.4xlarge`, AKS `NC80adis`) can false-fail a healthy run.
+`inference-ttft-p99` is a per-request latency at fixed concurrency-per-GPU
+and does not need GPU-count normalization. A normalized per-GPU throughput
+floor is tracked in [#1254](https://github.com/NVIDIA/aicr/issues/1254).
 
 `inference-model` and `inference-concurrency-per-gpu` are optional: omit them to
 use the compiled defaults (Qwen3-8B at 256 concurrent requests per GPU), set them

--- a/pkg/recipe/performance_goals_aks_test.go
+++ b/pkg/recipe/performance_goals_aks_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+)
+
+func TestAKSDynamoInferencePerformanceGoalsFollowPattern(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+
+	store, err := loadMetadataStore(ctx)
+	if err != nil {
+		t.Fatalf("failed to load metadata store: %v", err)
+	}
+
+	overlay, ok := store.GetRecipeByName("h100-aks-ubuntu-inference-dynamo")
+	if !ok {
+		t.Fatal("overlay h100-aks-ubuntu-inference-dynamo not found in store")
+	}
+	result, err := store.BuildRecipeResult(ctx, overlay.Spec.Criteria)
+	if err != nil {
+		t.Fatalf("BuildRecipeResult failed: %v", err)
+	}
+	if result.Validation == nil || result.Validation.Performance == nil {
+		t.Fatal("performance phase missing from resolved recipe")
+	}
+
+	performance := result.Validation.Performance
+	wantChecks := []string{"inference-perf"}
+	if !slices.Equal(performance.Checks, wantChecks) {
+		t.Errorf("performance.checks = %v, want %v", performance.Checks, wantChecks)
+	}
+
+	wantConstraints := map[string]string{
+		"inference-model":               "Qwen/Qwen3-8B",
+		"inference-concurrency-per-gpu": "256",
+		"inference-throughput":          ">= 50000",
+		"inference-ttft-p99":            "<= 2000",
+	}
+	if len(performance.Constraints) != len(wantConstraints) {
+		t.Errorf("performance.constraints count = %d, want %d: %v",
+			len(performance.Constraints), len(wantConstraints), performance.Constraints)
+	}
+	for wantName, wantValue := range wantConstraints {
+		found := slices.ContainsFunc(performance.Constraints, func(c Constraint) bool {
+			return c.Name == wantName && c.Value == wantValue
+		})
+		if !found {
+			t.Errorf("performance.constraints missing %q=%q: %v", wantName, wantValue, performance.Constraints)
+		}
+	}
+}

--- a/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
@@ -70,6 +70,11 @@ spec:
       # applies 10% tolerance). A larger model would exercise the per-GPU
       # compute advantage and warrant a tighter gate. Model + concurrency are
       # pinned so the gate stays valid independent of the compiled defaults.
+      #
+      # NOTE: this throughput floor is a fixed absolute full-node value (here a
+      # 4-GPU GB200 node) and is not normalized for GPU count, so a smaller SKU
+      # of this accelerator can false-fail a healthy run. A normalized per-GPU
+      # floor is tracked in https://github.com/NVIDIA/aicr/issues/1254.
       constraints:
         - name: inference-model
           value: Qwen/Qwen3-8B

--- a/recipes/overlays/h100-aks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-aks-ubuntu-inference-dynamo.yaml
@@ -67,6 +67,31 @@ spec:
       constraints:
         - name: Deployment.gpu-operator.version
           value: ">= v24.6.0"
+    performance:
+      checks:
+        - inference-perf
+      # Conservative smoke gate mirrored from the H100 EKS/GKE Dynamo
+      # overlays until Azure-specific baselines are available. Model +
+      # concurrency are pinned so the gate stays valid independent of
+      # the compiled defaults.
+      #
+      # NOTE: inference-throughput here is a fixed absolute full-node value that
+      # assumes an 8-GPU ND H100 node (Standard_ND96isr_H100_v5 — the GPU
+      # nodepool the AKS setup guide documents). It is not normalized for GPU
+      # count, so a smaller NCads H100 SKU (Standard_NC80adis_H100_v5 = 2 GPUs,
+      # Standard_NC40ads_H100_v5 = 1 GPU) would false-fail; on those SKUs drop
+      # the throughput constraint and gate on inference-ttft-p99 only (a
+      # per-request latency, not GPU-count sensitive) until the per-GPU floor in
+      # https://github.com/NVIDIA/aicr/issues/1254 lands.
+      constraints:
+        - name: inference-model
+          value: Qwen/Qwen3-8B
+        - name: inference-concurrency-per-gpu
+          value: "256"
+        - name: inference-throughput
+          value: ">= 50000"
+        - name: inference-ttft-p99
+          value: "<= 2000"
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/h100-eks-training.yaml
+++ b/recipes/overlays/h100-eks-training.yaml
@@ -79,6 +79,13 @@ spec:
     performance:
       checks:
         - nccl-all-reduce-bw
+      # NOTE: this NCCL bus-bandwidth floor is a fixed absolute value calibrated
+      # on a full 8-GPU H100 NVLink/SXM node with multi-NIC transport. busbw is
+      # fabric-class dependent (not GPU-count scaled), so a smaller or
+      # different-fabric H100 SKU — e.g. a single-GPU-per-node shape, whose
+      # all-reduce is pure inter-node NIC with no intra-node NVLink — can
+      # false-fail. Making the gate fabric/transport-class aware is tracked in
+      # https://github.com/NVIDIA/aicr/issues/1256.
       constraints:
         - name: nccl-all-reduce-bw
           value: ">= 300"

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -82,6 +82,13 @@ spec:
       # not modest regressions. The TTFT p99 ceiling sits above the measured
       # value with margin. Model + concurrency are pinned so the gate stays
       # valid independent of the compiled defaults.
+      #
+      # NOTE: this is a full-node value calibrated on an 8-GPU H100 node. The
+      # evaluator's down-scaling only applies to PARTIAL occupancy of a node
+      # (fewer GPUs benchmarked than the node exposes) — it does NOT normalize
+      # across node sizes, so a smaller full H100 SKU (1-/2-GPU, e.g.
+      # p5.4xlarge) can false-fail. A normalized per-GPU floor is tracked in
+      # https://github.com/NVIDIA/aicr/issues/1254.
       constraints:
         - name: inference-model
           value: Qwen/Qwen3-8B

--- a/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
+++ b/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
@@ -82,6 +82,13 @@ spec:
       # not modest regressions. The TTFT p99 ceiling sits above the measured
       # value with margin. Model + concurrency are pinned so the gate stays
       # valid independent of the compiled defaults.
+      #
+      # NOTE: this is a full-node value calibrated on an 8-GPU H100 node. The
+      # evaluator's down-scaling only applies to PARTIAL occupancy of a node
+      # (fewer GPUs benchmarked than the node exposes) — it does NOT normalize
+      # across node sizes, so a smaller full H100 SKU (1-/2-GPU, e.g.
+      # a3-highgpu-1g/2g/4g) can false-fail. A normalized per-GPU floor is
+      # tracked in https://github.com/NVIDIA/aicr/issues/1254.
       constraints:
         - name: inference-model
           value: Qwen/Qwen3-8B

--- a/recipes/overlays/h100-gke-cos-training.yaml
+++ b/recipes/overlays/h100-gke-cos-training.yaml
@@ -87,6 +87,13 @@ spec:
     performance:
       checks:
         - nccl-all-reduce-bw
+      # NOTE: this NCCL bus-bandwidth floor is a fixed absolute value calibrated
+      # on a full 8-GPU H100 NVLink/SXM node with multi-NIC transport. busbw is
+      # fabric-class dependent (not GPU-count scaled), so a smaller or
+      # different-fabric H100 SKU — e.g. a single-GPU-per-node shape, whose
+      # all-reduce is pure inter-node NIC with no intra-node NVLink — can
+      # false-fail. Making the gate fabric/transport-class aware is tracked in
+      # https://github.com/NVIDIA/aicr/issues/1256.
       constraints:
         - name: nccl-all-reduce-bw
           value: ">= 250"

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
@@ -81,6 +81,11 @@ spec:
       # tolerance) so the gate catches real regressions without flaking on
       # run-to-run variance. Model + concurrency are pinned so the gate stays
       # valid independent of the compiled validator defaults.
+      #
+      # NOTE: this throughput floor is a fixed absolute full-node value (here an
+      # 8-GPU node) and is not normalized for GPU count, so a smaller SKU of
+      # this accelerator can false-fail a healthy run. A normalized per-GPU
+      # floor is tracked in https://github.com/NVIDIA/aicr/issues/1254.
       constraints:
         - name: inference-model
           value: Qwen/Qwen3-8B


### PR DESCRIPTION
## Summary

Adds a Dynamo inference performance phase to the H100 AKS Ubuntu inference overlay, mirroring the current H100 EKS/GKE `inference-perf` smoke gate, and documents a known limitation of the existing performance gates: the inference throughput and NCCL bus-bandwidth floors are fixed absolute **full-node** values calibrated on 8-GPU H100 nodes, not normalized for GPU count / fabric class.

> ⚠️ **Known limitation — the current performance gates assume a full 8-GPU H100 node.** The `inference-throughput >= 50000` floor (and the analogous NCCL `nccl-all-reduce-bw` busbw floors) was calibrated on a full 8-GPU H100 node (GB200 on a 4-GPU node) and is **not** normalized for GPU count or fabric class. Because the recipes are SKU-agnostic (`service` + `accelerator` only), the same recipe lands on smaller / different-fabric H100 SKUs (`p5.4xlarge`, `a3-highgpu-1g/2g/4g`, AKS `NC80adis`/`NC40ads`) where a healthy run can **false-fail**. This PR documents the 8-GPU happy path and the workaround (TTFT-only on smaller SKUs); the behavioral fixes are tracked in #1254 (inference, per-GPU normalization) and #1256 (NCCL, fabric/transport-class floors).

## Motivation / Context

The AKS Dynamo inference leaf was missing the recommended performance phase. This adds the same inference throughput and TTFT goals used by the current H100 EKS/GKE Dynamo overlays.

While adding the AKS gate it became clear the shared `>= 50000` throughput floor (and the analogous NCCL `busbw` floors) is a full-node value: on a smaller H100 SKU — which AKS commonly is (`NC80adis` = 2 GPUs, `NC40ads` = 1 GPU), and which exists on every provider (`p5.4xlarge`, `a3-highgpu-1g/2g/4g`) — it can false-fail a healthy run. Rather than ship that silently, this PR adds explicit NOTE comments to the affected overlays and a node-shape-assumption note to the validation docs, cross-referencing the normalization follow-ups.

Fixes: #1006
Related: #1254 (inference throughput per-GPU normalization), #1256 (NCCL fabric/transport-class floors)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Adds `performance.checks: [inference-perf]` to `h100-aks-ubuntu-inference-dynamo` with the same model, concurrency, throughput, and TTFT goals as the current H100 EKS/GKE Dynamo overlays: `Qwen/Qwen3-8B`, `256` concurrency per GPU, `>= 50000` throughput, `<= 2000` TTFT p99.
- Adds a resolved-recipe regression test so the AKS Dynamo leaf follows the inference pattern and does not pick up training NCCL checks.
- **Documents the 8-GPU ND H100 supported path for AKS:** `docs/integrator/aks-gpu-setup.md` now uses `Standard_ND96isr_H100_v5` (8-GPU ND H100 v5) for the example GPU nodepool instead of the 2-GPU `Standard_NC80adis_H100_v5`, with a note that the performance gates are full-node floors and that smaller NCads SKUs should gate on `inference-ttft-p99` only until #1254. The AKS overlay NOTE is framed the same way (assumes 8-GPU ND H100; NCads SKUs drop the throughput constraint / TTFT-only until #1254).
- **Full-node-assumption notes (no behavior change):**
  - `docs/user/validation.md` — adds a "Node-shape assumption" note to both the training (NCCL) and inference performance sections, explaining that the floors are fixed absolute full-node values and which SKUs can false-fail, linking #1254 / #1256. (Uses the file's bold-label-paragraph convention, matching `**Warm-up:**` / `**Determinism:**`.)
  - Inference Dynamo overlays (`h100-aks`, `h100-eks`, `h100-gke`, `gb200-eks`, `rtx-pro-6000-eks`) — adds a NOTE on the throughput floor. Corrects the EKS/GKE comments that implied the evaluator scales across node sizes (it only down-scales for *partial occupancy*, not across node shapes).
  - Active H100 training overlays (`h100-eks-training`, `h100-gke-cos-training`) — adds a NOTE that the `busbw` floor is fabric-class dependent, not GPU-count scaled.
- `inference-ttft-p99` is called out as a per-request latency at fixed concurrency-per-GPU that does not need GPU-count normalization.

**Scope note:** the AKS recipe criteria remain generic (`service: aks`, `accelerator: h100`), so a user on `NC40ads`/`NC80adis` can still generate/validate this recipe and hit the throughput false-fail. This PR documents the 8-GPU ND H100 happy path and the NCads workaround (TTFT-only); the behavioral fix (per-GPU normalization) is tracked in #1254 and intentionally out of scope here.

## Testing

```bash
go test ./pkg/recipe -count=1
env AICR_VALIDATION_FLOOR_STRICT=1 go test ./pkg/recipe -run 'TestOverlayValidationPhaseFloor/h100-aks-ubuntu-inference-dynamo$|TestAKSDynamoInferencePerformanceGoalsFollowPattern' -count=1
yamllint <changed overlays>          # clean
golangci-lint run -c .golangci.yaml ./pkg/recipe/...
unset GITLAB_TOKEN && make qualify
```

The added overlay/doc changes are comments and prose only (no semantic recipe change), so resolution is unchanged — `TestAKSDynamoInferencePerformanceGoalsFollowPattern` and `TestOverlayValidationPhaseFloor` still pass, and `yamllint` is clean on all changed overlays. `make qualify` completes the full gate; the vulnerability scan reports the existing `k8s.io/kubernetes` advisories and does not fail the gate.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** The AKS goals are provisional smoke-floor values mirrored from the current H100 EKS/GKE Dynamo overlays; recalibrate once Azure AKS H100 testbed data is available. The full-node-assumption notes are documentation only — the actual normalization fixes are tracked separately in #1254 (inference) and #1256 (NCCL).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

