### PR TITLE
fix(evidence): key-constrain all redaction allowlist subtypes

### DIFF
--- a/docs/design/007-recipe-evidence.md
+++ b/docs/design/007-recipe-evidence.md
@@ -602,15 +602,19 @@ raw container stdout). The bundle is therefore **minimized by default**, with
 
 The minimal policy (`policy: minimal`, `version: v1`) applies two transforms:
 
-- **Snapshot — fail-closed allowlist.** Only an enumerated set of measurement
-  subtypes/keys survives; anything a future collector adds is dropped until
-  explicitly allowlisted. v1 keeps `K8s.server`, an allowlisted subset of
-  `K8s.node` (provider, kubelet/runtime/OS versions — *not* `source-node`,
-  `provider-id`, `container-runtime-id`), `GPU.hardware`, `OS.release`, and
-  `NodeTopology.summary`. It drops `OS.{grub,sysctl,kmod}`, the entire
-  `SystemD` measurement, and `NodeTopology.{label,taint}`. The snapshot header
-  metadata is likewise allowlisted to `{timestamp, version}`, so `source-node`
-  (and any future key) is dropped by default.
+- **Snapshot — fail-closed allowlist, enforced at type, subtype, AND key
+  level.** Only enumerated types, subtypes, and data keys survive; a new type,
+  subtype, or key a future collector adds is dropped until explicitly
+  allowlisted (no subtype is keep-all). v1 keeps key-constrained
+  `K8s.server` (version, platform, goVersion) and `K8s.node` (provider,
+  kubelet/runtime/OS versions — *not* `source-node`, `provider-id`,
+  `container-runtime-id`), `GPU.hardware` (present/count/model/driver-loaded/
+  detection-source), `OS.release` (standard distro-identity keys only — the
+  collector ships all of `/etc/os-release`, so non-standard keys are dropped),
+  and `NodeTopology.summary` (counts). It drops `OS.{grub,sysctl,kmod}`, the
+  entire `SystemD` measurement, and `NodeTopology.{label,taint}`. The snapshot
+  header metadata is likewise allowlisted to `{timestamp, version}`, so
+  `source-node` (and any future key) is dropped by default.
 - **CTRF — log omission.** Per-test `stdout` and `message` are removed; the
   pass/fail signal (name, status, duration, suite, summary counts) is kept.
 

--- a/pkg/evidence/redact/redact.go
+++ b/pkg/evidence/redact/redact.go
@@ -24,11 +24,13 @@
 //
 // Two transforms are applied by the minimal policy:
 //
-//   - Snapshot: a fail-closed allowlist keeps only an enumerated set of
-//     measurement subtypes/keys. Node names, provider instance IDs, the raw
-//     node label/taint set, kernel/sysctl tuning, loaded modules, and systemd
-//     service config are dropped. Anything a future collector adds is dropped
-//     until explicitly allowlisted.
+//   - Snapshot: a fail-closed allowlist that is enforced at every level —
+//     measurement type, subtype, AND data key. Only enumerated types,
+//     subtypes, and keys survive; a new type, subtype, or key a future
+//     collector adds is dropped until explicitly allowlisted (there is no
+//     keep-all subtype). Node names, provider instance IDs, the raw node
+//     label/taint set, kernel/sysctl tuning, loaded modules, and systemd
+//     service config are dropped.
 //   - CTRF: per-test Stdout and Message (free-form log text that can leak IPs,
 //     DNS names, secret/cert names, internal URLs) are omitted; the pass/fail
 //     signal (name, status, duration, suite, summary counts) is preserved.
@@ -63,16 +65,15 @@ var headerMetadataAllowlist = map[string]struct{}{
 	"version":   {},
 }
 
-// subtypePolicy describes what survives within a kept subtype. A nil keys
-// set keeps every data key; a non-nil set keeps only the listed keys.
+// subtypePolicy is the allowlist of data keys that survive within a kept
+// subtype. Every kept subtype is key-constrained — there is no keep-all
+// escape hatch — so a key a future collector attaches to an allowlisted
+// subtype is dropped by default until added here (fail-closed at key level).
 type subtypePolicy struct {
 	keys map[string]struct{}
 }
 
 func keep(keys ...string) subtypePolicy {
-	if len(keys) == 0 {
-		return subtypePolicy{}
-	}
 	set := make(map[string]struct{}, len(keys))
 	for _, k := range keys {
 		set[k] = struct{}{}
@@ -81,9 +82,10 @@ func keep(keys ...string) subtypePolicy {
 }
 
 // snapshotAllowlist is the fail-closed allowlist: only the measurement types,
-// subtypes, and (where constrained) data keys listed here survive. A type not
-// present is dropped entirely; a subtype not present for a kept type is
-// dropped entirely.
+// subtypes, and data keys listed here survive. A type not present is dropped
+// entirely; a subtype not present for a kept type is dropped entirely; and a
+// data key not present in its subtype's policy is dropped. Every subtype is
+// key-constrained (no keep-all), so the guarantee holds at the key level too.
 //
 // The subtype names and data keys mirror the literals the collectors author
 // (pkg/collector/{k8s,os,gpu,topology}) — the same names pkg/fingerprint keys
@@ -93,7 +95,7 @@ func keep(keys ...string) subtypePolicy {
 // when the allowlist changes.
 var snapshotAllowlist = map[measurement.Type]map[string]subtypePolicy{
 	measurement.TypeK8s: {
-		"server": keep(), // version etc. — not sensitive
+		"server": keep("version", "platform", "goVersion"),
 		"node": keep(
 			"provider",
 			"kubelet-version",
@@ -105,14 +107,31 @@ var snapshotAllowlist = map[measurement.Type]map[string]subtypePolicy{
 		), // drops source-node, provider-id, container-runtime-id
 	},
 	measurement.TypeGPU: {
-		"hardware": keep(), // present/count/model/driver-loaded/detection-source
+		"hardware": keep(
+			"gpu-present",
+			"gpu-count",
+			"driver-loaded",
+			"detection-source",
+			"model",
+		),
 	},
 	measurement.TypeOS: {
-		"release": keep(), // /etc/os-release distro identity
+		// /etc/os-release distro identity. Key-constrained because the
+		// collector ships the whole file verbatim, so a non-standard distro
+		// could inject arbitrary (operator-influenced) keys otherwise.
+		"release": keep(
+			"ID",
+			"ID_LIKE",
+			"NAME",
+			"PRETTY_NAME",
+			"VERSION",
+			"VERSION_ID",
+			"VERSION_CODENAME",
+		),
 		// grub, sysctl, kmod intentionally absent → dropped (tuning/hardening posture)
 	},
 	measurement.TypeNodeTopology: {
-		"summary": keep(), // node-count etc. — counts, not identifiers
+		"summary": keep("node-count", "taint-count", "label-count"), // counts, not identifiers
 		// label, taint intentionally absent → dropped (node names + custom labels)
 	},
 	// TypeSystemD intentionally absent → entire measurement dropped.
@@ -190,24 +209,18 @@ func redactMeasurement(m *measurement.Measurement) *measurement.Measurement {
 	return out
 }
 
-// copySubtype copies st, retaining only the data keys permitted by pol.
-// Reading values are immutable wrappers, so sharing them is safe. The
-// subtype's Context is intentionally NOT carried over: it is not allowlisted
-// and carries no conformance signal, so passing it through would be a
-// fail-open path as collectors start attaching context.
+// copySubtype copies st, retaining only the data keys in pol — every other
+// key (including any a future collector adds to this subtype) is dropped,
+// fail-closed at the key level. Reading values are immutable wrappers, so
+// sharing them is safe. The subtype's Context is intentionally NOT carried
+// over: it is not allowlisted and carries no conformance signal, so passing
+// it through would be a fail-open path as collectors start attaching context.
 func copySubtype(st *measurement.Subtype, pol subtypePolicy) measurement.Subtype {
-	size := len(st.Data)
-	if pol.keys != nil {
-		size = len(pol.keys) // upper bound on survivors for a key-constrained subtype
-	}
-	data := make(map[string]measurement.Reading, size)
+	data := make(map[string]measurement.Reading, len(pol.keys)) // upper bound on survivors
 	for k, v := range st.Data {
-		if pol.keys != nil {
-			if _, allowed := pol.keys[k]; !allowed {
-				continue
-			}
+		if _, allowed := pol.keys[k]; allowed {
+			data[k] = v
 		}
-		data[k] = v
 	}
 	return measurement.Subtype{Name: st.Name, Data: data}
 }

--- a/pkg/evidence/redact/redact_test.go
+++ b/pkg/evidence/redact/redact_test.go
@@ -162,6 +162,64 @@ func TestSnapshotKeepsAllowlistedSubtypesAndKeys(t *testing.T) {
 	}
 }
 
+func TestSnapshotKeyConstrainsAllKeptSubtypes(t *testing.T) {
+	// Each formerly keep-all subtype now carries an extra unknown/sensitive
+	// key alongside its known keys; the unknown key must be dropped.
+	s := snapshotter.NewSnapshot()
+	s.Measurements = []*measurement.Measurement{
+		measurement.NewMeasurement(measurement.TypeK8s).
+			WithSubtypeBuilder(measurement.NewSubtypeBuilder("server").
+				SetString("version", "v1.33.1").
+				SetString("future-leak", "secret")).
+			Build(),
+		measurement.NewMeasurement(measurement.TypeGPU).
+			WithSubtypeBuilder(measurement.NewSubtypeBuilder("hardware").
+				SetString("model", "h100").
+				SetString("serial-number", "GPU-SENSITIVE-123")).
+			Build(),
+		measurement.NewMeasurement(measurement.TypeOS).
+			WithSubtypeBuilder(measurement.NewSubtypeBuilder("release").
+				SetString("ID", "ubuntu").
+				SetString("VERSION_ID", "22.04").
+				// non-standard / operator-influenced os-release keys
+				SetString("HOME_URL", "https://internal.example.com").
+				SetString("CUSTOM_TENANT", "acct-123")).
+			Build(),
+		measurement.NewMeasurement(measurement.TypeNodeTopology).
+			WithSubtypeBuilder(measurement.NewSubtypeBuilder("summary").
+				SetInt("node-count", 4).
+				SetString("internal-detail", "leak")).
+			Build(),
+	}
+	out, _ := redact.Snapshot(s)
+
+	cases := []struct {
+		typ        measurement.Type
+		sub        string
+		keptKey    string
+		droppedKey string
+	}{
+		{measurement.TypeK8s, "server", "version", "future-leak"},
+		{measurement.TypeGPU, "hardware", "model", "serial-number"},
+		{measurement.TypeOS, "release", "ID", "HOME_URL"},
+		{measurement.TypeOS, "release", "VERSION_ID", "CUSTOM_TENANT"},
+		{measurement.TypeNodeTopology, "summary", "node-count", "internal-detail"},
+	}
+	for _, c := range cases {
+		st := findSubtype(out, c.typ, c.sub)
+		if st == nil {
+			t.Errorf("%s.%s must be kept", c.typ, c.sub)
+			continue
+		}
+		if !st.Has(c.keptKey) {
+			t.Errorf("%s.%s.%s must be kept", c.typ, c.sub, c.keptKey)
+		}
+		if st.Has(c.droppedKey) {
+			t.Errorf("%s.%s.%s must be dropped (key-level fail-closed)", c.typ, c.sub, c.droppedKey)
+		}
+	}
+}
+
 func TestSnapshotHeaderMetadataIsAllowlisted(t *testing.T) {
 	in := fullSnapshot()
 	// A future/unknown metadata key must be dropped (fail-closed), not just


### PR DESCRIPTION
## Summary

Make the minimal-evidence snapshot allowlist fail-closed at the **key** level, not just at type/subtype. Every kept subtype is now key-constrained and the keep-all escape hatch is removed, so the package's stated guarantee holds at every level.

## Motivation / Context

Follow-up to a review comment on the merged #1414 ([discussion](https://github.com/NVIDIA/aicr/pull/1414#discussion_r3459754269), @mchmarny). The package doc claims "anything a future collector adds is dropped until explicitly allowlisted," but that held only at type and subtype granularity (plus key granularity for `K8s.node`). The `keep()`-all subtypes — `server`, `hardware`, `release`, `summary` — were **fail-open at the key level**: a sensitive key a future collector attaches to one of them would ship by default.

`OS.release` was the concrete risk: the collector ships all of `/etc/os-release` verbatim, so a non-standard distro could inject arbitrary operator-influenced keys that would publish in the "minimal" bundle.

Nothing leaks today (these subtypes currently carry only version/model/count/distro-identity keys), but the asymmetry with the deliberately key-constrained `node` subtype was exactly the trap. This change makes the implementation match the stated guarantee.

Fixes: N/A
Related: #1414, #1345

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Other: `pkg/evidence/redact`, `docs/design/007-recipe-evidence.md`

## Implementation Notes

- Every kept subtype is now an explicit key allowlist; the `keep()`-all variant is removed, so `copySubtype` always filters by the key set (no nil = keep-all path). A key not listed in its subtype's policy is dropped, fail-closed.
- `OS.release` is bound to standard distro-identity keys (`ID`, `ID_LIKE`, `NAME`, `PRETTY_NAME`, `VERSION`, `VERSION_ID`, `VERSION_CODENAME`); other `/etc/os-release` fields are dropped. `server`, `hardware`, and `summary` are pinned to their known collector keys.
- `PolicyVersion` is intentionally **not** bumped: v1 merged yesterday and has no consumers, so there is no signal to preserve.
- Package and allowlist doc comments now state the guarantee precisely (fail-closed at type, subtype, AND key level).

## Testing

```bash
go test ./pkg/evidence/... ./pkg/cli/...          # pass
golangci-lint run -c .golangci.yaml ./pkg/evidence/...   # 0 issues (pinned v2.12.2)
```

- New `TestSnapshotKeyConstrainsAllKeptSubtypes` proves an unknown/sensitive key on each formerly-keep-all subtype (incl. non-standard `os-release` keys) is dropped while known keys survive. `pkg/evidence/redact` coverage 98.1%.
- `-race` and the sigstore-dependent tests rely on CI (no local C compiler / sigstore network in my sandbox).

## Risk Assessment

- [x] **Low** — Isolated to the redaction allowlist; well-tested; easy to revert. Tightens (never loosens) what ships.
- [ ] **Medium**
- [ ] **High**

**Rollout notes:** Minimal bundles now ship slightly fewer `os-release` keys (standard identity only). No verification or schema impact; `--full` is unaffected. N/A migration.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — non-race suite passes locally; `-race` requires CI (no local C compiler)
- [x] Linter passes (`make lint`) — pinned `golangci-lint v2.12.2`, 0 issues
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (ADR-007)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
