### PR TITLE
fix(validator): pod-autoscaling passes on external-metric HPA path (DRA clusters)

### DIFF
--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -338,7 +338,7 @@ Valid feature names (from `pkg/evidence/cncf/collector.go`):
 | `ai-service-metrics` | Inference-service metrics via custom-metrics API |
 | `inference-gateway` | Gateway API + Inference Extension installation; also records the gateway `LoadBalancer` network exposure (open `0.0.0.0/0` vs scoped source ranges). Fails on an open gateway only when `AICR_REQUIRE_SCOPED_INFERENCE_GATEWAY=true`. |
 | `robust-operator` | Operator readiness and leader-election posture |
-| `pod-autoscaling` | HPA / custom-metrics-driven pod autoscaling |
+| `pod-autoscaling` | HPA-driven pod autoscaling: external GPU metric + behavioral scale-up/down test (pod-scoped custom metrics collected best-effort — absent for DRA-allocated GPUs, not a failure) |
 | `cluster-autoscaling` | Karpenter (preferred) or EKS managed node-group autoscaling fallback |
 
 ## Emitting recipe evidence

--- a/validators/conformance/pod_autoscaling_check.go
+++ b/validators/conformance/pod_autoscaling_check.go
@@ -52,9 +52,20 @@ type hpaBehaviorReport struct {
 }
 
 // CheckPodAutoscaling validates CNCF requirement #8b: Pod Autoscaling.
-// Verifies that the custom metrics API is available, GPU custom metrics have data
-// (with retries to account for prometheus-adapter relist delay), and the external
-// metrics API exposes GPU metrics.
+// Verifies that the custom metrics API is available and the external metrics API
+// exposes GPU metrics, then proves the capability end-to-end with an HPA
+// behavioral test (scale-up + scale-down) driven by a cluster-wide external GPU
+// metric.
+//
+// Pod-scoped GPU custom metrics (custom.metrics.k8s.io/.../pods/*/...) are
+// collected best-effort, not gated: they require dcgm-exporter to attribute each
+// GPU to its consuming pod via the kubelet pod-resources API, which today only
+// covers device-plugin (nvidia.com/gpu) allocations. DRA-claimed GPUs
+// (nvidia-dra-driver-gpu) are not attributed, so the per-pod series carry no
+// exported_pod label and the adapter returns empty. The autoscaling capability
+// is proven authoritatively by the external-metrics API plus the HPA behavioral
+// test below, which need no per-pod attribution — so absent pod-scoped metrics
+// is a warning, not a failure.
 func CheckPodAutoscaling(ctx *validators.Context) error {
 	if ctx.Clientset == nil {
 		return errors.New(errors.ErrCodeInvalidRequest, "kubernetes client is not available")
@@ -99,14 +110,19 @@ func CheckPodAutoscaling(ctx *validators.Context) error {
 		fmt.Sprintf("Endpoint:        %s\nHTTP Status:     %d\nGroupVersion:    %s\nResource count:  %d",
 			rawURL, statusCode, valueOrUnknown(customMetricsResp.GroupVersion), len(customMetricsResp.Resources)))
 
-	// 2. GPU custom metrics have data (poll with retries — adapter relist is 30s)
+	// 2. GPU custom metrics have data (best-effort poll — adapter relist is ~30s).
+	// This is no longer a gate (see godoc), so the retry budget is kept short:
+	// it only needs to cover one adapter relist cycle on device-plugin clusters
+	// where the metric will appear. On DRA clusters it never appears, so a long
+	// budget would just waste wall-clock before the warn-and-continue below.
 	metrics := []string{"gpu_utilization", "gpu_memory_used", "gpu_power_usage"}
 	namespaces := []string{defaults.GPUOperatorNamespace, namespaceDynamoSystem}
 
 	var found bool
 	var foundPath string
 	var foundItems int
-	maxAttempts := 12 // 2 minutes with 10s intervals
+	maxAttempts := 6 // ~1 minute with 10s intervals — covers one relist cycle
+pollLoop:
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		for _, metric := range metrics {
 			for _, ns := range namespaces {
@@ -136,22 +152,46 @@ func CheckPodAutoscaling(ctx *validators.Context) error {
 			break
 		}
 
-		// Wait before retry (respect context cancellation)
+		// Wait before retry. If the context is canceled during this best-effort
+		// poll, stop polling immediately; the guard below returns a clear timeout
+		// error for that case, while a plain attempt-exhaustion (no cancellation)
+		// falls through to warn-and-continue.
 		select {
 		case <-ctx.Ctx.Done():
-			return errors.Wrap(errors.ErrCodeTimeout,
-				"timed out waiting for GPU custom metrics", ctx.Ctx.Err())
+			break pollLoop
 		case <-time.After(defaults.HPAPollInterval):
 		}
 	}
 
-	if !found {
-		return errors.New(errors.ErrCodeNotFound,
-			"no GPU custom metrics available (DCGM → Prometheus → adapter pipeline broken)")
+	// Distinguish "ran out of best-effort attempts" (fall through to warn-and-
+	// continue) from "context canceled/deadline exceeded" (a genuine timeout that
+	// halts the whole check). The latter would also fail steps 3/4 below, but
+	// reporting it as a timeout here is clearer to an operator than a downstream
+	// "metric not available".
+	if !found && ctx.Ctx.Err() != nil {
+		return errors.Wrap(errors.ErrCodeTimeout,
+			"timed out waiting for GPU custom metrics", ctx.Ctx.Err())
 	}
-	recordRawTextArtifact(ctx, "Custom metric sample",
-		fmt.Sprintf("kubectl get --raw %s", foundPath),
-		fmt.Sprintf("Path:            %s\nItems observed:  %d", foundPath, foundItems))
+
+	if found {
+		recordRawTextArtifact(ctx, "Custom metric sample",
+			fmt.Sprintf("kubectl get --raw %s", foundPath),
+			fmt.Sprintf("Path:            %s\nItems observed:  %d", foundPath, foundItems))
+	} else {
+		// Best-effort, not a gate: pod-scoped GPU custom metrics are absent when
+		// dcgm-exporter cannot attribute GPUs to pods (e.g. DRA-claimed GPUs, which
+		// the kubelet pod-resources API does not surface for per-pod mapping). The
+		// autoscaling capability is still validated below via the external-metrics
+		// API and the HPA behavioral scale-up/down test, which drive off a
+		// cluster-wide GPU metric and need no per-pod attribution.
+		slog.Warn("pod-scoped GPU custom metrics unavailable; continuing with external-metric HPA validation " +
+			"(expected on DRA clusters where dcgm-exporter does not attribute GPUs to pods)")
+		recordRawTextArtifact(ctx, "Custom metric sample",
+			"kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/<ns>/pods/*/gpu_utilization",
+			"Pod-scoped GPU custom metrics not available (no exported_pod attribution; typical for "+
+				"DRA-allocated GPUs). Autoscaling capability validated via the external-metrics API and "+
+				"the HPA behavioral test below.")
+	}
 
 	// 3. External metrics API has GPU metrics
 	extPath := "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage"


### PR DESCRIPTION
## Summary

Make the `pod-autoscaling` conformance check (CNCF #8b) pass on DRA-based GPU clusters by treating pod-scoped GPU custom metrics as best-effort, and proving the autoscaling capability via the external-metric HPA behavioral test instead.

## Motivation / Context

On DRA clusters the check hard-failed with `no GPU custom metrics available (DCGM → Prometheus → adapter pipeline broken)`. Step 2 required pod-scoped metrics (`custom.metrics.k8s.io/.../pods/*/...`), whose `exported_pod` association only exists when dcgm-exporter attributes a GPU to its consuming pod via the kubelet pod-resources API — which surfaces device-plugin (`nvidia.com/gpu`) allocations, not DRA claims (`nvidia-dra-driver-gpu`, K8s 1.34+). External metrics work (cluster-wide aggregates), which is the observed asymmetry. Not an AICR regression — the adapter rules (#168) are unchanged; it's a dcgm-exporter DRA pod-attribution gap surfaced by a brittle precondition.

Fixes: #1407
Related: #1197

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `validators/conformance/pod_autoscaling_check.go`: step 2 (pod-scoped GPU custom metrics) demoted from a hard gate to best-effort — on empty results it logs a warning and records an evidence artifact, then continues. Steps 3 (external-metrics API) and 4 (HPA behavioral scale-up/down, driven by `dcgm_gpu_power_usage`) remain hard, fail-closed gates and are the authoritative capability proof; they need no per-pod attribution.
- Updated the function godoc and the `docs/user/validation.md` feature description.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./validators/conformance/...   # 0 issues
go build ./validators/conformance/...                              # ok
```

End-to-end on aicr3 (EKS H100, K8s 1.35, nvidia-dra-driver-gpu) with a rebuilt conformance image: conformance **11/11 passed** (`pod-autoscaling` now PASS via the external-metric HPA path); previously 10/11 with `pod-autoscaling` failing. The HPA behavioral test deployed/scaled/cleaned its own namespace successfully on the DRA cluster.

## Risk Assessment

- [x] **Low** — Relaxes one brittle precondition in a single conformance check; the authoritative HPA behavioral gate is unchanged and still fail-closed. Easy to revert.

**Rollout notes:** No API/recipe surface change. Conformance pass/fail semantics: clusters that previously failed only on empty pod-scoped GPU metrics (DRA) now pass when the external-metric HPA path validates.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A; check is live-cluster orchestration, no unit test exists for this file and no exported-function signature changed
- [x] Linter passes (`golangci-lint`, 0 issues)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (no unit-testable surface added)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
