### PR TITLE
feat(validate): warn on aicr version skew across inputs

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -838,6 +838,8 @@ Validation can be run in different phases to validate different aspects of the d
 
 > **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs.
 
+> **Version skew:** Snapshots and recipes record the `aicr` version that produced them. When the recipe, the snapshot, and the running binary report different release versions, `validate` logs a single advisory warning (`version skew detected across validate inputs`) naming all three. This is a debugging breadcrumb — mixing artifacts from different versions can surface as confusing failures — and does **not** fail the command. Dev (`dev`) and pre-release (`-next`) builds are ignored to avoid noise.
+
 Phases run sequentially with `--phase all` and all phases run by default, producing results regardless of earlier failures; use `--fail-fast` to stop after the first failing phase. For what each phase actually checks (deployment-phase readiness signals, graceful-skip semantics, RBAC, Day-N re-verification, and evidence), see [Validation](validation.md).
 
 #### Constraint paths and operators

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -765,6 +765,12 @@ Run validation without failing on check errors (informational mode):
 				}
 			}
 
+			// Advisory: warn when the running binary, the recipe-producing
+			// binary, and the snapshot-producing binary report different
+			// release versions. Mixed-version artifacts can cause confusing
+			// validation failures; this does not fail the command.
+			warnVersionSkew(version, rec.Resolved().Metadata.Version, snap.Metadata["version"])
+
 			// Warn when a requested phase has no checks defined in the recipe.
 			// The helper reads the full recipe's Validation section, which the
 			// lossy facade RecipeResult does not expose — reach the underlying

--- a/pkg/cli/version_skew.go
+++ b/pkg/cli/version_skew.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// isReleaseVersion reports whether v is a release build version string.
+// Dev builds ("dev") and snapshot builds ("...-next") carry non-release
+// strings whose skew is expected, so version-skew detection ignores them to
+// avoid noise in local and CI flows. An empty version (an older artifact that
+// predates the embedded-version field) is likewise treated as unknown.
+func isReleaseVersion(v string) bool {
+	return v != "" && v != versionDefault && !strings.Contains(v, "-next")
+}
+
+// versionSkewDetected reports whether the inputs contain two or more distinct
+// release versions. Only release versions are compared (see isReleaseVersion);
+// a single known version mixed with unknown/dev ones is not treated as skew.
+func versionSkewDetected(versions ...string) bool {
+	distinct := make(map[string]struct{})
+	for _, v := range versions {
+		if isReleaseVersion(v) {
+			distinct[v] = struct{}{}
+		}
+	}
+	return len(distinct) >= 2
+}
+
+// warnVersionSkew emits a single advisory warning when the running binary, the
+// recipe-producing binary, and the snapshot-producing binary report different
+// release versions. Mixing artifacts produced by different aicr versions can
+// surface as confusing validation failures with no obvious cause, so this is a
+// debugging breadcrumb pointing at version skew.
+//
+// The embedded versions are unsigned, advisory metadata — this deliberately
+// does not fail the command. See the schema-versioned compatibility gate
+// tracked as follow-up work for a stronger guarantee.
+func warnVersionSkew(binaryVersion, recipeVersion, snapshotVersion string) {
+	if !versionSkewDetected(binaryVersion, recipeVersion, snapshotVersion) {
+		return
+	}
+	slog.Warn("version skew detected across validate inputs; mixing artifacts from different aicr versions can cause hard-to-debug validation failures",
+		"binaryVersion", displayVersion(binaryVersion),
+		"recipeVersion", displayVersion(recipeVersion),
+		"snapshotVersion", displayVersion(snapshotVersion))
+}
+
+// displayVersion renders a version for logging, substituting a placeholder for
+// the empty string so the warning never shows a blank field.
+func displayVersion(v string) string {
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}

--- a/pkg/cli/version_skew_test.go
+++ b/pkg/cli/version_skew_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestIsReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"release", "0.14.0", true},
+		{"release with v prefix", "v0.14.0", true},
+		{"empty", "", false},
+		{"dev default", versionDefault, false},
+		{"next snapshot", "v0.14.0-next", false},
+		{"next snapshot mid-string", "0.14.0-next.3", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isReleaseVersion(tt.version); got != tt.want {
+				t.Errorf("isReleaseVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionSkewDetected(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions []string
+		want     bool
+	}{
+		{"all identical release", []string{"0.14.0", "0.14.0", "0.14.0"}, false},
+		{"two distinct releases", []string{"0.14.0", "0.13.0", "0.14.0"}, true},
+		{"three distinct releases", []string{"0.14.0", "0.13.0", "0.12.0"}, true},
+		{"one release rest empty", []string{"0.14.0", "", ""}, false},
+		{"one release rest dev", []string{"0.14.0", versionDefault, "v0.14.0-next"}, false},
+		{"all dev", []string{versionDefault, versionDefault, versionDefault}, false},
+		{"all empty", []string{"", "", ""}, false},
+		{"distinct but one is dev", []string{"0.14.0", "0.13.0", versionDefault}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := versionSkewDetected(tt.versions...); got != tt.want {
+				t.Errorf("versionSkewDetected(%v) = %v, want %v", tt.versions, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWarnVersionSkew(t *testing.T) {
+	tests := []struct {
+		name                     string
+		binary, recipe, snapshot string
+		wantWarn                 bool
+		wantContains             []string
+	}{
+		{
+			name:     "skew warns and names all three versions",
+			binary:   "0.14.0",
+			recipe:   "0.13.0",
+			snapshot: "0.13.0",
+			wantWarn: true,
+			wantContains: []string{
+				"version skew", "binaryVersion=0.14.0", "recipeVersion=0.13.0", "snapshotVersion=0.13.0",
+			},
+		},
+		{
+			name:     "aligned releases stay silent",
+			binary:   "0.14.0",
+			recipe:   "0.14.0",
+			snapshot: "0.14.0",
+			wantWarn: false,
+		},
+		{
+			name:         "empty snapshot version renders as unknown",
+			binary:       "0.14.0",
+			recipe:       "0.13.0",
+			snapshot:     "",
+			wantWarn:     true,
+			wantContains: []string{"snapshotVersion=unknown"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			original := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			defer slog.SetDefault(original)
+
+			warnVersionSkew(tt.binary, tt.recipe, tt.snapshot)
+
+			out := buf.String()
+			gotWarn := strings.Contains(out, "level=WARN")
+			if gotWarn != tt.wantWarn {
+				t.Fatalf("warn emitted = %v, want %v (output: %q)", gotWarn, tt.wantWarn, out)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q; got %q", want, out)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`aicr validate` now emits a single advisory warning when the running binary, the recipe-producing binary, and the snapshot-producing binary report two or more distinct **release** versions.

## Motivation / Context

Snapshots and recipes already embed the `aicr` version that produced them (`Metadata["version"]` / `Metadata.Version`), but `validate` never compared them against each other or the running binary. Mixing artifacts from different versions can surface as confusing validation failures with no obvious root cause. This adds a low-cost breadcrumb pointing at version skew.

The embedded versions are unsigned, advisory metadata, so this deliberately **does not fail** the command and ignores `dev`/`-next` builds to avoid noise. A stronger, schema-versioned compatibility gate (consolidating `apiVersion`, enforcing it on load) is tracked separately.

Fixes: N/A
Related: #1385

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New `pkg/cli/version_skew.go`: `isReleaseVersion` (ignores empty/`dev`/`-next`), `versionSkewDetected` (≥2 distinct release versions), and `warnVersionSkew` (single `slog.Warn` naming all three).
- Wired into the `validate` action after the snapshot loads (both the file and agent-capture paths populate `snap`), before phase warnings.
- Pure decision functions are table-tested; the log wrapper is verified via a captured `slog` handler.

## Testing

```bash
make test   # pass, total coverage 77.2% (>= 70% floor)
golangci-lint run -c .golangci.yaml ./pkg/cli/...   # 0 issues
```

## Risk Assessment

- [x] **Low** — Isolated, advisory-only CLI log line; no control-flow or exit-code change; easy to revert.

**Rollout notes:** N/A — no flags, no behavior change beyond an additional warning log.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)