### PR TITLE
fix(ci): unblock build-attested workflow on missing HOMEBREW_DEPLOY_KEY

### DIFF
--- a/.github/workflows/build-attested.yaml
+++ b/.github/workflows/build-attested.yaml
@@ -75,6 +75,11 @@ jobs:
       - name: Build and attest
         env:
           GOFLAGS: -mod=vendor
+          # The brews pipe templates {{ .Env.HOMEBREW_DEPLOY_KEY }}; goreleaser
+          # errors on a missing env key. Provide it empty so skip_upload evaluates
+          # true and the Homebrew tap publish is skipped. on-tag.yaml supplies the
+          # real secret for production releases.
+          HOMEBREW_DEPLOY_KEY: ""
         run: |
           set -euo pipefail
           goreleaser release --snapshot --clean --skip=publish,ko,sbom --timeout 20m


### PR DESCRIPTION
## Summary

`build-attested.yaml` failed after successfully attesting the binaries because
goreleaser's Homebrew (`brews`) pipe templates `{{ .Env.HOMEBREW_DEPLOY_KEY }}`,
an env var only wired into `on-tag.yaml`. With the key absent, goreleaser errors
("map has no entry for key") and the run dies before uploading the artifact.

## Motivation / Context

`build-attested.yaml` produces on-demand SLSA-attested binaries (as a job
artifact) for exercising the e2e signing flows locally and in CI without cutting
a release tag. It was erroring on every run, so no artifact was ever produced.
Setting `HOMEBREW_DEPLOY_KEY` to an empty string makes the existing
`skip_upload` template evaluate true, so the Homebrew tap publish is skipped
cleanly. `on-tag.yaml` still supplies the real secret for production releases.

Fixes: N/A
Related: #1214, #1215

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: GitHub Actions CI workflow (`.github/workflows/build-attested.yaml`)

## Implementation Notes

The cosign attestation step itself already worked; only the Homebrew publish
pipe broke. The empty env var keeps the key present in goreleaser's `.Env` map
(goreleaser hard-errors on a missing key) while `skip_upload` (`not
.Env.HOMEBREW_DEPLOY_KEY`) short-circuits the tap publish.

## Testing

Re-ran the workflow via `workflow_dispatch` after the fix
(run `27303432250`): completed successfully and uploaded the
`aicr-attested-binaries` artifact (4 archives, ~87 MB). CI-only YAML change; no
Go code touched.

## Risk Assessment

- [x] **Low** — Isolated CI workflow change, easy to revert

**Rollout notes:** N/A. `on-tag.yaml` production releases are unaffected (they
provide the real `HOMEBREW_DEPLOY_KEY` secret).

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
- [x] I did not skip/disable tests to make CI green
- [ ] Go test/lint gates: N/A (CI workflow YAML only, no Go changes)
