### PR TITLE
chore(evidence): refresh gb200-eks + h100-gke-cos attestations

### DIFF
--- a/recipes/evidence/gb200-eks-ubuntu-training.yaml
+++ b/recipes/evidence/gb200-eks-ubuntu-training.yaml
@@ -1,26 +1,12 @@
-# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 attestations:
-  - attestedAt: 2026-06-15T16:58:03Z
+  - attestedAt: 2026-06-23T18:24:27Z
     bundle:
-      digest: sha256:eb37c8d5b465f8edc3c28d8563a0ecd3e42c652716b63aafe5791fc18f109e1f
-      oci: ghcr.io/atif1996/aicr-evidence:gb200-eks-ubuntu-training-fa91b7c53f5a
+      digest: sha256:8274b6a1da24aa9782dc12162bf6a38265c30a852585ca64cfad5718efbbdec3
+      oci: ghcr.io/yuanchen8911/aicr-evidence:gb200-eks-ubuntu-training-a3fe1a7e7bcb
       predicateType: https://aicr.nvidia.com/recipe-evidence/v1
     signer:
-      identity: atif1996@gmail.com
+      identity: yuanchen97@gmail.com
       issuer: https://github.com/login/oauth
-      rekorLogIndex: 1826568564
+      rekorLogIndex: 1930094136
 recipe: gb200-eks-ubuntu-training
 schemaVersion: 1.0.0

--- a/recipes/evidence/h100-gke-cos-training.yaml
+++ b/recipes/evidence/h100-gke-cos-training.yaml
@@ -1,26 +1,12 @@
-# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 attestations:
-  - attestedAt: 2026-06-15T15:22:56Z
+  - attestedAt: 2026-06-23T19:40:07Z
     bundle:
-      digest: sha256:a72d34fb3c2e03e66bf3cb4623ce08559fd45faba33c8cae62dda19eb1d28270
-      oci: ghcr.io/atif1996/aicr-evidence:h100-gke-cos-training-c7c84d1ed2ce
+      digest: sha256:33d4cf36622ead990c43a596f6f53c62b87d9fa4708f59b7e3f356f215e54317
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-gke-cos-training-ee1657fedd59
       predicateType: https://aicr.nvidia.com/recipe-evidence/v1
     signer:
-      identity: atif1996@gmail.com
+      identity: yuanchen97@gmail.com
       issuer: https://github.com/login/oauth
-      rekorLogIndex: 1826548328
+      rekorLogIndex: 1931193974
 recipe: h100-gke-cos-training
 schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Refresh the conformance-evidence pointers for `gb200-eks-ubuntu-training` and `h100-gke-cos-training`. The recipe-evidence drift gate flagged both as **stale** after #1418 (aws-efa `v0.5.26` → `v0.5.29` + EKS overlay pin) changed their rendered digests. This updates each pointer to a freshly re-validated, signed bundle.

## Motivation / Context

#1418 bumped aws-efa to `v0.5.29`, changing the rendered digest of EKS/GKE recipes that include aws-efa. The committed evidence pointers still referenced pre-bump bundles, so the drift gate reported them stale.

Re-validated on matching clusters — all phases passed:
- **gb200-eks-ubuntu-training** — GB200 EKS (`p6e-gb200.36xlarge`, Ubuntu 24.04, K8s 1.34). Subject digest `5177d2ed…`. Bundle `ghcr.io/yuanchen8911/aicr-evidence:gb200-eks-ubuntu-training-a3fe1a7e7bcb`, Rekor `1930094136`.
- **h100-gke-cos-training** — H100 GKE/COS (K8s 1.35). NCCL all-reduce 338 GB/s. Subject digest `064f27fa…`. Bundle `ghcr.io/yuanchen8911/aicr-evidence:h100-gke-cos-training-ee1657fedd59`, Rekor `1931193974`.

Related: #1418. Note: the GKE NCCL run surfaced a separate validator bug (JobSet staging image) tracked in #1430; the evidence here was captured with that worked around.

## Type of Change

- [x] Build/CI/tooling (evidence refresh)

## Component(s) Affected

- [x] Recipe engine / data (`recipes/evidence`)

## Testing

```
aicr evidence verify recipes/evidence/gb200-eks-ubuntu-training.yaml   # bundle valid
aicr evidence verify recipes/evidence/h100-gke-cos-training.yaml       # bundle valid
```

Offline verification passes for both: signature (`yuanchen97@gmail.com` via github oauth), manifest-hash-check, and predicate-parse all green.
