### PR TITLE
chore(recipes): bump aws-efa to v0.5.29, align image tag to appVersion

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -32,7 +32,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | agentgateway | helm | agentgateway | v2.2.1 | 1 |
 | agentgateway-crds | helm | agentgateway-crds | v2.2.1 | 0 |
 | aws-ebs-csi-driver | helm | aws-ebs-csi-driver/aws-ebs-csi-driver | 2.59.0 | 6 |
-| aws-efa | helm | aws-efa-k8s-device-plugin | v0.5.26 | 1 |
+| aws-efa | helm | aws-efa-k8s-device-plugin | v0.5.29 | 1 |
 | cert-manager | helm | jetstack/cert-manager | v1.20.2 | 4 |
 | dynamo-platform | helm | dynamo-platform | 1.2.0 | 3 |
 | gatekeeper | helm | gatekeeper/gatekeeper | 3.22.2 | 3 |
@@ -78,7 +78,7 @@ _No images extracted._
 
 ### aws-efa
 
-- `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.5.18`
+- `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.5.20`
 
 ### cert-manager
 

--- a/recipes/components/aws-efa/values.yaml
+++ b/recipes/components/aws-efa/values.yaml
@@ -39,7 +39,10 @@
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
-  tag: v0.5.18
+  # Pin to the appVersion of the chart pinned in registry.yaml
+  # (aws-efa-k8s-device-plugin v0.5.29 → appVersion v0.5.20) so the
+  # image override matches the chart's default rather than drifting behind it.
+  tag: v0.5.20
 
 # AICR aws-efa securityContext — intentional divergence from upstream.
 #

--- a/recipes/overlays/eks.yaml
+++ b/recipes/overlays/eks.yaml
@@ -66,7 +66,7 @@ spec:
 
     - name: aws-efa
       type: Helm
-      version: v0.5.26
+      version: v0.5.29
       valuesFile: components/aws-efa/values.yaml
 
   validation:

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -160,7 +160,7 @@ components:
     helm:
       defaultRepository: https://aws.github.io/eks-charts
       defaultChart: aws-efa-k8s-device-plugin
-      defaultVersion: v0.5.26
+      defaultVersion: v0.5.29
       defaultNamespace: kube-system
     nodeScheduling:
       accelerated:


### PR DESCRIPTION
## Summary

Bump the `aws-efa` device plugin to current upstream (chart `v0.5.29`) and fix a chart-vs-image version drift: the image tag override in `values.yaml` was pinned behind the chart (`v0.5.18` while chart was `v0.5.26`). Align the image to the pinned chart's appVersion (`v0.5.20`).

## Motivation / Context

While investigating GB300 EFAv4 readiness (the public `p6e-gb300` fabric is EFA; the RoCE `p6e-gb300r` is DGXC-internal — see #1410), found two issues with the `aws-efa` component:

1. AICR was a few releases behind upstream (`aws/eks-charts` is at chart `v0.5.29` / appVersion `v0.5.20`).
2. The image tag was overridden to `v0.5.18` in `values.yaml` while the registry pinned chart `v0.5.26` (appVersion `v0.5.20`) — so the rendered image lagged the chart.

Keeping the public EFA device-plugin path current matters for the documented P6/P6e EFA family (H100/GB200/B200) and for eventual public GB300 EFAv4. Note: the primary version dependency for new EFA hardware is the host EFA kernel driver / EKS AMI, not this k8s device plugin (which just discovers present EFA devices and advertises `vpc.amazonaws.com/efa`).

Fixes: N/A
Related: #1410

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `recipes/registry.yaml`: `aws-efa-k8s-device-plugin` `defaultVersion` `v0.5.26` -> `v0.5.29`.
- `recipes/components/aws-efa/values.yaml`: image `tag` `v0.5.18` -> `v0.5.20` (the appVersion of chart v0.5.29), with a comment tying the override to the chart's appVersion.
- `docs/user/container-images.md`: regenerated BOM (`make bom-docs`).

`v0.5.20` is the declared appVersion of chart `v0.5.29` (from upstream `Chart.yaml`). Direct ECR tag verification was blocked by an expired SSO session at authoring time; the value is the chart's canonical appVersion and the AWS regional ECR mirrors upstream device-plugin releases.

## Testing

```bash
yamllint recipes/registry.yaml recipes/components/aws-efa/values.yaml   # clean
go test ./recipes/... -run TestComponentManifestImagesAreDigestPinned   # ok
make bom-docs                                                           # BOM regenerated
```

Recipe/YAML/docs-only change (no Go source touched). BOM diff confirms the coherent bump: chart `v0.5.26`->`v0.5.29`, image `v0.5.18`->`v0.5.20`.

## Risk Assessment

- [x] **Low** — Isolated version bump on a single component, easy to revert.

**Rollout notes:** Standard chart/image bump; no migration. EFA recipes re-render with the newer plugin on next bundle.

## Checklist

- [x] BOM regenerated and committed (`make bom-docs`)
- [x] yamllint clean
