### PR TITLE
ci(kwok): add argocd-git lane with in-cluster gitea

### DIFF
--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Recipe name to test'
     required: true
   deployer:
-    description: 'Deployer to exercise: helm | argocd-oci | argocd-helm-oci | flux-oci | flux-git'
+    description: 'Deployer to exercise: helm | argocd-oci | argocd-helm-oci | argocd-git | flux-oci | flux-git'
     required: false
     default: 'helm'
   go_version:

--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -228,7 +228,7 @@ jobs:
           # shard's matrix under the limit. Keep this deployer list in sync
           # with the test-tier1 matrix above and the input doc in
           # .github/actions/kwok-test/action.yml.
-          deployers='["helm","argocd-oci","argocd-helm-oci","flux-oci","flux-git"]'
+          deployers='["helm","argocd-oci","argocd-helm-oci","argocd-git","flux-oci","flux-git"]'
           readonly TIER3_BATCH_SIZE=200  # headroom under GitHub's 256 cap
 
           # Fail closed if the batch size is ever raised past the hard limit —
@@ -275,7 +275,7 @@ jobs:
       fail-fast: false
       matrix:
         recipe: ${{ fromJSON(needs.discover.outputs.tier1) }}
-        deployer: [helm, argocd-oci, argocd-helm-oci, flux-oci, flux-git]
+        deployer: [helm, argocd-oci, argocd-helm-oci, argocd-git, flux-oci, flux-git]
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/Makefile
+++ b/Makefile
@@ -781,14 +781,14 @@ kwok-test-all: build ## Run all KWOK recipe tests in a shared cluster
 	@bash kwok/scripts/run-all-recipes.sh
 
 .PHONY: kwok-test-deployer
-kwok-test-deployer: build ## Validate scheduling under a specific deployer (RECIPE=… DEPLOYER=helm|argocd-oci|argocd-helm-oci|flux-oci|flux-git)
+kwok-test-deployer: build ## Validate scheduling under a specific deployer (RECIPE=… DEPLOYER=helm|argocd-oci|argocd-helm-oci|argocd-git|flux-oci|flux-git)
 ifndef RECIPE
 	@echo "Error: RECIPE is required"
 	@echo "Usage: make kwok-test-deployer RECIPE=eks-training DEPLOYER=argocd-oci"
 	@exit 1
 endif
 ifndef DEPLOYER
-	@echo "Error: DEPLOYER is required (helm | argocd-oci | argocd-helm-oci | flux-oci | flux-git)"
+	@echo "Error: DEPLOYER is required (helm | argocd-oci | argocd-helm-oci | argocd-git | flux-oci | flux-git)"
 	@exit 1
 endif
 	@echo "Validating $(RECIPE) under deployer=$(DEPLOYER)"

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -241,8 +241,8 @@ real hardware. CI uses it to validate two things per recipe:
    the overlay expects.
 2. **Deployer output correctness.** The same recipe is re-rendered
    through every output adapter — `helm`, `argocd-oci`,
-   `argocd-helm-oci`, `flux-oci`, `flux-git` — and each renders to a
-   working bundle the GitOps controllers can reconcile.
+   `argocd-helm-oci`, `argocd-git`, `flux-oci`, `flux-git` — and each
+   renders to a working bundle the GitOps controllers can reconcile.
 
 KWOK nodes have no kubelet, so pods never actually run. KWOK testing
 **does not exercise** runtime validators (NCCL, inference-perf) or
@@ -256,8 +256,8 @@ simulated reflection of production shape, not a relaxed substitute.
 For the design rationale and the spike findings that justify the
 chart pin and Repository-secret shape, see
 [ADR-008](https://github.com/NVIDIA/aicr/blob/main/docs/design/008-kwok-deployer-matrix.md);
-for the Git-source lanes (in-cluster Gitea, `flux-git`), see
-[ADR-010](https://github.com/NVIDIA/aicr/blob/main/docs/design/010-kwok-git-source-lanes.md).
+for the Git-source lanes (in-cluster Gitea, `flux-git` and `argocd-git`),
+see [ADR-010](https://github.com/NVIDIA/aicr/blob/main/docs/design/010-kwok-git-source-lanes.md).
 For cluster-level KWOK setup (node profiles, recipe auto-discovery),
 see [kwok/README.md](https://github.com/NVIDIA/aicr/blob/main/kwok/README.md).
 
@@ -265,15 +265,16 @@ see [kwok/README.md](https://github.com/NVIDIA/aicr/blob/main/kwok/README.md).
 
 | Tier | Trigger | Deployers exercised |
 |------|---------|----------------------|
-| Tier 1 — generic overlays | every PR + push | `helm`, `argocd-oci`, `argocd-helm-oci`, `flux-oci`, `flux-git` |
+| Tier 1 — generic overlays | every PR + push | `helm`, `argocd-oci`, `argocd-helm-oci`, `argocd-git`, `flux-oci`, `flux-git` |
 | Tier 2 — diff-aware accelerator overlays | PR only, conditional on changed files | `helm` only |
-| Tier 3 — full overlay set | push to `main` + nightly schedule | `helm`, `argocd-oci`, `argocd-helm-oci`, `flux-oci`, `flux-git` |
+| Tier 3 — full overlay set | push to `main` + nightly schedule | `helm`, `argocd-oci`, `argocd-helm-oci`, `argocd-git`, `flux-oci`, `flux-git` |
 
 | Lane | Pull artifact | Apply manifests | Reconcile to Ready |
 |---|---|---|---|
 | `helm` | n/a (filesystem) | `helm install` | pods scheduled |
 | `argocd-oci` | repo-server OCI pull | Argo CD sync | `Synced+Healthy` |
 | `argocd-helm-oci` | `helm pull` OCI | wrapper chart install | `Synced+Healthy` |
+| `argocd-git` | repo-server Git clone (in-cluster Gitea) | Argo CD sync | root App Git `repoURL` + `Synced+Healthy` |
 | `flux-oci` | source-controller OCI pull | kustomize-controller apply | all HelmReleases `Ready=True` + ArtifactGenerators Ready |
 | `flux-git` | source-controller Git clone (in-cluster Gitea) | kustomize-controller apply | GitRepositories Ready + all HelmReleases `Ready=True` |
 
@@ -281,9 +282,10 @@ Tier 2 stays `helm`-only because its job is to verify accelerator-specific
 overlays still render correctly when their inputs change. The deployer
 shape is orthogonal — re-running through Argo CD would only re-exercise
 template rendering, which Tier 1 and Tier 3 already cover on the generic
-overlays. The `flux-git` lane covers the filesystem (Git-source)
-round-trip half of [#963](https://github.com/NVIDIA/aicr/issues/963);
-the `argocd-git` half is a follow-up on the same Gitea infrastructure.
+overlays. The `flux-git` and `argocd-git` lanes cover the filesystem
+(Git-source) round-trip of
+[#963](https://github.com/NVIDIA/aicr/issues/963) for both GitOps
+controllers, sharing the same in-cluster Gitea infrastructure.
 
 ### Running KWOK Locally
 
@@ -297,12 +299,12 @@ make kwok-test-deployer RECIPE=eks-training DEPLOYER=argocd-oci
 ```
 
 Valid `DEPLOYER` values: `helm`, `argocd-oci`, `argocd-helm-oci`,
-`flux-oci`, `flux-git`. The target invokes
+`argocd-git`, `flux-oci`, `flux-git`. The target invokes
 `kwok/scripts/run-all-recipes.sh --deployer <name> <recipe>`, which
 calls `install-infra.sh` once with `DEPLOYER` exported (in-cluster
 `registry:2` always; Argo CD for `argocd-*`; Flux 2 controllers for
-`flux-*`; Gitea additionally for `flux-git`), then runs
-`validate-scheduling.sh` for the recipe.
+`flux-*`; Gitea additionally for the Git-source lanes `flux-git` and
+`argocd-git`), then runs `validate-scheduling.sh` for the recipe.
 
 **Registry host port.** The Kind cluster exposes the in-cluster
 `registry:2` Service on **host port 5500** (`kwok/kind-config.yaml`'s
@@ -313,13 +315,13 @@ macOS. Linux runners have 5500 free too. The in-cluster NodePort
 independent — Argo CD's repo-server reaches the registry via Service
 DNS (`registry.aicr-registry.svc.cluster.local:5000`) regardless.
 
-**Gitea host port (flux-git).** The same pattern exposes the
-in-cluster Gitea on **host port 3300** (NodePort `30300`) so the
+**Gitea host port (flux-git / argocd-git).** The same pattern exposes
+the in-cluster Gitea on **host port 3300** (NodePort `30300`) so the
 runner can `git push` the filesystem bundle; 3300 avoids Gitea's
-default 3000, commonly held by Grafana / local dev servers. Flux's
-source-controller clones via Service DNS
-(`gitea.aicr-registry.svc.cluster.local:3000`). Clusters created
-before the 3300 mapping existed must be recreated
+default 3000, commonly held by Grafana / local dev servers. The GitOps
+controller (Flux's source-controller or Argo CD's repo-server) clones
+via Service DNS (`gitea.aicr-registry.svc.cluster.local:3000`).
+Clusters created before the 3300 mapping existed must be recreated
 (`kind delete cluster --name aicr-kwok-test`) — `install-infra.sh`
 exit code 71 is the telltale.
 
@@ -327,7 +329,7 @@ exit code 71 is the telltale.
 `helm`; there is no matrix-aware make target. Loop in shell:
 
 ```bash
-for d in helm argocd-oci argocd-helm-oci flux-oci flux-git; do
+for d in helm argocd-oci argocd-helm-oci argocd-git flux-oci flux-git; do
   make kwok-test-deployer RECIPE=eks-training DEPLOYER="$d" || break
 done
 
@@ -374,12 +376,13 @@ independent.
 | `KWOK_FLUX_SYNC_TIMEOUT` | `500` s | Deadline for source fetch (OCIRepository or GitRepository) + Kustomization apply + HelmReleases `Ready=True` + ArtifactGenerators Ready |
 | `KWOK_FLUX_ROOT_GRACE` | `30` s | Grace period for the outer Kustomization before deadline counting starts |
 
-The `flux-git` lane additionally honors `KWOK_GITEA_HOST_PORT`
-(default `3300`), `KWOK_GITEA_USER` (default `aicr`), and
-`KWOK_GITEA_PASSWORD` (default `aicr-kwok-ci`) — shared between
-`install-infra.sh` (Gitea install + admin bootstrap) and
+The Git-source lanes (`flux-git`, `argocd-git`) additionally honor
+`KWOK_GITEA_HOST_PORT` (default `3300`), `KWOK_GITEA_USER` (default
+`aicr`), and `KWOK_GITEA_PASSWORD` (default `aicr-kwok-ci`) — shared
+between `install-infra.sh` (Gitea install + admin bootstrap) and
 `validate-scheduling.sh` (`git push`). The password is a CI-only
 credential for the ephemeral in-cluster Gitea, not a secret.
+`argocd-git` reuses the `KWOK_ARGOCD_SYNC_TIMEOUT` budget.
 
 On a clean local Kind cluster `Synced+Healthy` lands in ~30 s; the
 300-second default exists to absorb CI variance. If a local run trips
@@ -396,7 +399,7 @@ When `kwok-test` fails, it uploads an artifact named
 - `<cluster>-argo-apps.yaml` plus the repo-server and application-controller logs (argocd lanes)
 - `<cluster>-flux-resources.yaml` (OCIRepositories, GitRepositories, Kustomizations, HelmReleases, ArtifactGenerators, ExternalArtifacts) plus source-, kustomize-, and helm-controller logs (flux-* lanes)
 - `<cluster>-registry.log` — last 200 lines of the in-cluster `registry:2`
-- `<cluster>-gitea.log` — last 200 lines of the in-cluster Gitea (flux-git lane)
+- `<cluster>-gitea.log` — last 200 lines of the in-cluster Gitea (Git-source lanes: `flux-git`, `argocd-git`)
 
 Start with the repo-server log (Argo CD) or source-controller log
 (Flux) for OCI-pull failures. Application-controller / kustomize-controller
@@ -406,18 +409,22 @@ helm-controller logs surface per-`HelmRelease` install outcomes.
 ### Adding a New Deployer Value
 
 The deployer set is finite and matches what `pkg/bundler` emits. To
-add a new value (say, `argocd-git`):
+add a new value:
 
 1. Add a `case` branch in `kwok/scripts/validate-scheduling.sh`'s
    `resolve_argocd_root_app()` (or `resolve_flux_root_names()` for
    Flux-reconciled lanes), plus branches in `generate_bundle` and
-   `deploy_bundle`. Reuse the existing `argocd-oci` / `flux-oci` /
-   `flux-git` branches as templates (`flux-git` is the closest model
-   for Git-source lanes — Gitea install, dual-view URLs, push-to-create).
+   `deploy_bundle`. Reuse the existing `argocd-oci` / `argocd-git` /
+   `flux-oci` / `flux-git` branches as templates. For a Git-source lane,
+   `argocd-git` and `flux-git` are the closest models — they share the
+   `compute_gitea_urls()` / `push_bundle_to_gitea()` helpers (Gitea
+   dual-view URLs, push-to-create, branch `main`).
 2. Extend the `DEPLOYER` allowlist in
    `kwok/scripts/run-all-recipes.sh` (`case "$DEPLOYER" in` in `main()`).
 3. Extend the `case "${DEPLOYER}"` branches in `install-infra.sh`'s
-   `main()` so the right controller stack is installed.
+   `main()` so the right controller stack is installed (a Git-source
+   lane composes its GitOps controller install with `install_gitea`,
+   as `argocd-git` and `flux-git` do).
 4. Extend the `deployer:` input description in
    `.github/actions/kwok-test/action.yml`.
 5. Add the value to the `deployer:` matrix in Tier 1 and Tier 3 of
@@ -505,5 +512,5 @@ the pre-push gate is local.
 - [validator.md](validator.md) — validator engine, chainsaw checks, container-per-validator pattern
 - [CLAUDE.md](https://github.com/NVIDIA/aicr/blob/main/.claude/CLAUDE.md) — coding rules and anti-patterns table
 - [ADR-008](https://github.com/NVIDIA/aicr/blob/main/docs/design/008-kwok-deployer-matrix.md) — KWOK deployer matrix rationale
-- [ADR-010](https://github.com/NVIDIA/aicr/blob/main/docs/design/010-kwok-git-source-lanes.md) — Git-source lanes (Gitea, flux-git)
+- [ADR-010](https://github.com/NVIDIA/aicr/blob/main/docs/design/010-kwok-git-source-lanes.md) — Git-source lanes (Gitea, flux-git, argocd-git)
 - [kwok/README.md](https://github.com/NVIDIA/aicr/blob/main/kwok/README.md) — KWOK cluster setup and node profiles

--- a/docs/design/010-kwok-git-source-lanes.md
+++ b/docs/design/010-kwok-git-source-lanes.md
@@ -2,13 +2,15 @@
 
 ## Status
 
-**Implemented (flux-git)** — 2026-06-10.
+**Implemented (flux-git, argocd-git)** — flux-git 2026-06-10; argocd-git
+2026-06-16, completing [#963](https://github.com/NVIDIA/aicr/issues/963).
 
 Extends [ADR-008](008-kwok-deployer-matrix.md) (KWOK CI Deployer
-Matrix). Implementation tracked under
-[#963](https://github.com/NVIDIA/aicr/issues/963). The `flux-git` lane
-ships first; the `argocd-git` lane described in the issue follows the
-same infrastructure and is a follow-up.
+Matrix). The `flux-git` lane shipped first; `argocd-git` follows on the
+same Gitea infrastructure — the runner pushes the filesystem bundle to
+the in-cluster Gitea and Argo CD's repo-server clones and reconciles the
+app-of-apps from the Git `repoURL`. Both lanes close the Git-source
+round-trip gap for their respective GitOps controllers.
 
 ## Problem
 
@@ -46,42 +48,61 @@ the Git lanes cover the second documented product surface.
 
 ## Goals
 
-1. CI fails when the flux deployer's filesystem/Git bundle shape does
-   not reconcile end-to-end (clone → kustomize apply → HelmRelease
-   terminal state → pods Running).
+1. CI fails when a deployer's filesystem/Git bundle shape does not
+   reconcile end-to-end (clone → apply → terminal state → pods Running).
+   For `flux-git` this is GitRepository → kustomize apply → HelmRelease;
+   for `argocd-git` it is the app-of-apps Git `repoURL` → Argo CD sync.
 2. The Git path is exercised with a real Git server and the real
-   `git push` → `source-controller` clone protocol, not a shape check.
+   `git push` → controller-clone protocol (Flux source-controller or
+   Argo CD repo-server), not a shape check.
 3. Local repro matches CI:
-   `make kwok-test-deployer RECIPE=<r> DEPLOYER=flux-git`.
+   `make kwok-test-deployer RECIPE=<r> DEPLOYER=flux-git` (and
+   `DEPLOYER=argocd-git`).
 
 ## Non-Goals
 
-- `argocd-git` lane (same Gitea infra; follow-up under [#963](https://github.com/NVIDIA/aicr/issues/963)).
-- Git auth flows (`GitRepository.spec.secretRef`, deploy keys). The
-  bundler's gitrepo template emits no `secretRef`, so the contract
-  under test is anonymous read access (see Decision).
+- Git auth flows (`GitRepository.spec.secretRef`, deploy keys, Argo CD
+  repository Secrets). Neither the bundler's gitrepo template nor the
+  argocd Application emits credentials, so the contract under test is
+  anonymous read access (see Decision).
 - Tier 2 coverage (stays helm-only per ADR-008's tier rationale).
 - Replacing the OCI lanes — both transports stay in the matrix.
 
 ## Decision
 
-Add a `flux-git` value to the deployer matrix (Tier 1 + Tier 3). The
-lane installs **Gitea** in the existing `aicr-registry` namespace via
-`install-infra.sh`, bundles to the filesystem, pushes the bundle tree
-to Gitea over the Kind host-port mapping, applies an outer
-`GitRepository` + `Kustomization` wrapper pair, and reuses the
-existing chainsaw sync-gate framing and pod verification.
+Add `flux-git` and `argocd-git` values to the deployer matrix (Tier 1 +
+Tier 3). Both install **Gitea** in the existing `aicr-registry`
+namespace via `install-infra.sh`, bundle to the filesystem, and push the
+bundle tree to Gitea over the Kind host-port mapping.
+
+- `flux-git` applies an outer `GitRepository` + `Kustomization` wrapper
+  pair and lets Flux reconcile; its sync gate asserts the GitRepository
+  is Ready before the Kustomization/HelmRelease stages.
+- `argocd-git` applies the bundle's own `app-of-apps.yaml` (whose
+  `spec.source.repoURL` is the Git URL passed via `--repo`, baked into
+  the parent and every child Application at bundle time) and lets Argo
+  CD's repo-server clone and reconcile. Its sync gate is the
+  `argocd-git-sync` sibling of `argocd-sync`, with one extra leading
+  step asserting the root Application's Git `repoURL` (the Git-mode
+  proof — the argocd analogue of flux-git's GitRepository-Ready step).
+
+Both reuse the shared `compute_gitea_urls()` / `push_bundle_to_gitea()`
+helpers in `validate-scheduling.sh` so the runner→Service-DNS rewrite
+and the `git init/commit/push --force main` block live in one place.
 
 Key choices, in dependency order:
 
 **Anonymous public repos, no secretRef.** The bundler's
-`gitrepo-source.yaml.tmpl` has no `secretRef`, so the repo MUST be
-anonymously clonable for the rendered bundle to reconcile at all.
-Gitea is configured with
+`gitrepo-source.yaml.tmpl` (flux) has no `secretRef`, and the argocd
+deployer's Application carries no repository credentials, so the repo
+MUST be anonymously clonable for either rendered bundle to reconcile at
+all. Gitea is configured with
 `GITEA__repository__DEFAULT_PUSH_CREATE_PRIVATE=false` so pushed
-repos are public; Flux's source-controller clones with no credentials
-— exactly what the bundle's own source CR requires. This is a
-product-contract test, not a CI convenience.
+repos are public; both Flux's source-controller and Argo CD's
+repo-server clone with no credentials over plain HTTP — exactly what
+the bundle requires. This is a product-contract test, not a CI
+convenience. (Argo CD clones a public `http://` repo referenced by an
+Application without a pre-registered repository Secret.)
 
 **Push-to-create, no per-recipe API calls.**
 `GITEA__repository__ENABLE_PUSH_CREATE_USER=true` means the first
@@ -98,10 +119,12 @@ Host 3300, not Gitea's default 3000, for the same collision-avoidance
 reason as the registry's 5500-vs-5000 (port 3000 is commonly held by
 Grafana / local dev servers).
 
-**Branch `main` is a hard requirement.** The bundler defaults
-`GitRepository.ref.branch` to `main` (`resolveTargetRevision()`), and
-there is no CLI flag to change it for filesystem output, so the test
-driver pushes `main`.
+**Branch `main` is a hard requirement.** The bundler defaults the flux
+`GitRepository.ref.branch` to `main` (`resolveTargetRevision()`) and the
+argocd Application `targetRevision` to `main`
+(`pkg/bundler/deployer/argocd/resolveRepoSettings()`), and there is no
+CLI flag to change either for filesystem output, so the test driver
+pushes `main`.
 
 **Two GitRepository objects, accepted duplication.** The driver
 applies an outer `aicr-bundle` GitRepository (the Kustomization's
@@ -205,6 +228,32 @@ Per `(recipe, flux-git)` matrix cell:
    HelmRelease finalizer sweep + namespace force-finalize.
 ```
 
+Per `(recipe, argocd-git)` matrix cell — same Gitea, Argo CD instead of
+Flux:
+
+```
+1. Infra (once per cell): install-infra.sh DEPLOYER=argocd-git
+   ├── install_registry   (unconditional, harmless if unused)
+   ├── install_argocd     (same as argocd-oci) + apply_repo_secret
+   └── install_gitea      (shared with flux-git; exit codes 70/71/72)
+
+2. Per-recipe: validate-scheduling.sh --deployer argocd-git <recipe>
+   ├── aicr bundle --recipe ... --deployer argocd --output $WORK/bundle \
+   │       --repo http://gitea.aicr-registry.svc.cluster.local:3000/aicr/<recipe>.git
+   ├── assert app-of-apps.yaml exists AND its repoURL == the Git URL
+   │       (proves argocd git mode engaged — not an oci:// repoURL)
+   ├── git init -b main; add -A; commit; push --force \
+   │       http://aicr:…@localhost:3300/aicr/<recipe>.git main   (shared helper)
+   ├── kubectl apply app-of-apps.yaml (root App nvidia-stack, Git repoURL)
+   ├── wait_for_argocd_sync → chainsaw tests/chainsaw/kwok/argocd-git-sync
+   │       (--set repoURL=<git-url>; --assert-timeout from KWOK_ARGOCD_SYNC_TIMEOUT)
+   └── verify_pods (existing)
+
+3. Cleanup: delete root Application nvidia-stack (prune cascade) →
+   namespaces. Gitea repo state is emptyDir-ephemeral + force-pushed,
+   so no repo cleanup is needed.
+```
+
 ## Sync Gate: All-Resources Semantics
 
 Implementing this lane surfaced a latent bug in the flux sync gate
@@ -233,6 +282,8 @@ changing it alters the behavior of existing argocd lanes.
 
 ## Files Changed
 
+### flux-git (initial)
+
 | File | Change |
 |---|---|
 | `.settings.yaml` | Pin `testing_tools.gitea_image` |
@@ -246,10 +297,24 @@ changing it alters the behavior of existing argocd lanes.
 | `.github/actions/kwok-test/action.yml` | `gitrepositories` + Gitea log in debug artifacts |
 | `Makefile` | `kwok-test-deployer` help text |
 
-No Go changes: the bundler's Git output shape
+### argocd-git (follow-up, completing #963)
+
+| File | Change |
+|---|---|
+| `kwok/scripts/install-infra.sh` | `argocd-git` case (Argo CD + repo secret + Gitea); reuses `install_gitea()` |
+| `kwok/scripts/validate-scheduling.sh` | Extracted shared `compute_gitea_urls()` / `push_bundle_to_gitea()` helpers (flux-git refactored onto them); `argocd-git` branch in `resolve_argocd_root_app` (`nvidia-stack`), `generate_bundle` (bundle+repoURL assert+push), `deploy_bundle` (apply app-of-apps), per-deployer chainsaw routing in `wait_for_argocd_sync`, `argocd-*` cleanup |
+| `kwok/scripts/run-all-recipes.sh` | Allowlist `argocd-git` (3-strike rule already matched `argocd-*`) |
+| `tests/chainsaw/kwok/argocd-git-sync/chainsaw-test.yaml` | New sibling sync gate (extra leading step asserts root App Git `repoURL`) |
+| `tests/chainsaw/kwok/argocd-sync/chainsaw-test.yaml` | SYNC NOTE header binding the sibling |
+| `.github/workflows/kwok-recipes.yaml` | `argocd-git` in Tier 1 matrix + Tier 3 deployer list |
+| `Makefile` | `kwok-test-deployer` help text |
+
+No Go changes for either lane: the bundlers' Git output shapes — flux's
 (`collectGitSources()`, `gitrepo-source.yaml.tmpl`, GitRepository
-`sourceRef` on local-chart HelmReleases) already existed; this ADR
-adds the CI lane that protects it.
+`sourceRef`) and argocd's (`resolveRepoSettings()` defaulting
+`targetRevision` to `main`, `app-of-apps.yaml.tmpl`, per-component
+`application.yaml` `repoURL`) — already existed; this ADR adds the CI
+lanes that protect them.
 
 ## Error Handling and Failure Modes
 
@@ -260,25 +325,31 @@ adds the CI lane that protects it.
 | 3 | Admin user bootstrap failed | `gitea admin user create` non-zero and not "already exists" → exit 72 | Dump + fail fast; "already exists" is success (idempotent re-runs) |
 | 4 | Bundler silently took OCI path | `sources/gitrepo-*.yaml` glob assert in `generate_bundle` | Fail fast — the lane must not pass without exercising the Git shape |
 | 5 | `git push` fails | Captured combined output, non-zero exit | Logged verbatim; push-to-create + force-push make re-runs self-healing |
-| 6 | Clone/reconcile failure | chainsaw `flux-git-sync` steps (GitRepository Ready first) | Per-step `catch` dumps sources, controller logs, Gitea log; exit 50 feeds the 3-strike rule |
+| 6 | Clone/reconcile failure | chainsaw `flux-git-sync` (GitRepository Ready first) / `argocd-git-sync` (root App Git `repoURL` first) steps | Per-step `catch` dumps sources, controller logs, Gitea log; exit 50 feeds the 3-strike rule |
+| 7 | argocd bundler silently took OCI path | root App `repoURL` grep in `generate_bundle` + `argocd-git-sync` step 1 | Fail fast at bundle time and at the sync gate — the lane must not pass without exercising the Git shape |
 
 ## Acceptance Criteria
 
-1. `make kwok-test-deployer RECIPE=eks-training DEPLOYER=flux-git`
-   passes against a fresh Kind cluster, and a re-run of the same
-   recipe passes (force-push idempotency).
-2. The sync gate holds until **every** HelmRelease reaches the
+1. `make kwok-test-deployer RECIPE=eks-training DEPLOYER=flux-git` and
+   `DEPLOYER=argocd-git` each pass against a fresh Kind cluster, and a
+   re-run of the same recipe passes (force-push idempotency).
+2. The flux-git sync gate holds until **every** HelmRelease reaches the
    terminal-pass state (verified live: 13-release dependsOn chain no
-   longer short-circuits on the first Ready release).
-3. A deliberate regression in `gitrepo-source.yaml.tmpl` (e.g. wrong
-   branch) turns the Tier 1 `flux-git` cell red.
-4. `flux-oci` lane behavior is unchanged except for the
-   strictly-stronger HelmRelease gate.
+   longer short-circuits on the first Ready release). The argocd-git gate
+   reuses the existing `argocd-sync` chainsaw gate (root App present +
+   Applications reach a terminal-pass arm), behaving identically to
+   `argocd-oci`.
+3. A deliberate regression in the Git output (e.g. wrong branch in
+   `gitrepo-source.yaml.tmpl`, or an OCI `repoURL` leaking into the
+   argocd app-of-apps) turns the Tier 1 `flux-git` / `argocd-git` cell
+   red.
+4. `flux-oci` / `argocd-oci` lane behavior is unchanged.
 
 ## References
 
 - Issue [#963](https://github.com/NVIDIA/aicr/issues/963); parent [#843](https://github.com/NVIDIA/aicr/issues/843); PR #956 (OCI lanes)
 - [ADR-008](008-kwok-deployer-matrix.md) — deployer matrix, OCI-first rationale this ADR extends
-- Bundler Git sources: `pkg/bundler/deployer/flux/sources.go`, `pkg/bundler/deployer/flux/templates/gitrepo-source.yaml.tmpl`
-- Sync gates: `tests/chainsaw/kwok/flux-sync/`, `tests/chainsaw/kwok/flux-git-sync/`
+- Bundler Git sources (flux): `pkg/bundler/deployer/flux/sources.go`, `pkg/bundler/deployer/flux/templates/gitrepo-source.yaml.tmpl`
+- Bundler Git sources (argocd): `pkg/bundler/deployer/argocd/argocd.go` (`resolveRepoSettings`, `DefaultAppName`), `pkg/bundler/deployer/argocd/templates/{app-of-apps,application}.yaml.tmpl`
+- Sync gates: `tests/chainsaw/kwok/{argocd-sync,argocd-git-sync,flux-sync,flux-git-sync}/`
 - Gitea push-to-create: <https://docs.gitea.com/administration/config-cheat-sheet#repository-repository>

--- a/kwok/README.md
+++ b/kwok/README.md
@@ -74,7 +74,7 @@ flowchart LR
 | `make kwok-nodes RECIPE=<name>` | Create simulated nodes |
 | `make kwok-nodes-delete` | Delete all KWOK-simulated nodes |
 | `make kwok-test RECIPE=<name>` | Validate scheduling only |
-| `make kwok-test-deployer RECIPE=<name> DEPLOYER=<d>` | Validate under a GitOps deployer lane (`helm`, `argocd-oci`, `argocd-helm-oci`, `flux-oci`, `flux-git`) |
+| `make kwok-test-deployer RECIPE=<name> DEPLOYER=<d>` | Validate under a GitOps deployer lane (`helm`, `argocd-oci`, `argocd-helm-oci`, `argocd-git`, `flux-oci`, `flux-git`) |
 | `make kwok-status` | Show cluster and node status |
 | `make kwok-cluster-delete` | Delete cluster |
 
@@ -83,13 +83,14 @@ flowchart LR
 The GitOps lanes install shared infrastructure once per cluster via
 `kwok/scripts/install-infra.sh` (keyed on `DEPLOYER`): an in-cluster
 OCI registry (always), Argo CD (`argocd-*`), Flux 2 (`flux-*`), and
-Gitea (`flux-git`). Two host-port mappings in `kwok/kind-config.yaml`
-expose the in-cluster services to the runner:
+Gitea (the Git-source lanes `flux-git` and `argocd-git`). Two host-port
+mappings in `kwok/kind-config.yaml` expose the in-cluster services to
+the runner:
 
 | Service | Host port | NodePort | In-cluster DNS | Used by |
 |---------|-----------|----------|----------------|---------|
 | registry | 5500 | 30500 | `registry.aicr-registry.svc.cluster.local:5000` | `aicr bundle --output oci://localhost:5500/...` (OCI lanes) |
-| gitea | 3300 | 30300 | `gitea.aicr-registry.svc.cluster.local:3000` | `git push` of the filesystem bundle (`flux-git` lane) |
+| gitea | 3300 | 30300 | `gitea.aicr-registry.svc.cluster.local:3000` | `git push` of the filesystem bundle (`flux-git`, `argocd-git` lanes) |
 
 Clusters created before a port mapping existed must be recreated
 (`kind delete cluster --name aicr-kwok-test`) to pick it up.

--- a/kwok/scripts/install-infra.sh
+++ b/kwok/scripts/install-infra.sh
@@ -46,16 +46,18 @@
 #      but unused. Flux does NOT require a separate repo-creds-style secret
 #      for the in-cluster registry: per-OCIRepository `spec.insecure: true`
 #      toggles plain-HTTP at the source level.
-#   4. DEPLOYER=flux-git: Gitea Deployment + NodePort Service in the
-#      `aicr-registry` namespace (issue #963), mirroring the registry
+#   4. DEPLOYER=flux-git|argocd-git: Gitea Deployment + NodePort Service in
+#      the `aicr-registry` namespace (issue #963), mirroring the registry
 #      pattern. Service is exposed on nodePort 30300; kwok/kind-config.yaml
 #      maps host port 3300 -> nodePort 30300 so the runner can `git push`
 #      the filesystem bundle. Push-to-create is enabled and created repos
-#      are PUBLIC so Flux's source-controller clones anonymously — the
-#      bundler's GitRepository template has no secretRef.
+#      are PUBLIC so the GitOps controller (Flux's source-controller or
+#      Argo CD's repo-server) clones anonymously — the bundler's git
+#      source carries no credentials. argocd-git installs BOTH Argo CD
+#      (step 2) AND Gitea (this step).
 #
 # Usage:
-#   DEPLOYER=helm|argocd-oci|argocd-helm-oci|flux-oci|flux-git ./install-infra.sh
+#   DEPLOYER=helm|argocd-oci|argocd-helm-oci|argocd-git|flux-oci|flux-git ./install-infra.sh
 #   (DEPLOYER defaults to "helm"; under helm only the registry is installed,
 #    which is harmless if unused.)
 #
@@ -86,6 +88,7 @@
 #                                           helm             - registry only
 #                                           argocd-oci       - registry + Argo CD
 #                                           argocd-helm-oci  - registry + Argo CD
+#                                           argocd-git       - registry + Argo CD + Gitea
 #                                           flux-oci         - registry + Flux 2
 #                                           flux-git         - registry + Flux 2 + Gitea
 #                                         Unknown values fall back to the
@@ -97,7 +100,7 @@
 #                                         KWOK_REGISTRY_HOST_PORT: must match
 #                                         the Kind extraPortMappings hostPort.
 #   KWOK_GITEA_USER          (optional, default "aicr") - Gitea admin user the
-#                                         flux-git lane pushes as.
+#                                         flux-git / argocd-git lanes push as.
 #   KWOK_GITEA_PASSWORD      (optional, default "aicr-kwok-ci") - Password for
 #                                         KWOK_GITEA_USER. CI-only credential
 #                                         for the ephemeral in-cluster Gitea —
@@ -774,6 +777,27 @@ main() {
             install_argocd "${argocd_chart}"
             log_debug "Step 3 (argocd): apply repository secret"
             apply_repo_secret
+            ;;
+        argocd-git)
+            # Git-source round-trip (issue #963): same Argo CD install as
+            # the OCI lanes, PLUS Gitea so the runner can `git push` the
+            # filesystem bundle and Argo CD's repo-server clones it back.
+            # The OCI repo-creds secret is harmless here (the Git source
+            # carries no credentials and Argo CD clones the public repo
+            # anonymously) — applied unconditionally to keep this branch a
+            # superset of the OCI lane.
+            local argocd_chart gitea_image
+            argocd_chart=$(read_setting '.testing_tools.argocd_chart')
+            gitea_image=$(read_setting '.testing_tools.gitea_image')
+            log_info "argocd_chart:          ${argocd_chart}"
+            log_info "gitea_image:           ${gitea_image}"
+            log_info "gitea host port:       ${GITEA_HOST_PORT}"
+            log_debug "Step 2 (argocd): install Argo CD"
+            install_argocd "${argocd_chart}"
+            log_debug "Step 3 (argocd): apply repository secret"
+            apply_repo_secret
+            log_debug "Step 4 (argocd-git): install Gitea"
+            install_gitea "${gitea_image}"
             ;;
         flux-oci)
             local flux_version

--- a/kwok/scripts/run-all-recipes.sh
+++ b/kwok/scripts/run-all-recipes.sh
@@ -27,6 +27,10 @@
 #                                           app-of-apps)
 #                         argocd-helm-oci  (in-cluster registry + Argo CD
 #                                           via OCI Helm chart wrapper)
+#                         argocd-git       (in-cluster registry + Argo CD +
+#                                           Gitea; filesystem bundle pushed
+#                                           to Git, app-of-apps cloned and
+#                                           reconciled from Git; issue #963)
 #                         flux-oci         (in-cluster registry + Flux 2
 #                                           OCIRepository → Kustomization →
 #                                           HelmRelease)
@@ -39,7 +43,7 @@
 #                       recipe loop with DEPLOYER exported so it installs the
 #                       shared in-cluster OCI registry plus the GitOps
 #                       controllers the selected deployer needs (Argo CD or
-#                       Flux, plus Gitea for flux-git). Their owning
+#                       Flux, plus Gitea for flux-git / argocd-git). Their owning
 #                       namespaces (`aicr-registry`, `argocd`, `flux-system`)
 #                       survive across recipe iterations.
 #
@@ -258,14 +262,15 @@ Usage: run-all-recipes.sh [--deployer <name>] [recipe1 recipe2 ...]
 
 Flags:
   --deployer <name>   Deployer to exercise for every recipe. One of:
-                        helm (default), argocd-oci, argocd-helm-oci, flux-oci,
-                        flux-git
+                        helm (default), argocd-oci, argocd-helm-oci, argocd-git,
+                        flux-oci, flux-git
 
 Examples:
   run-all-recipes.sh
   run-all-recipes.sh eks-training
   run-all-recipes.sh --deployer argocd-oci eks-training
   run-all-recipes.sh --deployer=argocd-helm-oci
+  run-all-recipes.sh --deployer argocd-git eks-training
   run-all-recipes.sh --deployer flux-oci eks-training
   run-all-recipes.sh --deployer flux-git eks-training
 EOF
@@ -315,11 +320,11 @@ main() {
     done
 
     case "$DEPLOYER" in
-        helm|argocd-oci|argocd-helm-oci|flux-oci|flux-git)
+        helm|argocd-oci|argocd-helm-oci|argocd-git|flux-oci|flux-git)
             ;;
         *)
             log_error "Invalid --deployer value: '${DEPLOYER}'"
-            log_error "Must be one of: helm, argocd-oci, argocd-helm-oci, flux-oci, flux-git"
+            log_error "Must be one of: helm, argocd-oci, argocd-helm-oci, argocd-git, flux-oci, flux-git"
             usage
             return 1
             ;;
@@ -349,7 +354,8 @@ main() {
 
     # Install shared in-cluster registry + the controller(s) the selected
     # deployer needs (Argo CD for argocd-*, Flux for flux-*, plus Gitea for
-    # flux-git). install-infra.sh is idempotent but unnecessary work per
+    # the Git-source lanes flux-git / argocd-git). install-infra.sh is
+    # idempotent but unnecessary work per
     # recipe; a failure here is fatal — the lane cannot run without it.
     # DEPLOYER is exported so install-infra.sh can branch on it. Its exit
     # code map: 10=yq/settings, 20=registry Deployment not Ready,

--- a/kwok/scripts/validate-scheduling.sh
+++ b/kwok/scripts/validate-scheduling.sh
@@ -31,6 +31,12 @@
 #                         argocd-helm-oci  (aicr bundle --deployer argocd-helm
 #                                           -> OCI push -> helm install OCI
 #                                           chart in argocd namespace)
+#                         argocd-git       (aicr bundle --deployer argocd ->
+#                                           filesystem output -> git push to
+#                                           in-cluster Gitea -> kubectl apply
+#                                           app-of-apps.yaml and let Argo CD
+#                                           clone + reconcile from Git;
+#                                           issue #963)
 #                         flux-oci         (aicr bundle --deployer flux ->
 #                                           OCI push -> apply OCIRepository +
 #                                           Kustomization wrappers and let
@@ -44,7 +50,7 @@
 #                       For argocd-* values the in-cluster registry + Argo CD
 #                       must already be installed; for flux-oci the registry
 #                       + Flux 2 controllers must be installed; for flux-git
-#                       additionally Gitea. All are managed by
+#                       and argocd-git additionally Gitea. All are managed by
 #                       `kwok/scripts/install-infra.sh` keyed on the DEPLOYER
 #                       env var.
 #
@@ -73,14 +79,14 @@
 #                            Kustomization after the grace window indicates
 #                            kubectl apply silently produced no resource
 #                            (RBAC denial, CRD missing). Default: 30.
-#   KWOK_GITEA_HOST_PORT     (flux-git only) Host port the in-cluster Gitea
-#                            is reachable on from the runner for `git push`.
-#                            MUST match install-infra.sh / kind-config.yaml.
-#                            Default: 3300.
-#   KWOK_GITEA_USER          (flux-git only) Gitea user to push as. Must
-#                            match the admin user bootstrapped by
+#   KWOK_GITEA_HOST_PORT     (flux-git / argocd-git) Host port the in-cluster
+#                            Gitea is reachable on from the runner for
+#                            `git push`. MUST match install-infra.sh /
+#                            kind-config.yaml. Default: 3300.
+#   KWOK_GITEA_USER          (flux-git / argocd-git) Gitea user to push as.
+#                            Must match the admin user bootstrapped by
 #                            install-infra.sh. Default: aicr.
-#   KWOK_GITEA_PASSWORD      (flux-git only) Password for KWOK_GITEA_USER.
+#   KWOK_GITEA_PASSWORD      (flux-git / argocd-git) Password for KWOK_GITEA_USER.
 #                            CI-only credential for the ephemeral in-cluster
 #                            Gitea — not a secret. Default: aicr-kwok-ci.
 #
@@ -159,6 +165,8 @@ OCI_IN_CLUSTER_REF=""
 # resolve_argocd_root_app():
 #   - argocd-oci      -> "nvidia-stack" (pkg/bundler/deployer/argocd/
 #                        templates/app-of-apps.yaml.tmpl)
+#   - argocd-git      -> "nvidia-stack" (same --deployer argocd app-of-apps;
+#                        only the source transport differs — Git vs OCI)
 #   - argocd-helm-oci -> "aicr-stack"   (pkg/bundler/deployer/argocdhelm/
 #                        argocdhelm.go: parentAppTemplate)
 # Default empty when DEPLOYER=helm; cleanup guards against empty before
@@ -169,9 +177,9 @@ ARGOCD_ROOT_APP=""
 # that consults ARGOCD_ROOT_APP (cleanup, wait_for_argocd_sync).
 resolve_argocd_root_app() {
     case "$DEPLOYER" in
-        argocd-oci)      ARGOCD_ROOT_APP="nvidia-stack" ;;
-        argocd-helm-oci) ARGOCD_ROOT_APP="aicr-stack"   ;;
-        *)               ARGOCD_ROOT_APP=""             ;;
+        argocd-oci|argocd-git) ARGOCD_ROOT_APP="nvidia-stack" ;;
+        argocd-helm-oci)       ARGOCD_ROOT_APP="aicr-stack"   ;;
+        *)                     ARGOCD_ROOT_APP=""             ;;
     esac
 }
 
@@ -204,12 +212,13 @@ FLUX_KUSTOMIZATION_NAME=""
 FLUX_OCIREPOSITORY_NAME=""
 FLUX_GITREPOSITORY_NAME=""
 
-# Git URLs for the flux-git lane (issue #963). Same dual-view pattern as
-# OCI_REF / OCI_IN_CLUSTER_REF: the runner pushes via the Kind host-port
-# mapping (localhost:3300), while Flux's source-controller clones via
-# Service DNS from inside the cluster. Populated in generate_bundle;
-# consumed by deploy_bundle. Script-globals so the runner→service-DNS
-# rewrite rule lives in exactly one place.
+# Git URLs for the Git-source lanes flux-git / argocd-git (issue #963).
+# Same dual-view pattern as OCI_REF / OCI_IN_CLUSTER_REF: the runner pushes
+# via the Kind host-port mapping (localhost:3300), while the GitOps
+# controller (Flux source-controller or Argo CD repo-server) clones via
+# Service DNS from inside the cluster. Populated by compute_gitea_urls()
+# in generate_bundle; consumed by deploy_bundle. Script-globals so the
+# runner→service-DNS rewrite rule lives in exactly one place.
 GIT_PUSH_URL=""
 GIT_IN_CLUSTER_URL=""
 
@@ -250,8 +259,10 @@ cleanup() {
         # Argo CD deployers: delete the root Application FIRST so prune
         # semantics tear down children before we touch the namespaces.
         # The Helm-OCI release (argocd-helm-oci) also needs to come down so
-        # the next recipe gets a clean argocd namespace.
-        if [[ "$DEPLOYER" == "argocd-oci" || "$DEPLOYER" == "argocd-helm-oci" ]]; then
+        # the next recipe gets a clean argocd namespace. argocd-git needs no
+        # repo cleanup: Gitea state is emptyDir-ephemeral and force-pushed
+        # each run, so deleting the root Application is sufficient.
+        if [[ "$DEPLOYER" == argocd-* ]]; then
             if [[ -n "$ARGOCD_ROOT_APP" ]]; then
                 log_info "Deleting Argo CD root Application ${ARGOCD_ROOT_APP} (prune cascade)..."
                 timeout 120s kubectl delete application "$ARGOCD_ROOT_APP" -n argocd \
@@ -647,6 +658,57 @@ verify_kwok_nodes() {
     log_info "Verified $actual_count KWOK nodes exist"
 }
 
+# compute_gitea_urls populates the dual-view Git URLs (GIT_IN_CLUSTER_URL,
+# GIT_PUSH_URL) for the Git-source lanes (flux-git, argocd-git; issue #963).
+# The IN-CLUSTER URL (Service DNS) is what gets baked into the bundle via
+# --repo and what the GitOps controller clones from inside the cluster; the
+# PUSH URL (localhost host-port + basic-auth) is what the runner pushes to.
+# Shared so the runner→Service-DNS rewrite rule lives in exactly one place.
+# The repo must be anonymously READABLE — install-infra.sh configures Gitea
+# with DEFAULT_PUSH_CREATE_PRIVATE=false because neither the flux gitrepo
+# source CR nor the argocd Application carries clone credentials.
+compute_gitea_urls() {
+    local recipe="$1"
+    local gitea_host_port="${KWOK_GITEA_HOST_PORT:-3300}"
+    local gitea_user="${KWOK_GITEA_USER:-aicr}"
+    local gitea_password="${KWOK_GITEA_PASSWORD:-aicr-kwok-ci}"
+    GIT_IN_CLUSTER_URL="http://gitea.aicr-registry.svc.cluster.local:3000/${gitea_user}/${recipe}.git"
+    GIT_PUSH_URL="http://${gitea_user}:${gitea_password}@localhost:${gitea_host_port}/${gitea_user}/${recipe}.git"
+}
+
+# push_bundle_to_gitea pushes the rendered bundle tree at ${WORK_DIR}/bundle
+# to Gitea on branch main. push-to-create makes the repo on first push;
+# --force resets state on re-runs so the lane is idempotent (Gitea state is
+# emptyDir-ephemeral anyway). Branch main is a hard requirement — both the
+# flux GitRepository refs and the argocd targetRevision default to main, and
+# there is no CLI flag to change it for filesystem output. compute_gitea_urls
+# must have run first (GIT_PUSH_URL / GIT_IN_CLUSTER_URL set).
+push_bundle_to_gitea() {
+    local recipe="$1"
+    local short_sha gitea_host_port gitea_user
+    short_sha=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
+    gitea_host_port="${KWOK_GITEA_HOST_PORT:-3300}"
+    gitea_user="${KWOK_GITEA_USER:-aicr}"
+
+    log_info "Pushing bundle to Gitea (localhost:${gitea_host_port}, repo ${gitea_user}/${recipe})..."
+    local git_output
+    if ! git_output=$(
+        {
+            cd "${WORK_DIR}/bundle" &&
+            git init -q -b main &&
+            git add -A &&
+            git -c user.name=aicr-kwok -c user.email=aicr@example.invalid \
+                commit -q -m "bundle ${recipe} ${short_sha}-${DEPLOYER}" &&
+            git push -q --force "$GIT_PUSH_URL" main
+        } 2>&1
+    ); then
+        log_error "git push to Gitea failed"
+        log_error "$git_output"
+        return 1
+    fi
+    log_info "Bundle pushed; GitOps controller will clone from ${GIT_IN_CLUSTER_URL} (branch main)"
+}
+
 # Generate recipe and bundle
 generate_bundle() {
     local recipe="$1"
@@ -963,22 +1025,11 @@ generate_bundle() {
             # Flux's source-controller clone it back. This exercises the
             # flux deployer's GIT shape — GitRepository source CRs in
             # sources/gitrepo-*.yaml — which the OCI lane never renders.
-            local short_sha
-            short_sha=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
-            local gitea_host_port="${KWOK_GITEA_HOST_PORT:-3300}"
-            local gitea_user="${KWOK_GITEA_USER:-aicr}"
-            local gitea_password="${KWOK_GITEA_PASSWORD:-aicr-kwok-ci}"
-            # Dual-view URLs (same pattern as OCI_REF / OCI_IN_CLUSTER_REF):
-            # the runner pushes via the Kind host-port mapping; Flux's
-            # source-controller clones via Service DNS. --repo gets the
-            # IN-CLUSTER URL because it is baked into the bundle's own
-            # GitRepository source CR, which source-controller resolves
-            # from inside the cluster. The repo must be anonymously
-            # readable: the bundler's gitrepo template has no secretRef
-            # (install-infra.sh configures Gitea so pushed repos are
-            # public via DEFAULT_PUSH_CREATE_PRIVATE=false).
-            GIT_IN_CLUSTER_URL="http://gitea.aicr-registry.svc.cluster.local:3000/${gitea_user}/${recipe}.git"
-            GIT_PUSH_URL="http://${gitea_user}:${gitea_password}@localhost:${gitea_host_port}/${gitea_user}/${recipe}.git"
+            #
+            # --repo gets the IN-CLUSTER URL because it is baked into the
+            # bundle's own GitRepository source CR, which source-controller
+            # resolves from inside the cluster.
+            compute_gitea_urls "$recipe"
 
             log_info "Bundling for flux (filesystem), repo URL ${GIT_IN_CLUSTER_URL}"
             # No --plain-http: that flag is OCI-only. No tag handling: the
@@ -1028,27 +1079,81 @@ generate_bundle() {
                 return 1
             fi
 
-            # Push the bundle tree to Gitea. push-to-create makes the repo
-            # on first push; --force resets state on re-runs so the lane is
-            # idempotent (Gitea state is emptyDir-ephemeral anyway). Branch
-            # main is a hard requirement — see the bundler note above.
-            log_info "Pushing bundle to Gitea (localhost:${gitea_host_port}, repo ${gitea_user}/${recipe})..."
-            local git_output
-            if ! git_output=$(
-                {
-                    cd "${WORK_DIR}/bundle" &&
-                    git init -q -b main &&
-                    git add -A &&
-                    git -c user.name=aicr-kwok -c user.email=aicr@example.invalid \
-                        commit -q -m "bundle ${recipe} ${short_sha}-${DEPLOYER}" &&
-                    git push -q --force "$GIT_PUSH_URL" main
-                } 2>&1
-            ); then
-                log_error "git push to Gitea failed"
-                log_error "$git_output"
+            # Push the bundle tree to Gitea (branch main, force-push for
+            # idempotent re-runs). See push_bundle_to_gitea for details.
+            if ! push_bundle_to_gitea "$recipe"; then
                 return 1
             fi
-            log_info "Bundle pushed; Flux will clone from ${GIT_IN_CLUSTER_URL} (branch main)"
+            ;;
+        argocd-git)
+            # Git-source round-trip for the argocd deployer (issue #963):
+            # bundle to a local directory with --repo set to the in-cluster
+            # Git URL, push the tree to Gitea, and let Argo CD's repo-server
+            # clone it back. This exercises the argocd deployer's GIT output
+            # shape — an app-of-apps plus per-component application.yaml whose
+            # spec.source.repoURL is the Git URL and targetRevision is `main`
+            # (pkg/bundler/deployer/argocd/resolveRepoSettings) — which the
+            # OCI lane never renders.
+            compute_gitea_urls "$recipe"
+
+            log_info "Bundling for argocd (filesystem), repo URL ${GIT_IN_CLUSTER_URL}"
+            # No --plain-http (OCI-only) and no OCI tag: with a filesystem
+            # --output the argocd deployer bakes --repo straight into every
+            # Application's repoURL and defaults targetRevision to main, so
+            # the push below MUST target main.
+            if ! bundle_output=$("$AICR_BIN" bundle \
+                --recipe "${WORK_DIR}/recipe.yaml" \
+                --deployer argocd \
+                --output "${WORK_DIR}/bundle" \
+                --repo "$GIT_IN_CLUSTER_URL" \
+                --system-node-selector "aicr.nvidia.com/node-type=system" \
+                --accelerated-node-selector "aicr.nvidia.com/node-type=accelerated" \
+                --system-node-toleration "kwok.x-k8s.io/node=fake:NoSchedule" \
+                --accelerated-node-toleration "nvidia.com/gpu=present:NoSchedule" \
+                --accelerated-node-toleration "kwok.x-k8s.io/node=fake:NoSchedule" \
+                --set "certmanager:startupapicheck.enabled=false" \
+                --set "slinkyslurmoperator:webhook.enabled=false" \
+                --set "slinkyslurmoperator:certManager.enabled=false" \
+                --set "slurmcluster:controller.persistence.enabled=false" \
+                --set "kubeprometheusstack:defaultRules.create=false" \
+                --set "kubeprometheusstack:alertmanager.enabled=false" \
+                --set "nodewright-customizations:enabled=false" \
+                --set "dynamoplatform:etcd.persistence.enabled=false" \
+                --set "dynamoplatform:nats.config.jetstream.fileStore.enabled=false" 2>&1); then
+                log_error "Bundle generation failed"
+                log_error "Bundle command output:"
+                echo "$bundle_output"
+                return 1
+            fi
+
+            # The argocd deployer's root manifest is app-of-apps.yaml; the
+            # deploy step applies it. Fail fast if it's missing.
+            if [[ ! -f "${WORK_DIR}/bundle/app-of-apps.yaml" ]]; then
+                log_error "Expected app-of-apps.yaml not found in bundle: ${WORK_DIR}/bundle"
+                log_error "Bundle contents:"
+                list_bundle_entries "${WORK_DIR}/bundle"
+                return 1
+            fi
+            # Git-mode proof: the root Application's repoURL must be the Git
+            # URL we passed via --repo. If it is an oci:// reference the
+            # bundler silently took the OCI path and the lane is no longer
+            # testing the Git shape it exists for. (The chainsaw gate asserts
+            # this on the live resource too; this is the fail-fast at bundle
+            # time before the push.) The repoURL is unquoted in app-of-apps
+            # and quoted in per-component application.yaml, so match either.
+            if ! grep -Eq "repoURL: '?${GIT_IN_CLUSTER_URL}'?[[:space:]]*$" \
+                    "${WORK_DIR}/bundle/app-of-apps.yaml"; then
+                log_error "app-of-apps.yaml repoURL is not the Git URL ${GIT_IN_CLUSTER_URL}"
+                log_error "argocd git mode did not engage; app-of-apps.yaml:"
+                cat "${WORK_DIR}/bundle/app-of-apps.yaml" || true
+                return 1
+            fi
+
+            # Push the bundle tree to Gitea (branch main, force-push for
+            # idempotent re-runs). See push_bundle_to_gitea for details.
+            if ! push_bundle_to_gitea "$recipe"; then
+                return 1
+            fi
             ;;
         *)
             log_error "Unknown deployer: ${DEPLOYER}"
@@ -1139,7 +1244,12 @@ deploy_bundle() {
                 return 1
             fi
             ;;
-        argocd-oci)
+        argocd-oci|argocd-git)
+            # Both lanes apply the same app-of-apps root manifest; they
+            # differ only in the source the Applications point at (OCI
+            # registry vs in-cluster Gitea), which is baked into the bundle
+            # at generate time. The sync gate (wait_for_argocd_sync) routes
+            # to the right chainsaw test per DEPLOYER.
             log_info "Applying app-of-apps manifest: ${bundle_dir}/app-of-apps.yaml"
             if ! kubectl apply -f "${bundle_dir}/app-of-apps.yaml"; then
                 log_error "kubectl apply -f app-of-apps.yaml failed"
@@ -1422,7 +1532,26 @@ wait_for_argocd_sync() {
         return 1
     fi
 
-    local test_dir="${REPO_ROOT}/tests/chainsaw/kwok/argocd-sync"
+    # Per-deployer gate: argocd-oci / argocd-helm-oci use the source-agnostic
+    # argocd-sync test; argocd-git uses the argocd-git-sync sibling, which
+    # adds a leading step asserting the root Application's Git repoURL (the
+    # Git-mode proof). The two tests' shared steps (root-App-present, 4-arm
+    # terminal-pass) are byte-identical — see the sync-note headers in both
+    # chainsaw-test.yaml files. argocd-git passes the extra repoURL binding.
+    local test_dir extra_args=()
+    case "$DEPLOYER" in
+        argocd-git)
+            test_dir="${REPO_ROOT}/tests/chainsaw/kwok/argocd-git-sync"
+            if [[ -z "$GIT_IN_CLUSTER_URL" ]]; then
+                log_error "GIT_IN_CLUSTER_URL is empty for argocd-git (bundle step skipped?)"
+                return 1
+            fi
+            extra_args+=(--set "repoURL=${GIT_IN_CLUSTER_URL}")
+            ;;
+        *)
+            test_dir="${REPO_ROOT}/tests/chainsaw/kwok/argocd-sync"
+            ;;
+    esac
     local sync_timeout="${KWOK_ARGOCD_SYNC_TIMEOUT:-300}s"
 
     log_info "Argo CD sync gate (chainsaw): rootApp=${ARGOCD_ROOT_APP} timeout=${sync_timeout}"
@@ -1440,6 +1569,7 @@ wait_for_argocd_sync() {
     # overrides.
     if "$chainsaw_bin" test "$test_dir" \
             --set "rootApp=${ARGOCD_ROOT_APP}" \
+            "${extra_args[@]}" \
             --assert-timeout "$sync_timeout" \
             --no-color; then
         log_info "Argo CD sync PASS (chainsaw)"
@@ -1809,11 +1939,11 @@ main() {
     fi
 
     case "$DEPLOYER" in
-        helm|argocd-oci|argocd-helm-oci|flux-oci|flux-git)
+        helm|argocd-oci|argocd-helm-oci|argocd-git|flux-oci|flux-git)
             ;;
         *)
             log_error "Invalid --deployer value: '${DEPLOYER}'"
-            log_error "Must be one of: helm, argocd-oci, argocd-helm-oci, flux-oci, flux-git"
+            log_error "Must be one of: helm, argocd-oci, argocd-helm-oci, argocd-git, flux-oci, flux-git"
             exit 1
             ;;
     esac

--- a/tests/chainsaw/kwok/argocd-git-sync/chainsaw-test.yaml
+++ b/tests/chainsaw/kwok/argocd-git-sync/chainsaw-test.yaml
@@ -14,80 +14,90 @@
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 #
-# KWOK argocd-* sync gate. Replaces the bash `wait_for_argocd_sync` +
-# `wait_for_argocd_root_app` + `dump_argocd_failures` functions previously
-# in kwok/scripts/validate-scheduling.sh. Driven by the `validate-scheduling.sh`
-# argocd-oci / argocd-helm-oci / argocd-git deployer branches; see issue #962
-# for the migration rationale.
+# KWOK argocd-git sync gate (issue #963). Sibling of ../argocd-sync/ — the
+# ONLY intended divergence is the extra step 1, which asserts the root
+# Application's Git source (spec.source.repoURL) so the lane fails closed
+# when the bundler silently rendered an OCI repoURL instead of the Git URL
+# it was given via --repo. The assert-root-app-present and
+# assert-all-applications-pass steps MUST stay byte-identical with
+# argocd-sync/chainsaw-test.yaml; when changing one, change both. See
+# ADR-010 (docs/design/010-kwok-git-source-lanes.md).
 #
-# SYNC NOTE (issue #963): ../argocd-git-sync/chainsaw-test.yaml is a sibling
-# of this test whose only intended divergence is an EXTRA leading step that
-# asserts the root Application's Git source (spec.source.repoURL). The
-# assert-root-app-present and assert-all-applications-pass steps MUST stay
-# byte-identical between the two files — when changing one, change both.
-#
-# The test takes one binding via `chainsaw test --values rootApp=<name>`:
-#   - rootApp: the parent App-of-Apps name (`nvidia-stack` for --deployer
-#     argocd, `aicr-stack` for --deployer argocd-helm). The bash driver
-#     selects the right name from DEPLOYER.
+# Driven by validate-scheduling.sh's argocd-git deployer branch via
+# `chainsaw test --set rootApp=<name> --set repoURL=<git-url>`. The driver
+# passes the IN-CLUSTER Git URL it baked into the bundle (Service DNS),
+# which is exactly what Argo CD's repo-server clones from.
 #
 # Pass predicate — every Application in the `argocd` namespace must match
-# one of these 4 terminal-pass states (mirroring the pre-migration jq
-# disjunction at validate-scheduling.sh:~1378):
+# one of these 4 terminal-pass states (mirroring argocd-sync):
 #
 #   1. Synced + Healthy                                   — canonical pass
 #   2. Synced + Progressing                               — KWOK pod-readiness gap (ADR-008)
 #   3. OutOfSync + Healthy + operationState=Succeeded     — operator mutation (ClusterPolicy, DeviceClass, etc.)
 #   4. Synced + Degraded + operationState=Succeeded       — health controller divergence after successful op
-#
-# The 4-arm disjunction is encoded as a single JMESPath expression that
-# Chainsaw re-evaluates per Application matched by the resource selector.
-# Chainsaw polls until ALL matched Applications satisfy the expression
-# (or the assert timeout fires).
-#
-# On failure, the catch block dumps per-App status + repo-server and
-# application-controller logs. The StatefulSet/Deployment fallback for
-# application-controller matches Argo CD chart 9.x (StatefulSet) and
-# older chart layouts (Deployment).
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: kwok-argocd-sync
+  name: kwok-argocd-git-sync
 spec:
   description: |
-    Wait for Argo CD reconciliation to converge on the KWOK deployer matrix.
-    Asserts that the root Application is present and every Application in
-    the argocd namespace reaches one of the 4 terminal-pass states.
+    Wait for Argo CD reconciliation of a Git-sourced (Gitea) bundle to
+    converge on the KWOK deployer matrix. Asserts the root Application
+    sources from the expected Git URL, is present, and every Application
+    in the argocd namespace reaches one of the 4 terminal-pass states.
   bindings:
-    # rootApp is overridden via `chainsaw test --set rootApp=<name>`.
-    # The CLI's `--set key=value` populates the implicit `$values`
-    # binding; we surface it here as a top-level `$rootApp` binding so
-    # callers can leave the test invocable without arguments (defaulting
-    # to argocd-helm-oci's root App). The `$values.rootApp || 'aicr-stack'`
-    # fallback handles the no-arg case for ad-hoc local invocation.
+    # See the argocd-sync test for the $values vs bindings pattern.
+    # CLI `--set <key>=<value>` populates `$values.<key>`; the bindings
+    # below pull that through with a default fallback for ad-hoc runs.
     - name: rootApp
-      value: ($values.rootApp || 'aicr-stack')
+      value: ($values.rootApp || 'nvidia-stack')
+    # repoURL is the in-cluster Git URL the bundler baked into the
+    # app-of-apps source. No fallback default: an empty value here would
+    # make the step-1 assert vacuous, so leave it empty and let the
+    # assert fail loudly if the driver forgot to pass it.
+    - name: repoURL
+      value: ($values.repoURL || '')
   timeouts:
-    # KWOK_ARGOCD_SYNC_TIMEOUT default. The argocd-helm-oci wrapper takes
-    # slightly longer to converge than argocd-oci because the parent
-    # Application has to render the child Apps before they begin
-    # reconciling. 5 minutes is conservative for KWOK pod-readiness sim.
+    # KWOK_ARGOCD_SYNC_TIMEOUT default. Matches argocd-sync.
     assert: 5m
-  # Skip namespace and resource deletion during cleanup. The test creates
-  # no resources of its own (it only asserts on Application CRs in the
-  # argocd namespace), so there's nothing to clean. Chainsaw's default
-  # cleanup deletes the auto-created per-test namespace, which on KWOK
-  # gets stuck in Terminating forever — there's no kube-controller-manager
-  # to finalize the `kubernetes` namespace finalizer — and the 30s
-  # cleanup timeout fires, reporting the test as failed even when every
-  # assertion passed. See PR #1050.
+  # See argocd-sync for the skipDelete rationale (KWOK has no
+  # kube-controller-manager to finalize the auto-created test namespace).
   skipDelete: true
   steps:
+    - name: assert-root-app-git-source
+      description: |
+        Git-mode proof. The root App-of-Apps must source from the Git URL
+        the driver passed via --repo. If repoURL is an oci:// reference
+        instead, the bundler silently took the OCI path and this lane is
+        no longer exercising the Git output shape it exists to protect.
+        This is the argocd analogue of flux-git-sync's GitRepository-Ready
+        step.
+      try:
+        - assert:
+            timeout: 30s
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Application
+              metadata:
+                name: ($rootApp)
+                namespace: argocd
+              spec:
+                source:
+                  (repoURL == ($repoURL)): true
+      catch:
+        - script:
+            content: |
+              echo "--- root Application source ---"
+              kubectl get application ($rootApp) -n argocd \
+                -o jsonpath='{.spec.source}' 2>&1 || true
+              echo "--- Applications in argocd namespace ---"
+              kubectl get applications -n argocd 2>&1 || true
+
     - name: assert-root-app-present
       description: |
         The root Application must exist within the grace period. If it
-        doesn't, the bundle apply step (helm install / kubectl apply)
-        either failed silently or produced no Application resource.
+        doesn't, the bundle apply step (kubectl apply) either failed
+        silently or produced no Application resource.
       try:
         - assert:
             timeout: 30s


### PR DESCRIPTION
## Summary

<!-- What changed? Keep it short (1-2 sentences). -->

Adds the `argocd-git` KWOK deployer lane: the filesystem bundle is `git push`ed to
the in-cluster Gitea and Argo CD's repo-server clones + reconciles the app-of-apps
from the Git `repoURL`  the Argo CD counterpart to `flux-git`, completing the
Git-source round-trip matrix.

## Motivation / Context

The OCI lanes (`argocd-oci`, `argocd-helm-oci`, `flux-oci`) and `flux-git` (#1290)
left one documented product surface uncovered: the Argo CD **filesystem/Git output
shape**. With `--output ./dir --repo <git-url>`, the argocd deployer bakes the Git
URL into the app-of-apps and every per-component `application.yaml` (`targetRevision:
main`, path-based) — entirely different rendering from the OCI path, and previously
exercised by no lane. This lane reuses the in-cluster Gitea infra `flux-git` already
established (same host-port 3300, same anonymous-public-repo contract).

<!-- Why is this change needed? Link issues/discussions. -->

Fixes: #963
Related: #1290 (flux-git), #843 (KWOK deployer matrix), #1288 (argocd sync-gate
exists-semantics, tracked separately)

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: KWOK test infra (`kwok/`, `tests/chainsaw/kwok`), CI workflow (`.github/`)

## Implementation Notes

- **No Go changes.** The argocd deployer's Git filesystem shape already exists
  (`resolveRepoSettings()` defaulting `targetRevision` to `main`,
  `app-of-apps.yaml.tmpl`, per-component `application.yaml` `repoURL`); this PR adds
  the CI lane that protects it.
- **Shared Gitea helpers.** Extracted `compute_gitea_urls()` /
  `push_bundle_to_gitea()` in `validate-scheduling.sh` and refactored the existing
  `flux-git` branch onto them, so the runner→Service-DNS dual-view URL rule and the
  `git init/commit/push --force main` block live in one place.
- **`install-infra.sh` `argocd-git` case** installs Argo CD + repo secret **and**
  Gitea (a superset of the `argocd-oci` install, mirroring how `flux-git` composes
  `install_flux` + `install_gitea`).
- **Sync gate.** `argocd-git` reuses the existing source-agnostic `argocd-sync`
  chainsaw gate (root app `nvidia-stack`), via a dedicated `argocd-git-sync` sibling
  that adds one leading step asserting the root Application's `spec.source.repoURL`
  is the Git URL — the "Git mode engaged" proof (analogue of `flux-git-sync`'s
  GitRepository-Ready step). The shared steps stay byte-identical between the two
  files (SYNC NOTE headers enforce this by convention).
- **Contract under test:** anonymous public Git over plain HTTP (no repo
  credentials), exactly what the bundler's argocd output emits.
- The known exists-semantics weakness of `argocd-sync` (`assert-all-applications-pass`)
  is **out of scope** here and tracked in a separate issue (#1288 argocd half); this
  lane behaves identically to the existing `argocd-oci`/`argocd-helm-oci` lanes.
## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

CI matrix grows by one cell per generic overlay (Tier 1) and one
deployer (Tier 3), staying under GitHub's 256-config cap. No new cluster topology —
the Gitea Service + host-port 3300 mapping shipped with #1290; clusters created
after that need no recreation. Existing argocd-oci/argocd-helm-oci/flux-* lanes
are unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
