### PR TITLE
docs(network-operator): fix 101c/101e NIC comments to ConnectX-6/mlx5Gen VFs

### DIFF
--- a/recipes/components/network-operator/manifests/nfd-network-rule.yaml
+++ b/recipes/components/network-operator/manifests/nfd-network-rule.yaml
@@ -15,12 +15,15 @@
 # NFD NodeFeatureRule for Mellanox InfiniBand NICs
 #
 # Labels nodes with feature.node.kubernetes.io/pci-15b3.present=true when a
-# Mellanox ConnectX-7 NIC is present (PCI device IDs 101c or 101e). This label
-# is used by the NicClusterPolicy nodeAffinity and the ib-node-config DaemonSet
-# to target only IB-capable nodes.
+# Mellanox InfiniBand virtual function is present (PCI device IDs 101c or 101e).
+# 101c is the ConnectX-6 Virtual Function (MT28908) and 101e is the generic
+# mlx5Gen Virtual Function — Azure ND-series VMs surface the IB NIC to the guest
+# via SR-IOV as one of these VFs (e.g. ND A100 v4 exposes the ConnectX-6 VF
+# 101c, ND H100 v5 the mlx5Gen VF). This label is used by the NicClusterPolicy
+# nodeAffinity and the ib-node-config DaemonSet to target only IB-capable nodes.
 #
 # The network-operator chart's built-in deployNodeFeatureRules targets generic
-# Ethernet NICs (class 0200/0207). This rule targets ConnectX-7 specifically,
+# Ethernet NICs (class 0200/0207). This rule targets the IB VFs specifically,
 # which is why values-aks.yaml sets nfd.deployNodeFeatureRules=false.
 #
 # Reference: https://github.com/Azure/aks-rdma-infiniband/blob/main/tests/setup-infra/network-operator-nfd.yaml

--- a/recipes/components/network-operator/values-aks.yaml
+++ b/recipes/components/network-operator/values-aks.yaml
@@ -22,6 +22,8 @@
 nfd:
   # AICR delivers a targeted NFD NodeFeatureRule via manifest instead of the
   # chart's built-in rule. The chart's rule targets generic Ethernet NICs
-  # (class 0200/0207); the manifest targets ConnectX-7 specifically (device
-  # IDs 101c/101e). Disable the chart's rule to avoid the broader match.
+  # (class 0200/0207); the manifest targets the InfiniBand virtual functions
+  # specifically (device IDs 101c = ConnectX-6 VF, 101e = generic mlx5Gen VF,
+  # as exposed by Azure ND-series via SR-IOV). Disable the chart's rule to
+  # avoid the broader match.
   deployNodeFeatureRules: false


### PR DESCRIPTION
## Summary

Correct the AKS network-operator comments that describe PCI device IDs `101c`/`101e` as ConnectX-7-specific. They are actually InfiniBand virtual-function IDs (`101c` = ConnectX-6 VF, `101e` = generic mlx5Gen VF). Comment-only; no behavior change.

## Motivation / Context

The `nfd-network-rule.yaml` manifest and `values-aks.yaml` both stated that `101c`/`101e` indicate a "ConnectX-7" NIC. Per the PCI ID registry, `15b3:101c` is the ConnectX-6 Virtual Function (MT28908) and `15b3:101e` is the generic mlx5Gen Virtual Function. Azure ND-series VMs surface the IB NIC to the guest via SR-IOV as one of these VFs — e.g. ND A100 v4 exposes the ConnectX-6 VF `101c`, so the rule already matches A100 nodes correctly. Only the explanatory comments were wrong.

This drift was surfaced during review of #1295 (A100 AKS overlays): the inaccurate "ConnectX-7" wording made it look like A100/ConnectX-6 nodes would be excluded from RDMA/MOFED setup, when in fact they match.

Fixes: N/A
Related: #1295

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Comment-only edits in two files:
- `recipes/components/network-operator/manifests/nfd-network-rule.yaml`
- `recipes/components/network-operator/values-aks.yaml`

The `NodeFeatureRule` spec (vendor `15b3`, devices `101c`/`101e`) is unchanged — it already matches the IB VFs that Azure ND-series exposes. Verified against the upstream Azure `aks-rdma-infiniband` reference NFD rule, which matches the same IDs.

## Testing

```bash
yamllint recipes/components/network-operator/values-aks.yaml \
         recipes/components/network-operator/manifests/nfd-network-rule.yaml   # clean
```

Comment-only change to YAML files (zero `.go`, no spec/value changes), so Go test/lint/e2e gates cannot regress from it. Full `make qualify` skipped per the doc/infra-only verification policy; ran the matching check (yamllint) on both touched files — clean.

## Risk Assessment

- [x] **Low** — Comment-only, no functional change, trivially reversible.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A (comment-only YAML)
- [x] Linter passes (`make lint`) — yamllint clean on touched files
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A (comment-only)
- [x] I updated docs if user-facing behavior changed — N/A (no behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
