### PR TITLE
fix(ci): build patched nvkind with --config-source=file (#1237)

### DIFF
--- a/.github/actions/gpu-cluster-setup/install-nvkind.sh
+++ b/.github/actions/gpu-cluster-setup/install-nvkind.sh
@@ -13,6 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Installs nvkind at the pinned commit, patched so that its
+# ConfigureContainerRuntime step invokes
+#   nvidia-ctk runtime configure --runtime=containerd --config-source=file
+# instead of the upstream default
+#   nvidia-ctk runtime configure --runtime=containerd --config-source=command
+#
+# Why (issue #1237):
+#   The upstream nvkind path runs `containerd config dump` (via
+#   --config-source=command) to read the current containerd config
+#   before merging in the NVIDIA runtime block. As of containerd
+#   2.3.x (shipped in kindest/node:v1.36.1) `config dump` emits
+#   schema version=4 / io.containerd.cri.v1.runtime, while the kind
+#   node base /etc/containerd/config.toml is still hand-written at
+#   version=2 / io.containerd.grpc.v1.cri. The merged drop-in then
+#   disagrees with the base on `version`, so the subsequent
+#   `systemctl restart containerd` fails ("Job for containerd.service
+#   failed") and the worker node never becomes Ready.
+#
+#   Switching to --config-source=file makes nvidia-ctk read the
+#   actual /etc/containerd/config.toml the kind image ships, so the
+#   emitted drop-in matches the base's schema version. This is the
+#   remediation recommended by the nvidia-container-toolkit
+#   maintainers (see #1237 discussion) — the toolkit's
+#   --config-source=command behavior is by design, and they will
+#   not ship a compat flag.
+#
+#   Scope: this patch is intentionally narrow — it changes only the
+#   nvkind binary's behavior. No other invocation of nvidia-ctk in
+#   this repo is affected (the host-level
+#   configure-nvidia-container-toolkit.sh targets --runtime=docker
+#   on a different code path).
+
 set -euo pipefail
 
 if [[ -z "${NVKIND_VERSION:-}" ]]; then
@@ -20,6 +52,43 @@ if [[ -z "${NVKIND_VERSION:-}" ]]; then
   exit 1
 fi
 
-go install "github.com/NVIDIA/nvkind/cmd/nvkind@${NVKIND_VERSION}"
+nvkind_src="$(mktemp -d)"
+trap 'rm -rf "${nvkind_src}"' EXIT
+
+echo "Cloning nvkind at ${NVKIND_VERSION} into ${nvkind_src}"
+git clone --quiet https://github.com/NVIDIA/nvkind "${nvkind_src}"
+git -C "${nvkind_src}" checkout --quiet "${NVKIND_VERSION}"
+
+node_file="${nvkind_src}/pkg/nvkind/node.go"
+if [[ ! -f "${node_file}" ]]; then
+  echo "::error::expected nvkind source file not found: ${node_file}"
+  exit 1
+fi
+
+# Confirm the upstream string we're about to rewrite is still present;
+# if nvkind upstream changes it, fail loud rather than silently
+# building an unpatched binary.
+if ! grep -q -- '--config-source=command' "${node_file}"; then
+  echo "::error::nvkind ${NVKIND_VERSION} no longer contains '--config-source=command' in ${node_file#"${nvkind_src}/"}; review whether this patch is still needed"
+  exit 1
+fi
+
+echo "Patching --config-source=command → --config-source=file (issue #1237)"
+sed -i.bak 's/--config-source=command/--config-source=file/g' "${node_file}"
+rm -f "${node_file}.bak"
+
+# Verify the patch landed and that the source line we removed is gone.
+if grep -q -- '--config-source=command' "${node_file}"; then
+  echo "::error::patch did not apply cleanly; --config-source=command still present"
+  exit 1
+fi
+if ! grep -q -- '--config-source=file' "${node_file}"; then
+  echo "::error::patch did not apply cleanly; --config-source=file not present after sed"
+  exit 1
+fi
+
+echo "Building patched nvkind"
+(cd "${nvkind_src}" && go install ./cmd/nvkind)
+
 nvkind_bin="${GOBIN:-$(go env GOPATH)/bin}/nvkind"
 "${nvkind_bin}" --help


### PR DESCRIPTION
## Summary

Patches `install-nvkind.sh` to clone nvkind at the pinned commit, rewrite its hard-coded `nvidia-ctk runtime configure --runtime=containerd --config-source=command` to `--config-source=file`, and build from source. Unblocks every GPU CI job, which has been red on every PR and on `main` since 2026-06-07.

## Motivation / Context

Confirmed root cause for #1237 via the toml dumps captured in the previous PR's debug artifacts:

| File | `version` | CRI plugin path |
|---|---|---|
| `/etc/containerd/config.toml` (kind base) | `2` | `io.containerd.grpc.v1.cri` |
| `/etc/containerd/conf.d/99-nvidia.toml` (toolkit 1.19.1, `--config-source=command`) | `4` | `io.containerd.cri.v1.runtime` |

nvidia-container-toolkit 1.19.1 invokes `containerd config dump` under `--config-source=command`, which returns the containerd 2.3.1 binary's native `version = 4` schema. The kind node base `config.toml` is still the hand-written `version = 2`. containerd refuses to merge drop-ins whose `version` disagrees with the base, so `systemctl restart containerd` fails and the worker never reaches Ready.

The toolkit maintainers confirmed `--config-source=command` is by design, declined to ship a compat flag (the 1.19.x line is required for a HIGH-severity CVE fix), and recommended `--config-source=file` as the remediation. nvkind upstream hard-codes the `command` source in `pkg/nvkind/node.go`, so we patch it at build time.

Fixes: #1237
Related: #1252 (added the toml dump that confirmed the schema mismatch)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] CI / GPU runners (`.github/actions/gpu-cluster-setup`)

## Implementation Notes

- Scope is intentionally narrow: only the nvkind binary's behavior changes. No other invocation of `nvidia-ctk` in this repo is affected (e.g., `configure-nvidia-container-toolkit.sh` targets `--runtime=docker` on a different code path).
- A pre-check in `install-nvkind.sh` greps for the upstream string before patching and fails loudly if nvkind renames or removes it — we will not silently ship an unpatched binary.
- A post-check verifies the patched string is present after `sed`.
- Tested the install script end-to-end locally (`bash install-nvkind.sh` produces a runnable `nvkind --help`).

## Testing

Local build verification:

```bash
NVKIND_VERSION='56db9be854036c2f5a0133e3ccb0990e13ea9e6c' \
GOBIN=$(mktemp -d) \
bash .github/actions/gpu-cluster-setup/install-nvkind.sh
```

End-to-end CI signal: the three GPU jobs on this PR.

## Risk Assessment

- [x] **Low** — Touches only `install-nvkind.sh`; no Go source, no runtime image, no recipe. Easy to revert.

**Rollout notes:** Once `kubernetes-sigs/kind` ships a `kindest/node` tag with a `version = 4` base `config.toml`, this patch becomes unnecessary and `install-nvkind.sh` can revert to the simpler `go install` form. Tracked in #1237.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — not applicable; no Go source changes
- [x] Linter passes (`shellcheck` + `bash -n` clean)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — pre/post-check guards added to the install script itself
- [x] I updated docs if user-facing behavior changed — comment block in the script explains the rationale
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)