### PR TITLE
docs(cli): explain recipe input modes (snapshot vs criteria) and why

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -311,6 +311,21 @@ aicr recipe [flags]
 
 **Modes:**
 
+`aicr recipe` resolves a recipe from **criteria** — `service`, `accelerator`, `os`, `intent`, `platform`, `nodes`. You can supply those criteria three ways, composed with the precedence **CLI flags > `--config` file > `--snapshot`**:
+
+- **Snapshot** (`--snapshot`) — criteria are auto-detected from a captured cluster snapshot: accelerator from the `nvidia.com/gpu.product` GFD label (primary — cluster-wide, so it surfaces heterogeneous clusters) or the per-node PCI device ID (fallback — maps the device ID to a SKU, e.g. `h100`, with no driver or GFD label required); service from the node's cloud-provider ID; OS from the node's OS release; node count from cluster topology. Use this when you already have a running cluster: you don't hand-specify the hardware, AICR reads it. (A detected SKU fills `criteria.accelerator` only when it's in the supported accelerator set; an unsupported GPU is recorded descriptively but not as a recipe criterion.)
+- **Config file** (`--config`) — criteria (and bundle settings) from an `AICRConfig` document; good for reproducible, version-controlled workflows.
+- **Query flags** (`--service`, `--accelerator`, …) — state the criteria directly. Use this when there is **no cluster to snapshot yet** — the common case when you generate a recipe in order to *provision* a cluster, or build one offline/ahead of time for hardware you can't reach.
+
+**Why you sometimes specify criteria the snapshot could detect:** recipe generation **does not collect live cluster state or deploy/modify workloads** — it reads inputs (criteria, embedded/`--data` catalog, an optional snapshot) and does **not** snapshot a cluster for you. Its only cluster interaction is explicit `cm://` ConfigMap reads/writes (snapshot input or recipe output). This keeps generation hermetic and reproducible (same inputs → same recipe) and lets it run before a target cluster even exists. So you state criteria explicitly when there's no cluster to read; when a cluster is available, capture it first and let detection fill them in:
+
+```shell
+aicr snapshot -o cm://default/snapshot      # captures the cluster (deploys the collector agent)
+aicr recipe   -s cm://default/snapshot --intent training
+```
+
+When both a snapshot and explicit criteria are given, the explicit values win (e.g. `--snapshot … --service gke` overrides the detected service).
+
 #### Config File Mode (Recommended)
 
 Generate recipes using an `AICRConfig` document. The same file format also drives the `bundle` command, so a single file can describe an end-to-end recipe-to-bundle workflow.


### PR DESCRIPTION
## Summary

Document how `aicr recipe` input modes (snapshot / config / query flags) compose, and why criteria are sometimes specified even though a snapshot could detect them.

## Motivation / Context

The `aicr recipe` reference lists three input modes but never explains the precedence between them or the design rationale. A common question is "the accelerator/service is detectable from the cluster — why do I have to specify it?" The answer is deliberate: recipe generation is offline and read-only (it never collects a snapshot or touches a cluster), so criteria are stated explicitly when no cluster exists yet, and auto-detected from a snapshot when one does. This adds a short intro making that explicit.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Adds an intro to the `aicr recipe` → **Modes** section covering: the three input paths, the precedence **CLI flags > `--config` > `--snapshot`**, when to use each, the offline/read-only/hermetic rationale, and the `snapshot → recipe --snapshot` detect-from-cluster flow. No behavior change.

## Testing

```bash
# Doc-only change — no code paths affected.
```

Doc-only edit to `docs/user/cli-reference.md`; no Go/YAML/CI changes, so `make qualify` (tests/lint/e2e/scan) cannot regress. Anchor links are CI-checked by lychee on `docs/**`; this change adds no new headings or anchor links.

## Risk Assessment

- [x] **Low** — Isolated docs-only change, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] I updated docs if user-facing behavior changed (docs-only)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

---

Note (out of scope, flagged for follow-up): the `--nodes` flag is documented as "Number of GPU nodes," but the `nodes` criterion is currently projected from the **total** node count (`fingerprint.ToCriteria` uses `NodeCount`, not `GPUNodeCount`). That doc/code mismatch is intentionally left out of this PR since the correct fix may be in code, not docs.
