### PR TITLE
fix(ci): always upload recipe-evidence report so comment gate works

### DIFF
--- a/.github/workflows/recipe-evidence-comment.yaml
+++ b/.github/workflows/recipe-evidence-comment.yaml
@@ -56,6 +56,11 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       - name: Download evidence report
+        # The verify workflow only produces this artifact when it got far
+        # enough to write a report; a build failure before the script runs
+        # leaves none. Don't fail this warning-only gate on a missing
+        # artifact — the comment step below no-ops when report.md is absent.
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: recipe-evidence-report

--- a/.github/workflows/recipe-evidence.yaml
+++ b/.github/workflows/recipe-evidence.yaml
@@ -90,11 +90,18 @@ jobs:
         run: .github/scripts/recipe-evidence-check.sh
 
       - name: Upload evidence report
-        # Always upload so even a partial report (build failed mid-loop,
-        # discovery errored) reaches the comment workflow.
-        if: ${{ always() && hashFiles(format('{0}/report.md', runner.temp)) != '' }}
+        # Always attempt upload so even a partial report (build failed
+        # mid-loop, discovery errored) reaches the comment workflow.
+        # `if-no-files-found: ignore` makes a genuinely-absent report a
+        # no-op instead of a failure. We can NOT guard this with
+        # hashFiles(): that expression only matches paths inside
+        # GITHUB_WORKSPACE, and the report lives under runner.temp — so
+        # the guard always evaluated empty and the upload was always
+        # skipped. upload-artifact itself reads the absolute path fine.
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: recipe-evidence-report
           path: ${{ runner.temp }}/report.md
+          if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary

Fix the recipe-evidence comment workflow, which has failed on every run since the gate was introduced with `Artifact not found for name: recipe-evidence-report`.

## Motivation / Context

`recipe-evidence.yaml` writes its report to `${{ runner.temp }}/report.md`, but its upload step was gated on `hashFiles(format('{0}/report.md', runner.temp)) != ''`. `hashFiles()` only matches files **inside `GITHUB_WORKSPACE`**, and `runner.temp` is outside it — so the expression always returned `''`, the guard was always false, and the upload was **always skipped**. The companion `recipe-evidence-comment.yaml` workflow then unconditionally tried to download an artifact that never existed and hard-failed.

Confirmed against run history: the last 12 successful "Recipe Evidence: Verify" runs all show `Upload evidence report → skipped`, and every triggered comment run failed at the download step. Broken since #1065 (2026-05-28).

Fixes: N/A
Related: #1065

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: GitHub Actions workflows (`.github/workflows/recipe-evidence*.yaml`)

## Implementation Notes

- **`recipe-evidence.yaml`** — dropped the broken `hashFiles` guard. The upload step now runs on `if: always()` with `if-no-files-found: ignore`. `upload-artifact` reads the absolute `runner.temp` path without issue (only `hashFiles` couldn't see it), so the report now actually uploads, and a genuinely-absent report is a quiet no-op rather than an error.
- **`recipe-evidence-comment.yaml`** — added `continue-on-error: true` to the download step. For the legitimate case where verify fails before writing a report (no artifact), the warning-only comment gate no longer turns red; it falls through to the existing `[[ ! -s report.md ]]` guard that skips posting.

## Testing

```bash
yamllint -c .yamllint.yaml \
  .github/workflows/recipe-evidence.yaml \
  .github/workflows/recipe-evidence-comment.yaml   # exit 0
```

Full end-to-end validation requires a live `recipes/**` PR run on GitHub: "Recipe Evidence: Verify" should show `Upload evidence report → success`, and "Recipe Evidence: Comment" should post the sticky comment instead of failing at download. No Go code changed, so `make test`/lint gates are not exercised by this change.

## Risk Assessment

- [x] **Low** — Isolated CI-only change, easy to revert. The affected gate is warning-only and never blocks merge.

**Rollout notes:** N/A — takes effect on the next `recipes/**` PR.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (yamllint, exit 0)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI workflow fix)
- [ ] I updated docs if user-facing behavior changed — N/A (no user-facing behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
