### PR TITLE
fix(ci): resolve fork PRs for recipe-evidence sticky comment

### DIFF
--- a/.github/workflows/recipe-evidence-comment.yaml
+++ b/.github/workflows/recipe-evidence-comment.yaml
@@ -72,18 +72,32 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Ask GitHub which open PR(s) contain this head SHA. This is
-          # the trusted source — never trust an artifact-supplied number.
-          pulls=$(gh api "repos/${BASE_REPO}/commits/${HEAD_SHA}/pulls" \
-            --jq '[.[] | select(.state == "open")]')
-
-          # Cross-check the PR's head-repo owner against the workflow_run's
-          # head_repository owner so two PRs sharing a head SHA across
-          # forks don't get confused. Require exactly one match — if a
-          # single fork-owner has somehow opened multiple open PRs from
-          # the same head SHA, refuse to guess.
-          matches=$(echo "$pulls" | jq -r --arg owner "$HEAD_OWNER" \
-            '[.[] | select(.head.repo.owner.login == $owner) | .number]')
+          # Resolve the PR from the trusted workflow_run.head_sha by
+          # listing open PRs and matching on head SHA + head-repo owner.
+          #
+          # We deliberately do NOT use `commits/${HEAD_SHA}/pulls`: that
+          # endpoint does not reliably return fork-originated PRs (the head
+          # commit lives in the contributor's fork, not the base repo), so
+          # every external-contributor PR resolved to zero matches and the
+          # comment was silently skipped. Listing open PRs and comparing
+          # `.head.sha` works uniformly for same-repo and fork PRs.
+          #
+          # This is still the trusted source — both the SHA and the owner
+          # come from the workflow_run event, never an artifact. Matching
+          # the head-repo owner keeps two PRs that share a head SHA across
+          # forks from being confused. Require exactly one match — refuse
+          # to guess if a single owner has multiple open PRs at this SHA.
+          #
+          # --paginate streams matching PR numbers across all pages
+          # (gh applies --jq per page); `jq -s` then slurps that stream
+          # into a JSON array. HEAD_SHA/HEAD_OWNER are read via jq's
+          # `env.` rather than interpolated into the filter, so a hostile
+          # value can't break out of the jq expression. (gh's --jq does
+          # not accept jq's --arg, hence env.)
+          matches=$(gh api --paginate \
+            "repos/${BASE_REPO}/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.head.sha == env.HEAD_SHA and .head.repo.owner.login == env.HEAD_OWNER) | .number' \
+            | jq -s '.')
           match_count=$(echo "$matches" | jq 'length')
 
           if [[ "$match_count" -ne 1 ]]; then


### PR DESCRIPTION
## Summary

Resolve the PR number for the recipe-evidence sticky comment by listing open PRs and matching on head SHA, so the comment posts on **fork** PRs instead of being silently skipped.

## Motivation / Context

The comment workflow resolved the PR via `GET /repos/<base>/commits/{HEAD_SHA}/pulls`. That endpoint does not reliably return fork-originated PRs — the head commit lives in the contributor's fork, not the base repo — so every external-contributor PR resolved to **0 matches** and the comment was skipped with:

```
Warning: expected exactly 1 open PR for head c3daa9f… from yuanchen8911; got 0; skipping comment
```

Confirmed empirically: `commits/c3daa9f…/pulls` on `NVIDIA/aicr` returns `[]`, yet PR #1295 (open, from `yuanchen8911`) has exactly that commit as its head. Listing open PRs and matching `.head.sha` finds it.

Fixes: N/A
Related: #1292 (companion fix: the upload step that produces the artifact this workflow consumes)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: GitHub Actions workflow (`.github/workflows/recipe-evidence-comment.yaml`)

## Implementation Notes

- Replaced the `commits/{sha}/pulls` lookup with `gh api --paginate "…/pulls?state=open" --jq` streaming PR numbers, slurped into a JSON array with `jq -s`. This matches both same-repo and fork PRs uniformly.
- `HEAD_SHA`/`HEAD_OWNER` are read via jq's `env.` rather than interpolated into the filter, so a hostile value can't break out of the jq expression. (gh's `--jq` doesn't accept jq's `--arg`.)
- Used the repo's existing `gh api --paginate --jq` + standalone `jq -s` pattern rather than `gh api --slurp`, which isn't available in the pinned `gh`.
- Still derives the PR strictly from the trusted `workflow_run` event (SHA + owner), never an artifact. The exactly-one-match guard and owner cross-check are unchanged.

## Testing

```bash
yamllint -c .yamllint.yaml .github/workflows/recipe-evidence-comment.yaml   # exit 0

# Live replay of the failing case against NVIDIA/aicr:
#   HEAD_SHA=c3daa9f… HEAD_OWNER=yuanchen8911 → match_count=1, pr_number=1295
#   bogus owner       → [] (count 0, skips cleanly)
```

End-to-end validation requires a live fork PR run on GitHub. No Go code changed.

## Risk Assessment

- [x] **Low** — Isolated CI-only change, easy to revert. The affected gate is warning-only and never blocks merge.

**Rollout notes:** N/A — takes effect on the next `recipes/**` PR.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (yamllint, exit 0)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI workflow fix)
- [ ] I updated docs if user-facing behavior changed — N/A (no user-facing behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
