### PR TITLE
fix(ci): correct docs-only detection in merge gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -78,26 +78,29 @@ jobs:
               - '.github/renovate.json5'
               - 'Makefile'
 
-      # Detect docs-only PRs: true only when EVERY changed file is docs/md
+      # code = true iff at least one changed file is NOT docs/markdown/LICENSE.
+      #
+      # Exclusion idiom: dorny's `predicate-quantifier: 'every'` requires a file
+      # to match EVERY pattern in the filter, so a file matches `code` only when
+      # it matches '**' AND none of the docs patterns. The filter output is true
+      # when ANY changed file is code — so a docs-only PR yields code=false.
+      #
+      # NOTE: 'every' does NOT mean "every changed file matches"; the prior
+      # `only: [**.md, docs/**, LICENSE]` form required a single file to match
+      # all three at once (impossible), so it was always false and code was
+      # always true — docs-only PRs ran full qualification. '**' matches
+      # dotfiles too (dorny sets picomatch dot:true), so '.golangci.yaml',
+      # '.settings.yaml', etc. still count as code.
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
-        id: docs
+        id: code
         with:
           predicate-quantifier: 'every'
           filters: |
-            only:
-              - '**.md'
-              - 'docs/**'
-              - 'LICENSE'
-
-      # code = NOT docs-only (inverted because paths-filter can't negate)
-      - name: Compute code flag
-        id: code
-        run: |
-          if [ "${{ steps.docs.outputs.only }}" = "true" ]; then
-            echo "code=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "code=true" >> "$GITHUB_OUTPUT"
-          fi
+            code:
+              - '**'
+              - '!**.md'
+              - '!docs/**'
+              - '!LICENSE'
 
   # ---------------------------------------------------------------------------
   # Qualification (Test, Lint, CLI E2E, E2E, Security Scan)


### PR DESCRIPTION
## Summary

Fix the `check-paths` job in `merge-gate.yaml` so docs-only PRs actually skip Go qualification. The docs-only filter was permanently false, so every PR (including pure-docs ones like #1379) ran the full gate.

## Motivation / Context

`check-paths` used `dorny/paths-filter` with `predicate-quantifier: 'every'` over `[**.md, docs/**, LICENSE]`, intending "every changed file is docs". But `every` means a *single file* must match *every pattern* in the filter — no path can match `**.md` AND `docs/**` AND `LICENSE` simultaneously, so the `only` output was always `false`, the compute step always set `code=true`, and `tests` / `analyze` / `malware-scan` ran on every PR.

This has been latent since the merge gate was introduced (#651); docs-only skipping never worked. Observed on #1379 (single `docs/contributor/component.md` edit) which ran Test, Lint, CLI E2E, E2E, Security Scan, CodeQL, and ClamAV.

Fixes: N/A
Related: #1379

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI (`.github/workflows/merge-gate.yaml`)

## Implementation Notes

Switched to the documented exclusion idiom: `code=true` iff at least one changed file is **not** docs/markdown/LICENSE.

```yaml
code:
  - '**'
  - '\!**.md'
  - '\!docs/**'
  - '\!LICENSE'
```

With `predicate-quantifier: 'every'`, a file matches `code` only when it matches `**` AND none of the docs patterns; the filter is true if any changed file is code. Dorny sets picomatch `dot: true` (verified at the pinned SHA), so `**` still matches dotfile code like `.golangci.yaml` / `.settings.yaml` — no fail-open on hidden config. The manual inversion step is removed; `outputs.code` already maps to `steps.code.outputs.code`.

## Testing

```bash
actionlint .github/workflows/merge-gate.yaml   # clean
```

Behavior validated by reasoning against dorny semantics (README + picomatch `dot:true` at the pinned commit). The fix is exercised end-to-end by this PR itself: as a non-docs change it should set `code=true` and run the full gate; a follow-up docs-only PR should now show `tests-skip` / `analyze-skip` / `malware-scan-skip`.

## Risk Assessment

- [x] **Low** — Isolated CI logic change, easy to revert. Worst case mirrors today's behavior (over-running checks); the dotfile check guards the only fail-open direction.

**Rollout notes:** N/A

## Checklist

- [x] Linter passes (actionlint clean)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)