### PR TITLE
chore(recipes): update nodewright to v0.17.0 (OCI chart)

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -48,7 +48,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | network-operator | helm | nvidia/network-operator | 26.1.1 | 5 |
 | nfd | helm | node-feature-discovery | 0.18.3 | 1 |
 | nodewright-customizations | manifest | — | — | 5 |
-| nodewright-operator | helm | skyhook-operator | v0.15.1 | 3 |
+| nodewright-operator | helm | nodewright | v0.17.0 | 3 |
 | nvidia-dra-driver-gpu | helm | dra-driver-nvidia-gpu | 0.4.1-rc.1 | 1 |
 | nvsentinel | helm | nvsentinel | v1.9.0 | 6 |
 | prometheus-adapter | helm | prometheus-community/prometheus-adapter | 5.3.0 | 1 |
@@ -184,7 +184,7 @@ _No images extracted._
 ### nodewright-operator
 
 - `bitnami/kubectl:latest@sha256:1bc359beb3ae3982591349df11db50b0917b0596e8bed8ab9cf0c8a84a3502d1`
-- `nvcr.io/nvidia/skyhook/operator:v0.15.0@sha256:09e4f71cca8757818515f9e7dd4b8f47d30c642dc3a7efe1329d5c19efea76b9`
+- `ghcr.io/nvidia/nodewright/operator:v0.17.0@sha256:1511449bf51f2844b6bb3a03bde3d5590caf2ca283e3e39c0745a8016af2132f`
 - `quay.io/brancz/kube-rbac-proxy:v0.15.0@sha256:2c7b120590cbe9f634f5099f2cbb91d0b668569023a81505ca124a5c437e7663`
 
 ### nvidia-dra-driver-gpu

--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -142,10 +142,10 @@ componentRefs:
       - kube-prometheus-stack
   - name: nodewright-operator
     namespace: skyhook
-    chart: skyhook-operator
+    chart: nodewright
     type: Helm
-    source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: v0.15.1
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    version: v0.17.0
     valuesFile: components/nodewright-operator/values.yaml
 deploymentOrder:
   - cert-manager

--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -147,10 +147,10 @@ componentRefs:
 
   - name: nodewright-operator
     namespace: skyhook
-    chart: skyhook-operator
+    chart: nodewright
     type: Helm
-    source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: v0.15.1
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    version: v0.17.0
     valuesFile: components/nodewright-operator/values.yaml
     overrides:
       customization: ubuntu

--- a/examples/recipes/eks-training.yaml
+++ b/examples/recipes/eks-training.yaml
@@ -56,10 +56,10 @@ componentRefs:
       - cert-manager
   - name: nodewright-operator
     namespace: skyhook
-    chart: skyhook-operator
+    chart: nodewright
     type: Helm
-    source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: v0.15.1
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    version: v0.17.0
     valuesFile: components/nodewright-operator/values.yaml
   - name: prometheus-operator-crds
     namespace: monitoring

--- a/examples/recipes/kind.yaml
+++ b/examples/recipes/kind.yaml
@@ -34,10 +34,10 @@ componentRefs:
     valuesFile: components/cert-manager/values.yaml
   - name: nodewright-operator
     namespace: skyhook
-    chart: skyhook-operator
+    chart: nodewright
     type: Helm
-    source: https://helm.ngc.nvidia.com/nvidia/skyhook
-    version: v0.15.1
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    version: v0.17.0
     valuesFile: components/nodewright-operator/values.yaml
   - name: prometheus-operator-crds
     namespace: nvidia-system

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -63,8 +63,8 @@ spec:
 
     - name: nodewright-operator
       type: Helm
-      source: https://helm.ngc.nvidia.com/nvidia/skyhook
-      version: v0.15.1
+      source: oci://ghcr.io/nvidia/nodewright/charts
+      version: v0.17.0
       valuesFile: components/nodewright-operator/values.yaml
 
     - name: prometheus-operator-crds

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -201,9 +201,9 @@ components:
     healthCheck:
       assertFile: checks/nodewright-operator/health-check.yaml
     helm:
-      defaultRepository: https://helm.ngc.nvidia.com/nvidia/skyhook
-      defaultChart: skyhook-operator
-      defaultVersion: v0.15.1
+      defaultRepository: oci://ghcr.io/nvidia/nodewright/charts
+      defaultChart: nodewright
+      defaultVersion: v0.17.0
       defaultNamespace: skyhook
     nodeScheduling:
       nodeCountPaths:


### PR DESCRIPTION
## Summary

Bump the `nodewright-operator` component to chart `v0.17.0` and repoint it to the new OCI-only chart with renamed images.

## Motivation / Context

The upstream chart (formerly `skyhook-operator`) moved to an OCI-only distribution and renamed its container images:
- Chart source: `https://helm.ngc.nvidia.com/nvidia/skyhook` (chart `skyhook-operator`) → `oci://ghcr.io/nvidia/nodewright/charts` (chart `nodewright`).
- Operator image: `nvcr.io/nvidia/skyhook/operator` → `ghcr.io/nvidia/nodewright/operator`.

Version bumped `v0.15.1` → `v0.17.0`.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Updated the chart pin everywhere it appears: `recipes/registry.yaml` (`defaultRepository`/`defaultChart`/`defaultVersion`), `recipes/overlays/base.yaml` (`source`/`version`), and the four `examples/recipes/*.yaml` that embed a resolved nodewright-operator entry.
- The OCI repo/chart split mirrors the existing `nvsentinel` entry: `defaultRepository` is the prefix, `defaultChart` is appended → `oci://ghcr.io/nvidia/nodewright/charts/nodewright`.
- Regenerated `docs/user/container-images.md` via `make bom-docs` (required by CLAUDE.md on any chart-pin change); the operator image now renders as `ghcr.io/nvidia/nodewright/operator:v0.17.0`.
- **Deliberately unchanged:** `recipes/components/nodewright-operator/values.yaml` keeps `fullnameOverride: skyhook-operator`. Rendering v0.17.0 with that override confirms the chart still emits the Deployment `skyhook-operator-controller-manager`, all `skyhook-operator-*` RBAC/Service/webhook resources, and the CRD `skyhooks.skyhook.nvidia.com` (group `skyhook.nvidia.com`, served `v1alpha1`, kind `Skyhook`). So the health check, `assert-skyhook.yaml`, and the `nodewright-customizations` Skyhook CRs (incl. the `part-of: skyhook-operator` label, which is descriptive metadata, not a selector) all remain valid without edits. Namespace stays `skyhook`.

## Testing

```bash
make qualify
```

- `go test ./recipes/... ./pkg/recipe/...` → pass
- `yamllint` on changed YAML → clean
- `helm template oci://ghcr.io/nvidia/nodewright/charts/nodewright --version v0.17.0 -n skyhook --set fullnameOverride=skyhook-operator` → renders expected resource names and CRDs

## Risk Assessment

- [x] **Low** — Isolated config/docs change, easy to revert.

**Rollout notes:** Generated recipes are point-in-time artifacts; regenerate with the new binary before re-bundling.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
