### PR TITLE
feat(health): chart_pinned signal + declared_coverage descriptor

### DIFF
--- a/pkg/health/doc.go
+++ b/pkg/health/doc.go
@@ -34,11 +34,17 @@
 // # Signals and rollup
 //
 // Each leaf is scored on graded dimensions whose per-dimension state is one
-// of pass, warn, fail, or unknown. The resolves dimension (this package) is
-// graded from whether the recipe builder resolves the criteria without
-// error. Additional dimensions (chart_pinned, declared_coverage,
-// constraints_wellformed) are layered on by later work and feed the same
-// generic rollup without changing rollup logic.
+// of pass, warn, fail, or unknown. Two graded dimensions ship today: resolves
+// (whether the recipe builder resolves the criteria without error) and
+// chart_pinned (whether every resolved Helm component references an explicit
+// chart version — ADR-006 layer 1, a pure field read with no Helm render).
+// One more graded dimension, constraints_wellformed, is layered on by later
+// work and feeds the same generic rollup without changing rollup logic.
+//
+// declared_coverage is a separate descriptor, not a graded dimension: it
+// records, per validation phase, whether the phase is declared, its named
+// checks, and its constraint count. It is surfaced but never moves the status,
+// so a deliberately minimal recipe is not penalized for declaring fewer checks.
 //
 // The rolled-up per-recipe status is fail if any graded dimension fails,
 // else warn if any warns, else unknown if any is held (transient resolver

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 	"sort"
+	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -48,12 +49,16 @@ const (
 	StatusUnknown = "unknown"
 )
 
-// Graded dimension keys. Later work adds more keys (chart_pinned,
-// declared_coverage, constraints_wellformed) without changing the rollup.
+// Graded dimension keys. Later work adds more keys (constraints_wellformed)
+// without changing the rollup.
 const (
 	// DimResolves is the graded dimension scoring whether the recipe builder
 	// resolves the criteria into a RecipeResult without error.
 	DimResolves = "resolves"
+
+	// DimChartPinned is the graded dimension scoring whether every resolved
+	// Helm component references an explicit chart version (ADR-006 layer 1).
+	DimChartPinned = "chart_pinned"
 )
 
 // Options configures a Compute run.
@@ -74,8 +79,7 @@ type Options struct {
 
 // PhaseCoverage records which named checks and how many phase-level
 // constraints a single validation phase declares. It is a descriptor, never
-// graded. Populated by the declared_coverage signal (added in later work);
-// the resolves-only core leaves it at its zero value.
+// graded.
 type PhaseCoverage struct {
 	// Declared is true when the phase block is present after overlay merge.
 	Declared bool `json:"declared" yaml:"declared"`
@@ -108,12 +112,15 @@ type StructureHealth struct {
 	Dimensions map[string]string `json:"dimensions" yaml:"dimensions"`
 
 	// Detail maps a graded dimension key to a human-readable note (e.g., the
-	// resolver error for a fail or held-unknown). Absent for clean dimensions.
+	// resolver error for a fail/held-unknown, or the not-applicable note on a
+	// vacuous chart_pinned pass). A genuinely clean dimension has no entry.
 	Detail map[string]string `json:"detail,omitempty" yaml:"detail,omitempty"`
 
 	// Coverage is a descriptor recording which validations the recipe defines.
-	// It is never graded. Populated by later work; zero-valued here.
-	Coverage DeclaredCoverage `json:"coverage" yaml:"coverage"`
+	// It is never graded. Non-nil only when the recipe resolves; nil otherwise
+	// (no RecipeResult to read), so the field is omitted rather than emitting a
+	// misleading all-zero block for a combo whose coverage is simply unknown.
+	Coverage *DeclaredCoverage `json:"coverage,omitempty" yaml:"coverage,omitempty"`
 }
 
 // ComboHealth is the health of a single leaf recipe / criteria combination.
@@ -199,11 +206,24 @@ func computeCombo(ctx context.Context, builder *recipe.Builder, entry recipe.Cat
 		Detail:     make(map[string]string),
 	}
 
-	_, err := builder.BuildFromCriteria(ctx, entry.Criteria)
+	result, err := builder.BuildFromCriteria(ctx, entry.Criteria)
 	state, detail := classifyResolve(err)
 	structure.Dimensions[DimResolves] = state
 	if detail != "" {
 		structure.Detail[DimResolves] = detail
+	}
+
+	// The remaining structural signals are pure reads of the resolved
+	// RecipeResult, so they only apply when resolution succeeded — a failed or
+	// held combo has no result to inspect.
+	if err == nil {
+		pinnedState, pinnedDetail := classifyChartPinned(result)
+		structure.Dimensions[DimChartPinned] = pinnedState
+		if pinnedDetail != "" {
+			structure.Detail[DimChartPinned] = pinnedDetail
+		}
+		cov := computeCoverage(result)
+		structure.Coverage = &cov
 	}
 
 	structure.Status = rollup(structure.Dimensions)
@@ -213,6 +233,88 @@ func computeCombo(ctx context.Context, builder *recipe.Builder, entry recipe.Cat
 		LeafOverlay: entry.Name,
 		Structure:   structure,
 	}
+}
+
+// classifyChartPinned grades the chart_pinned dimension: every enabled Helm
+// component must reference an explicit chart version (ADR-006 layer 1 — the
+// chart-version pin, not image digests). An unpinned Helm component is a fail.
+//
+// This is a pure in-repo field check — no Helm render. It is a presence check
+// (non-empty Version), not range/exact-pin validation: a floating version
+// would score pass, but the registry pins exact versions, so layer 1 is
+// satisfied by presence. Disabled components (overrides.enabled: false) are
+// skipped — they are never bundled or deployed, so an unpinned disabled
+// component must not flip the recipe to fail; this matches every other
+// consumer of ComponentRefs (bundler, deployers, mirror, BOM).
+//
+// A recipe with no enabled Helm components (e.g. pure-Kustomize) scores a
+// vacuous pass with an explanatory detail, since Kustomize defaultTag pinning
+// is out of scope and the column must not be misread as "supply-chain pinned".
+//
+// The dimension therefore has three distinguishable states for a downstream
+// renderer: pass with a detail (vacuous — no Helm to pin), pass with no detail
+// (genuinely pinned), and absent from Dimensions entirely (resolve failed/held,
+// so it was never scored).
+func classifyChartPinned(result *recipe.RecipeResult) (state, detail string) {
+	if result == nil {
+		return StatusPass, ""
+	}
+
+	helmCount := 0
+	var unpinned []string
+	for _, ref := range result.ComponentRefs {
+		if ref.Type != recipe.ComponentTypeHelm || !ref.IsEnabled() {
+			continue
+		}
+		helmCount++
+		if ref.Version == "" {
+			unpinned = append(unpinned, ref.Name)
+		}
+	}
+
+	if len(unpinned) > 0 {
+		sort.Strings(unpinned)
+		return StatusFail, "unpinned Helm chart version for: " + strings.Join(unpinned, ", ")
+	}
+	if helmCount == 0 {
+		return StatusPass, "no enabled Helm components; chart-version pinning not applicable (Kustomize tag pinning is out of scope)"
+	}
+	return StatusPass, ""
+}
+
+// computeCoverage builds the declared_coverage descriptor from the resolved
+// recipe's validation config. A nil config (or nil phase) yields a zero-value
+// PhaseCoverage (Declared=false) — a minimal recipe that drops phases is not
+// penalized, since coverage is descriptive and never graded.
+func computeCoverage(result *recipe.RecipeResult) DeclaredCoverage {
+	if result == nil || result.Validation == nil {
+		return DeclaredCoverage{}
+	}
+	v := result.Validation
+	return DeclaredCoverage{
+		Readiness:   phaseCoverage(v.Readiness),
+		Deployment:  phaseCoverage(v.Deployment),
+		Performance: phaseCoverage(v.Performance),
+		Conformance: phaseCoverage(v.Conformance),
+	}
+}
+
+// phaseCoverage describes one validation phase: whether it is declared, the
+// sorted names of its checks, and its phase-level constraint count.
+func phaseCoverage(p *recipe.ValidationPhase) PhaseCoverage {
+	if p == nil {
+		return PhaseCoverage{}
+	}
+	pc := PhaseCoverage{
+		Declared:    true,
+		Constraints: len(p.Constraints),
+	}
+	if len(p.Checks) > 0 {
+		pc.Checks = make([]string, len(p.Checks))
+		copy(pc.Checks, p.Checks)
+		sort.Strings(pc.Checks)
+	}
+	return pc
 }
 
 // classifyResolve grades the resolves dimension from a build error.

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	stderrors "errors"
 	"io/fs"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -109,9 +110,110 @@ func TestRollup(t *testing.T) {
 	}
 }
 
+func TestClassifyChartPinned(t *testing.T) {
+	helm := func(name, version string) recipe.ComponentRef {
+		return recipe.ComponentRef{Name: name, Type: recipe.ComponentTypeHelm, Version: version}
+	}
+	disabledHelm := func(name, version string) recipe.ComponentRef {
+		return recipe.ComponentRef{
+			Name: name, Type: recipe.ComponentTypeHelm, Version: version,
+			Overrides: map[string]any{"enabled": false},
+		}
+	}
+	kustomize := func(name string) recipe.ComponentRef {
+		return recipe.ComponentRef{Name: name, Type: recipe.ComponentTypeKustomize}
+	}
+	result := func(refs ...recipe.ComponentRef) *recipe.RecipeResult {
+		return &recipe.RecipeResult{ComponentRefs: refs}
+	}
+
+	tests := []struct {
+		name        string
+		result      *recipe.RecipeResult
+		wantState   string
+		detailMatch string // substring that must appear in detail ("" = detail must be empty)
+	}{
+		{"nil result passes", nil, StatusPass, ""},
+		{"all helm pinned passes", result(helm("a", "1.0.0"), helm("b", "2.1.0")), StatusPass, ""},
+		{"unpinned helm fails", result(helm("a", "1.0.0"), helm("b", "")), StatusFail, "b"},
+		{
+			"multiple unpinned listed sorted",
+			result(helm("zebra", ""), helm("alpha", ""), helm("ok", "1.0.0")),
+			StatusFail, "alpha, zebra",
+		},
+		{"pure kustomize is vacuous pass", result(kustomize("k1"), kustomize("k2")), StatusPass, "not applicable"},
+		{"no components is vacuous pass", result(), StatusPass, "not applicable"},
+		{"mixed pinned helm and kustomize passes", result(helm("a", "1.0.0"), kustomize("k")), StatusPass, ""},
+		{
+			"disabled unpinned helm is skipped",
+			result(helm("a", "1.0.0"), disabledHelm("off", "")),
+			StatusPass, "",
+		},
+		{
+			"only disabled unpinned helm is vacuous pass",
+			result(disabledHelm("off", "")),
+			StatusPass, "not applicable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, detail := classifyChartPinned(tt.result)
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			if tt.detailMatch == "" {
+				if detail != "" {
+					t.Errorf("detail = %q, want empty", detail)
+				}
+			} else if !strings.Contains(detail, tt.detailMatch) {
+				t.Errorf("detail = %q, want substring %q", detail, tt.detailMatch)
+			}
+		})
+	}
+}
+
+func TestComputeCoverage(t *testing.T) {
+	t.Run("nil result yields zero coverage", func(t *testing.T) {
+		if got := computeCoverage(nil); !reflect.DeepEqual(got, DeclaredCoverage{}) {
+			t.Errorf("got %+v, want zero value", got)
+		}
+	})
+	t.Run("nil validation yields zero coverage", func(t *testing.T) {
+		if got := computeCoverage(&recipe.RecipeResult{}); !reflect.DeepEqual(got, DeclaredCoverage{}) {
+			t.Errorf("got %+v, want zero value", got)
+		}
+	})
+	t.Run("populated phases recorded with sorted checks", func(t *testing.T) {
+		res := &recipe.RecipeResult{Validation: &recipe.ValidationConfig{
+			Deployment: &recipe.ValidationPhase{
+				Checks:      []string{"gpu-operator-version", "check-nvidia-smi", "operator-health"},
+				Constraints: []recipe.Constraint{{Name: "c1"}, {Name: "c2"}},
+			},
+			// Readiness/Performance/Conformance intentionally nil (minimal recipe).
+		}}
+		cov := computeCoverage(res)
+
+		if !cov.Deployment.Declared {
+			t.Error("Deployment.Declared = false, want true")
+		}
+		wantChecks := []string{"check-nvidia-smi", "gpu-operator-version", "operator-health"}
+		if !reflect.DeepEqual(cov.Deployment.Checks, wantChecks) {
+			t.Errorf("Deployment.Checks = %v, want sorted %v", cov.Deployment.Checks, wantChecks)
+		}
+		if cov.Deployment.Constraints != 2 {
+			t.Errorf("Deployment.Constraints = %d, want 2", cov.Deployment.Constraints)
+		}
+		// A dropped phase must not be penalized — it is simply not declared.
+		if cov.Readiness.Declared || cov.Performance.Declared || cov.Conformance.Declared {
+			t.Errorf("undeclared phases marked declared: %+v", cov)
+		}
+	})
+}
+
 // TestComputeEmbeddedCatalog resolves the real embedded catalog: every leaf
 // must carry a resolves dimension and a status consistent with the rollup of
-// its dimensions, and at least one leaf must resolve cleanly.
+// its dimensions, and at least one leaf must resolve cleanly. Cleanly-resolved
+// leaves also carry the chart_pinned dimension (a pure read of the result).
 func TestComputeEmbeddedCatalog(t *testing.T) {
 	report, err := Compute(context.Background(), Options{})
 	if err != nil {
@@ -141,6 +243,11 @@ func TestComputeEmbeddedCatalog(t *testing.T) {
 		}
 		if state == StatusPass {
 			sawPass = true
+			// A cleanly-resolved leaf is a pure-readable result, so chart_pinned
+			// must have been scored.
+			if _, ok := combo.Structure.Dimensions[DimChartPinned]; !ok {
+				t.Errorf("combo %q resolved but missing chart_pinned dimension", combo.LeafOverlay)
+			}
 		}
 	}
 	if !sawPass {
@@ -252,6 +359,78 @@ components:
 	}
 	if d := broken.Structure.Detail[DimResolves]; !strings.Contains(d, "assertFile") {
 		t.Errorf("detail = %q, want it to surface the assertFile read failure", d)
+	}
+	// No RecipeResult to read, so the descriptor must be omitted (nil), not an
+	// all-zero block a consumer could misread as "declares no checks".
+	if broken.Structure.Coverage != nil {
+		t.Errorf("Coverage = %+v, want nil on a failed resolve", *broken.Structure.Coverage)
+	}
+}
+
+// TestComputeChartPinnedFailThroughBuilder drives a chart_pinned fail through
+// the real builder: a leaf with a Helm component whose registry entry declares
+// no default chart version, so the resolved ComponentRef carries an empty
+// Version. The recipe resolves cleanly (resolves=pass) but chart_pinned must
+// fail, dragging the rolled-up status to fail.
+func TestComputeChartPinnedFailThroughBuilder(t *testing.T) {
+	provider := newInMemoryProvider(map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/unpinned-leaf.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: unpinned-leaf
+spec:
+  criteria:
+    service: eks
+  componentRefs:
+    - name: unpinned-helm
+`),
+		"registry.yaml": []byte(`apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components:
+  - name: unpinned-helm
+    displayName: Unpinned Helm Component
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/unpinned-helm
+`),
+	})
+
+	report, err := Compute(context.Background(), Options{Provider: provider})
+	if err != nil {
+		t.Fatalf("Compute() error = %v", err)
+	}
+
+	var combo *ComboHealth
+	for i := range report.Combos {
+		if report.Combos[i].LeafOverlay == "unpinned-leaf" {
+			combo = &report.Combos[i]
+		}
+	}
+	if combo == nil {
+		t.Fatalf("unpinned-leaf was not enumerated; combos = %+v", report.Combos)
+	}
+	if got := combo.Structure.Dimensions[DimResolves]; got != StatusPass {
+		t.Errorf("resolves = %q, want %q (recipe should resolve cleanly)", got, StatusPass)
+	}
+	if got := combo.Structure.Dimensions[DimChartPinned]; got != StatusFail {
+		t.Errorf("chart_pinned = %q, want %q (unpinned Helm chart)", got, StatusFail)
+	}
+	if combo.Structure.Status != StatusFail {
+		t.Errorf("status = %q, want %q", combo.Structure.Status, StatusFail)
+	}
+	if d := combo.Structure.Detail[DimChartPinned]; !strings.Contains(d, "unpinned-helm") {
+		t.Errorf("detail = %q, want it to name the unpinned component", d)
+	}
+	// The recipe resolved, so the descriptor must be populated (non-nil).
+	if combo.Structure.Coverage == nil {
+		t.Error("Coverage = nil, want non-nil on a resolved recipe")
 	}
 }
 


### PR DESCRIPTION
## Summary

Layers the two pure-read structural signals onto the `pkg/health` core (ADR-009 V1), both computed only when a leaf resolves cleanly: `chart_pinned` (graded) and `declared_coverage` (descriptor).

## Motivation / Context

Next step of the Recipe health tracking epic (ADR-009 V1), building directly on the merged core (#1225). These are the two signals that are pure reads of the resolved `RecipeResult` — no external integration, no Helm render.

Fixes: #1226
Related: #1224 (epic), #1225 (core, merged), #1227, #1228, #1229

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — `pkg/health` only (reads `RecipeResult`)

## Implementation Notes

- **`chart_pinned` (graded):** iterate `RecipeResult.ComponentRefs`; every `Type == ComponentTypeHelm` must have a non-empty `Version`. Any unpinned Helm component → `fail` (offending names sorted into `Detail`), dragging the rolled-up status to `fail`. **ADR-006 layer 1 only** — the chart-version pin, not image digests; pure field check, no render. A recipe with **no Helm components** (pure-Kustomize/empty) scores a **vacuous `pass`** with an explanatory `Detail`, since Kustomize `defaultTag` pinning is out of scope and the column must not be misread as "supply-chain pinned". Feeds the existing generic rollup unchanged.
- **`declared_coverage` (descriptor, never graded):** from `RecipeResult.Validation.{Readiness,Deployment,Performance,Conformance}`, record per phase `Declared bool`, sorted `Checks []string`, and `len(Constraints)`. Lives in `StructureHealth.Coverage` (a separate field, not in the `Dimensions` map), so it can never move the status — a minimal recipe that drops phases is not penalized.
- Both signals are computed only on a clean resolve (no `RecipeResult` to read otherwise); a failed/held combo carries neither.
- Determinism preserved: unpinned names and `Checks` are sorted; pass-path `Detail` is a static string only in the vacuous-Kustomize case.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/health/...   # 0 issues
make test                                               # pass, total 76.6%
```

- Unit: `classifyChartPinned` (all-pinned pass; unpinned fail with sorted names; pure-Kustomize vacuous pass; mixed); `computeCoverage`/`phaseCoverage` (nil → zero, sorted checks, undeclared phases not penalized).
- Integration through the real builder: a leaf whose registry Helm component declares no default version resolves cleanly (`resolves=pass`) but `chart_pinned=fail` → status `fail` with the component named in `Detail`.
- `pkg/health` coverage: **97.6%** (was 95.8%; new helpers fully covered).

## Risk Assessment

- [x] **Low** — Additive, isolated to `pkg/health`, no user-facing surface (CLI/docs/matrix rendering land in #1228/#1229).

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — no user-facing surface yet)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)