### PR TITLE
docs: make CI evidence-verify example robust under pipefail

### DIFF
--- a/docs/user/artifact-verification.md
+++ b/docs/user/artifact-verification.md
@@ -197,16 +197,21 @@ Both verifiers emit machine-readable JSON for pipeline gating.
 aicr verify ./my-bundle --format json
 
 # Evidence verification as JSON to a file.
-aicr evidence verify recipes/evidence/<recipe>.yaml -o result.json -t json
+aicr evidence verify recipes/evidence/<recipe>.yaml --format json -o result.json
 ```
 
 `aicr evidence verify` exits `0` when every check passes and `2` when the
 bundle is invalid or recorded validator results show failures. The JSON
 output's `exit` field further distinguishes recorded phase failures (`1`) from
-an invalid bundle (`2`), so a shell consumer can branch on it:
+an invalid bundle (`2`), so a shell consumer can branch on it. Write the JSON to
+a file and read the `exit` field from it rather than piping `aicr evidence
+verify` straight into `jq`: under `set -o pipefail` (common in CI) the verifier's
+non-zero exit would otherwise propagate through the pipeline and abort the script
+before the `case` runs. The `|| true` keeps that exit from tripping `set -e`:
 
 ```shell
-case "$(aicr evidence verify recipes/evidence/<recipe>.yaml --format json | jq '.exit')" in
+aicr evidence verify recipes/evidence/<recipe>.yaml --format json -o result.json || true
+case "$(jq '.exit' result.json)" in
   0) echo "evidence valid" ;;
   1) echo "validator phases failed" ;;
   2) echo "bundle invalid" ;;


### PR DESCRIPTION
## Summary

Make the "JSON Output for CI" evidence-verify example in `docs/user/artifact-verification.md` robust under `set -o pipefail`, and normalize the evidence-verify JSON flags.

## Motivation / Context

Follow-up to the deferred review nit on #1357. The previous example piped `aicr evidence verify ... | jq '.exit'` inside a command substitution. Under `set -o pipefail` (common in CI), the verifier's non-zero exit (e.g. exit 2 = bundle invalid) propagates through the pipeline and can abort the script before the `case` runs. It fails closed, but it does not behave as the guide implies. The fix writes the JSON to a file first, absorbs the exit with `|| true`, then reads `.exit` from the file. Also normalized the nearby example from `-t json` to `--format json` for consistency.

Fixes: #1364
Related: #1357

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Rewrote the `case` example to: `aicr evidence verify ... --format json -o result.json || true` then `case "$(jq '.exit' result.json)" in ...`.
- Added one sentence explaining why the file-based form is used (pipefail / `set -e` robustness).
- Normalized `aicr evidence verify ... -o result.json -t json` to `--format json -o result.json`.

## Testing

```bash
make check-docs-mdx check-docs-filenames
```

Docs-only change; MDX-safe and filename checks pass. CI runs the full gate plus the lychee anchor check.

## Risk Assessment

- [x] **Low** — Documentation only; trivially reversible.

**Rollout notes:** N/A

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
