### PR TITLE
fix(bundler): disable kataSandboxDevicePlugin in gpu-operator values

### DIFF
--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -193,3 +193,7 @@ nfd:
 # it off until AICR has explicit CC-capable hardware support.
 ccManager:
   enabled: false
+
+# Chart default (enabled) renders an undeclared CRD field.
+kataSandboxDevicePlugin:
+  enabled: false


### PR DESCRIPTION
## Summary

Disable `kataSandboxDevicePlugin` in the base gpu-operator Helm values so the field is never rendered into ClusterPolicy.

## Motivation / Context

The gpu-operator chart defaults `kataSandboxDevicePlugin.enabled: true`, which renders `.spec.kataSandboxDevicePlugin` into the ClusterPolicy CR. The v26.3.1 CRD schema does not declare that field, causing ArgoCD's structured-merge diff to fail permanently (`ComparisonError` / `Unknown` health) on clusters using that chart version. No AICR recipe uses kata containers, so the field is unused.

Fixes: #1340
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)

## Implementation Notes

Single-line disable in `recipes/components/gpu-operator/values.yaml`, mirroring the existing `ccManager.enabled: false` precedent directly above it. Because `recipes/overlays/base.yaml` pins every recipe's gpu-operator to this values file as its base, the fix covers all services/accelerators/intents without per-overlay duplication.

BOM regeneration (`make bom-docs`) confirmed no image change — disabling this feature does not remove a container image from the Helm chart's rendered output.

## Testing

```bash
go test -race ./recipes/... ./pkg/recipe/...
yamllint recipes/components/gpu-operator/values.yaml
```

All relevant tests pass.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — disabling an unused feature flag. Existing deployed ClusterPolicies are unaffected; only newly generated bundles will omit the field.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)