### PR TITLE
feat(cli): add --no-health opt-out to recipe list

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -564,6 +564,7 @@ aicr recipe list [flags]
 | `--platform` | | string | | Filter by platform/framework type (e.g. dynamo, kubeflow, nim) |
 | `--format` | `-t` | string | table | Output format: json, yaml, table |
 | `--data` | | string | | External data directory to include alongside embedded overlays |
+| `--no-health` | `--skip-health` | bool | false | Skip per-leaf structural-health computation; render only the enumeration columns/fields |
 
 Filter flags narrow the output to overlays whose criteria carry that exact value.
 Unspecified flags match all overlays for that dimension. Multiple filters are combined
@@ -588,6 +589,14 @@ Conformance). Non-leaf overlays render `-` in both columns. A dimension whose
 grader cannot reach a confident verdict surfaces as `unknown`, and the status
 column still renders.
 
+Resolving every leaf overlay to compute its health verdict adds latency on each
+invocation. For purely interactive "what overlays exist?" lookups — or scripted
+callers that only consume `name`/`criteria`/`is_leaf`/`source` — pass
+`--no-health` (alias `--skip-health`) to skip the health computation entirely.
+With the flag set the `table` format omits the `STATUS`/`COVERAGE` columns and
+the `json`/`yaml` formats omit the `health` block, leaving only the enumeration
+columns/fields.
+
 **Examples:**
 
 ```shell
@@ -605,6 +614,9 @@ aicr recipe list --accelerator h100 --format json
 
 # Include external overlays from a custom data directory
 aicr recipe list --data /etc/aicr/custom-recipes --format yaml
+
+# Skip the structural-health computation for a faster enumeration-only listing
+aicr recipe list --no-health
 ```
 
 **Example table output:**

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -35,6 +35,7 @@ const (
 	flagIntent      = "intent"
 	flagOS          = "os"
 	flagPlatform    = "platform"
+	flagNoHealth    = "no-health"
 )
 
 // criteriaAny is the wildcard value for any criteria dimension.

--- a/pkg/cli/recipe_list.go
+++ b/pkg/cli/recipe_list.go
@@ -116,6 +116,12 @@ Include overlays from an external data directory:
 				Usage:    "Output format (json, yaml, table)",
 				Category: catOutput,
 			}, func() []string { return []string{"json", "yaml", "table"} }),
+			&cli.BoolFlag{
+				Name:     flagNoHealth,
+				Aliases:  []string{"skip-health"},
+				Usage:    "Skip per-leaf structural-health computation. Omits the STATUS/COVERAGE table columns and the health block in json/yaml output.",
+				Category: catOutput,
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if err := validateSingleValueFlags(cmd, flagService, flagAccelerator, flagIntent, flagOS, flagPlatform, flagFormat); err != nil {
@@ -151,20 +157,30 @@ Include overlays from an external data directory:
 					fmt.Sprintf("unknown output format %q, valid formats are: json, yaml, table", cmd.String(flagFormat)))
 			}
 
-			// Delegate the structural-health computation to pkg/health (via the
-			// facade, which binds this Client's own provider so --data overlays
-			// are scored). Health is keyed by leaf overlay name so each catalog
-			// entry can be paired with its verdict during rendering.
-			report, err := client.ComputeHealth(ctx, filter)
-			if err != nil {
-				return err
-			}
-			healthByName := make(map[string]*health.StructureHealth, len(report.Combos))
-			for i := range report.Combos {
-				healthByName[report.Combos[i].LeafOverlay] = &report.Combos[i].Structure
+			// The --no-health opt-out skips the per-leaf structural-health
+			// computation entirely and renders the pre-#1228 catalog shape (no
+			// STATUS/COVERAGE columns, no health block). A nil healthByName map
+			// signals writeCatalogEntries to drop the health axis.
+			showHealth := !cmd.Bool(flagNoHealth)
+
+			var healthByName map[string]*health.StructureHealth
+			if showHealth {
+				// Delegate the structural-health computation to pkg/health (via
+				// the facade, which binds this Client's own provider so --data
+				// overlays are scored). Health is keyed by leaf overlay name so
+				// each catalog entry can be paired with its verdict during
+				// rendering.
+				report, err := client.ComputeHealth(ctx, filter)
+				if err != nil {
+					return err
+				}
+				healthByName = make(map[string]*health.StructureHealth, len(report.Combos))
+				for i := range report.Combos {
+					healthByName[report.Combos[i].LeafOverlay] = &report.Combos[i].Structure
+				}
 			}
 
-			return writeCatalogEntries(ctx, cmd, entries, healthByName, format)
+			return writeCatalogEntries(ctx, cmd, entries, healthByName, showHealth, format)
 		},
 	}
 }
@@ -232,7 +248,12 @@ func buildCatalogFilter(cmd *cli.Command, client *aicr.Client) (*aicr.Criteria, 
 // json/yaml emit the full per-dimension status map and declared_coverage under
 // a health object; table renders a compact structural status column and an
 // R/D/P/C coverage summary.
-func writeCatalogEntries(ctx context.Context, cmd *cli.Command, entries []aicr.CatalogEntry, healthByName map[string]*health.StructureHealth, format serializer.Format) error {
+//
+// When showHealth is false (the --no-health opt-out), the health axis is
+// dropped entirely: the table omits the STATUS/COVERAGE columns and json/yaml
+// omit the health block, reproducing the pre-#1228 catalog shape. healthByName
+// is nil in that case.
+func writeCatalogEntries(ctx context.Context, cmd *cli.Command, entries []aicr.CatalogEntry, healthByName map[string]*health.StructureHealth, showHealth bool, format serializer.Format) error {
 	w := cmd.Root().Writer
 
 	switch format {
@@ -256,12 +277,31 @@ func writeCatalogEntries(ctx context.Context, cmd *cli.Command, entries []aicr.C
 
 	case serializer.FormatTable:
 		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		if _, err := fmt.Fprintln(tw, "NAME\tSERVICE\tACCELERATOR\tINTENT\tOS\tPLATFORM\tIS_LEAF\tSTATUS\tCOVERAGE\tSOURCE"); err != nil {
+		header := "NAME\tSERVICE\tACCELERATOR\tINTENT\tOS\tPLATFORM\tIS_LEAF\tSTATUS\tCOVERAGE\tSOURCE"
+		if !showHealth {
+			header = "NAME\tSERVICE\tACCELERATOR\tINTENT\tOS\tPLATFORM\tIS_LEAF\tSOURCE"
+		}
+		if _, err := fmt.Fprintln(tw, header); err != nil {
 			return errors.Wrap(errors.ErrCodeInternal, "failed to write table header", err)
 		}
 		for _, e := range entries {
 			if err := ctx.Err(); err != nil {
 				return errors.Wrap(errors.ErrCodeTimeout, "write canceled", err)
+			}
+			if !showHealth {
+				if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%v\t%s\n",
+					e.Name,
+					orAny(e.Criteria.Service),
+					orAny(e.Criteria.Accelerator),
+					orAny(e.Criteria.Intent),
+					orAny(e.Criteria.OS),
+					orAny(e.Criteria.Platform),
+					e.IsLeaf,
+					e.Source,
+				); err != nil {
+					return errors.Wrap(errors.ErrCodeInternal, "failed to write table row", err)
+				}
+				continue
 			}
 			h := healthByName[e.Name]
 			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%v\t%s\t%s\t%s\n",

--- a/pkg/cli/recipe_list_test.go
+++ b/pkg/cli/recipe_list_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/aicr/pkg/health"
 )
@@ -220,6 +221,134 @@ func TestRecipeList_EmptyResult(t *testing.T) {
 	out := runRecipeList(t, "--service", "eks", "--accelerator", "gb200", "--os", "cos")
 	if !strings.Contains(out, "(no matching overlays)") {
 		t.Errorf("expected empty-result message, got:\n%s", out)
+	}
+}
+
+// TestRecipeList_EmptyResultNoHealth exercises the empty + --no-health
+// intersection: the nil healthByName map must not panic when there are zero
+// rows, and the empty-overlays message still renders.
+func TestRecipeList_EmptyResultNoHealth(t *testing.T) {
+	out := runRecipeList(t, "--no-health", "--service", "eks", "--accelerator", "gb200", "--os", "cos")
+	if !strings.Contains(out, "(no matching overlays)") {
+		t.Errorf("expected empty-result message, got:\n%s", out)
+	}
+	if strings.Contains(firstLine(out), "STATUS") {
+		t.Errorf("--no-health empty result should omit the STATUS column; got header: %s", firstLine(out))
+	}
+}
+
+// TestRecipeList_NoHealthTable asserts --no-health renders the pre-#1228 table
+// shape: the STATUS/COVERAGE columns are gone and every row carries exactly the
+// eight #1208 columns, with no coverage/status tokens leaking in.
+func TestRecipeList_NoHealthTable(t *testing.T) {
+	out := runRecipeList(t, "--no-health")
+
+	header := firstLine(out)
+	for _, col := range []string{"NAME", "IS_LEAF", "SOURCE"} {
+		if !strings.Contains(header, col) {
+			t.Errorf("table header missing %q column; got: %s", col, header)
+		}
+	}
+	for _, col := range []string{"STATUS", "COVERAGE"} {
+		if strings.Contains(header, col) {
+			t.Errorf("--no-health header should omit %q column; got: %s", col, header)
+		}
+	}
+	// No compact coverage cell should appear anywhere in the body.
+	if strings.Contains(out, "R:") || strings.Contains(out, "C:") {
+		t.Errorf("--no-health output leaked a coverage cell:\n%s", out)
+	}
+	// A stable leaf row ("gb200-any") must collapse to exactly 8 fields.
+	row := lineContaining(out, "gb200-any ")
+	if row == "" {
+		t.Fatalf("expected a gb200-any row in --no-health output:\n%s", out)
+	}
+	if got := len(strings.Fields(row)); got != 8 {
+		t.Fatalf("expected 8 columns in --no-health row, got %d: %q", got, row)
+	}
+}
+
+// TestRecipeList_NoHealthSkipFlagAlias confirms the --skip-health alias is wired
+// to the same flag as --no-health and produces byte-identical output.
+func TestRecipeList_NoHealthSkipFlagAlias(t *testing.T) {
+	alias := runRecipeList(t, "--skip-health")
+	primary := runRecipeList(t, "--no-health")
+	if alias != primary {
+		t.Errorf("--skip-health output should equal --no-health output\nalias:\n%s\nprimary:\n%s", alias, primary)
+	}
+	if strings.Contains(firstLine(alias), "STATUS") {
+		t.Errorf("--skip-health should omit the STATUS column; got header: %s", firstLine(alias))
+	}
+}
+
+// TestRecipeList_NoHealthJSON asserts --no-health drops the health block from
+// every json entry — including leaves that would otherwise carry one — yielding
+// the pre-#1228 shape (#1208 fields only).
+func TestRecipeList_NoHealthJSON(t *testing.T) {
+	out := runRecipeList(t, "--no-health", "--format", "json")
+
+	if strings.Contains(out, "\"health\"") {
+		t.Errorf("--no-health json must not contain a health block:\n%s", out)
+	}
+
+	var entries []struct {
+		Name   string                  `json:"name"`
+		IsLeaf bool                    `json:"is_leaf"`
+		Source string                  `json:"source"`
+		Health *health.StructureHealth `json:"health"`
+	}
+	if err := json.Unmarshal([]byte(out), &entries); err != nil {
+		t.Fatalf("unmarshal json output: %v\n%s", err, out)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one catalog entry")
+	}
+	var sawLeaf bool
+	for _, e := range entries {
+		if e.Name == "" || e.Source == "" {
+			t.Errorf("entry missing #1208 name/source field: %+v", e)
+		}
+		if e.IsLeaf {
+			sawLeaf = true
+		}
+		if e.Health != nil {
+			t.Errorf("--no-health entry %q should carry no health block", e.Name)
+		}
+	}
+	if !sawLeaf {
+		t.Fatal("expected at least one leaf entry to confirm health is suppressed even for leaves")
+	}
+}
+
+// TestRecipeList_NoHealthYAML asserts --no-health drops the health block from
+// the yaml output while keeping the #1208 fields at the top level. It decodes
+// the YAML and asserts no entry carries a "health" key (rather than a fragile
+// substring scan), and that at least one leaf entry is present — so the test
+// fails loudly if the catalog ever renders empty.
+func TestRecipeList_NoHealthYAML(t *testing.T) {
+	out := runRecipeList(t, "--no-health", "--format", "yaml")
+
+	var entries []map[string]any
+	if err := yaml.Unmarshal([]byte(out), &entries); err != nil {
+		t.Fatalf("unmarshal yaml output: %v\n%s", err, out)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one catalog entry in yaml output")
+	}
+	var sawLeaf bool
+	for _, e := range entries {
+		if _, ok := e["health"]; ok {
+			t.Errorf("--no-health yaml entry %v must not carry a health key", e["name"])
+		}
+		if e["name"] == nil || e["source"] == nil {
+			t.Errorf("yaml entry missing #1208 name/source field: %v", e)
+		}
+		if leaf, _ := e["is_leaf"].(bool); leaf {
+			sawLeaf = true
+		}
+	}
+	if !sawLeaf {
+		t.Fatal("expected at least one leaf entry to confirm health is suppressed even for leaves")
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a `--no-health` (alias `--skip-health`) opt-out flag to `aicr recipe list` that skips the per-leaf structural-health computation and renders only the #1208 enumeration columns/fields.

## Motivation / Context

As of #1228, `aicr recipe list` resolves every leaf overlay through `pkg/health.Compute` (via `client.ComputeHealth`) on **every** invocation to populate the `STATUS`/`COVERAGE` columns (table) and the `health` block (json/yaml). The previously-cheap catalog enumeration now always pays the full health-compute cost, with no way to opt out. For purely interactive "what overlays exist?" lookups — or scripted/CI callers that only consume `name`/`criteria`/`is_leaf`/`source` — the health resolution is wasted latency.

Raised as a non-blocking follow-up in PR #1302 review.

Fixes: #1311
Related: #1228, #1302

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- The `client.ComputeHealth(...)` call is gated behind `showHealth := !cmd.Bool(flagNoHealth)` and skipped **entirely** when the flag is set — a real latency win, not just a column drop.
- When skipped, `healthByName` stays `nil`: the table emits the pre-#1228 8-column header (no `STATUS`/`COVERAGE`), and json/yaml omit the `health` block via the existing `omitempty` (reading a nil map yields the zero-value pointer, so each entry's `Health` is nil).
- Gating lives in `pkg/cli` only; no `pkg/health` or facade changes. Default behavior (no flag) is unchanged from #1228.

## Testing

```bash
go test ./pkg/cli/...          # pass
golangci-lint run -c .golangci.yaml ./pkg/cli/...   # 0 issues (pinned v2.12.2)
```

New tests cover the flag across table/json/yaml, the `--skip-health` alias (byte-identical output), and the empty-result + `--no-health` intersection — including that the `health` block is absent in json/yaml when set. The YAML test decodes and asserts no `health` key (rather than a substring scan) plus a leaf-present guard.

`pkg/cli` coverage: 68.7% → 68.7% (flat, no regression). No new exported functions.

## Risk Assessment

- [x] **Low** — Isolated, additive CLI flag; default path unchanged; easy to revert.

**Rollout notes:** Backwards compatible. The flag defaults to `false`, so existing invocations and scripts see the #1228 output unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
