### PR TITLE
test(uat): allow NATS ingress on UAT AWS/GCP clusters

### DIFF
--- a/tests/uat/aws/cluster-config.yaml
+++ b/tests/uat/aws/cluster-config.yaml
@@ -35,6 +35,7 @@ cluster:
         - 216.228.127.128/30
         - 52.41.222.58/32
         - 54.68.11.139/32
+        - 128.77.49.32/30
     addOns:
       coreDns: ""
       kubeProxy: ""
@@ -64,6 +65,17 @@ network:
         - cidr: 100.65.0.0/16
           zone: us-east-1e
           disableEndpoints: true
+    securityGroups:
+      additionalRules:
+        - target: system
+          direction: ingress
+          fromPort: 4222
+          toPort: 4222
+          protocol: tcp
+          # VPC-CNI does not SNAT in-VPC pod-to-pod traffic, so NATS on the
+          # system node sees the pod source IP (pod subnet), not the node IP.
+          cidrBlocks: ["10.0.128.0/17", "100.65.0.0/16"]  # worker node + pod subnet CIDRs
+          description: "Allow NATS from worker nodes and pods"
 
 compute:
   eks:

--- a/tests/uat/gcp/cluster-config.yaml
+++ b/tests/uat/gcp/cluster-config.yaml
@@ -41,12 +41,21 @@ cluster:
 
 network:
   gke:
+    subnets:
+      nodes:
+        - name: system-subnet
+          cidr: "10.0.0.0/22"
+        - name: worker-subnet
+          cidr: "10.0.128.0/17"
     gpuNets:
       count: 8
       mtu: 8244
       cidrBase: "192.168.0.0/16"
       gvnicCidr: "192.168.128.0/20"
     firewallRules:
+      # Allows all intra-VPC TCP/UDP/ICMP from 10.0.0.0/8, which covers node
+      # subnets and the GKE pod secondary ranges. NATS (4222) is already
+      # permitted by this rule, so no dedicated allow-nats rule is needed.
       - name: nccl-internal
         direction: INGRESS
         priority: 900


### PR DESCRIPTION
## Summary

Allow NATS (4222/tcp) ingress on the UAT AWS and GCP clusters.

## Motivation / Context

Dynamo's NATS clients (in worker pods) could not reach the NATS server on the system nodes in the UAT environments.

Fixes: N/A
Related: #1369

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT cluster infra config (`tests/uat/`)

## Implementation Notes

- **AWS:** added an EKS security-group ingress rule for 4222/tcp. It sources **both** the worker node subnet (`10.0.128.0/17`) **and** the pod subnet (`100.65.0.0/16`) — AWS VPC-CNI does not SNAT in-VPC pod-to-pod traffic, so the system node hosting NATS sees the *pod* source IP, not the node IP. A node-only rule would never match.
- **AWS:** added the HQ CIDR `128.77.49.32/30` to the control-plane endpoint `allowedCidrs`, for parity with the GKE `authorizedNetworks` `nw3` entry. (This is an HQ-access addition, not the worker CIDR — corrected from the earlier description.)
- **GCP:** declared explicit `system`/`worker` node subnets. **No dedicated NATS firewall rule is added** — the existing `nccl-internal` rule already allows all intra-VPC TCP from `10.0.0.0/8` (covering node primaries and the GKE pod secondary ranges), which includes 4222. The initial draft tightened `nccl-internal` to node-only CIDRs and added a redundant `allow-nats` rule; both were reverted after review since they would have dropped pod-range coverage.
- Port 9090 (Prometheus query, `ai-service-metrics`) is already enabled by default, so no rule is needed for Prometheus queries from worker nodes.

## Testing

```bash
# Config-only change to UAT infra YAML; no code paths exercised by make qualify.
```

## Risk Assessment

- [x] **Low** — Isolated change to UAT-only infra config, easy to revert

**Rollout notes:** Applied when the UAT clusters are next provisioned/reconciled. N/A for runtime code.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)