### PR TITLE
fix(recipes): pin nvidia-dra-driver-gpu to 0.4.1-rc.1 for strict-YAML fix

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -49,7 +49,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | nfd | helm | node-feature-discovery | 0.18.3 | 1 |
 | nodewright-customizations | manifest | — | — | 5 |
 | nodewright-operator | helm | skyhook-operator | v0.15.1 | 3 |
-| nvidia-dra-driver-gpu | helm | dra-driver-nvidia-gpu | 0.4.0 | 1 |
+| nvidia-dra-driver-gpu | helm | dra-driver-nvidia-gpu | 0.4.1-rc.1 | 1 |
 | nvsentinel | helm | nvsentinel | v1.9.0 | 6 |
 | prometheus-adapter | helm | prometheus-community/prometheus-adapter | 5.3.0 | 1 |
 | prometheus-operator-crds | helm | prometheus-community/prometheus-operator-crds | 28.0.1 | 0 |
@@ -189,7 +189,7 @@ _No images extracted._
 
 ### nvidia-dra-driver-gpu
 
-- `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.0`
+- `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1-rc.1`
 
 ### nvsentinel
 
@@ -325,9 +325,9 @@ Component: nvidia-dra-driver-gpu (1 images)
 Presence-only check: does NOT verify publisher trust/identity.
 Y = artifact attached, - = artifact absent, ? = could not probe.
 
-  Image                                                           Sig  SBOM  Prov  Notes
-  --------------------------------------------------------------  ---  ----  ----  -----
-  registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.0  Y    -     -
+  Image                                                                Sig  SBOM  Prov  Notes
+  -------------------------------------------------------------------  ---  ----  ----  -----
+  registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1-rc.1  Y    -     -
 
 Summary: 1/1 signed · 0/1 SBOM · 0/1 provenance
 ```

--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -113,7 +113,7 @@ componentRefs:
     chart: dra-driver-nvidia-gpu
     type: Helm
     source: oci://registry.k8s.io/dra-driver-nvidia/charts
-    version: 0.4.0
+    version: 0.4.1-rc.1
     valuesFile: components/nvidia-dra-driver-gpu/values.yaml
     overrides:
       controller:

--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -130,7 +130,7 @@ componentRefs:
     chart: dra-driver-nvidia-gpu
     type: Helm
     source: oci://registry.k8s.io/dra-driver-nvidia/charts
-    version: 0.4.0
+    version: 0.4.1-rc.1
     valuesFile: components/nvidia-dra-driver-gpu/values.yaml
     dependencyRefs:
       - gpu-operator

--- a/recipes/components/nvidia-dra-driver-gpu/values.yaml
+++ b/recipes/components/nvidia-dra-driver-gpu/values.yaml
@@ -45,7 +45,7 @@
 # - fullnameOverride strips the aicr-stack- release prefix from the
 #   resources that use the chart's fullname helper (ServiceAccounts,
 #   RoleBindings).
-# - nameOverride is needed because v0.4.0 of the chart uses the
+# - nameOverride is needed because the chart uses the
 #   `dra-driver-nvidia-gpu.name` helper for the controller Deployment
 #   and the kubelet-plugin DaemonSet. That helper resolves to
 #   `nameOverride || .Chart.Name`, so without it the rendered names

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -96,7 +96,10 @@ spec:
     - name: nvidia-dra-driver-gpu
       type: Helm
       source: oci://registry.k8s.io/dra-driver-nvidia/charts
-      version: "0.4.0"
+      # TEMPORARY: pinned to 0.4.1-rc.1 to fix the duplicate pod-template label
+      # key 0.4.0 emits (invalid YAML breaking Argo CD/Flux/strict consumers).
+      # Bump to 0.4.1 GA once released (week of 2026-06-29). See registry.yaml.
+      version: "0.4.1-rc.1"
       valuesFile: components/nvidia-dra-driver-gpu/values.yaml
       dependencyRefs:
         - gpu-operator

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -286,7 +286,12 @@ components:
     helm:
       defaultRepository: oci://registry.k8s.io/dra-driver-nvidia/charts
       defaultChart: dra-driver-nvidia-gpu
-      defaultVersion: "0.4.0"
+      # TEMPORARY: pinned to 0.4.1-rc.1 to pick up the fix for the duplicate
+      # pod-template label key that 0.4.0 emits with our values (invalid YAML
+      # that breaks strict consumers — Argo CD/Flux/kustomize/yq). Bump to the
+      # 0.4.1 GA release once it lands (scheduled week of 2026-06-29).
+      # See https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1184
+      defaultVersion: "0.4.1-rc.1"
       defaultNamespace: nvidia-dra-driver
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary

Pin `nvidia-dra-driver-gpu` from `0.4.0` to `0.4.1-rc.1` (same `oci://registry.k8s.io/dra-driver-nvidia/charts` chart) to fix a duplicate pod-template label key that produces invalid YAML for strict consumers.

## Motivation / Context

The `0.4.0` chart emits the `nvidia-dra-driver-gpu-component` label twice in the pod template (`metadata.labels`) for both the controller Deployment and the kubelet-plugin DaemonSet when rendered with AICR's values. Plain Helm tolerates the duplicate, but strict-YAML consumers that post-process the rendered manifests (Argo CD, Flux, kustomize, yq) fail the install with `mapping key "nvidia-dra-driver-gpu-component" already defined`. This breaks GitOps deployments — notably Flux reconciliation.

Upstream `0.4.1-rc.1` collapses the label to a single key. This is the RC cut specifically for AICR to pin to; the pin is **temporary** and will be bumped to the `0.4.1` GA release once it lands (scheduled week of 2026-06-29).

Fixes: 1289
Related: #1285 (the migration to registry.k8s.io v0.4.0 that introduced the regression), (upstream https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1184)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Bumps the version pin in two canonical sites: `recipes/registry.yaml` (`defaultVersion`) and `recipes/overlays/base.yaml` (`version`), with an inline `TEMPORARY` comment at each explaining the RC rationale and the GA follow-up.
- Regenerated `docs/user/container-images.md` via `make bom-docs` (chart version + image tag updated to `v0.4.1-rc.1`).
- No source or values changes — the fix is entirely upstream in the chart.

## Testing

```bash
make bom-docs
yamllint recipes/registry.yaml recipes/overlays/base.yaml   # clean
go test ./pkg/recipe/...                                    # ok
make qualify                                                # run before merge
```

End-to-end Flux-path verification using the exact `spec.values` AICR's Flux deployer injects (controller + kubeletPlugin nodeSelector/tolerations), rendering the OCI chart and running `kustomize build`:

- `0.4.0`: `kustomize build` **FAILS** — `mapping key "nvidia-dra-driver-gpu-component" already defined`
- `0.4.1-rc.1`: `kustomize build` **PASSES**; label appears once per pod template

## Risk Assessment

- [x] **Low** — Isolated version-pin change, easy to revert; fix verified against the strict-YAML failure mode.

**Rollout notes:** Temporary RC pin. Follow-up PR will bump to `0.4.1` GA when released (~week of 2026-06-29).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
