### PR TITLE
feat(validation): switch inference-perf frontend routing to least-loaded

### DIFF
--- a/docs/contributor/inference-perf-fluctuation.md
+++ b/docs/contributor/inference-perf-fluctuation.md
@@ -25,8 +25,9 @@ H100/RTX clusters showed:
 **Mitigations shipped/in-PR:** dynamo runtime image bump 0.9.0→1.0.2 (#1193, the
 panic fix); reproducible gate — TTFT `<= 2000` ms + pinned AIPerf inputs (#1196);
 centralized dynamo image reference + drift guard (#1194).
-**Long-term:** Dynamo 1.2 KV-cache-aware routing with live worker KV events,
-plus a sub-knee, throughput-primary gate.
+**Long-term:** Dynamo 1.2 load-aware least-loaded routing
+(`DYN_ROUTER_MODE=least-loaded`, shipped for #1197), plus a sub-knee,
+throughput-primary gate.
 
 ---
 
@@ -363,10 +364,14 @@ workers / frontend / AIPerf Job in place for exactly this kind of post-mortem.
    condition at a **sub-knee operating point** (e.g. 1024) with a **generous TTFT
    ceiling** (≥2000 ms) as a guardrail; deterministic AIPerf inputs. The verdict
    then reflects deployment health, not RNG or knee jitter.
-2. **KV-cache-aware routing on Dynamo 1.2** — route with live worker KV-cache
-   events instead of 1.0.2-era static assumptions. Bump operator chart **and**
-   runtime images together to avoid re-introducing version skew, keep
-   `DYN_ROUTER_MODE=kv`, and ensure workers publish KV events for the router.
+2. **Load-aware routing on Dynamo 1.2** — route by each worker's active
+   in-flight load (`DYN_ROUTER_MODE=least-loaded`) instead of capacity-blind
+   round-robin or KV-overlap routing, so a transiently-slow worker stops
+   receiving its full share at the saturation knee. Bump operator chart **and**
+   runtime images together to avoid re-introducing version skew. *(Implemented
+   for #1197: the inference-perf workload now defaults to `least-loaded`. KV
+   routing remains available but lets a backed-up worker keep accumulating
+   KV-overlap-matched requests, which least-loaded avoids.)*
 3. **Version-drift guard (#1194):** single source of truth for the dynamo runtime
    image (repo+tag) + a `make` check tying the tag to the operator chart version,
    so the 0.9.0/1.0.2 skew can't recur.

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -478,13 +478,15 @@ run-to-run TTFT fluctuation (see NVIDIA/aicr#1192):
   counts (stddev 0), a pinned prompt pool, and greedy decoding
   (`temperature: 0`). Input determinism stabilizes *throughput*; it does not
   remove system-side p99 jitter at the knee.
-- **Routing matters.** The inference-perf workload uses Dynamo's KV router
-  (`DYN_ROUTER_MODE=kv`) with live worker KV events. Frontend-to-worker
+- **Routing matters.** The inference-perf workload uses Dynamo's load-aware
+  least-loaded router (`DYN_ROUTER_MODE=least-loaded`), which balances by each
+  worker's active in-flight load so a transiently-slow worker stops receiving
+  its full share — mitigating the stochastic EKS H100 worker-stall / throughput
+  degradation at the saturation knee (issue #1197). Frontend-to-worker
   requests use Dynamo's request plane (Dynamo 1.2 defaults to TCP; AICR does
-  not set `DYN_REQUEST_PLANE=nats`). The platform chart enables the NATS event
-  plane, the local vLLM engine publishes KV-cache events through its ZMQ
-  publisher, and the Dynamo worker runtime relays those events onto NATS so
-  routing decisions use observed cache state instead of approximate prediction.
+  not set `DYN_REQUEST_PLANE=nats`). Workers still publish local vLLM KV-cache
+  events through their ZMQ publisher (relayed onto the NATS event plane), but
+  least-loaded routing does not consume them.
   The `inference-routing-mode` recipe input defaults to `dynamo-router`; set
   `gateway-epp` to validate the GAIE/EPP path through agentgateway with worker
   frontend sidecars in direct mode. The direct-mode sidecars honor EPP routing

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -190,12 +190,14 @@ with the `AICR_INFERENCE_PERF_MODEL` / `AICR_INFERENCE_PERF_CONCURRENCY_PER_GPU`
 catalog knobs (recipe wins over catalog env wins over default).
 
 `inference-routing-mode` selects the Dynamo 1.2 Kubernetes routing path. The
-default `dynamo-router` mode deploys a Dynamo frontend with KV-cache-aware
-routing (`DYN_ROUTER_MODE=kv`). Normal frontend-to-worker request/response
-traffic uses Dynamo's request plane (Dynamo 1.2 defaults to TCP); AICR does not
-set `DYN_REQUEST_PLANE=nats`. Workers publish local vLLM KV-cache events with
-the vLLM ZMQ publisher and the Dynamo worker runtime relays those events onto
-the NATS-backed event plane for the router to consume. Set it to `gateway-epp`
+default `dynamo-router` mode deploys a Dynamo frontend with load-aware
+least-loaded routing (`DYN_ROUTER_MODE=least-loaded`), which balances by each
+worker's active in-flight load so a transiently-slow worker stops receiving its
+full share (see issue #1197). Normal frontend-to-worker request/response traffic
+uses Dynamo's request plane (Dynamo 1.2 defaults to TCP); AICR does not set
+`DYN_REQUEST_PLANE=nats`. Workers still run the vLLM ZMQ KV-cache event
+publisher relayed onto the NATS event plane, but least-loaded routing does not
+consume those events. Set it to `gateway-epp`
 to exercise GAIE/EPP: the validator deploys an EPP component, worker frontend
 sidecars in direct mode, and an HTTPRoute through the AICR-managed inference
 gateway. The direct-mode sidecars honor EPP routing headers; they are not the

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1758,10 +1758,12 @@ func resolveModel(ctx *validators.Context) string {
 	return resolveInferenceModel()
 }
 
-// resolveRoutingMode returns where KV-aware routing decisions are made for the
+// resolveRoutingMode returns where routing decisions are made for the
 // benchmark workload. The default `dynamo-router` mode keeps routing in the
-// Dynamo frontend. `gateway-epp` switches to Gateway API Inference Extension:
-// EPP performs KV-aware endpoint selection and worker frontend sidecars run in
+// Dynamo frontend, which uses load-aware least-loaded routing
+// (DYN_ROUTER_MODE=least-loaded) — see the deployment template and issue
+// #1197. `gateway-epp` switches to Gateway API Inference Extension: EPP
+// performs KV-aware endpoint selection and worker frontend sidecars run in
 // direct mode so they honor EPP's routing headers. The sidecars do not relay
 // local vLLM ZMQ KV events onto NATS; that relay is handled by the worker
 // runtime.

--- a/validators/performance/testdata/inference/dynamo-deployment.yaml
+++ b/validators/performance/testdata/inference/dynamo-deployment.yaml
@@ -50,8 +50,15 @@ spec:
                   # boolean-like name that passes validateModelID) parses as a
                   # string, not int/bool/null, after ${MODEL} substitution.
                   value: "${MODEL}"
+                # Least-loaded routing balances by each worker's active
+                # in-flight load rather than KV-overlap, so a transiently-slow
+                # worker stops receiving its full share. This mitigates the
+                # stochastic EKS H100 worker-stall / throughput degradation at
+                # the saturation knee (see issue #1197): capacity-blind and
+                # KV-overlap routing both let a backed-up worker accumulate
+                # requests, spiking TTFT p99 to 4-77s.
                 - name: DYN_ROUTER_MODE
-                  value: kv
+                  value: least-loaded
                 - name: HF_TOKEN
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Summary

Switch the `inference-perf` validation workload's Dynamo frontend from KV-cache-aware routing (`DYN_ROUTER_MODE=kv`) to load-aware least-loaded routing (`DYN_ROUTER_MODE=least-loaded`).

## Motivation / Context

The inference-perf frontend routed by KV overlap, which can keep sending a transiently-slow worker its full share of requests. On EKS H100 at the 2048-concurrency saturation knee this produced stochastic worker-stall / throughput degradation — TTFT p99 spiking from ~700 ms to 4–77 s and aggregate throughput dropping 30–85% — while GKE H100 stayed consistently clean. `least-loaded` balances by each worker's active in-flight load, so a backed-up worker stops receiving new requests until it drains, removing the positive-feedback loop behind the stall.

**Why least-loaded is the best fit for the AICR performance benchmark.** The performance phase drives the workload with AIPerf under deliberately uniform, reproducible conditions — a single served model, a pinned prompt pool, fixed input/output token counts (stddev 0), and greedy decoding (`temperature: 0`) — against a homogeneous pool of identical single-GPU vLLM workers (one H100 per worker via DRA). Under those conditions KV-overlap (`kv`) routing has no advantage to exploit: there is no worker heterogeneity to weigh, and the synthetic prompts carry no meaningful cross-request prefix-cache reuse for the router to capitalize on. What KV routing *does* do is bias requests toward an "overlap-matching" worker, which lets a transiently-slow worker keep accumulating load — exactly the saturation-knee failure mode in #1197. Least-loaded optimizes for the one signal that actually governs tail latency in this benchmark — instantaneous per-worker queue depth — so it is the most appropriate mode for AICR's AIPerf-driven throughput/TTFT measurement. (KV-aware routing remains the right default for production traffic with real prompt-prefix reuse; this change scopes only the benchmark workload.)

Fixes: N/A
Related: #1197, #1043 (epic)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- One-line behavior change: `DYN_ROUTER_MODE` on the Frontend container in `validators/performance/testdata/inference/dynamo-deployment.yaml` flips `kv` → `least-loaded`.
- `least-loaded` is a first-class Dynamo 1.2 router mode (set via the same frontend env var). No image/runtime bump required — the manifest already targets Dynamo 1.2.0.
- Workers keep the vLLM ZMQ KV-cache event publisher; least-loaded simply does not consume those events. Left in place to avoid widening scope and to keep `kv` mode trivially restorable.
- The `gateway-epp` routing path (`--router-mode direct` sidecars, external endpoint-picker) is unchanged and out of scope.
- Docs updated to match: `docs/user/validation.md`, `docs/contributor/validator.md`, and the investigation report `docs/contributor/inference-perf-fluctuation.md`.

## Testing

```bash
yamllint validators/performance/testdata/inference/dynamo-deployment.yaml   # clean
```

YAML + testdata/docs only — no Go source changed, so test/e2e/Go-lint cannot regress. End-to-end behavior (degradation no longer reproduces under least-loaded on EKS H100) needs a cluster run before this leaves draft.

## Risk Assessment

- [x] **Low** — Single env-value change in a validator testdata manifest, easy to revert; `kv` mode remains available.

**Rollout notes:** Affects only the inference-perf validation workload, not user-deployed recipes/bundles.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (yamllint on changed manifest)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (testdata value change)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
