### PR TITLE
fix(validator): address PR #1231 review on chainsaw hydration runtime

### DIFF
--- a/pkg/recipe/hydrate_test.go
+++ b/pkg/recipe/hydrate_test.go
@@ -213,6 +213,36 @@ func TestHydrateHealthCheckAsserts_ReadError(t *testing.T) {
 	}
 }
 
+// TestHydrateHealthCheckAsserts_ExpectedResourcesWins verifies hydration is
+// skipped when the overlay also declared ExpectedResources. The deployment
+// validator's current mutex
+// (validators/deployment/expected_resources.go:86) only runs the chainsaw
+// path when ExpectedResources is empty, so hydrating in this case would
+// write inert content onto the resolved recipe. k8s-nim-operator is the
+// canonical example flagged in PR #1231 review (registry assertFile +
+// overlay expectedResources). PR #1220 will drop both the validator-side
+// mutex and this skip simultaneously.
+func TestHydrateHealthCheckAsserts_ExpectedResourcesWins(t *testing.T) {
+	provider := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
+	registry, err := GetComponentRegistryFor(provider)
+	if err != nil {
+		t.Fatalf("GetComponentRegistryFor: %v", err)
+	}
+	refs := []ComponentRef{{
+		Name: "nfd",
+		ExpectedResources: []ExpectedResource{
+			{Kind: "Deployment", Namespace: "node-feature-discovery", Name: "nfd-master"},
+		},
+	}}
+	if err := hydrateHealthCheckAsserts(provider, registry, refs); err != nil {
+		t.Fatalf("hydrateHealthCheckAsserts: %v", err)
+	}
+	if refs[0].HealthCheckAsserts != "" {
+		t.Fatalf("HealthCheckAsserts should remain empty when ExpectedResources is set, got %q",
+			refs[0].HealthCheckAsserts)
+	}
+}
+
 // TestHydrateHealthCheckAsserts_NoAssertFile verifies the no-op branch when
 // a component is in the registry but has no healthCheck.assertFile declared.
 // Uses a synthetic ComponentRegistry to isolate the branch from in-tree

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -1172,8 +1172,18 @@ func applyRegistryDefaults(provider DataProvider, refs []ComponentRef) error {
 // ComponentRef.HealthCheckAsserts. Hydration is skipped when:
 //   - the overlay has set HealthCheckSkip (rollback / external-data override
 //     path — see ComponentRef field doc), or
-//   - the overlay already declared HealthCheckAsserts inline (the inline value
-//     wins; never silently overwrite caller intent), or
+//   - the overlay already declared HealthCheckAsserts inline (the inline
+//     value wins; never silently overwrite caller intent), or
+//   - the overlay declared ExpectedResources. The deployment validator's
+//     current mutex (`validators/deployment/expected_resources.go:86`)
+//     only runs the chainsaw path when ExpectedResources is empty;
+//     hydrating in that case would write inert content onto the resolved
+//     recipe — flagged in PR #1231 review against k8s-nim-operator
+//     (registry assertFile + overlay expectedResources). PR #1220 drops
+//     both this skip and the validator-side mutex so the two paths run
+//     side-by-side; until then, the registry assertFile is a fallback
+//     used only when no ExpectedResources are declared, and the artifact
+//     reflects what actually runs.
 //   - the registry has no assertFile entry for this component.
 //
 // Disabled components (overrides.enabled: false) ARE hydrated unconditionally
@@ -1196,6 +1206,9 @@ func hydrateHealthCheckAsserts(provider DataProvider, registry *ComponentRegistr
 			continue
 		}
 		if ref.HealthCheckAsserts != "" {
+			continue
+		}
+		if len(ref.ExpectedResources) > 0 {
 			continue
 		}
 		config := registry.Get(ref.Name)

--- a/validators/chainsaw/binary.go
+++ b/validators/chainsaw/binary.go
@@ -20,10 +20,21 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
+
+// canonicalChainsawPath is the install location the deployment validator
+// image will use once the chainsaw binary ships (see issue #1220). Probed
+// as a fallback when exec.LookPath misses, e.g., when the image places
+// chainsaw at a known absolute path but does not extend PATH.
+//
+// Mutable (var, not const) so tests can swap it for a TempDir entry — the
+// real /usr/local/bin/chainsaw may exist on developer machines, which
+// would otherwise make Available()==false assertions flake.
+var canonicalChainsawPath = "/usr/local/bin/chainsaw"
 
 // ChainsawBinary abstracts chainsaw CLI invocation for testability.
 type ChainsawBinary interface {
@@ -45,18 +56,44 @@ type chainsawBinary struct {
 }
 
 // NewChainsawBinary creates a ChainsawBinary that invokes the chainsaw CLI.
-// It resolves the binary path from PATH, falling back to /usr/local/bin/chainsaw.
-// Availability is recorded at construction time so callers can branch on it
-// without repeating the exec.LookPath probe.
+// It resolves the binary path from PATH first, then probes the canonical
+// install path (/usr/local/bin/chainsaw) for an executable file. The
+// rationale for the fallback probe: a container image may place chainsaw
+// at a known absolute path without extending PATH, in which case
+// exec.LookPath misses but the file is still callable directly. Without
+// the probe, Available() would report false while RunTest could in fact
+// succeed — an inconsistency flagged in PR #1231 review.
+//
+// Availability is recorded at construction time so callers can branch on
+// it without repeating the discovery.
 func NewChainsawBinary() ChainsawBinary {
-	binPath, err := exec.LookPath("chainsaw")
-	if err != nil {
-		// Fall through with the canonical install path; RunTest will surface
-		// the missing-binary error if invoked, but Available() reports false
-		// so the deployment validator can short-circuit upstream.
-		return &chainsawBinary{binPath: "/usr/local/bin/chainsaw", available: false}
+	if binPath, err := exec.LookPath("chainsaw"); err == nil {
+		return &chainsawBinary{binPath: binPath, available: true}
 	}
-	return &chainsawBinary{binPath: binPath, available: true}
+	if isExecutableFile(canonicalChainsawPath) {
+		return &chainsawBinary{binPath: canonicalChainsawPath, available: true}
+	}
+	// Fall through with the canonical install path so the eventual
+	// RunTest error names a real, expected location; Available() reports
+	// false so the deployment validator can short-circuit Test-format
+	// dispatch upstream.
+	return &chainsawBinary{binPath: canonicalChainsawPath, available: false}
+}
+
+// isExecutableFile reports whether path resolves to a regular file with
+// at least one execute bit set. Used by NewChainsawBinary's fallback
+// probe; symlinks resolve via os.Stat. Errors (ENOENT, EACCES) are
+// treated as "not executable" — the probe is best-effort and the
+// caller's downstream RunTest will surface any deeper issue.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
 }
 
 func (b *chainsawBinary) Available() bool { return b.available }

--- a/validators/chainsaw/binary_test.go
+++ b/validators/chainsaw/binary_test.go
@@ -20,17 +20,29 @@ import (
 	"testing"
 )
 
-// TestNewChainsawBinary_Available exercises both branches of the
-// availability probe in NewChainsawBinary by manipulating PATH so the
-// chainsaw binary is found / not found. Required so the deployment
-// validator's runtime gate (which keeps issue #1219 runtime-neutral
-// until #1220 ships the binary) is itself covered.
+// TestNewChainsawBinary_Available exercises every branch of the
+// availability probe in NewChainsawBinary by manipulating PATH and the
+// canonical fallback path so the binary is found / not found. The
+// fallback-path branch was added in PR #1231 review (yuanchen8911):
+// previously NewChainsawBinary reported Available()==false even when
+// /usr/local/bin/chainsaw existed and was callable.
+//
+// canonicalChainsawPath is swapped to a TempDir entry per subtest so
+// the real /usr/local/bin/chainsaw on developer machines doesn't make
+// the unavailable assertions flake.
 func TestNewChainsawBinary_Available(t *testing.T) {
-	t.Run("unavailable when not on PATH", func(t *testing.T) {
+	withCanonicalPath := func(t *testing.T, p string) {
+		orig := canonicalChainsawPath
+		canonicalChainsawPath = p
+		t.Cleanup(func() { canonicalChainsawPath = orig })
+	}
+
+	t.Run("unavailable when missing from PATH and fallback path", func(t *testing.T) {
 		t.Setenv("PATH", t.TempDir())
+		withCanonicalPath(t, filepath.Join(t.TempDir(), "chainsaw"))
 		bin := NewChainsawBinary()
 		if bin.Available() {
-			t.Fatal("Available() = true, want false when chainsaw is not on PATH")
+			t.Fatal("Available() = true, want false when chainsaw is on neither PATH nor fallback")
 		}
 	})
 
@@ -43,9 +55,79 @@ func TestNewChainsawBinary_Available(t *testing.T) {
 			t.Fatalf("write stub: %v", err)
 		}
 		t.Setenv("PATH", dir)
+		withCanonicalPath(t, filepath.Join(t.TempDir(), "chainsaw"))
 		bin := NewChainsawBinary()
 		if !bin.Available() {
 			t.Fatal("Available() = false, want true when chainsaw is on PATH")
 		}
 	})
+
+	t.Run("available via fallback path when PATH misses", func(t *testing.T) {
+		// PATH dir has no chainsaw, but the canonical fallback does.
+		t.Setenv("PATH", t.TempDir())
+		fallbackDir := t.TempDir()
+		fallback := filepath.Join(fallbackDir, "chainsaw")
+		if err := os.WriteFile(fallback, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // test fixture
+			t.Fatalf("write fallback: %v", err)
+		}
+		withCanonicalPath(t, fallback)
+		bin := NewChainsawBinary()
+		if !bin.Available() {
+			t.Fatal("Available() = false, want true when fallback path is executable")
+		}
+	})
+}
+
+// TestIsExecutableFile covers the fallback probe used by NewChainsawBinary
+// when PATH lookup misses.
+func TestIsExecutableFile(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  bool
+	}{
+		{
+			name: "executable regular file",
+			setup: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "chainsaw")
+				if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture
+					t.Fatalf("write: %v", err)
+				}
+				return p
+			},
+			want: true,
+		},
+		{
+			name: "regular file without exec bit",
+			setup: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "chainsaw")
+				if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				return p
+			},
+			want: false,
+		},
+		{
+			name: "missing path",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "does-not-exist")
+			},
+			want: false,
+		},
+		{
+			name: "directory (not a regular file)",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isExecutableFile(tt.setup(t)); got != tt.want {
+				t.Fatalf("isExecutableFile = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/validators/chainsaw/runner.go
+++ b/validators/chainsaw/runner.go
@@ -114,16 +114,19 @@ func Run(ctx context.Context, asserts []ComponentAssert, timeout time.Duration, 
 	return results
 }
 
-// isChainsawTest returns true if the YAML content is a Chainsaw Test
-// (apiVersion: chainsaw.kyverno.io/v1alpha1, kind: Test).
-func isChainsawTest(raw string) bool {
+// IsChainsawTest returns true if the YAML content is a Chainsaw Test
+// (apiVersion: chainsaw.kyverno.io/v1alpha1, kind: Test). Exported so the
+// deployment validator can partition Test-format asserts (which require
+// the chainsaw binary) from raw K8s resource YAML (which uses the Go
+// assertion library and does not need the binary) — see PR #1231.
+func IsChainsawTest(raw string) bool {
 	return strings.Contains(raw, "chainsaw.kyverno.io") && strings.Contains(raw, "kind: Test")
 }
 
 // assertComponent runs assertions for a single component.
 // Chainsaw Test format is dispatched to the binary; raw K8s YAML uses the Go library.
 func assertComponent(ctx context.Context, ca ComponentAssert, timeout time.Duration, fetcher ResourceFetcher, cfg *runConfig) Result {
-	if isChainsawTest(ca.AssertYAML) {
+	if IsChainsawTest(ca.AssertYAML) {
 		return runChainsawBinary(ctx, ca.Name, ca.AssertYAML, timeout, cfg)
 	}
 	return assertRawResources(ctx, ca, timeout, fetcher)

--- a/validators/chainsaw/runner_test.go
+++ b/validators/chainsaw/runner_test.go
@@ -62,9 +62,9 @@ kind: Test`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isChainsawTest(tt.raw)
+			got := IsChainsawTest(tt.raw)
 			if got != tt.want {
-				t.Errorf("isChainsawTest() = %v, want %v", got, tt.want)
+				t.Errorf("IsChainsawTest() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -104,26 +104,38 @@ func checkExpectedResources(ctx *validators.Context) error {
 	failures = append(failures, verifyGPUReadinessSignals(ctx, enabledRefs)...)
 
 	if len(chainsawAsserts) > 0 {
-		// Gate activation on chainsaw binary availability. Hydration of
-		// healthCheck.assertFile populates ref.HealthCheckAsserts upstream
-		// (pkg/recipe), but the deployment validator image does not ship the
-		// chainsaw binary yet — see issue #1220. Without this gate, every
-		// component with a registry-declared assertFile would trigger a
-		// failed binary invocation. When the binary is absent, log once and
-		// skip; this preserves the pre-hydration runtime behavior (these
-		// components had no validation path at all before).
+		// Partition asserts by dispatch path so the chainsaw-binary gate
+		// blocks only the Test-format subset. Raw K8s YAML asserts use the
+		// chainsaw Go library (assertRawResources) and need no external
+		// binary — they must run regardless of binary availability.
+		// Per-assert partitioning was flagged in PR #1231 review: the
+		// previous batch-level gate over-blocked raw-YAML asserts. All
+		// registry checks today happen to be Test-format, but the contract
+		// must be content-aware so this gate doesn't silently skip future
+		// raw-YAML checks once the deployment image ships chainsaw
+		// (#1220).
 		bin := chainsaw.NewChainsawBinary()
-		if !bin.Available() {
-			slog.Warn("chainsaw binary not available; skipping registry-declared health check assertions",
-				"components", len(chainsawAsserts),
+		runnable := make([]chainsaw.ComponentAssert, 0, len(chainsawAsserts))
+		var skippedTestFormat []string
+		for _, ca := range chainsawAsserts {
+			if chainsaw.IsChainsawTest(ca.AssertYAML) && !bin.Available() {
+				skippedTestFormat = append(skippedTestFormat, ca.Name)
+				continue
+			}
+			runnable = append(runnable, ca)
+		}
+		if len(skippedTestFormat) > 0 {
+			slog.Warn("chainsaw binary not available; skipping Chainsaw Test-format assertions",
+				"components", skippedTestFormat,
 				"hint", "ships in a later release; see https://github.com/NVIDIA/aicr/issues/1220")
-		} else {
-			slog.Info("running health check assertions", "components", len(chainsawAsserts))
+		}
+		if len(runnable) > 0 {
+			slog.Info("running health check assertions", "components", len(runnable))
 			fetcher, fetcherErr := buildResourceFetcher(ctx)
 			if fetcherErr != nil {
 				return fetcherErr
 			}
-			results := chainsaw.Run(ctx.Ctx, chainsawAsserts, defaults.ChainsawAssertTimeout, fetcher,
+			results := chainsaw.Run(ctx.Ctx, runnable, defaults.ChainsawAssertTimeout, fetcher,
 				chainsaw.WithChainsawBinary(bin))
 			for _, r := range results {
 				if r.Passed {


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1231 addressing three review findings from
`@yuanchen8911`. No new functionality — tightens correctness around the
hydration runtime gate and the registry/overlay interaction so the
artifact matches what the deployment validator actually runs.

## Motivation / Context

After #1231 merged, three issues were flagged against
`feat/1219-hydrate-healthcheck-assertfile@26aa48eb`:

1. **Major** — the `bin.Available()` gate at
   `validators/deployment/expected_resources.go` over-blocked raw-K8s-YAML
   asserts. `chainsaw.Run` dispatches raw YAML through the Go assertion
   library and only Test format requires the binary. A future raw-YAML
   registry check would have been silently dropped once #1220 ships the
   image.
2. **Medium** — `NewChainsawBinary` returned `Available()==false` when
   `exec.LookPath` missed, even if `/usr/local/bin/chainsaw` existed and
   was callable. Container images may install at a known absolute path
   without extending PATH.
3. **Medium** — hydration stamped `HealthCheckAsserts` onto refs that
   also declared `ExpectedResources`. The validator's mutex
   (`expected_resources.go:86`) only runs the chainsaw path when
   `ExpectedResources` is empty, so the hydrated content was inert.
   `k8s-nim-operator` is the canonical example (registry assertFile +
   overlay `expectedResources` via `h100-eks-ubuntu-inference-nim.yaml`).

Fixes the runtime correctness in #1231 — does not change validation
outcomes for any current component.

Fixes: <!-- N/A — review follow-up, no new issue -->
Related: #1231, #1219, #1220, #660

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`validators/deployment`, `validators/chainsaw`)

## Implementation Notes

### Finding 1 — per-assert partition

`chainsaw.IsChainsawTest` is now exported. The deployment validator
partitions `chainsawAsserts` into Test-format vs raw-YAML, gates only
the Test-format subset on `bin.Available()`, and always runs the raw
subset. Skipped Test-format components are logged by name. All current
registry checks happen to be Test-format, so the per-batch warning
becomes a per-component warning today; the partition guarantees the
gate stays correct as raw-YAML checks land.

### Finding 2 — fallback executability probe

`NewChainsawBinary` first tries `exec.LookPath`, then falls back to
stat-ing the canonical install path (`/usr/local/bin/chainsaw`) for a
regular file with at least one execute bit. `canonicalChainsawPath` is
a `var` (not `const`) so tests can swap it — necessary because real
developer machines often have `/usr/local/bin/chainsaw` installed,
which would otherwise make the `Available()==false` subtest flake.

### Finding 3 — skip hydration when ExpectedResources is set

`hydrateHealthCheckAsserts` skips when `len(ref.ExpectedResources) > 0`.
This mirrors the deployment validator's mutex at
`expected_resources.go:86` so the artifact matches what runs. PR #1220
will simultaneously drop both the validator mutex and this hydration
skip so the two paths run side-by-side with dedup/source-tag CLI
output.

## Testing

```bash
go test -race -count=1 ./pkg/recipe/ ./validators/chainsaw/ ./validators/deployment/
golangci-lint run -c .golangci.yaml ./pkg/recipe/... ./validators/chainsaw/... ./validators/deployment/...
```

New tests:

- `TestHydrateHealthCheckAsserts_ExpectedResourcesWins` — finding 3.
- `TestIsExecutableFile` — 4-case table covering executable / non-exec /
  missing / directory.
- `TestNewChainsawBinary_Available` gains `available via fallback path
  when PATH misses` subtest and patches `canonicalChainsawPath` per
  subtest to avoid dev-machine flakes.

All tests + lint clean.

## Risk Assessment

- [x] **Low** — Isolated changes, well-tested, easy to revert. No
  validation-outcome change for any current component (every registry
  assertFile today is Test format, and `k8s-nim-operator` already had
  its assertFile content silently dropped by the validator mutex).

**Rollout notes:** No user-visible behavior change. Log messages now
warn per-component instead of per-batch when binary is missing; the
operator hint still links to #1220.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (changed paths)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] No user-facing CLI/API/recipe-field behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
