### PR TITLE
feat(recipe): lint guard requiring healthCheck.assertFile + allowlist

### DIFF
--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -97,7 +97,7 @@ components:
 | `podScheduling` | `PodSchedulingConfig` | no | Helm value paths for workload pod scheduling injection |
 | `storageClassPaths` | []string | no | Helm value paths where `--storage-class` is written |
 | `validations` | []`ComponentValidationConfig` | no | Bundle-time validation checks (function, severity, conditions, message) |
-| `healthCheck.assertFile` | string | no | Chainsaw assert YAML (relative to data dir) for conformance phase |
+| `healthCheck.assertFile` | string | **yes** | Chainsaw assert YAML (relative to data dir) consumed by `aicr validate --phase deployment` (runtime — #1220) and by `make check-health` locally. Content is restricted to the read-only `assert` / `error` operation allowlist. Enforced at PR time by `pkg/recipe.TestComponentRegistry_RequiresHealthCheck` (every component must declare a path) and `validators/chainsaw.TestValidateTestReadOnly_RegistryContent` (every declared path must pass the allowlist) — see #1223. |
 | `gkeCriticalPriority` | bool | no | Synthesize ResourceQuota on GKE so `system-*-critical` pods admit |
 | `hasSelfRefCRDs` | bool | no | Tells helmfile to emit `disableValidation: true` (chart ships CRD + CR in same release) |
 
@@ -403,17 +403,31 @@ externally-visible product. Fields beyond `ComponentRefs` and
 2. **Write the YAML** in the correct directory. For an overlay, set
    `spec.base` to the most specific shared ancestor and let the chain
    carry shared constraints; only declare what differs.
-3. **Run `make bom-docs` and commit `docs/user/container-images.md`**
+3. **Ship the chainsaw health check** (registry entries only). Every
+   new component in `recipes/registry.yaml` MUST declare
+   `healthCheck.assertFile` pointing at
+   `recipes/checks/<name>/health-check.yaml`, and that file MUST use
+   only the read-only `assert` / `error` operation allowlist (no
+   `script`, `apply`, `wait`, `command`, etc. — see
+   `validators/chainsaw/allowlist.go`). The contract is enforced at
+   PR time by `pkg/recipe.TestComponentRegistry_RequiresHealthCheck`
+   and `validators/chainsaw.TestValidateTestReadOnly_RegistryContent`
+   — both gate `make qualify`. See #1223 and the
+   [chainsaw health check section in validator.md](validator.md#chainsaw-health-checks)
+   for the assertion patterns currently in use (DaemonSet
+   `numberReady == desiredNumberScheduled`, Deployment
+   `Available=True`, CRD `Established=True`).
+4. **Run `make bom-docs` and commit `docs/user/container-images.md`**
    if your change touches `registry.yaml`, a component's `values.yaml`,
    or a chart version pin (see [BOM regeneration](#bom-regeneration)).
-4. **Unit tests.** `make test` runs the recipe-resolution suite —
+5. **Unit tests.** `make test` runs the recipe-resolution suite —
    `pkg/recipe/yaml_test.go` (static catalog: parse, refs, enum
    values, inheritance depth, no cycles) and
    `pkg/recipe/metadata_test.go` (runtime merge, topological sort).
    Both gate `make qualify`. If your change adds a registry entry, a
    new overlay file, or a mixin, the static suite typically picks it
    up without new test code.
-5. **Integration validation.** For a new chart pin, run `make qualify`
+6. **Integration validation.** For a new chart pin, run `make qualify`
    and let the e2e pipeline render the bundle. KWOK simulated
    clusters (`make kwok-e2e RECIPE=<name>`) catch most resolution
    regressions without GPU hardware.

--- a/pkg/recipe/components_test.go
+++ b/pkg/recipe/components_test.go
@@ -15,6 +15,7 @@
 package recipe
 
 import (
+	"context"
 	"maps"
 	"slices"
 	"strings"
@@ -51,6 +52,57 @@ func TestComponentRegistry_Validate(t *testing.T) {
 		for _, e := range errs {
 			t.Errorf("validation error: %v", e)
 		}
+	}
+}
+
+// TestComponentRegistry_RequiresHealthCheck enforces issue #1223's contract:
+// every component in recipes/registry.yaml MUST declare
+// healthCheck.assertFile, and that path MUST resolve through the data
+// provider to a readable file. Together with
+// TestValidateTestReadOnly_RegistryContent in validators/chainsaw —
+// which separately validates that every file the registry points at
+// passes the read-only allowlist — this closes the registry-side half
+// of the contract that #1220 introduced at runtime: deployment-phase
+// chainsaw assertions are only ever driven by registry-declared,
+// allowlist-compliant content.
+//
+// Surface is lint-time (this Go test under `make qualify`) rather than
+// load-time (rejecting at `aicr recipe`). Two reasons: (1) catches the
+// violation at PR review, before any operator runs `aicr`; (2) external
+// `--data` overlays may add components that an in-process registry
+// merge sees but aren't subject to this contract — only the in-tree
+// `recipes/registry.yaml` is. The embedded registry is the source of
+// truth for this assertion.
+func TestComponentRegistry_RequiresHealthCheck(t *testing.T) {
+	registry, err := GetComponentRegistry()
+	if err != nil {
+		t.Fatalf("failed to load component registry: %v", err)
+	}
+	provider := defaultEmbeddedProvider
+
+	for _, comp := range registry.Components {
+		t.Run(comp.Name, func(t *testing.T) {
+			if comp.HealthCheck.AssertFile == "" {
+				t.Errorf("component %q must declare healthCheck.assertFile in recipes/registry.yaml "+
+					"and ship the corresponding recipes/checks/%s/health-check.yaml — see #1223 "+
+					"and validators/chainsaw/allowlist.go for the read-only allowlist contract",
+					comp.Name, comp.Name)
+				return
+			}
+			// Verify the path resolves through the same data provider that
+			// hydration uses at recipe-resolution time (pkg/recipe/
+			// metadata_store.go:hydrateHealthCheckAsserts). An embedded
+			// read is in-memory and instantaneous; no timeout needed.
+			data, err := provider.ReadFile(context.Background(), comp.HealthCheck.AssertFile)
+			if err != nil {
+				t.Errorf("component %q assertFile %q is unreadable through the embedded data provider: %v",
+					comp.Name, comp.HealthCheck.AssertFile, err)
+				return
+			}
+			if len(data) == 0 {
+				t.Errorf("component %q assertFile %q is empty", comp.Name, comp.HealthCheck.AssertFile)
+			}
+		})
 	}
 }
 

--- a/validators/chainsaw/allowlist_test.go
+++ b/validators/chainsaw/allowlist_test.go
@@ -15,15 +15,15 @@
 package chainsaw
 
 import (
+	"context"
 	stderrors "errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 func TestValidateTestReadOnly(t *testing.T) {
@@ -327,46 +327,51 @@ func TestDisallowedOperation_AllowlistFailsClosed(t *testing.T) {
 	}
 }
 
-// TestValidateTestReadOnly_RegistryContent walks every in-tree
-// healthCheck.assertFile under recipes/checks/*/health-check.yaml and
-// verifies it passes the allowlist. If this regresses, a registry-declared
-// check has crept in that violates the read-only contract — block at PR
-// time (PR #1223 will add the same check at lint time, with structured
-// reporting that names every offender, not just the first).
+// TestValidateTestReadOnly_RegistryContent walks every registry-declared
+// healthCheck.assertFile (via the embedded recipe data provider) and
+// verifies it passes the read-only allowlist. PR #1223 changed this from
+// a filesystem walk to a registry walk so a registry entry pointing at a
+// non-conventional path (anything other than
+// recipes/checks/<name>/health-check.yaml) is still validated — the
+// runtime hydration path resolves through the same registry +
+// DataProvider, so any path the runtime would honor must also be
+// allowlist-compliant.
+//
+// Paired with pkg/recipe.TestComponentRegistry_RequiresHealthCheck which
+// enforces that every component HAS an assertFile, this gives the full
+// PR-time contract: every registry entry has a readable, allowlist-
+// compliant chainsaw check.
 func TestValidateTestReadOnly_RegistryContent(t *testing.T) {
-	// Walk repo-relative recipes/checks. The test runs from the package
-	// directory (validators/chainsaw), so walk up two levels to the repo
-	// root. If the path changes, the t.Fatalf below makes the cause
-	// obvious instead of letting the test silently pass.
-	root := filepath.Join("..", "..", "recipes", "checks")
-	if _, err := os.Stat(root); err != nil {
-		t.Fatalf("recipes/checks not found at %s: %v", root, err)
-	}
-	entries, err := os.ReadDir(root)
+	provider := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), ".")
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
-		t.Fatalf("read recipes/checks: %v", err)
+		t.Fatalf("failed to load component registry: %v", err)
 	}
 	checked := 0
-	for _, e := range entries {
-		if !e.IsDir() {
+	for _, comp := range registry.Components {
+		assertFile := comp.HealthCheck.AssertFile
+		if assertFile == "" {
+			// Lint guard in pkg/recipe (TestComponentRegistry_RequiresHealthCheck)
+			// fails first with a clearer message; skip here so this test
+			// doesn't double-report on the same root cause.
 			continue
 		}
-		path := filepath.Join(root, e.Name(), "health-check.yaml")
-		data, err := os.ReadFile(path)
+		data, err := provider.ReadFile(context.Background(), assertFile)
 		if err != nil {
-			// Component dir without a health-check.yaml is allowed (e.g.,
-			// the 3 backfill components #1221 will add).
-			if os.IsNotExist(err) {
-				continue
-			}
-			t.Fatalf("read %s: %v", path, err)
+			// Path-readability is also covered by
+			// TestComponentRegistry_RequiresHealthCheck. Skip here for the
+			// same reason — single source of truth on that failure mode.
+			continue
 		}
 		if !IsChainsawTest(string(data)) {
-			// The allowlist only applies to Chainsaw Test format.
+			// The allowlist only applies to Chainsaw Test format. Raw K8s
+			// YAML asserts are evaluated by the chainsaw Go library and
+			// have no operations to gate.
 			continue
 		}
-		if err := ValidateTestReadOnly(e.Name(), string(data)); err != nil {
-			t.Errorf("%s violates read-only allowlist: %v", path, err)
+		if err := ValidateTestReadOnly(comp.Name, string(data)); err != nil {
+			t.Errorf("component %q assertFile %q violates read-only allowlist: %v",
+				comp.Name, assertFile, err)
 		}
 		checked++
 	}


### PR DESCRIPTION
## Summary

Final piece of epic #660. Adds the PR-time lint contract:

1. **Every registry entry must declare `healthCheck.assertFile`**, and
   the path must be readable through the embedded data provider.
2. **Every declared assertFile must pass the read-only allowlist**
   (`assert` / `error` operations only; no `script`, `apply`, `wait`,
   `command`, etc.).

Together with #1235's runtime allowlist enforcement, this means
violations are caught at PR review and never reach the validator
runtime.

Fixes: #1223
Closes epic #660 once merged.
Related: #1219, #1220, #1221.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe` — new test only)
- [x] Validator (`validators/chainsaw` — tightened existing test)
- [x] Docs (`docs/contributor/recipe.md`)

## Implementation Notes

### New: `pkg/recipe.TestComponentRegistry_RequiresHealthCheck`

Walks the embedded registry; per-component subtest verifies:

- `healthCheck.assertFile` is non-empty
- The declared path resolves through the same data provider used by
  recipe-resolution hydration
  (`pkg/recipe/metadata_store.go:hydrateHealthCheckAsserts`)
- The file is non-empty

Failure messages name the offending component and the suggested
remediation (ship `recipes/checks/<name>/health-check.yaml` + cite
the allowlist contract).

### Tightened: `validators/chainsaw.TestValidateTestReadOnly_RegistryContent`

Was a `recipes/checks/*` directory walk; now walks via
`recipe.GetComponentRegistryFor(provider)`. This closes a path-
mismatch gap: a registry entry pointing at a non-conventional path
(anything other than `recipes/checks/<name>/health-check.yaml`) is
now validated, because runtime hydration honors whatever the registry
says.

Empty-assertFile and unreadable-path failure modes fall through here
gracefully — the `pkg/recipe` test above is the single source of
truth for those failures, so this test doesn't double-report on the
same root cause.

### Surface decision: lint-time, not load-time

The issue's open question was "lint at `make qualify` time vs.
load-time at `aicr recipe`". This PR uses lint-time. Two reasons
documented inline:

1. Catches violations at PR review, before any operator runs `aicr`.
2. External `--data` overlays may add components that aren't subject
   to this contract — only the in-tree `recipes/registry.yaml` is.
   The embedded registry is the source of truth this test asserts on.

### Docs

`docs/contributor/recipe.md`:

- Table row for `healthCheck.assertFile` flipped from optional (`no`)
  to required (**`yes`**) with a description that names both tests
  enforcing the contract.
- "Adding a Recipe" gains a new step (#3) describing the requirement
  for new components, including pointers to the chainsaw assertion
  patterns currently in use (DaemonSet `numberReady ==
  desiredNumberScheduled`, Deployment `Available=True`, CRD
  `Established=True`).

## Testing

```bash
go test -race -count=1 ./pkg/recipe/ ./validators/chainsaw/
golangci-lint run -c .golangci.yaml ./pkg/recipe/... ./validators/chainsaw/...
```

- `TestComponentRegistry_RequiresHealthCheck`: 27/27 components
  pass.
- `TestValidateTestReadOnly_RegistryContent`: registry walker
  validates all 27 declared assertFiles pass the allowlist.
- All existing `pkg/recipe` and `validators/chainsaw` tests still
  pass.
- Lint clean.

**Regression-positive check:** to manually verify the new lint
guard works, remove any `healthCheck` block from a registry entry
locally and re-run `go test ./pkg/recipe/`. The subtest for that
component fails with a clear pointer to the missing assertFile +
the read-only contract.

## Risk Assessment

- [x] **Low** — Tests + docs only. No production code changes. No
  runtime behavior change. Easy to revert.

**Rollout notes:** No user-facing CLI/API change. After merge, any
PR that adds a registry entry without `healthCheck.assertFile` (or
points at a missing file, or ships a file with a disallowed
chainsaw op) fails `make qualify` with a per-component diagnostic.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (changed paths)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (this PR is the
      test)
- [x] I updated docs for the new contract (`docs/contributor/recipe.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
