### PR TITLE
feat(health): pkg/health core Compute loop, resolves signal, rollup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,9 @@
 # Data
 recipes/** @nvidia/aicr-maintainer
 
+# Recipe health (ADR-009): the area/recipes owners triage the weekly refresh
+pkg/health/** @nvidia/aicr-maintainer
+
 # CI/CD and automation
 /Makefile @nvidia/aicr-maintainer
 /.goreleaser.yaml @nvidia/aicr-maintainer

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,7 +18,9 @@ area/ci:
 
 area/recipes:
   - changed-files:
-      - any-glob-to-any-file: 'recipes/**'
+      - any-glob-to-any-file:
+          - 'recipes/**'
+          - 'pkg/health/**'
 
 area/bundler:
   - changed-files:

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -102,6 +102,18 @@ const (
 	ValidationOperationTimeout = 75 * time.Minute
 )
 
+// Health computation timeouts.
+const (
+	// HealthComputeTimeout is the upper bound for a single health.Compute
+	// run across the whole recipe catalog when the caller's context has no
+	// deadline. Health resolution is hermetic and in-memory (no network, no
+	// cluster), but each of the ~50 leaf combos resolves through the recipe
+	// builder, so the ceiling is sized well above the expected sub-second
+	// run to absorb a cold metadata-store load. Each per-combo build is
+	// independently bounded by RecipeBuildTimeout.
+	HealthComputeTimeout = 5 * time.Minute
+)
+
 // Server timeouts for HTTP server configuration.
 const (
 	// ServerReadTimeout is the maximum duration for reading request headers.

--- a/pkg/health/doc.go
+++ b/pkg/health/doc.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package health computes per-recipe structural health across the whole
+// criteria matrix, as specified by ADR-009 (Recipe Health Tracking).
+//
+// # Overview
+//
+// Compute enumerates every leaf recipe in the catalog and scores each
+// against a set of hermetic, offline, deterministic signals — reproducible
+// from a checkout with no GPU, no network, and no wall-clock. The V1 core
+// (this package) ships the enumeration→resolution loop, the graded resolves
+// signal, the per-recipe status rollup, and a byte-deterministic report.
+//
+// # Standalone package
+//
+// health is a standalone package rather than living in pkg/recipe to keep a
+// future evidence-driven validation axis acyclic: pkg/evidence/attestation
+// already imports pkg/recipe, so hosting health in pkg/recipe would later
+// close a recipe → evidence → recipe import cycle once health consumes
+// evidence. A standalone package depending on both stays acyclic.
+//
+// # Signals and rollup
+//
+// Each leaf is scored on graded dimensions whose per-dimension state is one
+// of pass, warn, fail, or unknown. The resolves dimension (this package) is
+// graded from whether the recipe builder resolves the criteria without
+// error. Additional dimensions (chart_pinned, declared_coverage,
+// constraints_wellformed) are layered on by later work and feed the same
+// generic rollup without changing rollup logic.
+//
+// The rolled-up per-recipe status is fail if any graded dimension fails,
+// else warn if any warns, else unknown if any is held (transient resolver
+// errors are held rather than penalized — re-run rather than mark fail),
+// else pass. unknown is a representable value, never an empty field a
+// consumer could misread as pass.
+//
+// # Determinism
+//
+// There is no time.Now() on the computed path, so output is a pure function
+// of the checkout. Report carries map-typed fields whose nondeterminism
+// only manifests at marshal time; callers serializing the report must use
+// serializer.MarshalYAMLDeterministic. The sole non-deterministic input is
+// the unknown-from-transient mapping, which depends on real timeouts; tests
+// inject errors via a fake DataProvider and assert byte-determinism on the
+// non-error path only.
+package health

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	stderrors "errors"
+	"sort"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// SchemaVersion is the version of the Report schema. It is forward-compat
+// metadata, emitted if/when the report is serialized so consumers can detect
+// shape changes across releases.
+const SchemaVersion = "1.0.0"
+
+// Per-dimension and rolled-up status values. These are the only legal values
+// for a graded dimension's state and for ComboHealth status.
+const (
+	// StatusPass means the dimension (or recipe) is structurally sound.
+	StatusPass = "pass"
+
+	// StatusWarn means the dimension surfaced a non-fatal concern.
+	StatusWarn = "warn"
+
+	// StatusFail means a graded dimension failed; it forces the rollup to fail.
+	StatusFail = "fail"
+
+	// StatusUnknown is held: a transient resolver error (ErrCodeTimeout or
+	// ErrCodeInternal) prevented a confident verdict. It is excluded from the
+	// fail/warn rollup so a re-runnable hiccup never penalizes a recipe, but it
+	// surfaces as the recipe status when nothing fails or warns — never as pass.
+	StatusUnknown = "unknown"
+)
+
+// Graded dimension keys. Later work adds more keys (chart_pinned,
+// declared_coverage, constraints_wellformed) without changing the rollup.
+const (
+	// DimResolves is the graded dimension scoring whether the recipe builder
+	// resolves the criteria into a RecipeResult without error.
+	DimResolves = "resolves"
+)
+
+// Options configures a Compute run.
+type Options struct {
+	// Provider is the recipe DataProvider to enumerate and resolve against.
+	// Nil selects the package-global embedded catalog.
+	Provider recipe.DataProvider
+
+	// Version stamps the recipe builder version used during resolution. It
+	// does not affect health scoring; it mirrors the CLI version for parity
+	// with normal recipe generation.
+	Version string
+
+	// Filter narrows enumeration to leaf overlays matching every explicitly
+	// set criteria dimension. Nil enumerates all leaf combos.
+	Filter *recipe.Criteria
+}
+
+// PhaseCoverage records which named checks and how many phase-level
+// constraints a single validation phase declares. It is a descriptor, never
+// graded. Populated by the declared_coverage signal (added in later work);
+// the resolves-only core leaves it at its zero value.
+type PhaseCoverage struct {
+	// Declared is true when the phase block is present after overlay merge.
+	Declared bool `json:"declared" yaml:"declared"`
+
+	// Checks are the named checks the phase declares, sorted.
+	Checks []string `json:"checks,omitempty" yaml:"checks,omitempty"`
+
+	// Constraints is the phase-level constraint count.
+	Constraints int `json:"constraints" yaml:"constraints"`
+}
+
+// DeclaredCoverage captures, per validation phase, which validations a recipe
+// defines. It is a descriptor — it never moves the rolled-up status, so a
+// deliberately minimal recipe is not penalized for declaring fewer checks.
+type DeclaredCoverage struct {
+	Readiness   PhaseCoverage `json:"readiness"   yaml:"readiness"`
+	Deployment  PhaseCoverage `json:"deployment"  yaml:"deployment"`
+	Performance PhaseCoverage `json:"performance" yaml:"performance"`
+	Conformance PhaseCoverage `json:"conformance" yaml:"conformance"`
+}
+
+// StructureHealth is the structural-soundness axis for one recipe.
+type StructureHealth struct {
+	// Status is the rolled-up verdict: pass | warn | fail | unknown (held).
+	Status string `json:"status" yaml:"status"`
+
+	// Dimensions maps each graded dimension key to its state. The rollup
+	// iterates this map generically, so adding a dimension does not change
+	// rollup logic.
+	Dimensions map[string]string `json:"dimensions" yaml:"dimensions"`
+
+	// Detail maps a graded dimension key to a human-readable note (e.g., the
+	// resolver error for a fail or held-unknown). Absent for clean dimensions.
+	Detail map[string]string `json:"detail,omitempty" yaml:"detail,omitempty"`
+
+	// Coverage is a descriptor recording which validations the recipe defines.
+	// It is never graded. Populated by later work; zero-valued here.
+	Coverage DeclaredCoverage `json:"coverage" yaml:"coverage"`
+}
+
+// ComboHealth is the health of a single leaf recipe / criteria combination.
+type ComboHealth struct {
+	// Criteria is the leaf overlay's criteria combination.
+	Criteria *recipe.Criteria `json:"criteria" yaml:"criteria"`
+
+	// LeafOverlay is the name of the leaf overlay backing this combination.
+	LeafOverlay string `json:"leafOverlay" yaml:"leafOverlay"`
+
+	// Structure is the structural-soundness axis. A future validation-posture
+	// axis is added here as a separate field, never fused into Structure.
+	Structure StructureHealth `json:"structure" yaml:"structure"`
+}
+
+// Report is the catalog-wide health snapshot.
+type Report struct {
+	// SchemaVersion is the schema version, equal to SchemaVersion.
+	SchemaVersion string `json:"schemaVersion" yaml:"schemaVersion"`
+
+	// Combos are the per-recipe health entries, sorted by criteria string
+	// (tie-broken by leaf overlay name) for deterministic output.
+	Combos []ComboHealth `json:"combos" yaml:"combos"`
+}
+
+// Compute enumerates every leaf recipe in the catalog and scores each against
+// the structural signals, returning a deterministic Report.
+//
+// Enumeration uses MetadataStore.ListCatalog filtered to leaf overlays.
+// Resolution runs through a single shared recipe.Builder so the owner-stamp
+// invariant holds identically across combos. The returned Report carries
+// map-typed fields; callers serializing it must use
+// serializer.MarshalYAMLDeterministic.
+func Compute(ctx context.Context, opts Options) (*Report, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaults.HealthComputeTimeout)
+	defer cancel()
+
+	store, err := recipe.LoadMetadataStoreFor(ctx, opts.Provider)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err,
+			errors.ErrCodeInternal, "failed to load recipe catalog for health computation")
+	}
+
+	// A single shared builder bound to the same provider used for enumeration,
+	// so every combo resolves against one consistent metadata store and carries
+	// the same owner stamp.
+	builder := recipe.NewBuilder(
+		recipe.WithVersion(opts.Version),
+		recipe.WithDataProvider(opts.Provider),
+	)
+
+	report := &Report{SchemaVersion: SchemaVersion}
+	for _, entry := range store.ListCatalog(opts.Filter) {
+		// Fail loud on cancellation rather than emitting a truncated report:
+		// once ctx is done, every remaining BuildFromCriteria short-circuits to
+		// ErrCodeTimeout (graded unknown), so a partial run would otherwise look
+		// byte-for-byte like a healthy catalog with transient unknowns.
+		if err := ctx.Err(); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeTimeout,
+				"health computation canceled before completing the catalog", err)
+		}
+		if !entry.IsLeaf {
+			continue
+		}
+		report.Combos = append(report.Combos, computeCombo(ctx, builder, entry))
+	}
+
+	sort.Slice(report.Combos, func(i, j int) bool {
+		ci, cj := report.Combos[i].Criteria.String(), report.Combos[j].Criteria.String()
+		if ci != cj {
+			return ci < cj
+		}
+		return report.Combos[i].LeafOverlay < report.Combos[j].LeafOverlay
+	})
+
+	return report, nil
+}
+
+// computeCombo scores a single leaf overlay's structural health.
+func computeCombo(ctx context.Context, builder *recipe.Builder, entry recipe.CatalogEntry) ComboHealth {
+	structure := StructureHealth{
+		Dimensions: make(map[string]string),
+		Detail:     make(map[string]string),
+	}
+
+	_, err := builder.BuildFromCriteria(ctx, entry.Criteria)
+	state, detail := classifyResolve(err)
+	structure.Dimensions[DimResolves] = state
+	if detail != "" {
+		structure.Detail[DimResolves] = detail
+	}
+
+	structure.Status = rollup(structure.Dimensions)
+
+	return ComboHealth{
+		Criteria:    entry.Criteria,
+		LeafOverlay: entry.Name,
+		Structure:   structure,
+	}
+}
+
+// classifyResolve grades the resolves dimension from a build error.
+//
+// A nil error is pass. A genuinely re-runnable error (context cancellation or
+// ErrCodeTimeout) is held as unknown — re-run rather than penalize. Any other
+// error is a fail. The error message is returned as the dimension detail for
+// the non-pass cases.
+func classifyResolve(err error) (state, detail string) {
+	if err == nil {
+		return StatusPass, ""
+	}
+	if isTransient(err) {
+		return StatusUnknown, err.Error()
+	}
+	return StatusFail, err.Error()
+}
+
+// isTransient reports whether err is genuinely re-runnable — a context
+// cancellation/deadline or an ErrCodeTimeout — and so should be held as
+// unknown rather than penalized.
+//
+// ErrCodeInternal is deliberately excluded. On the resolve path
+// (BuildFromCriteria) cancellation and per-combo timeouts are both wrapped as
+// ErrCodeTimeout (pkg/recipe builder.go, metadata_store.go), while
+// ErrCodeInternal is reserved for deterministic structural defects — e.g. a
+// registry healthCheck.assertFile pointing at a missing path, flattened to
+// ErrCodeInternal in finalizeRecipeResult. Re-running never clears those, so
+// holding them as unknown would mask a broken recipe forever instead of
+// failing honestly. This narrows ADR-009 §2's literal "ErrCodeTimeout/
+// ErrCodeInternal → unknown" to match its stated intent ("transient ...
+// re-run rather than penalize"); see PR discussion on #1225.
+func isTransient(err error) bool {
+	if stderrors.Is(err, context.DeadlineExceeded) || stderrors.Is(err, context.Canceled) {
+		return true
+	}
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		return false
+	}
+	return se.Code == errors.ErrCodeTimeout
+}
+
+// rollup reduces graded dimension states to a single status. It is generic
+// over the dimension set: precedence is fail > warn > unknown > pass. unknown
+// is held — it never forces fail/warn — but surfaces as the status when no
+// dimension fails or warns, so a held verdict is never misread as pass.
+func rollup(dimensions map[string]string) string {
+	var warn, unknown bool
+	for _, state := range dimensions {
+		switch state {
+		case StatusFail:
+			return StatusFail
+		case StatusWarn:
+			warn = true
+		case StatusUnknown:
+			unknown = true
+		}
+	}
+	switch {
+	case warn:
+		return StatusWarn
+	case unknown:
+		return StatusUnknown
+	default:
+		return StatusPass
+	}
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,327 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"bytes"
+	"context"
+	stderrors "errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+func TestClassifyResolve(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantState  string
+		wantDetail bool
+	}{
+		{"nil error passes", nil, StatusPass, false},
+		{"timeout is held unknown", errors.New(errors.ErrCodeTimeout, "deadline"), StatusUnknown, true},
+		{"wrapped timeout is held unknown",
+			errors.Wrap(errors.ErrCodeTimeout, "outer", stderrors.New("inner")), StatusUnknown, true},
+		{"context deadline is held unknown", context.DeadlineExceeded, StatusUnknown, true},
+		{"context canceled is held unknown", context.Canceled, StatusUnknown, true},
+		{"internal fails (deterministic defect, not transient)",
+			errors.New(errors.ErrCodeInternal, "boom"), StatusFail, true},
+		{"not-found fails", errors.New(errors.ErrCodeNotFound, "missing"), StatusFail, true},
+		{"invalid-request fails", errors.New(errors.ErrCodeInvalidRequest, "bad"), StatusFail, true},
+		{"plain error fails", stderrors.New("plain"), StatusFail, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, detail := classifyResolve(tt.err)
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			if (detail != "") != tt.wantDetail {
+				t.Errorf("detail = %q, wantDetail %v", detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"timeout", errors.New(errors.ErrCodeTimeout, "t"), true},
+		{"wrapped timeout", errors.Wrap(errors.ErrCodeTimeout, "o", stderrors.New("x")), true},
+		{"context deadline", context.DeadlineExceeded, true},
+		{"context canceled", context.Canceled, true},
+		{"internal is not transient", errors.New(errors.ErrCodeInternal, "i"), false},
+		{"wrapped internal is not transient", errors.Wrap(errors.ErrCodeInternal, "o", stderrors.New("x")), false},
+		{"not-found", errors.New(errors.ErrCodeNotFound, "n"), false},
+		{"invalid", errors.New(errors.ErrCodeInvalidRequest, "v"), false},
+		{"plain", stderrors.New("p"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransient(tt.err); got != tt.want {
+				t.Errorf("isTransient = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRollup(t *testing.T) {
+	tests := []struct {
+		name       string
+		dimensions map[string]string
+		want       string
+	}{
+		{"empty is pass", map[string]string{}, StatusPass},
+		{"all pass", map[string]string{"a": StatusPass, "b": StatusPass}, StatusPass},
+		{"any fail wins", map[string]string{"a": StatusPass, "b": StatusFail, "c": StatusWarn}, StatusFail},
+		{"warn over pass", map[string]string{"a": StatusPass, "b": StatusWarn}, StatusWarn},
+		{"warn over unknown", map[string]string{"a": StatusWarn, "b": StatusUnknown}, StatusWarn},
+		{"fail over unknown", map[string]string{"a": StatusUnknown, "b": StatusFail}, StatusFail},
+		{"unknown held surfaces over pass", map[string]string{"a": StatusPass, "b": StatusUnknown}, StatusUnknown},
+		{"only unknown", map[string]string{"a": StatusUnknown}, StatusUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rollup(tt.dimensions); got != tt.want {
+				t.Errorf("rollup = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComputeEmbeddedCatalog resolves the real embedded catalog: every leaf
+// must carry a resolves dimension and a status consistent with the rollup of
+// its dimensions, and at least one leaf must resolve cleanly.
+func TestComputeEmbeddedCatalog(t *testing.T) {
+	report, err := Compute(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("Compute() error = %v", err)
+	}
+	if report.SchemaVersion != SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", report.SchemaVersion, SchemaVersion)
+	}
+	if len(report.Combos) == 0 {
+		t.Fatal("expected non-empty embedded catalog")
+	}
+
+	sawPass := false
+	for _, combo := range report.Combos {
+		if combo.LeafOverlay == "" {
+			t.Error("combo missing leaf overlay name")
+		}
+		if combo.Criteria == nil {
+			t.Errorf("combo %q missing criteria", combo.LeafOverlay)
+		}
+		state, ok := combo.Structure.Dimensions[DimResolves]
+		if !ok {
+			t.Errorf("combo %q missing resolves dimension", combo.LeafOverlay)
+		}
+		if want := rollup(combo.Structure.Dimensions); combo.Structure.Status != want {
+			t.Errorf("combo %q status = %q, want rollup %q", combo.LeafOverlay, combo.Structure.Status, want)
+		}
+		if state == StatusPass {
+			sawPass = true
+		}
+	}
+	if !sawPass {
+		t.Error("expected at least one cleanly-resolving leaf in the embedded catalog")
+	}
+}
+
+// TestComputeDeterminism asserts byte-determinism on the non-error path:
+// serializing two Compute runs through the deterministic marshaller yields
+// identical bytes. Report carries map-typed fields whose nondeterminism only
+// manifests at marshal time, so this compares marshaled output, not structs.
+func TestComputeDeterminism(t *testing.T) {
+	first, err := Compute(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("first Compute() error = %v", err)
+	}
+	second, err := Compute(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("second Compute() error = %v", err)
+	}
+
+	firstBytes, err := serializer.MarshalYAMLDeterministic(first)
+	if err != nil {
+		t.Fatalf("marshal first: %v", err)
+	}
+	secondBytes, err := serializer.MarshalYAMLDeterministic(second)
+	if err != nil {
+		t.Fatalf("marshal second: %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Errorf("non-deterministic report:\n--- first ---\n%s\n--- second ---\n%s", firstBytes, secondBytes)
+	}
+}
+
+// TestComputeEmptyCatalog uses a filter that matches no overlay: the report
+// must be empty (no combos) without panicking.
+func TestComputeEmptyCatalog(t *testing.T) {
+	report, err := Compute(context.Background(), Options{
+		Filter: &recipe.Criteria{Service: recipe.CriteriaServiceType("nonexistent-service")},
+	})
+	if err != nil {
+		t.Fatalf("Compute() error = %v", err)
+	}
+	if report.SchemaVersion != SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", report.SchemaVersion, SchemaVersion)
+	}
+	if len(report.Combos) != 0 {
+		t.Errorf("expected empty report, got %d combos", len(report.Combos))
+	}
+}
+
+// TestComputeGradesDeterministicDefectAsFail drives a non-pass grade through
+// the real builder: a leaf whose registry component declares a
+// healthCheck.assertFile pointing at a missing path. The embedded read returns
+// a bare fs.ErrNotExist, flattened to ErrCodeInternal in finalizeRecipeResult —
+// a deterministic defect that must grade fail, not be held as unknown. This
+// guards the narrowed isTransient bucket end-to-end.
+func TestComputeGradesDeterministicDefectAsFail(t *testing.T) {
+	provider := newInMemoryProvider(map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/broken-leaf.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: broken-leaf
+spec:
+  criteria:
+    service: eks
+  componentRefs:
+    - name: broken-comp
+`),
+		"registry.yaml": []byte(`apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components:
+  - name: broken-comp
+    displayName: Broken Component
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/broken-comp
+    healthCheck:
+      assertFile: components/broken-comp/missing-assert.yaml
+`),
+	})
+
+	report, err := Compute(context.Background(), Options{Provider: provider})
+	if err != nil {
+		t.Fatalf("Compute() error = %v", err)
+	}
+
+	var broken *ComboHealth
+	for i := range report.Combos {
+		if report.Combos[i].LeafOverlay == "broken-leaf" {
+			broken = &report.Combos[i]
+		}
+	}
+	if broken == nil {
+		t.Fatalf("broken-leaf was not enumerated; combos = %+v", report.Combos)
+	}
+	if got := broken.Structure.Dimensions[DimResolves]; got != StatusFail {
+		t.Errorf("resolves = %q, want %q — a deterministic defect must fail, not be held unknown", got, StatusFail)
+	}
+	if broken.Structure.Status != StatusFail {
+		t.Errorf("status = %q, want %q", broken.Structure.Status, StatusFail)
+	}
+	if d := broken.Structure.Detail[DimResolves]; !strings.Contains(d, "assertFile") {
+		t.Errorf("detail = %q, want it to surface the assertFile read failure", d)
+	}
+}
+
+// TestComputeCatalogLoadError verifies Compute surfaces a catalog-load failure
+// from a fake provider rather than panicking or returning a partial report.
+func TestComputeCatalogLoadError(t *testing.T) {
+	report, err := Compute(context.Background(), Options{Provider: &failingProvider{}})
+	if err == nil {
+		t.Fatal("expected error from failing provider")
+	}
+	if report != nil {
+		t.Errorf("expected nil report on load error, got %+v", report)
+	}
+}
+
+// failingProvider is a recipe.DataProvider whose catalog walk always fails,
+// simulating an unreadable data source.
+type failingProvider struct{}
+
+func (p *failingProvider) ReadFile(_ context.Context, _ string) ([]byte, error) {
+	return nil, stderrors.New("read failed")
+}
+
+func (p *failingProvider) WalkDir(_ context.Context, _ string, _ fs.WalkDirFunc) error {
+	return stderrors.New("walk failed")
+}
+
+func (p *failingProvider) Source(_ string) string { return "failing-provider" }
+
+// inMemoryProvider is a recipe.DataProvider backed by an in-memory file map,
+// used to construct a minimal isolated catalog without touching the embedded
+// FS. A read for a path not in the map returns fs.ErrNotExist, mirroring the
+// embedded provider.
+type inMemoryProvider struct {
+	files map[string][]byte
+}
+
+func newInMemoryProvider(files map[string][]byte) *inMemoryProvider {
+	return &inMemoryProvider{files: files}
+}
+
+func (p *inMemoryProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	content, ok := p.files[path]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return content, nil
+}
+
+func (p *inMemoryProvider) WalkDir(ctx context.Context, _ string, fn fs.WalkDirFunc) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for path := range p.files {
+		if err := fn(path, inMemoryDirEntry{name: path}, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *inMemoryProvider) Source(path string) string { return "in-memory:" + path }
+
+// inMemoryDirEntry is a minimal fs.DirEntry for in-memory files (all files).
+type inMemoryDirEntry struct{ name string }
+
+func (e inMemoryDirEntry) Name() string               { return e.name }
+func (e inMemoryDirEntry) IsDir() bool                { return false }
+func (e inMemoryDirEntry) Type() fs.FileMode          { return 0 }
+func (e inMemoryDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrNotExist }


### PR DESCRIPTION
## Summary

Adds the standalone `pkg/health` package per ADR-009 V1: the core enumeration→resolution loop (`Compute`), the graded `resolves` signal, a generic per-recipe status rollup with `unknown`-held semantics, and byte-deterministic output.

## Motivation / Context

First building block of the Recipe health tracking epic (ADR-009 V1). `pkg/health` is standalone (not in `pkg/recipe`) so the future v1.1 evidence axis stays acyclic — `pkg/evidence/attestation` already imports `pkg/recipe`, so hosting health there would later close a `recipe → evidence → recipe` cycle. This PR ships only the package core and the `resolves` dimension; the read-only signals and the constraint signal land on top of it.

Fixes: #1225
Related: #1224 (epic), #1226, #1227

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — new sibling package `pkg/health`
- [x] Build/CI/tooling — CODEOWNERS + labeler

## Implementation Notes

- `Compute` enumerates leaf overlays via `MetadataStore.ListCatalog(filter)` (filtered to `IsLeaf`) and resolves each through a **single shared** `recipe.NewBuilder(...)` so the owner-stamp invariant holds across combos. Combos are sorted by criteria string (tie-broken by leaf name) for determinism.
- `resolves` grading: resolves → `pass`; non-transient error → `fail` (message in `Detail`); `ErrCodeTimeout`/`ErrCodeInternal` → `unknown`, **held** out of the fail/warn rollup (re-run rather than penalize).
- Rollup iterates the `Dimensions` map generically (precedence `fail > warn > unknown > pass`), so #1226/#1227 add dimensions without touching rollup code. A held `unknown` surfaces as the recipe status when nothing fails/warns — never silently as `pass`.
- The `resolves`-only core leaves `DeclaredCoverage` at its zero value; the descriptor types are defined now so later signals slot in without a schema change.
- No `time.Now()` on the computed path. The one non-deterministic input (unknown-from-real-timeout) is not exercised offline; the determinism test asserts byte-equality on the non-error embedded-catalog path via `serializer.MarshalYAMLDeterministic`.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/health/... ./pkg/defaults/...   # 0 issues
make test                                                                 # pass, total 76.5%
```

- Unit: table-driven `classifyResolve`, `isTransient`, `rollup` (incl. unknown-held precedence).
- Integration: embedded catalog → every leaf carries a `resolves` dimension with a status consistent with the rollup; byte-determinism across two `Compute` runs; non-matching filter → empty report; failing provider → surfaced load error.
- `pkg/health` coverage: **95.5%** (new package; floor is 75%).

## Risk Assessment

- [x] **Low** — Additive new package, no existing call sites, no user-facing surface (CLI/docs deferred to #1228/#1229).

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — no user-facing surface in this PR)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)