### PR TITLE
feat(cli): warn before keyless signing publishes identity to public log

### DIFF
--- a/docs/design/007-recipe-evidence.md
+++ b/docs/design/007-recipe-evidence.md
@@ -822,6 +822,24 @@ see `## Future direction`.
   per recipe lives in the pointer at a time. A second contributor's
   attestation overwrites the first; multi-cluster diversity isn't
   captured.
+- **Keyless signing publishes the signer's identity (PII) to a public,
+  immutable log.** The Fulcio certificate embeds the authenticated OIDC
+  identity — typically the signer's **email address** plus the issuer —
+  and with the public-good defaults (`fulcio.sigstore.dev` /
+  `rekor.sigstore.dev`) that identity is written to the **public,
+  append-only Rekor transparency log**, where it is permanent and
+  globally searchable, and is also attached to the pushed OCI artifact.
+  The consequence is irreversible, so consent must be explicit rather
+  than implicit: the CLI emits an endpoint-aware disclosure banner and,
+  on a TTY, pauses for confirmation before any interactive
+  (browser/device-code) login opens (`--yes` / `AICR_ASSUME_YES` skips
+  the prompt; non-interactive stdin proceeds without blocking so CI is
+  not wedged). Pre-fetched `--identity-token`, ambient CI OIDC, and
+  `--signing-key` paths are unaffected. Exposure is controlled by signing
+  from a non-personal CI/service identity, supplying a pre-fetched token,
+  or pointing `--fulcio-url`/`--rekor-url` at private Sigstore
+  infrastructure. See the
+  [CLI reference](../user/cli-reference.md#privacy-identity-in-keyless-signatures).
 
 ## Alternatives Considered
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -823,6 +823,7 @@ aicr validate [flags]
 | `--insecure-tls` | | bool | false | Skip TLS verification for evidence push (self-signed registries). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for `--push` keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr bundle --attest`. |
 | `--oidc-device-flow` | | bool | false | Use the OAuth 2.0 device authorization grant for `--push` OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. |
+| `--yes` | `--assume-yes` | bool | false | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. See [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures). |
 | `--data` | | string | | External data directory to overlay on embedded data |
 
 **Input Sources:**
@@ -954,6 +955,8 @@ aicr validate \
   --emit-attestation ./out \
   --push ghcr.io/myorg/aicr-evidence  # tag optional; aicr derives :<recipe-slug>-<fingerprint>
 # After this, copy ./out/pointer.yaml to recipes/evidence/<recipe>.yaml
+# NOTE: keyless --push signing publishes the signer's identity (email + issuer)
+# to the public Rekor log. On a TTY, aicr pauses for confirmation first (--yes skips it).
 
 # Validate on a cluster with custom GPU node labels (non-standard labels that AICR doesn't
 # recognize by default, e.g., using a custom node pool label instead of cloud-provider defaults)
@@ -1264,6 +1267,7 @@ aicr bundle [flags]
 | `--fulcio-url` | | string | Override the Fulcio CA URL for `--attest` keyless signing, pointing at a private Sigstore instance. Must be an absolute `https://` URL with no embedded credentials. Defaults to the public-good Fulcio when omitted. Also reads `AICR_FULCIO_URL`. |
 | `--rekor-url` | | string | Override the Rekor transparency-log URL for `--attest` keyless signing, pointing at a private Sigstore instance. Must be an absolute `https://` URL with no embedded credentials. Defaults to the public-good Rekor when omitted. Also reads `AICR_REKOR_URL`. The two URLs are independent — a private Fulcio can pair with the public Rekor or vice versa. |
 | `--signing-key` | | string | Sign the `--attest` bundle with a KMS-backed key instead of keyless OIDC, for CI/CD environments without OIDC (Jenkins, internal pipelines). Takes a cloud KMS URI; supported schemes are `awskms://`, `gcpkms://`, and `azurekms://`. Mutually exclusive with `--identity-token`, `--oidc-device-flow`, and `--fulcio-url` (the keyless-only flags); passing both is a validation error. `--rekor-url` may still be combined to log to a private Rekor. See [KMS-Backed Signing](#kms-backed-signing). |
+| `--yes` | `--assume-yes` | bool | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. See [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures). |
 
 #### Bundle Config File Mode
 
@@ -2153,6 +2157,56 @@ Both interactive flows time out after 5 minutes.
 
 Attestation works with all deployers (`helm`, `argocd`, `argocd-helm`, `flux`). External `--data` files are included in `checksums.txt` and listed as resolved dependencies in the attestation.
 
+##### Privacy: identity in keyless signatures
+
+Keyless signing trades a long-lived key for a short-lived Fulcio certificate
+minted from **your identity** — and that identity becomes part of the public
+record. Before any of the interactive sources above (device-code or browser)
+opens a login, understand what is published:
+
+- The Fulcio certificate embeds the **authenticated OIDC identity** — typically
+  your **email address** plus the OIDC **issuer** — in the certificate's subject
+  alternative name.
+- With the **public-good** Sigstore defaults (`fulcio.sigstore.dev` /
+  `rekor.sigstore.dev`), the signature and certificate are recorded in the
+  **Rekor transparency log**, which is **public, append-only, and permanent** —
+  entries cannot be deleted, so the identity is **globally searchable forever**.
+- The same identity-bearing Sigstore bundle is **attached to the pushed OCI
+  artifact** as a referrer, visible to anyone who can pull it.
+
+This applies equally to `aicr bundle --attest`, `aicr validate --emit-attestation --push`,
+and `aicr evidence publish --push`.
+
+**Controlling exposure.** To avoid publishing a personal identity:
+
+- Sign from a **service / CI ambient identity** (e.g. GitHub Actions OIDC)
+  rather than a personal browser login.
+- Supply a **pre-fetched `--identity-token`** minted from a non-personal
+  identity (a workload-identity exchange, a CI bot account).
+- Point `--fulcio-url` / `--rekor-url` at **private Sigstore infrastructure** so
+  the identity stays inside your organization rather than the public commons.
+  (Note: the `validate --emit-attestation` / `evidence publish` paths always use
+  the public-good endpoints today; only `bundle --attest` exposes these flags.)
+- Use `--signing-key` (KMS-backed signing) instead of keyless — no OIDC identity
+  is embedded. See [KMS-Backed Signing](#kms-backed-signing).
+
+**Interactive confirmation gate.** Because the consequence is irreversible on
+public Sigstore, the CLI gates the interactive login behind an explicit
+confirmation. When `aicr` is about to open a **browser or device-code** flow it
+prints a disclosure banner naming the Fulcio/Rekor endpoints in effect and what
+will be published, then:
+
+- **On a TTY**, it pauses for a `y/N` confirmation (default **no**) and aborts
+  cleanly — no browser opens — if you decline.
+- **On non-interactive stdin** (CI, pipes), it prints the banner and proceeds
+  without blocking, so scripted/CI signing is never wedged.
+- Pre-fetched `--identity-token`, ambient GitHub Actions OIDC, and `--signing-key`
+  paths are **not** gated — they neither open a browser nor publish a surprise
+  identity.
+
+Pass `--yes` (alias `--assume-yes`, env `AICR_ASSUME_YES`) to skip the prompt for
+trusted interactive automation; the banner is still printed.
+
 ##### KMS-Backed Signing
 
 Keyless signing depends on an OIDC identity provider. Some CI/CD environments
@@ -2578,15 +2632,22 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 | `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Omit the tag and aicr derives a unique per-recipe one (`<recipe-slug>-<short-fingerprint>`); pass an explicit tag to override. See [`aicr validate --push`](#aicr-validate). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
 | `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
+| `--yes` | `--assume-yes` | bool | `false` | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. See [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures). |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
 | `--insecure-tls` | | bool | `false` | Skip TLS verification when pushing the OCI artifact (self-signed registries). |
+
+> **Identity disclosure:** `evidence publish` always signs. On the interactive
+> (browser / device-code) keyless paths it publishes the signer's identity
+> (email + issuer) to the public Rekor log, so on a TTY it pauses for
+> confirmation first (`--yes` skips it). See
+> [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures).
 
 **Exit codes:**
 
 | Code | Meaning |
 |------|---------|
 | 0 | Bundle signed, pushed, and `pointer.yaml` written. |
-| non-zero | Bundle could not be loaded, signed, or pushed. |
+| non-zero | Identity-disclosure prompt declined, or bundle could not be loaded, signed, or pushed. |
 
 **Examples:**
 

--- a/pkg/bundler/attestation/resolver.go
+++ b/pkg/bundler/attestation/resolver.go
@@ -69,41 +69,81 @@ type ResolveOptions struct {
 	PromptWriter io.Writer
 }
 
-// ResolveOIDCToken walks the OIDC source precedence chain and returns the
-// resulting identity token string. Suitable for callers that build their
-// own signer around a raw token and do not want the bundler's Attester
-// abstraction.
+// OIDCSourceKind identifies which keyless OIDC token source ResolveOIDCToken
+// will consult for a given ResolveOptions. It is the single source of truth
+// for the source-precedence decision, shared by ResolveOIDCToken and by
+// callers (e.g. the CLI identity-disclosure gate) that must reason about
+// whether an interactive login is about to open without driving the login
+// themselves.
+type OIDCSourceKind int
+
+const (
+	// OIDCSourceIdentityToken — a pre-fetched token (no login, no prompt).
+	OIDCSourceIdentityToken OIDCSourceKind = iota
+	// OIDCSourceAmbient — GitHub Actions ambient OIDC (no login, no prompt).
+	OIDCSourceAmbient
+	// OIDCSourceDeviceFlow — RFC 8628 device-code login (interactive).
+	OIDCSourceDeviceFlow
+	// OIDCSourceBrowser — interactive browser callback login (interactive).
+	OIDCSourceBrowser
+)
+
+// Interactive reports whether the source opens a user-facing login (browser
+// callback or device-code) that mints a Fulcio certificate from the signer's
+// identity. The pre-fetched-token and ambient sources are non-interactive.
+func (k OIDCSourceKind) Interactive() bool {
+	return k == OIDCSourceDeviceFlow || k == OIDCSourceBrowser
+}
+
+// SelectOIDCSource reports which token source ResolveOIDCToken will use for
+// opts, following the precedence below. It does not read the environment or
+// perform any network/login work — it is a pure classification of opts.
 //
 // Precedence (highest first):
 //  1. IdentityToken — explicit pre-fetched token.
-//  2. AmbientURL+AmbientToken — GitHub Actions ambient OIDC.
+//  2. AmbientURL+AmbientToken — GitHub Actions ambient OIDC (both required).
 //  3. DeviceFlow — RFC 8628 device-code flow.
 //  4. Interactive browser flow (default).
+//
+// KMS (SigningKey) signing is not an OIDC source: it is selected earlier, in
+// ResolveAttester / ResolveAttesterLazy, before ResolveOIDCToken is reached,
+// so it is intentionally outside this classifier.
+func SelectOIDCSource(opts ResolveOptions) OIDCSourceKind {
+	switch {
+	case opts.IdentityToken != "":
+		return OIDCSourceIdentityToken
+	case opts.AmbientURL != "" && opts.AmbientToken != "":
+		return OIDCSourceAmbient
+	case opts.DeviceFlow:
+		return OIDCSourceDeviceFlow
+	default:
+		return OIDCSourceBrowser
+	}
+}
+
+// ResolveOIDCToken walks the OIDC source precedence chain and returns the
+// resulting identity token string. Suitable for callers that build their
+// own signer around a raw token and do not want the bundler's Attester
+// abstraction. The branch taken is decided by SelectOIDCSource, so callers
+// can predict it without driving a login.
 //
 // Errors from the OIDC helpers are returned as-is to preserve their
 // pkg/errors classification (timeout / unavailable / internal). The
 // function does not read the runtime environment itself — callers
 // populate ResolveOptions from their own surface (flags, env vars).
 func ResolveOIDCToken(ctx context.Context, opts ResolveOptions) (string, error) {
-	// 1. Pre-fetched identity token.
-	if opts.IdentityToken != "" {
+	switch SelectOIDCSource(opts) { //nolint:exhaustive // OIDCSourceBrowser is the default branch (the lowest-precedence fallback)
+	case OIDCSourceIdentityToken:
 		slog.Info("using pre-fetched OIDC identity token")
 		return opts.IdentityToken, nil
-	}
-
-	// 2. Ambient OIDC (GitHub Actions).
-	if opts.AmbientURL != "" && opts.AmbientToken != "" {
+	case OIDCSourceAmbient:
 		return FetchAmbientOIDCToken(ctx, opts.AmbientURL, opts.AmbientToken)
-	}
-
-	// 3. Device-code flow — works on headless hosts.
-	if opts.DeviceFlow {
+	case OIDCSourceDeviceFlow:
 		return FetchDeviceCodeOIDCToken(ctx, opts.PromptWriter)
+	default: // OIDCSourceBrowser
+		slog.Info("no ambient OIDC token, attempting interactive authentication")
+		return FetchInteractiveOIDCToken(ctx, opts.PromptWriter)
 	}
-
-	// 4. Interactive browser flow (default).
-	slog.Info("no ambient OIDC token, attempting interactive authentication")
-	return FetchInteractiveOIDCToken(ctx, opts.PromptWriter)
 }
 
 // ResolveAttester returns the Attester implementation selected by opts.

--- a/pkg/bundler/attestation/resolver_test.go
+++ b/pkg/bundler/attestation/resolver_test.go
@@ -23,6 +23,61 @@ import (
 	"testing"
 )
 
+// TestSelectOIDCSource pins the source-precedence classifier that both
+// ResolveOIDCToken and the CLI disclosure gate consume, so the two cannot
+// drift: identity-token > ambient (both values) > device-flow > browser.
+func TestSelectOIDCSource(t *testing.T) {
+	tests := []struct {
+		name            string
+		opts            ResolveOptions
+		want            OIDCSourceKind
+		wantInteractive bool
+	}{
+		{
+			name:            "identity token wins over everything",
+			opts:            ResolveOptions{IdentityToken: "tok", AmbientURL: "u", AmbientToken: "t", DeviceFlow: true},
+			want:            OIDCSourceIdentityToken,
+			wantInteractive: false,
+		},
+		{
+			name:            "ambient requires both url and token",
+			opts:            ResolveOptions{AmbientURL: "u", AmbientToken: "t", DeviceFlow: true},
+			want:            OIDCSourceAmbient,
+			wantInteractive: false,
+		},
+		{
+			name:            "ambient url alone falls through to device-flow",
+			opts:            ResolveOptions{AmbientURL: "u", DeviceFlow: true},
+			want:            OIDCSourceDeviceFlow,
+			wantInteractive: true,
+		},
+		{
+			name:            "device-flow when no non-interactive source",
+			opts:            ResolveOptions{DeviceFlow: true},
+			want:            OIDCSourceDeviceFlow,
+			wantInteractive: true,
+		},
+		{
+			name:            "empty options default to browser",
+			opts:            ResolveOptions{},
+			want:            OIDCSourceBrowser,
+			wantInteractive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SelectOIDCSource(tt.opts)
+			if got != tt.want {
+				t.Errorf("SelectOIDCSource() = %v, want %v", got, tt.want)
+			}
+			if got.Interactive() != tt.wantInteractive {
+				t.Errorf("%v.Interactive() = %v, want %v", got, got.Interactive(), tt.wantInteractive)
+			}
+		})
+	}
+}
+
 // TestResolveAttester exercises the four-tier OIDC source precedence
 // (identity-token > ambient > device-flow > interactive browser) plus the
 // disabled short-circuit. The ambient case uses an httptest server so the

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -96,6 +96,10 @@ type bundleCmdOptions struct {
 	// (RFC 8628) for headless hosts where a browser callback is unavailable.
 	oidcDeviceFlow bool
 
+	// assumeYes bypasses the interactive keyless-signing identity-disclosure
+	// prompt (--yes / AICR_ASSUME_YES). The banner is still emitted.
+	assumeYes bool
+
 	// fulcioURL and rekorURL override the public-good Sigstore endpoints so
 	// keyless signing targets a private Fulcio CA and/or Rekor transparency
 	// log. Empty leaves the public defaults in place. See #408.
@@ -144,6 +148,7 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		identityToken:             cmd.String(flagIdentityToken),
 		signingKey:                cmd.String(flagSigningKey),
 		oidcDeviceFlow:            boolFlagOrConfig(cmd, flagOIDCDeviceFlow, resolved.OIDCDeviceFlow),
+		assumeYes:                 cmd.Bool(flagAssumeYes),
 		fulcioURL:                 stringFlagOrConfig(cmd, flagFulcioURL, resolved.FulcioURL),
 		rekorURL:                  stringFlagOrConfig(cmd, flagRekorURL, resolved.RekorURL),
 		insecureTLS:               boolFlagOrConfig(cmd, flagInsecureTLS, resolved.InsecureTLS),
@@ -720,6 +725,7 @@ Package with explicit tag (overrides CLI version):
 				Sources:  cli.EnvVars("AICR_REKOR_URL"),
 				Category: catDeployment,
 			},
+			assumeYesFlag(catDeployment),
 			kubeconfigFlag(),
 			dataFlag(),
 			// OCI registry connection flags (used when --output is oci://...)
@@ -834,6 +840,16 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 		config.WithAppName(opts.appName),
 	)
 
+	// Gate the interactive keyless-signing login behind an identity-disclosure
+	// prompt before any browser/device-code flow opens. Only fires when
+	// --attest is set and the resolved OIDC path is interactive; pre-fetched
+	// token / ambient / KMS-key paths and non-TTY runs pass through.
+	if opts.attest {
+		if discErr := confirmKeylessSigningDisclosure(bundleOIDCResolveOptions(opts), opts.assumeYes, os.Stdin, os.Stderr); discErr != nil {
+			return discErr
+		}
+	}
+
 	// Note: binary attestation pre-flight check is handled inside
 	// MakeBundle via bundler.New().
 	attester, err := selectAttester(ctx, opts)
@@ -904,7 +920,19 @@ func runBundleCmd(ctx context.Context, cmd *cli.Command) error {
 // escape hatch — the underlying error is propagated unchanged so its
 // pkg/errors classification (and the resulting CLI exit code) is preserved.
 func selectAttester(ctx context.Context, opts *bundleCmdOptions) (attestation.Attester, error) {
-	att, err := attestation.ResolveAttesterLazy(ctx, attestation.ResolveOptions{
+	att, err := attestation.ResolveAttesterLazy(ctx, bundleOIDCResolveOptions(opts))
+	if err != nil && opts.attest {
+		slog.Error("bundle attestation requires authentication; remove --attest to bundle without signing", "error", err)
+	}
+	return att, err
+}
+
+// bundleOIDCResolveOptions translates the bundle command's signing flags and
+// runtime environment into the attestation package's ResolveOptions. Shared
+// by selectAttester (which builds the lazy attester) and the keyless-signing
+// disclosure gate so both reason about the identical token-source precedence.
+func bundleOIDCResolveOptions(opts *bundleCmdOptions) attestation.ResolveOptions {
+	return attestation.ResolveOptions{
 		Attest:        opts.attest,
 		IdentityToken: opts.identityToken,
 		SigningKey:    opts.signingKey,
@@ -916,11 +944,7 @@ func selectAttester(ctx context.Context, opts *bundleCmdOptions) (attestation.At
 		// Prompts (verification URL + user code) go to stderr so they don't
 		// pollute stdout when callers redirect bundle output.
 		PromptWriter: os.Stderr,
-	})
-	if err != nil && opts.attest {
-		slog.Error("bundle attestation requires authentication; remove --attest to bundle without signing", "error", err)
 	}
-	return att, err
 }
 
 // pushOCIBundle packages and pushes the bundle to an OCI registry.

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -53,6 +53,10 @@ const (
 	flagInsecureTLS    = "insecure-tls"
 	flagPlainHTTP      = "plain-http"
 	flagPush           = "push"
+	// flagAssumeYes bypasses the interactive keyless-signing identity
+	// disclosure prompt (see confirmKeylessSigningDisclosure). The banner is
+	// still emitted; only the y/N pause is skipped.
+	flagAssumeYes = "yes"
 )
 
 // Category labels (urfave/cli flag.Category values, grouping flags in help output).

--- a/pkg/cli/evidence_publish.go
+++ b/pkg/cli/evidence_publish.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -90,6 +91,7 @@ Example:
 				Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
 				Category: catEvidence,
 			},
+			assumeYesFlag(catEvidence),
 		},
 		Action: runEvidencePublishCmd,
 	}
@@ -110,13 +112,22 @@ func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
 		return errors.New(errors.ErrCodeInvalidRequest, "--push <oci-ref> is required")
 	}
 
+	// `evidence publish` always signs (push is required), so gate the
+	// interactive keyless login behind the identity-disclosure prompt before
+	// it can open a browser/device-code flow. Non-interactive token sources
+	// and non-TTY runs pass through inside the gate.
+	oidcResolve := oidcResolveOptionsFromFlags(cmd)
+	if err := confirmKeylessSigningDisclosure(oidcResolve, cmd.Bool(flagAssumeYes), os.Stdin, os.Stderr); err != nil {
+		return err
+	}
+
 	err := attestation.Publish(ctx, attestation.PublishOptions{
 		BundleDir:   dir,
 		Push:        push,
 		PlainHTTP:   cmd.Bool(flagPlainHTTP),
 		InsecureTLS: cmd.Bool(flagInsecureTLS),
 		AICRVersion: version,
-		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
+		OIDCResolve: oidcResolve,
 	})
 	// Publish already returns coded pkg/errors; PropagateOrWrap preserves
 	// those and only classifies any uncoded error that slips through.

--- a/pkg/cli/signing_disclosure.go
+++ b/pkg/cli/signing_disclosure.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
+
+	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// assumeYesFlag builds the shared --yes / --assume-yes bypass flag for the
+// keyless-signing identity-disclosure prompt. category groups it alongside
+// the owning command's other signing flags (Evidence for validate/publish,
+// Deployment for bundle).
+func assumeYesFlag(category string) cli.Flag {
+	return &cli.BoolFlag{
+		Name:    flagAssumeYes,
+		Aliases: []string{"assume-yes"},
+		Usage: "Skip the interactive confirmation prompt shown before keyless signing publishes " +
+			"your OIDC identity. The disclosure banner is still printed. For trusted interactive " +
+			"automation; CI / non-TTY runs already proceed without prompting.",
+		Sources:  cli.EnvVars("AICR_ASSUME_YES"),
+		Category: category,
+	}
+}
+
+// keylessOIDCPathIsInteractive reports whether the OIDC source precedence
+// encoded in opts would fall through to an interactive login (browser
+// callback or device-code) that mints a Fulcio certificate from the
+// signer's personal identity.
+//
+// It mirrors the precedence in bundleattest.ResolveOIDCToken: a pre-fetched
+// identity token, GitHub Actions ambient OIDC, or a KMS signing key all
+// short-circuit before any browser/device-code prompt, so none of those is
+// interactive. Everything else (explicit --oidc-device-flow, or the default
+// browser flow) is interactive and surprises the user with a login that
+// publishes their identity. Kept in lock-step with the resolver so the gate
+// fires exactly when — and only when — a browser/device-code flow would open.
+func keylessOIDCPathIsInteractive(opts bundleattest.ResolveOptions) bool {
+	switch {
+	case opts.SigningKey != "":
+		// KMS key-based signing embeds no OIDC identity in the artifact.
+		return false
+	case opts.IdentityToken != "":
+		return false
+	case opts.AmbientURL != "" && opts.AmbientToken != "":
+		return false
+	default:
+		// --oidc-device-flow or the default browser callback.
+		return true
+	}
+}
+
+// buildKeylessSigningBanner renders the privacy disclosure shown before an
+// interactive keyless-signing login. It is endpoint-aware: it names the
+// Fulcio and Rekor URLs actually in effect (the configured private instance
+// or the public-good defaults) and calls out the irreversible, world-readable
+// consequence only when the public-good Rekor is the destination.
+func buildKeylessSigningBanner(opts bundleattest.ResolveOptions) string {
+	fulcioURL := opts.FulcioURL
+	if fulcioURL == "" {
+		fulcioURL = defaults.SigstoreFulcioURL
+	}
+	rekorURL := opts.RekorURL
+	if rekorURL == "" {
+		rekorURL = defaults.SigstoreRekorURL
+	}
+	publicRekor := rekorURL == defaults.SigstoreRekorURL
+
+	var b strings.Builder
+	b.WriteString("─────────────────────────────────────────────────────────────────────\n")
+	b.WriteString("  Keyless signing — identity disclosure\n")
+	b.WriteString("─────────────────────────────────────────────────────────────────────\n")
+	b.WriteString("Interactive keyless signing will open a browser/device-code login and\n")
+	b.WriteString("exchange your OIDC identity for a short-lived signing certificate at:\n")
+	fmt.Fprintf(&b, "  Fulcio (CA):   %s\n", fulcioURL)
+	fmt.Fprintf(&b, "  Rekor (log):   %s\n", rekorURL)
+	b.WriteString("\n")
+	b.WriteString("The certificate embeds your authenticated identity (your email address\n")
+	b.WriteString("and OIDC issuer). That identity is then:\n")
+	fmt.Fprintf(&b, "  • recorded in the Rekor transparency log (%s), and\n", rekorURL)
+	b.WriteString("  • attached to the pushed OCI artifact, visible to anyone who can pull it.\n")
+	b.WriteString("\n")
+	if publicRekor {
+		b.WriteString("This is the PUBLIC-GOOD Sigstore log: the entry is public, append-only,\n")
+		b.WriteString("and PERMANENT — it cannot be deleted, and your email becomes globally\n")
+		b.WriteString("searchable. To avoid publishing a personal identity, use a CI/service\n")
+		b.WriteString("ambient identity, supply a pre-fetched --identity-token from a\n")
+		b.WriteString("non-personal identity, or point --fulcio-url/--rekor-url at a private\n")
+		b.WriteString("Sigstore instance.\n")
+	} else {
+		b.WriteString("These are PRIVATE Sigstore endpoints, so the identity stays inside your\n")
+		b.WriteString("organization's infrastructure rather than a public log. The identity is\n")
+		b.WriteString("still recorded permanently in that log and attached to the artifact.\n")
+	}
+	b.WriteString("─────────────────────────────────────────────────────────────────────")
+	return b.String()
+}
+
+// confirmKeylessSigningDisclosure gates an interactive keyless-signing login
+// behind an informed-consent banner. It lives in the CLI layer so the
+// business-logic packages stay non-interactive.
+//
+// When the resolved OIDC path is non-interactive (pre-fetched token, ambient
+// OIDC, or KMS key — see keylessOIDCPathIsInteractive) it returns nil with no
+// output: those paths neither open a browser nor surprise the user.
+//
+// For an interactive path it always emits the disclosure banner to out, then:
+//   - assumeYes (--yes / AICR_ASSUME_YES): prints a notice and proceeds.
+//   - non-TTY stdin (CI, pipes): proceeds without blocking — a fail-safe so
+//     scripted/CI signing is never wedged waiting on input that won't arrive.
+//   - TTY stdin: pauses for an explicit y/N confirmation, defaulting to no.
+//     A declined or empty answer returns an error so the caller aborts before
+//     any browser opens.
+//
+// in is treated as a TTY unless it is a non-terminal *os.File (the pattern
+// used by confirmOverwrite); test readers such as strings.Reader exercise the
+// interactive branch directly.
+func confirmKeylessSigningDisclosure(opts bundleattest.ResolveOptions, assumeYes bool, in io.Reader, out io.Writer) error {
+	if !keylessOIDCPathIsInteractive(opts) {
+		return nil
+	}
+
+	fmt.Fprintln(out, buildKeylessSigningBanner(opts))
+
+	if assumeYes {
+		fmt.Fprintln(out, "Proceeding without confirmation (--yes / AICR_ASSUME_YES set).")
+		return nil
+	}
+
+	if !isInteractiveStream(in) {
+		fmt.Fprintln(out, "Non-interactive stdin detected; emitting disclosure and proceeding.")
+		return nil
+	}
+
+	fmt.Fprint(out, "\nProceed with interactive keyless signing and publish this identity? [y/N]: ")
+
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to read signing confirmation", err)
+		}
+		return errSigningDeclined()
+	}
+	switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+	case "y", "yes":
+		return nil
+	default:
+		return errSigningDeclined()
+	}
+}
+
+// errSigningDeclined is the clean-abort error returned when the user declines
+// the interactive keyless-signing prompt. ErrCodeUnavailable matches the
+// classification the OIDC helpers use for a caller-side cancel, so a declined
+// prompt and a canceled login surface the same way to the CLI exit-code mapper.
+func errSigningDeclined() error {
+	return errors.New(errors.ErrCodeUnavailable,
+		"keyless signing declined at the identity-disclosure prompt; no identity was published "+
+			"(re-run with --yes / AICR_ASSUME_YES to skip this prompt, or supply --identity-token)")
+}
+
+// isInteractiveStream reports whether in is an interactive terminal. A
+// non-terminal *os.File (pipe, redirect, /dev/null) is non-interactive;
+// other reader types (e.g. a strings.Reader in tests) bypass the TTY check
+// and are treated as interactive so the confirmation branch is exercisable.
+func isInteractiveStream(in io.Reader) bool {
+	if f, ok := in.(*os.File); ok {
+		return term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: os file descriptors fit safely in int
+	}
+	return true
+}

--- a/pkg/cli/signing_disclosure.go
+++ b/pkg/cli/signing_disclosure.go
@@ -45,31 +45,22 @@ func assumeYesFlag(category string) cli.Flag {
 	}
 }
 
-// keylessOIDCPathIsInteractive reports whether the OIDC source precedence
-// encoded in opts would fall through to an interactive login (browser
-// callback or device-code) that mints a Fulcio certificate from the
-// signer's personal identity.
+// keylessOIDCPathIsInteractive reports whether signing with opts would fall
+// through to an interactive login (browser callback or device-code) that
+// mints a Fulcio certificate from the signer's personal identity.
 //
-// It mirrors the precedence in bundleattest.ResolveOIDCToken: a pre-fetched
-// identity token, GitHub Actions ambient OIDC, or a KMS signing key all
-// short-circuit before any browser/device-code prompt, so none of those is
-// interactive. Everything else (explicit --oidc-device-flow, or the default
-// browser flow) is interactive and surprises the user with a login that
-// publishes their identity. Kept in lock-step with the resolver so the gate
-// fires exactly when — and only when — a browser/device-code flow would open.
+// The OIDC source-precedence decision is delegated to
+// bundleattest.SelectOIDCSource — the same classifier ResolveOIDCToken
+// switches on — so the gate cannot drift from the resolver: a new
+// non-interactive source added there is reflected here automatically. The
+// only thing the gate adds is the KMS short-circuit: a SigningKey selects
+// key-based signing in ResolveAttester before any OIDC source applies, and
+// embeds no OIDC identity in the artifact.
 func keylessOIDCPathIsInteractive(opts bundleattest.ResolveOptions) bool {
-	switch {
-	case opts.SigningKey != "":
-		// KMS key-based signing embeds no OIDC identity in the artifact.
+	if opts.SigningKey != "" {
 		return false
-	case opts.IdentityToken != "":
-		return false
-	case opts.AmbientURL != "" && opts.AmbientToken != "":
-		return false
-	default:
-		// --oidc-device-flow or the default browser callback.
-		return true
 	}
+	return bundleattest.SelectOIDCSource(opts).Interactive()
 }
 
 // buildKeylessSigningBanner renders the privacy disclosure shown before an

--- a/pkg/cli/signing_disclosure_test.go
+++ b/pkg/cli/signing_disclosure_test.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+)
+
+func TestKeylessOIDCPathIsInteractive(t *testing.T) {
+	tests := []struct {
+		name string
+		opts bundleattest.ResolveOptions
+		want bool
+	}{
+		{
+			name: "pre-fetched identity token is non-interactive",
+			opts: bundleattest.ResolveOptions{IdentityToken: "eyJ..."},
+			want: false,
+		},
+		{
+			name: "ambient github actions OIDC is non-interactive",
+			opts: bundleattest.ResolveOptions{AmbientURL: "https://token", AmbientToken: "tok"},
+			want: false,
+		},
+		{
+			name: "ambient with only URL falls through to interactive",
+			opts: bundleattest.ResolveOptions{AmbientURL: "https://token"},
+			want: true,
+		},
+		{
+			name: "KMS signing key is non-interactive (no OIDC identity in cert)",
+			opts: bundleattest.ResolveOptions{SigningKey: "awskms://key"},
+			want: false,
+		},
+		{
+			name: "device-code flow is interactive",
+			opts: bundleattest.ResolveOptions{DeviceFlow: true},
+			want: true,
+		},
+		{
+			name: "empty options default to interactive browser flow",
+			opts: bundleattest.ResolveOptions{},
+			want: true,
+		},
+		{
+			name: "identity token wins over device flow",
+			opts: bundleattest.ResolveOptions{IdentityToken: "eyJ...", DeviceFlow: true},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := keylessOIDCPathIsInteractive(tt.opts); got != tt.want {
+				t.Errorf("keylessOIDCPathIsInteractive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildKeylessSigningBanner(t *testing.T) {
+	t.Run("public-good Sigstore names the permanent public log", func(t *testing.T) {
+		banner := buildKeylessSigningBanner(bundleattest.ResolveOptions{})
+		// Endpoint URLs are matched verbatim; the consent keywords are
+		// matched case-insensitively since the banner emphasizes some in
+		// caps (PERMANENT) for readability.
+		for _, want := range []string{defaults.SigstoreRekorURL, defaults.SigstoreFulcioURL} {
+			if !strings.Contains(banner, want) {
+				t.Errorf("public banner missing %q\nbanner:\n%s", want, banner)
+			}
+		}
+		lower := strings.ToLower(banner)
+		for _, want := range []string{"identity", "public", "permanent", "email"} {
+			if !strings.Contains(lower, want) {
+				t.Errorf("public banner missing concept %q\nbanner:\n%s", want, banner)
+			}
+		}
+	})
+
+	t.Run("private Sigstore names the configured endpoints", func(t *testing.T) {
+		banner := buildKeylessSigningBanner(bundleattest.ResolveOptions{
+			FulcioURL: "https://fulcio.internal.example.com",
+			RekorURL:  "https://rekor.internal.example.com",
+		})
+
+		if !strings.Contains(banner, "https://rekor.internal.example.com") {
+			t.Errorf("private banner missing custom rekor URL\nbanner:\n%s", banner)
+		}
+		if strings.Contains(banner, defaults.SigstoreRekorURL) {
+			t.Errorf("private banner should not name the public-good Rekor\nbanner:\n%s", banner)
+		}
+	})
+}
+
+func TestConfirmKeylessSigningDisclosure_TTYConfirmation(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantInOut string
+	}{
+		{"yes lower proceeds", "y\n", false, "rekor.sigstore.dev"},
+		{"yes word proceeds", "yes\n", false, "rekor.sigstore.dev"},
+		{"yes uppercase proceeds", "Y\n", false, "rekor.sigstore.dev"},
+		{"no declines", "n\n", true, "rekor.sigstore.dev"},
+		{"empty defaults to decline", "\n", true, "rekor.sigstore.dev"},
+		{"eof defaults to decline", "", true, "rekor.sigstore.dev"},
+		{"unrecognized declines", "maybe\n", true, "rekor.sigstore.dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			// strings.Reader is not an *os.File, so it bypasses the TTY
+			// check and is read directly (simulates an interactive shell).
+			err := confirmKeylessSigningDisclosure(
+				bundleattest.ResolveOptions{}, false, strings.NewReader(tt.input), &out)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("confirmKeylessSigningDisclosure() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !strings.Contains(out.String(), tt.wantInOut) {
+				t.Errorf("banner missing %q from output:\n%s", tt.wantInOut, out.String())
+			}
+			if !strings.Contains(out.String(), "[y/N]") {
+				t.Errorf("TTY prompt missing from output:\n%s", out.String())
+			}
+		})
+	}
+}
+
+func TestConfirmKeylessSigningDisclosure_NonInteractiveTokenSkipsGate(t *testing.T) {
+	nonInteractive := []struct {
+		name string
+		opts bundleattest.ResolveOptions
+	}{
+		{"identity token", bundleattest.ResolveOptions{IdentityToken: "eyJ..."}},
+		{"ambient github actions", bundleattest.ResolveOptions{AmbientURL: "https://t", AmbientToken: "tok"}},
+		{"KMS signing key", bundleattest.ResolveOptions{SigningKey: "gcpkms://key"}},
+	}
+
+	for _, tt := range nonInteractive {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			// An input that *would* decline if the gate were consulted.
+			err := confirmKeylessSigningDisclosure(tt.opts, false, strings.NewReader("n\n"), &out)
+			if err != nil {
+				t.Fatalf("non-interactive source should not gate, got error: %v", err)
+			}
+			if out.String() != "" {
+				t.Errorf("non-interactive source should emit no banner, got:\n%s", out.String())
+			}
+		})
+	}
+}
+
+func TestConfirmKeylessSigningDisclosure_NonTTYProceeds(t *testing.T) {
+	// /dev/null is a non-terminal *os.File, simulating piped/redirected
+	// stdin in CI. The gate must emit the banner and proceed (return nil)
+	// without reading a confirmation.
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("failed to open /dev/null: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out bytes.Buffer
+	if err := confirmKeylessSigningDisclosure(bundleattest.ResolveOptions{}, false, f, &out); err != nil {
+		t.Fatalf("non-TTY stdin should proceed, got error: %v", err)
+	}
+	if !strings.Contains(out.String(), defaults.SigstoreRekorURL) {
+		t.Errorf("non-TTY banner missing, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Errorf("non-TTY path must not prompt, got:\n%s", out.String())
+	}
+}
+
+func TestConfirmKeylessSigningDisclosure_AssumeYesBypass(t *testing.T) {
+	var out bytes.Buffer
+	// Input would decline, but --yes must bypass the prompt entirely.
+	err := confirmKeylessSigningDisclosure(
+		bundleattest.ResolveOptions{}, true, strings.NewReader("n\n"), &out)
+	if err != nil {
+		t.Fatalf("--yes should bypass the prompt, got error: %v", err)
+	}
+	if !strings.Contains(out.String(), defaults.SigstoreRekorURL) {
+		t.Errorf("--yes path should still emit the banner, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Errorf("--yes path must not prompt, got:\n%s", out.String())
+	}
+}
+
+// TestConfirmKeylessSigningDisclosure_DeviceFlowGated proves the device-code
+// path is gated identically to the default browser path: an interactive
+// decline aborts before any login.
+func TestConfirmKeylessSigningDisclosure_DeviceFlowGated(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmKeylessSigningDisclosure(
+		bundleattest.ResolveOptions{DeviceFlow: true}, false, strings.NewReader("n\n"), &out)
+	if err == nil {
+		t.Fatal("device-flow decline should abort, got nil error")
+	}
+	if !strings.Contains(out.String(), "[y/N]") {
+		t.Errorf("device-flow path should prompt, got:\n%s", out.String())
+	}
+}
+
+// TestConfirmKeylessSigningDisclosure_PrivateEndpointGated exercises the gate
+// over a private Sigstore instance: the banner names the private endpoint
+// (not the public-good Rekor) and the interactive decision is still honored.
+func TestConfirmKeylessSigningDisclosure_PrivateEndpointGated(t *testing.T) {
+	opts := bundleattest.ResolveOptions{
+		FulcioURL: "https://fulcio.internal.example.com",
+		RekorURL:  "https://rekor.internal.example.com",
+	}
+
+	t.Run("accept proceeds", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := confirmKeylessSigningDisclosure(opts, false, strings.NewReader("y\n"), &out); err != nil {
+			t.Fatalf("private-endpoint accept should proceed, got error: %v", err)
+		}
+		if !strings.Contains(out.String(), "rekor.internal.example.com") {
+			t.Errorf("banner should name the private rekor endpoint, got:\n%s", out.String())
+		}
+		if strings.Contains(out.String(), defaults.SigstoreRekorURL) {
+			t.Errorf("private-endpoint banner must not name the public-good Rekor, got:\n%s", out.String())
+		}
+	})
+
+	t.Run("decline aborts", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := confirmKeylessSigningDisclosure(opts, false, strings.NewReader("n\n"), &out); err == nil {
+			t.Fatal("private-endpoint decline should abort, got nil error")
+		}
+	})
+}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -579,6 +579,7 @@ func validateCmdFlags() []cli.Flag {
 			Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
 			Category: catEvidence,
 		},
+		assumeYesFlag(catEvidence),
 		configFlag(),
 		dataFlag(),
 		outputFlag(),

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -43,6 +43,10 @@ type recipeEvidenceConfig struct {
 	// issue, and a multi-minute validation run between resolve and sign
 	// invalidates it.
 	OIDCResolve bundleattest.ResolveOptions
+
+	// AssumeYes bypasses the interactive keyless-signing identity-disclosure
+	// prompt (--yes / AICR_ASSUME_YES). The banner is still emitted.
+	AssumeYes bool
 }
 
 // buildRecipeEvidenceConfig parses the --emit-attestation flag family with
@@ -65,6 +69,7 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 		PlainHTTP:   boolFlagOrConfig(cmd, flagPlainHTTP, att.PlainHTTP),
 		InsecureTLS: boolFlagOrConfig(cmd, flagInsecureTLS, att.InsecureTLS),
 		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
+		AssumeYes:   cmd.Bool(flagAssumeYes),
 	}
 }
 
@@ -103,6 +108,16 @@ func emitRecipeEvidence(
 	results []*validator.PhaseResult,
 	cfg *recipeEvidenceConfig,
 ) error {
+
+	// Signing happens only when --push is set (see attestation.Emit). Gate the
+	// interactive keyless login behind the identity-disclosure prompt before
+	// the long validation-and-push run can open a browser/device-code flow.
+	// Non-interactive token sources and non-TTY runs pass through inside the gate.
+	if cfg.Push != "" {
+		if err := confirmKeylessSigningDisclosure(cfg.OIDCResolve, cfg.AssumeYes, os.Stdin, os.Stderr); err != nil {
+			return err
+		}
+	}
 
 	cat, err := catalog.LoadWithDataProvider(ctx, dp, version, commit)
 	if err != nil {


### PR DESCRIPTION
## Summary

Add an interactive identity-disclosure gate before keyless evidence signing: when `aicr` is about to open a browser/device-code OIDC login, it prints an endpoint-aware banner explaining that the signer's identity (email + issuer) will be published permanently to the public Rekor transparency log, and on a TTY pauses for `y/N` confirmation. A `--yes` / `AICR_ASSUME_YES` bypass is added for interactive automation.

## Motivation / Context

The evidence-signing paths (`aicr validate --emit-attestation --push`, `aicr evidence publish --push`, `aicr bundle --attest`) can fall through to an interactive OIDC login that mints a Fulcio cert from the user's identity. With public-good Sigstore, that identity — typically the signer's **email** plus the OIDC issuer — is written to the **public, immutable Rekor log** (permanently searchable, cannot be deleted) and attached to the pushed OCI artifact. Previously the only hint was a couple of `slog.Info` lines; there was no warning and no confirmation before the browser opened. This adds informed consent at the point of action plus the supporting docs.

Fixes: #1257
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New `pkg/cli/signing_disclosure.go`:
  - `keylessOIDCPathIsInteractive` mirrors `bundleattest.ResolveOIDCToken`'s source precedence exactly, so the gate fires on **every** interactive path (browser/device-code) and **never** on a non-interactive one (pre-fetched `--identity-token`, ambient GitHub Actions OIDC, KMS `--signing-key`).
  - `buildKeylessSigningBanner` is endpoint-aware: it names the Fulcio/Rekor URLs in effect and only claims "public, permanent, globally searchable" when the public-good Rekor is the destination; private endpoints get a softer, accurate message.
  - `confirmKeylessSigningDisclosure`: on a TTY it prompts `y/N` (default **no**, clean abort — no browser, non-zero exit, mirroring the existing `confirmOverwrite` TTY pattern); on non-interactive stdin it emits the banner and **proceeds** (fail-safe so CI/scripts are never wedged).
- Gate lives entirely in `pkg/cli` (business-logic packages stay non-interactive). It runs **before** the browser opens in all three commands: before `selectAttester` in `bundle` (lazy attester), before `attestation.Emit` in `validate` (only when `--push`), before `attestation.Publish` in `evidence publish` (always — push is required).
- `--yes` (alias `--assume-yes`, env `AICR_ASSUME_YES`) suppresses the prompt while still printing the banner.
- A declined prompt returns `ErrCodeUnavailable`, matching how the OIDC helpers classify a user-canceled login, so aborting at the consent prompt and aborting at the browser produce the same exit code.
- Refactored the inline `ResolveOptions` literal in `selectAttester` into a shared `bundleOIDCResolveOptions` so the gate and the real attester reason about identical token-source inputs (no drift).

## Testing

```bash
# pkg/cli with race detector + lint (pinned golangci-lint 2.12.2)
go test -race ./pkg/cli/...
golangci-lint -c .golangci.yaml run ./pkg/cli/...
go build ./... && go vet ./pkg/cli/...
```

- All `pkg/cli` tests pass with `-race`; lint clean; full module builds/vets.
- New table-driven tests cover the issue's success criteria: TTY accept/decline (incl. empty/EOF default-to-no), non-TTY pass-through, `--yes` bypass, non-interactive token sources never gate, device-flow gating, and public-vs-private endpoint-aware banner. New file is ~98% covered.
- Note: `pkg/bundler/attestation` `TestNewKeyVerificationIdentity_PEM` fails in my local env on a blocked `tuf-repo-cdn.sigstore.dev` fetch — a network/environment issue unrelated to and untouched by this change.

## Risk Assessment

- [x] **Low** — Isolated, CLI-only change; non-interactive token/ambient/KMS paths and CI runs are unaffected; well-tested and easy to revert.

**Rollout notes:** Backwards compatible. CI and scripted signing (which use ambient/non-personal identities or pre-fetched tokens) never hit the gate. Interactive workstation signers see a one-time `y/N` prompt; `--yes` / `AICR_ASSUME_YES` restores the old no-prompt behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
