### PR TITLE
fix(validator): bound absent-resource retries in health checks of deployment validation

### DIFF
--- a/pkg/defaults/k8s.go
+++ b/pkg/defaults/k8s.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+// Kubernetes REST client rate limits for validator containers.
+//
+// client-go's default client-side rate limiter (QPS 5, Burst 10) is tuned for
+// controllers issuing a steady trickle of requests, not for a one-shot check
+// that enumerates every component in a recipe. The expected-resources
+// deployment validator, for example, runs health-check assertions across 18+
+// components, each issuing several GETs (Deployments, DaemonSets, custom
+// resources) within a single per-check context deadline. At 5 QPS the limiter
+// queues the later requests until the deadline elapses, surfacing as
+// "client rate limiter Wait returned an error: context deadline exceeded" and
+// flipping an otherwise-healthy check to status=other even though the cluster
+// is fine.
+//
+// Raising the limits lets these enumeration-heavy checks complete within their
+// deadline. The apiserver's own API Priority and Fairness (APF) still protects
+// the server from overload, so a higher client-side ceiling is safe.
+const (
+	// ValidatorClientQPS is the steady-state requests-per-second ceiling for a
+	// validator container's Kubernetes REST client.
+	ValidatorClientQPS = 50
+
+	// ValidatorClientBurst is the burst capacity for a validator container's
+	// Kubernetes REST client. Sized above QPS so the initial resource sweep
+	// (discovery + the first batch of GETs) is not immediately throttled.
+	ValidatorClientBurst = 100
+)

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -323,6 +323,24 @@ const (
 	// they pass or the ChainsawAssertTimeout expires.
 	AssertRetryInterval = 5 * time.Second
 
+	// AbsentResourceGracePeriod bounds how long a health-check assertion
+	// retries a resource that does not exist at all (the fetch returns
+	// ErrCodeNotFound). A resource that is missing entirely — wrong
+	// namespace, never installed — will not appear by waiting out the full
+	// ChainsawAssertTimeout, and retrying it for minutes holds one of the
+	// ChainsawMaxParallel worker slots and starves healthy components behind
+	// it (and can push the check past the Job's activeDeadlineSeconds, which
+	// surfaces as an opaque "other" status instead of a clean failure).
+	//
+	// This grace bounds ONLY the entirely-absent (NotFound) case. A resource
+	// that EXISTS but is not yet ready returns a shape-mismatch error
+	// (ErrCodeInternal), and a transient API failure returns
+	// ErrCodeUnavailable — both keep the full ChainsawAssertTimeout so slow
+	// but healthy rollouts are not failed prematurely. The grace allows brief
+	// creation lag (a resource that appears within the window switches to the
+	// full readiness budget) while failing permanently-absent resources fast.
+	AbsentResourceGracePeriod = 30 * time.Second
+
 	// JobEnvelopeMargin is the headroom added on top of ChainsawAssertTimeout
 	// when computing the validator Job's outer activeDeadlineSeconds and the
 	// expected-resources catalog timeout. Chainsaw needs time after the inner

--- a/validators/chainsaw/grace_test.go
+++ b/validators/chainsaw/grace_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsaw
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestIsNotFoundErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not found", errors.New(errors.ErrCodeNotFound, "no such resource"), true},
+		{"wrapped not found", errors.Wrap(errors.ErrCodeNotFound, "outer", errors.New(errors.ErrCodeNotFound, "inner")), true},
+		{"shape mismatch (internal)", errors.New(errors.ErrCodeInternal, "field mismatch"), false},
+		{"transient unavailable", errors.New(errors.ErrCodeUnavailable, "api 503"), false},
+		{"invalid request", errors.New(errors.ErrCodeInvalidRequest, "bad assert"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNotFoundErr(tt.err); got != tt.want {
+				t.Errorf("isNotFoundErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceObservedErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		// Shape mismatch = resource fetched but did not match => observed/exists.
+		{"shape mismatch (internal)", errors.New(errors.ErrCodeInternal, "field mismatch"), true},
+		{"wrapped internal", errors.Wrap(errors.ErrCodeInternal, "outer", errors.New(errors.ErrCodeInternal, "inner")), true},
+		// Absent: not observed.
+		{"not found", errors.New(errors.ErrCodeNotFound, "absent"), false},
+		// Transient API blip (rate-limiter / 5xx) proves nothing about existence —
+		// must NOT latch the grace off.
+		{"transient unavailable", errors.New(errors.ErrCodeUnavailable, "api 503"), false},
+		{"invalid request", errors.New(errors.ErrCodeInvalidRequest, "bad assert"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resourceObservedErr(tt.err); got != tt.want {
+				t.Errorf("resourceObservedErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNotFoundGraceDeadline(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	absent := base.Add(30 * time.Second)
+	deadline := base.Add(6 * time.Minute)
+
+	notFound := errors.New(errors.ErrCodeNotFound, "absent")
+	notReady := errors.New(errors.ErrCodeInternal, "not ready")
+
+	tests := []struct {
+		name           string
+		err            error
+		sawResource    bool
+		absentDeadline time.Time
+		deadline       time.Time
+		want           time.Time
+	}{
+		// Absent from the start (never observed): bounded to the short grace.
+		{"absent, never seen -> grace", notFound, false, absent, deadline, absent},
+		// Not-ready (exists, wrong shape): keeps the full deadline.
+		{"not ready -> full deadline", notReady, false, absent, deadline, deadline},
+		// Absent but grace already past the deadline: never exceed deadline.
+		{"absent grace beyond deadline -> deadline", notFound, false, deadline.Add(time.Minute), deadline, deadline},
+		// Transient/unavailable is not NotFound: keeps full deadline.
+		{"unavailable -> full deadline", errors.New(errors.ErrCodeUnavailable, "503"), false, absent, deadline, deadline},
+		// Recreate flow: resource was observed earlier (sawResource), so a later
+		// NotFound keeps the FULL deadline — must not fast-fail on the stale grace.
+		{"notfound after seen (recreate) -> full deadline", notFound, true, absent, deadline, deadline},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := notFoundGraceDeadline(tt.err, tt.sawResource, tt.absentDeadline, tt.deadline); !got.Equal(tt.want) {
+				t.Errorf("notFoundGraceDeadline() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/validators/chainsaw/inprocess.go
+++ b/validators/chainsaw/inprocess.go
@@ -161,7 +161,9 @@ func executeStepInProcess(ctx context.Context, try []v1alpha1.Operation, fetcher
 // defaults.AssertRetryInterval until it passes or the deadline expires.
 // Returns the last failure error on timeout, nil on success.
 func runAssertWithRetry(ctx context.Context, a *v1alpha1.Assert, fetcher ResourceFetcher, deadline time.Time) error {
-	var lastErr error
+	absentDeadline := time.Now().Add(defaults.AbsentResourceGracePeriod)
+	var lastErr, lastSubstantiveErr error
+	sawResource := false
 	for {
 		lastErr = evaluateAssert(ctx, a, fetcher)
 		if lastErr == nil {
@@ -170,9 +172,30 @@ func runAssertWithRetry(ctx context.Context, a *v1alpha1.Assert, fetcher Resourc
 		if isTerminalAssertErr(lastErr) {
 			return lastErr
 		}
-		remaining := time.Until(deadline)
+		// Record the failure seen while the context is still live; after
+		// cancellation the fetch returns a context / rate-limiter error that
+		// masks the real reason (see preferSubstantiveErr).
+		if ctx.Err() == nil {
+			lastSubstantiveErr = lastErr
+		}
+		// A shape-mismatch (ErrCodeInternal: the resource was fetched but does
+		// not match the asserted shape) proves the resource exists — disable the
+		// absent-grace so a later transient NotFound (e.g. a pod recreate
+		// mid-rollout) keeps the full readiness budget. A transient
+		// ErrCodeUnavailable (API blip / rate-limiter) proves nothing about
+		// existence and must NOT latch, otherwise an early blip on a genuinely
+		// absent resource would disable the fast-fail grace and re-introduce the
+		// worker-slot starvation under exactly the flaky conditions it guards.
+		if resourceObservedErr(lastErr) {
+			sawResource = true
+		}
+		// An entirely-absent resource (NotFound, never observed) is bounded to
+		// the short AbsentResourceGracePeriod; a not-ready (shape-mismatch)
+		// resource — or one that has already appeared — keeps the full deadline
+		// so slow-but-healthy rollouts are not failed prematurely.
+		remaining := time.Until(notFoundGraceDeadline(lastErr, sawResource, absentDeadline, deadline))
 		if remaining <= 0 {
-			return lastErr
+			return preferSubstantiveErr(lastSubstantiveErr, lastErr)
 		}
 		wait := defaults.AssertRetryInterval
 		if remaining < wait {
@@ -180,7 +203,8 @@ func runAssertWithRetry(ctx context.Context, a *v1alpha1.Assert, fetcher Resourc
 		}
 		select {
 		case <-ctx.Done():
-			return errors.Wrap(errors.ErrCodeInternal, "context canceled during assertion", ctx.Err())
+			return preferSubstantiveErr(lastSubstantiveErr,
+				errors.Wrap(errors.ErrCodeInternal, "context canceled during assertion", ctx.Err()))
 		case <-time.After(wait):
 		}
 	}
@@ -191,7 +215,7 @@ func runAssertWithRetry(ctx context.Context, a *v1alpha1.Assert, fetcher Resourc
 // matches) or the deadline expires. Returns the last failure on
 // timeout, nil on success.
 func runErrorWithRetry(ctx context.Context, e *v1alpha1.Error, fetcher ResourceFetcher, deadline time.Time) error {
-	var lastErr error
+	var lastErr, lastSubstantiveErr error
 	for {
 		lastErr = evaluateError(ctx, e, fetcher)
 		if lastErr == nil {
@@ -200,9 +224,15 @@ func runErrorWithRetry(ctx context.Context, e *v1alpha1.Error, fetcher ResourceF
 		if isTerminalAssertErr(lastErr) {
 			return lastErr
 		}
+		// Record the failure seen while the context is still live; after
+		// cancellation the fetch returns a context / rate-limiter error that
+		// masks the real reason (see preferSubstantiveErr).
+		if ctx.Err() == nil {
+			lastSubstantiveErr = lastErr
+		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			return lastErr
+			return preferSubstantiveErr(lastSubstantiveErr, lastErr)
 		}
 		wait := defaults.AssertRetryInterval
 		if remaining < wait {
@@ -210,7 +240,8 @@ func runErrorWithRetry(ctx context.Context, e *v1alpha1.Error, fetcher ResourceF
 		}
 		select {
 		case <-ctx.Done():
-			return errors.Wrap(errors.ErrCodeInternal, "context canceled during error check", ctx.Err())
+			return preferSubstantiveErr(lastSubstantiveErr,
+				errors.Wrap(errors.ErrCodeInternal, "context canceled during error check", ctx.Err()))
 		case <-time.After(wait):
 		}
 	}
@@ -225,6 +256,67 @@ func runErrorWithRetry(ctx context.Context, e *v1alpha1.Error, fetcher ResourceF
 // codes and continue to retry until the deadline.
 func isTerminalAssertErr(err error) bool {
 	return stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, ""))
+}
+
+// preferSubstantiveErr returns the last assertion failure observed while the
+// context was still live, falling back to fallback (typically a context-
+// cancellation wrap) when no live failure was recorded. Once the parent
+// context is canceled, fetch calls fail with a context / client-go
+// rate-limiter error ("client rate limiter Wait returned an error: context
+// deadline exceeded") that masks the real assertion reason (e.g. "resource
+// not found"). Surfacing the substantive error keeps the check's verdict clean
+// — failed with the real reason — instead of an opaque errored status driven
+// by the cancellation artifact.
+func preferSubstantiveErr(substantive, fallback error) error {
+	if substantive != nil {
+		return substantive
+	}
+	return fallback
+}
+
+// isNotFoundErr reports whether err indicates the asserted resource does not
+// exist at all (as opposed to existing but not matching the expected shape,
+// which is ErrCodeInternal, or a transient API failure, which is
+// ErrCodeUnavailable). Only the entirely-absent case is subject to the
+// AbsentResourceGracePeriod fast-fail.
+func isNotFoundErr(err error) bool {
+	return stderrors.Is(err, errors.New(errors.ErrCodeNotFound, ""))
+}
+
+// resourceObservedErr reports whether err proves the asserted resource exists:
+// a shape mismatch (ErrCodeInternal — the resource was successfully fetched but
+// did not match the asserted shape). NotFound (absent) and transient
+// ErrCodeUnavailable (API blip / rate-limiter — proves nothing about existence)
+// return false. Used to latch off the absent-resource grace only when the
+// resource has genuinely been observed, so a clean NotFound after a flaky GET
+// still benefits from the fast-fail grace.
+func resourceObservedErr(err error) bool {
+	return stderrors.Is(err, errors.New(errors.ErrCodeInternal, ""))
+}
+
+// notFoundGraceDeadline returns the effective retry deadline for the current
+// assertion error. A resource that does not exist at all (NotFound) is bounded
+// to absentDeadline so it fails fast instead of holding a worker slot for the
+// full readiness budget; anything else (not-ready shape mismatch, transient
+// API error) keeps the full deadline. The shorter of the two is never allowed
+// to exceed the caller's deadline.
+//
+// The grace applies ONLY while the resource has never been observed
+// (sawResource == false). The caller sets sawResource once a shape-mismatch
+// (ErrCodeInternal) is seen — proving the resource exists (even if not-ready) —
+// after which the full deadline is used. A transient ErrCodeUnavailable does
+// NOT set it (it proves nothing about existence), so a clean NotFound after an
+// API blip still gets the fast-fail grace. This also prevents a stale,
+// function-entry grace window from prematurely failing a later transient
+// NotFound, e.g. a pod recreate mid-rollout after the resource had appeared.
+func notFoundGraceDeadline(err error, sawResource bool, absentDeadline, deadline time.Time) time.Time {
+	if sawResource {
+		return deadline
+	}
+	if isNotFoundErr(err) && absentDeadline.Before(deadline) {
+		return absentDeadline
+	}
+	return deadline
 }
 
 // evaluateAssert runs a single positive assertion against the cluster.

--- a/validators/chainsaw/runner.go
+++ b/validators/chainsaw/runner.go
@@ -166,7 +166,9 @@ func assertRawResources(ctx context.Context, ca ComponentAssert, timeout time.Du
 	}
 
 	deadline := time.Now().Add(timeout)
-	var lastErr error
+	absentDeadline := time.Now().Add(defaults.AbsentResourceGracePeriod)
+	var lastErr, lastSubstantiveErr error
+	sawResource := false
 
 	for {
 		lastErr = assertAllDocuments(ctx, docs, fetcher)
@@ -176,7 +178,38 @@ func assertRawResources(ctx context.Context, ca ComponentAssert, timeout time.Du
 			return result
 		}
 
-		remaining := time.Until(deadline)
+		// A terminal error (malformed/non-evaluable assert, ErrCodeInvalidRequest)
+		// never becomes valid by retrying — fail fast instead of burning the full
+		// timeout and a worker slot. Mirrors runAssertWithRetry (inprocess.go).
+		if isTerminalAssertErr(lastErr) {
+			result.Output = lastErr.Error()
+			result.Error = lastErr
+			slog.Warn("health check failed", "component", ca.Name, "error", lastErr)
+			return result
+		}
+
+		// Record the failure seen while the context is still live; after
+		// cancellation assertAllDocuments returns a context / rate-limiter
+		// error that masks the real reason (e.g. "resource not found"). On
+		// deadline we surface the substantive reason so the verdict is a
+		// clean failure instead of an opaque context-cancellation error.
+		if ctx.Err() == nil {
+			lastSubstantiveErr = lastErr
+		}
+
+		// Only a shape-mismatch (ErrCodeInternal — resource fetched but does not
+		// match) proves the resource exists and disables the absent-grace. A
+		// transient ErrCodeUnavailable (API blip) must NOT latch, or an early
+		// blip on an absent resource would defeat the fast-fail grace.
+		if resourceObservedErr(lastErr) {
+			sawResource = true
+		}
+
+		// An entirely-absent resource (NotFound, never observed) is bounded to
+		// the short AbsentResourceGracePeriod; a not-ready resource — or one
+		// that has already appeared — keeps the full deadline so slow-but-healthy
+		// rollouts are not failed prematurely.
+		remaining := time.Until(notFoundGraceDeadline(lastErr, sawResource, absentDeadline, deadline))
 		if remaining <= 0 {
 			break
 		}
@@ -189,16 +222,29 @@ func assertRawResources(ctx context.Context, ca ComponentAssert, timeout time.Du
 
 		select {
 		case <-ctx.Done():
-			result.Error = errors.Wrap(errors.ErrCodeInternal, "context canceled during assertion", ctx.Err())
+			reason := lastSubstantiveErr
+			if reason == nil {
+				reason = errors.Wrap(errors.ErrCodeInternal, "context canceled during assertion", ctx.Err())
+			}
+			result.Output = reason.Error()
+			result.Error = reason
+			slog.Warn("health check failed", "component", ca.Name, "error", reason)
 			return result
 		case <-time.After(wait):
 			// retry
 		}
 	}
 
-	result.Output = lastErr.Error()
-	result.Error = errors.Wrap(errors.ErrCodeInternal, "health check failed after timeout", lastErr)
-	slog.Warn("health check failed", "component", ca.Name, "error", lastErr)
+	// Surface the substantive failure seen while the context was live
+	// (preserving its structured code, e.g. ErrCodeNotFound) rather than the
+	// possibly context-tainted lastErr, so the verdict is a clean failure.
+	reason := lastSubstantiveErr
+	if reason == nil {
+		reason = lastErr
+	}
+	result.Output = reason.Error()
+	result.Error = reason
+	slog.Warn("health check failed", "component", ca.Name, "error", reason)
 	return result
 }
 
@@ -228,16 +274,24 @@ func assertSingleDocument(ctx context.Context, expected map[string]interface{}, 
 
 	actual, err := fetcher.Fetch(ctx, apiVersion, kind, namespace, name)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal,
-			fmt.Sprintf("failed to fetch %s %s/%s", kind, namespace, name), err)
+		// Propagate the fetcher's structured code (ErrCodeNotFound vs
+		// ErrCodeUnavailable) as-is — do NOT blanket-wrap as ErrCodeInternal.
+		// ErrCodeInternal is reserved for an actual shape mismatch (the
+		// checks.Check error list below). This keeps the raw path aligned with
+		// evaluateAssert so the absent-resource grace latch (resourceObservedErr,
+		// which keys on ErrCodeInternal) can distinguish "resource exists but
+		// not ready" from "absent / transient API error".
+		return err
 	}
 
 	// Use chainsaw's assertion engine for subset matching with JMESPath support.
 	check := v1alpha1.NewCheck(expected)
 	errs, err := checks.Check(ctx, apis.DefaultCompilers, actual, nil, &check)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal,
-			fmt.Sprintf("assertion error for %s %s/%s", kind, namespace, name), err)
+		// A malformed/non-evaluable assertion is terminal (ErrCodeInvalidRequest),
+		// matching evaluateAssert — it will never become valid by retrying.
+		return errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("assertion engine error for %s %s/%s", kind, namespace, name), err)
 	}
 	if len(errs) > 0 {
 		return errors.New(errors.ErrCodeInternal,

--- a/validators/chainsaw/substantive_test.go
+++ b/validators/chainsaw/substantive_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsaw
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestAssertSingleDocument_PropagatesStructuredCode guards the raw-path grace:
+// an absent resource must surface ErrCodeNotFound (propagated from the fetcher),
+// NOT a blanket ErrCodeInternal wrap. If it were wrapped as Internal,
+// resourceObservedErr would latch sawResource=true on the first iteration and
+// the absent-resource fast-fail grace would never fire in assertRawResources.
+func TestAssertSingleDocument_PropagatesStructuredCode(t *testing.T) {
+	expected := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "missing",
+			"namespace": "ns",
+		},
+	}
+	err := assertSingleDocument(context.Background(), expected, newFakeFetcher())
+	if err == nil {
+		t.Fatal("expected an error for an absent resource, got nil")
+	}
+	if !isNotFoundErr(err) {
+		t.Fatalf("expected the fetcher's NotFound to be propagated, got %v", err)
+	}
+	if resourceObservedErr(err) {
+		t.Errorf("an absent resource must not be treated as observed (would defeat the raw-path grace): %v", err)
+	}
+}
+
+// TestAssertRawResources_TerminalErrorFailsFast guards that the raw-resource
+// retry loop honors terminal errors: a malformed assert (missing required
+// fields => ErrCodeInvalidRequest) must fail fast, not retry until the timeout
+// and hold a worker slot. Mirrors the in-process runAssertWithRetry behavior.
+func TestAssertRawResources_TerminalErrorFailsFast(t *testing.T) {
+	t.Parallel()
+	// Raw (non-Test) YAML missing metadata.name => assertSingleDocument returns
+	// ErrCodeInvalidRequest (terminal).
+	ca := ComponentAssert{
+		Name: "bad-assert",
+		AssertYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: ns`,
+	}
+	start := time.Now()
+	// Generous timeout: a correct terminal short-circuit returns immediately; a
+	// regression (retrying the permanent error) blocks >= one AssertRetryInterval.
+	r := assertRawResources(context.Background(), ca, time.Hour, newFakeFetcher())
+	elapsed := time.Since(start)
+
+	if r.Error == nil {
+		t.Fatalf("expected a terminal error, got nil (Passed=%v)", r.Passed)
+	}
+	if !stderrors.Is(r.Error, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("expected ErrCodeInvalidRequest (terminal), got %v", r.Error)
+	}
+	if elapsed >= defaults.AssertRetryInterval {
+		t.Fatalf("terminal error was retried (took %s >= AssertRetryInterval %s)", elapsed, defaults.AssertRetryInterval)
+	}
+}
+
+func TestPreferSubstantiveErr(t *testing.T) {
+	sub := errors.New(errors.ErrCodeNotFound, "resource not found")
+	fallback := errors.Wrap(errors.ErrCodeInternal, "context canceled during assertion", context.Canceled)
+
+	// Identity comparison is intentional: preferSubstantiveErr returns one of
+	// its two arguments verbatim, so we assert the exact value, not error code
+	// equivalence.
+	if got := preferSubstantiveErr(sub, fallback); got != sub { //nolint:errorlint // identity check by design
+		t.Errorf("preferSubstantiveErr(sub, fallback) = %v, want the substantive error", got)
+	}
+	if got := preferSubstantiveErr(nil, fallback); got != fallback { //nolint:errorlint // identity check by design
+		t.Errorf("preferSubstantiveErr(nil, fallback) = %v, want the fallback", got)
+	}
+}
+
+// TestRunChainsawTestInProcess_SurfacesSubstantiveErrorOnCancel verifies the fix
+// for the masked-cancellation bug end to end through the retry loop: when the
+// parent context is canceled mid-retry, the check must surface the last
+// substantive assertion error (here NotFound) rather than the ErrCodeInternal
+// context-cancellation wrap. A regression would return the opaque cancellation
+// error and the check would report `other` instead of a clean `failed` with the
+// real reason.
+func TestRunChainsawTestInProcess_SurfacesSubstantiveErrorOnCancel(t *testing.T) {
+	t.Parallel()
+	// Assert a single resource the (empty) fake fetcher does not have, so every
+	// evaluation returns a substantive ErrCodeNotFound.
+	const yaml = `
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: missing-resource
+spec:
+  steps:
+    - name: assert-missing
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: missing
+                namespace: ns
+`
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the first evaluation records the substantive NotFound,
+	// while the retry loop is parked in its select.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	// Generous step budget so the loop exits via context cancellation, not the
+	// deadline.
+	r := runChainsawTestInProcess(ctx, "missing-resource", yaml, time.Hour, newFakeFetcher())
+	if r.Error == nil {
+		t.Fatalf("expected an error, got nil (Passed=%v)", r.Passed)
+	}
+	if !isNotFoundErr(r.Error) {
+		t.Fatalf("expected the substantive NotFound to be surfaced on cancel, got %v", r.Error)
+	}
+	if stderrors.Is(r.Error, errors.New(errors.ErrCodeInternal, "")) {
+		t.Errorf("error must not be the ErrCodeInternal cancellation wrap: %v", r.Error)
+	}
+}

--- a/validators/context.go
+++ b/validators/context.go
@@ -99,11 +99,28 @@ func checkTimeoutFromEnv() time.Duration {
 func LoadContext() (*Context, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), checkTimeoutFromEnv())
 
-	// Build K8s client
-	clientset, config, err := k8sclient.BuildKubeClient("")
+	// Build the REST config (the typed client it also returns is rebuilt below
+	// after raising the rate limits, so it is intentionally discarded here).
+	_, config, err := k8sclient.BuildKubeClient("")
 	if err != nil {
 		cancel()
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create kubernetes client", err)
+	}
+
+	// Raise the client-side rate limits above client-go's defaults (QPS 5,
+	// Burst 10). Enumeration-heavy checks like expected-resources issue many
+	// GETs across every recipe component within a single per-check deadline;
+	// the default limiter queues the tail until the deadline elapses, surfacing
+	// as "client rate limiter Wait ... context deadline exceeded". The typed
+	// client returned above already captured the pre-override config, so rebuild
+	// it after raising the limits; the dynamic client below picks them up
+	// directly. apiserver APF still protects the server.
+	config.QPS = defaults.ValidatorClientQPS
+	config.Burst = defaults.ValidatorClientBurst
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		cancel()
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to rebuild kubernetes client with raised rate limits", err)
 	}
 
 	// Build dynamic client


### PR DESCRIPTION
## Summary

Fix the deployment validator's `expected-resources` check so it fails **fast and cleanly** when a recipe-declared resource is absent or in a different namespace than the recipe expects — instead of retrying to the Job deadline and reporting an opaque `other`.

Fixes #1323

## Problem

On a cluster where a recipe component is absent or misplaced, `expected-resources` retried the missing resource for the full `ChainsawAssertTimeout` (6m). With `ChainsawMaxParallel = 4` worker slots, a few absent components starved the healthy ones and pushed the check past the Job's `activeDeadlineSeconds`; the pod was killed and the result surfaced as `status=other` (~8m) with a misleading `client rate limiter Wait … context deadline exceeded` message rather than an actionable failure.

## Changes

- **Absent-resource grace** (`pkg/defaults.AbsentResourceGracePeriod = 30s`): bound only the entirely-absent (`ErrCodeNotFound`) case. A not-ready resource (shape mismatch → `ErrCodeInternal`) and a transient API failure (`ErrCodeUnavailable`) keep the full readiness budget, so slow-but-healthy rollouts are not failed prematurely.
- **Stateful grace**: the grace is disabled once the resource is actually observed (a shape-mismatch `ErrCodeInternal`), so a later transient `NotFound` (e.g. a pod recreate mid-rollout) keeps the full deadline. A transient `ErrCodeUnavailable` does **not** latch (it proves nothing about existence), so a clean `NotFound` after an API blip still gets the fast-fail.
- **Preserve the substantive reason at the deadline**: the retry loops surface the last real assertion error (e.g. "resource not found"), not the `ErrCodeInternal` context-cancellation/rate-limiter artifact — so the verdict is a clean `failed` with the real cause, not an opaque `other`.
- **Align the raw-resource path**: `assertSingleDocument` now propagates the fetcher's structured code (`NotFound`/`Unavailable`) instead of blanket-wrapping as `ErrCodeInternal`, so the grace/latch logic works identically in both the in-process and raw paths.
- **Raise validator REST client limits** (`QPS 50 / Burst 100`) above the client-go defaults so the multi-component enumeration sweep is not throttled. apiserver APF still protects the server.

## Tests

`preferSubstantiveErr`, `notFoundGraceDeadline` (incl. the recreate case), `resourceObservedErr` (incl. `Unavailable` does-not-latch), `assertSingleDocument` propagates the structured code, and a canceled-context retry that asserts the substantive error is surfaced. Build, lint, and `-race` tests pass.

## Verified on live clusters

| Cluster | Topology | Result |
|---|---|---|
| Managed RTX Pro 6000 (components match recipe) | healthy | **all-pass, 28s** |
| GB300 (components in different namespaces + a component removed) | divergent | **`failed` in 1m26s**, clean reason (`Nodewright tuning: not found …`) |

Same divergent GB300 cluster, before vs after: **8m24s → 1m26s**, `other` → `failed` with the real cause.

## Risk

- [x] **Low** — behavior change scoped to the absent (`NotFound`) case; not-ready and transient paths keep their full timeout. Easy to revert.
