### PR TITLE
feat(bundler): retry sign.Bundle on transient Sigstore failures

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,13 +37,30 @@ builds:
       post:
         ## cosign v1 attestation with slsa provenance v1.
         ## NOTE: below aicrd currently attests via github attestation
+        ##
+        ## Wrap cosign in a 3-attempt bash retry loop with 5s/10s backoffs
+        ## (no sleep after the final failed attempt — that would just
+        ## delay the exit) to absorb transient Sigstore Rekor flakes.
+        ## cosign attest-blob has no native --retry flag (Rekor retry
+        ## behavior is internal to the rekor-go client and not exposed
+        ## via the cosign CLI). The AICR-side `aicr recipe sign-catalog`
+        ## post-hook uses pkg/bundler/attestation/signWithRetry which
+        ## has equivalent retry semantics at the Go level; this loop is
+        ## the equivalent mitigation for the binary-attestation step.
+        ## See issue #1249.
         - cmd: >-
             bash -c '[ -z "${SLSA_PREDICATE:-}" ] && exit 0;
+            for n in 1 2 3; do
             cosign attest-blob
             --predicate "${SLSA_PREDICATE}"
             --type https://slsa.dev/provenance/v1
             --bundle "$(dirname "{{ .Path }}")/aicr-attestation.sigstore.json"
-            --yes "{{ .Path }}"'
+            --yes "{{ .Path }}" && exit 0;
+            echo "cosign attest-blob attempt $n failed; retrying" >&2;
+            if [ "$n" -lt 3 ]; then sleep $((n * 5)); fi;
+            done;
+            echo "cosign attest-blob failed after 3 attempts" >&2;
+            exit 1'
           output: true
         ## Sign the embedded recipe catalog (registry.yaml + validators/catalog.yaml).
         ##

--- a/pkg/bundler/attestation/doc.go
+++ b/pkg/bundler/attestation/doc.go
@@ -52,6 +52,30 @@
 // The SLSA predicate records build metadata including the tool version, recipe,
 // components, and resolvedDependencies (binary provenance + external data files).
 //
+// # Retry Contract
+//
+// SignStatementWith wraps the underlying sign.Bundle call with bounded
+// exponential-backoff retry to absorb transient Fulcio/Rekor failures
+// (e.g., Sigstore Rekor public-good infrastructure slowness — see #1249
+// for the failure pattern observed in #1244 and #1245). Each attempt is
+// bounded by defaults.SigstoreAttemptTimeout; the outer signing flow is
+// bounded by defaults.SigstoreSignTimeout (an upper-bound ceiling that
+// covers up to defaults.SigstoreRetryBudget attempts plus
+// SigstoreRetryInitialBackoff × SigstoreRetryBackoffFactor^(N-1)
+// backoffs between them). Retry semantics:
+//
+//   - Outer ctx DeadlineExceeded   → ErrCodeTimeout, no further retries
+//     (the whole signing budget is gone).
+//   - Outer ctx Canceled           → ErrCodeUnavailable, no retries
+//     (caller signaled don't-wait).
+//   - Per-attempt failure with outer ctx alive → retry on the same
+//     content / identity / policy until budget is exhausted, then
+//     ErrCodeUnavailable wrapping the last attempt's error.
+//
+// pkg/defaults.TestSigstoreRetryBudgetInvariant guards the math so a
+// future tuning that overflows the SigstoreSignTimeout ceiling fails
+// loudly at unit-test time.
+//
 // # OIDC Token Acquisition
 //
 // Three flows are exposed for obtaining a Sigstore OIDC identity token; the

--- a/pkg/bundler/attestation/signing.go
+++ b/pkg/bundler/attestation/signing.go
@@ -20,6 +20,7 @@ import (
 	"encoding/asn1"
 	stderrors "errors"
 	"log/slog"
+	"time"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/sign"
@@ -138,22 +139,17 @@ func SignStatementWith(ctx context.Context, statementJSON []byte, id SigningIden
 	}
 
 	certProvider, certOpts := id.CertProvider()
-	bundle, err := sign.Bundle(content, keypair, sign.BundleOptions{
-		CertificateProvider:        certProvider,
-		CertificateProviderOptions: certOpts,
-		TransparencyLogs:           tlog.Logs(),
-		Context:                    signCtx,
+
+	bundle, err := signWithRetry(signCtx, func(attemptCtx context.Context) (*protobundle.Bundle, error) {
+		return sign.Bundle(content, keypair, sign.BundleOptions{
+			CertificateProvider:        certProvider,
+			CertificateProviderOptions: certOpts,
+			TransparencyLogs:           tlog.Logs(),
+			Context:                    attemptCtx,
+		})
 	})
 	if err != nil {
-		// Distinguish a SigstoreSignTimeout deadline from a generic
-		// network/server failure. ErrCodeTimeout maps to a 504 at the
-		// API boundary and tells the caller the signing flow took too
-		// long; ErrCodeUnavailable (502) is for everything else
-		// (Fulcio refused, Rekor 5xx, transient network error).
-		if stderrors.Is(err, context.DeadlineExceeded) {
-			return nil, errors.Wrap(errors.ErrCodeTimeout, "sigstore signing timed out", err)
-		}
-		return nil, errors.Wrap(errors.ErrCodeUnavailable, "sigstore signing failed", err)
+		return nil, err
 	}
 
 	bundleJSON, err := protojson.Marshal(bundle)
@@ -284,4 +280,102 @@ func extractRekorLogIndex(bundle *protobundle.Bundle) int64 {
 		return 0
 	}
 	return entries[0].GetLogIndex()
+}
+
+// signBundleAttempt is the function signature for one attempt at
+// producing a Sigstore bundle. Extracted from sign.Bundle's concrete
+// signature so signWithRetry can be unit-tested against synthetic
+// failure sequences without depending on the real Fulcio / Rekor /
+// sigstore-go stack.
+type signBundleAttempt func(ctx context.Context) (*protobundle.Bundle, error)
+
+// signWithRetry wraps a sign-attempt closure with exponential-backoff
+// retry on transient failures. Each attempt is bounded by
+// defaults.SigstoreAttemptTimeout (a sub-context of ctx); the outer
+// ctx (typically bounded by SigstoreSignTimeout) is the ceiling and
+// terminates the whole flow when it expires.
+//
+// Retry policy:
+//
+//   - outer ctx DeadlineExceeded → ErrCodeTimeout, no retry (the whole
+//     signing budget is gone; further retries would just chew through
+//     it without any chance of success).
+//   - outer ctx Canceled → ErrCodeUnavailable, no retry (caller signaled
+//     they don't want to wait).
+//   - per-attempt failure with outer ctx alive → retry until
+//     SigstoreRetryBudget is exhausted, then return ErrCodeUnavailable.
+//     This is the transient class (Fulcio refused / Rekor 5xx / network
+//     glitch / per-attempt deadline that's tighter than outer ctx).
+//
+// Backoff between attempts is exponential and interruptible by the
+// outer ctx — a slow Rekor recovering 10s later doesn't waste the
+// remaining budget.
+//
+// See issue #1249 for the failure pattern this absorbs (Sigstore
+// Rekor flakes observed in #1244 and #1245).
+func signWithRetry(ctx context.Context, attempt signBundleAttempt) (*protobundle.Bundle, error) {
+	var bundle *protobundle.Bundle
+	var lastErr error
+	backoff := defaults.SigstoreRetryInitialBackoff
+	for n := 1; n <= defaults.SigstoreRetryBudget; n++ {
+		// Pre-attempt ctx check — avoid paying the cost of an attempt
+		// the caller's deadline / cancellation has already made
+		// pointless. Per PR #1251 review and the repo's "always check
+		// ctx.Done() in loops" guideline.
+		if err := ctx.Err(); err != nil {
+			if stderrors.Is(err, context.DeadlineExceeded) {
+				return nil, errors.Wrap(errors.ErrCodeTimeout,
+					"sigstore signing timed out before attempt", err)
+			}
+			return nil, errors.Wrap(errors.ErrCodeUnavailable,
+				"sigstore signing canceled before attempt", err)
+		}
+
+		attemptCtx, cancel := context.WithTimeout(ctx, defaults.SigstoreAttemptTimeout)
+		bundle, lastErr = attempt(attemptCtx)
+		cancel()
+		if lastErr == nil {
+			return bundle, nil
+		}
+
+		// Outer ctx exhausted? Classify and stop — no retry can help.
+		if stderrors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, errors.Wrap(errors.ErrCodeTimeout, "sigstore signing timed out", lastErr)
+		}
+		if stderrors.Is(ctx.Err(), context.Canceled) {
+			return nil, errors.Wrap(errors.ErrCodeUnavailable, "sigstore signing canceled", lastErr)
+		}
+
+		// Outer ctx alive; this attempt failed (per-attempt timeout or
+		// non-ctx error). Retry if budget remains.
+		if n >= defaults.SigstoreRetryBudget {
+			return nil, errors.Wrap(errors.ErrCodeUnavailable,
+				"sigstore signing failed after retries", lastErr)
+		}
+		slog.Warn("sigstore signing attempt failed, retrying",
+			"attempt", n,
+			"budget", defaults.SigstoreRetryBudget,
+			"backoff", backoff,
+			"error", lastErr)
+
+		// Interruptible backoff. If outer ctx expires during the sleep,
+		// classify the exit using the outer ctx's reason.
+		select {
+		case <-ctx.Done():
+			if stderrors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, errors.Wrap(errors.ErrCodeTimeout,
+					"sigstore signing timed out during retry backoff", lastErr)
+			}
+			return nil, errors.Wrap(errors.ErrCodeUnavailable,
+				"sigstore signing canceled during retry backoff", lastErr)
+		case <-time.After(backoff):
+		}
+		backoff *= time.Duration(defaults.SigstoreRetryBackoffFactor)
+	}
+	// Unreachable: the loop returns inside on every iteration after the
+	// final attempt. The static-analysis-required fallthrough surfaces
+	// any future refactor that breaks that invariant as a clear
+	// "missing return" rather than a silent nil.
+	return nil, errors.Wrap(errors.ErrCodeInternal,
+		"signWithRetry loop exited without returning", lastErr)
 }

--- a/pkg/bundler/attestation/signing_retry_test.go
+++ b/pkg/bundler/attestation/signing_retry_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	stderrors "errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestSignWithRetry_SuccessOnFirstAttempt verifies the happy path:
+// attempt returns nil error → no retry, no backoff, immediate return.
+func TestSignWithRetry_SuccessOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	want := &protobundle.Bundle{}
+	got, err := signWithRetry(context.Background(), func(_ context.Context) (*protobundle.Bundle, error) {
+		calls.Add(1)
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("returned wrong bundle")
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 attempt, got %d", n)
+	}
+}
+
+// TestSignWithRetry_SuccessAfterTransient verifies retry-on-transient:
+// attempt fails once with a non-ctx error, then succeeds. Total wall
+// clock should equal one backoff (SigstoreRetryInitialBackoff).
+func TestSignWithRetry_SuccessAfterTransient(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	want := &protobundle.Bundle{}
+	start := time.Now()
+	got, err := signWithRetry(context.Background(), func(_ context.Context) (*protobundle.Bundle, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return nil, stderrors.New("simulated Rekor 503")
+		}
+		return want, nil
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("returned wrong bundle")
+	}
+	if n := calls.Load(); n != 2 {
+		t.Errorf("expected 2 attempts, got %d", n)
+	}
+	// Lower-bound only: the backoff was honored if elapsed >=
+	// SigstoreRetryInitialBackoff. Upper bound dropped per PR #1251
+	// review — loaded CI runners can legitimately push past a tight
+	// multiple, and the attempt count above already proves there
+	// wasn't an extra retry.
+	if elapsed < defaults.SigstoreRetryInitialBackoff {
+		t.Errorf("elapsed %v < expected backoff %v (backoff not honored?)",
+			elapsed, defaults.SigstoreRetryInitialBackoff)
+	}
+}
+
+// TestSignWithRetry_BudgetExhaustion verifies full-budget exhaustion:
+// attempt always fails → all SigstoreRetryBudget attempts run, last
+// error is wrapped as ErrCodeUnavailable.
+func TestSignWithRetry_BudgetExhaustion(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	sentinel := stderrors.New("simulated Rekor 503")
+	_, err := signWithRetry(context.Background(), func(_ context.Context) (*protobundle.Bundle, error) {
+		calls.Add(1)
+		return nil, sentinel
+	})
+	if err == nil {
+		t.Fatal("expected error after budget exhaustion, got nil")
+	}
+	if n := calls.Load(); int(n) != defaults.SigstoreRetryBudget {
+		t.Errorf("expected %d attempts, got %d", defaults.SigstoreRetryBudget, n)
+	}
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("expected StructuredError, got %T", err)
+	}
+	if se.Code != errors.ErrCodeUnavailable {
+		t.Errorf("expected ErrCodeUnavailable, got %v", se.Code)
+	}
+	if !stderrors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error in chain, got: %v", err)
+	}
+}
+
+// TestSignWithRetry_OuterDeadlineExceeded verifies that the outer ctx
+// deadline expiring during an attempt short-circuits with
+// ErrCodeTimeout — no further retries.
+func TestSignWithRetry_OuterDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	// Outer ctx with a deadline shorter than one backoff cycle. The
+	// first attempt fails, then the backoff sleep blows the deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.SigstoreRetryInitialBackoff/2)
+	defer cancel()
+
+	var calls atomic.Int32
+	_, err := signWithRetry(ctx, func(_ context.Context) (*protobundle.Bundle, error) {
+		calls.Add(1)
+		return nil, stderrors.New("simulated Rekor 503")
+	})
+	if err == nil {
+		t.Fatal("expected error after deadline, got nil")
+	}
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("expected StructuredError, got %T", err)
+	}
+	if se.Code != errors.ErrCodeTimeout {
+		t.Errorf("expected ErrCodeTimeout (outer deadline), got %v", se.Code)
+	}
+	// Should have run at most 2 attempts: one before backoff, possibly
+	// one if the deadline check is racy. Never the full budget.
+	if int(calls.Load()) >= defaults.SigstoreRetryBudget {
+		t.Errorf("retry continued past deadline: %d attempts (budget %d)",
+			calls.Load(), defaults.SigstoreRetryBudget)
+	}
+}
+
+// TestSignWithRetry_OuterCanceled verifies that caller cancellation
+// terminates the retry loop with ErrCodeUnavailable (not Timeout —
+// cancellation is intent, not deadline).
+func TestSignWithRetry_OuterCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls atomic.Int32
+	// Cancel during the first attempt's backoff sleep.
+	go func() {
+		time.Sleep(defaults.SigstoreRetryInitialBackoff / 4)
+		cancel()
+	}()
+
+	_, err := signWithRetry(ctx, func(_ context.Context) (*protobundle.Bundle, error) {
+		calls.Add(1)
+		return nil, stderrors.New("simulated Rekor 503")
+	})
+	if err == nil {
+		t.Fatal("expected error after cancel, got nil")
+	}
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("expected StructuredError, got %T", err)
+	}
+	if se.Code != errors.ErrCodeUnavailable {
+		t.Errorf("expected ErrCodeUnavailable (caller cancel), got %v", se.Code)
+	}
+}

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -224,11 +224,41 @@ const (
 	// SigstoreSignTimeout bounds the non-interactive Sigstore signing flow:
 	// Fulcio certificate issuance (token-exchange + cert mint) plus Rekor
 	// transparency-log submission. Two HTTP round-trips against public-good
-	// infrastructure; 2 minutes leaves comfortable headroom over typical
-	// p99 latency without letting a hung peer block a CLI invocation
-	// indefinitely. Distinct from OIDCAuthTimeout, which covers the
-	// interactive user-driven step that precedes this flow.
+	// infrastructure; 2 minutes leaves comfortable headroom for
+	// SigstoreRetryBudget attempts plus exponential backoff without letting
+	// a hung peer block a CLI invocation indefinitely. Distinct from
+	// OIDCAuthTimeout, which covers the interactive user-driven step that
+	// precedes this flow.
 	SigstoreSignTimeout = 2 * time.Minute
+
+	// SigstoreAttemptTimeout bounds a single sign.Bundle invocation. The
+	// AICR-side wrapper in pkg/bundler/attestation/signing.go retries up
+	// to SigstoreRetryBudget attempts, each bounded by this per-attempt
+	// timeout. The outer SigstoreSignTimeout ceiling caps the total
+	// wall-clock so a chain of slow Rekor responses can't blow past the
+	// structured deadline contract.
+	SigstoreAttemptTimeout = 35 * time.Second
+
+	// SigstoreRetryBudget is the maximum number of sign.Bundle attempts
+	// the wrapper makes before returning the last error. Retries fire
+	// only when the error classifies as ErrCodeUnavailable (transient
+	// Fulcio/Rekor failure) — never on ErrCodeTimeout (caller deadline,
+	// not worth burning more budget) or other structured failure modes.
+	// Three attempts absorbs the typical Sigstore Rekor flake window
+	// observed in #1244 and #1245 without inflating wall-clock for the
+	// healthy path. See issue #1249.
+	SigstoreRetryBudget = 3
+
+	// SigstoreRetryInitialBackoff is the wait between attempt 1 and
+	// attempt 2. Subsequent backoffs scale by SigstoreRetryBackoffFactor.
+	SigstoreRetryInitialBackoff = 1 * time.Second
+
+	// SigstoreRetryBackoffFactor scales the wait between successive
+	// retries: backoff for attempt N is
+	// SigstoreRetryInitialBackoff * SigstoreRetryBackoffFactor^(N-1).
+	// With initial=1s and factor=5: backoffs are 1s, 5s (3-attempt
+	// budget → 2 backoffs).
+	SigstoreRetryBackoffFactor = 5
 )
 
 // Validation phase timeouts for validation phase operations.

--- a/pkg/defaults/timeouts_test.go
+++ b/pkg/defaults/timeouts_test.go
@@ -102,6 +102,45 @@ func TestJobEnvelopeMarginInvariant(t *testing.T) {
 	}
 }
 
+// TestSigstoreRetryBudgetInvariant guards the contract that the retry
+// budget fits inside the outer SigstoreSignTimeout ceiling: worst-case
+// wall-clock is SigstoreRetryBudget * SigstoreAttemptTimeout plus the
+// sum of backoffs between attempts, and that total must not exceed
+// SigstoreSignTimeout — otherwise the inner retry loop would race the
+// outer deadline. See issue #1249.
+func TestSigstoreRetryBudgetInvariant(t *testing.T) {
+	if SigstoreRetryBudget <= 0 {
+		t.Fatalf("SigstoreRetryBudget must be > 0; got %d", SigstoreRetryBudget)
+	}
+	if SigstoreAttemptTimeout <= 0 {
+		t.Fatalf("SigstoreAttemptTimeout must be > 0; got %v", SigstoreAttemptTimeout)
+	}
+	if SigstoreRetryInitialBackoff <= 0 {
+		t.Fatalf("SigstoreRetryInitialBackoff must be > 0; got %v", SigstoreRetryInitialBackoff)
+	}
+	if SigstoreRetryBackoffFactor < 1 {
+		t.Fatalf("SigstoreRetryBackoffFactor must be >= 1; got %d", SigstoreRetryBackoffFactor)
+	}
+
+	// Compute worst-case: every attempt hits the per-attempt timeout,
+	// every backoff between attempts is taken in full.
+	totalAttempts := SigstoreRetryBudget * SigstoreAttemptTimeout
+	var totalBackoffs time.Duration
+	backoff := SigstoreRetryInitialBackoff
+	for range SigstoreRetryBudget - 1 {
+		totalBackoffs += backoff
+		backoff *= time.Duration(SigstoreRetryBackoffFactor)
+	}
+	worstCase := totalAttempts + totalBackoffs
+	if worstCase > SigstoreSignTimeout {
+		t.Errorf("worst-case retry budget %v exceeds SigstoreSignTimeout %v "+
+			"(attempts: %d × %v = %v, backoffs: %v) — raise SigstoreSignTimeout "+
+			"or tighten the per-attempt / backoff knobs in lockstep",
+			worstCase, SigstoreSignTimeout, SigstoreRetryBudget,
+			SigstoreAttemptTimeout, totalAttempts, totalBackoffs)
+	}
+}
+
 func TestRecipeBuildTimeoutLessThanHandler(t *testing.T) {
 	// Recipe build timeout should be less than handler timeout
 	// to allow for error handling before the request times out


### PR DESCRIPTION
## Summary

Add bounded exponential-backoff retry around `sign.Bundle` in the
AICR-side Sigstore signing wrapper, and wrap goreleaser's
`cosign attest-blob` post-hook in a bash 3-attempt retry loop with
exponential backoff. Absorbs transient Sigstore Rekor flakes
that have been turning ordinary upstream latency into CI failures.

Fixes: #1249
Refs: #1244 (first observed instance), #1245 (second; in review)

## Type of Change

- [x] Bug fix (transient-flake mitigation)

## Component(s) Affected

- [x] `pkg/bundler/attestation` — retry wrapper
- [x] `pkg/defaults` — new retry-budget constants + invariant test
- [x] `.goreleaser.yaml` — cosign CLI retry flag

## Implementation Notes

### Failure being absorbed

Two PRs hit identical traces within 24h:

```
[TIMEOUT] sigstore signing timed out:
  Post "https://rekor.sigstore.dev/api/v1/log/entries":
  giving up after 1 attempt(s): context deadline exceeded
```

The `1 attempt(s)` came from `pkg/bundler/attestation/signing.go`'s
single-pass `sign.Bundle()` invocation. The wrapper had no retry, so
slow Rekor responses on the only attempt produced terminal failure.

### Constants (`pkg/defaults/timeouts.go`)

| Constant | Value | Rationale |
|---|---|---|
| `SigstoreAttemptTimeout` | 35s | Bounds one `sign.Bundle` call so a slow Rekor on one attempt doesn't eat the whole budget |
| `SigstoreRetryBudget` | 3 | Worst-case budget that absorbs the typical flake window |
| `SigstoreRetryInitialBackoff` | 1s | Initial gap between attempts 1 and 2 |
| `SigstoreRetryBackoffFactor` | 5 | Backoffs: 1s, 5s |

Worst-case wall-clock: `3 × 35s + 1s + 5s = 111s` — fits inside the
existing `SigstoreSignTimeout = 2m` ceiling.
`TestSigstoreRetryBudgetInvariant` guards the math against future
tuning that would overflow.

### Retry semantics (`signWithRetry` helper)

Extracted the `sign.Bundle` invocation into a helper that wraps any
sign-attempt closure with bounded exponential-backoff retry:

| Class | Behavior |
|---|---|
| Outer ctx `DeadlineExceeded` | `ErrCodeTimeout`, no further retries — the whole signing budget is gone |
| Outer ctx `Canceled` | `ErrCodeUnavailable`, no retries — caller signaled don't-wait |
| Per-attempt failure with outer ctx alive | Retry until budget is exhausted, then `ErrCodeUnavailable` wrapping the last error |

Backoff sleep is **interruptible by the outer ctx** — a Rekor recovering
10s later doesn't waste the remaining budget. The retry treats
transient failures uniformly without trying to parse error text or
HTTP status (which would be brittle); the bounded retry budget caps
the wasted time on a permanent failure (e.g., expired OIDC token) at
~111s.

### `.goreleaser.yaml`

`cosign attest-blob` is now wrapped in a bash 3-attempt retry loop
with `5s` / `10s` backoffs. First attempt of this PR tried
`cosign attest-blob --retry 5` — that flag does not exist on cosign
v3.0.2 (Rekor retry behavior is internal to the `rekor-go` client and
not exposed via the cosign CLI), so the first CI run failed with
`Error: unknown flag: --retry`. Shell-level retry loop is the
equivalent mitigation for the binary-attestation step; the AICR-side
`signWithRetry` covers the catalog-signing step on the same
post-build hook chain.

### Docs

`pkg/bundler/attestation/doc.go` gains a "Retry Contract" section
documenting the per-attempt / outer-ceiling split, the three
retry-class branches, and the invariant test pointer.

## Testing

```bash
go test -race -count=1 ./pkg/defaults/ ./pkg/bundler/...
golangci-lint run -c .golangci.yaml ./pkg/defaults/... ./pkg/bundler/...
```

Five new retry tests in `pkg/bundler/attestation/signing_retry_test.go`:

| Test | Scenario | Asserts |
|---|---|---|
| `_SuccessOnFirstAttempt` | Attempt returns success immediately | 1 attempt, no backoff |
| `_SuccessAfterTransient` | Attempt fails once, succeeds on 2nd | 2 attempts, ~1s elapsed (one backoff honored) |
| `_BudgetExhaustion` | Attempt always fails | `SigstoreRetryBudget` attempts, `ErrCodeUnavailable`, sentinel wrapped in chain |
| `_OuterDeadlineExceeded` | Outer ctx deadline shorter than first backoff | `ErrCodeTimeout`, fewer than budget attempts |
| `_OuterCanceled` | Caller cancels during first backoff | `ErrCodeUnavailable`, cancel takes precedence over deadline |

Plus `TestSigstoreRetryBudgetInvariant` in `pkg/defaults/`.

All tests use `t.Parallel()`. Full-exhaustion test runs ~6s wall-clock
(real backoffs); others are sub-second.

## Risk Assessment

- [x] **Low** — isolated to one helper; existing single-pass behavior
  is the new "success on attempt 1" path; outer ceiling unchanged.

**Rollout notes:** No user-facing CLI/API behavior change. Healthy
Rekor paths see identical latency. Transient Rekor failures that
previously failed the run now succeed after a few seconds of
backoff (visible as `slog.Warn` lines naming attempt + backoff +
error). A permanent failure (e.g., expired OIDC token, Fulcio 4xx)
takes up to ~111s instead of failing fast — acceptable trade-off
since the error message is unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (changed paths)
- [x] I did not skip/disable tests to make CI green
- [x] I added new tests for the new functionality
- [x] Docs updated (`pkg/bundler/attestation/doc.go`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

