### PR TITLE
fix(uat): wait for nodewright tuning before validate readiness gate

### DIFF
--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -63,11 +63,13 @@ TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
 TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
 TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
 HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
-# Convergence budget for the post-install readiness gate. Cold-boot p5.48xlarge
+# Convergence budget for the post-install readiness gate. Spans nodewright
+# (skyhook) node tuning -- which REBOOTS the GPU node and re-inits the operator
+# stack after gpu-operator first reports ready -- plus cold-boot p5.48xlarge
 # GPU-operator convergence (driver build/load -> toolkit -> device-plugin ->
-# DCGM exporter) plus prometheus-adapter APIService aggregation can take many
-# minutes, so this is generous; the gate fails closed if exceeded.
-READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-900}" # 15 min
+# DCGM exporter) and prometheus-adapter APIService aggregation. Generous; the
+# gate fails closed if exceeded.
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-1200}" # 20 min
 
 # wait_for polls <check-cmd...> every 10s until it succeeds (exit 0) or
 # <timeout-seconds> elapses. Fail-closed: returns non-zero with diagnostics on
@@ -105,6 +107,21 @@ _clusterpolicy_ready() {
 _apiservice_available() {
   [[ "$(kubectl get apiservice "$1" \
     -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)" == "True" ]]
+}
+# _skyhook_complete is true when every nodewright (Skyhook) CR reports
+# status.status=complete. Skyhook node tuning REBOOTS the GPU node, which
+# re-initializes the gpu-operator operands AFTER ClusterPolicy first reports
+# ready — so this must clear before the GPU/metrics checks, else the gate passes
+# on a transient pre-reboot ready state and validate races the re-convergence.
+# Empty list (CR not created yet) => not complete => keep waiting. If the Skyhook
+# CRD is absent the recipe has no nodewright, so skip rather than block. Skyhook
+# CRs are cluster-scoped (see validators/deployment/expected_resources.go).
+_skyhook_complete() {
+  kubectl get crd skyhooks.skyhook.nvidia.com >/dev/null 2>&1 || return 0
+  local states
+  states="$(kubectl get skyhooks.skyhook.nvidia.com \
+    -o jsonpath='{range .items[*]}{.status.status}{"\n"}{end}' 2>/dev/null)"
+  [[ -n "$states" ]] && ! grep -qxv 'complete' <<<"$states"
 }
 
 # Per-run unique OCI repo suffix. The committed config carries the stable
@@ -223,10 +240,18 @@ phase_install() {
   # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
   # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
   # prometheus-adapter is serving custom/external metrics.
-  # All three checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute one
-  # deadline up front and pass each call the time remaining until it, so the
+  # All readiness checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute
+  # one deadline up front and pass each call the time remaining until it, so the
   # combined barrier cannot run N x the per-check timeout.
+  #
+  # nodewright (skyhook) tuning is waited on FIRST: it reboots the GPU node to
+  # apply kernel tuning, re-initializing the gpu-operator operands after the
+  # operator first reports ClusterPolicy=ready. Checking ClusterPolicy/operands
+  # before that reboot lets the gate pass on a transient pre-reboot ready state,
+  # so wait for tuning to complete before the GPU/metrics checks.
   local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
+  wait_for "nodewright (skyhook) tuning complete" "$(( ready_deadline - SECONDS ))" \
+    _skyhook_complete
   wait_for "gpu-operator ClusterPolicy state=ready" "$(( ready_deadline - SECONDS ))" \
     _clusterpolicy_ready
   wait_for "custom.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -63,11 +63,13 @@ TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
 TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
 TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
 HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
-# Convergence budget for the post-install readiness gate. Cold-boot GPU-operator
+# Convergence budget for the post-install readiness gate. Spans nodewright
+# (skyhook) node tuning -- which REBOOTS the GPU node and re-inits the operator
+# stack after gpu-operator first reports ready -- plus cold-boot GPU-operator
 # convergence (driver build/load -> toolkit -> device-plugin -> DCGM exporter)
-# plus prometheus-adapter APIService aggregation can take many minutes, so this
-# is generous; the gate fails closed if exceeded.
-READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-900}" # 15 min
+# and prometheus-adapter APIService aggregation. Generous; the gate fails closed
+# if exceeded.
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-1200}" # 20 min
 
 # wait_for polls <check-cmd...> every 10s until it succeeds (exit 0) or
 # <timeout-seconds> elapses. Fail-closed: returns non-zero with diagnostics on
@@ -105,6 +107,21 @@ _clusterpolicy_ready() {
 _apiservice_available() {
   [[ "$(kubectl get apiservice "$1" \
     -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)" == "True" ]]
+}
+# _skyhook_complete is true when every nodewright (Skyhook) CR reports
+# status.status=complete. Skyhook node tuning REBOOTS the GPU node, which
+# re-initializes the gpu-operator operands AFTER ClusterPolicy first reports
+# ready — so this must clear before the GPU/metrics checks, else the gate passes
+# on a transient pre-reboot ready state and validate races the re-convergence.
+# Empty list (CR not created yet) => not complete => keep waiting. If the Skyhook
+# CRD is absent the recipe has no nodewright, so skip rather than block. Skyhook
+# CRs are cluster-scoped (see validators/deployment/expected_resources.go).
+_skyhook_complete() {
+  kubectl get crd skyhooks.skyhook.nvidia.com >/dev/null 2>&1 || return 0
+  local states
+  states="$(kubectl get skyhooks.skyhook.nvidia.com \
+    -o jsonpath='{range .items[*]}{.status.status}{"\n"}{end}' 2>/dev/null)"
+  [[ -n "$states" ]] && ! grep -qxv 'complete' <<<"$states"
 }
 
 # Per-run unique OCI repo suffix. The committed config carries the stable
@@ -223,10 +240,18 @@ phase_install() {
   # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
   # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
   # prometheus-adapter is serving custom/external metrics.
-  # All three checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute one
-  # deadline up front and pass each call the time remaining until it, so the
+  # All readiness checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute
+  # one deadline up front and pass each call the time remaining until it, so the
   # combined barrier cannot run N x the per-check timeout.
+  #
+  # nodewright (skyhook) tuning is waited on FIRST: it reboots the GPU node to
+  # apply kernel tuning, re-initializing the gpu-operator operands after the
+  # operator first reports ClusterPolicy=ready. Checking ClusterPolicy/operands
+  # before that reboot lets the gate pass on a transient pre-reboot ready state,
+  # so wait for tuning to complete before the GPU/metrics checks.
   local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
+  wait_for "nodewright (skyhook) tuning complete" "$(( ready_deadline - SECONDS ))" \
+    _skyhook_complete
   wait_for "gpu-operator ClusterPolicy state=ready" "$(( ready_deadline - SECONDS ))" \
     _clusterpolicy_ready
   wait_for "custom.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \


### PR DESCRIPTION
## Summary

Wait for nodewright/skyhook node tuning to reach `complete` **before** the UAT readiness gate checks the GPU/metrics stack, so `aicr validate` isn't handed a cluster that's mid-reboot.

## Motivation / Context

Follow-up to #1426. On a **fresh** cluster, nodewright (skyhook) applies kernel tuning that **reboots the GPU node** — and it does so *after* gpu-operator first reports `ClusterPolicy=ready`. The reboot re-initializes the gpu-operator operands (their pods drop back to `Init`, i.e. phase `Pending`). The gate added in #1426 checks `ClusterPolicy=ready` + the metrics APIServices, which were satisfied in that transient pre-reboot window, so it passed; `aicr validate` then ran against the re-converging cluster and the deployment-phase `expected-resources` check failed on the `Pending` pods in `gpu-operator`.

Observed in a UAT run as synchronized restarts of every node-local DaemonSet (`aws-node`, `kube-proxy`, `ebs-csi-node`, `nfd-*`) at the same moment — the signature of a single node reboot.

Fixes: N/A
Related: #1426

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT test harness (`tests/uat/{aws,gcp}`)

## Implementation Notes

- **`_skyhook_complete` predicate**: true only when every `Skyhook` CR (`skyhook.nvidia.com/v1alpha1`, cluster-scoped) reports `status.status=complete`. Empty list (CR not created yet) → keep waiting; Skyhook CRD absent → the recipe has no nodewright, so skip rather than block. Mirrors the nodewright signal `expected-resources` itself asserts (`validators/deployment/expected_resources.go`).
- **Ordered first** in `phase_install`, ahead of the `ClusterPolicy` / metrics-APIService waits, because the tuning reboot disrupts the GPU stack *after* `ClusterPolicy` first goes ready — gating the GPU/metrics checks before tuning completes is what let the gate pass prematurely.
- **`READINESS_TIMEOUT_SECONDS` 900 → 1200** (still a single budget shared across all four checks): it now spans a node reboot plus double GPU-stack convergence. Fail-closed; overridable via env.
- No-op cost on clusters that don't reboot: the CR reaches `complete` immediately (or the CRD is absent → skipped), so the new wait only blocks while tuning is genuinely in flight.

## Testing

```bash
bash -n tests/uat/aws/run tests/uat/gcp/run   # shell syntax OK
shellcheck -S warning tests/uat/{aws,gcp}/run # clean
```

- Predicate truth table verified: only all-CRs-`complete` passes; in-progress / mixed / missing-status / empty all keep waiting; `set -e`-safe.
- Not validated end-to-end on a live cluster — the UAT cluster was torn down before re-test. The diagnosis rests on the observed node-reboot signature plus skyhook's documented reboot-for-tuning behavior. yamllint/shellcheck run in CI via `make qualify`.

## Risk Assessment

- [x] **Low** — UAT test harness only (`tests/uat`); no product/runtime code; fail-closed; no-op when no reboot occurs; trivially revertable.

**Rollout notes:** N/A — UAT-only. Gate budget overridable via `READINESS_TIMEOUT_SECONDS`.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [ ] Linter passes (`make lint`) — `bash -n` + shellcheck verified locally; yamllint/shellcheck also run in CI
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (shell harness; predicate logic validated as above)
- [ ] I updated docs if user-facing behavior changed — N/A (internal UAT harness)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
