### PR TITLE
fix(cli): validate/recipe UX papercuts (#1383 items 1-7)

### DIFF
--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -146,6 +146,11 @@ Override snapshot-detected criteria:
 				return err
 			}
 
+			// Mode banner: recipe generation reads inputs (criteria, embedded
+			// data, an optional snapshot) and never deploys to or modifies a
+			// live cluster, so make that explicit up front (issue #1383).
+			slog.Info("generating recipe offline — reads inputs only; does not deploy to or modify any cluster")
+
 			// Build a per-command Client bound to the resolved data source
 			// (--data / spec.recipe.data, else embedded). The Client owns its
 			// own DataProvider and per-provider criteria registry, replacing
@@ -227,9 +232,15 @@ Override snapshot-detected criteria:
 				return errors.Wrap(errors.ErrCodeInternal, "failed to serialize recipe", err)
 			}
 
+			componentNames := make([]string, len(resolved.ComponentRefs))
+			for i, ref := range resolved.ComponentRefs {
+				componentNames[i] = ref.Name
+			}
+
 			slog.Info("recipe generation completed",
 				"output", output,
 				"components", len(resolved.ComponentRefs),
+				"componentNames", strings.Join(componentNames, ", "),
 				"overlays", len(resolved.Metadata.AppliedOverlays))
 
 			return nil

--- a/pkg/cli/recipe_list.go
+++ b/pkg/cli/recipe_list.go
@@ -326,6 +326,12 @@ func writeCatalogEntries(ctx context.Context, cmd *cli.Command, entries []aicr.C
 			if _, err := fmt.Fprintln(w, "(no matching overlays)"); err != nil {
 				return errors.Wrap(errors.ErrCodeInternal, "failed to write empty message", err)
 			}
+		} else {
+			// Legend so a bare "any" in the criteria columns reads as an
+			// intentional wildcard rather than a missing/unknown value (issue #1383).
+			if _, err := fmt.Fprintf(w, "\n%s = wildcard (dimension unconstrained — matches any value)\n", criteriaAny); err != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed to write legend", err)
+			}
 		}
 	}
 

--- a/pkg/cli/recipe_list_test.go
+++ b/pkg/cli/recipe_list_test.go
@@ -179,6 +179,15 @@ func TestRecipeList_NonLeafStatusPlaceholder(t *testing.T) {
 	}
 }
 
+// TestRecipeList_WildcardLegend confirms the table output explains that a
+// bare "any" in the criteria columns is an intentional wildcard (issue #1383).
+func TestRecipeList_WildcardLegend(t *testing.T) {
+	out := runRecipeList(t)
+	if !strings.Contains(out, criteriaAny+" = wildcard") {
+		t.Errorf("expected wildcard legend for %q in table output:\n%s", criteriaAny, out)
+	}
+}
+
 // TestRecipeList_FilteredJSONHealth drives the CLI filter end-to-end and
 // confirms ListCatalog and ComputeHealth agree on the same narrowed set: every
 // returned leaf carries a health block and matches the filter.

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -675,6 +675,16 @@ Run validation without failing on check errors (informational mode):
 			failFast := boolFlagOrConfig(cmd, "fail-fast", derefBoolOr(resolved.FailFast, false))
 			noCluster := boolFlagOrConfig(cmd, "no-cluster", resolved.NoCluster)
 
+			// Mode banner: make it explicit whether this run touches a live
+			// cluster (issue #1383). --no-cluster is an offline dry-run that
+			// reports checks as skipped; otherwise validation deploys
+			// validator Jobs against the active kube-context.
+			if noCluster {
+				slog.Info("validating in --no-cluster mode — offline dry-run; checks are reported as skipped, no cluster is contacted")
+			} else {
+				slog.Info("validating against the live cluster — validator Jobs will be deployed to the active kube-context")
+			}
+
 			// Resolve shared fields once, before the snapshot/agent split, so
 			// CLI-overrides-config log lines fire exactly once per field even
 			// when both the agent-deploy path and the validator Job want the

--- a/pkg/logging/cli.go
+++ b/pkg/logging/cli.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -106,9 +107,12 @@ func (h *CLIHandler) Handle(_ context.Context, r slog.Record) error {
 		msg = msg + ": " + strings.Join(attrs, " ")
 	}
 
-	// Add color for error messages and success messages when supported.
+	// Add color when supported. Error-level records are red; otherwise the
+	// record is red when it carries a failure status attr (so a
+	// "validator completed status=failed" line logged at Info reads red, not
+	// green) and green for everything else.
 	if h.color {
-		if r.Level >= slog.LevelError {
+		if r.Level >= slog.LevelError || h.hasFailureStatus(r) {
 			msg = colorRed + msg + colorReset
 		} else {
 			msg = colorGreen + msg + colorReset
@@ -119,6 +123,37 @@ func (h *CLIHandler) Handle(_ context.Context, r slog.Record) error {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to write log output", err)
 	}
 	return nil
+}
+
+// hasFailureStatus reports whether the record (or a handler-bound attr)
+// carries a `status` attribute whose value indicates failure. This lets the
+// CLI color a non-error-level completion line red — e.g. CTRF reports a failed
+// validator via slog.Info("validator completed", "status", "failed"), which
+// would otherwise render green because it is below LevelError.
+func (h *CLIHandler) hasFailureStatus(r slog.Record) bool {
+	isFailure := func(a slog.Attr) bool {
+		if a.Key != "status" {
+			return false
+		}
+		switch strings.ToLower(a.Value.String()) {
+		case "failed", "error":
+			return true
+		default:
+			return false
+		}
+	}
+	if slices.ContainsFunc(h.attrs, isFailure) {
+		return true
+	}
+	found := false
+	r.Attrs(func(a slog.Attr) bool {
+		if isFailure(a) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 // formatAttr renders a slog.Attr as "key=value", prefixing key with the

--- a/pkg/logging/cli_test.go
+++ b/pkg/logging/cli_test.go
@@ -93,6 +93,54 @@ func TestCLIHandler_ErrorMessage(t *testing.T) {
 	}
 }
 
+func TestCLIHandler_FailureStatusColoredRed(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  string
+		wantRed bool
+	}{
+		{"failed status at info level is red", "failed", true},
+		{"error status at info level is red", "error", true},
+		{"passed status at info level is green", "passed", false},
+		{"skipped status at info level is green", "skipped", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := newCLIHandler(&buf, slog.LevelInfo)
+			handler.color = true // force color even though the writer is a buffer
+			logger := slog.New(handler)
+
+			logger.Info("validator completed", "name", "deployment", "status", tt.status)
+
+			output := buf.String()
+			gotRed := strings.Contains(output, colorRed)
+			if gotRed != tt.wantRed {
+				t.Errorf("status=%q colored red = %v, want %v (output: %q)", tt.status, gotRed, tt.wantRed, output)
+			}
+			// A non-red line must still be colored green (not left uncolored).
+			if !tt.wantRed && !strings.Contains(output, colorGreen) {
+				t.Errorf("status=%q should be green, got: %q", tt.status, output)
+			}
+		})
+	}
+
+	// A handler-bound status attr (logger.With) must also trigger red, since
+	// hasFailureStatus inspects h.attrs in addition to the record attrs.
+	t.Run("handler-bound failed status at info level is red", func(t *testing.T) {
+		var buf bytes.Buffer
+		handler := newCLIHandler(&buf, slog.LevelInfo)
+		handler.color = true
+		logger := slog.New(handler).With("status", "failed")
+
+		logger.Info("validator completed", "name", "deployment")
+
+		if output := buf.String(); !strings.Contains(output, colorRed) {
+			t.Errorf("handler-bound status=failed should be red, got: %q", output)
+		}
+	})
+}
+
 func TestCLIHandler_NoColorWhenNotTTY(t *testing.T) {
 	var buf bytes.Buffer
 	handler := newCLIHandler(&buf, slog.LevelInfo)

--- a/pkg/serializer/writer.go
+++ b/pkg/serializer/writer.go
@@ -255,21 +255,74 @@ func flattenValue(out map[string]any, val reflect.Value, prefix string) {
 			flattenValue(out, val.Field(i), key)
 		}
 	case reflect.Map:
-		for _, mapKey := range val.MapKeys() {
-			key := joinKey(prefix, fmt.Sprintf("%v", mapKey.Interface()))
-			flattenValue(out, val.MapIndex(mapKey), key)
+		// Render maps as a single-line compact-JSON value rather than
+		// exploding every key into its own row. Deeply nested values.yaml
+		// fragments would otherwise flood the table, and a raw %v dump of a
+		// nested map breaks the FIELD/VALUE columns (issue #1383). An empty
+		// top-level map yields no rows so the caller prints "<empty>".
+		if prefix == "" && val.Len() == 0 {
+			return
 		}
+		storeTableLeaf(out, prefix, compactJSONLeaf(val))
 	case reflect.Slice, reflect.Array:
-		for i := 0; i < val.Len(); i++ {
-			key := joinKey(prefix, fmt.Sprintf("[%d]", i))
-			flattenValue(out, val.Index(i), key)
+		// Slices of structs (e.g. []ComponentRef) still recurse so each
+		// element's scalar fields get their own row; slices of scalars
+		// (e.g. deploymentOrder) collapse to one compact-JSON value.
+		if val.Len() > 0 && derefedKind(val.Index(0)) == reflect.Struct {
+			for i := 0; i < val.Len(); i++ {
+				key := joinKey(prefix, fmt.Sprintf("[%d]", i))
+				flattenValue(out, val.Index(i), key)
+			}
+		} else {
+			// An empty top-level slice yields no rows so the caller prints
+			// "<empty>"; a nested empty slice still renders as "[]".
+			if prefix == "" && val.Len() == 0 {
+				return
+			}
+			storeTableLeaf(out, prefix, compactJSONLeaf(val))
 		}
 	default:
-		if prefix == "" {
-			prefix = defaultValueKey
+		// Scalars render natively; a string with an embedded newline, tab, or
+		// carriage return is JSON-escaped so it can't shatter the tabwriter
+		// FIELD/VALUE columns.
+		if s, ok := val.Interface().(string); ok && strings.ContainsAny(s, "\n\r\t") {
+			storeTableLeaf(out, prefix, compactJSONLeaf(val))
+		} else {
+			storeTableLeaf(out, prefix, val.Interface())
 		}
-		out[prefix] = val.Interface()
 	}
+}
+
+// storeTableLeaf records a flattened leaf, substituting defaultValueKey when
+// the value sits at the root (no prefix).
+func storeTableLeaf(out map[string]any, prefix string, v any) {
+	if prefix == "" {
+		prefix = defaultValueKey
+	}
+	out[prefix] = v
+}
+
+// compactJSONLeaf renders a non-scalar (or multi-line) value as single-line
+// JSON so the table's FIELD/VALUE columns stay intact. Falls back to %v when
+// the value cannot be marshaled (e.g. a map with non-string keys).
+func compactJSONLeaf(val reflect.Value) string {
+	b, err := json.Marshal(val.Interface())
+	if err != nil {
+		return fmt.Sprintf("%v", val.Interface())
+	}
+	return string(b)
+}
+
+// derefedKind returns the underlying kind of v after unwrapping pointers and
+// interfaces; reflect.Invalid for a nil along the way.
+func derefedKind(v reflect.Value) reflect.Kind {
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return reflect.Invalid
+		}
+		v = v.Elem()
+	}
+	return v.Kind()
 }
 
 func joinKey(prefix, suffix string) string {

--- a/pkg/serializer/writer_test.go
+++ b/pkg/serializer/writer_test.go
@@ -117,6 +117,51 @@ func TestWriter_SerializeTable(t *testing.T) {
 	}
 }
 
+func TestWriter_SerializeTable_CompactNestedLeaves(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewWriter(FormatTable, &buf)
+
+	data := map[string]any{
+		"driver":          map[string]any{"version": "570.86", "rdma": true},
+		"deploymentOrder": []string{"cert-manager", "gpu-operator"},
+		"notes":           "line1\nline2",
+		"tabbed":          "col1\tcol2",
+		"replicas":        3,
+	}
+	if err := writer.Serialize(context.Background(), data); err != nil {
+		t.Fatalf("Serialize failed: %v", err)
+	}
+	output := buf.String()
+
+	// Nested map collapses to one compact-JSON cell (not exploded into
+	// driver.version / driver.rdma rows).
+	if !strings.Contains(output, `driver`) || !strings.Contains(output, `"version":"570.86"`) {
+		t.Errorf("nested map not rendered as compact JSON: %q", output)
+	}
+	if strings.Contains(output, "driver.version") {
+		t.Errorf("nested map should not be exploded into dotted rows: %q", output)
+	}
+	// Scalar slice collapses to a compact-JSON array.
+	if !strings.Contains(output, `["cert-manager","gpu-operator"]`) {
+		t.Errorf("scalar slice not rendered as compact JSON: %q", output)
+	}
+	// A multi-line string must not leak a raw newline into the value cell.
+	if strings.Contains(output, "line1\nline2") {
+		t.Errorf("multi-line string should be escaped, not raw: %q", output)
+	}
+	if !strings.Contains(output, `"line1\nline2"`) {
+		t.Errorf("multi-line string should be JSON-escaped: %q", output)
+	}
+	// A tab-containing string must likewise be escaped so it can't break columns.
+	if !strings.Contains(output, `"col1\tcol2"`) {
+		t.Errorf("tab string should be JSON-escaped: %q", output)
+	}
+	// Plain scalar stays native.
+	if !strings.Contains(output, "replicas") || !strings.Contains(output, "3") {
+		t.Errorf("scalar value missing: %q", output)
+	}
+}
+
 func TestWriter_UnsupportedFormat(t *testing.T) {
 	// Note: NewWriter now defaults unknown formats to JSON instead of erroring
 	// This test is kept to verify the fallback behavior

--- a/pkg/snapshotter/agent.go
+++ b/pkg/snapshotter/agent.go
@@ -206,6 +206,8 @@ func deployAndWaitForResult(ctx context.Context, clientset k8sclient.Interface, 
 			// understand why agent logs are missing from their output.
 			if logCtx.Err() == nil {
 				slog.Warn("agent log streaming skipped: pod did not become ready",
+					slog.String("namespace", agentConfig.Namespace),
+					slog.String("job", agentConfig.JobName),
 					"error", podErr)
 			}
 			return
@@ -227,7 +229,10 @@ func deployAndWaitForResult(ctx context.Context, clientset k8sclient.Interface, 
 		msg := "job failed"
 		if autoInjectedGPUSelector {
 			msg = "job failed (auto-injected node selector nvidia.com/gpu.present=true — " +
-				"if no GPU nodes are schedulable, pass --node-selector or --require-gpu explicitly)"
+				"if no GPU nodes are schedulable, target a GPU node explicitly, e.g. " +
+				"--node-selector kubernetes.io/hostname=<gpu-node> " +
+				"(repeat the flag per key=value), or pass --require-gpu to schedule onto " +
+				"a node advertising the nvidia.com/gpu resource)"
 		}
 		return nil, errors.Wrap(errors.ErrCodeInternal, msg, waitErr)
 	}


### PR DESCRIPTION
## Summary

Resolves items 1–7 of the #1383 tracker — the remaining `validate`/`recipe` CLI UX papercuts split out from #1361. (The big symptom, the repeated `chainsaw: no such file`, was already fixed by the in-process chainsaw executor; item 8 came along with that move and is left to confirm/close separately.)

## Motivation / Context

These are small, independent, same-area UX fixes that make the CLI legible to a confused user. Bundled per the tracker's own framing ("fixable in one or two PRs").

Fixes: #1383

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/logging`, `pkg/serializer`

## Implementation Notes

1. **Failed validator now red, not green.** `pkg/logging/cli.go` colored strictly by log level, so a `slog.Info("validator completed", "status", "failed")` rendered green. The handler now also reds a record carrying `status=failed`/`error` (`hasFailureStatus`). No log-level reclassification, so `AICR_LOG_LEVEL` filtering is untouched.
2. **`recipe` lists component names**, not just the count, on the completion line.
3. **Mode banners.** `recipe` logs that it runs offline (reads inputs, never deploys/modifies a cluster); `validate` distinguishes live-cluster vs `--no-cluster` dry-run.
4. **`-o table` nested rendering.** The table flattener now renders maps, scalar slices, and multi-line strings as single-line compact JSON (struct and struct-slice recursion preserved), so nested `values.yaml` fragments no longer shatter the FIELD/VALUE columns. Empty top-level collections still print `<empty>`.
5. **`any` legend.** `recipe list` table output appends a one-line legend that `any` = wildcard/unconstrained. Human-readable surface only — the recipe YAML/JSON body still emits the literal `any`.
6. **Agent readiness warning** now names `namespace` and `jobName`.
7. **GPU-scheduling hint** shows concrete, repeatable `--node-selector key=value` syntax.

## Testing

```bash
make test   # pass, total coverage 77.2% (>= 70% floor)
golangci-lint run -c .golangci.yaml ./pkg/logging/... ./pkg/serializer/... ./pkg/cli/... ./pkg/snapshotter/...   # 0 issues
```

New tests: status-attr coloring (failed/error→red, passed/skipped→green); table compact-JSON leaves (nested map, scalar slice, multi-line string) + empty-data still `<empty>`; `recipe list` wildcard legend.

## Risk Assessment

- [x] **Low** — UX/output changes only; no control-flow changes. The only behavior change with test surface is `-o table` nested rendering, covered by new + existing tests.

**Rollout notes:** `-o table` now collapses nested values into compact JSON cells instead of exploding/garbling them — more readable, but anyone scraping the old per-key table rows should use `-o json`/`-o yaml` (the machine-readable formats, unchanged).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)