### PR TITLE
docs: add contributor Claude skills page

### DIFF
--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -310,6 +310,7 @@ By contributor task:
 - **Adding a bundle-time component validation** → [validator.md](validator.md#component-validations-bundle-time)
 - **Maintaining recipes and cutting releases** → [maintaining.md](maintaining.md)
 - **Writing or running tests (unit, chainsaw, KWOK, e2e)** → [tests.md](tests.md)
+- **Using the project's Claude skills (snapshot analysis, docs audit, demos, decks, OpenVEX, release notes)** → [skills.md](skills.md)
 
 By reference:
 

--- a/docs/contributor/skills.md
+++ b/docs/contributor/skills.md
@@ -1,0 +1,57 @@
+# Claude Skills
+
+AICR ships a set of **Claude skills** under
+[`.claude/skills/`](https://github.com/NVIDIA/aicr/tree/main/.claude/skills).
+A skill is a self-contained, model-invocable procedure: a `SKILL.md` with
+YAML frontmatter (`name`, `description`) plus any supporting files
+(templates, skeletons). When a request matches a skill's description,
+Claude Code loads it and follows it directly — so the skills encode the
+project's preferred way to do recurring, judgment-heavy tasks instead of
+re-deriving the steps each time.
+
+These are repo-scoped: they live in the codebase, are versioned with it,
+and are available to any contributor running Claude Code in this working
+tree. They complement — they do not replace — the coding rules in
+[CLAUDE.md](https://github.com/NVIDIA/aicr/blob/main/.claude/CLAUDE.md).
+
+## Available Skills
+
+| Skill | Use it when you want to... |
+|-------|----------------------------|
+| [`aicr-analyzing-snapshots`](https://github.com/NVIDIA/aicr/blob/main/.claude/skills/aicr-analyzing-snapshots/SKILL.md) | Analyze a snapshot YAML — cluster identity, provider characteristics, GPU/network topology, node health, software stack — and produce a structured assessment report. |
+| [`aicr-auditing-docs`](https://github.com/NVIDIA/aicr/blob/main/.claude/skills/aicr-auditing-docs/SKILL.md) | Audit the Markdown docs for duplication, drift, bloat, and gaps, producing a prioritized findings report (research, not edits) across README, `docs/`, demos, and governance files. |
+| [`aicr-creating-guided-demos`](https://github.com/NVIDIA/aicr/blob/main/.claude/skills/aicr-creating-guided-demos/SKILL.md) | Scaffold an interactive guided demo script (`demos/*.sh`) — live or self-paced — using the Frame → Tell → Show → Close narrative pattern. |
+| [`aicr-creating-slide-decks`](https://github.com/NVIDIA/aicr/blob/main/.claude/skills/aicr-creating-slide-decks/SKILL.md) | Build a self-contained HTML slide deck (`demos/*.html`) — inline CSS/SVG, no build step — to present or teach a concept full-screen or projected. |
+| [`aicr-managing-openvex`](https://github.com/NVIDIA/aicr/blob/main/.claude/skills/aicr-managing-openvex/SKILL.md) | Add, update, or remove CVE/GHSA suppressions in `.openvex.json`, the OpenVEX document consumed by the daily image vulnerability scan. |
+| [`aicr-release-notes`](https://github.com/NVIDIA/aicr/blob/main/.claude/skills/aicr-release-notes/SKILL.md) | Draft the human-readable GitHub release-notes summary for an upcoming release by grouping commits since the last tag into thematic highlights. |
+
+## How Skills Are Invoked
+
+Skills are matched against their `description` frontmatter. There are two
+paths:
+
+- **Automatic.** When a request matches a skill's triggers, Claude Code
+  loads the skill before responding. The `description` field is the
+  matcher — it lists the phrases and intents that should activate the
+  skill, so write it for recall.
+- **Explicit.** A contributor can name a skill directly (for example,
+  `/aicr-auditing-docs`) to force its use.
+
+Never read a `SKILL.md` with a plain file read to "follow it" — invoke it
+so its supporting files and conventions load as intended.
+
+## Adding a Skill
+
+1. Create `.claude/skills/<skill-name>/SKILL.md` with `name` and
+   `description` frontmatter. The `name` must match the directory.
+2. Write the `description` for matching: enumerate the triggers (phrases,
+   file paths, intents) that should activate it. This is the single most
+   important field — a skill that never matches is dead weight.
+3. Keep the body a procedure, not prose: when to use, when *not* to use,
+   and the concrete steps. Add supporting files (skeletons, templates)
+   alongside `SKILL.md` and reference them by relative path.
+4. Add a row to the [Available Skills](#available-skills) table above so
+   contributors can discover it.
+
+Skills are design-time tooling for working *on* AICR — they are not part
+of the shipped product and do not affect generated artifacts.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -84,5 +84,7 @@ navigation:
         path: contributor/api-server.md
       - page: Testing
         path: contributor/tests.md
+      - page: Claude Skills
+        path: contributor/skills.md
       - page: Maintaining AICR
         path: contributor/maintaining.md


### PR DESCRIPTION
## Summary

Add a new contributor docs page cataloging the six repo-scoped Claude skills under `.claude/skills/`, and wire it into the contributor index and Fern sidebar.

## Motivation / Context

The project ships several Claude skills (snapshot analysis, docs audit, demos, slide decks, OpenVEX, release notes), but they were undocumented — contributors had no discoverable list of what exists or how it's invoked. This adds a single catalog page.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New page `docs/contributor/skills.md`: explains what repo-scoped skills are, a catalog table (with GitHub blob links and a "use it when" column), automatic vs. explicit invocation, and a short "Adding a Skill" procedure.
- `docs/contributor/index.md`: added a "Where to Next" entry linking to the page.
- `docs/index.yml`: added a "Claude Skills" page to the Contributor Guide sidebar, between Testing and Maintaining AICR.
- Follows project doc style: auto-anchors (no TOC), GitHub blob links for repo files. The one internal anchor (`#available-skills`) resolves correctly.

## Testing

```bash
make check-docs-filenames
make check-docs-mdx
```

Docs-only change; both doc checks pass. Skipped `make qualify` as no code/YAML schema behavior changed.

## Risk Assessment

- [x] **Low** — Isolated docs addition, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)