### PR TITLE
feat(validate): enforce artifact apiVersion compatibility

### DIFF
--- a/docs/design/011-artifact-apiversion-policy.md
+++ b/docs/design/011-artifact-apiversion-policy.md
@@ -1,0 +1,107 @@
+# ADR-011: Artifact apiVersion Policy and Compatibility Gate
+
+## Problem
+
+`aicr validate` consumes three artifacts that may have been produced by
+different `aicr` versions: the snapshot, the recipe, and the running binary.
+Until now nothing enforced a compatibility contract between them. Two failure
+modes followed:
+
+- **Silent schema drift.** A recipe or snapshot produced by an incompatible
+  `aicr` version could be loaded structurally with no signal, surfacing later
+  as a confusing validation failure with no obvious cause.
+- **No meaningful version contract.** Every artifact carries an `apiVersion`
+  (`aicr.nvidia.com/v1alpha1`), but the string was:
+  - **frozen since repo init** — never bumped, with breaking schema changes
+    shipped *within* `v1alpha1`;
+  - **redefined as ~5 independent string literals** (`pkg/snapshotter`,
+    `pkg/recipe` result + criteria, `pkg/config`) that agreed only by
+    coincidence, with doc drift (`/v1` vs `/v1alpha1`) already present;
+  - **unenforced on read** — snapshot loading ignored it entirely; recipe
+    loading checked only `Kind`.
+
+So an `apiVersion` match guaranteed nothing and a mismatch never occurred. This
+ADR makes the `apiVersion` a real, single-sourced, enforced contract.
+
+A predecessor change (#1386) added a *soft, advisory* warning comparing the
+embedded **binary version** strings. That remains useful as a debugging
+breadcrumb but is unsigned and noisy across dev builds; it is not a contract.
+This ADR establishes the durable, schema-level gate.
+
+## Non-Goals
+
+- **Bumping to `v1alpha2` now.** No breaking schema change is being made, so
+  the version stays `v1alpha1`. Bumping with no schema change would orphan
+  every existing artifact for zero benefit. The bump happens the next time the
+  schema changes incompatibly.
+- **Gating non-artifact `apiVersion`s.** The validator catalog
+  (`validator.nvidia.com/...`), provenance predicate, and Zarf/Hauler mirror
+  formats are separate schemas with their own domains/versions and are out of
+  scope.
+- **Signing or authenticating the artifact header.** The embedded `apiVersion`
+  (like the snapshot fingerprint) is unsigned, advisory metadata. This gate
+  catches accidental version skew, not a motivated attacker editing the file.
+- **A `--skip-version-check` escape hatch.** The gate fails closed with no
+  bypass; the well-formed path is to regenerate the artifact with a matching
+  `aicr` version.
+
+## Decision
+
+### 1. Single source of truth
+
+`pkg/header` is the canonical home for the artifact group/version:
+
+- `header.APIGroup` = `aicr.nvidia.com`
+- `header.APIVersionV1Alpha1` = `v1alpha1`
+- `header.GroupVersion` = `aicr.nvidia.com/v1alpha1`
+
+All package-local constants alias `header.GroupVersion` rather than redeclaring
+the literal: `snapshotter.FullAPIVersion`, `recipe.RecipeAPIVersion`,
+`recipe.RecipeCriteriaAPIVersion`, and `config.APIVersion`.
+
+### 2. Evolution rule
+
+- Schema changes within a version MUST be **additive-only** (new optional
+  fields). Existing artifacts must continue to deserialize. This matches the
+  current backward-compat strategy already covered by
+  `pkg/serializer/reader_recipe_compat_test.go`.
+- A **breaking** change (removing/renaming a field, changing semantics, or a
+  required-field addition) requires a **new version segment**
+  (e.g. `v1alpha2`).
+
+### 3. Compatibility gate (accept-known / reject-unknown)
+
+`header.IsSupportedAPIVersion(v)` reports whether a non-empty `apiVersion` is
+one this binary understands. The snapshot and recipe loaders apply it:
+
+- **Empty `apiVersion`** → accepted (older artifacts predate the field; matches
+  the existing empty-`Kind` tolerance).
+- **Known `apiVersion`** → accepted.
+- **Non-empty unknown `apiVersion`** → rejected with
+  `ErrCodeInvalidRequest` and a message naming the value, the expected value,
+  and the remediation (regenerate/recapture with a matching `aicr` version).
+
+The gate lives in the shared loaders — `recipe.LoadFromFileWithProvider` (used
+by both CLI and server via `pkg/client/v1`) and the new
+`snapshotter.LoadFromFile` / `LoadFromFileWithKubeconfig`, which `validate`,
+`query`, and `diff` route through — so enforcement is uniform across entry
+points. This mirrors the strict reject already in `pkg/config` (`Validate`) and
+`pkg/recipe` criteria parsing.
+
+### 4. Transition window on a future bump
+
+When the schema is bumped (e.g. to `v1alpha2`), add the new value to
+`header.IsSupportedAPIVersion` **while keeping the old one**, so a transition
+window accepts both. Retire the old value only after the deprecation window
+closes. Add a regression test asserting an out-of-window version is rejected.
+
+## Consequences
+
+- An artifact stamped with an unsupported `apiVersion` now fails fast at load
+  with a clear, actionable error instead of failing obscurely downstream.
+- The `apiVersion` literal exists exactly once; future bumps are a one-line
+  change plus a transition-window entry.
+- No behavior change for current artifacts: everything in the wild is
+  `v1alpha1` (accepted) or has an empty `apiVersion` (tolerated).
+- The gate is intentionally not a security control; the unsigned header can
+  still be edited. Authenticated provenance remains the supply-chain workstream.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -840,6 +840,8 @@ Validation can be run in different phases to validate different aspects of the d
 
 > **Version skew:** Snapshots and recipes record the `aicr` version that produced them. When the recipe, the snapshot, and the running binary report different release versions, `validate` logs a single advisory warning (`version skew detected across validate inputs`) naming all three. This is a debugging breadcrumb — mixing artifacts from different versions can surface as confusing failures — and does **not** fail the command. Dev (`dev`) and pre-release (`-next`) builds are ignored to avoid noise.
 
+> **apiVersion gate:** Snapshots and recipes also carry a schema `apiVersion` (currently `aicr.nvidia.com/v1alpha1`). Loading an artifact stamped with an `apiVersion` this build does not support fails fast with an `invalid apiVersion` error; regenerate or recapture the artifact with a matching `aicr` version. An empty `apiVersion` (older artifacts that predate the field) is still accepted. See [ADR-011](../design/011-artifact-apiversion-policy.md) for the evolution policy.
+
 Phases run sequentially with `--phase all` and all phases run by default, producing results regardless of earlier failures; use `--fail-fast` to stop after the first failing phase. For what each phase actually checks (deployment-phase readiness signals, graceful-skip semantics, RBAC, Day-N re-verification, and evidence), see [Validation](validation.md).
 
 #### Constraint paths and operators

--- a/pkg/cli/diff.go
+++ b/pkg/cli/diff.go
@@ -107,12 +107,12 @@ func runDiffCmd(ctx context.Context, cmd *cli.Command) error {
 
 	slog.Debug("snapshot diff", slog.String("baseline", baselinePath), slog.String("target", targetPath))
 
-	baseline, err := serializer.FromFileWithKubeconfig[snapshotter.Snapshot](baselinePath, kubeconfig)
+	baseline, err := snapshotter.LoadFromFileWithKubeconfig(ctx, baselinePath, kubeconfig)
 	if err != nil {
 		return err
 	}
 
-	target, err := serializer.FromFileWithKubeconfig[snapshotter.Snapshot](targetPath, kubeconfig)
+	target, err := snapshotter.LoadFromFileWithKubeconfig(ctx, targetPath, kubeconfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -170,9 +170,9 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 
 	if snapFilePath != "" {
 		slog.Info("loading snapshot from", "uri", snapFilePath)
-		snap, loadErr := serializer.FromFileWithKubeconfig[snapshotter.Snapshot](snapFilePath, cmd.String("kubeconfig"))
+		snap, loadErr := snapshotter.LoadFromFileWithKubeconfig(ctx, snapFilePath, cmd.String("kubeconfig"))
 		if loadErr != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to load snapshot from %q", snapFilePath), loadErr)
+			return nil, loadErr
 		}
 
 		criteria := fingerprint.FromMeasurements(snap.Measurements).ToCriteria(reg)

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -749,9 +749,9 @@ Run validation without failing on check errors (informational mode):
 
 			if snapshotFilePath != "" {
 				slog.Info("loading snapshot", "uri", snapshotFilePath)
-				snap, err = serializer.FromFileWithKubeconfig[snapshotter.Snapshot](snapshotFilePath, kubeconfig)
+				snap, err = snapshotter.LoadFromFileWithKubeconfig(ctx, snapshotFilePath, kubeconfig)
 				if err != nil {
-					return errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to load snapshot from %q", snapshotFilePath), err)
+					return err
 				}
 			} else {
 				slog.Info("deploying agent to capture snapshot")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,11 +14,14 @@
 
 package config
 
+import "github.com/NVIDIA/aicr/pkg/header"
+
 // Kind is the kind value for AICRConfig documents.
 const Kind = "AICRConfig"
 
-// APIVersion is the apiVersion for AICRConfig documents.
-const APIVersion = "aicr.nvidia.com/v1alpha1"
+// APIVersion is the apiVersion for AICRConfig documents. It aliases the
+// canonical header.GroupVersion (single source of truth).
+const APIVersion = header.GroupVersion
 
 // AICRConfig is the top-level schema for the --config file accepted by
 // the aicr CLI's snapshot, recipe, bundle, and validate commands.

--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -18,6 +18,44 @@ import (
 	"time"
 )
 
+// AICR artifact API versioning. These constants are the single source of
+// truth for the group/version stamped into every AICR artifact header
+// (snapshot, recipe, config). Package-local aliases (e.g.
+// snapshotter.FullAPIVersion, recipe.RecipeAPIVersion, config.APIVersion)
+// must reference GroupVersion rather than redeclaring the literal.
+//
+// Evolution policy (see docs/design/011-artifact-apiversion-policy.md):
+// schema changes within a version must be additive-only; a breaking change
+// requires a new version segment, after which both the old and new value are
+// accepted during a transition window before the old one is retired.
+const (
+	// APIGroup is the API group for AICR artifacts.
+	APIGroup = "aicr.nvidia.com"
+
+	// APIVersionV1Alpha1 is the current artifact API version segment.
+	APIVersionV1Alpha1 = "v1alpha1"
+
+	// GroupVersion is the canonical "group/version" string for AICR artifacts.
+	GroupVersion = APIGroup + "/" + APIVersionV1Alpha1
+)
+
+// IsSupportedAPIVersion reports whether v is an artifact apiVersion this binary
+// understands. The empty string is intentionally NOT supported here: callers
+// that tolerate a missing apiVersion for backward compatibility with older
+// artifacts must special-case "" before calling this.
+//
+// When the artifact schema is bumped, add the new value to the set below
+// (keeping the prior value) for the transition window, then remove the old
+// value once the deprecation window closes.
+func IsSupportedAPIVersion(v string) bool {
+	switch v {
+	case GroupVersion:
+		return true
+	default:
+		return false
+	}
+}
+
 // Kind represents the type of AICR resource.
 // All AICR resources should use these constants for consistency.
 type Kind string

--- a/pkg/header/header_test.go
+++ b/pkg/header/header_test.go
@@ -22,6 +22,41 @@ import (
 // Test API version constant - matches aicr.nvidia.com/v1alpha1 used by snapshotter and recipe packages
 const testAPIVersion = "aicr.nvidia.com/v1alpha1"
 
+func TestGroupVersion(t *testing.T) {
+	t.Parallel()
+
+	if GroupVersion != testAPIVersion {
+		t.Errorf("GroupVersion = %q, want %q", GroupVersion, testAPIVersion)
+	}
+	if want := APIGroup + "/" + APIVersionV1Alpha1; GroupVersion != want {
+		t.Errorf("GroupVersion = %q, want %q", GroupVersion, want)
+	}
+}
+
+func TestIsSupportedAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"current group version", GroupVersion, true},
+		{"empty not supported here", "", false},
+		{"future version not yet supported", "aicr.nvidia.com/v1alpha2", false},
+		{"foreign group", "validator.nvidia.com/v1alpha1", false},
+		{"garbage", "not-a-version", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsSupportedAPIVersion(tt.version); got != tt.want {
+				t.Errorf("IsSupportedAPIVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKind_String(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -779,7 +779,9 @@ func ParseCriteriaFromValues(values url.Values, reg *CriteriaRegistry) (*Criteri
 const RecipeCriteriaKind = "RecipeCriteria"
 
 // RecipeCriteriaAPIVersion is the API version for RecipeCriteria resources.
-const RecipeCriteriaAPIVersion = "aicr.nvidia.com/v1alpha1"
+// It aliases RecipeAPIVersion (ultimately header.GroupVersion) so every AICR
+// artifact apiVersion has a single source of truth.
+const RecipeCriteriaAPIVersion = RecipeAPIVersion
 
 // RecipeCriteria represents a Kubernetes-style criteria resource.
 // This is the format used in criteria files and API requests.

--- a/pkg/recipe/loader.go
+++ b/pkg/recipe/loader.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
@@ -31,9 +32,15 @@ import (
 func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version string, dp DataProvider) (*RecipeResult, error) {
 	rec, err := serializer.FromFileWithKubeconfig[RecipeResult](path, kubeconfig)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal,
-			fmt.Sprintf("failed to load recipe from %q", path), err)
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			fmt.Sprintf("failed to load recipe from %q", path))
 	}
+
+	// Capture the apiVersion declared in the source file before any overlay
+	// hydration reassigns rec; otherwise an unsupported apiVersion on a
+	// RecipeMetadata overlay input would slip past the gate below (the
+	// hydrated RecipeResult always carries a supported version).
+	inputAPIVersion := rec.APIVersion
 
 	// Users often pass overlay files directly; auto-hydrate so they don't need
 	// a separate "aicr recipe" step before consuming the recipe.
@@ -85,6 +92,18 @@ func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version str
 			fmt.Sprintf("recipe file has kind %q, but %q is required; "+
 				"run \"aicr recipe\" to generate a hydrated RecipeResult first",
 				rec.Kind, RecipeResultKind))
+	}
+
+	// Reject a recipe stamped with an apiVersion this build does not understand.
+	// Empty is tolerated (older files predate the field); a non-empty unknown
+	// value means the recipe was produced by an incompatible aicr version, so
+	// fail closed rather than risk a schema mismatch downstream. Checked against
+	// the source file's declared version, not the (always-supported) hydrated one.
+	if inputAPIVersion != "" && !header.IsSupportedAPIVersion(inputAPIVersion) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe file has apiVersion %q, which this aicr build does not support (expected %q); "+
+				"regenerate the recipe with a matching aicr version",
+				inputAPIVersion, header.GroupVersion))
 	}
 
 	return rec, nil

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -34,7 +34,7 @@ func TestLoadFromFile(t *testing.T) {
 			name:       "nonexistent file returns error",
 			filePath:   "/tmp/does-not-exist-aicr-test.yaml",
 			wantErr:    true,
-			errContain: "failed to load recipe",
+			errContain: "/tmp/does-not-exist-aicr-test.yaml",
 		},
 		{
 			name:        "RecipeResult loads directly",
@@ -87,6 +87,29 @@ func TestLoadFromFile(t *testing.T) {
 				t.Helper()
 				if rec.Kind != "" {
 					t.Errorf("kind = %q, want empty", rec.Kind)
+				}
+			},
+		},
+		{
+			name:        "unsupported apiVersion rejected",
+			yamlContent: "kind: RecipeResult\napiVersion: aicr.nvidia.com/v1alpha2\ncriteria:\n  service: eks\n",
+			wantErr:     true,
+			errContain:  `apiVersion "aicr.nvidia.com/v1alpha2"`,
+		},
+		{
+			name:        "unsupported apiVersion on RecipeMetadata overlay rejected",
+			yamlContent: "kind: RecipeMetadata\napiVersion: aicr.nvidia.com/v1alpha2\nmetadata:\n  name: test\nspec:\n  criteria:\n    service: eks\n    accelerator: h100\n    intent: training\n",
+			wantErr:     true,
+			errContain:  `apiVersion "aicr.nvidia.com/v1alpha2"`,
+		},
+		{
+			name:        "empty apiVersion allowed for backward compat",
+			yamlContent: "kind: RecipeResult\ncriteria:\n  service: eks\n",
+			wantErr:     false,
+			checkResult: func(t *testing.T, rec *RecipeResult) {
+				t.Helper()
+				if rec.APIVersion != "" {
+					t.Errorf("apiVersion = %q, want empty", rec.APIVersion)
 				}
 			},
 		},

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"gopkg.in/yaml.v3"
 )
@@ -34,7 +35,8 @@ const RecipeMetadataKind = "RecipeMetadata"
 const RecipeResultKind = "RecipeResult"
 
 // RecipeAPIVersion is the API version for recipe metadata and result resources.
-const RecipeAPIVersion = "aicr.nvidia.com/v1alpha1"
+// It aliases the canonical header.GroupVersion (single source of truth).
+const RecipeAPIVersion = header.GroupVersion
 
 // ComponentType represents the type of component deployment.
 type ComponentType string

--- a/pkg/snapshotter/loader.go
+++ b/pkg/snapshotter/loader.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshotter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+// LoadFromFile reads a snapshot from path (local file, HTTP(S) URL, or cm://
+// ConfigMap URI) and enforces apiVersion compatibility. It is equivalent to
+// LoadFromFileWithKubeconfig with an empty kubeconfig.
+func LoadFromFile(ctx context.Context, path string) (*Snapshot, error) {
+	return LoadFromFileWithKubeconfig(ctx, path, "")
+}
+
+// LoadFromFileWithKubeconfig reads a snapshot from path using kubeconfig for
+// cm:// resolution, then rejects a snapshot stamped with an apiVersion this
+// build does not understand.
+//
+// An empty apiVersion is tolerated (older snapshots predate the field); a
+// non-empty unknown value means the snapshot was produced by an incompatible
+// aicr version, so we fail closed rather than risk a schema mismatch during
+// validation.
+func LoadFromFileWithKubeconfig(ctx context.Context, path, kubeconfig string) (*Snapshot, error) {
+	snap, err := serializer.FromFileWithKubeconfigContext[Snapshot](ctx, path, kubeconfig)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			fmt.Sprintf("failed to load snapshot from %q", path))
+	}
+
+	if snap.APIVersion != "" && !header.IsSupportedAPIVersion(snap.APIVersion) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("snapshot file has apiVersion %q, which this aicr build does not support (expected %q); "+
+				"recapture the snapshot with a matching aicr version",
+				snap.APIVersion, header.GroupVersion))
+	}
+
+	return snap, nil
+}

--- a/pkg/snapshotter/loader_test.go
+++ b/pkg/snapshotter/loader_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshotter
+
+import (
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestLoadFromFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlContent string
+		filePath    string // override; skip writing yamlContent
+		wantErr     bool
+		errContain  string
+		wantCode    errors.ErrorCode // optional structured code assertion
+	}{
+		{
+			name:       "nonexistent file returns error",
+			filePath:   "/tmp/does-not-exist-aicr-snapshot-test.yaml",
+			wantErr:    true,
+			errContain: "/tmp/does-not-exist-aicr-snapshot-test.yaml",
+		},
+		{
+			name:        "supported apiVersion loads",
+			yamlContent: "kind: Snapshot\napiVersion: " + FullAPIVersion + "\nmeasurements: []\n",
+			wantErr:     false,
+		},
+		{
+			name:        "empty apiVersion allowed for backward compat",
+			yamlContent: "kind: Snapshot\nmeasurements: []\n",
+			wantErr:     false,
+		},
+		{
+			name:        "unsupported apiVersion rejected",
+			yamlContent: "kind: Snapshot\napiVersion: aicr.nvidia.com/v1alpha2\nmeasurements: []\n",
+			wantErr:     true,
+			errContain:  `apiVersion "aicr.nvidia.com/v1alpha2"`,
+			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapFile := tt.filePath
+			if snapFile == "" {
+				dir := t.TempDir()
+				snapFile = filepath.Join(dir, "snapshot.yaml")
+				if err := os.WriteFile(snapFile, []byte(tt.yamlContent), 0o600); err != nil {
+					t.Fatalf("failed to write test snapshot file: %v", err)
+				}
+			}
+
+			_, err := LoadFromFile(t.Context(), snapFile)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.errContain != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("error = %v, want error containing %q", err, tt.errContain)
+				}
+			}
+			if tt.wantCode != "" {
+				if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+					t.Errorf("error = %v, want structured code %q", err, tt.wantCode)
+				}
+			}
+		})
+	}
+}

--- a/pkg/snapshotter/version.go
+++ b/pkg/snapshotter/version.go
@@ -14,13 +14,9 @@
 
 package snapshotter
 
-const (
-	// apiDomain is the API domain for snapshot resources
-	apiDomain = "aicr.nvidia.com"
+import "github.com/NVIDIA/aicr/pkg/header"
 
-	// apiVersion is the current API version for snapshots
-	apiVersion = "v1alpha1"
-
-	// FullAPIVersion is the complete API version string
-	FullAPIVersion = apiDomain + "/" + apiVersion
-)
+// FullAPIVersion is the complete API version string stamped into snapshot
+// headers. It aliases the canonical header.GroupVersion so the artifact
+// apiVersion has a single source of truth across packages.
+const FullAPIVersion = header.GroupVersion


### PR DESCRIPTION
## Summary

Make the AICR artifact `apiVersion` a single-sourced, enforced compatibility contract: consolidate the duplicate literals into `header.GroupVersion`, and gate the recipe and snapshot loaders to reject artifacts stamped with an unsupported `apiVersion`.

## Motivation / Context

The artifact `apiVersion` (`aicr.nvidia.com/v1alpha1`) was redefined as ~5 independent string literals (snapshotter, recipe result + criteria, config) and was never enforced on read — snapshot loading ignored it entirely, recipe loading checked only `Kind`. A mismatched or incompatible artifact loaded silently and could surface later as a confusing validation failure. This is the durable, schema-level follow-up to the advisory binary-version warning in #1386.

Fixes: #1385
Related: #1386

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/header`, `pkg/config`
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- **Single source of truth:** `pkg/header` gains `APIGroup`, `APIVersionV1Alpha1`, and canonical `GroupVersion`. `snapshotter.FullAPIVersion`, `recipe.RecipeAPIVersion`, `recipe.RecipeCriteriaAPIVersion`, and `config.APIVersion` now alias it.
- **Compatibility gate (accept-known / reject-unknown):** `header.IsSupportedAPIVersion` drives enforcement. The recipe loader (`LoadFromFileWithProvider`, shared by CLI + server via `pkg/client/v1`) and a new context-aware `snapshotter.LoadFromFile{,WithKubeconfig}` reject a non-empty unsupported `apiVersion` with `ErrCodeInvalidRequest`. `validate`, `query`, and `diff` route snapshot loads through the new loader. Empty `apiVersion` stays accepted for older artifacts (mirrors the existing empty-`Kind` tolerance).
- **No bump to `v1alpha2`:** no breaking schema change is made; bumping with no change would orphan existing artifacts. ADR-011 documents the evolution policy and the transition-window approach for a future bump.

## Testing

```bash
make test   # pass, total coverage 77.2% (>= 70% floor)
golangci-lint run -c .golangci.yaml ./pkg/header/... ./pkg/snapshotter/... ./pkg/recipe/... ./pkg/config/... ./pkg/cli/...   # 0 issues
```

New table-driven tests: recipe + snapshot loaders (accept known/empty, reject unknown), and `header.IsSupportedAPIVersion` / `GroupVersion`.

## Risk Assessment

- [x] **Low** — No behavior change for current artifacts (all `v1alpha1` or empty). Adds a fail-closed gate only for unsupported versions; easy to revert.

**Rollout notes:** No new flags. An artifact with an unsupported `apiVersion` now fails at load with an actionable error instead of failing obscurely downstream.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)