### PR TITLE
fix(validator): stop unenforced nccl-all-reduce-bw gates; wire eks+h200

### DIFF
--- a/docs/user/recipe-health.md
+++ b/docs/user/recipe-health.md
@@ -34,23 +34,26 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 <!-- BEGIN AICR-HEALTH -->
 ## Summary
 
-- Recipes: **32**
-- Pass: **32** · Warn: **0** · Fail: **0** · Unknown: **0**
+- Recipes: **37**
+- Pass: **37** · Warn: **0** · Fail: **0** · Unknown: **0**
 
 ## Recipes
 
 | Recipe | Service | Accelerator | OS | Intent | Platform | Status | Coverage | Evidence |
 |--------|---------|-------------|----|--------|----------|--------|----------|----------|
+| a100-any | — | a100 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | b200-any | — | b200 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | gb200-any | — | gb200 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | h100-any | — | h100 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | h200-any | — | h200 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | rtx-pro-6000-any | — | rtx-pro-6000 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | monitoring-hpa | — | — | — | — | — | pass | R:0 D:0 P:0 C:0 | pending |
+| a100-aks-ubuntu-training-kubeflow | aks | a100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
 | h100-aks-ubuntu-inference-dynamo | aks | h100 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
-| h100-aks-ubuntu-training-kubeflow | aks | h100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:1 C:10 | pending |
+| h100-aks-ubuntu-training-kubeflow | aks | h100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
 | bcm-inference | bcm | — | — | inference | — | pass | R:0 D:0 P:0 C:5 | pending |
 | h100-bcm-ubuntu-training | bcm | h100 | ubuntu | training | — | pass | R:0 D:4 P:0 C:5 | pending |
+| a100-eks-ubuntu-training-kubeflow | eks | a100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
 | gb200-eks-ubuntu-inference-dynamo | eks | gb200 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:10 | pending |
 | gb200-eks-ubuntu-training-kubeflow | eks | gb200 | ubuntu | training | kubeflow | pass | R:0 D:4 P:2 C:8 | pending |
 | h100-eks-ubuntu-inference-dynamo | eks | h100 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
@@ -61,8 +64,9 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 | h200-eks-training | eks | h200 | — | training | — | pass | R:0 D:4 P:1 C:10 | pending |
 | rtx-pro-6000-eks-ubuntu-inference-dynamo | eks | rtx-pro-6000 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
 | rtx-pro-6000-eks-ubuntu-inference-nim | eks | rtx-pro-6000 | ubuntu | inference | nim | pass | R:0 D:4 P:0 C:11 | pending |
+| a100-gke-cos-training-kubeflow | gke | a100 | cos | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
 | b200-gke-cos-inference-dynamo | gke | b200 | cos | inference | dynamo | pass | R:0 D:4 P:0 C:11 | pending |
-| b200-gke-cos-training-kubeflow | gke | b200 | cos | training | kubeflow | pass | R:0 D:4 P:1 C:10 | pending |
+| b200-gke-cos-training-kubeflow | gke | b200 | cos | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
 | h100-gke-cos-inference-dynamo | gke | h100 | cos | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
 | h100-gke-cos-training-kubeflow | gke | h100 | cos | training | kubeflow | pass | R:0 D:4 P:1 C:10 | pending |
 | h100-gke-cos-training-slurm | gke | h100 | cos | training | slurm | pass | R:0 D:4 P:0 C:10 | pending |
@@ -71,6 +75,7 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 | h100-kind-training-slurm | kind | h100 | — | training | slurm | pass | R:0 D:4 P:0 C:9 | pending |
 | rtx-pro-6000-lke-ubuntu-inference | lke | rtx-pro-6000 | ubuntu | inference | — | pass | R:0 D:4 P:0 C:8 | pending |
 | rtx-pro-6000-lke-ubuntu-training | lke | rtx-pro-6000 | ubuntu | training | — | pass | R:0 D:4 P:0 C:8 | pending |
+| a100-oke-ubuntu-training-kubeflow | oke | a100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:0 C:8 | pending |
 | gb200-oke-ubuntu-inference-dynamo | oke | gb200 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:10 | pending |
 | gb200-oke-ubuntu-training-kubeflow | oke | gb200 | ubuntu | training | kubeflow | pass | R:0 D:4 P:1 C:8 | pending |
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -47,7 +47,7 @@ ones) that match the target fabric:
 
 | Check | Transport | When it's selected |
 |---|---|---|
-| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | Default for H100 on EKS/GKE, and for GB200/B200 on non-EKS services without a named-variant pairing (e.g. B200, or GB200 outside EKS/OKE). Preserves the pre-variant behavior. |
+| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | H100/H200 on EKS, H100 on GKE, and B200/GB200 on self-managed clusters (`service=any`). Preserves the pre-variant behavior. |
 | `nccl-all-reduce-bw-net` | NET (EFA on EKS) | GB200 + EKS. Asserts EFA actually carried traffic — catches silent fallback to Socket when the NVIDIA driver is missing `NVreg_GrdmaPciTopoCheckOverride=1`. |
 | `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS, and GB200 + OKE. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA (EKS) or Socket (OKE) when the IMEX domain is misconfigured. |
 

--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -168,12 +168,6 @@ validation:
       - expected-resources
       - gpu-operator-version
       - check-nvidia-smi
-  performance:
-    constraints:
-      - name: nccl-all-reduce-bw
-        value: '>= 100'
-    checks:
-      - nccl-all-reduce-bw
   conformance:
     checks:
       - platform-health

--- a/recipes/overlays/b200-gke-cos-training.yaml
+++ b/recipes/overlays/b200-gke-cos-training.yaml
@@ -87,20 +87,14 @@ spec:
         # accelerator-wide floor in b200-any.yaml.
         - name: Deployment.gpu-operator.version
           value: ">= v25.10.0"
-    performance:
-      # Single-fabric NCCL on GKE A4 — no MNNVL / NVL72 IMEX domain on B200
-      # (that is a GB200 feature), so a single all-reduce constraint is
-      # sufficient. The floor is a conservative placeholder; A4 reaches
-      # high-bandwidth NCCL via GPU Operator's gdrcopy + GKE's native
-      # multi-NIC fabric rather than via a TCPX/RDMA installer DaemonSet,
-      # so the H100 GKE TCPXO baseline (>= 250 GB/s) is not the right
-      # anchor. Tighten once empirical numbers from the B200 GKE testbed
-      # (nvcf-dgxc-k8s-gcp-azne1-prd7) are captured.
-      checks:
-        - nccl-all-reduce-bw
-      constraints:
-        - name: nccl-all-reduce-bw
-          value: ">= 100"
+    # No performance phase: the nccl-all-reduce-bw check is intentionally not
+    # declared here. The validator does not yet support gke+b200 (its only GKE
+    # NCCL template is TCPXO/FastRak-specific to a3-megagpu H100, while A4 uses
+    # GPUDirect RDMA over RoCE/CX-7), so a declared check would silently skip
+    # and report the phase as passed without measuring anything — false
+    # assurance. Wire it (testbed-validated testdata/b200/gke/runtime.yaml +
+    # support-table entry + real threshold) once the B200 GKE testbed
+    # (nvcf-dgxc-k8s-gcp-azne1-prd7) is characterized. See issue #1337.
     conformance:
       checks:
         - platform-health

--- a/recipes/overlays/h100-aks-training.yaml
+++ b/recipes/overlays/h100-aks-training.yaml
@@ -66,12 +66,13 @@ spec:
       constraints:
         - name: Deployment.gpu-operator.version
           value: ">= v24.6.0"
-    performance:
-      checks:
-        - nccl-all-reduce-bw
-      constraints:
-        - name: nccl-all-reduce-bw
-          value: ">= 100"
+    # No performance phase: the nccl-all-reduce-bw check is intentionally not
+    # declared here. The validator has no AKS NCCL runtime template or
+    # scheduling path (AKS is not in the support table), so a declared check
+    # would silently skip and report the phase as passed without measuring
+    # anything — false assurance. Wire it (testbed-validated AKS runtime
+    # template + scheduling path + support-table entry + real threshold) once
+    # an H100 AKS testbed is characterized. See issue #1337.
     conformance:
       checks:
         - platform-health

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -150,7 +150,10 @@ func templatePath(accelerator recipe.CriteriaAcceleratorType, service recipe.Cri
 // targeted transport-class coverage.
 var supportedNCCLCombinations = map[ncclVariant]map[recipe.CriteriaServiceType][]recipe.CriteriaAcceleratorType{
 	variantDefault: {
-		recipe.CriteriaServiceEKS: {recipe.CriteriaAcceleratorH100},
+		// H200 is Hopper on EFA, electrically identical to H100 for NCCL
+		// (NVLink4 intra-node, EFA inter-node), so it reuses the EKS H100
+		// runtime template and the same calibrated >= 300 GB/s floor.
+		recipe.CriteriaServiceEKS: {recipe.CriteriaAcceleratorH100, recipe.CriteriaAcceleratorH200},
 		recipe.CriteriaServiceGKE: {recipe.CriteriaAcceleratorH100},
 		recipe.CriteriaServiceAny: {recipe.CriteriaAcceleratorB200, recipe.CriteriaAcceleratorGB200},
 	},
@@ -359,12 +362,13 @@ const (
 // that reports whether a given nvidia.com/gpu.product label value belongs to
 // that accelerator family. Exact matches are used where GFD emits a single
 // product string (GB200, B200, L40 family, RTX Pro 6000); prefix matches cover
-// accelerators with multiple concrete SKUs (H100 SXM/PCIe/NVL, A100 SXM/PCIe).
+// accelerators with multiple concrete SKUs (H100 SXM/PCIe/NVL, H200, A100 SXM/PCIe).
 // No entry for CriteriaAcceleratorAny — "any" deliberately skips the filter.
 var acceleratorProductMatchers = map[recipe.CriteriaAcceleratorType]func(string) bool{
 	recipe.CriteriaAcceleratorGB200:      func(s string) bool { return s == "NVIDIA-GB200" },
 	recipe.CriteriaAcceleratorB200:       func(s string) bool { return s == "NVIDIA-B200" },
 	recipe.CriteriaAcceleratorH100:       func(s string) bool { return strings.HasPrefix(s, "NVIDIA-H100-") },
+	recipe.CriteriaAcceleratorH200:       func(s string) bool { return strings.HasPrefix(s, "NVIDIA-H200-") },
 	recipe.CriteriaAcceleratorA100:       func(s string) bool { return strings.HasPrefix(s, "NVIDIA-A100-") },
 	recipe.CriteriaAcceleratorL40:        func(s string) bool { return s == "NVIDIA-L40" || s == "NVIDIA-L40S" },
 	recipe.CriteriaAcceleratorRTXPro6000: func(s string) bool { return s == "NVIDIA-RTX-PRO-6000" },

--- a/validators/performance/nccl_test.go
+++ b/validators/performance/nccl_test.go
@@ -369,6 +369,8 @@ func TestAcceleratorProductMatchers(t *testing.T) {
 		{recipe.CriteriaAcceleratorH100, "NVIDIA-H100-PCIe", true},
 		{recipe.CriteriaAcceleratorH100, "NVIDIA-H100-NVL", true},
 		{recipe.CriteriaAcceleratorH100, "NVIDIA-H200-141GB-HBM3e", false},
+		{recipe.CriteriaAcceleratorH200, "NVIDIA-H200-141GB-HBM3e", true},
+		{recipe.CriteriaAcceleratorH200, "NVIDIA-H100-80GB-HBM3", false},
 		{recipe.CriteriaAcceleratorA100, "NVIDIA-A100-SXM4-80GB", true},
 		{recipe.CriteriaAcceleratorA100, "NVIDIA-A100-PCIe", true},
 		{recipe.CriteriaAcceleratorA100, "NVIDIA-A10G", false},
@@ -610,6 +612,14 @@ func TestTemplatePath(t *testing.T) {
 			variant:     variantDefault,
 			filename:    "runtime.yaml",
 			expected:    filepath.Join("testdata", "h100", "eks", "runtime.yaml"),
+		},
+		{
+			name:        "eks h200 runtime default",
+			accelerator: recipe.CriteriaAcceleratorH200,
+			service:     recipe.CriteriaServiceEKS,
+			variant:     variantDefault,
+			filename:    "runtime.yaml",
+			expected:    filepath.Join("testdata", "h200", "eks", "runtime.yaml"),
 		},
 		{
 			name:        "eks h100 trainjob default",
@@ -873,8 +883,10 @@ func TestSupportedNCCLCombinations_Variants(t *testing.T) {
 
 	// Legacy default variant must still list the original combinations
 	// so existing recipes that reference "nccl-all-reduce-bw" keep working.
-	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceEKS]; len(accels) != 1 || accels[0] != recipe.CriteriaAcceleratorH100 {
-		t.Errorf("variantDefault EKS = %v, want [H100]", accels)
+	// EKS default carries H100 and H200 (Hopper on EFA, shared template).
+	wantEKS := []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100, recipe.CriteriaAcceleratorH200}
+	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceEKS]; !reflect.DeepEqual(accels, wantEKS) {
+		t.Errorf("variantDefault EKS = %v, want %v", accels, wantEKS)
 	}
 	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceAny]; len(accels) != 2 {
 		t.Errorf("variantDefault Any count = %d, want 2 (B200, GB200)", len(accels))
@@ -923,6 +935,46 @@ func TestSupportedNCCLCombinationsHaveRuntimeTemplates(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestH200EKSRuntimeMatchesH100 enforces the "keep in sync with H100" contract
+// declared in the header of testdata/h200/eks/runtime.yaml. H200 is Hopper on
+// EFA — electrically identical to H100 for NCCL — so the two EKS runtime
+// templates must stay byte-identical apart from their leading comment/license
+// headers. This converts the comment-only guarantee into an enforced one: an
+// EFA-related edit to one template that is not mirrored in the other fails here
+// instead of silently diverging. If the transport setup ever legitimately
+// diverges by SKU, fork the templates and delete this test.
+func TestH200EKSRuntimeMatchesH100(t *testing.T) {
+	h100 := readTemplateBody(t, filepath.Join("testdata", "h100", "eks", "runtime.yaml"))
+	h200 := readTemplateBody(t, filepath.Join("testdata", "h200", "eks", "runtime.yaml"))
+	if h100 != h200 {
+		t.Errorf("testdata/h200/eks/runtime.yaml diverged from the H100 EKS template "+
+			"(comparing bodies after stripping leading comment headers).\nH100:\n%s\nH200:\n%s", h100, h200)
+	}
+}
+
+// readTemplateBody returns the file contents with the leading run of blank and
+// comment (#-prefixed) lines removed, i.e. everything from the first YAML line
+// onward. Lets header comments (license, per-file notes) differ while the
+// template body is compared exactly.
+func readTemplateBody(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := strings.Split(string(content), "\n")
+	start := 0
+	for start < len(lines) {
+		trimmed := strings.TrimSpace(lines[start])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			start++
+			continue
+		}
+		break
+	}
+	return strings.Join(lines[start:], "\n")
 }
 
 func TestParseThreshold(t *testing.T) {

--- a/validators/performance/testdata/h200/eks/runtime.yaml
+++ b/validators/performance/testdata/h200/eks/runtime.yaml
@@ -1,0 +1,209 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# EKS NCCL All-Reduce TrainingRuntime — H200 (Hopper) over EFA.
+#
+# H200 is electrically identical to H100 for NCCL (NVLink4 intra-node, EFA
+# inter-node), so this template mirrors testdata/h100/eks/runtime.yaml. Keep
+# the two in sync; if the EFA transport setup diverges by SKU, fork here.
+#
+# Must stay in sync with ncclTrainingRuntimeName in nccl_all_reduce_bw_constraint.go.
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: nccl-all-reduce-runtime
+  namespace: ${NAMESPACE}
+  labels:
+    trainer.kubeflow.org/framework: mpi
+spec:
+  mlPolicy:
+    mpi:
+      mpiImplementation: OpenMPI
+      numProcPerNode: ${GPU_COUNT_PER_NODE}
+      runLauncherAsNode: false
+      # Mount the SSH secret to /tmp/mpi-keys (not /root/.ssh) so that init containers
+      # can copy the private key to /root/.ssh with chmod 600. Kubernetes secret volumes
+      # default to 0644, and SSH refuses to use a private key with permissions > 0600.
+      sshAuthMountPath: /tmp/mpi-keys
+  template:
+    spec:
+      network:
+        # Required: JobSet sets spec.subdomain on pods and creates the headless service
+        # that makes pod FQDNs (e.g. nccl-all-reduce-tj-node-0-0.nccl-all-reduce-tj) resolvable.
+        enableDNSHostnames: true
+        # Required: publish DNS records for pods not yet Ready so mpirun can resolve
+        # workers before they finish initialization.
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - name: launcher
+        replicas: 1
+        template:
+          spec:
+            template:
+              spec:
+                tolerations:
+                - operator: Exists
+                initContainers:
+                # Fix SSH key permissions: the MPI plugin mounts the secret at /tmp/mpi-keys
+                # with default 0644 permissions. SSH refuses to use id_rsa with > 0600.
+                # This init container copies the key to a writable emptyDir (/root/.ssh)
+                # with correct permissions before mpirun starts.
+                - name: fix-ssh-perms
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/id_rsa /root/.ssh/id_rsa
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys
+                  volumeMounts:
+                  # mpi-ssh-auth is injected by the MPI plugin into the pod volumes list
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                # Container must be named "node" — the MPI plugin only processes containers
+                # with this name (constants.Node) to inject: SSH auth mount, hostfile mount,
+                # and OpenMPI env vars (OMPI_MCA_orte_default_hostfile, OMPI_MCA_plm_rsh_args,
+                # OMPI_MCA_orte_default_slots, OMPI_MCA_orte_keep_fqdn_hostnames).
+                - name: node
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  env:
+                  # /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu is where libnccl-net.so
+                  # (the aws-ofi-nccl EFA plugin) is installed in the hpc-cloud/nccl-tests image.
+                  # mpirun propagates this path to workers via -x LD_LIBRARY_PATH below.
+                  - name: LD_LIBRARY_PATH
+                    value: "/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/usr/local/nvidia/lib"
+                  - name: PATH
+                    value: "$PATH:/opt/amazon/efa/bin:/usr/bin"
+                  command:
+                  - /opt/amazon/openmpi/bin/mpirun
+                  - -np
+                  - "${GPU_COUNT}"
+                  - --allow-run-as-root
+                  - -bind-to
+                  - none
+                  - --mca
+                  - plm_rsh_agent
+                  - ssh
+                  # Override plm_rsh_args to suppress host-key checking (known_hosts is empty
+                  # on fresh pods) and include retry count so mpirun waits for worker sshd.
+                  - --mca
+                  - plm_rsh_args
+                  - -o StrictHostKeyChecking=no -o ConnectionAttempts=10
+                  - -x
+                  - LD_LIBRARY_PATH
+                  - -x
+                  - PATH
+                  - -x
+                  - NCCL_DEBUG=WARN
+                  - -x
+                  - FI_PROVIDER=efa
+                  - -x
+                  - FI_EFA_USE_DEVICE_RDMA=1
+                  - -x
+                  - FI_EFA_FORK_SAFE=1
+                  - -x
+                  - NCCL_SOCKET_IFNAME=eth0
+                  - -x
+                  - NCCL_IGNORE_DISABLED_P2P=1
+                  - /opt/nccl-tests/build/${TEST_TYPE}
+                  - -b
+                  - ${MIN_MESSAGE_SIZE}
+                  - -e
+                  - ${MAX_MESSAGE_SIZE}
+                  - -f
+                  - "2"
+                  - -g
+                  - "1"
+                  resources:
+                    limits:
+                      cpu: "2"
+                      memory: 128Mi
+                  volumeMounts:
+                  # ssh-config emptyDir holds the chmod-fixed keys from the init container.
+                  # The plugin will also mount mpi-ssh-auth at /tmp/mpi-keys on this container.
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+      # This replicatedJob must be named "node" — the MPI plugin identifies the training
+      # workers by constants.Node ("node") to override replicas from TrainJob.spec.trainer.numNodes
+      # and to mount SSH auth credentials so the launcher can SSH in.
+      - name: node
+        template:
+          spec:
+            template:
+              spec:
+                initContainers:
+                # Fix authorized_keys permissions so sshd accepts incoming connections.
+                # The MPI plugin mounts the secret at /tmp/mpi-keys with 0644; sshd
+                # with StrictModes requires authorized_keys to not be group/world writable,
+                # and requires the .ssh directory to be 0700.
+                - name: fix-ssh-perms
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/authorized_keys
+                  volumeMounts:
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                # Container must be named "node" for the MPI plugin to mount SSH auth volume.
+                - name: node
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  # Run sshd in foreground so the launcher can SSH in and run the NCCL test.
+                  command: ["/usr/sbin/sshd", "-De"]
+                  resources:
+                    limits:
+                      nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
+${EFA_RESOURCE_LIMITS}
+                    requests:
+                      nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
+${EFA_RESOURCE_REQUESTS}
+                  securityContext:
+                    capabilities:
+                      add: ["IPC_LOCK"]
+                  volumeMounts:
+                  # ssh-config holds the chmod-fixed authorized_keys from the init container.
+                  # The plugin will also mount mpi-ssh-auth at /tmp/mpi-keys on this container.
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                  - name: dshm
+                    mountPath: /dev/shm
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+                - name: dshm
+                  emptyDir:
+                    medium: Memory
+      successPolicy:
+        operator: All
+        targetReplicatedJobs:
+        - launcher


### PR DESCRIPTION
## Summary

Stops three `nccl-all-reduce-bw` performance gates that were declared in recipes but silently skipped by the validator (false "passed" without measuring). Removes the two that can't be enforced without a new testbed-validated template, and wires the one (`eks+h200`) that reuses the existing H100/EFA template.

## Motivation / Context

The performance validator resolves NCCL support via an exact `(variant, service) → []accelerator` table with no `Any` fallback, so any declared tuple absent from the table returns `skipped`. A skipped check does not fail, so the performance phase reports `passed` without ever measuring or enforcing the threshold. An audit of all recipes declaring `nccl-all-reduce-bw*` found three affected tuples.

Fixes: #1337
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Audit result (every recipe with an active NCCL check):

| Recipe | Tuple | Validator | Resolution |
|--------|-------|-----------|------------|
| `b200-gke-cos-training` (+ Kubeflow child) | `gke+b200` | skipped | **remove** — A4 uses GPUDirect RDMA over RoCE/CX-7; the only GKE template is TCPXO/FastRak-specific to a3-megagpu H100, and the GKE Go path is hardwired to TCPXO 8-NIC discovery. Needs a new testbed-validated template. |
| `h100-aks-training` (+ ubuntu child) | `aks+h100` | skipped | **remove** — no AKS template or scheduling path exists at all. |
| `h200-eks-training` | `eks+h200` | skipped | **wire** — H200 is Hopper on EFA, electrically identical to H100 for NCCL. |
| `gb200-eks-training`, `gb200-oke-training`, `h100-eks-training`, `h100-gke-cos-training` | — | enforced | no change |

Wiring for `eks+h200`: added `H200` to `variantDefault.EKS`, added a `NVIDIA-H200-` prefix product matcher, and added `testdata/h200/eks/runtime.yaml` (mirrors the H100 EKS template). Recipe keeps its conservative `>= 300 GB/s` floor (loose for H200's HBM3e envelope; wants one EFA-testbed confirmation to tighten). Removed tuples are replaced with comments documenting what wiring each would require.

## Testing

```bash
go test -race ./validators/performance/   # ok
go test ./pkg/recipe/...                   # ok
golangci-lint run -c .golangci.yaml ./validators/performance/...  # 0 issues
```

`TestSupportedNCCLCombinationsHaveRuntimeTemplates` (wiring guard) now covers `h200/eks`; added `TestTemplatePath` and `TestAcceleratorProductMatchers` cases for H200 and updated the `variantDefault.EKS` assertion. Full `make qualify` still pending — PR is **WIP/draft**.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** The two removed checks were no-ops (already reporting `passed` without measuring), so removal changes no observed behavior. The H200 wiring activates a check that previously skipped; the floor is conservative.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`) — scoped to changed package
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
