### PR TITLE
feat(health): constraints_wellformed signal (parse-only, hermetic)

### DIFF
--- a/docs/design/009-recipe-health-tracking.md
+++ b/docs/design/009-recipe-health-tracking.md
@@ -205,17 +205,19 @@ to the Supported/Preview/Experimental vocabulary, applied to the grade:
 letter grades are deferred until the validation axis can fuse into them
 (deferred table).
 
-**Compute budget.** As shipped, V1's `constraints_wellformed` is parse-only,
-not a `--no-cluster` constraint replay: it resolves each leaf through the
-constraint-aware path with a satisfied-stub evaluator (no snapshot) and runs
-the snapshot-free parsers over the merged constraints. The dominant cost is
-therefore the per-combo resolve across the ~50 leaf combos, not constraint
-evaluation. The target is a sub-minute generator run, well inside the weekly
-cadence's tolerance. If it grows past a few minutes, the redesign levers — in
-order — are: cache per-combo results keyed by the resolved-recipe digest;
-parallelize resolution; or gate the scheduled job to PRs touching `recipes/**`.
-None are needed at v1 scale. (Actual snapshot-dependent replay is deferred to
-the validation axis's `coverage_declared_vs_run`.)
+**Compute budget.** `constraints_wellformed` is specified as parse-only rather
+than a `--no-cluster` constraint replay: each leaf is resolved through the
+constraint-aware path with a satisfied-stub evaluator (no snapshot) and the
+snapshot-free parsers run over the merged constraints (the original
+`--no-cluster` replay phrasing is unachievable offline, since the evaluator
+extracts a snapshot value before parsing). The dominant cost is therefore the
+per-combo resolve across the ~50 leaf combos, not constraint evaluation. The
+target is a sub-minute generator run, well inside the weekly cadence's
+tolerance. If it grows past a few minutes, the redesign levers — in order —
+are: cache per-combo results keyed by the resolved-recipe digest; parallelize
+resolution; or gate the scheduled job to PRs touching `recipes/**`. None are
+needed at v1 scale. (Actual snapshot-dependent replay is deferred to the
+validation axis's `coverage_declared_vs_run`.)
 
 **Two originally proposed structural signals are deferred, not dropped:**
 - `chart_drift` (upstream image drift on a pinned chart) requires a live

--- a/docs/design/009-recipe-health-tracking.md
+++ b/docs/design/009-recipe-health-tracking.md
@@ -173,7 +173,7 @@ Each combination is scored from signals that are **all hermetic and offline**
 | Dimension | Role | Signal | Source |
 |---|---|---|---|
 | `resolves` | graded | `BuildFromCriteria` returns a `RecipeResult` without error | `pkg/recipe/builder.go` |
-| `constraints_wellformed` | graded | Every `Constraint.Value` parses; inline replay under `--no-cluster` is clean; no `ConstraintWarning`s | `pkg/recipe/metadata.go`, `pkg/validator` (no-cluster mode) |
+| `constraints_wellformed` | graded | Every merged constraint's `Name` (path) and `Value` (expression) parse with the snapshot-free parsers (`fail` on any parse error); resolution surfacing a `ConstraintWarning`/`ExcludedOverlay` is `warn` | `pkg/constraints` (parsers), `pkg/health` (classifier) |
 | `chart_pinned` | graded | Every resolved component references an explicit pinned chart version/digest per [ADR-006](006-image-pinning-policy.md) — a pure in-repo check on the resolved recipe, **no Helm render** | resolved `RecipeResult` components; ADR-006 policy |
 | `declared_coverage` | descriptor | For each of readiness/deployment/performance/conformance: present-or-not, the **named checks** declared, and the phase-level constraint count | `pkg/recipe/validation.go` (`ValidationPhase.Checks`, `.Constraints`) |
 
@@ -205,13 +205,17 @@ to the Supported/Preview/Experimental vocabulary, applied to the grade:
 letter grades are deferred until the validation axis can fuse into them
 (deferred table).
 
-**Compute budget.** The dominant cost is the `--no-cluster` constraint replay
-across the ~50 leaf combos. The target is a sub-minute generator run, well
-inside the weekly cadence's tolerance. If it grows past a few minutes, the
-redesign levers — in order — are: cache per-combo results keyed by the
-resolved-recipe digest; parallelize the replay; or drop inline replay from
-the scheduled job and gate it to PRs touching `recipes/**`. None are needed
-at v1 scale.
+**Compute budget.** As shipped, V1's `constraints_wellformed` is parse-only,
+not a `--no-cluster` constraint replay: it resolves each leaf through the
+constraint-aware path with a satisfied-stub evaluator (no snapshot) and runs
+the snapshot-free parsers over the merged constraints. The dominant cost is
+therefore the per-combo resolve across the ~50 leaf combos, not constraint
+evaluation. The target is a sub-minute generator run, well inside the weekly
+cadence's tolerance. If it grows past a few minutes, the redesign levers — in
+order — are: cache per-combo results keyed by the resolved-recipe digest;
+parallelize resolution; or gate the scheduled job to PRs touching `recipes/**`.
+None are needed at v1 scale. (Actual snapshot-dependent replay is deferred to
+the validation axis's `coverage_declared_vs_run`.)
 
 **Two originally proposed structural signals are deferred, not dropped:**
 - `chart_drift` (upstream image drift on a pinned chart) requires a live

--- a/pkg/health/doc.go
+++ b/pkg/health/doc.go
@@ -34,12 +34,25 @@
 // # Signals and rollup
 //
 // Each leaf is scored on graded dimensions whose per-dimension state is one
-// of pass, warn, fail, or unknown. Two graded dimensions ship today: resolves
-// (whether the recipe builder resolves the criteria without error) and
+// of pass, warn, fail, or unknown. Three graded dimensions ship today:
+// resolves (whether the recipe builder resolves the criteria without error),
 // chart_pinned (whether every resolved Helm component references an explicit
-// chart version — ADR-006 layer 1, a pure field read with no Helm render).
-// One more graded dimension, constraints_wellformed, is layered on by later
-// work and feeds the same generic rollup without changing rollup logic.
+// chart version — ADR-006 layer 1, a pure field read with no Helm render), and
+// constraints_wellformed (whether every merged constraint parses with the
+// snapshot-free constraint parsers — fail — and whether the constraint-aware
+// resolution surfaced composition warnings — warn). Each feeds the same
+// generic rollup without changing rollup logic.
+//
+// constraints_wellformed is parse-only well-formedness and hermetic: the leaf
+// is resolved through the constraint-aware path with a satisfied stub
+// evaluator, so the signal never replays a constraint against cluster or
+// snapshot state. Its fail grade (a constraint that does not parse) is the
+// load-bearing signal; the warn grade reads ConstraintWarnings/ExcludedOverlays
+// but, because the stub fails no constraint, does not fire under the current
+// hermetic resolution (it is retained for forward-compatibility — see
+// classifyConstraintsWellformed). Value semantics and snapshot-dependent
+// constraint replay are deferred to the evidence-driven validation axis
+// (ADR-009 coverage_declared_vs_run).
 //
 // declared_coverage is a separate descriptor, not a graded dimension: it
 // records, per validation phase, whether the phase is declared, its named

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -17,9 +17,11 @@ package health
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/NVIDIA/aicr/pkg/constraints"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -59,6 +61,15 @@ const (
 	// DimChartPinned is the graded dimension scoring whether every resolved
 	// Helm component references an explicit chart version (ADR-006 layer 1).
 	DimChartPinned = "chart_pinned"
+
+	// DimConstraintsWellformed is the graded dimension scoring whether every
+	// merged constraint parses with the snapshot-free constraint parsers
+	// (fail), and whether the constraint-aware resolution surfaced any
+	// composition warnings (warn). It is parse-only well-formedness — V1 is
+	// hermetic and never replays a constraint against cluster/snapshot state.
+	// See classifyConstraintsWellformed for why the warn branch is inert under
+	// the current satisfied-stub resolution.
+	DimConstraintsWellformed = "constraints_wellformed"
 )
 
 // Options configures a Compute run.
@@ -206,7 +217,14 @@ func computeCombo(ctx context.Context, builder *recipe.Builder, entry recipe.Cat
 		Detail:     make(map[string]string),
 	}
 
-	result, err := builder.BuildFromCriteria(ctx, entry.Criteria)
+	// Resolve through the constraint-aware path with a hermetic satisfied stub.
+	// With every constraint reported satisfied this merges exactly the overlays
+	// BuildFromCriteria would (no cluster-dependent exclusions), so the resolves
+	// grade is unchanged — but the result additionally carries the merged
+	// Constraints and any ConstraintWarnings/ExcludedOverlays the constraint-aware
+	// path surfaces, which the constraints_wellformed signal reads. One build,
+	// no snapshot, no cluster.
+	result, err := builder.BuildFromCriteriaWithEvaluator(ctx, entry.Criteria, satisfiedEvaluator)
 	state, detail := classifyResolve(err)
 	structure.Dimensions[DimResolves] = state
 	if detail != "" {
@@ -222,6 +240,13 @@ func computeCombo(ctx context.Context, builder *recipe.Builder, entry recipe.Cat
 		if pinnedDetail != "" {
 			structure.Detail[DimChartPinned] = pinnedDetail
 		}
+
+		cwState, cwDetail := classifyConstraintsWellformed(result)
+		structure.Dimensions[DimConstraintsWellformed] = cwState
+		if cwDetail != "" {
+			structure.Detail[DimConstraintsWellformed] = cwDetail
+		}
+
 		cov := computeCoverage(result)
 		structure.Coverage = &cov
 	}
@@ -279,6 +304,75 @@ func classifyChartPinned(result *recipe.RecipeResult) (state, detail string) {
 	if helmCount == 0 {
 		return StatusPass, "no enabled Helm components; chart-version pinning not applicable (Kustomize tag pinning is out of scope)"
 	}
+	return StatusPass, ""
+}
+
+// satisfiedEvaluator is the hermetic stub fed to BuildFromCriteriaWithEvaluator
+// so the constraint-aware resolution path executes offline. It reports every
+// constraint satisfied, so no overlay is excluded and no ConstraintWarning is
+// emitted — the resolution exercises the merge/compose machinery without any
+// snapshot measurement, which is all the parse-only signal needs.
+func satisfiedEvaluator(recipe.Constraint) recipe.ConstraintEvalResult {
+	return recipe.ConstraintEvalResult{Passed: true}
+}
+
+// classifyConstraintsWellformed grades the constraints_wellformed dimension
+// hermetically — no snapshot, no cluster.
+//
+// Primary (fail): every merged constraint must parse. Both the path
+// (ParseConstraintPath over Name) and the value expression
+// (ParseConstraintExpression over Value) are checked with the exported,
+// snapshot-free parsers. The first malformed constraint fails the dimension,
+// naming the offending constraint and the parser error in the detail — a
+// malformed constraint is never a silent pass. The merged constraint order is
+// deterministic for a given leaf (sorted by name once any overlay/mixin merges,
+// base-file order otherwise), so the reported failure is stable across runs.
+//
+// This is structural parse well-formedness only: it does not validate value
+// semantics. A version-comparison value that parses but is not a usable version
+// (e.g. ">= not-a-version") scores pass here — semantic/range checking and any
+// snapshot-dependent constraint replay are deferred to the evidence-driven
+// validation axis (ADR-009 coverage_declared_vs_run).
+//
+// Secondary (warn): if every constraint parses but the resolution surfaced
+// ConstraintWarnings or ExcludedOverlays, the dimension warns. NOTE: these
+// fields are populated only when the injected evaluator reports a constraint
+// failed or errored (see metadata_store.evaluateOverlayConstraints /
+// evaluateMixinConstraints). satisfiedEvaluator never does, so under the
+// current hermetic resolution the warn branch does not fire — composition
+// problems surface instead as resolve errors. The branch is retained because it
+// is the correct reading of a resolved result and is forward-compatible with a
+// future evaluator wired into this path; it is exercised by unit tests via
+// direct field injection.
+//
+// A nil result (resolve failed or held) is never scored by the caller; pass is
+// returned defensively.
+func classifyConstraintsWellformed(result *recipe.RecipeResult) (state, detail string) {
+	if result == nil {
+		return StatusPass, ""
+	}
+
+	for _, c := range result.Constraints {
+		if _, err := constraints.ParseConstraintPath(c.Name); err != nil {
+			return StatusFail, fmt.Sprintf("constraint %q: malformed path: %v", c.Name, err)
+		}
+		if _, err := constraints.ParseConstraintExpression(c.Value); err != nil {
+			return StatusFail, fmt.Sprintf("constraint %q: malformed value %q: %v", c.Name, c.Value, err)
+		}
+	}
+
+	if warnings := result.Metadata.ConstraintWarnings; len(warnings) > 0 {
+		w := warnings[0]
+		return StatusWarn, fmt.Sprintf(
+			"%d constraint warning(s) during resolution; first: overlay %q constraint %q: %s",
+			len(warnings), w.Overlay, w.Constraint, w.Reason)
+	}
+	if excluded := result.Metadata.ExcludedOverlays; len(excluded) > 0 {
+		return StatusWarn, fmt.Sprintf(
+			"%d overlay(s) excluded during constraint-aware resolution; first: %q (%s)",
+			len(excluded), excluded[0].Name, excluded[0].Reason)
+	}
+
 	return StatusPass, ""
 }
 

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -172,6 +172,109 @@ func TestClassifyChartPinned(t *testing.T) {
 	}
 }
 
+func TestClassifyConstraintsWellformed(t *testing.T) {
+	constraint := func(name, value string) recipe.Constraint {
+		return recipe.Constraint{Name: name, Value: value}
+	}
+	result := func(constraints ...recipe.Constraint) *recipe.RecipeResult {
+		return &recipe.RecipeResult{Constraints: constraints}
+	}
+	withWarnings := func(r *recipe.RecipeResult, warnings ...recipe.ConstraintWarning) *recipe.RecipeResult {
+		r.Metadata.ConstraintWarnings = warnings
+		return r
+	}
+	withExcluded := func(r *recipe.RecipeResult, excluded ...recipe.ExcludedOverlay) *recipe.RecipeResult {
+		r.Metadata.ExcludedOverlays = excluded
+		return r
+	}
+
+	tests := []struct {
+		name        string
+		result      *recipe.RecipeResult
+		wantState   string
+		detailMatch string // substring that must appear in detail ("" = detail must be empty)
+	}{
+		{"nil result passes", nil, StatusPass, ""},
+		{"no constraints passes", result(), StatusPass, ""},
+		{
+			"all well-formed constraints pass",
+			result(constraint("K8s.server.version", ">= 1.32.4"), constraint("OS.release.name", "ubuntu")),
+			StatusPass, "",
+		},
+		{
+			"malformed path (too few segments) fails",
+			result(constraint("bogus", "1.0")),
+			StatusFail, "bogus",
+		},
+		{
+			"malformed path (invalid measurement type) fails",
+			result(constraint("NotAType.sub.key", "1.0")),
+			StatusFail, "malformed path",
+		},
+		{
+			"malformed value (empty after operator) fails",
+			result(constraint("K8s.server.version", ">=")),
+			StatusFail, "malformed value",
+		},
+		{
+			"empty value fails",
+			result(constraint("K8s.server.version", "")),
+			StatusFail, "malformed value",
+		},
+		{
+			// Whitespace-only values are trimmed to empty by the parser, so they
+			// take the same fail path as an empty value.
+			"whitespace-only value fails",
+			result(constraint("K8s.server.version", "   ")),
+			StatusFail, "malformed value",
+		},
+		{
+			"parse failure beats resolution warning",
+			withWarnings(
+				result(constraint("bogus", "1.0")),
+				recipe.ConstraintWarning{Overlay: "o", Constraint: "c", Reason: "r"},
+			),
+			StatusFail, "bogus",
+		},
+		// The two warn cases below inject Metadata.ConstraintWarnings /
+		// ExcludedOverlays directly: with the production satisfiedEvaluator no
+		// constraint fails, so these fields are never populated through Compute
+		// (see classifyConstraintsWellformed). Direct injection is the only way
+		// to exercise the warn branch, by design.
+		{
+			"well-formed with constraint warning warns",
+			withWarnings(
+				result(constraint("K8s.server.version", ">= 1.32.4")),
+				recipe.ConstraintWarning{Overlay: "gke-overlay", Constraint: "K8s.server.version", Reason: "version too low"},
+			),
+			StatusWarn, "gke-overlay",
+		},
+		{
+			"well-formed with excluded overlay warns",
+			withExcluded(
+				result(constraint("K8s.server.version", ">= 1.32.4")),
+				recipe.ExcludedOverlay{Name: "dropped-overlay", Reason: recipe.ExcludedOverlayReasonConstraintFailed},
+			),
+			StatusWarn, "dropped-overlay",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, detail := classifyConstraintsWellformed(tt.result)
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			if tt.detailMatch == "" {
+				if detail != "" {
+					t.Errorf("detail = %q, want empty", detail)
+				}
+			} else if !strings.Contains(detail, tt.detailMatch) {
+				t.Errorf("detail = %q, want substring %q", detail, tt.detailMatch)
+			}
+		})
+	}
+}
+
 func TestComputeCoverage(t *testing.T) {
 	t.Run("nil result yields zero coverage", func(t *testing.T) {
 		if got := computeCoverage(nil); !reflect.DeepEqual(got, DeclaredCoverage{}) {
@@ -244,9 +347,12 @@ func TestComputeEmbeddedCatalog(t *testing.T) {
 		if state == StatusPass {
 			sawPass = true
 			// A cleanly-resolved leaf is a pure-readable result, so chart_pinned
-			// must have been scored.
+			// and constraints_wellformed must both have been scored.
 			if _, ok := combo.Structure.Dimensions[DimChartPinned]; !ok {
 				t.Errorf("combo %q resolved but missing chart_pinned dimension", combo.LeafOverlay)
+			}
+			if _, ok := combo.Structure.Dimensions[DimConstraintsWellformed]; !ok {
+				t.Errorf("combo %q resolved but missing constraints_wellformed dimension", combo.LeafOverlay)
 			}
 		}
 	}
@@ -431,6 +537,147 @@ components:
 	// The recipe resolved, so the descriptor must be populated (non-nil).
 	if combo.Structure.Coverage == nil {
 		t.Error("Coverage = nil, want non-nil on a resolved recipe")
+	}
+}
+
+// TestComputeConstraintsWellformedFailThroughBuilder drives a
+// constraints_wellformed fail through the real builder: a leaf carrying a
+// malformed constraint (a path with too few segments). The recipe resolves
+// cleanly (resolves=pass) but the snapshot-free parser rejects the constraint,
+// so constraints_wellformed must fail and drag the rolled-up status to fail —
+// a malformed constraint is never a silent pass. Hermetic: no snapshot.
+func TestComputeConstraintsWellformedFailThroughBuilder(t *testing.T) {
+	provider := newInMemoryProvider(map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/malformed-constraint-leaf.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: malformed-constraint-leaf
+spec:
+  criteria:
+    service: eks
+  componentRefs: []
+  constraints:
+    - name: not-a-valid-path
+      value: ">= 1.0"
+`),
+		"registry.yaml": []byte(`apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components: []
+`),
+	})
+
+	report, err := Compute(context.Background(), Options{Provider: provider})
+	if err != nil {
+		t.Fatalf("Compute() error = %v", err)
+	}
+
+	var combo *ComboHealth
+	for i := range report.Combos {
+		if report.Combos[i].LeafOverlay == "malformed-constraint-leaf" {
+			combo = &report.Combos[i]
+		}
+	}
+	if combo == nil {
+		t.Fatalf("malformed-constraint-leaf was not enumerated; combos = %+v", report.Combos)
+	}
+	if got := combo.Structure.Dimensions[DimResolves]; got != StatusPass {
+		t.Errorf("resolves = %q, want %q (recipe should resolve cleanly)", got, StatusPass)
+	}
+	if got := combo.Structure.Dimensions[DimConstraintsWellformed]; got != StatusFail {
+		t.Errorf("constraints_wellformed = %q, want %q (malformed constraint path)", got, StatusFail)
+	}
+	if combo.Structure.Status != StatusFail {
+		t.Errorf("status = %q, want %q", combo.Structure.Status, StatusFail)
+	}
+	if d := combo.Structure.Detail[DimConstraintsWellformed]; !strings.Contains(d, "not-a-valid-path") {
+		t.Errorf("detail = %q, want it to name the malformed constraint", d)
+	}
+}
+
+// TestComputeAllDimensionsCoexistAndRollUpClean proves the end-to-end
+// four-signal contract on one resolved leaf: the three graded dimensions
+// (resolves, chart_pinned, constraints_wellformed) all pass, the
+// declared_coverage descriptor is populated (not graded), and the rollup is
+// pass. A pinned Helm component, a well-formed constraint, and a declared
+// deployment phase are all present.
+func TestComputeAllDimensionsCoexistAndRollUpClean(t *testing.T) {
+	provider := newInMemoryProvider(map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/clean-leaf.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: clean-leaf
+spec:
+  criteria:
+    service: eks
+  componentRefs:
+    - name: pinned-helm
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.32.4"
+  validation:
+    deployment:
+      checks:
+        - operator-health
+`),
+		"registry.yaml": []byte(`apiVersion: aicr.nvidia.com/v1alpha1
+kind: ComponentRegistry
+components:
+  - name: pinned-helm
+    displayName: Pinned Helm Component
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/pinned-helm
+      defaultVersion: 1.2.3
+`),
+	})
+
+	report, err := Compute(context.Background(), Options{Provider: provider})
+	if err != nil {
+		t.Fatalf("Compute() error = %v", err)
+	}
+
+	var combo *ComboHealth
+	for i := range report.Combos {
+		if report.Combos[i].LeafOverlay == "clean-leaf" {
+			combo = &report.Combos[i]
+		}
+	}
+	if combo == nil {
+		t.Fatalf("clean-leaf was not enumerated; combos = %+v", report.Combos)
+	}
+
+	for _, dim := range []string{DimResolves, DimChartPinned, DimConstraintsWellformed} {
+		if got := combo.Structure.Dimensions[dim]; got != StatusPass {
+			t.Errorf("dimension %q = %q, want %q", dim, got, StatusPass)
+		}
+	}
+	if combo.Structure.Status != StatusPass {
+		t.Errorf("status = %q, want %q (all graded dimensions pass)", combo.Structure.Status, StatusPass)
+	}
+	// declared_coverage is a descriptor, not graded: it must be populated but
+	// must not move the rolled-up status.
+	if combo.Structure.Coverage == nil {
+		t.Fatal("Coverage = nil, want populated descriptor on a resolved leaf")
+	}
+	if !combo.Structure.Coverage.Deployment.Declared {
+		t.Error("Coverage.Deployment.Declared = false, want true (deployment phase declared)")
+	}
+	if want := []string{"operator-health"}; !reflect.DeepEqual(combo.Structure.Coverage.Deployment.Checks, want) {
+		t.Errorf("Coverage.Deployment.Checks = %v, want %v", combo.Structure.Coverage.Deployment.Checks, want)
 	}
 }
 

--- a/pkg/recipe/builder.go
+++ b/pkg/recipe/builder.go
@@ -121,8 +121,8 @@ func (b *Builder) BuildFromCriteria(ctx context.Context, c *Criteria) (*RecipeRe
 //   - Constraint warnings are included in the result metadata for visibility
 //   - Only overlays whose constraints pass (or have no constraints) are merged
 //
-// The evaluator function is typically created by wrapping validator.EvaluateConstraint
-// with the snapshot data.
+// The evaluator function is typically created by wrapping
+// constraints.Evaluate, binding it to the snapshot data (see pkg/client/v1).
 func (b *Builder) BuildFromCriteriaWithEvaluator(ctx context.Context, c *Criteria, evaluator ConstraintEvaluatorFunc) (*RecipeResult, error) {
 	return b.buildWithStore(ctx, c, func(store *MetadataStore, buildCtx context.Context) (*RecipeResult, error) {
 		return store.BuildRecipeResultWithEvaluator(buildCtx, c, evaluator)


### PR DESCRIPTION
## Summary

Adds the third graded health signal, `constraints_wellformed`, to `pkg/health`. It grades every leaf recipe on parse-only constraint well-formedness — fully hermetic (no snapshot, no cluster, no network).

## Motivation / Context

ADR-009 (Recipe Health Tracking, V1) calls for a graded `constraints_wellformed` signal. The ADR's original phrasing ("inline replay under `--no-cluster` is clean") is not achievable offline: the only evaluator (`constraints.Evaluate`) extracts a snapshot value *before* parsing and rejects a nil snapshot, so with no snapshot there is no clean replay to run. The V1 signal is therefore **parse-only well-formedness**; snapshot-dependent constraint replay is explicitly deferred to the validation/evidence axis (`coverage_declared_vs_run`).

Fixes: #1227
Related: #1224 (epic), #1225 / #1226 (deps), #1228 / #1229 (consumers)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/health` (structural health scoring)

## Implementation Notes

- **Primary (graded `fail`):** for every merged `Constraint`, `classifyConstraintsWellformed` calls the exported, snapshot-free parsers directly — `constraints.ParseConstraintPath(c.Name)` and `constraints.ParseConstraintExpression(c.Value)`. Any parse failure is `fail`, naming the offending constraint and parser error in `Detail`. A malformed constraint is never a silent `pass`.
- **Secondary (graded `warn`):** the leaf is resolved through `BuildFromCriteriaWithEvaluator` with an injected satisfied-stub evaluator (`satisfiedEvaluator`) so the constraint-aware path executes with no cluster data; any resulting `ConstraintWarnings`/`ExcludedOverlays` surface as `warn`. NOTE: those fields are only populated on a non-passing verdict, so under the satisfied stub the warn branch does not fire today — composition problems surface instead as resolve errors. The branch is the correct reading of a resolved result, is forward-compatible with a future evaluator wired into this path, and is unit-tested via direct injection. This is documented honestly in the code/doc comments.
- **Single build:** `computeCombo` now resolves once via `BuildFromCriteriaWithEvaluator(satisfiedEvaluator)`. With every constraint satisfied this merges exactly the overlays `BuildFromCriteria` would (no cluster-dependent exclusions), so the existing `resolves`/`chart_pinned` grades are unchanged while the result additionally carries the merged constraints and any warnings the new signal reads.
- **Seam:** no `pkg/validator` import — acyclic integration is `pkg/health → pkg/constraints → pkg/recipe`.
- **Drive-by (separate commit):** fixed a stale `pkg/recipe/builder.go` doc comment that referenced a non-existent `validator.EvaluateConstraint`; the real mechanism is `constraints.Evaluate` (see `pkg/client/v1`). Flagged in the issue.
- **Docs:** updated `pkg/health/doc.go` and synced the now-inaccurate ADR-009 spec-table row + compute-budget premise (the ADR still described the superseded `--no-cluster` replay design).

This change went through a four-persona agent review (architect/correctness, determinism, test/QA, docs/consistency); their convergent finding — that the `warn` branch is inert under the satisfied stub while the comments overclaimed it — was addressed by making every comment honest and keeping the (correct, forward-compatible, unit-tested) wiring.

## Testing

```bash
CGO_ENABLED=1 go test -race ./pkg/health/...      # ok
golangci-lint run -c .golangci.yaml ./pkg/health/... ./pkg/recipe/...   # 0 issues
go vet ./pkg/health/... && go build ./...          # clean
```

- All `pkg/health` tests pass under `-race` (new: table-driven `TestClassifyConstraintsWellformed`, end-to-end `TestComputeConstraintsWellformedFailThroughBuilder`, four-signal `TestComputeAllDimensionsCoexistAndRollUpClean`).
- Coverage `pkg/health`: 97.6% → 98.0% (+0.4%); all new functions at 100%.

## Risk Assessment

- [x] **Low** — Additive structural signal in an offline scoring package not yet wired into CLI/API (consumers are #1228/#1229). Existing graded dimensions verified unchanged. Easy to revert.

**Rollout notes:** N/A — no user-facing surface changes; hermetic and deterministic.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
