### PR TITLE
fix: drop removed dynamo-operator sshKeygen override

### DIFF
--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -50,15 +50,6 @@ spec:
         - cert-manager
         - kube-prometheus-stack
         - kai-scheduler
-      overrides:
-        # Kind inference CI does not require Dynamo's MPI SSH secret. Disable
-        # the chart's ssh-keygen pre-install hook here so fresh Kind runners do
-        # not spend hook budget creating an unused secret.
-        dynamo-operator:
-          dynamo:
-            mpiRun:
-              sshKeygen:
-                enabled: false
 
   validation:
     conformance:


### PR DESCRIPTION
## Summary

Remove the obsolete `dynamo-operator.dynamo.mpiRun.sshKeygen` override from the H100 Kind inference Dynamo overlay, which now hard-fails the `dynamo-platform` Helm install.

## Motivation / Context

The `dynamo-operator` subchart (under the `dynamo-platform` 1.2.0 pin from `helm.ngc.nvidia.com/nvidia/ai-dynamo`) introduced a breaking change that **removed** `dynamo.mpiRun.sshKeygen` and now fails values validation when the field is present:

```
Error: execution error at (dynamo-platform/charts/dynamo-operator/templates/validate-values.yaml:79:6):
BREAKING CHANGE: 'dynamo-operator.dynamo.mpiRun.sshKeygen' has been removed.
SSH key generation is now handled automatically by the operator during reconciliation.
```

This caused the **GPU Inference Test (nvkind + H100 x1)** "Install runtime bundle" step to fail on every PR (failed on all 6 retry attempts — deterministic, not a flake). First observed on the run for #1332.

SSH key generation is now automatic during operator reconciliation, so the override's original intent (no unused MPI SSH secret on fresh Kind runners) is preserved by simply not setting the field. The `overrides` block contained only this key, so it is removed in full.

Fixes: N/A
Related: #1332

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

YAML-only change to `recipes/overlays/h100-kind-inference-dynamo.yaml`. No Go code touched.

## Testing

```bash
go test ./pkg/recipe/...   # ok
yamllint recipes/overlays/h100-kind-inference-dynamo.yaml  # clean
```

Final validation is the GPU Inference Test itself, which exercises the actual `dynamo-platform` chart install on H100 hardware.

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert

**Rollout notes:** N/A — removing a value the upstream chart no longer accepts.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)