### PR TITLE
ci: add DevTrace PR contributor trust scoring

### DIFF
--- a/.github/workflows/devtrace.yaml
+++ b/.github/workflows/devtrace.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: DevTrace PR Check
+
+# Purely informational: posts (or updates) a single PR comment with each
+# contributor's trust score. No min-score gate, no check run — nothing here
+# blocks a merge.
+#
+# pull_request_target so the DEVTRACE_TOKEN secret is available when scoring
+# external/fork contributors — the contributors this check exists to evaluate.
+# Safe here because the action only reads PR and author metadata via the
+# DevTrace API; it never checks out or runs PR code.
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  score:
+    name: Score Contributor Trust
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # post/update the trust score comment
+    timeout-minutes: 5
+    steps:
+      - name: DevTrace
+        uses: thingzio/devtrace-action@b35e96e42494859cfbab25d17499efb5cb30a59d  # v1.0.2
+        with:
+          token: ${{ secrets.DEVTRACE_TOKEN }}
+          # trusted-orgs: members of these GitHub orgs receive a trust-score
+          # boost (per the action docs). NVIDIA is this repo's owning org, so
+          # known internal contributors are recognized as trusted; external
+          # contributors are still scored, just without the boost.
+          trusted-orgs: NVIDIA


### PR DESCRIPTION
## Summary

Adds the `thingzio/devtrace-action` workflow to score every PR author's supply-chain trust level. The workflow is **purely informational**: it posts (or updates) a single PR comment with each contributor's trust score, grade, and risk summary. It does **not** create a check run and does **not** block merges. `trusted-orgs=NVIDIA` is set so members of the repo's owning org receive a trust-score boost.

### Why this action is allowed under NVIDIA org policy

This repo's Actions permissions are set to **"Allow enterprise, and select non-enterprise, actions and reusable workflows"**, with **"Allow actions by Marketplace verified creators"** enabled. `thingzio/devtrace-action` is published on the GitHub Marketplace by a [verified creator](https://github.com/marketplace/actions/devtrace-pr-check), so it satisfies the org-wide allowlist without needing an explicit per-action entry. The action is additionally pinned to a full-length commit SHA per repo convention.

## Motivation / Context

Supply-chain attacks exploit contributor trust. DevTrace scores PR authors across 22+ identity/engagement/community/behavioral signals so maintainers get risk context before merge. NVIDIA org members receive a trust boost; everyone else is still scored, just without it. The score is surfaced as context only — maintainers decide what to do with it.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: GitHub Actions CI (`.github/workflows`)

## Implementation Notes

- **Trigger is `pull_request_target`**, matching the repo's existing fork-aware workflows (`labeler.yaml`, `welcome.yaml`). Plain `pull_request` withholds repo secrets from fork PRs, so `DEVTRACE_TOKEN` would be empty for exactly the external contributors this check is meant to evaluate.
- **Safe under `pull_request_target`**: the action only reads PR/author metadata via the DevTrace API — it never checks out or executes PR code, so there is no pwn-request exposure despite the elevated trigger.
- **Least-privilege permissions**: top-level `contents: read`; the job adds only `pull-requests: write` to post the score comment. No `checks: write` — the action's docs require that permission only when `min-score` is set to create a check run, which this workflow intentionally omits.
- **Informational only**: no `min-score` gate. To enforce a threshold later, a maintainer would add `min-score` plus `checks: write` and mark **DevTrace Score** as a required status check.
- **`trusted-orgs: NVIDIA`**: per the action docs, members of the listed GitHub orgs receive a trust-score boost. NVIDIA is the repo's owning org, so known internal contributors are recognized as trusted.
- **Action pinned to commit SHA** `b35e96e...` (v1.0.2) per repo convention; Dependabot's `github-actions` ecosystem will propose future bumps.
- `DEVTRACE_TOKEN` repo secret is already configured.

## Security Rationale — why secret access on this PR trigger is safe

The well-known danger of `pull_request_target` ("pwn-request") is that it runs in the **base-repo context** with secrets, so if a workflow then **checks out and executes attacker-controlled PR code** (build scripts, test runners, `npm install`, etc.), that code inherits the secrets. The exposure comes entirely from *executing untrusted code*, not from the trigger itself.

This workflow never reaches that condition:

- **No checkout of PR code.** There is no `actions/checkout` step (and certainly none with `ref: ${{ github.event.pull_request.head.* }}`). The fork's tree is never materialized or run.
- **No PR-controlled execution.** The only step is the SHA-pinned `devtrace-action`, which calls the DevTrace API with the PR number/author metadata GitHub provides. Nothing from the PR diff influences what code runs.
- **Inputs are not interpolated into a shell.** `trusted-orgs` is a static literal in the workflow; no `${{ github.event.* }}` PR fields are expanded into `run:` blocks where they could inject commands.
- **Token blast radius is bounded.** `DEVTRACE_TOKEN` is a scoped DevTrace API token (read-only scoring), and the `GITHUB_TOKEN` is limited to `pull-requests: write` — enough to post a comment, not to push code or alter protected settings.

Net: an attacker opening a fork PR cannot run any of their own code in this job, so handing it the secret carries no more risk than the existing `labeler.yaml` / `welcome.yaml` workflows, which use `pull_request_target` for the same fork-secret reason.

## Testing

```bash
# YAML structure mirrors existing pull_request_target workflows (labeler.yaml).
# Action behavior will be exercised on this PR once triggered.
```

## Risk Assessment

- [x] **Low** — Additive, informational-only CI workflow, no production code, trivially revertible by deleting the file.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] I updated docs if user-facing behavior changed (N/A — internal CI)
- [x] Commits are cryptographically signed (`git commit -S`)
