### PR TITLE
feat(measurement): NetworkTopology type + Subtype.Items for cross-repo l8k integration

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -1301,12 +1301,35 @@ components:
           description: Optional unit of measurement
           example: "MB"
 
+    ItemEntry:
+      type: object
+      description: |
+        One ordered element of a Subtype.items list. Mirrors Subtype's
+        scalar-value contract: data holds Reading scalars; context holds
+        string-typed descriptive metadata. Used when a subtype carries a
+        homogeneous array of structured records (e.g. one entry per PF).
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/Reading"
+          description: Key-value pairs of scalar measurements for this item.
+        context:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional descriptive metadata for this item (string-typed).
+
     Subtype:
       type: object
-      description: A subtype within a measurement containing specific configuration data
-      required: [name, data]
+      description: |
+        A subtype within a measurement. A subtype must carry at least one
+        entry in `data` or `items`. `items` is used when the subtype payload
+        is naturally a list of structured records (e.g. per-PF entries under
+        a NetworkTopology `pfs` subtype).
+      required: [subtype]
       properties:
-        name:
+        subtype:
           type: string
           description: Subtype identifier (e.g., service name, configuration category)
           example: containerd.service
@@ -1320,17 +1343,28 @@ components:
           additionalProperties: true
           description: Optional metadata about the source and collection method
           nullable: true
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemEntry"
+          description: |
+            Optional ordered list of structured records. Independent of `data` —
+            a subtype may carry either or both.
 
     Measurement:
       type: object
-      description: A measurement grouping related configuration subtypes
+      description: |
+        A measurement grouping related configuration subtypes. Most types
+        appear at most once per snapshot; `NetworkTopology` is currently
+        emitted at most once but is the planned multi-instance exception
+        (one Measurement per discovered hardware group).
       required: [type, subtypes]
       properties:
         type:
           type: string
           description: Measurement type category
-          enum: [systemd, os, k8s, gpu]
-          example: systemd
+          enum: [K8s, GPU, OS, SystemD, NodeTopology, NetworkTopology]
+          example: SystemD
         subtypes:
           type: array
           items:

--- a/docs/integrator/index.md
+++ b/docs/integrator/index.md
@@ -15,6 +15,7 @@ This section is for integrators who:
 | Document | Description |
 |----------|-------------|
 | [Public API Surface](public-api.md) | Stability tiers for every exported Go package; facade type ownership |
+| [Measurement Schema](measurement-api.md) | Cross-repo Measurement contract: Type cardinality, Subtype layout, NetworkTopology shape, constraint paths |
 | [Go Library Integration](go-library.md) | Using `github.com/NVIDIA/aicr/pkg/client/v1` as a Go library |
 | [Automation](automation.md) | CI/CD integration patterns for GitHub Actions, GitLab CI, Jenkins, and Terraform |
 | [Data Flow](data-flow.md) | Understanding snapshots, recipes, validation, and bundles data transformations |

--- a/docs/integrator/measurement-api.md
+++ b/docs/integrator/measurement-api.md
@@ -1,0 +1,196 @@
+# Measurement Schema
+
+The `Measurement` type in `github.com/NVIDIA/aicr/pkg/measurement` is the
+on-wire shape used throughout aicr's Snapshot → Recipe → Validate → Bundle
+pipeline. Snapshots serialize a `[]*Measurement` to YAML/JSON; recipes and
+validators consume the same shape. This page is the schema contract — any
+external producer (cross-repo Go library, CI tool, custom collector) emitting
+Measurements should follow it exactly.
+
+The Go types are documented in `pkg/measurement/types.go`. This page documents
+the conventions on top of the types (which Type appears how often, which
+Subtype names mean what, which fields live in `Context` vs `Data`).
+
+## Top-level structure
+
+```yaml
+measurements:
+  - type: K8s
+    subtypes: [...]
+  - type: GPU
+    subtypes: [...]
+  - type: OS
+    subtypes: [...]
+  - type: SystemD
+    subtypes: [...]
+  - type: NodeTopology
+    subtypes: [...]
+  - type: NetworkTopology     # 0 or 1 today; future: 0..N (one per group)
+    subtypes: [...]
+```
+
+### Type cardinality
+
+| Type | Cardinality today | Notes |
+|------|-------------------|-------|
+| `K8s` | 0 or 1 | Cluster-scoped Kubernetes state. |
+| `GPU` | 0 or 1 | GPU inventory + driver state. |
+| `OS` | 0 or 1 | Host OS metadata. |
+| `SystemD` | 0 or 1 | systemd unit states. |
+| `NodeTopology` | 0 or 1 | Cluster-wide node taints + labels (aggregate). |
+| `NetworkTopology` | 0 or 1 | Per-hardware-group network topology. **Planned multi-instance**: future versions will emit one per discovered group. |
+
+Find-first-by-Type consumers (constraint extractor, recipe validation, diff
+indexing) are sound today because every Type appears at most once. When
+`NetworkTopology` becomes multi-instance, the relevant consumer rewrites are
+tracked alongside the multi-group enablement work.
+
+## Subtype
+
+A `Subtype` has a name plus up to three payload fields:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `data` | `map[string]Reading` (scalar values) | Numeric / boolean / string measurements addressable by key. |
+| `context` | `map[string]string` | Descriptive metadata (provenance, identity, free-form labels). |
+| `items` | `[]ItemEntry` | Ordered list of structured records. Used when the payload is naturally an array. |
+
+A subtype must carry at least one entry in `data` or `items`. `data` and
+`items` are independent and may both be populated.
+
+### ItemEntry
+
+```yaml
+- context:
+    pciAddress: "0000:03:00.0"
+    deviceID: "1023"
+  data:
+    rail: 0
+    numaNode: 0
+    traffic: east-west
+```
+
+Each `ItemEntry` mirrors a Subtype's scalar contract: `data` holds `Reading`
+scalars; `context` holds string-typed descriptive fields. `ItemEntry` does
+NOT support nested `items` — the scalar Reading model is preserved.
+
+## NetworkTopology shape
+
+`TypeNetworkTopology` describes one hardware group's network layout (PFs,
+rails, RDMA capabilities, kernel modules, identity). When emitted, the
+Measurement MUST follow this layout:
+
+```yaml
+type: NetworkTopology
+subtypes:
+  - subtype: identity
+    context:
+      identifier:   <stable group identifier, lowercase, RFC-1123>
+      machineType:  <e.g. GB300-NVL>
+      gpuType:      <e.g. NVIDIA-GB300>
+      linkType:     <Ethernet | InfiniBand | "">    # empty if unknown
+      nodeSelector: <label=value selector that targets the group's nodes>
+    data:
+      pf-count:   <int>
+      rail-count: <int>
+  - subtype: capabilities
+    data:
+      sriov: <bool>
+      rdma:  <bool>
+      ib:    <bool>
+  - subtype: pfs
+    items:
+      - context:
+          pciAddress:       <e.g. 0000:03:00.0>
+          deviceID:         <hex, e.g. 1023>
+          psid:             <PSID string>
+          partNumber:       <part number string>
+          rdmaDevice:       <e.g. mlx5_0>
+          networkInterface: <e.g. enp3s0f0np0>
+        data:
+          rail:     <int>
+          numaNode: <int>
+          traffic:  <east-west | north-south>
+      - context: {...}
+        data:    {...}
+  - subtype: kernel-modules
+    data:
+      storage.0:    <module name>
+      storage.1:    <module name>
+      thirdParty.0: <module name>
+      thirdParty.1: <module name>
+```
+
+### Subtypes
+
+- **`identity`** — group identity and high-level facts. Strings (machineType,
+  gpuType, linkType, identifier, nodeSelector) live in `context`. Numeric
+  facts (pf-count, rail-count) live in `data`.
+- **`capabilities`** — boolean cluster capabilities (sriov, rdma, ib) as
+  scalar `Reading` values in `data`.
+- **`pfs`** — per-PF records as `items`. Per-PF descriptive identifiers
+  (PCI address, device ID, PSID, part number, RDMA device name, netdev
+  name) live in `context`; per-PF scalar facts (rail index, NUMA node,
+  traffic class) live in `data`.
+- **`kernel-modules`** — flat ordered lists of storage and third-party RDMA
+  modules. Keys are dotted with a numeric suffix (`storage.0`, `storage.1`,
+  `thirdParty.0`, ...) to preserve order and stay within the scalar
+  `Reading` model. (This is a deliberate exception to the array-via-items
+  pattern: the lists are short, lookup is rare, and the dotted-key form
+  is cheap.)
+
+### Field-placement convention
+
+- `context` — values that *describe* or *identify* a record: textual,
+  cardinality-low, used for grouping or display. Not constrained to be
+  scalar `Reading`s.
+- `data` — values that are *measured* or *counted*: int / float / bool /
+  short string, addressable by key, comparable in validator constraints.
+
+## Constraint paths
+
+The constraints package addresses a single value within a Measurement using:
+
+```text
+{Type}.{Subtype}.{Key}                                # legacy form, looks in Subtype.Data
+{Type}.{Subtype}[<selector>].{Key}                    # item form, looks in ItemEntry
+```
+
+Selector forms:
+
+| Form | Example | Meaning |
+|------|---------|---------|
+| Index | `NetworkTopology.pfs[0].rail` | Items entry at index 0. |
+| Predicate | `NetworkTopology.pfs[rail=3].pciAddress` | The unique Items entry whose `data["rail"].String() == "3"` (or `context["rail"] == "3"` if not in data). |
+
+Predicate behavior — deterministic single-match resolution:
+
+- LHS is looked up in `ItemEntry.Data` first (stringified via
+  `Reading.String()`); falls back to `ItemEntry.Context` if not found in
+  Data.
+- Exactly one matching entry is required.
+- Zero matches returns `ErrCodeNotFound`.
+- Two or more matches returns `ErrCodeConflict`. Predicates that can match
+  more than one entry are a recipe authoring error; pick a more specific
+  field to disambiguate.
+
+Key resolution inside the chosen `ItemEntry`:
+
+- `Data` is consulted first (returns `Reading.String()`).
+- `Context` is consulted next (returns the string directly).
+- Missing key returns `ErrCodeNotFound`.
+
+## Stability contract
+
+`pkg/measurement` is part of aicr's public API surface (see
+[public-api.md](public-api.md)). The Go types AND the schema conventions
+documented above are part of the contract. Field-level changes (renames,
+type changes, semantic shifts in which fields go in `data` vs `context`)
+are breaking and require a pseudo-version bump that downstream consumers
+(`k8s-launch-kit`, external CI tools) pin against.
+
+## See also
+
+- `pkg/measurement/types.go` — the Go types
+- [`docs/integrator/public-api.md`](public-api.md) — package stability tiers
+- [`docs/integrator/recipe-development.md`](recipe-development.md) — how recipes consume Measurement values via constraint paths

--- a/pkg/constraints/extractor.go
+++ b/pkg/constraints/extractor.go
@@ -16,6 +16,7 @@ package constraints
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -23,51 +24,192 @@ import (
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
-// keyType is the structured-error context key naming a measurement type.
-const keyType = "type"
+// Structured-error context keys used by this package.
+const (
+	keyType     = "type"
+	keyPath     = "path"
+	keySubtype  = "subtype"
+	keySelector = "selector"
+)
+
+// itemSelector represents an addressable element of a Subtype.Items list.
+// It is either an integer index (Index != nil) or a key=value predicate
+// (Predicate != nil); never both, never neither.
+type itemSelector struct {
+	Raw       string
+	Index     *int
+	Predicate *itemPredicate
+}
+
+type itemPredicate struct {
+	Key   string
+	Value string
+}
 
 // ConstraintPath represents a parsed fully qualified constraint path.
-// Format: {Type}.{Subtype}.{Key}
-// Example: "K8s.server.version" -> Type="K8s", Subtype="server", Key="version"
+//
+// Without item selector: "{Type}.{Subtype}.{Key}"
+//
+//	Example: "K8s.server.version" -> Type="K8s", Subtype="server", Key="version"
+//
+// With item selector: "{Type}.{Subtype}[<selector>].{Key}"
+//
+//	Index form:     "NetworkTopology.pfs[0].rail"
+//	Predicate form: "NetworkTopology.pfs[rail=3].pciAddress"
+//
+// The selector targets an entry in Subtype.Items; Key is then resolved against
+// that ItemEntry's Data (preferred) or Context. Paths without a selector keep
+// the legacy behavior of looking up Key in Subtype.Data.
+//
+// The key portion may contain dots (e.g., "/proc/sys/kernel/osrelease").
 type ConstraintPath struct {
-	Type    measurement.Type
-	Subtype string
-	Key     string
+	Type     measurement.Type
+	Subtype  string
+	Key      string
+	Selector *itemSelector
 }
 
 // ParseConstraintPath parses a fully qualified constraint path.
-// The path format is: {Type}.{Subtype}.{Key}
-// The key portion may contain dots (e.g., "/proc/sys/kernel/osrelease").
 func ParseConstraintPath(path string) (*ConstraintPath, error) {
 	if path == "" {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "constraint path cannot be empty")
 	}
 
-	// Split by dots, but we need at least 3 parts
-	parts := strings.SplitN(path, ".", 3)
-	if len(parts) < 3 {
+	typeDot := strings.Index(path, ".")
+	if typeDot < 0 {
 		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
-			"invalid constraint path: expected format {Type}.{Subtype}.{Key}",
-			map[string]any{"path": path})
+			"invalid constraint path: expected format {Type}.{Subtype}[selector].{Key}",
+			map[string]any{keyPath: path})
 	}
 
-	// Parse and validate the measurement type
-	measurementType, valid := measurement.ParseType(parts[0])
+	typeStr := path[:typeDot]
+	rest := path[typeDot+1:]
+
+	measurementType, valid := measurement.ParseType(typeStr)
 	if !valid {
 		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
 			"invalid measurement type in constraint path",
-			map[string]any{keyType: parts[0], "path": path, "validTypes": measurement.Types})
+			map[string]any{keyType: typeStr, keyPath: path, "validTypes": measurement.Types})
+	}
+
+	subtype, selector, key, err := parseSubtypeSelectorKey(rest, path)
+	if err != nil {
+		return nil, err
 	}
 
 	return &ConstraintPath{
-		Type:    measurementType,
-		Subtype: parts[1],
-		Key:     parts[2], // Key is everything after the second dot (preserves dots in key)
+		Type:     measurementType,
+		Subtype:  subtype,
+		Key:      key,
+		Selector: selector,
 	}, nil
+}
+
+// parseSubtypeSelectorKey parses the portion of the path after "{Type}." into
+// (subtype, optional selector, key). The Key may contain dots; everything
+// after the first separating dot (or after the closing `]` and its `.`)
+// belongs to Key.
+func parseSubtypeSelectorKey(rest, fullPath string) (string, *itemSelector, string, error) {
+	bracketStart := strings.Index(rest, "[")
+	dotIdx := strings.Index(rest, ".")
+
+	if bracketStart >= 0 && (dotIdx < 0 || bracketStart < dotIdx) {
+		// Subtype[selector].Key form.
+		subtype := rest[:bracketStart]
+		if subtype == "" {
+			return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				"invalid constraint path: subtype before '[' is empty",
+				map[string]any{keyPath: fullPath})
+		}
+
+		bracketEnd := strings.Index(rest[bracketStart:], "]")
+		if bracketEnd < 0 {
+			return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				"invalid constraint path: unclosed item selector bracket",
+				map[string]any{keyPath: fullPath})
+		}
+		bracketEnd += bracketStart
+
+		sel, err := parseItemSelector(rest[bracketStart+1:bracketEnd], fullPath)
+		if err != nil {
+			return "", nil, "", err
+		}
+
+		after := rest[bracketEnd+1:]
+		if after == "" {
+			return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				"invalid constraint path: missing key after item selector",
+				map[string]any{keyPath: fullPath})
+		}
+		if after[0] != '.' {
+			return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				"invalid constraint path: expected '.' after item selector",
+				map[string]any{keyPath: fullPath})
+		}
+		key := after[1:]
+		if key == "" {
+			return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				"invalid constraint path: missing key after item selector",
+				map[string]any{keyPath: fullPath})
+		}
+		return subtype, sel, key, nil
+	}
+
+	// Subtype.Key form (no selector).
+	if dotIdx < 0 {
+		return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"invalid constraint path: expected format {Type}.{Subtype}.{Key}",
+			map[string]any{keyPath: fullPath})
+	}
+	subtype := rest[:dotIdx]
+	key := rest[dotIdx+1:]
+	if subtype == "" || key == "" {
+		return "", nil, "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"invalid constraint path: subtype or key is empty",
+			map[string]any{keyPath: fullPath})
+	}
+	return subtype, nil, key, nil
+}
+
+// parseItemSelector parses the contents of `[ ... ]` into an itemSelector.
+// Forms accepted:
+//   - integer (no equals sign) -> index selector
+//   - key=value                -> predicate selector (LHS and RHS non-empty)
+func parseItemSelector(raw, fullPath string) (*itemSelector, error) {
+	if raw == "" {
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"invalid constraint path: item selector is empty",
+			map[string]any{keyPath: fullPath})
+	}
+	if eq := strings.Index(raw, "="); eq >= 0 {
+		k := raw[:eq]
+		v := raw[eq+1:]
+		if k == "" || v == "" {
+			return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				"invalid constraint path: predicate selector requires non-empty key and value",
+				map[string]any{keyPath: fullPath, keySelector: raw})
+		}
+		return &itemSelector{Raw: raw, Predicate: &itemPredicate{Key: k, Value: v}}, nil
+	}
+	idx, err := strconv.Atoi(raw)
+	if err != nil {
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"invalid constraint path: item selector must be an integer index or 'key=value' predicate",
+			map[string]any{keyPath: fullPath, keySelector: raw})
+	}
+	if idx < 0 {
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"invalid constraint path: item index cannot be negative",
+			map[string]any{keyPath: fullPath, keySelector: raw})
+	}
+	return &itemSelector{Raw: raw, Index: &idx}, nil
 }
 
 // String returns the fully qualified path string.
 func (cp *ConstraintPath) String() string {
+	if cp.Selector != nil {
+		return fmt.Sprintf("%s.%s[%s].%s", cp.Type, cp.Subtype, cp.Selector.Raw, cp.Key)
+	}
 	return fmt.Sprintf("%s.%s.%s", cp.Type, cp.Subtype, cp.Key)
 }
 
@@ -105,17 +247,92 @@ func (cp *ConstraintPath) ExtractValue(snap *snapshotter.Snapshot) (string, erro
 	if targetSubtype == nil {
 		return "", errors.NewWithContext(errors.ErrCodeNotFound,
 			"subtype not found in measurement",
-			map[string]any{"subtype": cp.Subtype, keyType: cp.Type})
+			map[string]any{keySubtype: cp.Subtype, keyType: cp.Type})
 	}
 
-	// Find the key in data
+	if cp.Selector != nil {
+		return extractFromItems(targetSubtype, cp)
+	}
+
+	// Find the key in data (legacy path).
 	reading, exists := targetSubtype.Data[cp.Key]
 	if !exists {
 		return "", errors.NewWithContext(errors.ErrCodeNotFound,
 			"key not found in subtype",
-			map[string]any{"key": cp.Key, "subtype": cp.Subtype, keyType: cp.Type})
+			map[string]any{"key": cp.Key, keySubtype: cp.Subtype, keyType: cp.Type})
 	}
 
 	// Convert reading to string
 	return reading.String(), nil
+}
+
+// extractFromItems resolves a path with an item selector against
+// targetSubtype.Items, then looks up cp.Key in the chosen ItemEntry.
+func extractFromItems(st *measurement.Subtype, cp *ConstraintPath) (string, error) {
+	if len(st.Items) == 0 {
+		return "", errors.NewWithContext(errors.ErrCodeNotFound,
+			"subtype has no items but path uses an item selector",
+			map[string]any{keySubtype: cp.Subtype, keyType: cp.Type, keySelector: cp.Selector.Raw})
+	}
+
+	if cp.Selector.Index != nil {
+		idx := *cp.Selector.Index
+		if idx >= len(st.Items) {
+			return "", errors.NewWithContext(errors.ErrCodeNotFound,
+				"item index out of bounds",
+				map[string]any{keySubtype: cp.Subtype, keyType: cp.Type, "index": idx, "itemCount": len(st.Items)})
+		}
+		return lookupInItem(&st.Items[idx], cp)
+	}
+
+	// Predicate match.
+	pred := cp.Selector.Predicate
+	var matchIdx = -1
+	for i := range st.Items {
+		if itemMatchesPredicate(&st.Items[i], pred) {
+			if matchIdx >= 0 {
+				return "", errors.NewWithContext(errors.ErrCodeConflict,
+					"item predicate matches multiple entries",
+					map[string]any{
+						keySubtype:  cp.Subtype,
+						keyType:     cp.Type,
+						"predicate": cp.Selector.Raw,
+						"matchedAt": []int{matchIdx, i},
+					})
+			}
+			matchIdx = i
+		}
+	}
+	if matchIdx < 0 {
+		return "", errors.NewWithContext(errors.ErrCodeNotFound,
+			"no item matches predicate",
+			map[string]any{keySubtype: cp.Subtype, keyType: cp.Type, "predicate": cp.Selector.Raw})
+	}
+	return lookupInItem(&st.Items[matchIdx], cp)
+}
+
+// itemMatchesPredicate reports whether an ItemEntry has a field (in Data or
+// Context) named pred.Key whose stringified value equals pred.Value.
+func itemMatchesPredicate(item *measurement.ItemEntry, pred *itemPredicate) bool {
+	if r, ok := item.Data[pred.Key]; ok && r != nil {
+		return r.String() == pred.Value
+	}
+	if v, ok := item.Context[pred.Key]; ok {
+		return v == pred.Value
+	}
+	return false
+}
+
+// lookupInItem looks up cp.Key in the ItemEntry: Data (Reading.String()) first,
+// then Context (string), then errors.
+func lookupInItem(item *measurement.ItemEntry, cp *ConstraintPath) (string, error) {
+	if r, ok := item.Data[cp.Key]; ok && r != nil {
+		return r.String(), nil
+	}
+	if v, ok := item.Context[cp.Key]; ok {
+		return v, nil
+	}
+	return "", errors.NewWithContext(errors.ErrCodeNotFound,
+		"key not found in item",
+		map[string]any{"key": cp.Key, keySubtype: cp.Subtype, keyType: cp.Type, keySelector: cp.Selector.Raw})
 }

--- a/pkg/constraints/extractor_test.go
+++ b/pkg/constraints/extractor_test.go
@@ -275,6 +275,281 @@ func TestConstraintPath_ExtractValue(t *testing.T) {
 	}
 }
 
+func TestParseConstraintPath_ItemSelector(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		path         string
+		wantType     measurement.Type
+		wantSubtype  string
+		wantKey      string
+		wantSelector string // empty means no selector expected
+		wantIndex    *int   // non-nil when index selector expected
+		wantPredKey  string // non-empty when predicate expected
+		wantPredVal  string
+		expectError  bool
+	}{
+		{
+			name:         "index selector",
+			path:         "NetworkTopology.pfs[0].rail",
+			wantType:     measurement.TypeNetworkTopology,
+			wantSubtype:  "pfs",
+			wantKey:      "rail",
+			wantSelector: "0",
+			wantIndex:    intPtr(0),
+		},
+		{
+			name:         "index selector larger",
+			path:         "NetworkTopology.pfs[7].pciAddress",
+			wantType:     measurement.TypeNetworkTopology,
+			wantSubtype:  "pfs",
+			wantKey:      "pciAddress",
+			wantSelector: "7",
+			wantIndex:    intPtr(7),
+		},
+		{
+			name:         "predicate selector numeric value",
+			path:         "NetworkTopology.pfs[rail=3].pciAddress",
+			wantType:     measurement.TypeNetworkTopology,
+			wantSubtype:  "pfs",
+			wantKey:      "pciAddress",
+			wantSelector: "rail=3",
+			wantPredKey:  "rail",
+			wantPredVal:  "3",
+		},
+		{
+			name:         "predicate selector string value",
+			path:         "NetworkTopology.pfs[traffic=east-west].rdmaDevice",
+			wantType:     measurement.TypeNetworkTopology,
+			wantSubtype:  "pfs",
+			wantKey:      "rdmaDevice",
+			wantSelector: "traffic=east-west",
+			wantPredKey:  "traffic",
+			wantPredVal:  "east-west",
+		},
+		{
+			name:         "selector with dotted key after",
+			path:         "NetworkTopology.pfs[0]./some/dotted/key",
+			wantType:     measurement.TypeNetworkTopology,
+			wantSubtype:  "pfs",
+			wantKey:      "/some/dotted/key",
+			wantSelector: "0",
+			wantIndex:    intPtr(0),
+		},
+
+		// Error cases
+		{name: "unclosed bracket", path: "NetworkTopology.pfs[0.rail", expectError: true},
+		{name: "missing dot after selector", path: "NetworkTopology.pfs[0]rail", expectError: true},
+		{name: "missing key after selector", path: "NetworkTopology.pfs[0]", expectError: true},
+		{name: "missing key after selector with dot", path: "NetworkTopology.pfs[0].", expectError: true},
+		{name: "empty selector", path: "NetworkTopology.pfs[].rail", expectError: true},
+		{name: "empty subtype before bracket", path: "NetworkTopology.[0].rail", expectError: true},
+		{name: "negative index", path: "NetworkTopology.pfs[-1].rail", expectError: true},
+		{name: "non-integer non-predicate", path: "NetworkTopology.pfs[notnumber].rail", expectError: true},
+		{name: "predicate empty key", path: "NetworkTopology.pfs[=3].rail", expectError: true},
+		{name: "predicate empty value", path: "NetworkTopology.pfs[rail=].pciAddress", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ParseConstraintPath(tt.path)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil; result=%+v", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Type != tt.wantType {
+				t.Errorf("Type = %v, want %v", result.Type, tt.wantType)
+			}
+			if result.Subtype != tt.wantSubtype {
+				t.Errorf("Subtype = %q, want %q", result.Subtype, tt.wantSubtype)
+			}
+			if result.Key != tt.wantKey {
+				t.Errorf("Key = %q, want %q", result.Key, tt.wantKey)
+			}
+			if result.Selector == nil {
+				t.Fatalf("Selector is nil; want %q", tt.wantSelector)
+			}
+			if result.Selector.Raw != tt.wantSelector {
+				t.Errorf("Selector.Raw = %q, want %q", result.Selector.Raw, tt.wantSelector)
+			}
+			if tt.wantIndex != nil {
+				if result.Selector.Index == nil {
+					t.Errorf("Selector.Index = nil, want %d", *tt.wantIndex)
+				} else if *result.Selector.Index != *tt.wantIndex {
+					t.Errorf("Selector.Index = %d, want %d", *result.Selector.Index, *tt.wantIndex)
+				}
+				if result.Selector.Predicate != nil {
+					t.Errorf("Selector.Predicate = %+v, want nil", result.Selector.Predicate)
+				}
+			}
+			if tt.wantPredKey != "" {
+				if result.Selector.Predicate == nil {
+					t.Errorf("Selector.Predicate = nil, want key=%s value=%s", tt.wantPredKey, tt.wantPredVal)
+				} else {
+					if result.Selector.Predicate.Key != tt.wantPredKey {
+						t.Errorf("Selector.Predicate.Key = %q, want %q", result.Selector.Predicate.Key, tt.wantPredKey)
+					}
+					if result.Selector.Predicate.Value != tt.wantPredVal {
+						t.Errorf("Selector.Predicate.Value = %q, want %q", result.Selector.Predicate.Value, tt.wantPredVal)
+					}
+				}
+				if result.Selector.Index != nil {
+					t.Errorf("Selector.Index = %d, want nil", *result.Selector.Index)
+				}
+			}
+		})
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+func TestConstraintPath_ExtractValue_ItemSelector(t *testing.T) {
+	t.Parallel()
+
+	snap := &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{
+			{
+				Type: measurement.TypeNetworkTopology,
+				Subtypes: []measurement.Subtype{
+					{
+						Name: "pfs",
+						Items: []measurement.ItemEntry{
+							{
+								Context: map[string]string{
+									"pciAddress": "0000:03:00.0",
+									"rdmaDevice": "mlx5_0",
+								},
+								Data: map[string]measurement.Reading{
+									"rail":    measurement.Int(0),
+									"traffic": measurement.Str("east-west"),
+								},
+							},
+							{
+								Context: map[string]string{
+									"pciAddress": "0000:03:00.1",
+									"rdmaDevice": "mlx5_1",
+								},
+								Data: map[string]measurement.Reading{
+									"rail":    measurement.Int(1),
+									"traffic": measurement.Str("east-west"),
+								},
+							},
+							{
+								Context: map[string]string{
+									"pciAddress": "0000:03:00.2",
+									"rdmaDevice": "mlx5_2",
+								},
+								Data: map[string]measurement.Reading{
+									"rail":    measurement.Int(2),
+									"traffic": measurement.Str("east-west"),
+								},
+							},
+						},
+					},
+					{
+						Name: "capabilities",
+						Data: map[string]measurement.Reading{
+							"sriov": measurement.Bool(true),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mustParse := func(t *testing.T, path string) *ConstraintPath {
+		t.Helper()
+		p, err := ParseConstraintPath(path)
+		if err != nil {
+			t.Fatalf("ParseConstraintPath(%q) error = %v", path, err)
+		}
+		return p
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		want        string
+		expectError bool
+	}{
+		// Index selectors
+		{name: "index 0 data field", path: "NetworkTopology.pfs[0].rail", want: "0"},
+		{name: "index 1 data field", path: "NetworkTopology.pfs[1].rail", want: "1"},
+		{name: "index 0 context field", path: "NetworkTopology.pfs[0].pciAddress", want: "0000:03:00.0"},
+		{name: "index 2 rdmaDevice", path: "NetworkTopology.pfs[2].rdmaDevice", want: "mlx5_2"},
+		// Predicate selectors
+		{name: "predicate by data field", path: "NetworkTopology.pfs[rail=1].pciAddress", want: "0000:03:00.1"},
+		{name: "predicate by context field", path: "NetworkTopology.pfs[pciAddress=0000:03:00.2].rail", want: "2"},
+		// Backward compat: non-item path still works
+		{name: "non-item path data", path: "NetworkTopology.capabilities.sriov", want: "true"},
+
+		// Errors
+		{name: "index out of bounds", path: "NetworkTopology.pfs[99].rail", expectError: true},
+		{name: "predicate no match", path: "NetworkTopology.pfs[rail=99].pciAddress", expectError: true},
+		{name: "key not in item", path: "NetworkTopology.pfs[0].nonexistent", expectError: true},
+		{name: "selector on subtype with no items", path: "NetworkTopology.capabilities[0].sriov", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustParse(t, tt.path)
+			got, err := path.ExtractValue(snap)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil; result=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ExtractValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConstraintPath_ExtractValue_PredicateAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	snap := &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{
+			{
+				Type: measurement.TypeNetworkTopology,
+				Subtypes: []measurement.Subtype{
+					{
+						Name: "pfs",
+						Items: []measurement.ItemEntry{
+							{Data: map[string]measurement.Reading{"traffic": measurement.Str("east-west"), "rail": measurement.Int(0)}},
+							{Data: map[string]measurement.Reading{"traffic": measurement.Str("east-west"), "rail": measurement.Int(1)}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	path, err := ParseConstraintPath("NetworkTopology.pfs[traffic=east-west].rail")
+	if err != nil {
+		t.Fatalf("ParseConstraintPath() error = %v", err)
+	}
+	_, err = path.ExtractValue(snap)
+	if err == nil {
+		t.Fatal("expected ambiguous-match error, got nil")
+	}
+}
+
 func TestConstraintPath_String(t *testing.T) {
 	t.Parallel()
 
@@ -300,6 +575,26 @@ func TestConstraintPath_String(t *testing.T) {
 				Key:     "/proc/sys/kernel/osrelease",
 			},
 			want: "OS.sysctl./proc/sys/kernel/osrelease",
+		},
+		{
+			name: "index selector",
+			path: ConstraintPath{
+				Type:     measurement.TypeNetworkTopology,
+				Subtype:  "pfs",
+				Key:      "rail",
+				Selector: &itemSelector{Raw: "0", Index: intPtr(0)},
+			},
+			want: "NetworkTopology.pfs[0].rail",
+		},
+		{
+			name: "predicate selector",
+			path: ConstraintPath{
+				Type:     measurement.TypeNetworkTopology,
+				Subtype:  "pfs",
+				Key:      "pciAddress",
+				Selector: &itemSelector{Raw: "rail=3", Predicate: &itemPredicate{Key: "rail", Value: "3"}},
+			},
+			want: "NetworkTopology.pfs[rail=3].pciAddress",
 		},
 	}
 

--- a/pkg/fingerprint/from_measurements.go
+++ b/pkg/fingerprint/from_measurements.go
@@ -77,6 +77,12 @@ func FromMeasurements(measurements []*measurement.Measurement) *Fingerprint {
 		case measurement.TypeSystemD:
 			// systemd measurements do not contribute to the cluster
 			// fingerprint; intentionally skipped.
+		case measurement.TypeNetworkTopology:
+			// network topology measurements describe per-group hardware
+			// (PFs, rails, RDMA capabilities) that doesn't currently feed
+			// any fingerprint dimension; intentionally skipped. Phase 4
+			// (multi-group support) will revisit this to derive multi-gpu
+			// from distinct `identity.gpuType` Context values.
 		}
 	}
 	if topo != nil {

--- a/pkg/measurement/builder.go
+++ b/pkg/measurement/builder.go
@@ -16,8 +16,10 @@ package measurement
 
 // SubtypeBuilder provides a fluent API for building Subtype instances.
 type SubtypeBuilder struct {
-	name string
-	data map[string]Reading
+	name    string
+	data    map[string]Reading
+	context map[string]string
+	items   []ItemEntry
 }
 
 // NewSubtypeBuilder creates a new SubtypeBuilder with the given name.
@@ -76,11 +78,48 @@ func (b *SubtypeBuilder) SetBool(key string, value bool) *SubtypeBuilder {
 	return b
 }
 
+// WithContext sets a single key/value entry in the subtype Context.
+func (b *SubtypeBuilder) WithContext(key, value string) *SubtypeBuilder {
+	if b.context == nil {
+		b.context = make(map[string]string)
+	}
+	b.context[key] = value
+	return b
+}
+
+// WithContextMap merges the provided map into the subtype Context.
+func (b *SubtypeBuilder) WithContextMap(ctx map[string]string) *SubtypeBuilder {
+	if len(ctx) == 0 {
+		return b
+	}
+	if b.context == nil {
+		b.context = make(map[string]string, len(ctx))
+	}
+	for k, v := range ctx {
+		b.context[k] = v
+	}
+	return b
+}
+
+// WithItem appends a single ItemEntry to the subtype Items list.
+func (b *SubtypeBuilder) WithItem(item ItemEntry) *SubtypeBuilder {
+	b.items = append(b.items, item)
+	return b
+}
+
+// WithItems appends a slice of ItemEntry to the subtype Items list.
+func (b *SubtypeBuilder) WithItems(items []ItemEntry) *SubtypeBuilder {
+	b.items = append(b.items, items...)
+	return b
+}
+
 // Build constructs and returns the Subtype.
 func (b *SubtypeBuilder) Build() Subtype {
 	return Subtype{
-		Name: b.name,
-		Data: b.data,
+		Name:    b.name,
+		Data:    b.data,
+		Context: b.context,
+		Items:   b.items,
 	}
 }
 

--- a/pkg/measurement/builder_test.go
+++ b/pkg/measurement/builder_test.go
@@ -15,6 +15,7 @@
 package measurement
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -133,6 +134,128 @@ func TestSubtypeBuilder(t *testing.T) {
 			t.Errorf("GetString(key) = %v, %v; want value2, nil", value, err)
 		}
 	})
+}
+
+func TestSubtypeBuilder_WithContext(t *testing.T) {
+	t.Parallel()
+
+	st := NewSubtypeBuilder("identity").
+		WithContext("machineType", "GB300-NVL").
+		WithContext("gpuType", "NVIDIA-GB300").
+		SetInt("pf-count", 8).
+		Build()
+
+	if got := st.Context["machineType"]; got != "GB300-NVL" {
+		t.Errorf("Context[machineType] = %q, want GB300-NVL", got)
+	}
+	if got := st.Context["gpuType"]; got != "NVIDIA-GB300" {
+		t.Errorf("Context[gpuType] = %q, want NVIDIA-GB300", got)
+	}
+	if pf, _ := st.GetInt64("pf-count"); pf != 8 {
+		t.Errorf("pf-count = %d, want 8", pf)
+	}
+}
+
+func TestSubtypeBuilder_WithContextMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges into empty context", func(t *testing.T) {
+		t.Parallel()
+		st := NewSubtypeBuilder("identity").
+			WithContextMap(map[string]string{
+				"identifier":  "gb300-nvl-nvidia-gb300",
+				"machineType": "GB300-NVL",
+			}).
+			SetInt("pf-count", 8).
+			Build()
+
+		if got := st.Context["identifier"]; got != "gb300-nvl-nvidia-gb300" {
+			t.Errorf("Context[identifier] = %q, want gb300-nvl-nvidia-gb300", got)
+		}
+		if got := st.Context["machineType"]; got != "GB300-NVL" {
+			t.Errorf("Context[machineType] = %q, want GB300-NVL", got)
+		}
+	})
+
+	t.Run("merges with WithContext", func(t *testing.T) {
+		t.Parallel()
+		st := NewSubtypeBuilder("identity").
+			WithContext("machineType", "GB300-NVL").
+			WithContextMap(map[string]string{
+				"identifier": "gb300-nvl-nvidia-gb300",
+				"gpuType":    "NVIDIA-GB300",
+			}).
+			SetInt("pf-count", 8).
+			Build()
+
+		if got := st.Context["machineType"]; got != "GB300-NVL" {
+			t.Errorf("Context[machineType] = %q, want GB300-NVL", got)
+		}
+		if got := st.Context["identifier"]; got != "gb300-nvl-nvidia-gb300" {
+			t.Errorf("Context[identifier] = %q, want gb300-nvl-nvidia-gb300", got)
+		}
+		if got := st.Context["gpuType"]; got != "NVIDIA-GB300" {
+			t.Errorf("Context[gpuType] = %q, want NVIDIA-GB300", got)
+		}
+	})
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		t.Parallel()
+		st := NewSubtypeBuilder("identity").
+			WithContextMap(nil).
+			WithContextMap(map[string]string{}).
+			SetInt("pf-count", 8).
+			Build()
+
+		if st.Context != nil {
+			t.Errorf("Context = %v, want nil", st.Context)
+		}
+	})
+}
+
+func TestSubtypeBuilder_WithItem(t *testing.T) {
+	t.Parallel()
+
+	st := NewSubtypeBuilder("pfs").
+		WithItem(ItemEntry{
+			Context: map[string]string{"pciAddress": "0000:03:00.0"},
+			Data:    map[string]Reading{"rail": Int(0)},
+		}).
+		WithItem(ItemEntry{
+			Context: map[string]string{"pciAddress": "0000:03:00.1"},
+			Data:    map[string]Reading{"rail": Int(1)},
+		}).
+		Build()
+
+	if len(st.Items) != 2 {
+		t.Fatalf("Items len = %d, want 2", len(st.Items))
+	}
+	if got := st.Items[0].Context["pciAddress"]; got != "0000:03:00.0" {
+		t.Errorf("Items[0].Context[pciAddress] = %q, want 0000:03:00.0", got)
+	}
+	if got := st.Items[1].Data["rail"].String(); got != "1" {
+		t.Errorf("Items[1].Data[rail] = %q, want 1", got)
+	}
+}
+
+func TestSubtypeBuilder_WithItems(t *testing.T) {
+	t.Parallel()
+
+	items := []ItemEntry{
+		{Data: map[string]Reading{"rail": Int(0)}},
+		{Data: map[string]Reading{"rail": Int(1)}},
+		{Data: map[string]Reading{"rail": Int(2)}},
+	}
+	st := NewSubtypeBuilder("pfs").WithItems(items).Build()
+
+	if len(st.Items) != 3 {
+		t.Fatalf("Items len = %d, want 3", len(st.Items))
+	}
+	for i := range items {
+		if got := st.Items[i].Data["rail"].String(); got != strconv.Itoa(i) {
+			t.Errorf("Items[%d].Data[rail] = %q, want %d", i, got, i)
+		}
+	}
 }
 
 func TestMeasurementBuilder(t *testing.T) {

--- a/pkg/measurement/doc.go
+++ b/pkg/measurement/doc.go
@@ -13,14 +13,29 @@
 // limitations under the License.
 
 // Package measurement provides types and utilities for collecting, comparing, and filtering
-// system measurements from various sources (Kubernetes, GPU, OS, SystemD).
+// system measurements from various sources (Kubernetes, GPU, OS, SystemD, NodeTopology,
+// NetworkTopology).
+//
+// # Public API contract
+//
+// This package is part of aicr's cross-repo public API. External producers
+// (e.g. k8s-launch-kit) import these types directly to emit Measurements that
+// aicr Snapshots can consume. The Go type definitions AND the schema
+// conventions (which Subtype names mean what, which fields belong in Data vs
+// Context, the NetworkTopology layout) are part of the contract — see
+// docs/integrator/measurement-api.md. Breaking changes require a
+// pseudo-version bump that downstream consumers pin against.
 //
 // # Core Types
 //
 // The package defines a hierarchical structure for measurements:
-//   - Type: Enum identifying the measurement source (K8s, GPU, OS, SystemD)
+//   - Type: Enum identifying the measurement source (K8s, GPU, OS, SystemD,
+//     NodeTopology, NetworkTopology)
 //   - Measurement: Contains a Type and a slice of Subtypes
-//   - Subtype: Named collection of key-value data (e.g., "cluster", "node")
+//   - Subtype: Named collection of key-value data (e.g., "cluster", "node");
+//     may also carry an ordered Items list of structured records
+//   - ItemEntry: One element of a Subtype.Items list. Data holds Reading
+//     scalars; Context holds string metadata. Mirrors Subtype's payload contract.
 //   - Reading: Interface for type-safe scalar values (int, float64, string, bool, etc.)
 //
 // # Creating Measurements

--- a/pkg/measurement/types.go
+++ b/pkg/measurement/types.go
@@ -69,6 +69,13 @@ const (
 )
 
 // Type represents the category of a measurement (e.g., Kubernetes, GPU, OS, SystemD).
+//
+// Cardinality: most Types appear at most once per snapshot — one K8s measurement,
+// one GPU measurement, etc. TypeNetworkTopology is the planned multi-instance
+// exception (one Measurement per discovered hardware group); today we emit at
+// most one to keep the existing find-first-by-Type consumers (constraints,
+// recipe validation, diff indexing, fingerprint) working unchanged. Lifting
+// that limit is a deliberate future step.
 type Type string
 
 // String returns the string representation of the measurement Type.
@@ -77,11 +84,12 @@ func (mt Type) String() string {
 }
 
 const (
-	TypeK8s          Type = "K8s"
-	TypeGPU          Type = "GPU"
-	TypeOS           Type = "OS"
-	TypeSystemD      Type = "SystemD"
-	TypeNodeTopology Type = "NodeTopology"
+	TypeK8s             Type = "K8s"
+	TypeGPU             Type = "GPU"
+	TypeOS              Type = "OS"
+	TypeSystemD         Type = "SystemD"
+	TypeNodeTopology    Type = "NodeTopology"
+	TypeNetworkTopology Type = "NetworkTopology"
 )
 
 // Types is the list of all supported measurement types.
@@ -91,6 +99,7 @@ var Types = []Type{
 	TypeOS,
 	TypeSystemD,
 	TypeNodeTopology,
+	TypeNetworkTopology,
 }
 
 // ParseType parses a string into a measurement Type.
@@ -114,10 +123,24 @@ type Measurement struct {
 // Subtype represents a specific subcategory of measurement with associated data.
 // Data contains the actual measurements as key-value pairs.
 // Context provides additional metadata about the measurement environment.
+// Items holds an ordered list of structured records (used when a subtype carries
+// a homogeneous array such as a list of PFs); each entry follows the same
+// scalar-only Reading discipline as Data. Data and Items are independent and
+// may both be populated.
 type Subtype struct {
 	Name    string             `json:"subtype,omitempty" yaml:"subtype,omitempty"`
-	Data    map[string]Reading `json:"data" yaml:"data"`
+	Data    map[string]Reading `json:"data,omitempty"    yaml:"data,omitempty"`
 	Context map[string]string  `json:"context,omitempty" yaml:"context,omitempty"`
+	Items   []ItemEntry        `json:"items,omitempty"   yaml:"items,omitempty"`
+}
+
+// ItemEntry is one element of a Subtype.Items list. It mirrors Subtype's
+// scalar-value contract: Data holds Reading scalars; Context holds string-typed
+// descriptive metadata. ItemEntry intentionally does NOT support nested Items
+// — the scalar-only Reading model is preserved.
+type ItemEntry struct {
+	Context map[string]string  `json:"context,omitempty" yaml:"context,omitempty"`
+	Data    map[string]Reading `json:"data,omitempty"    yaml:"data,omitempty"`
 }
 
 // UnmarshalJSON custom unmarshaler for Subtype to handle Reading interface
@@ -127,6 +150,7 @@ func (st *Subtype) UnmarshalJSON(data []byte) error {
 		Name    string            `json:"subtype"`
 		Data    map[string]any    `json:"data"`
 		Context map[string]string `json:"context"`
+		Items   []ItemEntry       `json:"items"`
 	}
 
 	if err := json.Unmarshal(data, &tmp); err != nil {
@@ -135,6 +159,7 @@ func (st *Subtype) UnmarshalJSON(data []byte) error {
 
 	st.Name = tmp.Name
 	st.Context = tmp.Context
+	st.Items = tmp.Items
 	st.Data = make(map[string]Reading)
 
 	// Convert each value to a Reading using ToReading
@@ -152,6 +177,7 @@ func (st *Subtype) UnmarshalYAML(node *yaml.Node) error {
 		Name    string            `yaml:"subtype"`
 		Data    map[string]any    `yaml:"data"`
 		Context map[string]string `yaml:"context"`
+		Items   []ItemEntry       `yaml:"items"`
 	}
 
 	if err := node.Decode(&tmp); err != nil {
@@ -160,11 +186,56 @@ func (st *Subtype) UnmarshalYAML(node *yaml.Node) error {
 
 	st.Name = tmp.Name
 	st.Context = tmp.Context
+	st.Items = tmp.Items
 	st.Data = make(map[string]Reading)
 
 	// Convert each value to a Reading using ToReading
 	for k, v := range tmp.Data {
 		st.Data[k] = ToReading(v)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON custom unmarshaler for ItemEntry to handle Reading interface
+// inside Data, mirroring Subtype's behavior.
+func (ie *ItemEntry) UnmarshalJSON(data []byte) error {
+	var tmp struct {
+		Context map[string]string `json:"context"`
+		Data    map[string]any    `json:"data"`
+	}
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "failed to unmarshal item entry JSON", err)
+	}
+
+	ie.Context = tmp.Context
+	ie.Data = make(map[string]Reading)
+
+	for k, v := range tmp.Data {
+		ie.Data[k] = ToReading(v)
+	}
+
+	return nil
+}
+
+// UnmarshalYAML custom unmarshaler for ItemEntry to handle Reading interface
+// inside Data, mirroring Subtype's behavior.
+func (ie *ItemEntry) UnmarshalYAML(node *yaml.Node) error {
+	var tmp struct {
+		Context map[string]string `yaml:"context"`
+		Data    map[string]any    `yaml:"data"`
+	}
+
+	if err := node.Decode(&tmp); err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "failed to decode item entry YAML", err)
+	}
+
+	ie.Context = tmp.Context
+	ie.Data = make(map[string]Reading)
+
+	for k, v := range tmp.Data {
+		ie.Data[k] = ToReading(v)
 	}
 
 	return nil
@@ -373,10 +444,19 @@ func copyReadings(src map[string]Reading) map[string]Reading {
 	return dst
 }
 
-// Validate checks if the subtype is properly formed.
+// Validate checks if the subtype is properly formed. A Subtype must have a
+// non-empty Name and carry at least one Data entry or one Items entry; Items
+// alone is sufficient for subtypes whose payload is a list of structured
+// records (e.g. a `pfs` subtype holding per-PF entries). The non-empty-Name
+// invariant honors the OpenAPI `required: [subtype]` schema — the `omitempty`
+// JSON/YAML tag elides the field on the wire only when it is intentionally
+// being left out, never on a Validate'd value.
 func (st *Subtype) Validate() error {
-	if len(st.Data) == 0 {
-		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "subtype data cannot be empty")
+	if st.Name == "" {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "subtype name cannot be empty")
+	}
+	if len(st.Data) == 0 && len(st.Items) == 0 {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "subtype must have at least one data entry or one item entry")
 	}
 	return nil
 }

--- a/pkg/measurement/types_test.go
+++ b/pkg/measurement/types_test.go
@@ -15,6 +15,7 @@
 package measurement
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -332,7 +333,7 @@ func TestSubtype_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid subtype",
+			name: "valid subtype with data",
 			st: &Subtype{
 				Name: "test",
 				Data: map[string]Reading{"key": Str("value")},
@@ -340,7 +341,28 @@ func TestSubtype_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "empty data",
+			name: "valid subtype with items only (no data)",
+			st: &Subtype{
+				Name: "test",
+				Items: []ItemEntry{
+					{Data: map[string]Reading{"rail": Int(0)}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid subtype with both data and items",
+			st: &Subtype{
+				Name: "test",
+				Data: map[string]Reading{"pf-count": Int(2)},
+				Items: []ItemEntry{
+					{Data: map[string]Reading{"rail": Int(0)}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty data and empty items",
 			st: &Subtype{
 				Name: "test",
 				Data: map[string]Reading{},
@@ -348,10 +370,28 @@ func TestSubtype_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "nil data",
+			name: "nil data and nil items",
 			st: &Subtype{
 				Name: "test",
 				Data: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty name with data",
+			st: &Subtype{
+				Name: "",
+				Data: map[string]Reading{"key": Str("value")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty name with items",
+			st: &Subtype{
+				Name: "",
+				Items: []ItemEntry{
+					{Data: map[string]Reading{"rail": Int(0)}},
+				},
 			},
 			wantErr: true,
 		},
@@ -678,6 +718,188 @@ func TestMeasurement_JSON(t *testing.T) {
 		if dataMap["version"] != testVersion {
 			t.Errorf("JSON subtype[0].data.version = %v, want 1.28.0", dataMap["version"])
 		}
+	}
+}
+
+// TestSubtype_Items_JSONRoundTrip verifies that a Subtype carrying an Items
+// list (and ItemEntry values with Reading inside Data) round-trips through
+// JSON correctly: scalars retain their type, Context strings survive, and
+// ordering is preserved.
+func TestSubtype_Items_JSONRoundTrip(t *testing.T) {
+	original := &Measurement{
+		Type: TypeNetworkTopology,
+		Subtypes: []Subtype{
+			{
+				Name: "identity",
+				Context: map[string]string{
+					"identifier":  "gb300-nvl-nvidia-gb300",
+					"machineType": "GB300-NVL",
+					"gpuType":     "NVIDIA-GB300",
+					"linkType":    "InfiniBand",
+				},
+				Data: map[string]Reading{
+					"pf-count":   Int(2),
+					"rail-count": Int(2),
+				},
+			},
+			{
+				Name: "pfs",
+				Items: []ItemEntry{
+					{
+						Context: map[string]string{
+							"pciAddress": "0000:03:00.0",
+							"deviceID":   "1023",
+							"rdmaDevice": "mlx5_0",
+						},
+						Data: map[string]Reading{
+							"rail":     Int(0),
+							"numaNode": Int(0),
+							"traffic":  Str("east-west"),
+						},
+					},
+					{
+						Context: map[string]string{
+							"pciAddress": "0000:03:00.1",
+							"deviceID":   "1023",
+							"rdmaDevice": "mlx5_1",
+						},
+						Data: map[string]Reading{
+							"rail":     Int(1),
+							"numaNode": Int(0),
+							"traffic":  Str("east-west"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var decoded Measurement
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if decoded.Type != TypeNetworkTopology {
+		t.Errorf("decoded type = %v, want %v", decoded.Type, TypeNetworkTopology)
+	}
+	if len(decoded.Subtypes) != 2 {
+		t.Fatalf("decoded subtypes len = %d, want 2", len(decoded.Subtypes))
+	}
+
+	identity := decoded.Subtypes[0]
+	if identity.Name != "identity" {
+		t.Errorf("identity subtype name = %q, want identity", identity.Name)
+	}
+	if got := identity.Context["machineType"]; got != "GB300-NVL" {
+		t.Errorf("identity.context.machineType = %q, want GB300-NVL", got)
+	}
+	if pf, _ := identity.GetInt64("pf-count"); pf != 2 {
+		t.Errorf("identity.data.pf-count = %d, want 2", pf)
+	}
+
+	pfs := decoded.Subtypes[1]
+	if pfs.Name != "pfs" {
+		t.Errorf("pfs subtype name = %q, want pfs", pfs.Name)
+	}
+	if len(pfs.Items) != 2 {
+		t.Fatalf("pfs items len = %d, want 2", len(pfs.Items))
+	}
+	if pfs.Items[0].Context["pciAddress"] != "0000:03:00.0" {
+		t.Errorf("pfs[0].context.pciAddress = %q, want 0000:03:00.0", pfs.Items[0].Context["pciAddress"])
+	}
+	rail0, ok := pfs.Items[0].Data["rail"]
+	if !ok || rail0 == nil {
+		t.Fatalf("pfs[0].data.rail missing")
+	}
+	if got := rail0.String(); got != "0" {
+		t.Errorf("pfs[0].data.rail = %s, want 0", got)
+	}
+	if got := pfs.Items[1].Context["pciAddress"]; got != "0000:03:00.1" {
+		t.Errorf("pfs[1].context.pciAddress = %q, want 0000:03:00.1", got)
+	}
+}
+
+// TestSubtype_Items_YAMLRoundTrip mirrors TestSubtype_Items_JSONRoundTrip via
+// gopkg.in/yaml.v3 to cover the YAML un/marshal path on ItemEntry.
+func TestSubtype_Items_YAMLRoundTrip(t *testing.T) {
+	original := &Measurement{
+		Type: TypeNetworkTopology,
+		Subtypes: []Subtype{
+			{
+				Name: "pfs",
+				Items: []ItemEntry{
+					{
+						Context: map[string]string{"pciAddress": "0000:03:00.0"},
+						Data:    map[string]Reading{"rail": Int(0), "numaNode": Int(0)},
+					},
+					{
+						Context: map[string]string{"pciAddress": "0000:03:00.1"},
+						Data:    map[string]Reading{"rail": Int(1), "numaNode": Int(0)},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("yaml.Marshal() error = %v", err)
+	}
+
+	var decoded Measurement
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	if len(decoded.Subtypes) != 1 {
+		t.Fatalf("decoded subtypes len = %d, want 1", len(decoded.Subtypes))
+	}
+	pfs := decoded.Subtypes[0]
+	if len(pfs.Items) != 2 {
+		t.Fatalf("pfs items len = %d, want 2", len(pfs.Items))
+	}
+	if pfs.Items[0].Data["rail"].String() != "0" {
+		t.Errorf("pfs[0].data.rail = %s, want 0", pfs.Items[0].Data["rail"].String())
+	}
+	if pfs.Items[1].Context["pciAddress"] != "0000:03:00.1" {
+		t.Errorf("pfs[1].context.pciAddress = %q, want 0000:03:00.1", pfs.Items[1].Context["pciAddress"])
+	}
+}
+
+// TestSubtype_BackwardCompat_NoItems verifies that a Subtype with no Items
+// produces output that does NOT contain an `items` key when marshaled — the
+// `omitempty` tag is honored so existing snapshots stay byte-identical after
+// the Items field is added.
+func TestSubtype_BackwardCompat_NoItems(t *testing.T) {
+	m := &Measurement{
+		Type: TypeK8s,
+		Subtypes: []Subtype{
+			{
+				Name: testSubtypeCluster,
+				Data: map[string]Reading{"version": Str(testVersion)},
+			},
+		},
+	}
+
+	jsonOut, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if bytes.Contains(jsonOut, []byte("items")) {
+		t.Errorf("JSON output contains `items` key but Items is empty: %s", jsonOut)
+	}
+
+	yamlOut, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("yaml.Marshal() error = %v", err)
+	}
+	if bytes.Contains(yamlOut, []byte("items")) {
+		t.Errorf("YAML output contains `items` key but Items is empty: %s", yamlOut)
 	}
 }
 


### PR DESCRIPTION
…
# Why

aicr models cluster state as a Snapshot of `Measurement`s (K8s, GPU, OS, SystemD, NodeTopology). NodeTopology is cluster-wide and only carries node taints + labels. The model has no slot for per-hardware-group network topology -- PFs and their PCI addresses, rails, NUMA, RDMA capability, link type, kernel module lists, machine/GPU identity -- which makes it impossible to recipe or validate networking beyond a single all-or-nothing network-operator toggle.

k8s-launch-kit (l8k) already discovers exactly this data via its `cluster-config.yaml`. The intended integration is library-mode: l8k imports `pkg/measurement` and emits `*Measurement` values directly that aicr Snapshots can consume. The dependency direction is l8k -> aicr; the Measurement schema is aicr's contract.

This commit is Phase 1 -- the schema affordances l8k needs to implement that contract. No l8k import is introduced here; the snapshotter and CLI are untouched. The producer side (Phase 2, in the l8k repo) and the consumer side (Phase 3, the aicr collector + CLI flag) land separately.

Part of https://github.com/NVIDIA/aicr/issues/828

# What changes

Schema additions to `pkg/measurement`:

  - New `TypeNetworkTopology` enum value. Today at most one Measurement of this Type per snapshot, keeping all find-first-by-Type consumers (constraints extractor, recipe validation, diff indexing, fingerprint) correct. Multi-instance support is a deliberate future step.

  - New `Subtype.Items []ItemEntry` field. `ItemEntry` mirrors Subtype's scalar contract: `Data map[string]Reading` for scalar measurements plus `Context map[string]string` for descriptive metadata. This lets homogeneous record lists (per-PF entries under a `pfs` subtype) be represented as real YAML arrays rather than packed-string-encoded scalars or numbered subtypes (`pf-0`, `pf-1`, ...). `Reading` itself is NOT extended -- it stays scalar-only.

  - Custom `UnmarshalJSON`/`UnmarshalYAML` on `ItemEntry` so `Reading` values inside `ItemEntry.Data` round-trip the same way they do in `Subtype.Data` today.

  - `Subtype.Validate` relaxed: a subtype is valid with either non-empty `Data` or non-empty `Items` (or both). The existing `len(Data) > 0` invariant predated Items.

  - `Items` carries `omitempty` so subtypes that don't use it serialize byte-identically to today's output. `Data`'s tag also gains `omitempty` so Items-only subtypes don't emit a noisy `data: {}`; this is behavior-safe because every existing subtype satisfies `len(Data) > 0` (Validate guaranteed it).

  - New SubtypeBuilder helpers: `WithContext(k, v)`, `WithContextMap(map)`, `WithItem(entry)`, `WithItems(slice)`.

Constraint path grammar extension in `pkg/constraints`:

  - New optional item-selector segment: `{Type}.{Subtype}[<selector>].{Key}`. Two selector forms:
      Index:     `NetworkTopology.pfs[0].rail`
      Predicate: `NetworkTopology.pfs[rail=3].pciAddress`
    Predicates evaluate against `ItemEntry.Data` first, then
    `ItemEntry.Context`. First match wins; multiple matches return
    `ErrCodeConflict`. Key resolution inside the matched entry tries
    `Data` then `Context`. Paths without a selector continue to use the
    legacy `Subtype.Data` lookup unchanged.

OpenAPI (`api/aicr/v1/server.yaml`):

  - `Measurement.type` enum corrected from the stale `[systemd, os, k8s, gpu]` to match `measurement.Types`: `[K8s, GPU, OS, SystemD, NodeTopology, NetworkTopology]`. The pre-existing miss (`NodeTopology` and `SystemD` were never added) is bundled into this fix.
  - New `ItemEntry` schema mirroring `data` + `context`.
  - `Subtype` gains an optional `items` array property; `data` is no longer required at the schema level (Validate still enforces "at least one of data/items").

Docs:

  - New `docs/integrator/measurement-api.md` publishing the cross-repo Measurement schema contract: Type cardinality table, Subtype layout rules, the NetworkTopology shape (subtype names, what lives in Context vs Data, item structure for `pfs`), and the constraint-path grammar including selectors. l8k's Phase 2 implementation targets this spec.
  - `pkg/measurement/doc.go` updated to flag the package as part of aicr's cross-repo public API surface.
  - `docs/integrator/index.md` adds the new page to the integrator TOC.

# Testing

  - `pkg/measurement/types_test.go`: Items-only subtype validation, JSON + YAML round-trip of Items with Reading values inside ItemEntry, byte-identity check that pre-existing Items-less subtypes don't suddenly emit an `items:` key.
  - `pkg/measurement/builder_test.go`: 100% coverage on each new builder helper (WithContext / WithContextMap / WithItem / WithItems).
  - `pkg/constraints/extractor_test.go`: parser tests for both selector forms and every error path; ExtractValue tests for index/predicate hits, out-of-bounds, no-match, no-items, ambiguous-predicate (ErrCodeConflict).

Coverage on touched packages vs main:

  pkg/measurement: 96.0% -> 96.6% (+0.6%)
  pkg/constraints: 80.9% -> 87.6% (+6.7%)

`go test ./...` passes (the pre-existing `pkg/trust` sandbox failure is unrelated -- it writes to `~/.sigstore` which is outside this environment's write allowlist; passes outside the sandbox). `go vet ./...` clean. `golangci-lint` not available in this environment per project notes -- run `make qualify` before pushing.

# Not in this commit

Phase 2 (in the l8k repo): embed l8k's discovery-only runtime artifacts (presets, default config; profiles deferred), rename `LaunchKubernetesConfig` -> `LaunchKitConfig`, add a library-friendly `Discover(ctx, kubeClient)` entry point, vendor aicr's `pkg/measurement`, and add `DiscoverMeasurements` / `ParseClusterConfigMeasurements` wrappers that emit `*aicrmeasurement.Measurement` values per the contract this commit publishes.

Phase 3 (in aicr): new `pkg/collector/network/` calling l8k's library, `--cluster-config` / `--discover-network` flags on `aicr snapshot`, RBAC additions for the agent Job, single-group enforcement.

Multi-group `NetworkTopology` is a future iteration; the consumer rewrites it requires (constraint @<id> grammar, recipe-validator iteration, diff (Type, identifier) keying, fingerprint group-aware logic) are deliberately deferred until the single-group integration has shaken out.

## Summary

<!-- What changed? Keep it short (1-2 sentences). -->

## Motivation / Context

<!-- Why is this change needed? Link issues/discussions. -->

Fixes: <!-- #123 or N/A -->
Related: <!-- #123 or N/A -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
