### PR TITLE
feat(recipes): add A100 EKS training Kubeflow overlay chain

### DIFF
--- a/recipes/overlays/a100-eks-training.yaml
+++ b/recipes/overlays/a100-eks-training.yaml
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-eks-training
+
+spec:
+  # Inherits from eks-training recipe (EKS + training settings)
+  base: eks-training
+
+  criteria:
+    service: eks
+    accelerator: a100
+    intent: training
+
+  # Specific constraints for A100 on EKS training workloads.
+  # A100 has no IMEX/NVLink ComputeDomain requirement, so the recipe keeps
+  # the EKS training baseline rather than the H100/H200 1.32.4 floor.
+  # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs:
+    # A100-specific GPU Operator overrides (inherits valuesFile from eks-training).
+    - name: gpu-operator
+      type: Helm
+      dependencyRefs:
+        - nfd
+        - cert-manager
+        - kube-prometheus-stack
+        - nodewright-customizations
+      overrides:
+        cdi:
+          enabled: true
+        gdrcopy:
+          enabled: true
+
+    # A100 reuses the h100 nodewright tuning profile (tuning.yaml). nvidia-setup
+    # ships baked-in (service, accelerator) configs only for eks-h100 /
+    # eks-gb200, with no separate A100 target — but per the nodewright
+    # maintainer the h100 tuning is the correct profile for A100 on EKS/GKE:
+    # the A100-vs-H100 deltas in the DGX Base OS tunings pertain only to
+    # baremetal and do not apply in EKS/GKE, so h100 is effectively the A100
+    # tuning here. This mirrors h200-eks-training, which reuses the h100 profile
+    # the same way. The recipe criteria above stays a100; only this tuning
+    # profile selector is h100.
+    - name: nodewright-customizations
+      type: Helm
+      manifestFiles:
+        - components/nodewright-customizations/manifests/tuning.yaml
+      overrides:
+        service: eks
+        accelerator: h100
+        intent: multiNodeTraining
+      dependencyRefs:
+        - nodewright-operator
+
+    - name: nfd
+      type: Helm
+      overrides:
+        topologyUpdater:
+          enable: true
+
+  # Validation checks for A100 on EKS training workloads.
+  # Defined at the intent layer (not OS-specific) so all OS variants inherit them.
+  #
+  # The deployment-phase floor (4 standard checks + gpu-operator version pin)
+  # is contributed by the a100-any cross-cutting overlay and is not duplicated
+  # here.
+  #
+  # Performance gating is intentionally omitted until an empirical A100-on-EKS
+  # NCCL baseline is established. The H100/H200 EKS training overlays pin an
+  # absolute nccl-all-reduce-bw floor (>= 300) calibrated on 8-GPU Hopper
+  # NVLink nodes with EFA; that value is neither fabric-class aware
+  # (https://github.com/NVIDIA/aicr/issues/1256) nor valid for A100, so
+  # carrying it would only false-fail healthy runs.
+  validation:
+    conformance:
+      checks:
+        - platform-health
+        - gpu-operator-health
+        - dra-support
+        - accelerator-metrics
+        - ai-service-metrics
+        - gang-scheduling
+        - pod-autoscaling
+        - cluster-autoscaling
+        - robust-controller
+        - secure-accelerator-access

--- a/recipes/overlays/a100-eks-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/a100-eks-ubuntu-training-kubeflow.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-eks-ubuntu-training-kubeflow
+
+spec:
+  # Inherits from a100-eks-ubuntu-training recipe (A100 + EKS + Ubuntu + training settings)
+  # This overlay adds Kubeflow Training Operator for distributed training with TrainJob
+  base: a100-eks-ubuntu-training
+
+  criteria:
+    service: eks
+    accelerator: a100
+    os: ubuntu
+    intent: training
+    platform: kubeflow
+
+  # Ubuntu OS constraints + Kubeflow trainer via mixins
+  mixins:
+    - os-ubuntu
+    - platform-kubeflow
+
+  # A100 + EKS specific constraints (not covered by mixin)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs: []

--- a/recipes/overlays/a100-eks-ubuntu-training.yaml
+++ b/recipes/overlays/a100-eks-ubuntu-training.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: a100-eks-ubuntu-training
+
+spec:
+  # Inherits from a100-eks-training recipe (A100 + EKS + training settings)
+  # This overlay adds Ubuntu-specific configurations
+  base: a100-eks-training
+
+  criteria:
+    service: eks
+    accelerator: a100
+    os: ubuntu
+    intent: training
+
+  # Ubuntu OS constraints via mixin (defined once in recipes/mixins/os-ubuntu.yaml)
+  mixins:
+    - os-ubuntu
+
+  # A100 + EKS specific constraints (not covered by mixin)
+  constraints:
+    - name: K8s.server.version
+      value: ">= 1.30"
+
+  componentRefs: []
+
+  # Validation is inherited from a100-eks-training (not OS-specific)


### PR DESCRIPTION
## Summary

Add **A100 EKS** overlays (issue #1002): the EKS Ubuntu **Kubeflow training** leaf plus its ancestor chain and the cross-cutting deployment-phase floor. Modeled on the H100/H200 EKS training overlays.

## Motivation / Context

`a100` is a declared accelerator in `pkg/recipe/criteria.go` but has zero overlays in `recipes/overlays/`, so `aicr recipe --accelerator a100 --service eks ...` cannot resolve. Companion to the A100 OKE (#1294) and AKS (#1295) PRs; this slice covers EKS.

Fixes: N/A (incremental — part of #1002)
Related: #1002, #1294, #1295, #1306, #969, #1256

**A100 overlay series — tracked in #1002:** #1294 (OKE) · #1295 (AKS) · #1305 (EKS) ← this PR · #1306 (GKE)

> **Coordination:** `a100-any.yaml` (the cross-service A100 deployment floor) is byte-identical across #1294, #1295, and this PR. Only one needs to introduce it — whichever lands first, the others drop the duplicate on rebase.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

New overlays (reuse existing `eks`/`eks-training` parents and `values-eks-training.yaml` — no new component values files):

- **`a100-any`** — deployment-phase floor: 4 standard checks + `Deployment.gpu-operator.version >= v24.6.0` (H100/H200-generation baseline; A100 operator-supported since v22.9).
- **`a100-eks-training`** — `base: eks-training`; `K8s >= 1.30`. A100 has no NVLink ComputeDomain requirement, so it keeps the EKS training baseline rather than H100/H200's `1.32.4`. gpu-operator `cdi` + `gdrcopy`, nfd `topologyUpdater`. Conformance mirrors the H100/H200 EKS training set.
- **`a100-eks-ubuntu-training`** — `+ os-ubuntu` mixin.
- **`a100-eks-ubuntu-training-kubeflow`** — `+ platform-kubeflow` (Kubeflow Trainer for distributed `TrainJob`).

Key decisions documented in-file:

- **Nodewright tuning reuses the h100 profile** (`tuning.yaml`, `accelerator: h100`), mirroring `h200-eks-training`. `nvidia-setup` ships baked-in profiles only for `eks-h100` / `eks-gb200`, with no separate A100 target — but per the nodewright maintainer the A100-vs-H100 deltas in the DGX Base OS tunings pertain only to baremetal and do not apply in EKS/GKE, so h100 is the correct tuning profile for A100 here. The recipe criteria stays `a100`; only the tuning profile selector is `h100`.

- **Performance gating intentionally omitted.** The H100/H200 EKS sibling pins `nccl-all-reduce-bw >= 300`, calibrated on 8-GPU Hopper NVLink nodes with EFA — neither fabric-class aware (#1256) nor valid for A100. An A100-on-EKS NCCL baseline is deferred to a follow-up.

## Testing

```bash
go test ./pkg/recipe/...                 # PASS (incl. TestOverlayValidationPhaseFloor auto-discovery)
yamllint recipes/overlays/a100-*.yaml    # clean
# End-to-end resolution of the new leaf:
aicr recipe --service eks --accelerator a100 --os ubuntu --intent training --platform kubeflow
#   -> components=14 overlays=8; K8s '>= 1.30'; Deployment.gpu-operator.version '>= v24.6.0';
#      kubeflow-trainer present; nodewright-customizations renders tuning-generic (accelerator=generic);
#      gpu-operator inherits values-eks-training.yaml
```

Full `make qualify` not required: this touches **only YAML overlay files** (zero `.go` changes), so the Go lint/test/e2e gates cannot regress from it. The embedded overlays are exercised by `go test ./pkg/recipe/...` (passes) and yamllint (clean). No `docs/` page enumerates individual overlay leaves, so no doc update is needed.

## Risk Assessment

- [x] **Low** — Additive overlays only; no existing recipe or Go path changes. Easy to revert.

**Rollout notes:** Additive. Other A100 EKS leaves (plain training, inference, dynamo) and remaining services tracked under #1002.

## Checklist

- [x] Tests pass locally (`go test ./pkg/recipe/...`)
- [x] Linter passes (yamllint clean; no `.go` files changed)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (covered by existing auto-discovery `TestOverlayValidationPhaseFloor`)
- [x] I updated docs if user-facing behavior changed (N/A — no leaf enumeration in docs)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

