### PR TITLE
fix(attestation): retry ambient OIDC token acquisition

### DIFF
--- a/pkg/bundler/attestation/doc.go
+++ b/pkg/bundler/attestation/doc.go
@@ -81,7 +81,11 @@
 // Three flows are exposed for obtaining a Sigstore OIDC identity token; the
 // CLI selects one and may also accept a pre-fetched token directly:
 //   - FetchAmbientOIDCToken: Uses ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN env vars
-//     (GitHub Actions). No browser required.
+//     (GitHub Actions). No browser required. The token request is wrapped in
+//     the same defaults.Sigstore* bounded exponential-backoff retry as the
+//     signing path: transient transport failures (e.g. a TLS handshake
+//     timeout to GitHub's idtoken endpoint) and 5xx responses are retried,
+//     while a 4xx or an empty/undecodable token body fails fast (see #1363).
 //   - FetchInteractiveOIDCToken: Opens a browser and binds a localhost
 //     redirect callback (default for workstations). Has a 5-minute timeout.
 //   - FetchDeviceCodeOIDCToken: OAuth 2.0 Device Authorization Grant

--- a/pkg/bundler/attestation/oidc.go
+++ b/pkg/bundler/attestation/oidc.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -32,6 +33,14 @@ import (
 // FetchAmbientOIDCToken retrieves an OIDC identity token from the GitHub Actions
 // ambient credential endpoint. This is used for keyless Fulcio signing in CI.
 //
+// The request is wrapped in bounded exponential-backoff retry (the same
+// defaults.Sigstore* budget used by the signing path) so a transient TLS
+// handshake timeout or 5xx from GitHub's idtoken endpoint does not fail the
+// whole build. Only transient transport failures and 5xx responses are
+// retried; a 4xx (bad/missing request token) or an empty/undecodable token
+// body fails fast because no retry will recover it. See issue #1363 for the
+// CI-flake pattern this absorbs.
+//
 // Parameters:
 //   - requestURL: the ACTIONS_ID_TOKEN_REQUEST_URL environment variable
 //   - requestToken: the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable
@@ -40,9 +49,6 @@ func FetchAmbientOIDCToken(ctx context.Context, requestURL, requestToken string)
 		return "", errors.New(errors.ErrCodeInvalidRequest, "OIDC request URL is empty")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaults.HTTPClientTimeout)
-	defer cancel()
-
 	u, err := url.Parse(requestURL)
 	if err != nil {
 		return "", errors.Wrap(errors.ErrCodeInternal, "failed to parse OIDC request URL", err)
@@ -50,42 +56,116 @@ func FetchAmbientOIDCToken(ctx context.Context, requestURL, requestToken string)
 	q := u.Query()
 	q.Set("audience", "sigstore")
 	u.RawQuery = q.Encode()
+	reqURL := u.String()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create OIDC request", err)
+	var lastErr error
+	backoff := defaults.SigstoreRetryInitialBackoff
+	for n := 1; n <= defaults.SigstoreRetryBudget; n++ {
+		// Pre-attempt ctx check — don't pay for an attempt the caller's
+		// deadline / cancellation has already made pointless.
+		if err := ctx.Err(); err != nil {
+			return "", classifyOIDCFetchContextError(err, "before attempt")
+		}
+
+		attemptCtx, cancel := context.WithTimeout(ctx, defaults.HTTPClientTimeout)
+		token, retryable, attemptErr := fetchAmbientOIDCTokenAttempt(attemptCtx, reqURL, requestToken)
+		cancel()
+		if attemptErr == nil {
+			return token, nil
+		}
+		lastErr = attemptErr
+
+		// Outer ctx exhausted? Classify and stop — no retry can help.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", classifyOIDCFetchContextError(ctxErr, "during attempt")
+		}
+
+		// Terminal failure (4xx, empty/undecodable token): the error is
+		// already structured; surface it without burning retries.
+		if !retryable {
+			return "", attemptErr
+		}
+
+		if n >= defaults.SigstoreRetryBudget {
+			return "", errors.Wrap(errors.ErrCodeUnavailable,
+				"OIDC token request failed after retries", lastErr)
+		}
+		slog.Warn("OIDC token request attempt failed, retrying",
+			"attempt", n,
+			"budget", defaults.SigstoreRetryBudget,
+			"backoff", backoff,
+			"error", lastErr)
+
+		// Interruptible backoff: a recovering endpoint shouldn't waste the
+		// remaining budget, and a canceled/expired outer ctx exits promptly.
+		select {
+		case <-ctx.Done():
+			return "", classifyOIDCFetchContextError(ctx.Err(), "during retry backoff")
+		case <-time.After(backoff):
+		}
+		backoff *= time.Duration(defaults.SigstoreRetryBackoffFactor)
 	}
+	// Unreachable: the loop returns inside on every iteration after the final
+	// attempt. Kept so a future refactor that breaks the invariant surfaces as
+	// a clear error rather than a silent empty token.
+	return "", errors.Wrap(errors.ErrCodeInternal,
+		"OIDC token retry loop exited without returning", lastErr)
+}
 
+// fetchAmbientOIDCTokenAttempt performs a single ambient OIDC token request.
+// It returns the token on success. On failure, retryable is true for transient
+// transport errors and 5xx responses (worth another attempt) and false for
+// 4xx responses or an empty/undecodable token body (won't recover).
+func fetchAmbientOIDCTokenAttempt(ctx context.Context, reqURL, requestToken string) (token string, retryable bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", false, errors.Wrap(errors.ErrCodeInternal, "failed to create OIDC request", err)
+	}
 	req.Header.Set("Authorization", "Bearer "+requestToken)
 
 	client := defaults.NewHTTPClient(0)
 	resp, err := client.Do(req) //nolint:gosec // URL is from ACTIONS_ID_TOKEN_REQUEST_URL (trusted GitHub Actions env var)
 	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeUnavailable, "OIDC token request failed", err)
+		// Transport-level failure (TLS handshake timeout, connection reset,
+		// per-attempt deadline): transient, worth retrying.
+		return "", true, errors.Wrap(errors.ErrCodeUnavailable, "OIDC token request failed", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, defaults.MaxErrorBodySize))
 		msg := "OIDC token request returned " + resp.Status + ": " + string(body)
+		// 5xx is a server-side blip (retry); 4xx is a client error such as a
+		// bad/expired request token (fail fast — retry won't fix it).
+		retryable = resp.StatusCode >= http.StatusInternalServerError
 		if readErr != nil {
-			return "", errors.Wrap(errors.ErrCodeUnavailable, msg, readErr)
+			return "", retryable, errors.Wrap(errors.ErrCodeUnavailable, msg, readErr)
 		}
-		return "", errors.New(errors.ErrCodeUnavailable, msg)
+		return "", retryable, errors.New(errors.ErrCodeUnavailable, msg)
 	}
 
 	var result struct {
 		Value string `json:"value"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, defaults.MaxErrorBodySize)).Decode(&result); err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to decode OIDC token response", err)
+		return "", false, errors.Wrap(errors.ErrCodeInternal, "failed to decode OIDC token response", err)
 	}
 
 	if result.Value == "" {
-		return "", errors.New(errors.ErrCodeInternal, "OIDC token response contained empty value")
+		return "", false, errors.New(errors.ErrCodeInternal, "OIDC token response contained empty value")
 	}
 
-	return result.Value, nil
+	return result.Value, false, nil
+}
+
+// classifyOIDCFetchContextError maps an outer-context error encountered during
+// the ambient OIDC fetch to a structured error: deadline expiry is a timeout,
+// any other cause (typically caller cancellation) is reported as unavailable.
+func classifyOIDCFetchContextError(err error, phase string) error {
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		return errors.Wrap(errors.ErrCodeTimeout, "OIDC token request timed out "+phase, err)
+	}
+	return errors.Wrap(errors.ErrCodeUnavailable, "OIDC token request canceled "+phase, err)
 }
 
 // Sigstore public-good OIDC configuration.

--- a/pkg/bundler/attestation/oidc_test.go
+++ b/pkg/bundler/attestation/oidc_test.go
@@ -21,7 +21,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 func TestFetchAmbientOIDCToken(t *testing.T) {
@@ -58,15 +62,78 @@ func TestFetchAmbientOIDCToken_EmptyURL(t *testing.T) {
 	}
 }
 
+// TestFetchAmbientOIDCToken_ServerError verifies a persistent 5xx exhausts the
+// retry budget (every attempt runs) and then fails as ErrCodeUnavailable.
+// Parallel so its real backoff (1s + 5s) overlaps other tests' wall clock.
 func TestFetchAmbientOIDCToken_ServerError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
 	_, err := FetchAmbientOIDCToken(context.Background(), server.URL, "token")
 	if err == nil {
-		t.Error("FetchAmbientOIDCToken() with server error should return error")
+		t.Fatal("FetchAmbientOIDCToken() with server error should return error")
+	}
+	if n := calls.Load(); int(n) != defaults.SigstoreRetryBudget {
+		t.Errorf("expected %d attempts on persistent 5xx, got %d", defaults.SigstoreRetryBudget, n)
+	}
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) || se.Code != errors.ErrCodeUnavailable {
+		t.Errorf("expected ErrCodeUnavailable after retries, got %v", err)
+	}
+}
+
+// TestFetchAmbientOIDCToken_RetryThenSuccess verifies a transient 5xx is
+// retried and a later success returns the token.
+func TestFetchAmbientOIDCToken_RetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(w, "transient", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"value":"recovered-token"}`)
+	}))
+	defer server.Close()
+
+	token, err := FetchAmbientOIDCToken(context.Background(), server.URL, "token")
+	if err != nil {
+		t.Fatalf("FetchAmbientOIDCToken() error after transient 5xx: %v", err)
+	}
+	if token != "recovered-token" {
+		t.Errorf("token = %q, want %q", token, "recovered-token")
+	}
+	if n := calls.Load(); n != 2 {
+		t.Errorf("expected 2 attempts (1 fail + 1 success), got %d", n)
+	}
+}
+
+// TestFetchAmbientOIDCToken_ClientErrorFailsFast verifies a 4xx (bad request
+// token) is NOT retried — a single attempt, then fail.
+func TestFetchAmbientOIDCToken_ClientErrorFailsFast(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := FetchAmbientOIDCToken(context.Background(), server.URL, "token")
+	if err == nil {
+		t.Fatal("FetchAmbientOIDCToken() with 4xx should return error")
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected exactly 1 attempt on 4xx (no retry), got %d", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wrap the ambient OIDC token fetch (`FetchAmbientOIDCToken`) in bounded exponential-backoff retry so a transient TLS handshake timeout or 5xx from GitHub's idtoken endpoint no longer fails the whole keyless-signing step.

## Motivation / Context

The release/e2e `recipe sign-catalog` goreleaser post-hook failed on a transient OIDC-token network blip because `FetchAmbientOIDCToken` issued a single `client.Do` with no retry. The sibling `cosign attest-blob` hook already wraps its invocation in a bash retry loop, leaving an inconsistent resilience gap. Fixing it at the Go layer means all keyless callers (CLI `sign-catalog`, API, future consumers) benefit — not just the goreleaser hook — and avoids re-running the full signing flow per attempt.

Fixes: #1363
Related: #1249 (prior Fulcio/Rekor retry hardening), #1350 (surfaced on)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`) — `pkg/bundler/attestation`

## Implementation Notes

- Reuses the existing `defaults.Sigstore*` retry budget (`SigstoreRetryBudget`, `SigstoreRetryInitialBackoff`, `SigstoreRetryBackoffFactor`) — same contract as the signing path, no new knobs.
- **Retry only transient failures:** transport errors (TLS handshake timeout, reset, per-attempt deadline) and 5xx responses are retried; a 4xx (bad/missing request token) or an empty/undecodable token body fails fast (`retryable=false`) since no retry recovers it.
- Each attempt is bounded by `defaults.HTTPClientTimeout`; the outer caller context is the ceiling. Outer-context deadline → `ErrCodeTimeout`, cancellation → `ErrCodeUnavailable`, both stop the loop. Backoff is interruptible by the outer context.
- URL validation/parsing happens once, outside the loop (deterministic — nothing to retry).

## Testing

```bash
go test -race ./pkg/bundler/attestation/...   # pass, no races, pkg coverage 77.2%
golangci-lint run -c .golangci.yaml ./pkg/bundler/attestation/...   # 0 issues
```

New tests: retry-then-success on a transient 5xx (1 backoff), budget exhaustion on persistent 5xx (all attempts run → `ErrCodeUnavailable`), and fail-fast on 4xx (exactly one attempt). New funcs covered at ~87%.

## Risk Assessment

- [x] **Low** — Isolated to one function's error path; success path unchanged; bounded retry budget; easy to revert.

**Rollout notes:** No new flags or config. Worst case adds the existing Sigstore backoff budget (≈6s) before a hard failure on a persistently-down endpoint.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (package doc retry contract)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)