### PR TITLE
feat(recipes): add A100 OKE training Kubeflow overlay chain

### DIFF
--- a/recipes/overlays/a100-any.yaml
+++ b/recipes/overlays/a100-any.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cross-cutting overlay applied via criteria-wildcard matching.
+#
+# Carries the deployment-phase floor (the 4 standard checks plus the
+# gpu-operator version pin) and applies to every A100 query regardless
+# of service or intent, so every concrete A100 leaf (training or
+# inference, any service) inherits the version pin.
+#
+# Per-field union merge (see pkg/recipe/metadata.go) means concrete leaves
+# that declare their own `deployment:` block add to or override this floor
+# without dropping its inherited checks — same-name constraints from the
+# leaf win, additional checks are appended.
+#
+# See docs/contributor/recipe.md#criteria-wildcard-overlays for details.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-any
+
+spec:
+  base: base
+
+  criteria:
+    service: any
+    accelerator: a100
+
+  validation:
+    deployment:
+      checks:
+        - operator-health
+        - expected-resources
+        - gpu-operator-version
+        - check-nvidia-smi
+      constraints:
+        # A100 has been supported since the early gpu-operator releases
+        # (v22.9). Floor at the same generation baseline as H100/H200
+        # (v24.6.0) rather than the Blackwell floor; concrete leaves can
+        # tighten if they pin to a later working version.
+        - name: Deployment.gpu-operator.version
+          value: ">= v24.6.0"

--- a/recipes/overlays/a100-oke-training.yaml
+++ b/recipes/overlays/a100-oke-training.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-oke-training
+
+spec:
+  # Inherits from oke-training recipe (OKE + training settings)
+  base: oke-training
+
+  criteria:
+    service: oke
+    accelerator: a100
+    intent: training
+
+  # Specific constraints for A100 on OKE training workloads.
+  # A100 has no IMEX/NVLink ComputeDomain requirement (unlike GB200, which
+  # floors at 1.34 for the NVLS performance path), so the recipe keeps the
+  # OKE training baseline.
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs:
+    # A100-specific GPU Operator overrides (inherits valuesFile from oke-training).
+    # Nodewright tuning is omitted, mirroring the GB200 OKE training overlay:
+    # the nodewright-customizations packages do not target service: oke.
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - nfd
+        - cert-manager
+        - kube-prometheus-stack
+      overrides:
+        gdrcopy:
+          enabled: true
+
+    - name: nfd
+      type: Helm
+      overrides:
+        topologyUpdater:
+          enable: true
+
+  # Validation checks for A100 on OKE training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  #
+  # The deployment-phase floor (4 standard checks + gpu-operator version pin)
+  # is contributed by the a100-any cross-cutting overlay and is not duplicated
+  # here, matching the GB200 OKE training pattern.
+  #
+  # Performance gating is intentionally omitted until an empirical A100-on-OCI
+  # NCCL baseline is established. The H100 training overlays pin an absolute
+  # nccl-all-reduce-bw floor (>= 300) calibrated on an 8-GPU H100 NVLink node;
+  # that value is neither fabric-class aware (https://github.com/NVIDIA/aicr/issues/1256)
+  # nor valid for A100, so carrying it would only false-fail healthy runs.
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling

--- a/recipes/overlays/a100-oke-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/a100-oke-ubuntu-training-kubeflow.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-oke-ubuntu-training-kubeflow
+
+spec:
+  # Inherits from a100-oke-ubuntu-training recipe (A100 + OKE + Ubuntu + training settings)
+  # This overlay adds Kubeflow Training Operator for distributed training with TrainJob
+  base: a100-oke-ubuntu-training
+
+  criteria:
+    service: oke
+    accelerator: a100
+    os: ubuntu
+    intent: training
+    platform: kubeflow
+
+  # Ubuntu OS constraints + Kubeflow trainer via mixins
+  mixins:
+    - os-ubuntu
+    - platform-kubeflow
+
+  # A100 + OKE specific constraints (not covered by mixin)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs: []

--- a/recipes/overlays/a100-oke-ubuntu-training.yaml
+++ b/recipes/overlays/a100-oke-ubuntu-training.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-oke-ubuntu-training
+
+spec:
+  # Inherits from a100-oke-training recipe (A100 + OKE + training settings)
+  # This overlay adds Ubuntu-specific configurations
+  base: a100-oke-training
+
+  criteria:
+    service: oke
+    accelerator: a100
+    os: ubuntu
+    intent: training
+
+  # Ubuntu OS constraints via mixin (defined once in recipes/mixins/os-ubuntu.yaml)
+  mixins:
+    - os-ubuntu
+
+  # A100 + OKE specific constraints (not covered by mixin)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs: []
+
+  # Validation is inherited from a100-oke-training (not OS-specific)


### PR DESCRIPTION
## Summary

Add the first concrete **A100** overlays (issue #1002): the OKE Ubuntu **Kubeflow training** leaf plus its ancestor chain and the cross-cutting deployment-phase floor.

## Motivation / Context

`a100` is a declared accelerator in `pkg/recipe/criteria.go` but has zero overlays in `recipes/overlays/`, so `aicr recipe --accelerator a100 --service oke ...` cannot resolve. This is the dedicated tracker spun out of the #969 validation-coverage audit. This PR seeds the A100 OKE chain starting with the Kubeflow training leaf.

Training is modeled on the **H100 training overlays** — the GB200 OKE training recipe centers on an NVLS performance path that A100 does not have — with the OKE-specific plumbing taken from `gb200-oke-training`.

Fixes: N/A (incremental — first slice of #1002)
Related: #1002, #1295, #1305, #1306, #969, #1256

**A100 overlay series — tracked in #1002:** #1294 (OKE) ← this PR · #1295 (AKS) · #1305 (EKS) · #1306 (GKE)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

New overlays (reuse existing `oke`/`oke-training` parents and `values-oke*.yaml` — no new component values files):

- **`a100-any`** — deployment-phase floor: 4 standard checks + `Deployment.gpu-operator.version >= v24.6.0`. A100 floored at the H100/H200 generation baseline, not the Blackwell `v25.10.0`, since A100 has been operator-supported since v22.9.
- **`a100-oke-training`** — `base: oke-training`; `K8s >= 1.30`. A100 has no IMEX/NVLink ComputeDomain requirement, so it keeps the OKE training baseline rather than GB200's `1.34`. gpu-operator deps + `gdrcopy`, nfd `topologyUpdater`. Nodewright tuning omitted (packages don't target `service: oke`), matching `gb200-oke-training`. Conformance set mirrors `gb200-oke-training` (training-appropriate; no inference-only checks).
- **`a100-oke-ubuntu-training`** — `+ os-ubuntu` mixin.
- **`a100-oke-ubuntu-training-kubeflow`** — `+ platform-kubeflow` (Kubeflow Trainer for distributed `TrainJob`).

Key decisions documented in-file:

- **Driver management inherited unchanged** (`driver.enabled: false` from `oke.yaml`). OKE managed GPU node pools provision the Oracle Linux **GPU image** with drivers pre-installed on bare-metal A100 shapes (`BM.GPU4.8`, `BM.GPU.A100-v2.8`), confirmed against [OCI docs](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengrunninggpunodes.htm) and the [Oracle GPU-operator guidance](https://blogs.oracle.com/developers/streamlining-gpu-management-on-oci-kubernetes-engine-oke-with-the-nvidia-gpu-operator). Same as the GB200/B200 OKE siblings.
- **Performance gating intentionally omitted.** The H100 sibling pins an absolute 8-GPU-node `nccl-all-reduce-bw >= 300` floor that is neither fabric-class aware (#1256) nor valid for A100; carrying it would false-fail healthy runs. An A100-on-OCI NCCL baseline is deferred to a follow-up.

## Testing

```bash
go test ./pkg/recipe/...                 # PASS (incl. TestOverlayValidationPhaseFloor auto-discovery)
yamllint recipes/overlays/a100-*.yaml    # clean
# End-to-end resolution of the new leaf:
aicr recipe --service oke --accelerator a100 --os ubuntu --intent training --platform kubeflow
#   -> components=12 overlays=8; K8s '>= 1.30'; Deployment.gpu-operator.version '>= v24.6.0';
#      kubeflow-trainer present; conformance includes gang-scheduling/pod-autoscaling/cluster-autoscaling;
#      gpu-operator inherits values-oke-training.yaml (driver.enabled:false via oke.yaml)
```

Full `make qualify` not required: this touches **only YAML overlay files** (zero `.go` changes), so the Go lint/test/e2e gates cannot regress from it. The embedded overlays are exercised by `go test ./pkg/recipe/...` (passes) and yamllint (clean). No `docs/` page enumerates individual overlay leaves, so no doc update is needed.

## Risk Assessment

- [x] **Low** — Additive overlays only; no existing recipe or Go path changes. Easy to revert.

**Rollout notes:** Additive. Subsequent A100 OKE leaves (plain training, inference, dynamo) and other services (EKS/GKE/AKS) tracked as follow-ups under #1002.

## Checklist

- [x] Tests pass locally (`go test ./pkg/recipe/...`)
- [x] Linter passes (yamllint clean; no `.go` files changed)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (covered by existing auto-discovery `TestOverlayValidationPhaseFloor`)
- [x] I updated docs if user-facing behavior changed (N/A — no leaf enumeration in docs)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
