### PR TITLE
chore: add license header to slide-deck skeleton.html

### DIFF
--- a/.claude/skills/aicr-creating-slide-decks/skeleton.html
+++ b/.claude/skills/aicr-creating-slide-decks/skeleton.html
@@ -1,4 +1,20 @@
 <!DOCTYPE html>
+<!--
+ Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <!-- Self-contained slide deck skeleton. Copy, rename, and fill in the slides.
      No build, no dependencies, no network — inline CSS + inline SVG only.
      See the creating-slide-decks skill and demos/evidence-demo-slides.html. -->


### PR DESCRIPTION
## Summary

Add the Apache 2.0 license header to `.claude/skills/aicr-creating-slide-decks/skeleton.html`, the only HTML asset in the repo missing it.

## Motivation / Context

`skeleton.html` was committed without the standard Apache 2.0 header that every sibling HTML asset carries (`demos/*.html` and the other slide-deck skill files). The file is not in the addlicense ignore list, so `make lint` (via the `license` target → `addlicense`) flags it and rewrites it in place on every run, leaving a dirty working tree. This was surfaced when an unrelated `make qualify` run mutated the file as a side effect.

Adding the header closes the gap so the tree stays clean and the file matches repo convention.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.claude/skills` (slide-deck skill asset)

## Implementation Notes

- Header inserted by the repo's own tooling: `addlicense -f .github/headers/LICENSE`.
- A full-repo `make license` run touches only this one file, confirming it is the sole remaining gap.
- Purely additive (16 lines); no existing content changed.

## Testing

```bash
make license   # whole-tree run modifies only skeleton.html
```

## Risk Assessment

- [x] **Low** — Comment-only header addition to a non-shipping skill asset; trivially reversible.

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [ ] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
