### PR TITLE
feat(recipes): backfill chainsaw health checks for 5 missing components

### DIFF
--- a/recipes/checks/agentgateway-crds/health-check.yaml
+++ b/recipes/checks/agentgateway-crds/health-check.yaml
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# agentgateway-crds Health Check
+#
+# CRD-only component. Validates that every CRD this component installs
+# has reached the `Established=True` condition (CRD storage is up and
+# the apiserver will accept CRs of those kinds).
+#
+# Scope: this component bundles BOTH the chart's
+# agentgateway.dev/v1alpha1 CRDs AND the vendored Gateway API +
+# Inference Extension manifests under
+# recipes/components/agentgateway-crds/manifests/. The asserts below
+# cover the vendored set (deterministic from in-tree files). The
+# chart's own CRDs are described in
+# recipes/components/agentgateway-crds/values.yaml as
+# {AgentgatewayBackend, AgentgatewayPolicy, AgentgatewayParameters}
+# under agentgateway.dev/v1alpha1; their plural metadata.name values
+# are not vendored in-tree at v2.2.1 and should be added here once
+# verified against a real cluster install (live-run is the load-bearing
+# step). See #1221.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: agentgateway-crds-health-check
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    - name: validate-gateway-api-crds-established
+      # Standard Gateway API CRDs vendored under
+      # manifests/gateway-api-crds.yaml. Verified against the in-tree
+      # manifest content.
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: gatewayclasses.gateway.networking.k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: gateways.gateway.networking.k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: grpcroutes.gateway.networking.k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: httproutes.gateway.networking.k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: referencegrants.gateway.networking.k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+    - name: validate-inference-extension-crds-established
+      # Gateway API Inference Extension CRDs vendored under
+      # manifests/inference-extension-crds.yaml.
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: inferencemodelrewrites.inference.networking.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: inferenceobjectives.inference.networking.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: inferencepoolimports.inference.networking.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: inferencepools.inference.networking.k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: inferencepools.inference.networking.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"

--- a/recipes/checks/gke-nccl-tcpxo/health-check.yaml
+++ b/recipes/checks/gke-nccl-tcpxo/health-check.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GKE NCCL-TCPXO Health Check
+#
+# Validates the manifest-only gke-nccl-tcpxo component. The component
+# ships two DaemonSets that AICR applies directly (no Helm release),
+# from recipes/components/gke-nccl-tcpxo/manifests/:
+#
+#   1. nccl-tcpxo-installer (kube-system) — installs NCCL TCPXO plugin
+#      binaries on each GPU node's host filesystem so workloads can
+#      LD_LOAD them.
+#   2. device-injector (kube-system) — NRI device-injection DaemonSet
+#      that exposes the host's TCPXO ENV / devices to containers.
+#
+# Both DaemonSets must roll out fully. The asserts gate on
+# `numberReady == desiredNumberScheduled` (with `desiredNumberScheduled
+# > 0` as a guard against vacuous pass on a 0-node selector). We assert
+# on `numberReady` rather than `numberUnavailable == 0` because
+# `numberUnavailable` is `omitempty` and disappears from the status
+# when zero — making the equality compare null on a healthy DaemonSet
+# (see recipes/checks/nfd/health-check.yaml for the same rationale).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gke-nccl-tcpxo-health-check
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    - name: validate-nccl-tcpxo-installer-daemonset
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: nccl-tcpxo-installer
+                namespace: kube-system
+              status:
+                (desiredNumberScheduled > `0`): true
+                (numberReady == desiredNumberScheduled): true
+    - name: validate-device-injector-daemonset
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: device-injector
+                namespace: kube-system
+              status:
+                (desiredNumberScheduled > `0`): true
+                (numberReady == desiredNumberScheduled): true

--- a/recipes/checks/grove/health-check.yaml
+++ b/recipes/checks/grove/health-check.yaml
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Grove Health Check
+#
+# Validates the Grove pod-lifecycle controller for the Dynamo inference
+# platform. The chart deploys a single `grove-operator` Deployment in
+# the `dynamo-system` namespace. We gate on the Available condition
+# transitioning to True — mirrors the existing assertion in
+# tests/chainsaw/ai-conformance/kind-inference-dynamo/assert-dynamo.yaml
+# so this registry check produces the same readiness signal that the
+# ai-conformance suite exercises.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: grove-health-check
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    - name: validate-grove-operator-deployment
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: grove-operator
+                namespace: dynamo-system
+              status:
+                (conditions[?type == 'Available']):
+                  - status: "True"
+    - name: validate-grove-pods-healthy
+      try:
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: dynamo-system
+                labels:
+                  app.kubernetes.io/name: grove-operator
+              status:
+                phase: Pending
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: dynamo-system
+                labels:
+                  app.kubernetes.io/name: grove-operator
+              status:
+                phase: Failed
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: dynamo-system
+                labels:
+                  app.kubernetes.io/name: grove-operator
+              status:
+                containerStatuses:
+                  - state:
+                      waiting:
+                        reason: CrashLoopBackOff

--- a/recipes/checks/prometheus-operator-crds/health-check.yaml
+++ b/recipes/checks/prometheus-operator-crds/health-check.yaml
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# prometheus-operator-crds Health Check
+#
+# CRD-only component. Validates that every CRD this chart installs has
+# reached the `Established=True` condition (CRD storage is up and the
+# apiserver will accept CRs of those kinds).
+#
+# CRDs come from the upstream prometheus-community/prometheus-operator-crds
+# chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+# monitoring.coreos.com/v1 are enumerated in
+# recipes/components/prometheus-operator-crds/values.yaml header:
+# Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+# PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+# long-standing upstream prometheus-operator chart shape.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prometheus-operator-crds-health-check
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    - name: validate-prometheus-operator-crds-established
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: alertmanagers.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: alertmanagerconfigs.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: podmonitors.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: probes.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: prometheuses.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: prometheusrules.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: servicemonitors.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: thanosrulers.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"

--- a/recipes/checks/slinky-slurm-operator-crds/health-check.yaml
+++ b/recipes/checks/slinky-slurm-operator-crds/health-check.yaml
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# slinky-slurm-operator-crds Health Check
+#
+# CRD-only component. Validates that every CRD this chart installs has
+# reached the `Established=True` condition (CRD storage is up and the
+# apiserver will accept CRs of those kinds).
+#
+# CRDs come from the upstream SchedMD Slinky slurm-operator-crds chart
+# pinned to 1.1.0 (oci://ghcr.io/slinkyproject/charts) in
+# recipes/registry.yaml. The 6 kinds under slinky.slurm.net are
+# enumerated in recipes/components/slinky-slurm-operator-crds/values.yaml
+# header: Accounting, Controller, LoginSet, NodeSet, RestApi, Token.
+# Plural metadata.name values follow the controller-gen default
+# (lowercase + standard pluralization). Live-cluster verification is
+# the load-bearing step — if a plural disagrees with the chart-shipped
+# manifest, update here in lockstep. See #1221.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: slinky-slurm-operator-crds-health-check
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    - name: validate-slinky-slurm-operator-crds-established
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: accountings.slinky.slurm.net
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: controllers.slinky.slurm.net
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: loginsets.slinky.slurm.net
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: nodesets.slinky.slurm.net
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: restapis.slinky.slurm.net
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: tokens.slinky.slurm.net
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -143,6 +143,8 @@ components:
     displayName: gke-nccl-tcpxo
     valueOverrideKeys:
       - gkenccltcpxo
+    healthCheck:
+      assertFile: checks/gke-nccl-tcpxo/health-check.yaml
     helm:
       # Manifest-only component - no external Helm chart, uses manifestFiles
       defaultRepository: ""
@@ -302,6 +304,8 @@ components:
     displayName: prometheus-operator-crds
     valueOverrideKeys:
       - prometheusoperatorcrds
+    healthCheck:
+      assertFile: checks/prometheus-operator-crds/health-check.yaml
     # CRDs-only chart for the prometheus-operator; kube-prometheus-stack
     # (and any sibling chart that creates ServiceMonitor / PodMonitor /
     # Alertmanager / Prometheus / etc. CRs) consumes the kinds it
@@ -449,6 +453,8 @@ components:
     displayName: grove
     valueOverrideKeys:
       - grove
+    healthCheck:
+      assertFile: checks/grove/health-check.yaml
     helm:
       defaultRepository: oci://ghcr.io/ai-dynamo/grove
       defaultChart: grove-charts
@@ -484,6 +490,8 @@ components:
     displayName: agentgateway-crds
     valueOverrideKeys:
       - agentgatewaycrds
+    healthCheck:
+      assertFile: checks/agentgateway-crds/health-check.yaml
     # CRDs-only chart; agentgateway consumes the kinds it registers
     # via its templates, so agentgateway must declare this chart as a
     # DependencyRef for the DAG-stratified helmfile layout to install
@@ -593,6 +601,8 @@ components:
     valueOverrideKeys:
       - slinkyslurmoperatorcrds
       - slurmoperatorcrds
+    healthCheck:
+      assertFile: checks/slinky-slurm-operator-crds/health-check.yaml
     # CRDs-only chart; slinky-slurm-operator consumes the kinds it
     # registers via its templates, so slinky-slurm-operator must
     # declare this chart as a DependencyRef for the DAG-stratified


### PR DESCRIPTION
## Summary

Backfill `healthCheck.assertFile` for the 5 registry components that
don't have one. After this PR lands, every current component has a
chainsaw health check — the precondition for #1223's lint guard.

Fixes: #1221
Related: #660 (epic), #1223

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe` — registry.yaml + new
      recipes/checks/* health-check files)

## Implementation Notes

### Scope drift from #1221's original text

#1221 named `gke-nccl-tcpxo`, `dynamo-crds`, and `kgateway-crds`. The
registry has drifted since the issue was written: `dynamo-crds` and
`kgateway-crds` aren't in the current `recipes/registry.yaml` (they
were renamed or folded into other components). The actual 5 current
gaps are covered here. The acceptance criterion is "every current
registry component has a `healthCheck.assertFile`" — sticking to the
dated list would leave 4 gaps and prevent #1223 from enforcing.

Per out-of-band agreement, the issue body is not updated; the scope
drift is captured here in the PR description instead.

### The 5 components

| Component | Type | Assertions |
|---|---|---|
| `gke-nccl-tcpxo` | Manifest-only | 2 DaemonSets in `kube-system` (`nccl-tcpxo-installer`, `device-injector`) — `numberReady == desiredNumberScheduled` |
| `grove` | Helm chart | `grove-operator` Deployment in `dynamo-system` — `Available=True` + Pod-phase/container-state error guards |
| `agentgateway-crds` | CRD-only | 10 vendored Gateway API + Inference Extension CRDs — `Established=True` |
| `prometheus-operator-crds` | CRD-only | 8 `monitoring.coreos.com/v1` CRDs — `Established=True` |
| `slinky-slurm-operator-crds` | CRD-only | 6 `slinky.slurm.net` CRDs — `Established=True` |

### Resource-name provenance

- **`gke-nccl-tcpxo`** — DaemonSet names verified from in-tree
  `recipes/components/gke-nccl-tcpxo/manifests/{nccl-tcpxo-installer,nri-device-injector}.yaml`.
- **`grove`** — Deployment name + namespace verified from the existing
  `tests/chainsaw/ai-conformance/kind-inference-dynamo/assert-dynamo.yaml`
  assertion (so the registry check produces the same signal the
  ai-conformance suite exercises).
- **`agentgateway-crds`** — 10 CRD names verified from the in-tree
  vendored manifests under
  `recipes/components/agentgateway-crds/manifests/`. The chart's own
  `agentgateway.dev/v1alpha1` CRDs (per the chart's values.yaml header:
  AgentgatewayBackend / Policy / Parameters) are documented in the
  check header but not asserted — their plural `metadata.name` values
  aren't vendored in-tree at v2.2.1 and need live verification.
- **`prometheus-operator-crds`** — 8 CRD names from the chart's
  values.yaml header; well-known upstream prometheus-operator shape.
- **`slinky-slurm-operator-crds`** — 6 CRD kinds from the chart's
  values.yaml header (Accounting / Controller / LoginSet / NodeSet /
  RestApi / Token). Plural `metadata.name` values derived from
  controller-gen defaults; flagged for live verification in the check
  header.

### DaemonSet rollout pattern

For `gke-nccl-tcpxo`, both DaemonSets use
`numberReady == desiredNumberScheduled` (with `desiredNumberScheduled
> 0` as a vacuous-pass guard). Same pattern as the NFD fix in 627ad48:
`numberUnavailable` is `omitempty` and disappears from the status
when zero, so `numberUnavailable == 0` evaluates `null == 0` (false)
on a healthy DaemonSet.

## Testing

```bash
go test -race -count=1 ./validators/chainsaw/ ./pkg/recipe/
golangci-lint run -c .golangci.yaml ./validators/chainsaw/... ./pkg/recipe/...
```

- `TestValidateTestReadOnly_RegistryContent` (validators/chainsaw)
  walks **every** `recipes/checks/*/health-check.yaml` and asserts it
  passes the read-only allowlist. With this PR's 5 new files, the
  sweep now covers 27 components (was 22). All pass.
- All in-tree `pkg/recipe` tests still pass.
- `lint` clean.

**Live-cluster validation required by #660 acceptance criteria —
deferred to @mchmarny per the same agreement as #1235. The two CRD
checks where chart-CRD plurals are not vendored in-tree
(`agentgateway-crds` chart CRDs, `slinky-slurm-operator-crds`) are
the priority for live verification; the others are deducible from
in-tree content.**

## Risk Assessment

- [x] **Low** — Five new declarative YAML files + 5 one-line registry
  entries. No Go code changes. No runtime behavior change for
  existing components. Easy to revert per-component.

**Rollout notes:** Once #1235 lit up the deployment-phase chainsaw
runner, every component with a registry `assertFile` runs its check
during `aicr validate --phase deployment`. The 5 new checks become
active on the next bundle + deploy. If a check has a name typo
that turns out wrong on the live cluster, the validator surfaces a
clear `[chainsaw] <component>: health check failed` line with the
chainsaw output; the resolution is to update the YAML and re-deploy.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (changed paths)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (allowlist sweep
      now covers 27 files; new tests not needed since the existing
      test walks the registry content)
- [x] User-facing behavior change covered in this description
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
