### PR TITLE
fix(validator): fail fast on eval errors; nil-safe health checks

### DIFF
--- a/recipes/checks/agentgateway/health-check.yaml
+++ b/recipes/checks/agentgateway/health-check.yaml
@@ -87,7 +87,7 @@ spec:
               metadata:
                 namespace: agentgateway-system
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -95,4 +95,4 @@ spec:
               metadata:
                 namespace: agentgateway-system
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/aws-ebs-csi-driver/health-check.yaml
+++ b/recipes/checks/aws-ebs-csi-driver/health-check.yaml
@@ -97,7 +97,7 @@ spec:
                 labels:
                   app.kubernetes.io/name: aws-ebs-csi-driver
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -107,4 +107,4 @@ spec:
                 labels:
                   app.kubernetes.io/name: aws-ebs-csi-driver
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/aws-efa/health-check.yaml
+++ b/recipes/checks/aws-efa/health-check.yaml
@@ -92,7 +92,7 @@ spec:
                 labels:
                   app.kubernetes.io/name: aws-efa-k8s-device-plugin
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -102,4 +102,4 @@ spec:
                 labels:
                   app.kubernetes.io/name: aws-efa-k8s-device-plugin
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/cert-manager/health-check.yaml
+++ b/recipes/checks/cert-manager/health-check.yaml
@@ -140,7 +140,7 @@ spec:
               metadata:
                 namespace: cert-manager
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -148,4 +148,4 @@ spec:
               metadata:
                 namespace: cert-manager
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/dynamo-platform/health-check.yaml
+++ b/recipes/checks/dynamo-platform/health-check.yaml
@@ -42,13 +42,20 @@ spec:
                   - status: "True"
     - name: validate-deployment-exists
       try:
+        # Match by label, not name: the Helm chart prefixes the Deployment
+        # with the release name (e.g. dynamo-platform-dynamo-operator-
+        # controller-manager), so a hardcoded name: dynamo-operator never
+        # matches and the assert retries to the deadline. The chart sets a
+        # stable app.kubernetes.io/name=dynamo-operator label on the manager
+        # Deployment regardless of release name; List-and-match on it.
         - assert:
             resource:
               apiVersion: apps/v1
               kind: Deployment
               metadata:
-                name: dynamo-operator
                 namespace: dynamo-system
+                labels:
+                  app.kubernetes.io/name: dynamo-operator
               status:
                 (availableReplicas > `0`): true
     - name: validate-all-pods-healthy
@@ -92,7 +99,7 @@ spec:
               metadata:
                 namespace: dynamo-system
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -100,4 +107,4 @@ spec:
               metadata:
                 namespace: dynamo-system
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/gatekeeper/health-check.yaml
+++ b/recipes/checks/gatekeeper/health-check.yaml
@@ -97,7 +97,7 @@ spec:
               metadata:
                 namespace: gatekeeper-system
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -105,4 +105,4 @@ spec:
               metadata:
                 namespace: gatekeeper-system
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/gpu-operator/health-check.yaml
+++ b/recipes/checks/gpu-operator/health-check.yaml
@@ -120,7 +120,7 @@ spec:
               metadata:
                 namespace: gpu-operator
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -128,4 +128,4 @@ spec:
               metadata:
                 namespace: gpu-operator
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/grove/health-check.yaml
+++ b/recipes/checks/grove/health-check.yaml
@@ -80,7 +80,7 @@ spec:
                 labels:
                   app.kubernetes.io/name: grove-operator
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -90,4 +90,4 @@ spec:
                 labels:
                   app.kubernetes.io/name: grove-operator
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/k8s-ephemeral-storage-metrics/health-check.yaml
+++ b/recipes/checks/k8s-ephemeral-storage-metrics/health-check.yaml
@@ -97,7 +97,7 @@ spec:
                 labels:
                   app.kubernetes.io/name: k8s-ephemeral-storage-metrics
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -107,4 +107,4 @@ spec:
                 labels:
                   app.kubernetes.io/name: k8s-ephemeral-storage-metrics
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/k8s-nim-operator/health-check.yaml
+++ b/recipes/checks/k8s-nim-operator/health-check.yaml
@@ -87,7 +87,7 @@ spec:
               metadata:
                 namespace: nvidia-nim
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -95,4 +95,4 @@ spec:
               metadata:
                 namespace: nvidia-nim
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/kai-scheduler/health-check.yaml
+++ b/recipes/checks/kai-scheduler/health-check.yaml
@@ -87,7 +87,7 @@ spec:
               metadata:
                 namespace: kai-scheduler
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -95,4 +95,4 @@ spec:
               metadata:
                 namespace: kai-scheduler
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/kube-prometheus-stack/health-check.yaml
+++ b/recipes/checks/kube-prometheus-stack/health-check.yaml
@@ -97,7 +97,7 @@ spec:
                 labels:
                   app.kubernetes.io/name: kube-prometheus-stack
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -107,4 +107,4 @@ spec:
                 labels:
                   app.kubernetes.io/name: kube-prometheus-stack
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/kubeflow-trainer/health-check.yaml
+++ b/recipes/checks/kubeflow-trainer/health-check.yaml
@@ -87,7 +87,7 @@ spec:
               metadata:
                 namespace: kubeflow
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -95,4 +95,4 @@ spec:
               metadata:
                 namespace: kubeflow
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/kueue/health-check.yaml
+++ b/recipes/checks/kueue/health-check.yaml
@@ -87,7 +87,7 @@ spec:
               metadata:
                 namespace: kueue-system
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -95,4 +95,4 @@ spec:
               metadata:
                 namespace: kueue-system
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/network-operator/health-check.yaml
+++ b/recipes/checks/network-operator/health-check.yaml
@@ -87,7 +87,7 @@ spec:
               metadata:
                 namespace: nvidia-network-operator
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -95,4 +95,4 @@ spec:
               metadata:
                 namespace: nvidia-network-operator
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/nfd/health-check.yaml
+++ b/recipes/checks/nfd/health-check.yaml
@@ -128,7 +128,7 @@ spec:
               metadata:
                 namespace: node-feature-discovery
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -136,4 +136,4 @@ spec:
               metadata:
                 namespace: node-feature-discovery
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/nodewright-operator/health-check.yaml
+++ b/recipes/checks/nodewright-operator/health-check.yaml
@@ -93,7 +93,7 @@ spec:
               metadata:
                 namespace: skyhook
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -101,4 +101,4 @@ spec:
               metadata:
                 namespace: skyhook
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/nvidia-dra-driver-gpu/health-check.yaml
+++ b/recipes/checks/nvidia-dra-driver-gpu/health-check.yaml
@@ -90,7 +90,7 @@ spec:
               metadata:
                 namespace: nvidia-dra-driver
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -98,4 +98,4 @@ spec:
               metadata:
                 namespace: nvidia-dra-driver
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/nvsentinel/health-check.yaml
+++ b/recipes/checks/nvsentinel/health-check.yaml
@@ -88,7 +88,7 @@ spec:
               metadata:
                 namespace: nvsentinel
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -96,4 +96,4 @@ spec:
               metadata:
                 namespace: nvsentinel
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/prometheus-adapter/health-check.yaml
+++ b/recipes/checks/prometheus-adapter/health-check.yaml
@@ -97,7 +97,7 @@ spec:
                 labels:
                   app.kubernetes.io/name: prometheus-adapter
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -107,4 +107,4 @@ spec:
                 labels:
                   app.kubernetes.io/name: prometheus-adapter
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/slinky-slurm-operator/health-check.yaml
+++ b/recipes/checks/slinky-slurm-operator/health-check.yaml
@@ -97,7 +97,7 @@ spec:
               metadata:
                 namespace: slinky
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -105,4 +105,4 @@ spec:
               metadata:
                 namespace: slinky
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/recipes/checks/slinky-slurm/health-check.yaml
+++ b/recipes/checks/slinky-slurm/health-check.yaml
@@ -161,7 +161,7 @@ spec:
               metadata:
                 namespace: slurm
               status:
-                (containerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
         - error:
             resource:
               apiVersion: v1
@@ -169,4 +169,4 @@ spec:
               metadata:
                 namespace: slurm
               status:
-                (initContainerStatuses[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+                ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true

--- a/validators/chainsaw/inprocess.go
+++ b/validators/chainsaw/inprocess.go
@@ -167,6 +167,9 @@ func runAssertWithRetry(ctx context.Context, a *v1alpha1.Assert, fetcher Resourc
 		if lastErr == nil {
 			return nil
 		}
+		if isTerminalAssertErr(lastErr) {
+			return lastErr
+		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			return lastErr
@@ -194,6 +197,9 @@ func runErrorWithRetry(ctx context.Context, e *v1alpha1.Error, fetcher ResourceF
 		if lastErr == nil {
 			return nil
 		}
+		if isTerminalAssertErr(lastErr) {
+			return lastErr
+		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			return lastErr
@@ -208,6 +214,17 @@ func runErrorWithRetry(ctx context.Context, e *v1alpha1.Error, fetcher ResourceF
 		case <-time.After(wait):
 		}
 	}
+}
+
+// isTerminalAssertErr reports whether err is a non-retryable failure: a
+// malformed or non-evaluable assert/error expression (ErrCodeInvalidRequest,
+// e.g. a JMESPath operation that throws "invalid type for: <nil>"). Such an
+// error will never become valid by retrying, so the retry loops fail fast
+// instead of burning the full assert deadline. Transient failures — a resource
+// not yet in the desired state (assertion mismatch) or not-found — carry other
+// codes and continue to retry until the deadline.
+func isTerminalAssertErr(err error) bool {
+	return stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, ""))
 }
 
 // evaluateAssert runs a single positive assertion against the cluster.
@@ -239,7 +256,7 @@ func evaluateAssert(ctx context.Context, a *v1alpha1.Assert, fetcher ResourceFet
 		}
 		errs, checkErr := checks.Check(ctx, apis.DefaultCompilers, actual, nil, &check)
 		if checkErr != nil {
-			return errors.Wrap(errors.ErrCodeInternal,
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("%s %s/%s: assertion engine error", kind, namespace, name), checkErr)
 		}
 		if len(errs) > 0 {
@@ -267,7 +284,7 @@ func evaluateAssert(ctx context.Context, a *v1alpha1.Assert, fetcher ResourceFet
 		}
 		errs, checkErr := checks.Check(ctx, apis.DefaultCompilers, actual, nil, &check)
 		if checkErr != nil {
-			return errors.Wrap(errors.ErrCodeInternal,
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("%s in %q: assertion engine error", kind, namespace), checkErr)
 		}
 		if len(errs) == 0 {
@@ -314,7 +331,7 @@ func evaluateError(ctx context.Context, e *v1alpha1.Error, fetcher ResourceFetch
 		}
 		errs, checkErr := checks.Check(ctx, apis.DefaultCompilers, actual, nil, &check)
 		if checkErr != nil {
-			return errors.Wrap(errors.ErrCodeInternal,
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("%s %s/%s: assertion engine error", kind, namespace, name), checkErr)
 		}
 		if len(errs) == 0 {
@@ -339,7 +356,7 @@ func evaluateError(ctx context.Context, e *v1alpha1.Error, fetcher ResourceFetch
 		}
 		errs, checkErr := checks.Check(ctx, apis.DefaultCompilers, actual, nil, &check)
 		if checkErr != nil {
-			return errors.Wrap(errors.ErrCodeInternal,
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("%s in %q: assertion engine error", kind, namespace), checkErr)
 		}
 		if len(errs) == 0 {

--- a/validators/chainsaw/inprocess_test.go
+++ b/validators/chainsaw/inprocess_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
@@ -293,5 +294,94 @@ func TestRunChainsawTestInProcess_RegistryCorpusParses(t *testing.T) {
 	}
 	if parsed == 0 {
 		t.Fatal("no Test-format checks were exercised — registry walker is broken")
+	}
+}
+
+// TestRunChainsawTestInProcess_TerminalEvalErrorFailsFast is a regression
+// guard for #1252: a permanent JMESPath evaluation error must fail fast, not
+// be retried for the entire assert window. `length(@)` on a nil field throws
+// "invalid type for: <nil>" — the exact error class that, before the fix,
+// runAssertWithRetry retried every AssertRetryInterval until the deadline.
+// With a 30s step budget, a correct terminal-error short-circuit returns in
+// well under a second; a regression would block for >= one retry interval.
+func TestRunChainsawTestInProcess_TerminalEvalErrorFailsFast(t *testing.T) {
+	t.Parallel()
+	// `length(@)` on the absent `missingField` throws "invalid type for:
+	// <nil>" — the exact terminal eval error. Exercised across the full
+	// matrix that shares the isTerminalAssertErr guard: both ops (assert →
+	// runAssertWithRetry, error → runErrorWithRetry) AND both fetch paths
+	// (named single-Get vs. List-and-match). The bug that prompted the fix
+	// was on List-based Pod checks, so the List path must be pinned too.
+	const throwExpr = "(missingField[?x == 'y'] | length(@) > `0`): true"
+	// named=true → single-Get branch (metadata.name set);
+	// named=false → List-and-match branch (selector, no name).
+	makeYAML := func(op string, named bool) string {
+		meta := "namespace: perfns"
+		if named {
+			meta = "name: foo\n                namespace: perfns"
+		}
+		return `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: terminal-eval-error
+spec:
+  steps:
+    - name: nil-throw
+      try:
+        - ` + op + `:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                ` + meta + `
+              status:
+                ` + throwExpr + `
+`
+	}
+	cases := []struct {
+		op    string
+		named bool
+	}{
+		{"assert", true}, {"error", true},
+		{"assert", false}, {"error", false},
+	}
+	for _, tc := range cases {
+		mode := "list"
+		if tc.named {
+			mode = "named"
+		}
+		t.Run(tc.op+"/"+mode, func(t *testing.T) {
+			t.Parallel()
+			f := newFakeFetcher()
+			// Seed a Deployment (without `missingField`) so the path reaches
+			// the assertion engine and throws, rather than short-circuiting on
+			// NotFound / empty-list. The List branch is what the original
+			// (init)containerStatuses bug rode in on, so both are pinned.
+			d := healthyDeployment()
+			if tc.named {
+				f.addGet("apps/v1", "Deployment", "perfns", "foo", d)
+			} else {
+				f.addList("apps/v1", "Deployment", "perfns", []map[string]any{d})
+			}
+
+			// Generous step budget: a correct terminal-error short-circuit
+			// returns in well under a second; a regression (retrying the
+			// permanent error) blocks for >= one AssertRetryInterval.
+			start := time.Now()
+			r := runChainsawTestInProcess(context.Background(), "comp", makeYAML(tc.op, tc.named), 30*time.Second, f)
+			elapsed := time.Since(start)
+
+			if r.Error == nil {
+				t.Fatalf("expected terminal eval error, got nil (Passed=%v Output=%s)", r.Passed, r.Output)
+			}
+			if !stderrors.Is(r.Error, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("expected ErrCodeInvalidRequest (terminal), got %v", r.Error)
+			}
+			if elapsed >= defaults.AssertRetryInterval {
+				t.Fatalf("terminal eval error was retried (took %s >= AssertRetryInterval %s) — #1252 regression",
+					elapsed, defaults.AssertRetryInterval)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Three regression fixes for deployment-phase health-check validation, introduced by the recent in-process executor + deepened-check stack (#1235/#1245/#1252):

1. **In-process executor retries permanent eval errors** (`inprocess.go`)
2. **Nil-unsafe container-status expressions** (22 health checks)
3. **dynamo-platform check asserts a non-existent Deployment name**

## Motivation / Context

On an EKS H100 cluster, `aicr validate --phase deployment` hung ~8 min and returned `status=other` ("pod not found for Job") instead of real results. Root cause is three interacting issues:

1. **#1252** — `runAssertWithRetry` / `runErrorWithRetry` retry on *any* non-nil error, so a permanent JMESPath evaluation error is retried for the full 6m assert window. The old chainsaw binary treated eval errors as terminal and failed fast.
2. **#1245** — `(init)containerStatuses[?...] | length(@)` throws `invalid type for: <nil>` on any pod without (init) containers (the common case), which *feeds* defect #1.
3. **dynamo-platform** — `validate-deployment-exists` asserts a Deployment named `dynamo-operator`, but the chart prefixes it with the release name (`dynamo-platform-dynamo-operator-controller-manager`), so the assert never matched and retried to the deadline — a false negative against a healthy component.

(Defects #1/#2 independently confirmed by Nathan.)

Related: #1235, #1245, #1252

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — `recipes/checks/*`
- [x] Validator (`pkg/validator`) — `validators/chainsaw/inprocess.go`

## Implementation Notes

1. Classify assertion-engine errors as `ErrCodeInvalidRequest` (terminal) and short-circuit both retry loops via a new `isTerminalAssertErr` helper, so a non-evaluable expression fails fast instead of burning the assert deadline. Transient failures (mismatch, NotFound) still retry. Adds a regression test asserting a terminal eval error returns in `< AssertRetryInterval` rather than retrying to the deadline.
2. Coalesce to an empty array — `(initContainerStatuses || ` + "`[]`" + `)[?...]` — across all 22 affected component health checks (both `initContainerStatuses` and `containerStatuses`).
3. Match the dynamo-operator manager Deployment by its stable `app.kubernetes.io/name=dynamo-operator` label (List-and-match) instead of a release-name-dependent hardcoded name.

**Scope note (`conditions[?...]` filters):** the remaining `(conditions[?type == '...'])` filters are intentionally *not* coalesced — they are projection asserts without `| length(@)` (so nil `.status.conditions` yields an empty match, not a `<nil>` throw) and target CRDs/Deployments that reliably populate `.status.conditions`. They are not the same throwing class as the `length()` expressions fixed here.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./validators/chainsaw/...   # 0 issues
go test ./validators/chainsaw/...                                # ok, coverage 60.7%
```

New regression test `TestRunChainsawTestInProcess_TerminalEvalErrorFailsFast` reproduces the exact `invalid type for: <nil>` throw and asserts fast-fail (returns in 0.00s vs. retrying to deadline).

On-cluster (EKS H100): deployment phase went from an 8m timeout (`status=other`) to **PASSED in ~21s**; full run on this branch = **deployment 4/4 + conformance 11/11 green**. (Performance phase ran a real Qwen3-8B benchmark and reports a true TTFT-p99 SLA miss — a separate cluster/SLA matter, not this change.) Full `make qualify` not run locally — recommend CI / a maintainer run before merge.

## Risk Assessment

- [x] **Low** — Data/expression fixes plus a localized executor error-classification change; no API or schema changes, easy to revert.

**Rollout notes:** Reclassifying assertion-engine errors `ErrCodeInternal → ErrCodeInvalidRequest` is a caller-visible semantic shift (CLI exit 8→2, HTTP 500→400) for a malformed bundled-registry expression — intentional and anticipated by the design comment; backwards compatible otherwise.

## Checklist

- [x] Linter passes (`golangci-lint` on changed package — 0 issues)
- [x] Tests pass locally (`go test ./validators/chainsaw/...`), incl. new regression test
- [ ] Full `make qualify` (recommend running in CI / before merge)
- [x] I did not skip/disable tests to make CI green
- [x] I added a regression test for the terminal-eval-error fast-fail
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
