### PR TITLE
feat(recipe): add OKE GB200 perf check

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1050,6 +1050,7 @@ that validators use by default:
 |----------|-----------------------------|----------|
 | GKE | `cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb` | Non-standard GPU node pool labels |
 | EKS | `node.kubernetes.io/instance-type: <discovered>` | Custom node pool labels |
+| OKE | `nvidia.com/gpu.product: <discovered>` (when GFD labels are present) | Pin NCCL workers to the accelerator cohort sized for the test; non-GFD clusters get no default selector |
 
 When `--toleration` is provided, it replaces the default tolerate-all policy
 (`operator: Exists`) on workloads that need to land on tainted GPU nodes.

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -47,14 +47,18 @@ ones) that match the target fabric:
 
 | Check | Transport | When it's selected |
 |---|---|---|
-| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | Default for H100 on EKS/GKE, and for GB200/B200 on non-EKS services. Preserves the pre-variant behavior. |
+| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | Default for H100 on EKS/GKE, and for GB200/B200 on non-EKS services without a named-variant pairing (e.g. B200, or GB200 outside EKS/OKE). Preserves the pre-variant behavior. |
 | `nccl-all-reduce-bw-net` | NET (EFA on EKS) | GB200 + EKS. Asserts EFA actually carried traffic — catches silent fallback to Socket when the NVIDIA driver is missing `NVreg_GrdmaPciTopoCheckOverride=1`. |
-| `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA when the IMEX domain is misconfigured. |
+| `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS, and GB200 + OKE. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA (EKS) or Socket (OKE) when the IMEX domain is misconfigured. |
 
 GB200/EKS recipes (both `training` and `inference` intents) enable `-net` and
 `-nvls` together rather than the auto-detect variant, because those nodes
 expose two inter-node fabrics simultaneously and a single auto-detect test
 would only exercise one of them.
+
+GB200/OKE recipes enable `-nvls` only: OKE NET/RDMA stays out of the support
+matrix until the OCI testbed proves a non-Socket NCCL transport end to end, so
+OKE validates the NVL72 IMEX fabric without an EFA/NET counterpart.
 
 ```bash
 # Capture snapshot, generate training recipe, validate the performance phase.

--- a/pkg/recipe/performance_goals_oke_test.go
+++ b/pkg/recipe/performance_goals_oke_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestOKEPerformanceGoalsFollowTrainingInferencePattern(t *testing.T) {
+	ctx := context.Background()
+	store, err := loadMetadataStore(ctx)
+	if err != nil {
+		t.Fatalf("failed to load metadata store: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		wantChecks      []string
+		wantConstraints map[string]string
+	}{
+		{
+			name:       "gb200-oke-training",
+			wantChecks: []string{"nccl-all-reduce-bw-nvls"},
+			wantConstraints: map[string]string{
+				"nccl-all-reduce-bw-nvls": ">= 500",
+			},
+		},
+		{
+			name:       "gb200-oke-ubuntu-training",
+			wantChecks: []string{"nccl-all-reduce-bw-nvls"},
+			wantConstraints: map[string]string{
+				"nccl-all-reduce-bw-nvls": ">= 500",
+			},
+		},
+		{
+			name:       "gb200-oke-ubuntu-training-kubeflow",
+			wantChecks: []string{"nccl-all-reduce-bw-nvls"},
+			wantConstraints: map[string]string{
+				"nccl-all-reduce-bw-nvls": ">= 500",
+			},
+		},
+		{
+			name:       "gb200-oke-ubuntu-inference-dynamo",
+			wantChecks: []string{"inference-perf"},
+			wantConstraints: map[string]string{
+				"inference-model":               "Qwen/Qwen3-8B",
+				"inference-concurrency-per-gpu": "256",
+				"inference-throughput":          ">= 50000",
+				"inference-ttft-p99":            "<= 2000",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overlay, ok := store.GetRecipeByName(tt.name)
+			if !ok {
+				t.Fatalf("overlay %q not found in store", tt.name)
+			}
+			result, err := store.BuildRecipeResult(ctx, overlay.Spec.Criteria)
+			if err != nil {
+				t.Fatalf("BuildRecipeResult failed: %v", err)
+			}
+			if result.Validation == nil || result.Validation.Performance == nil {
+				t.Fatalf("performance phase missing from resolved recipe")
+			}
+
+			performance := result.Validation.Performance
+			if !slices.Equal(performance.Checks, tt.wantChecks) {
+				t.Errorf("performance.checks = %v, want %v", performance.Checks, tt.wantChecks)
+			}
+			if len(performance.Constraints) != len(tt.wantConstraints) {
+				t.Errorf("performance.constraints count = %d, want %d: %v",
+					len(performance.Constraints), len(tt.wantConstraints), performance.Constraints)
+			}
+			for wantName, wantValue := range tt.wantConstraints {
+				found := slices.ContainsFunc(performance.Constraints, func(c Constraint) bool {
+					return c.Name == wantName && c.Value == wantValue
+				})
+				if !found {
+					t.Errorf("performance.constraints missing %q=%q: %v", wantName, wantValue, performance.Constraints)
+				}
+			}
+		})
+	}
+}

--- a/pkg/recipe/validation_phase_floor_test.go
+++ b/pkg/recipe/validation_phase_floor_test.go
@@ -60,19 +60,6 @@ const strictEnvVar = "AICR_VALIDATION_FLOOR_STRICT"
 // time-bounded escape hatch only when a follow-up issue exists to drain
 // them; the stale-entry guard at the end of TestOverlayValidationPhaseFloor
 // catches drift.
-//
-// Pending data gap (intentionally not listed here): #1052 retired the
-// `gb200-any-training.yaml` criteria-wildcard in favor of per-leaf NCCL
-// thresholds. The EKS GB200 training leaves carry their own perf blocks;
-// the OKE chain (`gb200-oke-training`, `gb200-oke-ubuntu-training`,
-// `gb200-oke-ubuntu-training-kubeflow`) currently ships without one and
-// is reported as a default-mode WARN ("WARN recommended performance ..."),
-// not a hard failure. A knownGaps entry would be stale-flagged because
-// performance is warn-only in non-strict mode. When the OCI GB200 testbed
-// lands (#1007) `gb200-oke-training` will ship its own
-// `nccl-all-reduce-bw` constraint and the WARN drains. If a future change
-// toggles AICR_VALIDATION_FLOOR_STRICT=1 in CI before that, add three
-// performance entries here referencing #1007.
 var knownGaps = map[string]map[string]bool{}
 
 // classification captures the inputs that drive the per-intent floor.

--- a/recipes/overlays/gb200-oke-training.yaml
+++ b/recipes/overlays/gb200-oke-training.yaml
@@ -29,8 +29,13 @@ spec:
   # Specific constraints for GB200 on OKE training workloads
   # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
   constraints:
+    # GB200 NVLS performance validation provisions the IMEX channel through a
+    # DRA ComputeDomain that requires the GA resource.k8s.io/v1 API, which
+    # ships in Kubernetes 1.34+. Floor the recipe there so a DRA-incapable
+    # cluster is rejected up front instead of failing the performance phase
+    # at runtime when the v1 ResourceClaimTemplate never reconciles.
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
 
   componentRefs:
     # GB200-specific GPU Operator overrides (inherits valuesFile from oke-training)
@@ -51,6 +56,14 @@ spec:
           enable: true
 
   validation:
+    performance:
+      # NVLS runtime support is OKE-specific. NET/RDMA is intentionally left
+      # out until OCI-specific pod RDMA exposure is verified on the testbed.
+      checks:
+        - nccl-all-reduce-bw-nvls
+      constraints:
+        - name: nccl-all-reduce-bw-nvls
+          value: ">= 500"
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/gb200-oke-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-oke-ubuntu-inference-dynamo.yaml
@@ -59,6 +59,27 @@ spec:
         - kai-scheduler
 
   validation:
+    performance:
+      checks:
+        - inference-perf
+      # Conservative smoke gate mirrored from the GB200 EKS Dynamo overlay
+      # until OCI-specific inference baselines are available. Model +
+      # concurrency are pinned so the gate stays valid independent of
+      # the compiled defaults.
+      #
+      # NOTE: this throughput floor is a fixed absolute full-node value (here a
+      # 4-GPU GB200 node) and is not normalized for GPU count, so a smaller SKU
+      # of this accelerator can false-fail a healthy run. A normalized per-GPU
+      # floor is tracked in https://github.com/NVIDIA/aicr/issues/1254.
+      constraints:
+        - name: inference-model
+          value: Qwen/Qwen3-8B
+        - name: inference-concurrency-per-gpu
+          value: "256"
+        - name: inference-throughput
+          value: ">= 50000"
+        - name: inference-ttft-p99
+          value: "<= 2000"
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/gb200-oke-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/gb200-oke-ubuntu-training-kubeflow.yaml
@@ -36,7 +36,9 @@ spec:
 
   # Constraints for GB200 on OKE with Ubuntu for Kubeflow training workloads
   constraints:
+    # GB200 NVLS performance validation needs the GA resource.k8s.io/v1 DRA
+    # API (Kubernetes 1.34+); keep this leaf aligned with gb200-oke-training.
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
 
   componentRefs: []

--- a/recipes/overlays/gb200-oke-ubuntu-training.yaml
+++ b/recipes/overlays/gb200-oke-ubuntu-training.yaml
@@ -34,8 +34,10 @@ spec:
 
   # Constraints for GB200 on OKE with Ubuntu for training workloads
   constraints:
+    # GB200 NVLS performance validation needs the GA resource.k8s.io/v1 DRA
+    # API (Kubernetes 1.34+); keep this leaf aligned with gb200-oke-training.
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
 
   componentRefs: []
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -93,7 +93,7 @@ const (
 	ncclComputeDomainName = "nccl-all-reduce-cd"
 
 	// ncclIMEXClaimTemplateName must match the resourceClaimTemplateName
-	// field in testdata/gb200/eks/runtime-nvls.yaml — the DRA driver uses
+	// field in runtime-nvls.yaml templates — the DRA driver uses
 	// this name when auto-generating the RCT from the ComputeDomain CR.
 	ncclIMEXClaimTemplateName = "nccl-all-reduce-imex"
 )
@@ -159,6 +159,7 @@ var supportedNCCLCombinations = map[ncclVariant]map[recipe.CriteriaServiceType][
 	},
 	variantNVLS: {
 		recipe.CriteriaServiceEKS: {recipe.CriteriaAcceleratorGB200},
+		recipe.CriteriaServiceOKE: {recipe.CriteriaAcceleratorGB200},
 	},
 }
 
@@ -244,7 +245,7 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	}
 
 	// For named variants, assert the expected transport actually carried traffic.
-	// This turns the variant label into a hard guarantee — a GB200/EKS cluster
+	// This turns the variant label into a hard guarantee — a GB200 cluster
 	// with a broken IMEX domain will fail loudly on the NVLS variant instead of
 	// silently falling back to EFA.
 	if err := verifyTransportFromLogs(logs, variant); err != nil {
@@ -598,9 +599,14 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	}
 
 	// Build effective worker scheduling: user override takes precedence over platform default.
-	defaultNodeSelector, defaultTolerations := platformWorkerScheduling(service, instanceType)
+	defaultNodeSelector, defaultTolerations := platformWorkerScheduling(service, instanceType, config.Nodes)
 	effectiveNodeSelector := defaultNodeSelector
-	if ctx.NodeSelector != nil {
+	// Gate on len() rather than != nil so an explicit but empty selector does
+	// not silently clear the platform default for scheduling while
+	// resolveTargetGPUNodes (which gates on len > 0) still narrows the counted
+	// set — that asymmetry would let workers schedule outside the cohort the
+	// job was sized for.
+	if len(ctx.NodeSelector) > 0 {
 		effectiveNodeSelector = ctx.NodeSelector
 		slog.Info("Using user-provided node selector override for NCCL workers", "selector", ctx.NodeSelector)
 	}
@@ -826,8 +832,11 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 }
 
 // platformWorkerScheduling returns the default nodeSelector and tolerations
-// for NCCL worker pods on the given service. instanceType is only used for EKS.
-func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType string) (map[string]string, []v1.Toleration) {
+// for NCCL worker pods on the given service. instanceType is only used for EKS;
+// nodes (the accelerator-narrowed target set from resolveTargetGPUNodes) is
+// only used for OKE, where the selector is derived from the shared
+// nvidia.com/gpu.product label.
+func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType string, nodes []v1.Node) (map[string]string, []v1.Toleration) {
 	switch service {
 	case recipe.CriteriaServiceEKS:
 		return map[string]string{
@@ -840,11 +849,48 @@ func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType s
 				{Operator: v1.TolerationOpExists},
 				{Key: "nvidia.com/gpu", Operator: v1.TolerationOpEqual, Value: "present", Effect: v1.TaintEffectNoSchedule},
 			}
-	case recipe.CriteriaServiceAny, recipe.CriteriaServiceAKS, recipe.CriteriaServiceOKE, recipe.CriteriaServiceKind, recipe.CriteriaServiceLKE, recipe.CriteriaServiceBCM:
+	case recipe.CriteriaServiceOKE:
+		// OKE bare-metal GB200 pools are commonly tainted and may coexist
+		// with other GPU shapes under one control plane. Tolerate the pool
+		// taint (mirroring EKS/GKE) and pin workers to the same cohort the
+		// node count was sized against by reusing the GFD gpu.product label
+		// that resolveTargetGPUNodes -> narrowByAccelerator already filtered
+		// on. On non-GFD installs no shared product label exists, so emit no
+		// selector — matching the counting path's unfiltered fallback so the
+		// two stay aligned.
+		var nodeSelector map[string]string
+		if product := commonGPUProduct(nodes); product != "" {
+			nodeSelector = map[string]string{gpuProductLabel: product}
+		}
+		return nodeSelector, []v1.Toleration{{Operator: v1.TolerationOpExists}}
+	case recipe.CriteriaServiceAny, recipe.CriteriaServiceAKS, recipe.CriteriaServiceKind, recipe.CriteriaServiceLKE, recipe.CriteriaServiceBCM:
 		return nil, nil
 	default:
 		return nil, nil
 	}
+}
+
+// commonGPUProduct returns the nvidia.com/gpu.product label shared by every
+// node, or "" when the nodes disagree or any node lacks the label (e.g. a
+// non-GFD install). Used to stamp an OKE worker nodeSelector that matches
+// exactly the accelerator-narrowed target set resolveTargetGPUNodes counted,
+// so worker placement cannot diverge from the sizing. Returning "" on non-GFD
+// clusters keeps scheduling aligned with the counting fallback, which also
+// returns the unfiltered set when GFD labels are absent.
+func commonGPUProduct(nodes []v1.Node) string {
+	product := ""
+	for _, n := range nodes {
+		p := n.Labels[gpuProductLabel]
+		if p == "" {
+			return ""
+		}
+		if product == "" {
+			product = p
+		} else if p != product {
+			return ""
+		}
+	}
+	return product
 }
 
 // applyNCCLWorkerScheduling sets the nodeSelector and tolerations on the "node"

--- a/validators/performance/nccl_preflight_nvreg_test.go
+++ b/validators/performance/nccl_preflight_nvreg_test.go
@@ -93,6 +93,10 @@ func TestGB200NetPreflightApplies(t *testing.T) {
 			"NET + GB200 + GKE → not required (no EFA on GKE)",
 			variantNET, recipe.CriteriaAcceleratorGB200, recipe.CriteriaServiceGKE, false,
 		},
+		{
+			"NET + GB200 + OKE → not required (no EFA on OKE)",
+			variantNET, recipe.CriteriaAcceleratorGB200, recipe.CriteriaServiceOKE, false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/validators/performance/nccl_test.go
+++ b/validators/performance/nccl_test.go
@@ -396,7 +396,7 @@ func TestAcceleratorProductMatchers(t *testing.T) {
 
 func TestPlatformWorkerScheduling(t *testing.T) {
 	t.Run("EKS returns instance-type selector", func(t *testing.T) {
-		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceEKS, "p5.48xlarge")
+		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceEKS, "p5.48xlarge", nil)
 		if ns["node.kubernetes.io/instance-type"] != "p5.48xlarge" {
 			t.Errorf("EKS nodeSelector = %v, want instance-type=p5.48xlarge", ns)
 		}
@@ -405,7 +405,7 @@ func TestPlatformWorkerScheduling(t *testing.T) {
 		}
 	})
 	t.Run("GKE returns gke-accelerator selector", func(t *testing.T) {
-		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceGKE, "")
+		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceGKE, "", nil)
 		if ns["cloud.google.com/gke-accelerator"] != "nvidia-h100-mega-80gb" {
 			t.Errorf("GKE nodeSelector = %v, want gke-accelerator=nvidia-h100-mega-80gb", ns)
 		}
@@ -413,18 +413,84 @@ func TestPlatformWorkerScheduling(t *testing.T) {
 			t.Errorf("GKE tolerations count = %d, want 2", len(tols))
 		}
 	})
+	t.Run("OKE pins to shared gpu.product and tolerates taints", func(t *testing.T) {
+		nodes := []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-GB200"}}},
+			{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-GB200"}}},
+		}
+		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceOKE, "", nodes)
+		if ns[gpuProductLabel] != "NVIDIA-GB200" {
+			t.Errorf("OKE nodeSelector = %v, want %s=NVIDIA-GB200", ns, gpuProductLabel)
+		}
+		if len(tols) != 1 || tols[0].Operator != corev1.TolerationOpExists {
+			t.Errorf("OKE tolerations = %v, want tolerate-all", tols)
+		}
+	})
+	t.Run("OKE on non-GFD cluster omits selector but still tolerates taints", func(t *testing.T) {
+		nodes := []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}},
+		}
+		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceOKE, "", nodes)
+		if ns != nil {
+			t.Errorf("OKE non-GFD nodeSelector = %v, want nil", ns)
+		}
+		if len(tols) != 1 || tols[0].Operator != corev1.TolerationOpExists {
+			t.Errorf("OKE non-GFD tolerations = %v, want tolerate-all", tols)
+		}
+	})
 	t.Run("unknown service returns nil", func(t *testing.T) {
-		ns, tols := platformWorkerScheduling("unknown", "")
+		ns, tols := platformWorkerScheduling("unknown", "", nil)
 		if ns != nil || tols != nil {
 			t.Errorf("unknown service should return nil, got ns=%v tols=%v", ns, tols)
 		}
 	})
 	t.Run("any service returns nil", func(t *testing.T) {
-		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceAny, "")
+		ns, tols := platformWorkerScheduling(recipe.CriteriaServiceAny, "", nil)
 		if ns != nil || tols != nil {
 			t.Errorf("any service should return nil, got ns=%v tols=%v", ns, tols)
 		}
 	})
+}
+
+func TestCommonGPUProduct(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes []corev1.Node
+		want  string
+	}{
+		{"empty", nil, ""},
+		{
+			"all share product",
+			[]corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-GB200"}}},
+				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-GB200"}}},
+			},
+			"NVIDIA-GB200",
+		},
+		{
+			"mixed products",
+			[]corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-GB200"}}},
+				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-B200"}}},
+			},
+			"",
+		},
+		{
+			"one node missing label (non-GFD)",
+			[]corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-GB200"}}},
+				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}},
+			},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := commonGPUProduct(tt.nodes); got != tt.want {
+				t.Errorf("commonGPUProduct() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestTemplatePath(t *testing.T) {
@@ -491,6 +557,14 @@ func TestTemplatePath(t *testing.T) {
 			variant:     variantNVLS,
 			filename:    "runtime.yaml",
 			expected:    filepath.Join("testdata", "gb200", "eks", "runtime-nvls.yaml"),
+		},
+		{
+			name:        "gb200 oke NVLS variant",
+			accelerator: recipe.CriteriaAcceleratorGB200,
+			service:     recipe.CriteriaServiceOKE,
+			variant:     variantNVLS,
+			filename:    "runtime.yaml",
+			expected:    filepath.Join("testdata", "gb200", "oke", "runtime-nvls.yaml"),
 		},
 	}
 	for _, tt := range tests {
@@ -633,34 +707,69 @@ func TestBuildComputeDomain(t *testing.T) {
 }
 
 func TestNVLSRuntimeYAMLReferencesIMEXClaim(t *testing.T) {
-	// The runtime-nvls template hardcodes the same RCT name the Go code
+	// The runtime-nvls templates hardcode the same RCT name the Go code
 	// creates via buildComputeDomain. If these drift, the DRA driver
 	// generates one name and the worker pods reference another, and
 	// pod admission fails with an opaque "claim not found" error.
-	data, err := os.ReadFile(filepath.Join("testdata", "gb200", "eks", "runtime-nvls.yaml"))
-	if err != nil {
-		t.Fatalf("failed to read runtime-nvls.yaml: %v", err)
+	paths := []string{
+		filepath.Join("testdata", "gb200", "eks", "runtime-nvls.yaml"),
+		filepath.Join("testdata", "gb200", "oke", "runtime-nvls.yaml"),
 	}
-	s := string(data)
-	if !strings.Contains(s, "resourceClaimTemplateName: "+ncclIMEXClaimTemplateName) {
-		t.Errorf("runtime-nvls.yaml missing resourceClaimTemplateName: %s", ncclIMEXClaimTemplateName)
-	}
-	if !strings.Contains(s, "- name: imex-channel") {
-		t.Error("runtime-nvls.yaml missing 'name: imex-channel' in resourceClaims / claims blocks")
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", path, err)
+			}
+			s := string(data)
+			if !strings.Contains(s, "resourceClaimTemplateName: "+ncclIMEXClaimTemplateName) {
+				t.Errorf("%s missing resourceClaimTemplateName: %s", path, ncclIMEXClaimTemplateName)
+			}
+			if !strings.Contains(s, "- name: imex-channel") {
+				t.Errorf("%s missing 'name: imex-channel' in resourceClaims / claims blocks", path)
+			}
+		})
 	}
 }
 
 func TestSupportedNCCLCombinations_Variants(t *testing.T) {
-	if accels, ok := supportedNCCLCombinations[variantNET][recipe.CriteriaServiceEKS]; !ok {
-		t.Error("variantNET should support EKS")
-	} else if len(accels) != 1 || accels[0] != recipe.CriteriaAcceleratorGB200 {
-		t.Errorf("variantNET EKS accelerators = %v, want [GB200]", accels)
+	tests := []struct {
+		name    string
+		variant ncclVariant
+		service recipe.CriteriaServiceType
+		want    []recipe.CriteriaAcceleratorType
+	}{
+		{
+			name:    "NET EKS GB200",
+			variant: variantNET,
+			service: recipe.CriteriaServiceEKS,
+			want:    []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorGB200},
+		},
+		{
+			name:    "NVLS EKS GB200",
+			variant: variantNVLS,
+			service: recipe.CriteriaServiceEKS,
+			want:    []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorGB200},
+		},
+		{
+			name:    "NVLS OKE GB200",
+			variant: variantNVLS,
+			service: recipe.CriteriaServiceOKE,
+			want:    []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorGB200},
+		},
 	}
-	if accels, ok := supportedNCCLCombinations[variantNVLS][recipe.CriteriaServiceEKS]; !ok {
-		t.Error("variantNVLS should support EKS")
-	} else if len(accels) != 1 || accels[0] != recipe.CriteriaAcceleratorGB200 {
-		t.Errorf("variantNVLS EKS accelerators = %v, want [GB200]", accels)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accels, ok := supportedNCCLCombinations[tt.variant][tt.service]
+			if !ok {
+				t.Fatalf("%s should support %s", tt.variant, tt.service)
+			}
+			if !reflect.DeepEqual(accels, tt.want) {
+				t.Errorf("%s %s accelerators = %v, want %v", tt.variant, tt.service, accels, tt.want)
+			}
+		})
 	}
+
 	// Legacy default variant must still list the original combinations
 	// so existing recipes that reference "nccl-all-reduce-bw" keep working.
 	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceEKS]; len(accels) != 1 || accels[0] != recipe.CriteriaAcceleratorH100 {
@@ -668,6 +777,50 @@ func TestSupportedNCCLCombinations_Variants(t *testing.T) {
 	}
 	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceAny]; len(accels) != 2 {
 		t.Errorf("variantDefault Any count = %d, want 2 (B200, GB200)", len(accels))
+	}
+}
+
+func TestSupportedNCCLCombinationsHaveRuntimeTemplates(t *testing.T) {
+	// This is a wiring guard: every tuple advertised by
+	// supportedNCCLCombinations must have a syntactically valid runtime
+	// template. Transport viability is enforced by verifyTransportFromLogs
+	// against real NCCL logs during validation.
+	const efaIndent = "                      "
+	data := map[string]string{
+		"NAMESPACE":             "aicr-validation",
+		"WORKER_COUNT":          "2",
+		"GPU_COUNT_PER_NODE":    "8",
+		"GPU_COUNT":             "16",
+		"TEST_TYPE":             testType,
+		"MIN_MESSAGE_SIZE":      minMessageSize,
+		"MAX_MESSAGE_SIZE":      maxMessageSize,
+		"EFA_RESOURCE_LIMITS":   buildEFAResourceLine(1, efaIndent),
+		"EFA_RESOURCE_REQUESTS": buildEFAResourceLine(1, efaIndent),
+		"GKE_NETWORK_INTERFACES": buildGKENetworkInterfacesAnnotation([]string{
+			"gpu-nic-0",
+			"gpu-nic-1",
+			"gpu-nic-2",
+			"gpu-nic-3",
+			"gpu-nic-4",
+			"gpu-nic-5",
+			"gpu-nic-6",
+			"gpu-nic-7",
+		}),
+		"NRI_DEVICE_ANNOTATION": buildNRIDeviceAnnotation(8),
+	}
+
+	for variant, byService := range supportedNCCLCombinations {
+		for service, accelerators := range byService {
+			for _, accelerator := range accelerators {
+				name := strings.Join([]string{string(variant), string(service), string(accelerator)}, "/")
+				t.Run(name, func(t *testing.T) {
+					path := templatePath(accelerator, service, variant, "runtime.yaml")
+					if _, err := parseYAMLTemplate(path, data); err != nil {
+						t.Fatalf("supported NCCL combination has no parseable runtime template %s: %v", path, err)
+					}
+				})
+			}
+		}
 	}
 }
 

--- a/validators/performance/testdata/gb200/oke/runtime-nvls.yaml
+++ b/validators/performance/testdata/gb200/oke/runtime-nvls.yaml
@@ -1,0 +1,193 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NCCL all-reduce TrainingRuntime for GB200 on OKE, NVLS-transport variant.
+#
+# Validates Multi-Node NVLink (MNNVL / NVLS) through the DRA compute-domain
+# IMEX channel that the validator creates before launching the TrainJob.
+# NCCL_DEBUG=INFO emits the NVLS communicator-init lines that the validator
+# uses to reject silent fallback to a network transport.
+#
+# Must stay in sync with ncclTrainingRuntimeName in nccl_all_reduce_bw_constraint.go.
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: nccl-all-reduce-runtime
+  namespace: ${NAMESPACE}
+  labels:
+    trainer.kubeflow.org/framework: mpi
+spec:
+  mlPolicy:
+    mpi:
+      mpiImplementation: OpenMPI
+      numProcPerNode: ${GPU_COUNT_PER_NODE}
+      runLauncherAsNode: false
+      sshAuthMountPath: /tmp/mpi-keys
+  template:
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - name: launcher
+        replicas: 1
+        template:
+          spec:
+            template:
+              spec:
+                tolerations:
+                - operator: Exists
+                initContainers:
+                - name: fix-ssh-perms
+                  image: nvcr.io/nvidia/pytorch:25.06-py3
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/id_rsa /root/.ssh/id_rsa
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys
+                  volumeMounts:
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                - name: node
+                  image: nvcr.io/nvidia/pytorch:25.06-py3
+                  env:
+                  - name: LD_LIBRARY_PATH
+                    value: "/usr/local/nvidia/lib64:/usr/local/cuda/lib64"
+                  command:
+                  - /usr/local/mpi/bin/mpirun
+                  args:
+                  - -np
+                  - "${GPU_COUNT}"
+                  - --allow-run-as-root
+                  - --mca
+                  - plm_rsh_args
+                  - -o StrictHostKeyChecking=no -o ConnectionAttempts=10
+                  - --mca
+                  - btl
+                  - ^openib
+                  - --mca
+                  - btl_tcp_if_include
+                  - eth0
+                  - --mca
+                  - oob_tcp_if_include
+                  - eth0
+                  - -x
+                  - LD_LIBRARY_PATH
+                  - -x
+                  - NCCL_DEBUG=INFO
+                  - -x
+                  - NCCL_NVLS_ENABLE=1
+                  - -x
+                  - NCCL_NET_PLUGIN=none
+                  - -x
+                  - NCCL_SOCKET_IFNAME=eth0
+                  - -x
+                  - NCCL_IGNORE_DISABLED_P2P=1
+                  - /usr/local/bin/${TEST_TYPE}_mpi
+                  - -b
+                  - ${MIN_MESSAGE_SIZE}
+                  - -e
+                  - ${MAX_MESSAGE_SIZE}
+                  - -f
+                  - "2"
+                  - -g
+                  - "1"
+                  resources:
+                    limits:
+                      cpu: "2"
+                      memory: 128Mi
+                  volumeMounts:
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+      - name: node
+        template:
+          spec:
+            template:
+              spec:
+                resourceClaims:
+                - name: imex-channel
+                  resourceClaimTemplateName: nccl-all-reduce-imex
+                initContainers:
+                - name: fix-ssh-perms
+                  image: nvcr.io/nvidia/pytorch:25.06-py3
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    apt-get update &&
+                    apt-get install -y --no-install-recommends openssh-server &&
+                    mkdir -p /var/run/sshd &&
+                    chmod 0755 /var/run/sshd &&
+                    mkdir -p /root/.ssh &&
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys &&
+                    chmod 700 /root/.ssh &&
+                    chmod 600 /root/.ssh/authorized_keys
+                  volumeMounts:
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                - name: node
+                  image: nvcr.io/nvidia/pytorch:25.06-py3
+                  command: ["sh", "-c"]
+                  args:
+                  - |
+                    apt-get update &&
+                    apt-get install -y --no-install-recommends openssh-server &&
+                    mkdir -p /var/run/sshd &&
+                    chmod 0755 /var/run/sshd &&
+                    mkdir -p /root/.ssh &&
+                    cp /tmp/mpi-keys/* /root/.ssh/ &&
+                    chmod 700 /root/.ssh &&
+                    chmod 600 /root/.ssh/authorized_keys &&
+                    /usr/sbin/sshd -De
+                  resources:
+                    claims:
+                    - name: imex-channel
+                    limits:
+                      nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
+                    requests:
+                      nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
+                  securityContext:
+                    capabilities:
+                      add: ["IPC_LOCK"]
+                  volumeMounts:
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                  - name: dshm
+                    mountPath: /dev/shm
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+                - name: dshm
+                  emptyDir:
+                    medium: Memory
+      successPolicy:
+        operator: All
+        targetReplicatedJobs:
+        - launcher


### PR DESCRIPTION
## Summary

Adds GB200 OKE performance phases following the existing training/inference split: NCCL goals for training overlays and `inference-perf` throughput/TTFT goals for the Dynamo inference overlay. OKE training advertises NVLS only for now; OKE NET/RDMA stays out until the OCI testbed proves a non-Socket NCCL transport end to end.

## Motivation / Context

The OKE GB200 leaves were missing the recommended performance phase. This adds conservative smoke goals by mirroring the established EKS/GKE overlay pattern while avoiding an unverified OKE NET contract.

Fixes: #1007
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Adds `nccl-all-reduce-bw-nvls >= 500` at `gb200-oke-training` so `gb200-oke-ubuntu-training` and `gb200-oke-ubuntu-training-kubeflow` inherit the training performance goal.
- Registers only `CriteriaServiceOKE + CriteriaAcceleratorGB200` for the NCCL NVLS variant and ships the OKE NVLS runtime template.
- Keeps the OKE NVLS runtime template on the IMEX/ComputeDomain claim path via `resourceClaimTemplateName: nccl-all-reduce-imex`.
- Leaves OKE NET/RDMA out of the support matrix and recipe goals until #1007 or OCI testbed data proves pod RDMA exposure and non-Socket NCCL logs.
- Adds `inference-perf` to `gb200-oke-ubuntu-inference-dynamo`, mirroring the GB200 EKS Dynamo model/concurrency/throughput/TTFT goals.
- Removes the stale validation-floor comment that described OKE GB200 training performance as a pending gap.
- Gives OKE NCCL workers default scheduling in `platformWorkerScheduling`: a tolerate-all toleration (so workers schedule on tainted GB200 pools, not just the launcher) plus a `nvidia.com/gpu.product` node selector derived from the same accelerator-narrowed node set used for sizing — degrading to no selector on non-GFD installs. An explicit-but-empty `--node-selector` no longer clears that default asymmetrically (gated on `len()`, matching the counting path).
- Floors the three OKE GB200 **training** overlays at `K8s.server.version >= 1.34`, since the NVLS IMEX path waits on the GA `resource.k8s.io/v1` ResourceClaimTemplate (Kubernetes 1.34+); a DRA-incapable cluster is now rejected at recipe resolution rather than failing the performance phase at runtime. The EKS GB200 training chain shares this floor and is tracked in #1255.
- Documents OKE NVLS selection in `docs/user/validation.md` and the OKE default validator worker selector in `docs/user/cli-reference.md`.
- Adds regression coverage for resolved OKE performance goals, OKE NVLS support/template parsing, IMEX claim wiring, OKE worker scheduling (`gpu.product` selector + taint toleration, non-GFD fallback), `commonGPUProduct`, the EKS-only GB200 NET NVreg preflight, and the limited scope of runtime-template parse tests.

**Performance-gate assumption:** the bandwidth/throughput thresholds are conservative smoke gates that assume a **full 8-GPU node**. The `inference-perf` goal is mirrored from the EKS H100 8×GPU Dynamo measurement (Qwen/Qwen3-8B, 256 concurrency/GPU, `>= 50000` tok/s, TTFT-p99 `<= 2000 ms`) and the `nccl-all-reduce-bw-nvls >= 500 GB/s` figure is sized for a full-node 2-node pair — neither is yet calibrated against OKE GB200 silicon. They should be re-baselined once OCI testbed data is available; until then a partially-populated node (fewer than 8 GPUs) is expected to under-shoot these gates.

## Testing

```bash
go test ./validators/performance -count=1
go test ./pkg/recipe -count=1
golangci-lint run -c .golangci.yaml ./validators/performance/... ./pkg/recipe/...
env -u GITLAB_TOKEN make qualify
```

All checks passed locally on the rebased branch. `make qualify` completed the full gate; the vulnerability scan reported the existing `k8s.io/kubernetes` advisories and did not fail the gate.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** OKE NET/RDMA is intentionally excluded until an OCI-specific runtime template and passing non-Socket NCCL logs are available from the testbed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

