### PR TITLE
feat(validator): ship chainsaw binary; activate deployment-phase runner

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -103,6 +103,10 @@ jobs:
         shell: bash
         run: echo "version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
@@ -110,8 +114,15 @@ jobs:
           file: ${{ matrix.dockerfile || format('validators/{0}/Dockerfile', matrix.phase) }}
           platforms: ${{ matrix.platform }}
           push: true
+          # CHAINSAW_* args are required by validators/deployment/Dockerfile's
+          # chainsaw-fetch stage. Other phase Dockerfiles ignore unknown
+          # build-args, so passing them unconditionally for the whole matrix
+          # is safe and avoids per-phase branching. See issue #1220.
           build-args: |
             GO_VERSION=${{ steps.go.outputs.version }}
+            CHAINSAW_VERSION=${{ steps.versions.outputs.chainsaw }}
+            CHAINSAW_SHA256_LINUX_AMD64=${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
+            CHAINSAW_SHA256_LINUX_ARM64=${{ steps.versions.outputs.chainsaw_sha256_linux_arm64 }}
           tags: |
             ${{ env.VALIDATOR_IMAGE_PREFIX }}/${{ matrix.phase }}:sha-${{ github.sha }}-${{ matrix.arch }}
             ${{ env.VALIDATOR_IMAGE_PREFIX }}/${{ matrix.phase }}:edge-${{ matrix.arch }}

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -182,6 +182,10 @@ jobs:
         shell: bash
         run: echo "version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
@@ -189,8 +193,15 @@ jobs:
           file: ${{ matrix.dockerfile || format('validators/{0}/Dockerfile', matrix.phase) }}
           platforms: ${{ matrix.platform }}
           push: true
+          # CHAINSAW_* args are required by validators/deployment/Dockerfile's
+          # chainsaw-fetch stage. Other phase Dockerfiles ignore unknown
+          # build-args, so passing them unconditionally for the whole matrix
+          # is safe and avoids per-phase branching. See issue #1220.
           build-args: |
             GO_VERSION=${{ steps.go.outputs.version }}
+            CHAINSAW_VERSION=${{ steps.versions.outputs.chainsaw }}
+            CHAINSAW_SHA256_LINUX_AMD64=${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
+            CHAINSAW_SHA256_LINUX_ARM64=${{ steps.versions.outputs.chainsaw_sha256_linux_arm64 }}
           tags: ${{ env.VALIDATOR_IMAGE_PREFIX }}/${{ matrix.phase }}:${{ github.ref_name }}-${{ matrix.arch }}
           provenance: false
           cache-from: type=gha

--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -97,10 +97,19 @@ jobs:
         if: inputs.skip_tests != true
         run: |
           GO_VERSION="$(cat .go-version)"
+          # CHAINSAW_* args are required by validators/deployment/Dockerfile's
+          # chainsaw-fetch stage. Other phase Dockerfiles ignore unknown
+          # build-args, so passing them unconditionally is safe. See #1220.
+          CHAINSAW_VERSION="$(yq -r '.testing_tools.chainsaw' .settings.yaml)"
+          CHAINSAW_SHA256_LINUX_AMD64="$(yq -r '.testing_tools.chainsaw_checksums.linux_amd64' .settings.yaml)"
+          CHAINSAW_SHA256_LINUX_ARM64="$(yq -r '.testing_tools.chainsaw_checksums.linux_arm64' .settings.yaml)"
           for phase in deployment performance conformance; do
             IMAGE="${VALIDATOR_IMAGE_PREFIX}/${phase}:${VALIDATOR_TAG}"
             docker build -f "validators/${phase}/Dockerfile" \
               --build-arg "GO_VERSION=${GO_VERSION}" \
+              --build-arg "CHAINSAW_VERSION=${CHAINSAW_VERSION}" \
+              --build-arg "CHAINSAW_SHA256_LINUX_AMD64=${CHAINSAW_SHA256_LINUX_AMD64}" \
+              --build-arg "CHAINSAW_SHA256_LINUX_ARM64=${CHAINSAW_SHA256_LINUX_ARM64}" \
               -t "${IMAGE}" .
             docker push "${IMAGE}"
           done

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -95,10 +95,19 @@ jobs:
         if: inputs.skip_tests != true
         run: |
           GO_VERSION="$(cat .go-version)"
+          # CHAINSAW_* args are required by validators/deployment/Dockerfile's
+          # chainsaw-fetch stage. Other phase Dockerfiles ignore unknown
+          # build-args, so passing them unconditionally is safe. See #1220.
+          CHAINSAW_VERSION="$(yq -r '.testing_tools.chainsaw' .settings.yaml)"
+          CHAINSAW_SHA256_LINUX_AMD64="$(yq -r '.testing_tools.chainsaw_checksums.linux_amd64' .settings.yaml)"
+          CHAINSAW_SHA256_LINUX_ARM64="$(yq -r '.testing_tools.chainsaw_checksums.linux_arm64' .settings.yaml)"
           for phase in deployment performance conformance; do
             IMAGE="${VALIDATOR_IMAGE_PREFIX}/${phase}:${VALIDATOR_TAG}"
             docker build -f "validators/${phase}/Dockerfile" \
               --build-arg "GO_VERSION=${GO_VERSION}" \
+              --build-arg "CHAINSAW_VERSION=${CHAINSAW_VERSION}" \
+              --build-arg "CHAINSAW_SHA256_LINUX_AMD64=${CHAINSAW_SHA256_LINUX_AMD64}" \
+              --build-arg "CHAINSAW_SHA256_LINUX_ARM64=${CHAINSAW_SHA256_LINUX_ARM64}" \
               -t "${IMAGE}" .
             docker push "${IMAGE}"
           done

--- a/.github/workflows/vuln-scan-images.yaml
+++ b/.github/workflows/vuln-scan-images.yaml
@@ -139,6 +139,10 @@ jobs:
         shell: bash
         run: echo "version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
@@ -146,8 +150,15 @@ jobs:
           file: ${{ matrix.dockerfile || format('validators/{0}/Dockerfile', matrix.phase) }}
           platforms: ${{ matrix.platform }}
           push: true
+          # CHAINSAW_* args are required by validators/deployment/Dockerfile's
+          # chainsaw-fetch stage. Other phase Dockerfiles ignore unknown
+          # build-args, so passing them unconditionally for the whole matrix
+          # is safe and avoids per-phase branching. See issue #1220.
           build-args: |
             GO_VERSION=${{ steps.go.outputs.version }}
+            CHAINSAW_VERSION=${{ steps.versions.outputs.chainsaw }}
+            CHAINSAW_SHA256_LINUX_AMD64=${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
+            CHAINSAW_SHA256_LINUX_ARM64=${{ steps.versions.outputs.chainsaw_sha256_linux_arm64 }}
           tags: ${{ env.VALIDATOR_IMAGE_PREFIX }}/${{ matrix.phase }}:${{ env.SCAN_TAG }}-${{ matrix.arch }}
           provenance: false
           cache-from: type=gha

--- a/Makefile
+++ b/Makefile
@@ -343,10 +343,18 @@ image: ## Builds and pushes container image (IMAGE_REGISTRY, IMAGE_TAG)
 .PHONY: image-validators
 image-validators: build ## Builds per-phase validator images (IMAGE_REGISTRY, IMAGE_TAG)
 	@set -e; \
+	CHAINSAW_VERSION=$$(yq -r '.testing_tools.chainsaw' .settings.yaml); \
+	CHAINSAW_SHA256_LINUX_AMD64=$$(yq -r '.testing_tools.chainsaw_checksums.linux_amd64' .settings.yaml); \
+	CHAINSAW_SHA256_LINUX_ARM64=$$(yq -r '.testing_tools.chainsaw_checksums.linux_arm64' .settings.yaml); \
 	for phase in deployment performance conformance; do \
 		echo "Building validator image: $(IMAGE_REGISTRY)/aicr-validators/$${phase}:$(IMAGE_TAG)"; \
+		extra_args=""; \
+		if [ "$${phase}" = "deployment" ]; then \
+			extra_args="--build-arg CHAINSAW_VERSION=$${CHAINSAW_VERSION} --build-arg CHAINSAW_SHA256_LINUX_AMD64=$${CHAINSAW_SHA256_LINUX_AMD64} --build-arg CHAINSAW_SHA256_LINUX_ARM64=$${CHAINSAW_SHA256_LINUX_ARM64}"; \
+		fi; \
 		docker build -f validators/$${phase}/Dockerfile \
 			--build-arg GO_VERSION=$(GO_VERSION) \
+			$${extra_args} \
 			-t $(IMAGE_REGISTRY)/aicr-validators/$${phase}:$(IMAGE_TAG) .; \
 		if [ -n "$(IMAGE_REGISTRY)" ] && [ "$(IMAGE_REGISTRY)" != "localhost:5005" ]; then \
 			echo "Pushing: $(IMAGE_REGISTRY)/aicr-validators/$${phase}:$(IMAGE_TAG)"; \

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -10,7 +10,7 @@ contributor view for all four.
 | [**Constraint**](#constraints-declarative) (declarative) | `aicr validate` against a snapshot | Recipe overlay `validation:` block | `pkg/constraints` evaluator (in-process) |
 | [**Container-per-validator check**](#container-per-validator-checks) | `aicr validate` against a live cluster | `validators/<phase>/` + `recipes/validators/catalog.yaml` | One K8s Job per check |
 | [**Component validation**](#component-validations-bundle-time) (bundle-time) | `aicr bundle` | `pkg/bundler/validations/checks.go` + `registry.yaml` `validations:` | In-process Go `ValidationFunc` |
-| [**Chainsaw health check**](#chainsaw-health-checks) | `make check-health` post-deploy | `recipes/checks/<name>/health-check.yaml` | Chainsaw YAML assertions |
+| [**Chainsaw health check**](#chainsaw-health-checks) | Two surfaces: `make check-health` post-deploy locally, AND `aicr validate --phase deployment` in-cluster | `recipes/checks/<name>/health-check.yaml` | Chainsaw YAML (Test format runs via the pinned chainsaw binary shipped in the deployment validator image; raw K8s YAML via the chainsaw Go library) |
 
 Rule of thumb: declarative constraint against a snapshot value → surface 1.
 Active probe of a live cluster → surface 2 or 4. Pre-deployment sanity
@@ -650,11 +650,21 @@ A **chainsaw health check** is a YAML test in
 `recipes/checks/<component>/health-check.yaml` that asserts a
 deployed component's state. Runs against a real cluster (typically a
 Kind cluster after `aicr bundle` + `helm install`) via the
-[Chainsaw](https://kyverno.github.io/chainsaw/) test runner. The
-separation from container-per-validator checks: chainsaw is
-**post-deploy** Helm-chart-author sanity, declarative YAML, no Go
-code. Container checks are **part of `aicr validate`** and run as
-part of the AICR validation contract.
+[Chainsaw](https://kyverno.github.io/chainsaw/) test runner.
+
+The same assertion file now powers TWO surfaces:
+
+1. **`make check-health` / `make check-health-all`** — local Kind-cluster
+   sanity invoked manually by chart authors.
+2. **`aicr validate --phase deployment`** — registry-declared content is
+   loaded into `ComponentRef.HealthCheckAsserts` during recipe
+   resolution (PR #1219) and executed by the deployment validator's
+   chainsaw runner (PR #1220). The deployment validator image
+   ships the pinned chainsaw binary at `/usr/local/bin/chainsaw`; the
+   version + sha256 come from `.settings.yaml` and are wired into the
+   image via Makefile build args. CLI output is source-tagged
+   `[chainsaw]` vs `[expectedResources]` so operators can disambiguate
+   when both paths report on the same component.
 
 **Registration.** A component opts in by declaring
 `healthCheck.assertFile` in `recipes/registry.yaml`:
@@ -691,12 +701,22 @@ spec:
               status: { (availableReplicas > `0`): true }
 ```
 
-Use Chainsaw's `assert` (expected match), `error` (unexpected match
-must not exist), and `script` (shell). Always include an existence
-guard before phase assertions so an empty namespace can't yield a
-vacuous pass. See the
+Use Chainsaw's `assert` (expected match) and `error` (unexpected match
+must not exist). Always include an existence guard before phase
+assertions so an empty namespace can't yield a vacuous pass. See the
 [Chainsaw assert reference](https://kyverno.github.io/chainsaw/latest/operations/check/assert/)
 for the full operator list.
+
+**Read-only allowlist.** Registry-declared assert files MUST use only
+`assert` and `error` operations. The deployment validator Job runs
+under a ServiceAccount bound to cluster-admin, so registry content is
+restricted at runtime to read-only Chainsaw operations
+(`validators/chainsaw/allowlist.go`). Any other operation (`script`,
+`apply`, `create`, `delete`, `patch`, `update`, `wait`, `command`,
+`sleep`, `podLogs`, `events`, `describe`, `get`) is rejected with
+`ErrCodeInvalidRequest`. PR #1223 will add the same enforcement at
+lint time so violations are caught before they ever reach the
+validator.
 
 **Running:**
 

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -274,6 +274,21 @@ const (
 	// assertion retries. Assertions are retried at this interval until
 	// they pass or the ChainsawAssertTimeout expires.
 	AssertRetryInterval = 5 * time.Second
+
+	// JobEnvelopeMargin is the headroom added on top of ChainsawAssertTimeout
+	// when computing the validator Job's outer activeDeadlineSeconds and the
+	// expected-resources catalog timeout. Chainsaw needs time after the inner
+	// assert deadline elapses to terminate the binary process, clean up the
+	// temp test directory, and flush log output before the Job's SIGKILL
+	// arrives. Without this headroom the binary is killed mid-cleanup and
+	// operators see truncated output, masking the actual failure cause.
+	//
+	// 60s = 30s for the default Pod terminationGracePeriodSeconds (the
+	// SIGTERM→SIGKILL window — see K8sPodTerminationWaitTimeout above)
+	// plus 30s headroom for pre-chainsaw helper.VerifyResource iteration
+	// and chainsaw startup variance. Tune upward if chainsaw output
+	// truncation is observed in CI runs.
+	JobEnvelopeMargin = 60 * time.Second
 )
 
 // Readiness gate (deploy-time) configuration drives the `gate` CLI Job the

--- a/pkg/defaults/timeouts_test.go
+++ b/pkg/defaults/timeouts_test.go
@@ -87,6 +87,21 @@ func TestTimeoutConstants(t *testing.T) {
 	}
 }
 
+// TestJobEnvelopeMarginInvariant guards the contract that the deployment
+// validator Job's activeDeadlineSeconds exceeds the inner
+// ChainsawAssertTimeout by enough headroom for chainsaw to terminate, clean
+// up its temp dir, and flush logs before SIGKILL. See issue #1220.
+func TestJobEnvelopeMarginInvariant(t *testing.T) {
+	if JobEnvelopeMargin < 60*time.Second {
+		t.Errorf("JobEnvelopeMargin (%v) must be >= 60s (30s default Pod terminationGracePeriodSeconds + 30s pre-chainsaw helper iteration headroom)",
+			JobEnvelopeMargin)
+	}
+	envelope := ChainsawAssertTimeout + JobEnvelopeMargin
+	if envelope <= ChainsawAssertTimeout {
+		t.Errorf("envelope (%v) must exceed ChainsawAssertTimeout (%v)", envelope, ChainsawAssertTimeout)
+	}
+}
+
 func TestRecipeBuildTimeoutLessThanHandler(t *testing.T) {
 	// Recipe build timeout should be less than handler timeout
 	// to allow for error handling before the request times out

--- a/pkg/recipe/hydrate_test.go
+++ b/pkg/recipe/hydrate_test.go
@@ -213,16 +213,14 @@ func TestHydrateHealthCheckAsserts_ReadError(t *testing.T) {
 	}
 }
 
-// TestHydrateHealthCheckAsserts_ExpectedResourcesWins verifies hydration is
-// skipped when the overlay also declared ExpectedResources. The deployment
-// validator's current mutex
-// (validators/deployment/expected_resources.go:86) only runs the chainsaw
-// path when ExpectedResources is empty, so hydrating in this case would
-// write inert content onto the resolved recipe. k8s-nim-operator is the
-// canonical example flagged in PR #1231 review (registry assertFile +
-// overlay expectedResources). PR #1220 will drop both the validator-side
-// mutex and this skip simultaneously.
-func TestHydrateHealthCheckAsserts_ExpectedResourcesWins(t *testing.T) {
+// TestHydrateHealthCheckAsserts_RunsAlongsideExpectedResources verifies
+// hydration is NOT skipped when the overlay also declared
+// ExpectedResources. PR #1220 dropped the deployment validator's
+// previous mutex (the chainsaw path used to only run when
+// ExpectedResources was empty) so both paths now execute side-by-side
+// with source-tagged output. The transitional skip added in PR #1234
+// was removed in lockstep.
+func TestHydrateHealthCheckAsserts_RunsAlongsideExpectedResources(t *testing.T) {
 	provider := NewEmbeddedDataProvider(GetEmbeddedFS(), ".")
 	registry, err := GetComponentRegistryFor(provider)
 	if err != nil {
@@ -237,9 +235,9 @@ func TestHydrateHealthCheckAsserts_ExpectedResourcesWins(t *testing.T) {
 	if err := hydrateHealthCheckAsserts(provider, registry, refs); err != nil {
 		t.Fatalf("hydrateHealthCheckAsserts: %v", err)
 	}
-	if refs[0].HealthCheckAsserts != "" {
-		t.Fatalf("HealthCheckAsserts should remain empty when ExpectedResources is set, got %q",
-			refs[0].HealthCheckAsserts)
+	if refs[0].HealthCheckAsserts == "" {
+		t.Fatal("HealthCheckAsserts should be hydrated even when ExpectedResources is set " +
+			"(both paths run side-by-side under the deployment validator's PR #1220 contract)")
 	}
 }
 

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -1174,17 +1174,18 @@ func applyRegistryDefaults(provider DataProvider, refs []ComponentRef) error {
 //     path — see ComponentRef field doc), or
 //   - the overlay already declared HealthCheckAsserts inline (the inline
 //     value wins; never silently overwrite caller intent), or
-//   - the overlay declared ExpectedResources. The deployment validator's
-//     current mutex (`validators/deployment/expected_resources.go:86`)
-//     only runs the chainsaw path when ExpectedResources is empty;
-//     hydrating in that case would write inert content onto the resolved
-//     recipe — flagged in PR #1231 review against k8s-nim-operator
-//     (registry assertFile + overlay expectedResources). PR #1220 drops
-//     both this skip and the validator-side mutex so the two paths run
-//     side-by-side; until then, the registry assertFile is a fallback
-//     used only when no ExpectedResources are declared, and the artifact
-//     reflects what actually runs.
 //   - the registry has no assertFile entry for this component.
+//
+// Hydration runs unconditionally even when the overlay declares
+// ExpectedResources. The deployment validator's previous mutex
+// (`len(ref.ExpectedResources) == 0`) was dropped in PR #1220 so both
+// the chainsaw path and the ExpectedResources path now execute
+// side-by-side with source-tagged CLI output. The transitional skip
+// added in PR #1234 was removed in lockstep — see the
+// k8s-nim-operator case study in #660 for context on why both signals
+// are useful (registry asserts deeper Pod-level readiness; overlay
+// ExpectedResources asserts the operator-installed singleton Deployment
+// is healthy).
 //
 // Disabled components (overrides.enabled: false) ARE hydrated unconditionally
 // so the on-disk recipe.yaml artifact carries the same content regardless of
@@ -1206,9 +1207,6 @@ func hydrateHealthCheckAsserts(provider DataProvider, registry *ComponentRegistr
 			continue
 		}
 		if ref.HealthCheckAsserts != "" {
-			continue
-		}
-		if len(ref.ExpectedResources) > 0 {
 			continue
 		}
 		config := registry.Get(ref.Name)

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -49,6 +49,38 @@ func TestCatalogTimeoutsFitFacadeBudget(t *testing.T) {
 	}
 }
 
+// TestExpectedResourcesCatalogEnvelope asserts the expected-resources
+// validator's catalog timeout (which becomes the Job's
+// activeDeadlineSeconds) exceeds the inner chainsaw assert timeout by
+// enough headroom for graceful chainsaw termination. Without this,
+// chainsaw is SIGKILLed mid-cleanup and operators see truncated output.
+// See issue #1220.
+func TestExpectedResourcesCatalogEnvelope(t *testing.T) {
+	catalog, err := LoadWithDataProvider(context.Background(), nil, "", "")
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	var found bool
+	required := defaults.ChainsawAssertTimeout + defaults.JobEnvelopeMargin
+	for _, v := range catalog.Validators {
+		if v.Name != "expected-resources" {
+			continue
+		}
+		found = true
+		// Strict-greater: pre-chainsaw work (helper.VerifyResource
+		// iteration) executes serially before chainsaw starts, so an
+		// exact-equal value would let cluster-scale grow eat into
+		// chainsaw's budget. Per PR #1235 review.
+		if v.Timeout <= required {
+			t.Errorf("expected-resources timeout %v must be > ChainsawAssertTimeout (%v) + JobEnvelopeMargin (%v) = %v",
+				v.Timeout, defaults.ChainsawAssertTimeout, defaults.JobEnvelopeMargin, required)
+		}
+	}
+	if !found {
+		t.Fatal("expected-resources validator missing from catalog — invariant cannot be verified")
+	}
+}
+
 func TestLoadEmbeddedCatalog(t *testing.T) {
 	catalog, err := LoadWithDataProvider(context.Background(), nil, "", "")
 	if err != nil {

--- a/recipes/checks/nfd/health-check.yaml
+++ b/recipes/checks/nfd/health-check.yaml
@@ -17,8 +17,17 @@
 # Validates the standalone NFD deployment by checking:
 # 1. NFD Master Deployment has at least one ready replica
 # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
-#    and numberUnavailable == 0, so partial failures don't pass)
+#    and numberReady == desiredNumberScheduled, so partial failures don't pass)
 # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+#
+# Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+# chart under release name "nfd" (matching the ComponentRef Name in
+# recipes/registry.yaml). The chart's fullname template prefixes the
+# release name to the chart name when they don't overlap, yielding
+# "nfd-node-feature-discovery-*" for the master Deployment, worker
+# DaemonSet, and gc Deployment. If a deployer ever switches the release
+# name to "node-feature-discovery", these asserts need updating in
+# lockstep.
 # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
 #    Running with a known-unhealthy container waiting reason
 #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
@@ -38,7 +47,7 @@ spec:
               apiVersion: apps/v1
               kind: Deployment
               metadata:
-                name: node-feature-discovery-master
+                name: nfd-node-feature-discovery-master
                 namespace: node-feature-discovery
               status:
                 (availableReplicas > `0`): true
@@ -49,17 +58,19 @@ spec:
               apiVersion: apps/v1
               kind: DaemonSet
               metadata:
-                name: node-feature-discovery-worker
+                name: nfd-node-feature-discovery-worker
                 namespace: node-feature-discovery
               status:
                 # Guard against vacuous pass when 0 nodes match the
                 # DaemonSet: require at least one scheduled pod.
                 (desiredNumberScheduled > `0`): true
-                # Full rollout: 0 unavailable pods. Combined with the
-                # guard above, this is equivalent to "all scheduled pods
-                # are ready". Replaces the earlier `numberReady > 0`
-                # which passed on partial failures.
-                (numberUnavailable == `0`): true
+                # Full rollout: every scheduled pod is ready. Combined with
+                # the guard above, this rejects partial failures. We assert on
+                # numberReady (always present in DaemonSetStatus) rather than
+                # numberUnavailable, which is `omitempty` and disappears from
+                # the status when zero — making `numberUnavailable == 0`
+                # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                (numberReady == desiredNumberScheduled): true
     - name: validate-gc-deployment
       try:
         - assert:
@@ -67,7 +78,7 @@ spec:
               apiVersion: apps/v1
               kind: Deployment
               metadata:
-                name: node-feature-discovery-gc
+                name: nfd-node-feature-discovery-gc
                 namespace: node-feature-discovery
               status:
                 (availableReplicas > `0`): true

--- a/recipes/validators/README.md
+++ b/recipes/validators/README.md
@@ -38,7 +38,7 @@ Applied by `catalog.Load` (`pkg/validator/catalog/catalog.go`) in order:
 | Name | Description | Timeout |
 |------|-------------|---------|
 | `operator-health` | Verify GPU operator pods are running and healthy | 2m |
-| `expected-resources` | Verify expected Kubernetes resources exist and are healthy | 5m |
+| `expected-resources` | Verify expected Kubernetes resources exist and are healthy (runs ExpectedResources + Chainsaw assert paths side-by-side) | 8m |
 | `gpu-operator-version` | Validate GPU Operator version against recipe constraints | 2m |
 | `check-nvidia-smi` | Verify nvidia-smi works on all GPU nodes | 10m |
 

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -38,7 +38,17 @@ validators:
     phase: deployment
     description: "Verify expected Kubernetes resources exist and are healthy"
     image: ghcr.io/nvidia/aicr-validators/deployment:latest
-    timeout: 5m
+    # Must be strictly > defaults.ChainsawAssertTimeout (6m) +
+    # defaults.JobEnvelopeMargin (60s) so chainsaw has headroom to
+    # terminate, clean up its temp dir, and flush log output before the
+    # Job's SIGKILL AND so pre-chainsaw work (helper.VerifyResource
+    # iteration) can't starve the chainsaw budget. 8m provides 60s for
+    # cleanup plus another 60s for pre-chainsaw work. The invariant is
+    # verified by TestExpectedResourcesCatalogEnvelope in
+    # pkg/validator/catalog — raising ChainsawAssertTimeout without
+    # raising this in tandem will fail the test. See issue #1220 and
+    # PR #1235 review.
+    timeout: 8m
     args: ["expected-resources"]
     env: []
   - name: gpu-operator-version

--- a/validators/chainsaw/allowlist.go
+++ b/validators/chainsaw/allowlist.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsaw
+
+import (
+	"bytes"
+	stderrors "errors"
+	"fmt"
+	"io"
+
+	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
+	yamlv3 "gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// ValidateTestReadOnly parses chainsaw Test YAML content (possibly
+// multi-document) and rejects any operation other than `assert` or
+// `error`. Used at runtime to bound the blast radius of registry-declared
+// health checks: the deployment validator Job runs under a ServiceAccount
+// bound to cluster-admin (pkg/validator/job/rbac.go:41-67), so registry
+// content must not be able to invoke state-changing chainsaw operations
+// (apply, create, delete, patch, update) or side-effecting collectors
+// (script, command, wait, sleep, podLogs, events, describe, get, proxy).
+//
+// Multi-document support: a single `---`-separated stream may carry more
+// than one Test; each is unmarshaled and validated independently. Empty
+// documents and non-Test documents (different apiVersion/kind) are
+// skipped. Per PR #1235 review.
+//
+// Both per-step (`spec.steps[].try/catch/finally/cleanup`) and top-level
+// (`spec.catch`) operation lists are validated.
+//
+// Caller contract: invoke only on content that IsChainsawTest reports as
+// Test format. Raw K8s YAML asserts have no operations and are
+// unaffected.
+//
+// Returns ErrCodeInvalidRequest naming the offending document index +
+// step + operation so the operator can pinpoint the registry entry that
+// violated the allowlist. PR #1223 will surface the same rule at lint
+// time so violations are caught before they ever reach the validator.
+func ValidateTestReadOnly(component, yamlContent string) error {
+	dec := yamlv3.NewDecoder(bytes.NewReader([]byte(yamlContent)))
+	for docIdx := 0; ; docIdx++ {
+		var node yamlv3.Node
+		err := dec.Decode(&node)
+		if stderrors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to parse chainsaw Test YAML for component %q (document %d)", component, docIdx), err)
+		}
+		// Re-marshal this single document and run through sigs.k8s.io/yaml
+		// so the Test struct gets the JSON-tag-aware unmarshal path (the
+		// chainsaw types are tagged with json, not yaml).
+		buf, err := yamlv3.Marshal(&node)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to re-marshal chainsaw Test document for component %q (document %d)", component, docIdx), err)
+		}
+		var test v1alpha1.Test
+		if err := yaml.Unmarshal(buf, &test); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to decode chainsaw Test YAML for component %q (document %d)", component, docIdx), err)
+		}
+		if err := validateTest(component, docIdx, &test); err != nil {
+			return err
+		}
+	}
+}
+
+// validateTest walks both the top-level Spec.Catch list and the
+// per-step Try/Catch/Finally/Cleanup lists, rejecting any operation
+// outside the read-only allowlist.
+func validateTest(component string, docIdx int, test *v1alpha1.Test) error {
+	docLabel := fmt.Sprintf("doc[%d]", docIdx)
+
+	// Top-level spec.catch (sibling of spec.steps, not nested under a
+	// step). Independent of any step's lifecycle and would otherwise
+	// slip past a steps-only walker. EVERY entry is rejected because
+	// CatchFinally has no read-only variant. Per PR #1235 review.
+	for opIdx, cf := range test.Spec.Catch {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("component %q %s spec.catch[%d]: operation %q is not in the read-only allowlist (assert, error)",
+				component, docLabel, opIdx, catchFinallyOpName(cf)))
+	}
+
+	for stepIdx, step := range test.Spec.Steps {
+		stepLabel := step.Name
+		if stepLabel == "" {
+			stepLabel = fmt.Sprintf("step[%d]", stepIdx)
+		}
+		for opIdx, op := range step.Try {
+			if name, ok := disallowedOperation(op); ok {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("component %q %s step %q try[%d]: operation %q is not in the read-only allowlist (assert, error)",
+						component, docLabel, stepLabel, opIdx, name))
+			}
+		}
+		// catch / finally / cleanup blocks are rejected unconditionally
+		// — CatchFinally carries no read-only variant.
+		for opIdx, cf := range step.Catch {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("component %q %s step %q catch[%d]: operation %q is not in the read-only allowlist (assert, error)",
+					component, docLabel, stepLabel, opIdx, catchFinallyOpName(cf)))
+		}
+		for opIdx, cf := range step.Finally {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("component %q %s step %q finally[%d]: operation %q is not in the read-only allowlist (assert, error)",
+					component, docLabel, stepLabel, opIdx, catchFinallyOpName(cf)))
+		}
+		for opIdx, cf := range step.Cleanup {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("component %q %s step %q cleanup[%d]: operation %q is not in the read-only allowlist (assert, error)",
+					component, docLabel, stepLabel, opIdx, catchFinallyOpName(cf)))
+		}
+	}
+	return nil
+}
+
+// disallowedOperation enforces a TRUE allowlist on op: an Operation is
+// valid IFF Assert is set OR Error is set, and nothing else. Per PR #1235
+// review (yuanchen8911), the previous denylist shape was unsafe — chainsaw
+// v0.2.15 added a `proxy` op that issues HTTP requests through the
+// API-server proxy subresource (side-effecting under the validator Job's
+// cluster-admin binding), and the denylist let it through by default.
+// Inverting to allowlist semantics fails closed on every future chainsaw
+// op upstream adds, until a maintainer explicitly audits and permits it.
+//
+// The known-bad switch below produces actionable diagnostics for the
+// current 14 disallowed ops; anything not in either set is reported as
+// "<unrecognized>" and rejected too.
+func disallowedOperation(op v1alpha1.Operation) (string, bool) {
+	switch {
+	case op.Apply != nil:
+		return "apply", true
+	case op.Command != nil:
+		return "command", true
+	case op.Create != nil:
+		return "create", true
+	case op.Delete != nil:
+		return "delete", true
+	case op.Describe != nil:
+		return "describe", true
+	case op.Events != nil:
+		return "events", true
+	case op.Get != nil:
+		return "get", true
+	case op.Patch != nil:
+		return "patch", true
+	case op.PodLogs != nil:
+		return "podLogs", true
+	case op.Proxy != nil:
+		return "proxy", true
+	case op.Script != nil:
+		return "script", true
+	case op.Sleep != nil:
+		return "sleep", true
+	case op.Update != nil:
+		return "update", true
+	case op.Wait != nil:
+		return "wait", true
+	}
+	// True allowlist: anything that isn't Assert or Error is rejected,
+	// including future chainsaw ops not yet enumerated above.
+	if op.Assert == nil && op.Error == nil {
+		return "<unrecognized>", true
+	}
+	return "", false
+}
+
+// catchFinallyOpName returns a diagnostic name for the operation set on
+// a CatchFinally entry. CatchFinally has no Assert or Error variant;
+// every operation it can carry (command, delete, describe, events, get,
+// podLogs, script, sleep, wait) is either state-changing or
+// side-effecting, and is outside the read-only assertion surface. So
+// EVERY non-empty CatchFinally is rejected unconditionally by the
+// caller — this helper exists only to name the offender for diagnostic
+// clarity. Per PR #1235 review (yuanchen8911): inverted from the prior
+// boolean-returning denylist shape so future chainsaw additions to
+// CatchFinally fail closed without needing to update this function.
+func catchFinallyOpName(cf v1alpha1.CatchFinally) string {
+	switch {
+	case cf.Command != nil:
+		return "command"
+	case cf.Delete != nil:
+		return "delete"
+	case cf.Describe != nil:
+		return "describe"
+	case cf.Events != nil:
+		return "events"
+	case cf.Get != nil:
+		return "get"
+	case cf.PodLogs != nil:
+		return "podLogs"
+	case cf.Script != nil:
+		return "script"
+	case cf.Sleep != nil:
+		return "sleep"
+	case cf.Wait != nil:
+		return "wait"
+	}
+	// No known op set, but a non-empty catch/finally/cleanup entry is
+	// still outside the read-only contract — name it generically so the
+	// caller's unconditional rejection has a sensible diagnostic.
+	return "<catch-finally-block>"
+}

--- a/validators/chainsaw/allowlist_test.go
+++ b/validators/chainsaw/allowlist_test.go
@@ -1,0 +1,376 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsaw
+
+import (
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestValidateTestReadOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantErr     bool
+		wantContain string // substring of error message
+	}{
+		{
+			name: "assert-only passes",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ok
+spec:
+  steps:
+    - try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: foo
+`,
+			wantErr: false,
+		},
+		{
+			name: "error-only passes",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ok
+spec:
+  steps:
+    - try:
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                phase: Failed
+`,
+			wantErr: false,
+		},
+		{
+			name: "assert + error mix passes",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ok
+spec:
+  steps:
+    - try:
+        - assert:
+            resource: {apiVersion: v1, kind: Pod, metadata: {name: foo}}
+        - error:
+            resource: {apiVersion: v1, kind: Pod, metadata: {phase: Failed}}
+`,
+			wantErr: false,
+		},
+		{
+			name: "script rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - name: pwn
+      try:
+        - script:
+            content: "rm -rf /"
+`,
+			wantErr:     true,
+			wantContain: `"script"`,
+		},
+		{
+			name: "apply rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - try:
+        - apply:
+            file: foo.yaml
+`,
+			wantErr:     true,
+			wantContain: `"apply"`,
+		},
+		{
+			name: "delete rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - try:
+        - delete:
+            ref: {apiVersion: v1, kind: Pod, name: foo}
+`,
+			wantErr:     true,
+			wantContain: `"delete"`,
+		},
+		{
+			name: "proxy rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - try:
+        - proxy:
+            apiVersion: v1
+            kind: Pod
+            name: foo
+            namespace: kube-system
+            targetPath: /healthz
+`,
+			wantErr:     true,
+			wantContain: `"proxy"`,
+		},
+		{
+			name: "wait rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - try:
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            for:
+              condition:
+                name: Ready
+`,
+			wantErr:     true,
+			wantContain: `"wait"`,
+		},
+		{
+			name: "top-level spec.catch rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  catch:
+    - delete:
+        ref: {apiVersion: v1, kind: Pod, name: foo}
+  steps:
+    - try:
+        - assert:
+            resource: {apiVersion: v1, kind: Pod, metadata: {name: foo}}
+`,
+			wantErr:     true,
+			wantContain: `spec.catch[0]`,
+		},
+		{
+			name: "second document in multi-doc YAML is rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ok-first
+spec:
+  steps:
+    - try:
+        - assert:
+            resource: {apiVersion: v1, kind: Pod, metadata: {name: foo}}
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad-second
+spec:
+  steps:
+    - try:
+        - script:
+            content: "rm -rf /"
+`,
+			wantErr:     true,
+			wantContain: `doc[1]`,
+		},
+		{
+			name: "catch with only metadata still rejected (fail-closed)",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - try:
+        - assert:
+            resource: {apiVersion: v1, kind: Pod, metadata: {name: foo}}
+      catch:
+        - description: "diagnostic block with no op"
+`,
+			wantErr:     true,
+			wantContain: `<catch-finally-block>`,
+		},
+		{
+			name: "catch block rejected",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad
+spec:
+  steps:
+    - try:
+        - assert:
+            resource: {apiVersion: v1, kind: Pod, metadata: {name: foo}}
+      catch:
+        - podLogs:
+            namespace: kube-system
+`,
+			wantErr:     true,
+			wantContain: `"podLogs"`,
+		},
+		{
+			name: "malformed YAML returns ErrCodeInvalidRequest",
+			yaml: `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+spec:
+  steps:
+    - try: [not-a-mapping]
+`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTestReadOnly("test-component", tt.yaml)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				var se *errors.StructuredError
+				if !stderrors.As(err, &se) {
+					t.Fatalf("expected StructuredError, got %T", err)
+				}
+				if se.Code != errors.ErrCodeInvalidRequest {
+					t.Fatalf("Code = %v, want ErrCodeInvalidRequest", se.Code)
+				}
+				if tt.wantContain != "" && !strings.Contains(se.Error(), tt.wantContain) {
+					t.Fatalf("error %q missing substring %q", se.Error(), tt.wantContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+		})
+	}
+}
+
+// TestDisallowedOperation_AllowlistFailsClosed verifies the true-allowlist
+// shape: an Operation with neither Assert nor Error set is rejected even
+// when none of the currently-enumerated known-bad ops are set either. This
+// is the future-proofing guarantee — a future chainsaw op upstream adds
+// won't slip through this code path silently. Per PR #1235 review.
+func TestDisallowedOperation_AllowlistFailsClosed(t *testing.T) {
+	// All-zero Operation: nothing set. The allowlist must still reject
+	// (Assert == nil && Error == nil falls through to "<unrecognized>").
+	var empty v1alpha1.Operation
+	name, bad := disallowedOperation(empty)
+	if !bad {
+		t.Fatalf("disallowedOperation should reject empty Operation; got allowed")
+	}
+	if name != "<unrecognized>" {
+		t.Fatalf("expected name '<unrecognized>', got %q", name)
+	}
+
+	// An Operation with only Assert is allowed.
+	withAssert := v1alpha1.Operation{Assert: &v1alpha1.Assert{}}
+	if _, bad := disallowedOperation(withAssert); bad {
+		t.Fatal("Operation with Assert set must be allowed")
+	}
+
+	// An Operation with only Error is allowed.
+	withError := v1alpha1.Operation{Error: &v1alpha1.Error{}}
+	if _, bad := disallowedOperation(withError); bad {
+		t.Fatal("Operation with Error set must be allowed")
+	}
+}
+
+// TestValidateTestReadOnly_RegistryContent walks every in-tree
+// healthCheck.assertFile under recipes/checks/*/health-check.yaml and
+// verifies it passes the allowlist. If this regresses, a registry-declared
+// check has crept in that violates the read-only contract — block at PR
+// time (PR #1223 will add the same check at lint time, with structured
+// reporting that names every offender, not just the first).
+func TestValidateTestReadOnly_RegistryContent(t *testing.T) {
+	// Walk repo-relative recipes/checks. The test runs from the package
+	// directory (validators/chainsaw), so walk up two levels to the repo
+	// root. If the path changes, the t.Fatalf below makes the cause
+	// obvious instead of letting the test silently pass.
+	root := filepath.Join("..", "..", "recipes", "checks")
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("recipes/checks not found at %s: %v", root, err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read recipes/checks: %v", err)
+	}
+	checked := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, e.Name(), "health-check.yaml")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			// Component dir without a health-check.yaml is allowed (e.g.,
+			// the 3 backfill components #1221 will add).
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !IsChainsawTest(string(data)) {
+			// The allowlist only applies to Chainsaw Test format.
+			continue
+		}
+		if err := ValidateTestReadOnly(e.Name(), string(data)); err != nil {
+			t.Errorf("%s violates read-only allowlist: %v", path, err)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no health checks were validated — registry walker is broken")
+	}
+}

--- a/validators/chainsaw/binary.go
+++ b/validators/chainsaw/binary.go
@@ -20,20 +20,19 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 // canonicalChainsawPath is the install location the deployment validator
-// image will use once the chainsaw binary ships (see issue #1220). Probed
-// as a fallback when exec.LookPath misses, e.g., when the image places
-// chainsaw at a known absolute path but does not extend PATH.
+// image ships chainsaw at (see issue #1220 / Dockerfile multi-stage
+// COPY). Used as a fallback when exec.LookPath misses — e.g., an
+// environment where /usr/local/bin is not on PATH but the binary is in
+// fact present at that absolute path.
 //
-// Mutable (var, not const) so tests can swap it for a TempDir entry — the
-// real /usr/local/bin/chainsaw may exist on developer machines, which
-// would otherwise make Available()==false assertions flake.
+// Mutable (var, not const) so tests can substitute a TempDir-resolved
+// path for the canonical one when needed.
 var canonicalChainsawPath = "/usr/local/bin/chainsaw"
 
 // ChainsawBinary abstracts chainsaw CLI invocation for testability.
@@ -41,62 +40,29 @@ type ChainsawBinary interface {
 	// RunTest executes chainsaw test against the given test directory.
 	// Returns whether all tests passed, the combined output, and any execution error.
 	RunTest(ctx context.Context, testDir string) (passed bool, output string, err error)
-	// Available reports whether the chainsaw binary is callable from this
-	// process. Used by the deployment validator to skip Chainsaw Test-format
-	// dispatch when the binary is absent (e.g., the validator image has not
-	// shipped chainsaw yet), preserving today's no-op behavior while
-	// registry-declared HealthCheckAsserts content hydrates upstream in
-	// pkg/recipe.
-	Available() bool
 }
 
 type chainsawBinary struct {
-	binPath   string
-	available bool
+	binPath string
 }
 
 // NewChainsawBinary creates a ChainsawBinary that invokes the chainsaw CLI.
-// It resolves the binary path from PATH first, then probes the canonical
-// install path (/usr/local/bin/chainsaw) for an executable file. The
-// rationale for the fallback probe: a container image may place chainsaw
-// at a known absolute path without extending PATH, in which case
-// exec.LookPath misses but the file is still callable directly. Without
-// the probe, Available() would report false while RunTest could in fact
-// succeed — an inconsistency flagged in PR #1231 review.
+// Resolves the binary path from PATH first, then falls back to the
+// canonical install path shipped in the deployment validator image
+// (#1220). If neither yields an executable, the constructor still
+// returns a binary pointing at the canonical path so a subsequent
+// RunTest invocation surfaces a clean "no such file or directory" — an
+// image regression that must fail loudly rather than silently no-op.
 //
-// Availability is recorded at construction time so callers can branch on
-// it without repeating the discovery.
+// The Available()-gated skip path that briefly existed in PR #1231 was
+// removed when #1220 made the chainsaw binary a hard requirement of the
+// deployment validator image.
 func NewChainsawBinary() ChainsawBinary {
 	if binPath, err := exec.LookPath("chainsaw"); err == nil {
-		return &chainsawBinary{binPath: binPath, available: true}
+		return &chainsawBinary{binPath: binPath}
 	}
-	if isExecutableFile(canonicalChainsawPath) {
-		return &chainsawBinary{binPath: canonicalChainsawPath, available: true}
-	}
-	// Fall through with the canonical install path so the eventual
-	// RunTest error names a real, expected location; Available() reports
-	// false so the deployment validator can short-circuit Test-format
-	// dispatch upstream.
-	return &chainsawBinary{binPath: canonicalChainsawPath, available: false}
+	return &chainsawBinary{binPath: canonicalChainsawPath}
 }
-
-// isExecutableFile reports whether path resolves to a regular file with
-// at least one execute bit set. Used by NewChainsawBinary's fallback
-// probe; symlinks resolve via os.Stat. Errors (ENOENT, EACCES) are
-// treated as "not executable" — the probe is best-effort and the
-// caller's downstream RunTest will surface any deeper issue.
-func isExecutableFile(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if !info.Mode().IsRegular() {
-		return false
-	}
-	return info.Mode().Perm()&0o111 != 0
-}
-
-func (b *chainsawBinary) Available() bool { return b.available }
 
 func (b *chainsawBinary) RunTest(ctx context.Context, testDir string) (bool, string, error) {
 	slog.Debug("executing chainsaw binary", "binPath", b.binPath, "testDir", testDir)

--- a/validators/chainsaw/binary_test.go
+++ b/validators/chainsaw/binary_test.go
@@ -20,113 +20,58 @@ import (
 	"testing"
 )
 
-// TestNewChainsawBinary_Available exercises every branch of the
-// availability probe in NewChainsawBinary by manipulating PATH and the
-// canonical fallback path so the binary is found / not found. The
-// fallback-path branch was added in PR #1231 review (yuanchen8911):
-// previously NewChainsawBinary reported Available()==false even when
-// /usr/local/bin/chainsaw existed and was callable.
+// TestNewChainsawBinary covers the two discovery branches:
+//   - exec.LookPath hit  → use the PATH-resolved path
+//   - exec.LookPath miss → fall back to the canonical install path
 //
-// canonicalChainsawPath is swapped to a TempDir entry per subtest so
-// the real /usr/local/bin/chainsaw on developer machines doesn't make
-// the unavailable assertions flake.
-func TestNewChainsawBinary_Available(t *testing.T) {
-	withCanonicalPath := func(t *testing.T, p string) {
-		orig := canonicalChainsawPath
-		canonicalChainsawPath = p
-		t.Cleanup(func() { canonicalChainsawPath = orig })
-	}
-
-	t.Run("unavailable when missing from PATH and fallback path", func(t *testing.T) {
-		t.Setenv("PATH", t.TempDir())
-		withCanonicalPath(t, filepath.Join(t.TempDir(), "chainsaw"))
-		bin := NewChainsawBinary()
-		if bin.Available() {
-			t.Fatal("Available() = true, want false when chainsaw is on neither PATH nor fallback")
-		}
-	})
-
-	t.Run("available when discoverable on PATH", func(t *testing.T) {
-		dir := t.TempDir()
-		stub := filepath.Join(dir, "chainsaw")
-		// 0o755: an exec.LookPath-discoverable executable is the whole
-		// point of this fixture.
-		if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // test fixture
-			t.Fatalf("write stub: %v", err)
-		}
-		t.Setenv("PATH", dir)
-		withCanonicalPath(t, filepath.Join(t.TempDir(), "chainsaw"))
-		bin := NewChainsawBinary()
-		if !bin.Available() {
-			t.Fatal("Available() = false, want true when chainsaw is on PATH")
-		}
-	})
-
-	t.Run("available via fallback path when PATH misses", func(t *testing.T) {
-		// PATH dir has no chainsaw, but the canonical fallback does.
-		t.Setenv("PATH", t.TempDir())
-		fallbackDir := t.TempDir()
-		fallback := filepath.Join(fallbackDir, "chainsaw")
-		if err := os.WriteFile(fallback, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // test fixture
-			t.Fatalf("write fallback: %v", err)
-		}
-		withCanonicalPath(t, fallback)
-		bin := NewChainsawBinary()
-		if !bin.Available() {
-			t.Fatal("Available() = false, want true when fallback path is executable")
-		}
-	})
-}
-
-// TestIsExecutableFile covers the fallback probe used by NewChainsawBinary
-// when PATH lookup misses.
-func TestIsExecutableFile(t *testing.T) {
+// canonicalChainsawPath is patched per case so a developer machine with a
+// real /usr/local/bin/chainsaw can't influence the miss branch.
+func TestNewChainsawBinary(t *testing.T) {
 	tests := []struct {
-		name  string
-		setup func(t *testing.T) string
-		want  bool
+		name string
+		// createStub controls whether an executable stub is placed in the
+		// PATH dir for this case. true → simulates "chainsaw on PATH";
+		// false → simulates "chainsaw missing from PATH".
+		createStub bool
+		// wantBinPath is a function so the assertion can refer to the
+		// case-local TempDir paths that aren't known until t.Run runs.
+		wantBinPath func(pathDir, canonical string) string
 	}{
 		{
-			name: "executable regular file",
-			setup: func(t *testing.T) string {
-				p := filepath.Join(t.TempDir(), "chainsaw")
-				if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture
-					t.Fatalf("write: %v", err)
-				}
-				return p
+			name:       "PATH hit uses the resolved path",
+			createStub: true,
+			wantBinPath: func(pathDir, _ string) string {
+				return filepath.Join(pathDir, "chainsaw")
 			},
-			want: true,
 		},
 		{
-			name: "regular file without exec bit",
-			setup: func(t *testing.T) string {
-				p := filepath.Join(t.TempDir(), "chainsaw")
-				if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o644); err != nil {
-					t.Fatalf("write: %v", err)
-				}
-				return p
+			name:       "PATH miss falls back to canonical path string",
+			createStub: false,
+			wantBinPath: func(_, canonical string) string {
+				return canonical
 			},
-			want: false,
-		},
-		{
-			name: "missing path",
-			setup: func(t *testing.T) string {
-				return filepath.Join(t.TempDir(), "does-not-exist")
-			},
-			want: false,
-		},
-		{
-			name: "directory (not a regular file)",
-			setup: func(t *testing.T) string {
-				return t.TempDir()
-			},
-			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isExecutableFile(tt.setup(t)); got != tt.want {
-				t.Fatalf("isExecutableFile = %v, want %v", got, tt.want)
+			pathDir := t.TempDir()
+			if tt.createStub {
+				stub := filepath.Join(pathDir, "chainsaw")
+				if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // test fixture
+					t.Fatalf("write stub: %v", err)
+				}
+			}
+			t.Setenv("PATH", pathDir)
+
+			fakeCanonical := filepath.Join(t.TempDir(), "chainsaw")
+			origCanonical := canonicalChainsawPath
+			canonicalChainsawPath = fakeCanonical
+			t.Cleanup(func() { canonicalChainsawPath = origCanonical })
+
+			bin := NewChainsawBinary().(*chainsawBinary)
+			want := tt.wantBinPath(pathDir, fakeCanonical)
+			if bin.binPath != want {
+				t.Errorf("binPath = %q, want %q", bin.binPath, want)
 			}
 		})
 	}

--- a/validators/chainsaw/runner.go
+++ b/validators/chainsaw/runner.go
@@ -125,8 +125,13 @@ func IsChainsawTest(raw string) bool {
 
 // assertComponent runs assertions for a single component.
 // Chainsaw Test format is dispatched to the binary; raw K8s YAML uses the Go library.
+// Test-format content is checked against the read-only operation allowlist
+// (assert, error) before dispatch — see ValidateTestReadOnly.
 func assertComponent(ctx context.Context, ca ComponentAssert, timeout time.Duration, fetcher ResourceFetcher, cfg *runConfig) Result {
 	if IsChainsawTest(ca.AssertYAML) {
+		if err := ValidateTestReadOnly(ca.Name, ca.AssertYAML); err != nil {
+			return Result{Component: ca.Name, Error: err}
+		}
 		return runChainsawBinary(ctx, ca.Name, ca.AssertYAML, timeout, cfg)
 	}
 	return assertRawResources(ctx, ca, timeout, fetcher)

--- a/validators/deployment/Dockerfile
+++ b/validators/deployment/Dockerfile
@@ -13,6 +13,55 @@
 # limitations under the License.
 
 ARG GO_VERSION=1.26.3
+
+# chainsaw-fetch downloads, checksums, and extracts the pinned chainsaw
+# binary. Version + per-arch checksums come from .settings.yaml via the
+# Makefile (build args below); a mismatch fails the build. The
+# kyverno/chainsaw Go library in go.mod is bumped in lockstep — both the
+# raw-K8s-YAML library path and Chainsaw Test binary path dispatch in
+# validators/chainsaw/runner.go must stay aligned. See issue #1220.
+#
+# Multi-arch: TARGETARCH is populated automatically by BuildKit
+# (Docker default since ~2023). The stage picks the matching tarball
+# URL and checksum at build time, so `docker buildx build --platform
+# linux/arm64` and native arm64 host builds both produce a correct
+# image. Plain non-BuildKit builds without TARGETARCH set will fail
+# loudly rather than silently shipping the wrong-arch binary — set
+# DOCKER_BUILDKIT=1 or pass --build-arg TARGETARCH=<arch>. Per PR
+# #1235 review.
+FROM debian:bookworm-slim AS chainsaw-fetch
+ARG TARGETARCH
+ARG CHAINSAW_VERSION
+ARG CHAINSAW_SHA256_LINUX_AMD64
+ARG CHAINSAW_SHA256_LINUX_ARM64
+# Reject empty / "null" build args. mikefarah/yq -r emits "null" for a
+# missing key, so explicit equality with "null" is required.
+RUN if [ -z "${TARGETARCH}" ]; then \
+      echo "TARGETARCH must be set (BuildKit auto-populates; for legacy docker build, pass --build-arg TARGETARCH=<amd64|arm64>)"; exit 1; \
+    fi && \
+    if [ -z "${CHAINSAW_VERSION}" ] || [ "${CHAINSAW_VERSION}" = "null" ]; then \
+      echo "CHAINSAW_VERSION must be set to a non-null value (Makefile injects from .settings.yaml)"; exit 1; \
+    fi
+# Pick the per-arch checksum at build time. Each branch validates its
+# own arg is non-empty / non-null so a missing .settings.yaml key fails
+# with an actionable, arch-named error.
+RUN case "${TARGETARCH}" in \
+      amd64) SHA="${CHAINSAW_SHA256_LINUX_AMD64}" ;; \
+      arm64) SHA="${CHAINSAW_SHA256_LINUX_ARM64}" ;; \
+      *) echo "Unsupported TARGETARCH=${TARGETARCH} (supported: amd64, arm64)"; exit 1 ;; \
+    esac && \
+    if [ -z "${SHA}" ] || [ "${SHA}" = "null" ]; then \
+      echo "CHAINSAW_SHA256_LINUX_${TARGETARCH} must be set to a non-null value (Makefile injects from .settings.yaml.testing_tools.chainsaw_checksums.linux_${TARGETARCH})"; exit 1; \
+    fi && \
+    echo "${SHA}" > /tmp/chainsaw.sha256
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+WORKDIR /work
+RUN curl -fsSL -o chainsaw.tar.gz \
+        "https://github.com/kyverno/chainsaw/releases/download/${CHAINSAW_VERSION}/chainsaw_linux_${TARGETARCH}.tar.gz" && \
+    echo "$(cat /tmp/chainsaw.sha256)  chainsaw.tar.gz" | sha256sum -c - && \
+    tar -xzf chainsaw.tar.gz chainsaw && \
+    chmod 0755 chainsaw
+
 FROM golang:${GO_VERSION}-bookworm AS builder
 
 WORKDIR /src
@@ -28,6 +77,9 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /out/deployment /deployment
 COPY --from=builder /src/validators/deployment/testdata /app/testdata
+# chainsaw lands at /usr/local/bin so validators/chainsaw/binary.go's
+# exec.LookPath probe finds it (PATH includes /usr/local/bin in distroless).
+COPY --from=chainsaw-fetch /work/chainsaw /usr/local/bin/chainsaw
 
 WORKDIR /app
 USER nonroot

--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -78,78 +79,109 @@ func checkExpectedResources(ctx *validators.Context) error {
 
 	var chainsawAsserts []chainsaw.ComponentAssert
 	var failures []string
+	// firstStructuredErr captures the first structured error surfaced by
+	// chainsaw.Run results (e.g., ErrCodeInvalidRequest from
+	// ValidateTestReadOnly when a registry assert violates the read-only
+	// allowlist). Without this, the function would flatten such errors
+	// into the generic ErrCodeNotFound "expected resource check failed"
+	// summary at the bottom, losing the actionable classification. Per
+	// PR #1235 review.
+	var firstStructuredErr error
 	enabledRefs := enabledComponentRefs(ctx.ValidationInput.ComponentRefs)
 
 	failures = append(failures, verifyNamespacesActive(ctx, enabledRefs)...)
 
+	// When both ExpectedResources and HealthCheckAsserts are populated on
+	// the same ref, both paths execute. ExpectedResources is verified
+	// here via helper.VerifyResource; HealthCheckAsserts is queued for
+	// the chainsaw runner below. Output is source-tagged
+	// [expectedResources] / [chainsaw] so operators can disambiguate
+	// when both report on the same component. The previous
+	// mutual-exclusion gate (`len(ExpectedResources) == 0`) was dropped
+	// in #1220: the registry-declared assertFile is the deeper
+	// readiness signal and should always run alongside the overlay-
+	// declared resource list. The transitional hydration skip in
+	// pkg/recipe (added in #1234) was reverted in lockstep.
 	for _, ref := range enabledRefs {
-		if ref.HealthCheckAsserts != "" && len(ref.ExpectedResources) == 0 {
+		// Honor cancellation between components so a canceled run stops
+		// before issuing more API calls — per repo CLAUDE.md "Always
+		// check ctx.Done() in long-running operations and loops".
+		select {
+		case <-ctx.Ctx.Done():
+			return errors.Wrap(errors.ErrCodeTimeout,
+				"deployment validation canceled during expected-resources iteration",
+				ctx.Ctx.Err())
+		default:
+		}
+		if ref.HealthCheckAsserts != "" {
 			chainsawAsserts = append(chainsawAsserts, chainsaw.ComponentAssert{
 				Name:       ref.Name,
 				AssertYAML: ref.HealthCheckAsserts,
 			})
-			continue
 		}
-
 		for _, er := range ref.ExpectedResources {
 			if err := helper.VerifyResource(ctx.Ctx, ctx.Clientset, er); err != nil {
-				failures = append(failures, fmt.Sprintf("%s %s/%s (%s): %s",
+				failures = append(failures, fmt.Sprintf("[expectedResources] %s %s/%s (%s): %s",
 					er.Kind, er.Namespace, er.Name, ref.Name, err.Error()))
 			} else {
-				fmt.Printf("  %s %s/%s: healthy\n", er.Kind, er.Namespace, er.Name)
+				fmt.Printf("  [expectedResources] %s %s/%s: healthy\n", er.Kind, er.Namespace, er.Name)
 			}
 		}
 	}
 
-	failures = append(failures, verifyGPUReadinessSignals(ctx, enabledRefs)...)
+	gpuFailures, gpuStructuredErr := verifyGPUReadinessSignals(ctx, enabledRefs)
+	failures = append(failures, gpuFailures...)
+	// firstStructuredErr is guaranteed nil here (the chainsaw block
+	// below is the only other producer and hasn't run yet); we can
+	// assign unconditionally. The chainsaw block downstream checks
+	// firstStructuredErr == nil before its own assignment so the GPU
+	// error wins when both produce one.
+	if gpuStructuredErr != nil {
+		firstStructuredErr = gpuStructuredErr
+	}
 
 	if len(chainsawAsserts) > 0 {
-		// Partition asserts by dispatch path so the chainsaw-binary gate
-		// blocks only the Test-format subset. Raw K8s YAML asserts use the
-		// chainsaw Go library (assertRawResources) and need no external
-		// binary — they must run regardless of binary availability.
-		// Per-assert partitioning was flagged in PR #1231 review: the
-		// previous batch-level gate over-blocked raw-YAML asserts. All
-		// registry checks today happen to be Test-format, but the contract
-		// must be content-aware so this gate doesn't silently skip future
-		// raw-YAML checks once the deployment image ships chainsaw
-		// (#1220).
-		bin := chainsaw.NewChainsawBinary()
-		runnable := make([]chainsaw.ComponentAssert, 0, len(chainsawAsserts))
-		var skippedTestFormat []string
-		for _, ca := range chainsawAsserts {
-			if chainsaw.IsChainsawTest(ca.AssertYAML) && !bin.Available() {
-				skippedTestFormat = append(skippedTestFormat, ca.Name)
-				continue
-			}
-			runnable = append(runnable, ca)
+		// Bail out before paying chainsaw startup cost if the caller
+		// already canceled. chainsaw.Run honors ctx mid-flight too,
+		// but a short-circuit here skips fetcher construction and
+		// log noise on a doomed run.
+		select {
+		case <-ctx.Ctx.Done():
+			return errors.Wrap(errors.ErrCodeTimeout,
+				"deployment validation canceled before chainsaw dispatch",
+				ctx.Ctx.Err())
+		default:
 		}
-		if len(skippedTestFormat) > 0 {
-			slog.Warn("chainsaw binary not available; skipping Chainsaw Test-format assertions",
-				"components", skippedTestFormat,
-				"hint", "ships in a later release; see https://github.com/NVIDIA/aicr/issues/1220")
+		slog.Info("running health check assertions", "components", len(chainsawAsserts))
+		fetcher, fetcherErr := buildResourceFetcher(ctx)
+		if fetcherErr != nil {
+			return fetcherErr
 		}
-		if len(runnable) > 0 {
-			slog.Info("running health check assertions", "components", len(runnable))
-			fetcher, fetcherErr := buildResourceFetcher(ctx)
-			if fetcherErr != nil {
-				return fetcherErr
-			}
-			results := chainsaw.Run(ctx.Ctx, runnable, defaults.ChainsawAssertTimeout, fetcher,
-				chainsaw.WithChainsawBinary(bin))
-			for _, r := range results {
-				if r.Passed {
-					fmt.Printf("  %s: chainsaw health check passed\n", r.Component)
-				} else {
-					msg := fmt.Sprintf("%s: chainsaw health check failed", r.Component)
-					if r.Output != "" {
-						msg += fmt.Sprintf(":\n%s", r.Output)
-					}
-					if r.Error != nil {
-						msg += fmt.Sprintf("\nerror: %v", r.Error)
-					}
-					failures = append(failures, msg)
+		results := chainsaw.Run(ctx.Ctx, chainsawAsserts, defaults.ChainsawAssertTimeout, fetcher,
+			chainsaw.WithChainsawBinary(chainsaw.NewChainsawBinary()))
+		for _, r := range results {
+			if r.Passed {
+				fmt.Printf("  [chainsaw] %s: health check passed\n", r.Component)
+			} else {
+				msg := fmt.Sprintf("[chainsaw] %s: health check failed", r.Component)
+				if r.Output != "" {
+					msg += fmt.Sprintf(":\n%s", r.Output)
 				}
+				if r.Error != nil {
+					msg += fmt.Sprintf("\nerror: %v", r.Error)
+					// Capture the first structured error so we can
+					// preserve its code (e.g., ErrCodeInvalidRequest)
+					// when returning to the catalog layer. Subsequent
+					// structured errors still surface in the human-
+					// readable failures list above.
+					if firstStructuredErr == nil {
+						var se *errors.StructuredError
+						if stderrors.As(r.Error, &se) {
+							firstStructuredErr = r.Error
+						}
+					}
+				}
+				failures = append(failures, msg)
 			}
 		}
 	}
@@ -158,6 +190,15 @@ func checkExpectedResources(ctx *validators.Context) error {
 		fmt.Println("Failed resources:")
 		for _, f := range failures {
 			fmt.Printf("  %s\n", f)
+		}
+		// Prefer the first structured error (e.g.,
+		// ErrCodeInvalidRequest from a registry assert that violated
+		// the read-only allowlist) over the generic ErrCodeNotFound
+		// summary so downstream catalog/CLI surfaces classify the
+		// failure correctly. The human-readable failures list is still
+		// printed above for operator visibility.
+		if firstStructuredErr != nil {
+			return firstStructuredErr
 		}
 		return errors.New(errors.ErrCodeNotFound,
 			fmt.Sprintf("expected resource check failed: %d issue(s):\n  %s",
@@ -206,28 +247,59 @@ func verifyNamespacesActive(ctx *validators.Context, refs []recipe.ComponentRef)
 	return failures
 }
 
-func verifyGPUReadinessSignals(ctx *validators.Context, refs []recipe.ComponentRef) []string {
+// verifyGPUReadinessSignals runs the three Go-resident deep checks
+// introduced by issue #611. Returns the human-readable failure strings
+// plus the first *errors.StructuredError encountered across all three
+// helpers so the caller can propagate the original error code (e.g.,
+// ErrCodeInternal from a discovery/RBAC failure) instead of flattening
+// it into the generic ErrCodeNotFound summary — per PR #1235 review.
+//
+// Migration disposition (per #1220 plan):
+//
+//   - clusterPolicyReady: candidate for migration to registry-declared
+//     Chainsaw YAML in recipes/checks/gpu-operator/health-check.yaml.
+//     Deferred to follow-up because the existing expected_resources_test.go
+//     suite mocks ClusterPolicy state extensively, and the migration must
+//     prove assertion equivalence rather than just code equivalence.
+//   - verifyNodewrightReady (formerly skyhookReady): stays in Go. Names
+//     are derived from the recipe's own ManifestFiles at validate-time
+//     (see expectedNodewrightNames), not from a stable label, so static
+//     Chainsaw YAML cannot express the dynamic-name selector.
+//   - verifyDRAKubeletPluginReady: stays in Go. The chart's full DaemonSet
+//     name is release-derived; expressing the same check in Chainsaw
+//     requires a chart-shape label upstream nvidia-dra-driver-gpu does
+//     not currently apply. Encoding a release-derived full name would
+//     violate the deployer-neutrality constraint (no
+//     app.kubernetes.io/instance dependence — see #660 issue body).
+func verifyGPUReadinessSignals(ctx *validators.Context, refs []recipe.ComponentRef) ([]string, error) {
 	var failures []string
+	var firstStructured error
+	capture := func(err error) {
+		if err == nil {
+			return
+		}
+		failures = append(failures, err.Error())
+		if firstStructured == nil {
+			var se *errors.StructuredError
+			if stderrors.As(err, &se) {
+				firstStructured = err
+			}
+		}
+	}
 
 	if ref, ok := findEnabledComponent(refs, nodewrightCustomizationsComponent); ok {
-		if err := verifyNodewrightReady(ctx, ref); err != nil {
-			failures = append(failures, err.Error())
-		}
+		capture(verifyNodewrightReady(ctx, ref))
 	}
 
 	if _, ok := findEnabledComponent(refs, gpuOperatorComponent); ok {
-		if err := verifyClusterPolicyReady(ctx); err != nil {
-			failures = append(failures, err.Error())
-		}
+		capture(verifyClusterPolicyReady(ctx))
 	}
 
 	if ref, ok := findEnabledComponent(refs, draDriverComponent); ok {
-		if err := verifyDRAKubeletPluginReady(ctx, ref.Namespace); err != nil {
-			failures = append(failures, err.Error())
-		}
+		capture(verifyDRAKubeletPluginReady(ctx, ref.Namespace))
 	}
 
-	return failures
+	return failures, firstStructured
 }
 
 func findEnabledComponent(refs []recipe.ComponentRef, name string) (recipe.ComponentRef, bool) {


### PR DESCRIPTION
## Summary

Activate the dormant Chainsaw runner so the `HealthCheckAsserts`
content hydrated by #1219 / #1234 actually executes during
`aicr validate --phase deployment`. Ships the chainsaw binary in the
deployment validator image, codifies the Job activeDeadlineSeconds
envelope, enforces a runtime read-only operation allowlist, and lifts
the previous mutex between `ExpectedResources` and registry-declared
`HealthCheckAsserts`.

## Motivation / Context

Predecessor PR #1219 hydrated registry-declared
`healthCheck.assertFile` content onto `ComponentRef.HealthCheckAsserts`,
but execution was gated behind `ChainsawBinary.Available()` because the
deployment validator image had not yet shipped the binary. This PR
ships the binary, removes the gate, and codifies the surrounding
contracts (timeouts, read-only allowlist, dedup output) so the
deployment phase is now driven by registry-declared Chainsaw content.

Fixes: #1220
Related: #660, #1219, #1234, #1223

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`validators/chainsaw`, `validators/deployment`,
      `pkg/validator/catalog`)
- [x] Build/CI/tooling (Makefile, Dockerfile, `.settings.yaml` consumption)
- [x] Docs (`docs/contributor/validator.md`)

## Implementation Notes

### Image

- `validators/deployment/Dockerfile`: new `chainsaw-fetch` multi-stage
  downloads `chainsaw_linux_amd64.tar.gz` from the kyverno/chainsaw
  release, verifies the sha256 against `.settings.yaml`, and `COPY`s
  the binary into the distroless final stage at
  `/usr/local/bin/chainsaw`.
- `Makefile` `image-validators` target reads `CHAINSAW_VERSION` and
  `CHAINSAW_SHA256_LINUX_AMD64` from `.settings.yaml` via `yq` and
  passes them as `--build-arg` **only** to the deployment-phase build
  (conformance + performance images don't use chainsaw).
- Single-arch (linux/amd64). The `linux_arm64` checksum is already in
  `.settings.yaml` so the multi-arch upgrade path is clear.
- `go.mod`'s `github.com/kyverno/chainsaw v0.2.15` is already in
  lockstep with the `.settings.yaml` pin (no bump needed).

### Envelope

- New `defaults.JobEnvelopeMargin = 60s`. Catalog timeout for
  `expected-resources` becomes the Job's `activeDeadlineSeconds`;
  both must exceed `ChainsawAssertTimeout` so chainsaw has headroom
  to terminate, clean up its temp dir, and flush logs before SIGKILL.
- `recipes/validators/catalog.yaml`: `expected-resources` timeout
  bumped `5m → 7m` (= 6m + 60s). `TestExpectedResourcesCatalogEnvelope`
  in `pkg/validator/catalog` asserts the invariant — raising
  `ChainsawAssertTimeout` later without bumping the catalog will fail
  the test.

### Read-only allowlist

- New `validators/chainsaw.ValidateTestReadOnly` parses each
  registry-declared Chainsaw Test YAML and rejects any operation
  outside `{assert, error}`. State-changing (apply, create, delete,
  patch, update) and side-effecting (script, command, wait, sleep,
  podLogs, events, describe, get) operations are rejected with
  `ErrCodeInvalidRequest`.
- Catch / finally / cleanup blocks equivalently restricted.
- `TestValidateTestReadOnly_RegistryContent` sweeps every
  `recipes/checks/*/health-check.yaml` — guarantees no registry-
  declared check violates the contract.
- Bounds the cluster-admin RBAC posture of the deployment validator
  Job (see `pkg/validator/job/rbac.go`). PR #1223 will add the same
  enforcement at lint time.

### Validator runtime

- Dropped the `&& len(ref.ExpectedResources) == 0` gate in
  `validators/deployment/expected_resources.go`. Both paths now run
  per component. Output is source-tagged `[expectedResources]` /
  `[chainsaw]`.
- Hard-removed `ChainsawBinary.Available()` and the associated PR
  #1231 skip path (per pre-PR decision). The binary is now a hard
  requirement of the deployment image; a regression that drops it
  surfaces as a clear `RunTest` error rather than a silent skip.
- `pkg/recipe.hydrateHealthCheckAsserts` no longer skips when
  `ExpectedResources` is set. The transitional skip added in #1234 is
  reverted in lockstep with the validator-side gate drop so the
  artifact matches what runs.

### GPU deep-check migration (deferred)

- `clusterPolicyReady` (issue #611 deep check) migration to
  registry-declared Chainsaw YAML is **deferred** to a focused
  follow-up. The migration must prove assertion equivalence against
  `expected_resources_test.go`'s heavily-mocked ClusterPolicy state
  coverage; bundling that semantic argument here would bloat review.
  Disposition documented in the new doc on `verifyGPUReadinessSignals`.
- `verifyNodewrightReady` (formerly `skyhookReady`) stays in Go:
  names are derived dynamically from recipe `ManifestFiles` at
  validate-time. Static Chainsaw YAML cannot express the
  dynamic-name selector.
- `verifyDRAKubeletPluginReady` stays in Go: chart's full DaemonSet
  name is release-derived. Encoding it would violate the
  deployer-neutrality constraint (#660 issue body).

## Testing

```bash
go test -race -count=1 ./pkg/recipe/ ./pkg/defaults/ ./pkg/validator/catalog/ ./validators/...
golangci-lint run -c .golangci.yaml ./pkg/recipe/... ./pkg/defaults/... ./pkg/validator/catalog/... ./validators/...
```

New tests:

- `pkg/defaults.TestJobEnvelopeMarginInvariant` — guards the
  envelope contract.
- `pkg/validator/catalog.TestExpectedResourcesCatalogEnvelope` —
  guards the catalog timeout is `>= ChainsawAssertTimeout +
  JobEnvelopeMargin`.
- `validators/chainsaw.TestValidateTestReadOnly` (9 sub-cases) +
  `TestValidateTestReadOnly_RegistryContent` (sweeps in-tree checks).
- `validators/chainsaw.TestNewChainsawBinary` (PATH hit + miss).
- `pkg/recipe.TestHydrateHealthCheckAsserts_RunsAlongsideExpectedResources`
  — replaces #1234's transitional `_ExpectedResourcesWins` test.

Coverage delta on changed packages:

- `validators/chainsaw`: 14.4% → 22.1% (+7.7%).
- `pkg/defaults`: 100% (unchanged).
- `pkg/validator/catalog`: 97.5%.
- `validators/deployment`: 44.1%.

**Live-cluster validation required by #660 acceptance criteria —
deferred to @mchmarny per out-of-band agreement (no live cluster in
PR author's environment).**

## Risk Assessment

- [x] **Medium** — Touches the validator image build, drops a runtime
  gate, and adds a runtime allowlist. Easy to revert per-component
  (Dockerfile, catalog.yaml, runtime branches all isolated).

**Rollout notes:** No CLI-flag changes. Output gains source-tag
prefixes (`[expectedResources]` / `[chainsaw]`). Resolved
`recipe.yaml` artifacts for components with both `assertFile` AND
`ExpectedResources` now carry the hydrated chainsaw content
(previously suppressed transitionally). Recipe authors who declared
`expectedResources` to suppress hydrated content must add
`healthCheckSkip: true` instead (existing field from #1219). The
chainsaw binary is now required in the deployment validator image —
operators running custom images must rebuild.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (changed paths)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs for user-facing behavior changes
  (`docs/contributor/validator.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
