### PR TITLE
refactor(health): share declared-coverage Compact() across matrix and CLI

### DIFF
--- a/pkg/cli/recipe_list.go
+++ b/pkg/cli/recipe_list.go
@@ -330,12 +330,7 @@ func compactCoverage(c *health.DeclaredCoverage) string {
 	if c == nil {
 		return healthNotApplicable
 	}
-	return fmt.Sprintf("R:%d D:%d P:%d C:%d",
-		len(c.Readiness.Checks),
-		len(c.Deployment.Checks),
-		len(c.Performance.Checks),
-		len(c.Conformance.Checks),
-	)
+	return c.Compact()
 }
 
 // orAny returns s if non-empty, otherwise the wildcard placeholder.

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -112,6 +112,24 @@ type DeclaredCoverage struct {
 	Conformance PhaseCoverage `json:"conformance" yaml:"conformance"`
 }
 
+// Compact renders the per-phase declared-check counts as a single line in
+// phase order — readiness, deployment, performance, conformance — e.g.
+// "R:2 D:4 P:1 C:10". It is the single source of truth for this format,
+// shared by the recipe-health matrix (tools/health) and the `aicr recipe
+// list` table (pkg/cli) so the two cannot drift. The caller owns the nil
+// case: a nil *DeclaredCoverage means coverage is unknown (the recipe did
+// not resolve), which each surface renders with its own placeholder rather
+// than a misleading all-zero block, so this method is only valid on a
+// non-nil receiver.
+func (c *DeclaredCoverage) Compact() string {
+	return fmt.Sprintf("R:%d D:%d P:%d C:%d",
+		len(c.Readiness.Checks),
+		len(c.Deployment.Checks),
+		len(c.Performance.Checks),
+		len(c.Conformance.Checks),
+	)
+}
+
 // StructureHealth is the structural-soundness axis for one recipe.
 type StructureHealth struct {
 	// Status is the rolled-up verdict: pass | warn | fail | unknown (held).

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -337,6 +337,48 @@ func TestComputeCoverage(t *testing.T) {
 	})
 }
 
+// TestDeclaredCoverageCompact pins the byte-exact R/D/P/C format shared by the
+// recipe-health matrix (tools/health) and the `aicr recipe list` table
+// (pkg/cli). The format must not drift: the committed matrix and the
+// determinism/golden tests depend on it.
+func TestDeclaredCoverageCompact(t *testing.T) {
+	tests := []struct {
+		name     string
+		cov      DeclaredCoverage
+		expected string
+	}{
+		{
+			name:     "zero value",
+			cov:      DeclaredCoverage{},
+			expected: "R:0 D:0 P:0 C:0",
+		},
+		{
+			name: "all phases populated",
+			cov: DeclaredCoverage{
+				Readiness:   PhaseCoverage{Checks: []string{"a", "b"}},
+				Deployment:  PhaseCoverage{Checks: []string{"a", "b", "c", "d"}},
+				Performance: PhaseCoverage{Checks: []string{"a"}},
+				Conformance: PhaseCoverage{Checks: make([]string, 10)},
+			},
+			expected: "R:2 D:4 P:1 C:10",
+		},
+		{
+			name: "counts only Checks, not Declared or Constraints",
+			cov: DeclaredCoverage{
+				Deployment: PhaseCoverage{Declared: true, Constraints: 5},
+			},
+			expected: "R:0 D:0 P:0 C:0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cov.Compact(); got != tt.expected {
+				t.Errorf("Compact() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestComputeEmbeddedCatalog resolves the real embedded catalog: every leaf
 // must carry a resolves dimension and a status consistent with the rollup of
 // its dimensions, and at least one leaf must resolve cleanly. Cleanly-resolved

--- a/tools/health/markdown.go
+++ b/tools/health/markdown.go
@@ -156,10 +156,5 @@ func coverageCell(cov *health.DeclaredCoverage) string {
 	if cov == nil {
 		return "—"
 	}
-	return fmt.Sprintf("R:%d D:%d P:%d C:%d",
-		len(cov.Readiness.Checks),
-		len(cov.Deployment.Checks),
-		len(cov.Performance.Checks),
-		len(cov.Conformance.Checks),
-	)
+	return cov.Compact()
 }


### PR DESCRIPTION
## Summary

Consolidate the duplicated compact declared-coverage formatter (`R:n D:n P:n C:n`) into a single shared `(*DeclaredCoverage).Compact()` helper in `pkg/health`, and repoint both render sites at it so the recipe-health matrix and the `aicr recipe list` table cannot drift.

## Motivation / Context

Follow-up from the #1304 review. The compact per-phase coverage string was rendered by two independent `fmt.Sprintf` copies — `coverageCell()` in `tools/health/markdown.go` (#1304) and `compactCoverage()` in `pkg/cli/recipe_list.go` (#1302) — that had to be kept in sync by hand (phase order, separators). Both #1302 and #1304 have now merged, so this is the natural point to consolidate.

Fixes: #1312
Related: #1302, #1304

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/health`
- [x] Other: `tools/health`

## Implementation Notes

- New `func (c *DeclaredCoverage) Compact() string` in `pkg/health/health.go` is the single source of truth for the `R:n D:n P:n C:n` format (phase order: readiness, deployment, performance, conformance).
- Each call site keeps its **own** nil placeholder — em dash `—` in the matrix vs `healthNotApplicable` in the CLI table — so nil-handling stays at the callers and `Compact()` is defined only on a non-nil receiver (documented in the godoc).
- Pure refactor: the rendered string is **byte-identical**, so the committed matrix and the determinism/golden tests are unaffected.

## Testing

```bash
go build ./...
go vet ./pkg/health/... ./pkg/cli/... ./tools/health/...
go test ./pkg/health/... ./pkg/cli/... ./tools/health/...
golangci-lint run -c .golangci.yaml ./pkg/health/... ./pkg/cli/... ./tools/health/...   # pinned v2.12.2
```

- All three packages: `ok`. Linter: **0 issues**. Build/vet clean.
- Added table-driven `TestDeclaredCoverageCompact` pinning the phase order (distinct `2/4/1/10` counts guard against a P/C transposition) and that only per-phase `Checks` are counted (not `Declared`/`Constraints`).
- Race detector (`-race`) deferred to CI (no C compiler in the local env); the change introduces no concurrency.

## Risk Assessment

- [x] **Low** — Isolated, behavior-preserving refactor with byte-identical output; trivial to revert.

**Rollout notes:** N/A — no behavior change, no migration.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — `-race` deferred to CI (no local C compiler); non-race tests pass
- [x] Linter passes (`make lint`) — pinned golangci-lint v2.12.2, 0 issues
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (internal refactor, output byte-identical)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
