### PR TITLE
feat(verify): KMS/public-key bundle verification (aicr verify --key)

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2183,12 +2183,11 @@ The resulting bundle uses the same Sigstore bundle format as keyless signing,
 but its verification material is the signing key's public key rather than a
 Fulcio certificate.
 
-> **Verification:** a KMS-signed bundle is verified with cosign's public-key
-> path, e.g. `cosign verify-blob-attestation --key <same-kms-uri> ...`, supplying
-> the same KMS URI used to sign. Native `aicr verify --key` support is **not**
-> part of this change and does not exist yet; it is tracked under
-> [#1152](https://github.com/NVIDIA/aicr/issues/1152). Use cosign to verify
-> KMS-signed bundles in the meantime.
+> **Verification:** verify a KMS-signed bundle with `aicr verify --key <uri>`,
+> supplying the same KMS URI used to sign (or a local PEM public-key file). See
+> the [`aicr verify`](#aicr-verify) flags below. cosign's public-key path
+> (`cosign verify-blob-attestation --key <same-kms-uri> ...`) also works, since
+> the bundle uses the standard Sigstore bundle format.
 
 HashiCorp Vault (`hashivault://`) is not supported: its client libraries are MPL-2.0 licensed, which is incompatible with this project's license policy. This is a deliberate, ongoing exclusion rather than a not-yet-implemented feature at this time.
 
@@ -2448,7 +2447,7 @@ aicr mirror list --recipe recipe.yaml --set gpuoperator:driver.enabled=false
 
 ### aicr verify
 
-Verify the integrity and attestation chain of a bundle. Verification is fully offline — no network calls are made.
+Verify the integrity and attestation chain of a bundle. By default verification is offline and makes no network calls. The one exception is `--key` with a KMS URI, which reaches the KMS provider to fetch the public key (see the `--key` network behavior note below).
 
 **Synopsis:**
 ```shell
@@ -2462,6 +2461,7 @@ aicr verify <bundle-dir> [flags]
 | `--require-creator` | string | | Require a specific creator identity, matched against the bundle attestation signing certificate. |
 | `--cli-version-constraint` | string | | Version constraint for the aicr CLI version in the attestation predicate. Supports `>=`, `>`, `<=`, `<`, `==`, `!=`. A bare version (e.g. `"0.8.0"`) defaults to `>=`. |
 | `--certificate-identity-regexp` | string | | Override the certificate identity pattern for binary attestation verification. Must contain `"NVIDIA/aicr"`. For testing only. |
+| `--key` | string | | Verify a key-signed bundle attestation against a KMS key URI (`awskms://` \| `gcpkms://` \| `azurekms://`) or a local PEM public-key file. This is the counterpart to `bundle --signing-key`. It coexists with `--certificate-identity-regexp`, which pins the binary attestation; the two verify different attestations. |
 | `--format` | string | `text` | Output format: `text` or `json`. |
 
 #### Trust Levels
@@ -2495,8 +2495,19 @@ aicr verify ./my-bundle --cli-version-constraint ">= 0.8.0"
 
 # JSON output for CI pipelines
 aicr verify ./my-bundle --format json
+
+# Sign a bundle with a KMS key, then verify it with the same key
+aicr bundle -r recipe.yaml --attest --signing-key gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k -o ./bundles
+aicr verify ./bundles/<bundle-dir> --key gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k
+
+# Or verify against an exported PEM public key (no KMS access needed)
+aicr verify ./bundles/<bundle-dir> --key ./bundle-signer.pub
 ```
 
+> **`--key` network behavior:** Resolving a **KMS URI** (`awskms://`, `gcpkms://`, `azurekms://`) makes network calls to the KMS provider to fetch the public key, so credentials for that provider must be available in the environment. A **local PEM** public-key file is read from disk with no provider calls; export it once with `cosign public-key --key <kms-uri>` (or your provider's console) and verify anywhere.
+>
+> Resolving the key is only part of verification: by default the bundle's Rekor transparency-log entry is also checked. Its inclusion proof is embedded in the bundle, so no live Rekor call is made, but the check needs the Sigstore trusted root. That root is loaded from the local cache when present and otherwise fetched over the network, so run `aicr trust update` once to pre-populate it. A local PEM key therefore makes verification fully offline only when the trusted-root cache is already warm. Verification that drops the transparency-log requirement entirely, for true air-gapped use, is tracked in [#1154](https://github.com/NVIDIA/aicr/issues/1154).
+>
 > **Stale root:** If verification fails with certificate chain errors, run `aicr trust update` to refresh the Sigstore trusted root.
 
 ---

--- a/pkg/bundler/attestation/keylessverifyidentity.go
+++ b/pkg/bundler/attestation/keylessverifyidentity.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/trust"
+)
+
+// keylessVerificationIdentity verifies a keyless (Fulcio) signature against the
+// Sigstore public-good trusted root, pinning the signer to a Fulcio
+// certificate identity. It is the verification dual of keylessIdentity and the
+// VerificationIdentity used by both bundle attestation (any OIDC issuer) and
+// binary attestation (NVIDIA-pinned issuer + repository pattern); the caller
+// supplies the certificate matcher.
+type keylessVerificationIdentity struct{ id verify.CertificateIdentity }
+
+// NewKeylessVerificationIdentity returns a VerificationIdentity that validates
+// a keyless Fulcio signature against the Sigstore public-good trusted root and
+// requires the signing certificate to match id.
+func NewKeylessVerificationIdentity(id verify.CertificateIdentity) VerificationIdentity {
+	return &keylessVerificationIdentity{id: id}
+}
+
+func (k *keylessVerificationIdentity) TrustedMaterial(context.Context) (root.TrustedMaterial, error) {
+	// trust.GetTrustedMaterial is offline (ForceCache) and takes no context, so
+	// the ctx is accepted only to satisfy the interface and to keep the
+	// key-based identity (which may make a context-bounded KMS call) uniform.
+	tm, err := trust.GetTrustedMaterial()
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load trusted root", err)
+	}
+	return tm, nil
+}
+
+func (k *keylessVerificationIdentity) PolicyOption() verify.PolicyOption {
+	return verify.WithCertificateIdentity(k.id)
+}

--- a/pkg/bundler/attestation/keyverifyidentity.go
+++ b/pkg/bundler/attestation/keyverifyidentity.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"crypto"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"io"
+	"os"
+	"time"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/trust"
+)
+
+// keyVerificationIdentity verifies a public-key-signed bundle attestation
+// (#407 KMS signing, or a local PEM). Trust anchors are the public-good root
+// (so the Rekor tlog, which #407 uploads to by default, still verifies)
+// combined with the caller's public key (for the signature). The policy uses
+// verify.WithKey() instead of a certificate identity. It is the key-based
+// VerificationIdentity, dual of kmsIdentity on the signing side.
+type keyVerificationIdentity struct {
+	pub      crypto.PublicKey
+	identity string // KMS URI, or "pem:<sha256-fingerprint>" for a local key
+}
+
+// NewKeyVerificationIdentity resolves keyRef to a public key and returns the
+// key-based VerificationIdentity. keyRef is a KMS key URI
+// (awskms:// | gcpkms:// | azurekms://) or a path to a local PEM public-key
+// file. This factory is the only input-form branch in the feature: a KMS URI
+// is resolved via the shared resolveKMSPublicKey seam (so signing and verifying
+// agree on provider resolution and error classification), and anything else is
+// read as a local PEM. Scheme detection reuses isKMSURI (kmsidentity.go), the
+// single source of truth shared with the signing side.
+func NewKeyVerificationIdentity(ctx context.Context, keyRef string) (VerificationIdentity, error) {
+	if isKMSURI(keyRef) {
+		// Verification needs only the public half; the live signer seam is
+		// discarded. resolveKMSPublicKey already classifies the failure
+		// (unknown scheme → ErrCodeInvalidRequest, provider init →
+		// ErrCodeUnavailable), so its error is propagated as-is.
+		_, pub, err := resolveKMSPublicKey(ctx, keyRef)
+		if err != nil {
+			return nil, err
+		}
+		// Store the scheme-normalized URI so the identity (BundleCreator,
+		// --require-creator matching) is canonical regardless of caller casing,
+		// matching how resolveKMSPublicKey resolves the key.
+		return &keyVerificationIdentity{pub: pub, identity: normalizeURIScheme(keyRef)}, nil
+	}
+
+	pub, fp, err := loadPEMPublicKey(keyRef)
+	if err != nil {
+		return nil, err
+	}
+	return &keyVerificationIdentity{pub: pub, identity: "pem:" + fp}, nil
+}
+
+// Identity returns the key identity (KMS URI or pem:<fp>). The verifier
+// substitutes this as BundleCreator since a key-signed bundle has no cert SAN.
+func (k *keyVerificationIdentity) Identity() string { return k.identity }
+
+// TrustedMaterial combines the Sigstore public-good root (for the Rekor tlog,
+// which #407 uploads to by default) with a bare-public-key trust anchor (for
+// the signature itself). The key is wrapped in an always-valid ExpiringKey
+// (zero start/end) because a raw public key carries no notBefore/notAfter the
+// way a Fulcio certificate does, so there is no validity window to enforce.
+func (k *keyVerificationIdentity) TrustedMaterial(_ context.Context) (root.TrustedMaterial, error) {
+	publicGood, err := trust.GetTrustedMaterial()
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load trusted root", err)
+	}
+	ver, err := signature.LoadVerifier(k.pub, crypto.SHA256)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "unsupported public key", err)
+	}
+	keyMaterial := root.NewTrustedPublicKeyMaterial(func(string) (root.TimeConstrainedVerifier, error) {
+		return root.NewExpiringKey(ver, time.Time{}, time.Time{}), nil
+	})
+	return root.TrustedMaterialCollection{publicGood, keyMaterial}, nil
+}
+
+// PolicyOption binds verification to the public key rather than a Fulcio
+// certificate identity, the key-based dual of WithCertificateIdentity.
+func (k *keyVerificationIdentity) PolicyOption() verify.PolicyOption { return verify.WithKey() }
+
+// loadPEMPublicKey reads a PEM-encoded public key from path and returns the
+// parsed key plus the hex SHA-256 fingerprint of its DER (PKIX) encoding. The
+// read is bounded by defaults.MaxPublicKeyPEMBytes so an attacker-influenced
+// path (a /proc symlink, an NFS mount) cannot OOM the process the way
+// os.ReadFile would. A missing file or unparseable content is a user error
+// (a bad --key argument), classified ErrCodeInvalidRequest, mirroring how an
+// unrecognized KMS scheme is treated.
+func loadPEMPublicKey(path string) (crypto.PublicKey, string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", errors.Wrap(errors.ErrCodeInvalidRequest, "failed to open public key file", err)
+	}
+	// Read-only handle: a deferred Close without an error check is acceptable
+	// per project rules (Close errors only matter for writable handles).
+	defer func() { _ = f.Close() }()
+
+	limited := io.LimitReader(f, defaults.MaxPublicKeyPEMBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, "", errors.Wrap(errors.ErrCodeInvalidRequest, "failed to read public key file", err)
+	}
+	if int64(len(data)) > defaults.MaxPublicKeyPEMBytes {
+		return nil, "", errors.New(errors.ErrCodeInvalidRequest, "public key file exceeds size limit")
+	}
+
+	pub, err := cryptoutils.UnmarshalPEMToPublicKey(data)
+	if err != nil {
+		return nil, "", errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse PEM public key", err)
+	}
+
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, "", errors.Wrap(errors.ErrCodeInvalidRequest, "failed to encode public key", err)
+	}
+	sum := sha256.Sum256(der)
+	return pub, hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/bundler/attestation/keyverifyidentity_test.go
+++ b/pkg/bundler/attestation/keyverifyidentity_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// writeTempPubPEM marshals pub to PKIX DER, PEM-encodes it under a
+// "PUBLIC KEY" block, writes it to a temp file, and returns the path.
+func writeTempPubPEM(t *testing.T, pub interface{}) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	block := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	path := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(path, block, 0o600); err != nil {
+		t.Fatalf("failed to write temp PEM: %v", err)
+	}
+	return path
+}
+
+func TestNewKeyVerificationIdentity_UnknownScheme(t *testing.T) {
+	_, err := NewKeyVerificationIdentity(context.Background(), "bogus://x")
+	// A "bogus://" ref is not a recognized KMS URI, so it falls through to the
+	// PEM path and fails to open as a file — both surface ErrCodeInvalidRequest.
+	requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+}
+
+func TestNewKeyVerificationIdentity_PEM(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	pemPath := writeTempPubPEM(t, &priv.PublicKey)
+
+	id, err := NewKeyVerificationIdentity(context.Background(), pemPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	idStr := id.(interface{ Identity() string }).Identity()
+	if !strings.HasPrefix(idStr, "pem:") {
+		t.Errorf("expected identity to have pem: prefix, got %q", idStr)
+	}
+
+	tm, err := id.TrustedMaterial(context.Background())
+	if err != nil {
+		t.Fatalf("TrustedMaterial returned error: %v", err)
+	}
+	if tm == nil {
+		t.Fatal("expected non-nil TrustedMaterial")
+	}
+
+	if id.PolicyOption() == nil {
+		t.Error("expected non-nil PolicyOption")
+	}
+}
+
+func TestNewKeyVerificationIdentity_BadPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.pem")
+	if err := os.WriteFile(path, []byte("not a pem"), 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	_, err := NewKeyVerificationIdentity(context.Background(), path)
+	requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+}
+
+func TestNewKeyVerificationIdentity_MissingFile(t *testing.T) {
+	_, err := NewKeyVerificationIdentity(context.Background(), "/no/such/key.pem")
+	requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+}
+
+func TestNewKeyVerificationIdentity_OversizePEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.pem")
+	oversized := make([]byte, defaults.MaxPublicKeyPEMBytes+1)
+	if err := os.WriteFile(path, oversized, 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	_, err := NewKeyVerificationIdentity(context.Background(), path)
+	requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+}

--- a/pkg/bundler/attestation/kmsidentity.go
+++ b/pkg/bundler/attestation/kmsidentity.go
@@ -18,12 +18,11 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	stderrors "errors"
 	"io"
+	"strings"
 
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore/pkg/signature"
-	"github.com/sigstore/sigstore/pkg/signature/kms"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 
 	// Blank-import the cosign-style KMS providers so their schemes
@@ -36,13 +35,40 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
 
-	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 // ctxKeySigningKey is the structured-error context key carrying the KMS key
 // URI on KMS resolution failures.
 const ctxKeySigningKey = "signingKey"
+
+// kmsURISchemes are the cosign-style KMS key-URI scheme prefixes this project
+// supports. It is the single source of truth shared by the signing side
+// (NewKMSIdentity / resolveKMSPublicKey) and the verifying side
+// (NewKeyVerificationIdentity), so the two cannot drift on what counts as a
+// "KMS URI". The set mirrors the blank-imported provider packages above;
+// HashiCorp Vault (hashivault://) is intentionally omitted (MPL-2.0 license,
+// see issue #407).
+var kmsURISchemes = []string{"awskms://", "gcpkms://", "azurekms://"}
+
+// isKMSURI reports whether ref names a supported cosign-style KMS key
+// (awskms:// | gcpkms:// | azurekms://) rather than a local PEM path. It is the
+// input-form discriminator both signing and verifying use; resolveKMSPublicKey
+// still classifies the precise kms.Get failure (unknown scheme vs provider
+// init) once a candidate is handed to the provider registry.
+//
+// Scheme matching is case-insensitive (RFC 3986 schemes are case-insensitive),
+// so a variant like GCPKMS:// is routed to the KMS path rather than mistaken
+// for a local file; resolveKMSPublicKey lowercases the scheme before kms.Get.
+func isKMSURI(ref string) bool {
+	lower := strings.ToLower(ref)
+	for _, scheme := range kmsURISchemes {
+		if strings.HasPrefix(lower, scheme) {
+			return true
+		}
+	}
+	return false
+}
 
 // kmsIdentity signs with a KMS-held key. It carries no Fulcio certificate, so
 // SignStatementWith records public-key verification material and uses the key
@@ -60,41 +86,16 @@ func NewKMSIdentity(keyURI string) SigningIdentity { return &kmsIdentity{keyURI:
 // the bundle digest algorithm (the cloud KMS defaults — ECDSA P-256 / RSA-2048
 // — all sign over a SHA-256 digest).
 func (k *kmsIdentity) Keypair(ctx context.Context) (sign.Keypair, error) {
-	// Bound the provider lookup + PublicKey RPC so a caller that passes an
-	// unbounded context cannot hang here. When invoked from SignStatementWith
-	// the parent context is already bounded by SigstoreSignTimeout, so this
-	// nests harmlessly (the tighter deadline wins).
-	ctx, cancel := context.WithTimeout(ctx, defaults.SigstoreSignTimeout)
-	defer cancel()
-
-	sv, err := kms.Get(ctx, k.keyURI, crypto.SHA256)
+	// resolveKMSPublicKey (kmspublickey.go) bounds the provider lookup +
+	// PublicKey RPC, classifies kms.Get failures (unrecognized scheme →
+	// ErrCodeInvalidRequest, provider init failure → ErrCodeUnavailable), and
+	// reads the public key eagerly under ctx. Signing additionally needs the
+	// live SignerVerifier seam for SignDigest, so both halves are reused here
+	// without a second kms.Get RPC. Verification (#1152) reuses the same
+	// resolver but consumes only the public key.
+	sv, pub, err := resolveKMSPublicKey(ctx, k.keyURI)
 	if err != nil {
-		// kms.Get fails for two distinct reasons that must not be conflated at
-		// the HTTP boundary (the server path, #1150). An unrecognized scheme
-		// (or a missing out-of-process plugin) surfaces as ProviderNotFoundError
-		// and is a client error — the request named a key we cannot handle. A
-		// matched provider that then fails to initialize (credential resolution,
-		// network, IMDS) is an upstream-availability failure, not a bad request.
-		var notFound *kms.ProviderNotFoundError
-		if stderrors.As(err, &notFound) {
-			return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
-				"unsupported or unrecognized KMS signing-key scheme", err,
-				map[string]interface{}{ctxKeySigningKey: k.keyURI})
-		}
-		return nil, errors.WrapWithContext(errors.ErrCodeUnavailable,
-			"failed to initialize KMS provider for signing key", err,
-			map[string]interface{}{ctxKeySigningKey: k.keyURI})
-	}
-
-	// Read the public key eagerly here, where ctx is in scope: the kmsSigner
-	// seam's Public() takes no context, and the KMS PublicKey call is a remote
-	// RPC. Resolving it now lets the RPC honor the caller's deadline instead of
-	// falling back to a background context inside the adapter.
-	pub, err := sv.PublicKey(options.WithContext(ctx))
-	if err != nil {
-		return nil, errors.WrapWithContext(errors.ErrCodeUnavailable,
-			"failed to read KMS public key", err,
-			map[string]interface{}{ctxKeySigningKey: k.keyURI})
+		return nil, err
 	}
 
 	return newKMSKeypairFromSigner(&kmsSignerVerifier{sv: sv, pub: pub})

--- a/pkg/bundler/attestation/kmspublickey.go
+++ b/pkg/bundler/attestation/kmspublickey.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"crypto"
+	stderrors "errors"
+	"strings"
+
+	"github.com/sigstore/sigstore/pkg/signature/kms"
+	"github.com/sigstore/sigstore/pkg/signature/options"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// resolveKMSPublicKey looks up a cosign-style KMS key URI
+// (awskms:// | gcpkms:// | azurekms://), reads its public half, and returns
+// both the live SignerVerifier seam and the resolved public key. It is shared
+// by KMS signing (kmsidentity.go, which uses the returned signer for
+// SignDigest) and KMS verification (which needs only the public key) so both
+// agree on provider resolution and error classification.
+//
+// SHA-256 is fixed as the digest algorithm: the cloud KMS defaults
+// (ECDSA P-256 / RSA-2048) all sign over a SHA-256 digest.
+//
+// kms.Get fails for two distinct reasons that must not be conflated at the HTTP
+// boundary (the server path, #1150). An unrecognized scheme (or a missing
+// out-of-process plugin) surfaces as ProviderNotFoundError and is a client
+// error — the request named a key we cannot handle (ErrCodeInvalidRequest). A
+// matched provider that then fails to initialize (credential resolution,
+// network, IMDS) is an upstream-availability failure, not a bad request
+// (ErrCodeUnavailable).
+//
+// The PublicKey RPC is read eagerly here, where ctx is in scope, so it honors
+// the caller's deadline instead of falling back to a background context inside
+// a downstream adapter whose Public() takes no context.
+func resolveKMSPublicKey(ctx context.Context, keyURI string) (kmsRemoteSigner, crypto.PublicKey, error) {
+	// Bound the provider lookup + PublicKey RPC so a caller that passes an
+	// unbounded context cannot hang here. When invoked from SignStatementWith
+	// the parent context is already bounded by SigstoreSignTimeout, so this
+	// nests harmlessly (the tighter deadline wins).
+	ctx, cancel := context.WithTimeout(ctx, defaults.SigstoreSignTimeout)
+	defer cancel()
+
+	// kms.Get matches provider schemes case-sensitively, so normalize the scheme
+	// first: a variant like GCPKMS:// would otherwise fail to resolve.
+	keyURI = normalizeURIScheme(keyURI)
+
+	sv, err := kms.Get(ctx, keyURI, crypto.SHA256)
+	if err != nil {
+		if te := kmsTimeoutError(err, keyURI); te != nil {
+			return nil, nil, te
+		}
+		var notFound *kms.ProviderNotFoundError
+		if stderrors.As(err, &notFound) {
+			return nil, nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+				"unsupported or unrecognized KMS signing-key scheme", err,
+				map[string]interface{}{ctxKeySigningKey: keyURI})
+		}
+		return nil, nil, errors.WrapWithContext(errors.ErrCodeUnavailable,
+			"failed to initialize KMS provider for signing key", err,
+			map[string]interface{}{ctxKeySigningKey: keyURI})
+	}
+
+	pub, err := sv.PublicKey(options.WithContext(ctx))
+	if err != nil {
+		if te := kmsTimeoutError(err, keyURI); te != nil {
+			return nil, nil, te
+		}
+		return nil, nil, errors.WrapWithContext(errors.ErrCodeUnavailable,
+			"failed to read KMS public key", err,
+			map[string]interface{}{ctxKeySigningKey: keyURI})
+	}
+
+	return sv, pub, nil
+}
+
+// normalizeURIScheme lowercases the scheme component of a URI (the part before
+// "://"), leaving the remainder untouched. RFC 3986 schemes are
+// case-insensitive, but some consumers (e.g. kms.Get) match them
+// case-sensitively. The opaque part after "://" (which may be a case-sensitive
+// ARN or resource path) is preserved. Returns uri unchanged when it has no
+// "://" separator or begins with one.
+func normalizeURIScheme(uri string) string {
+	if i := strings.Index(uri, "://"); i > 0 {
+		return strings.ToLower(uri[:i]) + uri[i:]
+	}
+	return uri
+}
+
+// kmsTimeoutError classifies a context deadline or cancellation surfaced by a
+// KMS RPC as ErrCodeTimeout (504 at the HTTP boundary), distinct from the
+// ErrCodeUnavailable used for provider-init / network failures. It mirrors the
+// deadline handling in SignStatementWith. Returns nil when err is not a context
+// timeout or cancellation.
+func kmsTimeoutError(err error, keyURI string) error {
+	if stderrors.Is(err, context.DeadlineExceeded) || stderrors.Is(err, context.Canceled) {
+		return errors.WrapWithContext(errors.ErrCodeTimeout,
+			"KMS operation timed out", err,
+			map[string]interface{}{ctxKeySigningKey: keyURI})
+	}
+	return nil
+}

--- a/pkg/bundler/attestation/kmspublickey_test.go
+++ b/pkg/bundler/attestation/kmspublickey_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestResolveKMSPublicKey_UnknownScheme(t *testing.T) {
+	_, _, err := resolveKMSPublicKey(context.Background(), "bogus://nope")
+	if err == nil {
+		t.Fatal("want error for unknown scheme")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("want ErrCodeInvalidRequest, got %v", err)
+	}
+}
+
+func TestIsKMSURI(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want bool
+	}{
+		{"aws lowercase", "awskms://alias/key", true},
+		{"gcp lowercase", "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k", true},
+		{"azure lowercase", "azurekms://vault.vault.azure.net/keys/k", true},
+		{"aws uppercase scheme", "AWSKMS://alias/key", true},
+		{"gcp uppercase scheme", "GCPKMS://projects/p/locations/l/keyRings/r/cryptoKeys/k", true},
+		{"azure mixed case scheme", "AzureKMS://vault.vault.azure.net/keys/k", true},
+		{"local pem path", "./bundle-signer.pub", false},
+		{"absolute pem path", "/etc/keys/signer.pem", false},
+		{"scheme as substring not prefix", "prefix-awskms://alias/key", false},
+		{"scheme without :// separator", "awskms:alias/key", false},
+		{"scheme name only", "gcpkms", false},
+		{"unsupported scheme", "fookms://x/y", false},
+		{"unsupported scheme uppercase", "FOOKMS://x/y", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKMSURI(tt.ref); got != tt.want {
+				t.Errorf("isKMSURI(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeURIScheme(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"uppercase scheme", "GCPKMS://projects/P/keyRings/R", "gcpkms://projects/P/keyRings/R"},
+		{"mixed case scheme", "AzureKMS://Vault/keys/K", "azurekms://Vault/keys/K"},
+		{"already lowercase", "awskms://alias/Key", "awskms://alias/Key"},
+		{"preserves path case", "awskms://arn:aws:kms:us-East-1:ABC", "awskms://arn:aws:kms:us-East-1:ABC"},
+		{"no scheme separator", "/etc/keys/signer.pem", "/etc/keys/signer.pem"},
+		{"leading separator unchanged", "://x", "://x"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeURIScheme(tt.in); got != tt.want {
+				t.Errorf("normalizeURIScheme(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKMSTimeoutError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode bool // true => expect ErrCodeTimeout, false => expect nil
+	}{
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"canceled", context.Canceled, true},
+		{"wrapped deadline", errors.Wrap(errors.ErrCodeInternal, "rpc", context.DeadlineExceeded), true},
+		{"generic error", stderrors.New("kms down"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kmsTimeoutError(tt.err, "awskms://alias/key")
+			if tt.wantCode {
+				if got == nil {
+					t.Fatal("want ErrCodeTimeout, got nil")
+				}
+				if !stderrors.Is(got, errors.New(errors.ErrCodeTimeout, "")) {
+					t.Errorf("want ErrCodeTimeout, got %v", got)
+				}
+			} else if got != nil {
+				t.Errorf("want nil, got %v", got)
+			}
+		})
+	}
+}

--- a/pkg/bundler/attestation/verifying.go
+++ b/pkg/bundler/attestation/verifying.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"strings"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// VerificationIdentity is the verification dual of SigningIdentity: it supplies
+// the trust anchors and the signer-matching policy for one verification flavor.
+// It is one of the two composable axes of VerifyStatementWith; pair it with a
+// VerifyTransparencyPolicy.
+//
+// The keyless implementation lives in keylessverifyidentity.go; it loads the
+// Sigstore public-good trusted root and pins the signer via a Fulcio
+// certificate identity. Key-based identities (#1152, KMS public key) follow in
+// a later task and supply a public key instead of a certificate matcher.
+type VerificationIdentity interface {
+	// TrustedMaterial returns the trust anchors (Fulcio CAs, Rekor keys, or a
+	// bare public key) used to validate the bundle. Resolved with ctx so a
+	// slow trust-root load honors the caller's deadline; the error is already
+	// classified by the implementation.
+	TrustedMaterial(ctx context.Context) (root.TrustedMaterial, error)
+
+	// PolicyOption returns the sigstore-go policy option that binds the
+	// verification to a signer: WithCertificateIdentity for keyless, WithKey
+	// for key-based.
+	PolicyOption() verify.PolicyOption
+}
+
+// VerifyTransparencyPolicy is the dual of TransparencyPolicy: it decides which
+// transparency-log and timestamp guarantees a verification operation requires.
+// It is the second of the two composable axes of VerifyStatementWith; pair it
+// with a VerificationIdentity.
+type VerifyTransparencyPolicy interface {
+	// VerifierOptions returns the sigstore-go verifier options that encode the
+	// transparency/timestamp requirements (e.g. WithTransparencyLog,
+	// WithObserverTimestamps).
+	VerifierOptions() []verify.VerifierOption
+}
+
+// VerifyStatementWith verifies a Sigstore bundle against the given identity and
+// transparency policy, binding it to artifactDigest. It is the composable core
+// dual of SignStatementWith, shared by keyless verification
+// (verifier.verifySigstoreBundle / VerifyBinaryAttestation) and the key-based
+// flow (#1152). Returns the signer identity (Fulcio SAN) on success; for
+// key-based bundles there is no certificate and the returned identity is "".
+func VerifyStatementWith(ctx context.Context, bundleBytes []byte,
+	id VerificationIdentity, tlog VerifyTransparencyPolicy, artifactDigest []byte) (string, error) {
+
+	if id == nil || tlog == nil {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			"verification identity and transparency policy are required")
+	}
+	// Refuse to verify without content binding — an empty digest would let a
+	// valid signature over unrelated content masquerade as verified.
+	if len(artifactDigest) == 0 {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			"artifact digest is required for attestation verification")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", errors.Wrap(errors.ErrCodeTimeout, "context cancelled before attestation verification", err)
+	}
+
+	b, err := loadSigstoreBundleBytes(bundleBytes)
+	if err != nil {
+		return "", err
+	}
+
+	tm, err := id.TrustedMaterial(ctx)
+	if err != nil {
+		return "", err // already classified by the identity
+	}
+
+	v, err := verify.NewVerifier(tm, tlog.VerifierOptions()...)
+	if err != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create sigstore verifier", err)
+	}
+
+	result, err := v.Verify(b, verify.NewPolicy(
+		verify.WithArtifactDigest("sha256", artifactDigest),
+		id.PolicyOption(),
+	))
+	if err != nil {
+		// Detect staleness: if the error mentions certificate chain issues,
+		// suggest updating the trusted root.
+		if containsCertChainError(err.Error()) {
+			return "", errors.New(errors.ErrCodeUnauthorized,
+				"sigstore verification failed — the signing certificate may have been issued "+
+					"by a CA not present in your trusted root. This usually means Sigstore rotated "+
+					"their keys since your last update.\n\n  To fix: aicr trust update")
+		}
+		return "", errors.Wrap(errors.ErrCodeUnauthorized, "sigstore verification failed", err)
+	}
+
+	return signerIdentityFromResult(result), nil
+}
+
+// loadSigstoreBundleBytes parses protobuf-JSON bundle bytes into a sigstore-go
+// Bundle. It is the parse half of verifier.loadSigstoreBundle, extracted here
+// so both the verifier's bounded-read wrapper and VerifyStatementWith share one
+// definition. Callers are responsible for bounding the size of bundleBytes.
+func loadSigstoreBundleBytes(bundleBytes []byte) (*bundle.Bundle, error) {
+	var pb protobundle.Bundle
+	if err := protojson.Unmarshal(bundleBytes, &pb); err != nil {
+		// Malformed bundle bytes are invalid caller-supplied input, not a server
+		// fault: classify as ErrCodeInvalidRequest (400) rather than 500.
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse sigstore bundle", err)
+	}
+
+	b, err := bundle.NewBundle(&pb)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid sigstore bundle", err)
+	}
+
+	return b, nil
+}
+
+// signerIdentityFromResult extracts the signer SAN (Subject Alternative Name)
+// from a verification result's Fulcio certificate summary. Returns "" when the
+// bundle was signed with a public key (no certificate) or the result is
+// otherwise missing the certificate — callers must not treat "" as an error.
+func signerIdentityFromResult(result *verify.VerificationResult) string {
+	if result == nil || result.Signature == nil || result.Signature.Certificate == nil {
+		return ""
+	}
+	return result.Signature.Certificate.SubjectAlternativeName
+}
+
+// containsCertChainError reports whether an error message indicates a
+// certificate-chain verification failure, which typically means the local
+// trusted root is stale (Sigstore rotated keys since the last "aicr trust
+// update"). Lives here so both the signing-adjacent verification core and the
+// verifier package share one definition.
+func containsCertChainError(errMsg string) bool {
+	// Match specific stale-root phrases only. A bare "x509" substring is too
+	// broad: it also catches unrelated cert failures such as
+	// "x509: certificate has expired", which "aicr trust update" cannot fix, and
+	// would misdirect operators. Genuine stale-root errors still match the
+	// phrases below (e.g. "x509: certificate signed by unknown authority").
+	staleIndicators := []string{
+		"certificate signed by unknown authority",
+		"certificate chain",
+		"unable to verify certificate",
+		"root certificate",
+	}
+	lower := strings.ToLower(errMsg)
+	for _, indicator := range staleIndicators {
+		if strings.Contains(lower, indicator) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/bundler/attestation/verifying_test.go
+++ b/pkg/bundler/attestation/verifying_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// requireErrCode fails the test unless err carries the given pkg/errors code.
+func requireErrCode(t *testing.T, err error, code errors.ErrorCode) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with code %v, got nil", code)
+	}
+	if !stderrors.Is(err, errors.New(code, "")) {
+		t.Fatalf("expected error code %v, got %v", code, err)
+	}
+}
+
+// anyCertIdentity returns a keyless VerificationIdentity that matches any
+// OIDC-issued certificate, mirroring verifier.verifySigstoreBundle.
+func anyCertIdentity(t *testing.T) VerificationIdentity {
+	t.Helper()
+	certID, err := verify.NewShortCertificateIdentity("", ".+", "", ".+")
+	if err != nil {
+		t.Fatalf("failed to build certificate identity: %v", err)
+	}
+	return NewKeylessVerificationIdentity(certID)
+}
+
+func TestVerifyStatementWith_NilArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		id   VerificationIdentity
+		tlog VerifyTransparencyPolicy
+	}{
+		{"nil identity", nil, NewRequireTLogPolicy()},
+		{"nil transparency policy", anyCertIdentity(t), nil},
+		{"both nil", nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := VerifyStatementWith(context.Background(), []byte("{}"), tt.id, tt.tlog, []byte{1})
+			requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+		})
+	}
+}
+
+func TestVerifyStatementWith_EmptyDigest(t *testing.T) {
+	id := anyCertIdentity(t)
+	tlog := NewRequireTLogPolicy()
+
+	t.Run("nil digest", func(t *testing.T) {
+		_, err := VerifyStatementWith(context.Background(), []byte("{}"), id, tlog, nil)
+		requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+	})
+
+	t.Run("empty digest", func(t *testing.T) {
+		_, err := VerifyStatementWith(context.Background(), []byte("{}"), id, tlog, []byte{})
+		requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+	})
+}
+
+func TestVerifyStatementWith_CancelledContext(t *testing.T) {
+	id := anyCertIdentity(t)
+	tlog := NewRequireTLogPolicy()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := VerifyStatementWith(ctx, []byte("{}"), id, tlog, []byte{1})
+	requireErrCode(t, err, errors.ErrCodeTimeout)
+}
+
+func TestVerifyStatementWith_InvalidBundle(t *testing.T) {
+	id := anyCertIdentity(t)
+	tlog := NewRequireTLogPolicy()
+
+	// Valid guards (non-nil id/tlog, non-empty digest, live context) but the
+	// bundle bytes are not parseable as a Sigstore bundle: parsing fails as an
+	// invalid-request error (malformed caller input) before any verification.
+	// The signer identity is empty on the error path; capture it so the return
+	// value is exercised.
+	signer, err := VerifyStatementWith(context.Background(), []byte("not json"), id, tlog, []byte{1})
+	requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+	if signer != "" {
+		t.Errorf("signer identity = %q, want empty on error", signer)
+	}
+}
+
+func TestLoadSigstoreBundleBytes(t *testing.T) {
+	t.Run("invalid JSON", func(t *testing.T) {
+		_, err := loadSigstoreBundleBytes([]byte("not json"))
+		requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+		if !strings.Contains(err.Error(), "failed to parse sigstore bundle") {
+			t.Errorf("error = %v, want parse failure message", err)
+		}
+	})
+
+	t.Run("incomplete bundle", func(t *testing.T) {
+		// Valid protobuf-JSON but an incomplete sigstore bundle (no content).
+		bundleJSON := `{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.3"}`
+		_, err := loadSigstoreBundleBytes([]byte(bundleJSON))
+		requireErrCode(t, err, errors.ErrCodeInvalidRequest)
+		if !strings.Contains(err.Error(), "invalid sigstore bundle") {
+			t.Errorf("error = %v, want invalid bundle message", err)
+		}
+	})
+}
+
+func TestSignerIdentityFromResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *verify.VerificationResult
+		want   string
+	}{
+		{"nil result", nil, ""},
+		{"nil signature", &verify.VerificationResult{}, ""},
+		{
+			"nil certificate (key-based)",
+			&verify.VerificationResult{Signature: &verify.SignatureVerificationResult{}},
+			"",
+		},
+		{
+			"populated SAN (keyless)",
+			&verify.VerificationResult{Signature: &verify.SignatureVerificationResult{
+				Certificate: &certificate.Summary{
+					SubjectAlternativeName: "https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/v1.0.0",
+				},
+			}},
+			"https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/v1.0.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := signerIdentityFromResult(tt.result); got != tt.want {
+				t.Errorf("signerIdentityFromResult() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsCertChainError(t *testing.T) {
+	tests := []struct {
+		name   string
+		errMsg string
+		want   bool
+	}{
+		{"unknown authority", "certificate signed by unknown authority", true},
+		{"x509 unknown authority", "x509: certificate signed by unknown authority", true},
+		{"cert chain", "failed to verify certificate chain", true},
+		{"unable to verify", "unable to verify certificate", true},
+		{"root cert", "root certificate not found", true},
+		{"case insensitive", "Certificate Signed By Unknown Authority", true},
+		// Expiry is not a stale-root condition: trust update cannot fix it, so a
+		// bare x509 error must not trigger the stale-root remediation hint.
+		{"x509 expiry not stale-root", "x509: certificate has expired", false},
+		{"unrelated error", "connection refused", false},
+		{"empty string", "", false},
+		{"sigstore error", "sigstore verification failed", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsCertChainError(tt.errMsg); got != tt.want {
+				t.Errorf("containsCertChainError(%q) = %v, want %v", tt.errMsg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequireTLogPolicy_VerifierOptions(t *testing.T) {
+	opts := NewRequireTLogPolicy().VerifierOptions()
+	if len(opts) != 2 {
+		t.Fatalf("VerifierOptions() returned %d options, want 2", len(opts))
+	}
+}

--- a/pkg/bundler/attestation/verifytransparency.go
+++ b/pkg/bundler/attestation/verifytransparency.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"github.com/sigstore/sigstore-go/pkg/verify"
+)
+
+// requireTLogPolicy requires at least one transparency-log inclusion proof and
+// one observer timestamp. It is the verification dual of rekorPolicy and the
+// current default for all aicr verification flows: every bundle aicr produces
+// records a Rekor entry.
+//
+// The offline relaxation (no transparency log, key-based verification of an
+// air-gapped signature) is tracked as #1154 and will add a sibling policy
+// here, mirroring how noTLogPolicy complements rekorPolicy on the signing side.
+type requireTLogPolicy struct{}
+
+// NewRequireTLogPolicy returns a VerifyTransparencyPolicy that requires a
+// transparency-log inclusion proof and an observer timestamp.
+func NewRequireTLogPolicy() VerifyTransparencyPolicy { return requireTLogPolicy{} }
+
+func (requireTLogPolicy) VerifierOptions() []verify.VerifierOption {
+	return []verify.VerifierOption{
+		verify.WithTransparencyLog(1),
+		verify.WithObserverTimestamps(1),
+	}
+}

--- a/pkg/bundler/verifier/verifier.go
+++ b/pkg/bundler/verifier/verifier.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,18 +28,13 @@ import (
 	"runtime"
 	"strings"
 
-	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
-	"github.com/sigstore/sigstore-go/pkg/bundle"
-	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
-	"github.com/NVIDIA/aicr/pkg/trust"
 )
 
 // readBoundedFile streams a file through io.LimitReader against maxBytes.
@@ -47,12 +43,15 @@ import (
 func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
 	f, err := os.Open(path) //nolint:gosec // verifier paths are bundle-local
 	if err != nil {
-		return nil, err
+		// Wrap with a code while preserving the cause chain: callers propagate
+		// this error as-is, and the os.ErrNotExist sentinel stays reachable via
+		// errors.Is (StructuredError.Unwrap returns the cause).
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to open file "+path, err)
 	}
 	defer func() { _ = f.Close() }()
 	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read file "+path, err)
 	}
 	if int64(len(data)) > maxBytes {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
@@ -79,6 +78,13 @@ type VerifyOptions struct {
 	// for binary attestation verification. Must contain "NVIDIA/aicr".
 	// Defaults to TrustedRepositoryPattern if empty.
 	CertificateIdentityRegexp string
+
+	// Key selects public-key verification of the bundle attestation instead of
+	// keyless certificate-identity verification. A KMS key URI
+	// (awskms:// | gcpkms:// | azurekms://) or a local PEM public-key file.
+	// Independent of CertificateIdentityRegexp, which pins the (separate) binary
+	// attestation; the two coexist (see #1152).
+	Key string
 }
 
 // ValidateIdentityPattern checks that a certificate identity pattern contains
@@ -151,7 +157,15 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 	checksumHash := sha256.Sum256(checksumData)
 	checksumDigest := checksumHash[:]
 
-	bundleCreator, err := verifySigstoreBundle(ctx, bundleAttestPath, checksumDigest)
+	var (
+		bundleCreator string
+		err           error
+	)
+	if opts.Key != "" {
+		bundleCreator, err = verifyKeySignedBundle(ctx, bundleAttestPath, checksumDigest, opts.Key)
+	} else {
+		bundleCreator, err = verifySigstoreBundle(ctx, bundleAttestPath, checksumDigest)
+	}
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("bundle attestation verification failed: %v", err))
 		result.setTrust(TrustUnknown, "bundle attestation verification failed")
@@ -224,7 +238,7 @@ func verifyChecksumStep(bundleDir string, result *VerifyResult) ([]byte, bool) {
 	}
 	checksumData, err := readBoundedFile(checksumPath, defaults.MaxChecksumFileBytes)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if stderrors.Is(err, os.ErrNotExist) {
 			result.setTrust(TrustUnknown, "checksums.txt not found")
 			result.Errors = append(result.Errors, "checksums.txt not found")
 			return nil, true
@@ -243,25 +257,6 @@ func verifyChecksumStep(bundleDir string, result *VerifyResult) ([]byte, bool) {
 	result.ChecksumsPassed = true
 	result.ChecksumFiles = checksum.CountEntries(bundleDir)
 	return checksumData, false
-}
-
-// containsCertChainError checks if an error message indicates a certificate chain
-// verification failure, which typically means the trusted root is stale.
-func containsCertChainError(errMsg string) bool {
-	staleIndicators := []string{
-		"certificate signed by unknown authority",
-		"certificate chain",
-		"x509",
-		"unable to verify certificate",
-		"root certificate",
-	}
-	lower := strings.ToLower(errMsg)
-	for _, indicator := range staleIndicators {
-		if strings.Contains(lower, indicator) {
-			return true
-		}
-	}
-	return false
 }
 
 // resolveExecutablePath returns the best path for reading the running binary.
@@ -284,7 +279,7 @@ func resolveExecutablePath() string {
 func parseDSSEPayload(bundlePath string) ([]byte, error) {
 	data, err := readBoundedFile(bundlePath, defaults.MaxSigstoreBundleSize)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read bundle file", err)
+		return nil, err // already coded by readBoundedFile
 	}
 
 	var raw map[string]json.RawMessage
@@ -371,30 +366,6 @@ func extractBinaryDigest(bundlePath string) ([]byte, error) {
 	return nil, errors.New(errors.ErrCodeNotFound, "no binary digest found in bundle attestation resolvedDependencies")
 }
 
-// loadSigstoreBundle reads a .sigstore.json file and returns a parsed Bundle.
-// Rejects files larger than defaults.MaxSigstoreBundleSize.
-func loadSigstoreBundle(path string) (*bundle.Bundle, error) {
-	// readBoundedFile is authoritative on size: a stat-then-read sequence
-	// races on symlink swaps and network mounts, but io.LimitReader bounds
-	// what we actually load into memory.
-	data, err := readBoundedFile(path, defaults.MaxSigstoreBundleSize)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read sigstore bundle: "+path, err)
-	}
-
-	var pb protobundle.Bundle
-	if unmarshalErr := protojson.Unmarshal(data, &pb); unmarshalErr != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse sigstore bundle", unmarshalErr)
-	}
-
-	b, err := bundle.NewBundle(&pb)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "invalid sigstore bundle", err)
-	}
-
-	return b, nil
-}
-
 // verifySigstoreBundle verifies a Sigstore bundle (.sigstore.json) against the
 // public-good trusted root, binding the attestation to the given artifact digest.
 // Requires a valid OIDC-issued certificate from any issuer (bundle attestation
@@ -406,14 +377,9 @@ func verifySigstoreBundle(ctx context.Context, bundlePath string, artifactDigest
 		return "", errors.Wrap(errors.ErrCodeTimeout, "context cancelled before bundle attestation verification", err)
 	}
 
-	b, err := loadSigstoreBundle(bundlePath)
+	data, err := readBoundedFile(bundlePath, defaults.MaxSigstoreBundleSize)
 	if err != nil {
-		return "", err
-	}
-
-	trustedMaterial, err := trust.GetTrustedMaterial()
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to load trusted root", err)
+		return "", err // already coded by readBoundedFile (oversize -> ErrCodeInvalidRequest)
 	}
 
 	// Require any valid OIDC-issued certificate — confirms a real identity signed this
@@ -422,7 +388,35 @@ func verifySigstoreBundle(ctx context.Context, bundlePath string, artifactDigest
 		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create bundle identity matcher", err)
 	}
 
-	return verifyBundle(b, trustedMaterial, identity, artifactDigest)
+	return attestation.VerifyStatementWith(ctx, data,
+		attestation.NewKeylessVerificationIdentity(identity),
+		attestation.NewRequireTLogPolicy(), artifactDigest)
+}
+
+// verifyKeySignedBundle verifies a public-key-signed bundle attestation (#407
+// KMS signing or a local PEM) against the key named by keyRef, binding it to
+// artifactDigest. Returns the key identity (KMS URI or pem:<fp>) as the bundle
+// creator, since a key-signed bundle has no certificate SAN.
+func verifyKeySignedBundle(ctx context.Context, bundlePath string, artifactDigest []byte, keyRef string) (string, error) {
+	id, err := attestation.NewKeyVerificationIdentity(ctx, keyRef)
+	if err != nil {
+		return "", err // already classified (ErrCodeInvalidRequest / ErrCodeUnavailable)
+	}
+	data, err := readBoundedFile(bundlePath, defaults.MaxSigstoreBundleSize)
+	if err != nil {
+		return "", err // already coded by readBoundedFile (oversize -> ErrCodeInvalidRequest)
+	}
+	signer, err := attestation.VerifyStatementWith(ctx, data, id, attestation.NewRequireTLogPolicy(), artifactDigest)
+	if err != nil {
+		return "", err
+	}
+	if signer == "" {
+		// Key-signed bundles carry no cert SAN; fall back to the key identity.
+		if ki, ok := id.(interface{ Identity() string }); ok {
+			return ki.Identity(), nil
+		}
+	}
+	return signer, nil
 }
 
 // VerifyBinaryAttestation verifies the binary attestation with identity pinning
@@ -433,14 +427,9 @@ func VerifyBinaryAttestation(ctx context.Context, bundlePath string, identityPat
 		return "", errors.Wrap(errors.ErrCodeTimeout, "context cancelled before binary attestation verification", err)
 	}
 
-	b, err := loadSigstoreBundle(bundlePath)
+	data, err := readBoundedFile(bundlePath, defaults.MaxSigstoreBundleSize)
 	if err != nil {
-		return "", err
-	}
-
-	trustedMaterial, err := trust.GetTrustedMaterial()
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to load trusted root", err)
+		return "", err // already coded by readBoundedFile (oversize -> ErrCodeInvalidRequest)
 	}
 
 	// Pin identity to NVIDIA CI using the provided pattern
@@ -452,51 +441,7 @@ func VerifyBinaryAttestation(ctx context.Context, bundlePath string, identityPat
 		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create identity matcher", err)
 	}
 
-	return verifyBundle(b, trustedMaterial, identity, artifactDigest)
-}
-
-// verifyBundle performs sigstore-go verification on a bundle.
-// Both identity and artifactDigest are required — verification refuses to proceed
-// without content binding (artifact digest) and signer validation (identity).
-// Returns the SubjectAlternativeName from the signing certificate.
-func verifyBundle(b *bundle.Bundle, trustedMaterial root.TrustedMaterial, identity verify.CertificateIdentity, artifactDigest []byte) (string, error) {
-	v, err := verify.NewVerifier(trustedMaterial,
-		verify.WithTransparencyLog(1),
-		verify.WithObserverTimestamps(1),
-	)
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create sigstore verifier", err)
-	}
-
-	// Artifact digest is required — refuse to verify without content binding
-	if len(artifactDigest) == 0 {
-		return "", errors.New(errors.ErrCodeInvalidRequest,
-			"artifact digest is required for attestation verification")
-	}
-
-	policy := verify.NewPolicy(
-		verify.WithArtifactDigest("sha256", artifactDigest),
-		verify.WithCertificateIdentity(identity),
-	)
-
-	result, err := v.Verify(b, policy)
-	if err != nil {
-		// Detect staleness: if the error mentions certificate chain issues,
-		// suggest updating the trusted root
-		errMsg := err.Error()
-		if containsCertChainError(errMsg) {
-			return "", errors.New(errors.ErrCodeUnauthorized,
-				"sigstore verification failed — the signing certificate may have been issued "+
-					"by a CA not present in your trusted root. This usually means Sigstore rotated "+
-					"their keys since your last update.\n\n  To fix: aicr trust update")
-		}
-		return "", errors.Wrap(errors.ErrCodeUnauthorized, "sigstore verification failed", err)
-	}
-
-	// Extract signer identity from certificate
-	if result != nil && result.Signature != nil && result.Signature.Certificate != nil {
-		return result.Signature.Certificate.SubjectAlternativeName, nil
-	}
-
-	return "", nil
+	return attestation.VerifyStatementWith(ctx, data,
+		attestation.NewKeylessVerificationIdentity(identity),
+		attestation.NewRequireTLogPolicy(), artifactDigest)
 }

--- a/pkg/bundler/verifier/verifier_test.go
+++ b/pkg/bundler/verifier/verifier_test.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/sigstore/sigstore-go/pkg/verify"
 
+	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
+	"github.com/NVIDIA/aicr/pkg/defaults"
 )
 
 // createTestBundle creates a minimal bundle directory with checksums generated
@@ -123,24 +125,29 @@ func TestVerify_NonexistentDir(t *testing.T) {
 }
 
 func TestVerifyBundle_RejectsEmptyDigest(t *testing.T) {
-	// verifyBundle must reject empty artifact digests — this prevents
-	// accidental fallback to WithoutArtifactUnsafe().
-	identity, err := verify.NewShortCertificateIdentity("", ".+", "", ".+")
+	// The empty-digest guard now lives in attestation.VerifyStatementWith
+	// (the composed core both keyless verifier paths flow through). It must
+	// reject empty artifact digests — this prevents accidental fallback to
+	// WithoutArtifactUnsafe(). The guard runs before bundle parsing, so the
+	// bundle bytes need not be valid here.
+	certID, err := verify.NewShortCertificateIdentity("", ".+", "", ".+")
 	if err != nil {
 		t.Fatal(err)
 	}
+	id := attestation.NewKeylessVerificationIdentity(certID)
+	tlog := attestation.NewRequireTLogPolicy()
 
-	_, err = verifyBundle(nil, nil, identity, nil)
+	_, err = attestation.VerifyStatementWith(context.Background(), []byte("{}"), id, tlog, nil)
 	if err == nil {
-		t.Fatal("verifyBundle() with nil digest should return error")
+		t.Fatal("VerifyStatementWith() with nil digest should return error")
 	}
 	if !strings.Contains(err.Error(), "artifact digest is required") {
 		t.Errorf("error = %v, want message about artifact digest requirement", err)
 	}
 
-	_, err = verifyBundle(nil, nil, identity, []byte{})
+	_, err = attestation.VerifyStatementWith(context.Background(), []byte("{}"), id, tlog, []byte{})
 	if err == nil {
-		t.Fatal("verifyBundle() with empty digest should return error")
+		t.Fatal("VerifyStatementWith() with empty digest should return error")
 	}
 }
 
@@ -161,31 +168,6 @@ func TestVerify_NilOptions(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("Verify() returned nil result")
-	}
-}
-
-func TestContainsCertChainError(t *testing.T) {
-	tests := []struct {
-		name   string
-		errMsg string
-		want   bool
-	}{
-		{"unknown authority", "certificate signed by unknown authority", true},
-		{"cert chain", "failed to verify certificate chain", true},
-		{"x509 error", "x509: certificate has expired", true},
-		{"unable to verify", "unable to verify certificate", true},
-		{"root cert", "root certificate not found", true},
-		{"case insensitive", "Certificate Signed By Unknown Authority", true},
-		{"unrelated error", "connection refused", false},
-		{"empty string", "", false},
-		{"sigstore error", "sigstore verification failed", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := containsCertChainError(tt.errMsg); got != tt.want {
-				t.Errorf("containsCertChainError(%q) = %v, want %v", tt.errMsg, got, tt.want)
-			}
-		})
 	}
 }
 
@@ -369,25 +351,14 @@ func TestParseDSSEPayload(t *testing.T) {
 	})
 }
 
-func TestLoadSigstoreBundle_MissingFile(t *testing.T) {
-	_, err := loadSigstoreBundle("/nonexistent/path")
+func TestReadBoundedFile_MissingFile(t *testing.T) {
+	_, err := readBoundedFile("/nonexistent/path", defaults.MaxSigstoreBundleSize)
 	if err == nil {
-		t.Error("loadSigstoreBundle() with missing file should return error")
+		t.Error("readBoundedFile() with missing file should return error")
 	}
 }
 
-func TestLoadSigstoreBundle_InvalidJSON(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "bad.json")
-	if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	_, err := loadSigstoreBundle(path)
-	if err == nil {
-		t.Error("loadSigstoreBundle() with invalid JSON should return error")
-	}
-}
-
-func TestLoadSigstoreBundle_OversizedFile(t *testing.T) {
+func TestReadBoundedFile_OversizedFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "huge.json")
 	// Create a file just over the limit
 	f, err := os.Create(path)
@@ -403,9 +374,9 @@ func TestLoadSigstoreBundle_OversizedFile(t *testing.T) {
 	}
 	f.Close()
 
-	_, err = loadSigstoreBundle(path)
+	_, err = readBoundedFile(path, defaults.MaxSigstoreBundleSize)
 	if err == nil {
-		t.Error("loadSigstoreBundle() with oversized file should return error")
+		t.Error("readBoundedFile() with oversized file should return error")
 	}
 	if !strings.Contains(err.Error(), "exceeds maximum size") {
 		t.Errorf("error = %v, want message about maximum size", err)
@@ -490,22 +461,6 @@ func TestVerify_ContextCancelled(t *testing.T) {
 	}
 }
 
-func TestLoadSigstoreBundle_IncompleteBundle(t *testing.T) {
-	// Valid JSON/protobuf but incomplete sigstore bundle (missing content)
-	bundleJSON := `{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.3"}`
-	path := filepath.Join(t.TempDir(), "incomplete.sigstore.json")
-	if err := os.WriteFile(path, []byte(bundleJSON), 0600); err != nil {
-		t.Fatal(err)
-	}
-	_, err := loadSigstoreBundle(path)
-	if err == nil {
-		t.Error("loadSigstoreBundle() with incomplete bundle should return error")
-	}
-	if !strings.Contains(err.Error(), "invalid sigstore bundle") {
-		t.Errorf("error = %v, want message about invalid bundle", err)
-	}
-}
-
 func TestVerify_WithDataDir(t *testing.T) {
 	// Bundle with checksums + data dir → trust level capped at attested (but
 	// without real attestation, we test the checksum + no-attestation path)
@@ -566,6 +521,64 @@ func TestVerify_ChecksumsWithFakeAttestation(t *testing.T) {
 	}
 	if len(result.Errors) == 0 {
 		t.Error("expected errors for invalid attestation")
+	}
+}
+
+// writeFakeBundleAttestation creates the standard bundle attestation file path
+// under dir with the given JSON content, mirroring TestVerify_ContextCancelled.
+func writeFakeBundleAttestation(t *testing.T, dir, content string) {
+	t.Helper()
+	attestDir := filepath.Join(dir, "attestation")
+	if err := os.MkdirAll(attestDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	attestPath := filepath.Join(attestDir, "bundle-attestation.sigstore.json")
+	if err := os.WriteFile(attestPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerify_KeyOption_UnknownScheme(t *testing.T) {
+	// "bogus://x" is not a recognized KMS scheme, so NewKeyVerificationIdentity
+	// treats it as a PEM path, fails to open the file, and returns
+	// ErrCodeInvalidRequest. Verify() records this on result.Errors and sets
+	// TrustUnknown without hard-failing (returns nil error) — same contract as
+	// a keyless verifySigstoreBundle failure.
+	dir := createTestBundle(t)
+	writeFakeBundleAttestation(t, dir, `{"not":"a-valid-sigstore-bundle"}`)
+
+	result, err := Verify(context.Background(), dir, &VerifyOptions{Key: "bogus://x"})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if result.TrustLevel != TrustUnknown {
+		t.Errorf("TrustLevel = %s, want unknown", result.TrustLevel)
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected errors for key-resolution failure")
+	}
+	if result.BundleAttested {
+		t.Error("BundleAttested = true, want false on key-resolution failure")
+	}
+}
+
+func TestVerify_KeyOption_MissingPEMFile(t *testing.T) {
+	// A --key pointing at a nonexistent local PEM file is a user error
+	// (ErrCodeInvalidRequest from loadPEMPublicKey). Verify() surfaces it on
+	// result.Errors and sets TrustUnknown, returning nil error.
+	dir := createTestBundle(t)
+	writeFakeBundleAttestation(t, dir, `{"not":"a-valid-sigstore-bundle"}`)
+
+	keyPath := filepath.Join(t.TempDir(), "nonexistent-key.pem")
+	result, err := Verify(context.Background(), dir, &VerifyOptions{Key: keyPath})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if result.TrustLevel != TrustUnknown {
+		t.Errorf("TrustLevel = %s, want unknown", result.TrustLevel)
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected errors for missing PEM key file")
 	}
 }
 

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -699,7 +699,7 @@ Package with explicit tag (overrides CLI version):
 			},
 			&cli.StringFlag{
 				Name:     flagSigningKey,
-				Usage:    "Sign --attest bundles with a KMS-backed key (awskms:// | gcpkms:// | azurekms://) instead of keyless OIDC, for CI/CD without OIDC. Mutually exclusive with --identity-token, --oidc-device-flow, --fulcio-url. Combine with --rekor-url to log to a private Rekor. Verify with `cosign verify --key <uri>` until native `aicr verify --key` lands (#1152).",
+				Usage:    "Sign --attest bundles with a KMS-backed key (awskms:// | gcpkms:// | azurekms://) instead of keyless OIDC, for CI/CD without OIDC. Mutually exclusive with --identity-token, --oidc-device-flow, --fulcio-url. Combine with --rekor-url to log to a private Rekor. Verify the resulting bundle with `aicr verify --key <uri>`.",
 				Category: catDeployment,
 			},
 			&cli.BoolFlag{

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -88,6 +88,10 @@ Output as JSON:
 				Usage: `Override the certificate identity pattern for binary attestation verification.
 	Must contain "NVIDIA/aicr". Default pins to the release workflow on tag refs.`,
 			},
+			&cli.StringFlag{
+				Name:  "key",
+				Usage: "Verify a key-signed bundle attestation against a KMS key URI (awskms:// | gcpkms:// | azurekms://) or a local PEM public-key file. The counterpart to `bundle --signing-key`. Coexists with --certificate-identity-regexp (which pins the separate binary attestation).",
+			},
 			withCompletions(&cli.StringFlag{
 				Name:  flagFormat,
 				Value: verifyFormatText,
@@ -126,6 +130,7 @@ func runBundleVerifyCmd(ctx context.Context, cmd *cli.Command) error {
 		}
 		verifyOpts.CertificateIdentityRegexp = identityRegexp
 	}
+	verifyOpts.Key = cmd.String("key")
 
 	// Run verification
 	result, err := verifier.Verify(ctx, absDir, verifyOpts)

--- a/pkg/cli/bundle_verify_test.go
+++ b/pkg/cli/bundle_verify_test.go
@@ -16,10 +16,16 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
+	"github.com/urfave/cli/v3"
 )
 
 func TestBundleVerifyCmd_HasExpectedFlags(t *testing.T) {
@@ -29,7 +35,7 @@ func TestBundleVerifyCmd_HasExpectedFlags(t *testing.T) {
 		t.Errorf("Name = %q, want %q", cmd.Name, "verify")
 	}
 
-	expectedFlags := []string{"min-trust-level", "require-creator", "cli-version-constraint", "certificate-identity-regexp", "format"}
+	expectedFlags := []string{"min-trust-level", "require-creator", "cli-version-constraint", "certificate-identity-regexp", "key", "format"}
 	for _, name := range expectedFlags {
 		found := false
 		for _, f := range cmd.Flags {
@@ -62,6 +68,105 @@ func TestBundleVerifyCmd_MinTrustLevelDefault(t *testing.T) {
 		}
 	}
 	t.Error("min-trust-level flag not found")
+}
+
+// writeVerifiableKeyFixture builds a bundle directory that passes the checksum
+// step and carries a bundle-attestation file, so verification reaches the
+// bundle-attestation step (where --key takes effect) instead of stopping at
+// missing checksums. The attestation bytes only need to exist: with --key, key
+// resolution runs before they are parsed.
+func writeVerifiableKeyFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	valuesPath := filepath.Join(dir, "values.yaml")
+	if err := os.WriteFile(valuesPath, []byte("replicas: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// GenerateChecksums takes absolute file paths and records them relative to dir.
+	if err := checksum.GenerateChecksums(context.Background(), dir, []string{valuesPath}); err != nil {
+		t.Fatalf("GenerateChecksums: %v", err)
+	}
+	attestPath := filepath.Join(dir, attestation.BundleAttestationFile)
+	if err := os.MkdirAll(filepath.Dir(attestPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(attestPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestBundleVerifyCmd_KeyFlagPlumbing runs the real verify command with --key
+// against a fixture that passes checksums and has a bundle attestation, so
+// verification reaches the bundle-attestation step where --key takes effect. A
+// nonexistent PEM path drives the key-verification branch to a public-key
+// resolution error, which the keyless path would not produce (it would report a
+// sigstore-bundle parse error). Asserting that error proves verifyOpts.Key is
+// plumbed and routed to the key branch, and that --key coexists with
+// --certificate-identity-regexp (no mutual exclusivity).
+func TestBundleVerifyCmd_KeyFlagPlumbing(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(dir string) []string
+	}{
+		{
+			name: "key alone reaches key verification",
+			args: func(dir string) []string { return []string{"verify", dir, "--key", "/nonexistent/key.pem"} },
+		},
+		{
+			name: "key coexists with certificate-identity-regexp",
+			args: func(dir string) []string {
+				return []string{"verify", dir, "--key", "/nonexistent/key.pem", "--certificate-identity-regexp", "https://github.com/NVIDIA/aicr/.+"}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writeVerifiableKeyFixture(t)
+			cmd := bundleVerifyCmd()
+			var buf bytes.Buffer
+			cmd.Writer = &buf
+
+			err := cmd.Run(context.Background(), tt.args(dir))
+
+			// Must not be a flag-parse/usage error: the flags were accepted and
+			// the action ran (proves --key coexists with the identity regexp).
+			if err != nil {
+				for _, bad := range []string{"flag provided but not defined", "no such flag", "flag needs an argument"} {
+					if strings.Contains(err.Error(), bad) {
+						t.Fatalf("got flag-level error %q for args %v", err.Error(), tt.args(dir))
+					}
+				}
+			}
+
+			// Prove the key-verification branch ran: the public-key resolution
+			// error surfaces in the output. The keyless path would instead
+			// report a sigstore-bundle parse failure.
+			combined := buf.String()
+			if err != nil {
+				combined += " " + err.Error()
+			}
+			if !strings.Contains(combined, "public key") {
+				t.Errorf("output does not show the key-verification path was taken; got:\n%s", combined)
+			}
+		})
+	}
+}
+
+func TestBundleVerifyCmd_KeyFlagDefinition(t *testing.T) {
+	cmd := bundleVerifyCmd()
+	for _, f := range cmd.Flags {
+		if f.Names()[0] != "key" {
+			continue
+		}
+		// --key is a plain StringFlag (not completion-wrapped): there is no
+		// natural completion source for a KMS URI or PEM path.
+		if _, ok := f.(*cli.StringFlag); !ok {
+			t.Fatalf("--key should be a plain *cli.StringFlag, got %T", f)
+		}
+		return
+	}
+	t.Fatal("--key flag not found")
 }
 
 func TestOutputText_Verdict(t *testing.T) {

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -647,6 +647,13 @@ const (
 	// would allocate the whole file into memory.
 	MaxManifestFileBytes int64 = 1 * 1024 * 1024 // 1 MiB
 
+	// MaxPublicKeyPEMBytes caps the size of a local PEM public-key file passed
+	// to `aicr verify --key` (#1152). A PEM-encoded ECDSA P-256 or RSA-4096
+	// public key is well under 2 KiB; 64 KiB is generous headroom while
+	// bounding an attacker-influenced --key path (symlink to /proc, NFS mount,
+	// FUSE filesystem) before the bytes are read into memory.
+	MaxPublicKeyPEMBytes int64 = 64 * 1024 // 64 KiB
+
 	// MaxExternalDataFileBytes caps the size of recipe/registry data files
 	// read from the external data directory by LayeredDataProvider. This is
 	// the single source of truth for the external-data size limit:


### PR DESCRIPTION
## Summary

Adds `aicr verify --key <kms-uri-or-pem>`, verifying a key-signed bundle attestation against its public key. This is the verification counterpart to #407's KMS-backed signing, accepting a KMS key URI (`awskms://` | `gcpkms://` | `azurekms://`) or a local PEM public-key file.

## Motivation / Context

Epic #1149 (Closed Supply Chain, V1) requires that every signing mode have a matching verification path in the same environment. KMS-backed signing (#407) shipped, but `aicr verify` could only verify keyless bundles against the public-good trusted root, so a KMS-signed bundle was unverifiable by the toolchain. This closes that asymmetry for the key-based path.

Fixes: #1152
Related: #1149 (epic), #407 (KMS signing, the counterpart), #1153 / #1154 (private trust root / offline verify, future siblings), #1214 (KMS integration test)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes) — keyless verification routed through the new composer with behavior preserved

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Implemented as the verification dual of the signing-side interface composition. Two small interfaces in `pkg/bundler/attestation` — `VerificationIdentity` (trust anchors + signer-matching policy) and `VerifyTransparencyPolicy` (tlog requirement) — are composed by `VerifyStatementWith`, mirroring `SigningIdentity` × `TransparencyPolicy` → `SignStatementWith`.

- The existing keyless path was refactored to flow through the same composer; behavior is unchanged (existing tests are the regression gate).
- `keyVerificationIdentity` combines the public-good trusted root (so the Rekor tlog still verifies, since KMS signing uploads by default) with the caller's public key, using `verify.WithKey()`. KMS public-key resolution is shared with the signing path via an extracted `resolveKMSPublicKey`; local PEM is loaded with a bounded read against `defaults.MaxPublicKeyPEMBytes`.
- `--key` swaps only the **bundle** attestation verification. The **binary** attestation still runs and stays NVIDIA-keyless-pinned, so `--key` and `--certificate-identity-regexp` **coexist** (they verify different attestations). This diverges from the issue's literal "mutually exclusive" wording; rationale is in the issue thread.
- No-downgrade is enforced by sigstore-go itself: a Fulcio-cert bundle cannot verify under `WithKey()` (`"expected key signature, not certificate"`).
- Private trust root (#1153) and offline/skip-tlog (#1154) slot in later as additional implementations of these two interfaces, with no new branching in the verifier.

## Testing

```bash
make test-coverage   # full -short unit suite, race
make lint            # golangci-lint + yamllint + vet + license + agents-sync
```

- `make test-coverage`: full unit suite green, module total **75.7% ≥ 75%** threshold.
- `make lint`: golangci-lint **0 issues**, vet / license headers / AGENTS.md-sync clean.
- New exported funcs all covered (no 0%). Per-package: `pkg/bundler/attestation` 78.3% → 76.0% (the uncovered lines are live-KMS resolution and the sigstore crypto-success path, which require live KMS + Rekor and are covered by integration test #1214); `pkg/bundler/verifier` 64.0% → 65.1%.
- Not run locally (require infra; left to CI): `e2e` (KWOK/kind cluster) and `grype` scan.

## Risk Assessment

- [x] **Medium** — Touches the bundle-verification core across `pkg/bundler/{attestation,verifier}` and `pkg/cli`.

**Rollout notes:** Additive and backwards compatible. The keyless verification path is preserved (refactored through the new composer, behavior unchanged); `--key` is opt-in. No migration required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
