### PR TITLE
fix(uat): gate validate on cluster convergence (readiness wait + failFast)

### DIFF
--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -77,6 +77,11 @@ READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-900}" # 15 min
 # state), which the kubectl jsonpath checks below do by comparing to "".
 wait_for() {
   local desc="$1" timeout="$2"; shift 2
+  # Callers share one budget by passing the time remaining until a common
+  # deadline, which can reach 0 (or briefly go negative) once earlier checks
+  # consume it — clamp so the final check still gets one fail-closed attempt
+  # rather than a deadline in the past.
+  (( timeout < 0 )) && timeout=0
   local deadline=$(( SECONDS + timeout ))
   echo "::group::Wait: ${desc} (timeout ${timeout}s)"
   until "$@" >/dev/null 2>&1; do
@@ -218,11 +223,15 @@ phase_install() {
   # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
   # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
   # prometheus-adapter is serving custom/external metrics.
-  wait_for "gpu-operator ClusterPolicy state=ready" "${READINESS_TIMEOUT_SECONDS}" \
+  # All three checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute one
+  # deadline up front and pass each call the time remaining until it, so the
+  # combined barrier cannot run N x the per-check timeout.
+  local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
+  wait_for "gpu-operator ClusterPolicy state=ready" "$(( ready_deadline - SECONDS ))" \
     _clusterpolicy_ready
-  wait_for "custom.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+  wait_for "custom.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
     _apiservice_available v1beta1.custom.metrics.k8s.io
-  wait_for "external.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+  wait_for "external.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
     _apiservice_available v1beta1.external.metrics.k8s.io
 }
 

--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -63,6 +63,44 @@ TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
 TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
 TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
 HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
+# Convergence budget for the post-install readiness gate. Cold-boot p5.48xlarge
+# GPU-operator convergence (driver build/load -> toolkit -> device-plugin ->
+# DCGM exporter) plus prometheus-adapter APIService aggregation can take many
+# minutes, so this is generous; the gate fails closed if exceeded.
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-900}" # 15 min
+
+# wait_for polls <check-cmd...> every 10s until it succeeds (exit 0) or
+# <timeout-seconds> elapses. Fail-closed: returns non-zero with diagnostics on
+# timeout, so a cluster that never converges fails the install loudly instead of
+# handing a not-ready cluster to `aicr validate`. The check command must tolerate
+# the target resource not existing yet (a missing resource is a normal early
+# state), which the kubectl jsonpath checks below do by comparing to "".
+wait_for() {
+  local desc="$1" timeout="$2"; shift 2
+  local deadline=$(( SECONDS + timeout ))
+  echo "::group::Wait: ${desc} (timeout ${timeout}s)"
+  until "$@" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "::error::timed out after ${timeout}s waiting for: ${desc}" >&2
+      echo "::endgroup::"
+      return 1
+    fi
+    sleep 10
+  done
+  echo "ok: ${desc}"
+  echo "::endgroup::"
+}
+
+# Readiness predicates for the post-install gate. Each is fail-closed: an absent
+# resource or unset status yields a non-matching value, so wait_for keeps polling.
+_clusterpolicy_ready() {
+  [[ "$(kubectl get clusterpolicy cluster-policy \
+    -o jsonpath='{.status.state}' 2>/dev/null)" == "ready" ]]
+}
+_apiservice_available() {
+  [[ "$(kubectl get apiservice "$1" \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)" == "True" ]]
+}
 
 # Per-run unique OCI repo suffix. The committed config carries the stable
 # prefix only; we append `-${RUN_ID}` once, idempotently, so re-running a
@@ -171,6 +209,21 @@ phase_install() {
   kubectl get nodes -o wide
   kubectl get pods -A | grep -Ev '\s+Running\s+|\s+Completed\s+' || true
   echo "::endgroup::"
+
+  # Readiness barrier the helmfile path lacks. The helm deploy.sh `kubectl wait`s
+  # on operator-driven convergence; `helmfile apply` returns once each release's
+  # own objects are Ready, leaving the GPU stack (ClusterPolicy -> DCGM exporter)
+  # and the prometheus-adapter metrics APIServices still reconciling. Gating here
+  # lets the stack converge before `aicr validate` runs, so deployment- and
+  # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
+  # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
+  # prometheus-adapter is serving custom/external metrics.
+  wait_for "gpu-operator ClusterPolicy state=ready" "${READINESS_TIMEOUT_SECONDS}" \
+    _clusterpolicy_ready
+  wait_for "custom.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+    _apiservice_available v1beta1.custom.metrics.k8s.io
+  wait_for "external.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+    _apiservice_available v1beta1.external.metrics.k8s.io
 }
 
 phase_conformance() {

--- a/tests/uat/aws/tests/h100-training-config.yaml
+++ b/tests/uat/aws/tests/h100-training-config.yaml
@@ -81,6 +81,16 @@ spec:
       storageClass: gp3
 
   validate:
+    execution:
+      # The deployment phase is the readiness barrier (gpu-operator ClusterPolicy
+      # reaches state=ready, the DRA kubelet-plugin DaemonSet rolls out, nodewright
+      # node tuning completes). failFast stops the run if that phase fails, so the
+      # conformance/performance phases are not evaluated against a not-yet-converged
+      # cluster — which previously surfaced as misleading accelerator-metrics /
+      # ai-service-metrics / pod-autoscaling failures. The `../run` readiness gate
+      # gives the operator-driven stack time to converge before validate, so on a
+      # healthy cluster the deployment phase passes and all phases still run.
+      failFast: true
     input:
       recipe: recipe.yaml
       snapshot: snapshot.yaml

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -63,6 +63,44 @@ TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
 TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
 TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
 HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
+# Convergence budget for the post-install readiness gate. Cold-boot GPU-operator
+# convergence (driver build/load -> toolkit -> device-plugin -> DCGM exporter)
+# plus prometheus-adapter APIService aggregation can take many minutes, so this
+# is generous; the gate fails closed if exceeded.
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-900}" # 15 min
+
+# wait_for polls <check-cmd...> every 10s until it succeeds (exit 0) or
+# <timeout-seconds> elapses. Fail-closed: returns non-zero with diagnostics on
+# timeout, so a cluster that never converges fails the install loudly instead of
+# handing a not-ready cluster to `aicr validate`. The check command must tolerate
+# the target resource not existing yet (a missing resource is a normal early
+# state), which the kubectl jsonpath checks below do by comparing to "".
+wait_for() {
+  local desc="$1" timeout="$2"; shift 2
+  local deadline=$(( SECONDS + timeout ))
+  echo "::group::Wait: ${desc} (timeout ${timeout}s)"
+  until "$@" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "::error::timed out after ${timeout}s waiting for: ${desc}" >&2
+      echo "::endgroup::"
+      return 1
+    fi
+    sleep 10
+  done
+  echo "ok: ${desc}"
+  echo "::endgroup::"
+}
+
+# Readiness predicates for the post-install gate. Each is fail-closed: an absent
+# resource or unset status yields a non-matching value, so wait_for keeps polling.
+_clusterpolicy_ready() {
+  [[ "$(kubectl get clusterpolicy cluster-policy \
+    -o jsonpath='{.status.state}' 2>/dev/null)" == "ready" ]]
+}
+_apiservice_available() {
+  [[ "$(kubectl get apiservice "$1" \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)" == "True" ]]
+}
 
 # Per-run unique OCI repo suffix. The committed config carries the stable
 # prefix only; we append `-${RUN_ID}` once, idempotently, so re-running a
@@ -171,6 +209,21 @@ phase_install() {
   kubectl get nodes -o wide
   kubectl get pods -A | grep -Ev '\s+Running\s+|\s+Completed\s+' || true
   echo "::endgroup::"
+
+  # Readiness barrier the helmfile path lacks. The helm deploy.sh `kubectl wait`s
+  # on operator-driven convergence; `helmfile apply` returns once each release's
+  # own objects are Ready, leaving the GPU stack (ClusterPolicy -> DCGM exporter)
+  # and the prometheus-adapter metrics APIServices still reconciling. Gating here
+  # lets the stack converge before `aicr validate` runs, so deployment- and
+  # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
+  # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
+  # prometheus-adapter is serving custom/external metrics.
+  wait_for "gpu-operator ClusterPolicy state=ready" "${READINESS_TIMEOUT_SECONDS}" \
+    _clusterpolicy_ready
+  wait_for "custom.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+    _apiservice_available v1beta1.custom.metrics.k8s.io
+  wait_for "external.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+    _apiservice_available v1beta1.external.metrics.k8s.io
 }
 
 phase_conformance() {

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -77,6 +77,11 @@ READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-900}" # 15 min
 # state), which the kubectl jsonpath checks below do by comparing to "".
 wait_for() {
   local desc="$1" timeout="$2"; shift 2
+  # Callers share one budget by passing the time remaining until a common
+  # deadline, which can reach 0 (or briefly go negative) once earlier checks
+  # consume it — clamp so the final check still gets one fail-closed attempt
+  # rather than a deadline in the past.
+  (( timeout < 0 )) && timeout=0
   local deadline=$(( SECONDS + timeout ))
   echo "::group::Wait: ${desc} (timeout ${timeout}s)"
   until "$@" >/dev/null 2>&1; do
@@ -218,11 +223,15 @@ phase_install() {
   # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
   # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
   # prometheus-adapter is serving custom/external metrics.
-  wait_for "gpu-operator ClusterPolicy state=ready" "${READINESS_TIMEOUT_SECONDS}" \
+  # All three checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute one
+  # deadline up front and pass each call the time remaining until it, so the
+  # combined barrier cannot run N x the per-check timeout.
+  local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
+  wait_for "gpu-operator ClusterPolicy state=ready" "$(( ready_deadline - SECONDS ))" \
     _clusterpolicy_ready
-  wait_for "custom.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+  wait_for "custom.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
     _apiservice_available v1beta1.custom.metrics.k8s.io
-  wait_for "external.metrics.k8s.io APIService Available" "${READINESS_TIMEOUT_SECONDS}" \
+  wait_for "external.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
     _apiservice_available v1beta1.external.metrics.k8s.io
 }
 

--- a/tests/uat/gcp/tests/h100-training-config.yaml
+++ b/tests/uat/gcp/tests/h100-training-config.yaml
@@ -68,6 +68,16 @@ spec:
       storageClass: premium-rwo
 
   validate:
+    execution:
+      # The deployment phase is the readiness barrier (gpu-operator ClusterPolicy
+      # reaches state=ready, the DRA kubelet-plugin DaemonSet rolls out, nodewright
+      # node tuning completes). failFast stops the run if that phase fails, so the
+      # conformance/performance phases are not evaluated against a not-yet-converged
+      # cluster — which previously surfaced as misleading accelerator-metrics /
+      # ai-service-metrics / pod-autoscaling failures. The `../run` readiness gate
+      # gives the operator-driven stack time to converge before validate, so on a
+      # healthy cluster the deployment phase passes and all phases still run.
+      failFast: true
     input:
       recipe: recipe.yaml
       snapshot: snapshot.yaml


### PR DESCRIPTION
## Summary

Gate the UAT `validate` step on cluster convergence: add a post-`helmfile apply` readiness wait to the UAT runners and set `failFast` so a failed deployment phase doesn't yield misleading conformance failures.

## Motivation / Context

`helmfile apply` returns once each release's own objects are Ready, but **not** after operator-driven convergence (gpu-operator ClusterPolicy → DCGM exporter; prometheus-adapter's `custom`/`external` metrics APIServices). The helm `deploy.sh` path `kubectl wait`s on these; the helmfile path does not. When the UAT validate step moved to `--phase all` (#1416), the deployment phase (`expected-resources`) timed out and the conformance checks (`accelerator-metrics`, `ai-service-metrics`, `pod-autoscaling`) fast-failed — all because validation ran against a not-yet-converged cluster, not because of any check, recipe, or networking defect.

Confirmed empirically: re-running `aicr validate --phase conformance` against the **converged** UAT cluster passes all conformance validators. (An initial hypothesis that the multi-SG cluster topology blocked cross-subnet Prometheus/DCGM traffic was investigated and ruled out — the dials work once the stack is up.)

Fixes: N/A
Related: #1425

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT test harness (`tests/uat/{aws,gcp}`)

## Implementation Notes

- **Readiness gate** (`tests/uat/{aws,gcp}/run`): a `wait_for` poll helper blocks at the end of `phase_install` until `ClusterPolicy` reaches `state=ready` (⇒ GPU stack incl. DCGM exporter rolled out) and both `v1beta1.custom.metrics.k8s.io` / `v1beta1.external.metrics.k8s.io` APIServices are `Available` (⇒ prometheus-adapter serving). Predicates are **fail-closed**: an absent resource or unset status keeps polling, and the gate exits non-zero with a diagnostic on timeout (`READINESS_TIMEOUT_SECONDS`, default 15m) so a cluster that never converges fails the install loudly rather than handing a not-ready cluster to `validate`.
- **`failFast: true`** (`tests/uat/{aws,gcp}/tests/h100-training-config.yaml`, `spec.validate.execution.failFast`): on the rare path where the deployment phase still fails after the gate, conformance/performance are skipped instead of producing misleading failures. Mirrors the existing precedent in `tests/uat/chainsaw-config.yaml`.
- Chose `ClusterPolicy` + the two metrics APIServices as the gate signals because they were the actual failure surface; the deployment-phase validator (now gated by `failFast`) remains the comprehensive backstop, and the gate is easy to extend if DRA-rollout / nodewright ever prove to be the long pole.
- Deliberately **not** changed: the `kube-prometheus-stack` co-location selector (the Prometheus pod still carries `app.kubernetes.io/name=prometheus` on chart 84.4.0 — verified on the live cluster) and any validator Go code (the single-shot-probe hardening is tracked separately as #1425).

## Testing

```bash
bash -n tests/uat/aws/run tests/uat/gcp/run   # shell syntax OK
# YAML parses; spec.validate.execution.failFast=true present; comment lines within yamllint max (200)
```

- Empirical confirmation: re-ran `aicr validate --phase conformance` against the live, converged UAT EKS cluster → **all conformance validators pass**, confirming the failures were a pre-convergence timing race.
- yamllint + shellcheck run in CI via `make qualify` (not installed in the dev environment used here).

## Risk Assessment

- [x] **Low** — Isolated to the UAT test harness (`tests/uat`); no product/runtime code paths touched; fail-closed; trivially revertable.

**Rollout notes:** N/A — UAT-only. Gate budget is overridable via `READINESS_TIMEOUT_SECONDS`.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [ ] Linter passes (`make lint`) — `bash -n` + YAML parse verified locally; yamllint/shellcheck run in CI (tools not present in this dev env)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (shell/YAML harness; validated against the live cluster as above)
- [ ] I updated docs if user-facing behavior changed — N/A (internal UAT harness, no user-facing behavior)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
