### PR TITLE
fix(docs): escape bare < for Fern MDX + harden MDX checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ check-docs-filenames: ## Enforces lowercase kebab-case filenames in docs/
 	@./tools/check-docs-filenames
 
 .PHONY: check-docs-mdx
-check-docs-mdx: ## Checks docs/ markdown for MDX compatibility (void elements, bare braces, HTML comments)
+check-docs-mdx: ## Checks docs/ markdown for MDX compatibility (void elements, bare braces, HTML comments, autolinks, bare <tags>)
 	@./tools/check-docs-mdx
 
 .PHONY: lint-go

--- a/docs/contributor/inference-perf-fluctuation.md
+++ b/docs/contributor/inference-perf-fluctuation.md
@@ -284,7 +284,7 @@ which **cancelled that legitimate first request mid-warmup**; each retry
 restarts it, so no poll ever succeeded and the 5-minute window expired —
 **before AIPerf (which has its own warmup phase) ever started**. It is
 intermittent because RTX's cold first-token straddles the 30 s line (morning
-runs landed <30 s and passed; afternoon landed ~42 s and failed); H100/GB200
+runs landed \<30 s and passed; afternoon landed ~42 s and failed); H100/GB200
 cold-start stays under 30 s, so they never tripped it. Independent of the AIPerf
 determinism flags (the same tweaked image both passed and failed across runs)
 and of concurrency.

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -9,9 +9,10 @@
 # common violations before they reach CI or break versioned doc snapshots.
 #
 # Scope: docs/user/, docs/integrator/, and docs/contributor/ (all published
-# to Fern). container-images.md and recipe-health.md carry auto-generated
-# HTML comment splice markers that VitePress still needs; both are excluded
-# until VitePress is removed (see EXCLUDE_NAMES below).
+# to Fern). container-images.md carries auto-generated HTML comment splice
+# markers that VitePress still needs and is not published to Fern, so it is
+# excluded (see EXCLUDE_NAMES below). recipe-health.md IS published to Fern
+# and uses MDX-safe {/* ... */} comment markers, so it is checked.
 # Override with positional args for frozen version content.
 #
 # Checks:
@@ -28,10 +29,11 @@ set -euo pipefail
 
 ERRORS=0
 SEARCH_DIRS=("docs/user/" "docs/integrator/" "docs/contributor/")
-# Docs with auto-generated HTML-comment splice markers that VitePress still
-# needs (excluded until VitePress is removed): the BOM inventory and the
-# recipe-health matrix, both spliced by `make *-docs` between marker comments.
-EXCLUDE_NAMES=("container-images.md" "recipe-health.md")
+# Docs excluded from the MDX scan: container-images.md carries auto-generated
+# HTML-comment splice markers that VitePress still needs and is not published
+# to Fern. (recipe-health.md is intentionally NOT excluded — it is Fern-
+# published and uses MDX-safe {/* ... */} markers.)
+EXCLUDE_NAMES=("container-images.md")
 EXCLUDE_ARGS=()
 for name in "${EXCLUDE_NAMES[@]}"; do
   EXCLUDE_ARGS+=(! -name "${name}")
@@ -70,8 +72,19 @@ for dir in "${SEARCH_DIRS[@]}"; do
       /^```/ { in_fence = !in_fence; next }
       in_fence { next }
       {
-        # Strip inline code spans so backticked tokens don'\''t trigger.
         line = $0
+        # MDX comments {/* ... */} are valid (and used for license headers
+        # and the auto-generated splice markers in recipe-health.md). Treat
+        # them like code: continue an open multi-line comment, strip
+        # single-line ones, and open a region for an unterminated {/*.
+        if (in_mdx_comment) {
+          ci = index(line, "*/}")
+          if (ci > 0) { line = substr(line, ci + 3); in_mdx_comment = 0 }
+          else { next }
+        }
+        gsub(/\{\/\*.*\*\/\}/, "", line)
+        if (match(line, /\{\/\*/)) { line = substr(line, 1, RSTART - 1); in_mdx_comment = 1 }
+        # Strip inline code spans so backticked tokens don'\''t trigger.
         gsub(/`[^`]*`/, "", line)
         # Strip backslash-escaped angle brackets (\<word\>, or a lone \<) —
         # these are valid markdown escapes and MDX-safe.

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -68,11 +68,20 @@ done
 for dir in "${SEARCH_DIRS[@]}"; do
   while IFS= read -r file; do
     [[ -z "${file}" ]] && continue
-    awk '
+    # awk exits 1 when it finds a hazard; keep it inside the `if` condition so
+    # `set -e` does not abort the whole scan at the first offending file
+    # (otherwise violations in later files are silently skipped).
+    if ! awk '
       /^```/ { in_fence = !in_fence; next }
       in_fence { next }
       {
         line = $0
+        # Strip inline code spans FIRST so backticked tokens — including a
+        # backticked `{/*` or `*/}` — never trip the MDX-comment detection
+        # below (or any later check). Doing this before the comment scan
+        # prevents a backticked, unterminated `{/*` from opening a bogus
+        # multi-line region that swallows real hazards on following lines.
+        gsub(/`[^`]*`/, "", line)
         # MDX comments {/* ... */} are valid (and used for license headers
         # and the auto-generated splice markers in recipe-health.md). Treat
         # them like code: continue an open multi-line comment, strip
@@ -94,8 +103,6 @@ for dir in "${SEARCH_DIRS[@]}"; do
           if (ci > 0) { line = substr(line, 1, cstart - 1) substr(rest, ci + 3) }
           else { line = substr(line, 1, cstart - 1); in_mdx_comment = 1; break }
         }
-        # Strip inline code spans so backticked tokens don'\''t trigger.
-        gsub(/`[^`]*`/, "", line)
         # Strip backslash-escaped angle brackets (\<word\>, or a lone \<) —
         # these are valid markdown escapes and MDX-safe.
         gsub(/\\</, "", line)
@@ -126,8 +133,7 @@ for dir in "${SEARCH_DIRS[@]}"; do
         errors++
       }
       END { exit (errors > 0) ? 1 : 0 }
-    ' "$file" 2>/dev/null
-    if [[ $? -ne 0 ]]; then
+    ' "$file" 2>/dev/null; then
       ERRORS=$((ERRORS + 1))
     fi
   done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${EXCLUDE_ARGS[@]}" 2>/dev/null)

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -73,9 +73,10 @@ for dir in "${SEARCH_DIRS[@]}"; do
         # Strip inline code spans so backticked tokens don'\''t trigger.
         line = $0
         gsub(/`[^`]*`/, "", line)
-        # Strip backslash-escaped angle brackets (\<word\>) — these are
-        # valid markdown escapes and MDX-safe.
-        gsub(/\\<[^>]*\\>/, "", line)
+        # Strip backslash-escaped angle brackets (\<word\>, or a lone \<) —
+        # these are valid markdown escapes and MDX-safe.
+        gsub(/\\</, "", line)
+        gsub(/\\>/, "", line)
       }
       # Bare { not preceded by backslash escape. The leading
       # (^|[^\\]) form catches { in column 1 as well.
@@ -93,10 +94,11 @@ for dir in "${SEARCH_DIRS[@]}"; do
         printf "MDX: autolink outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }
-      # Bare angle-bracket placeholders: <word> that are not void HTML
-      # elements (check 1) or autolinks (check 4). MDX interprets these
-      # as JSX component tags.
-      line ~ /<[a-zA-Z]/ && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
+      # Bare angle-bracket placeholders: <word> or <digit> (e.g. <30 s,
+      # <13%) that are not void HTML elements (check 1) or autolinks
+      # (check 4). MDX interprets a `<` followed by a name-start character
+      # as a JSX tag and chokes on what follows.
+      line ~ /<[0-9a-zA-Z]/ && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
         printf "MDX: bare <word> tag outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -82,8 +82,18 @@ for dir in "${SEARCH_DIRS[@]}"; do
           if (ci > 0) { line = substr(line, ci + 3); in_mdx_comment = 0 }
           else { next }
         }
-        gsub(/\{\/\*.*\*\/\}/, "", line)
-        if (match(line, /\{\/\*/)) { line = substr(line, 1, RSTART - 1); in_mdx_comment = 1 }
+        # Strip MDX comments one {/* ... */} segment at a time. A greedy
+        # match would span from the first {/* to the last */} and delete a
+        # real hazard sitting between two separate comments on one line
+        # (e.g. `{/* a */} <30 s {/* b */}`), letting it evade the checks
+        # below. An unterminated {/* opens a multi-line region.
+        while (match(line, /\{\/\*/)) {
+          cstart = RSTART
+          rest = substr(line, cstart)
+          ci = index(rest, "*/}")
+          if (ci > 0) { line = substr(line, 1, cstart - 1) substr(rest, ci + 3) }
+          else { line = substr(line, 1, cstart - 1); in_mdx_comment = 1; break }
+        }
         # Strip inline code spans so backticked tokens don'\''t trigger.
         gsub(/`[^`]*`/, "", line)
         # Strip backslash-escaped angle brackets (\<word\>, or a lone \<) —


### PR DESCRIPTION
## Summary

Unblock the Fern docs publish (MDX) and close the two gaps in the local MDX checker that let the breakage reach the release tag.

## Motivation / Context

Fern parses docs as MDX, which treats a bare `<` followed by a name-start character as a JSX tag. `landed <30 s` in `docs/contributor/inference-perf-fluctuation.md` failed the `v0.15.0-rc2` Publish Fern Docs job:

```
Failed to parse ../docs/contributor/inference-perf-fluctuation.md: Unexpected character `3` (U+0033) before name ...
```

There is already a local gate for this — `tools/check-docs-mdx`, exposed as `make check-docs-mdx` and wired into `make lint` (hence `make qualify`) and the PR-CI `fern-docs-ci.yaml`. It should have caught both this and the earlier recipe-health.md breakage, but had two gaps:

1. **Digit gap:** the bare-tag check only matched `<` before a *letter* (`<[a-zA-Z]`), so `<30 s` / `<13%` slipped through.
2. **Stale exclusion:** `recipe-health.md` was excluded (on a now-obsolete VitePress HTML-marker assumption) — which is why its HTML comment reached the rc1 publish.

(`fern check` does not catch MDX *parse* errors, so publish was the first place these surfaced.)

Fixes: N/A
Related: https://github.com/NVIDIA/aicr/actions/runs/27557526326

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: docs MDX checker (`tools/check-docs-mdx`, `make check-docs-mdx`)

## Implementation Notes

Three commits:
1. **Doc fix** — escape `<30 s` as `\<30 s` (literal `<` in MDX and GitHub CommonMark). `<13%` on line 162 is inside a code fence, so MDX leaves it literal — consistent with the error pointing at `<30` (char `3`).
2. **Checker: digit gap** — broaden the bare-tag match to `<[0-9a-zA-Z]`, and strip `\<` / `\>` individually so a lone `\<` escape doesn't false-positive.
3. **Checker: exclusion + MDX comments** — drop the `recipe-health.md` exclusion (it is Fern-published and now uses MDX-safe `{/* ... */}` markers), and teach the checker to treat `{/* ... */}` comments (single- and multi-line) as safe so the valid markers don't trip the bare-brace check while real hazards on the same line are still caught. `container-images.md` stays excluded (HTML markers, not Fern-published).

## Testing

```bash
make check-docs-mdx     # OK on the full tree (now including recipe-health.md)
# probes: bare `<30 s` / `<13%` and `{foo}` are flagged; `\<...\>`, backticked
# `<...>`, and `{/* ... */}` comments are treated as safe.
```

A sweep of all 31 Fern-nav docs found `<30 s` to be the only remaining bare-`<` prose hazard and no stray `{` hazards beyond valid MDX comments.

## Risk Assessment

- [x] **Low** — one-char doc escape plus regex/handling fixes in a lint tool; easy to revert.

**Rollout notes:** With both checker gaps closed, `make lint` / `make qualify` now catch this class pre-merge — no separate pre-push hook needed.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A
- [x] Linter passes (`make check-docs-mdx`)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)