### PR TITLE
fix(toolkit): remove ACCEPT_NVIDIA_VISIBLE_DEVICES overrides from all recipes

### DIFF
--- a/recipes/components/gpu-operator/values-gke-cos-training.yaml
+++ b/recipes/components/gpu-operator/values-gke-cos-training.yaml
@@ -32,10 +32,6 @@ toolkit:
   enabled: true
   installDir: /home/kubernetes/bin/nvidia
   env:
-    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
-      value: "false"
-    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
-      value: "true"
     - name: RUNTIME_CONFIG_SOURCE
       value: "file"
 

--- a/recipes/components/gpu-operator/values-gke-cos.yaml
+++ b/recipes/components/gpu-operator/values-gke-cos.yaml
@@ -38,10 +38,6 @@ toolkit:
   enabled: true
   installDir: /home/kubernetes/bin/nvidia
   env:
-    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
-      value: "false"
-    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
-      value: "true"
     - name: RUNTIME_CONFIG_SOURCE
       value: "file"
 

--- a/recipes/components/gpu-operator/values.yaml
+++ b/recipes/components/gpu-operator/values.yaml
@@ -48,11 +48,6 @@ dcgm:
 
 toolkit:
   enabled: true
-  env:
-  - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
-    value: "false"
-  - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
-    value: "true"
 
 dcgmExporter:
   serviceMonitor:


### PR DESCRIPTION
## Summary

Removes \`ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED=false\` and \`ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS=true\` from all GPU Operator recipe overlay files.

## Motivation / Context

\`ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED\` is a **master gate** in nvidia-container-toolkit. When set to \`false\`, it silently blocks **all** GPU injection — env var path and \`default-kind\` management injection — regardless of CSP or GPU type. The flag defaults to \`true\` upstream; there is no operational or security justification for overriding it to \`false\` in the recipe defaults.

Root cause confirmed on GKE COS H100, GPU Operator v26.3.x: pods with \`runtimeClassName: nvidia\` received no GPUs after deploying the aicr bundle. Patching the ClusterPolicy to remove the override fully restored GPU access.

Fixes: #1354

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (\`pkg/recipe\`)

## Testing

- [x] Validated ACCEPT=false behavior end-to-end on GKE COS H100, GPU Operator v26.3.x
- [x] Confirmed \`runtimeClassName: nvidia\` + \`NVIDIA_VISIBLE_DEVICES=all\` returns \`nvidia-smi: not found\` with ACCEPT=false
- [x] Confirmed GPU access restored after removing the flag from ClusterPolicy
- [x] Deployed updated bundle and ran \`TestCDI_RuntimeClass_NvidiaSmi\` — test passed

## Risk Assessment

- [x] **Low** — Restores upstream default behavior; no new logic introduced

**Rollout notes:** N/A — restores upstream default, no migration needed.

## Checklist

- [x] Tests pass locally (\`make test\` with \`-race\`)
- [x] Linter passes (\`make lint\`)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (\`git commit -S\`)