### PR TITLE
fix(uat): gate install on the deployment validation phase

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -40,10 +40,12 @@ jobs:
   uat-aws:
     if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
-    # Bumped from 90 to 110 to absorb the validate step now running all phases
-    # (deployment readiness gate + conformance + NCCL performance) rather than
-    # conformance alone.
-    timeout-minutes: 110
+    # Bumped from 90 to 110 for the validate step running all phases (deployment
+    # readiness gate + conformance + NCCL performance), then to 130 so the
+    # install step's deployment-phase readiness gate (up to
+    # READINESS_TIMEOUT_SECONDS, spanning a nodewright reboot) fits on top of
+    # helmfile apply without the job cap truncating later steps.
+    timeout-minutes: 130
     permissions:
       contents: read
       actions: read
@@ -223,7 +225,12 @@ jobs:
       - name: UAT - install (helmfile apply)
         id: install
         if: steps.prep.outcome == 'success'
-        timeout-minutes: 25
+        # helmfile apply (up to HELMFILE_TIMEOUT_SECONDS) + the post-install
+        # readiness gate, which runs `aicr validate --phase deployment` until it
+        # passes (up to READINESS_TIMEOUT_SECONDS, 20m, spanning a nodewright
+        # reboot). Must exceed one helmfile attempt + the gate so the gate's own
+        # fail-closed path runs before GitHub Actions kills the step.
+        timeout-minutes: 45
         shell: bash
         env:
           AICR_BIN: ${{ github.workspace }}/aicr

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -40,10 +40,12 @@ jobs:
   uat-gcp:
     if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
-    # Bumped from 90 to 110 to absorb the validate step now running all phases
-    # (deployment readiness gate + conformance + NCCL performance) rather than
-    # conformance alone.
-    timeout-minutes: 110
+    # Bumped from 90 to 110 for the validate step running all phases (deployment
+    # readiness gate + conformance + NCCL performance), then to 130 so the
+    # install step's deployment-phase readiness gate (up to
+    # READINESS_TIMEOUT_SECONDS, spanning a nodewright reboot) fits on top of
+    # helmfile apply without the job cap truncating later steps.
+    timeout-minutes: 130
     permissions:
       contents: read
       actions: read
@@ -192,7 +194,12 @@ jobs:
       - name: UAT - install (helmfile apply)
         id: install
         if: steps.prep.outcome == 'success'
-        timeout-minutes: 25
+        # helmfile apply (up to HELMFILE_TIMEOUT_SECONDS) + the post-install
+        # readiness gate, which runs `aicr validate --phase deployment` until it
+        # passes (up to READINESS_TIMEOUT_SECONDS, 20m, spanning a nodewright
+        # reboot). Must exceed one helmfile attempt + the gate so the gate's own
+        # fail-closed path runs before GitHub Actions kills the step.
+        timeout-minutes: 45
         shell: bash
         env:
           AICR_BIN: ${{ github.workspace }}/aicr

--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -63,66 +63,13 @@ TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
 TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
 TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
 HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
-# Convergence budget for the post-install readiness gate. Spans nodewright
-# (skyhook) node tuning -- which REBOOTS the GPU node and re-inits the operator
-# stack after gpu-operator first reports ready -- plus cold-boot p5.48xlarge
-# GPU-operator convergence (driver build/load -> toolkit -> device-plugin ->
-# DCGM exporter) and prometheus-adapter APIService aggregation. Generous; the
-# gate fails closed if exceeded.
+# Budget for the post-install readiness gate, which runs the deployment
+# validation phase until it passes (see phase_install). Generous: it must span
+# nodewright (skyhook) node tuning -- which REBOOTS the GPU node and re-inits the
+# gpu-operator operands after the operator first reports ready -- plus cold-boot
+# p5.48xlarge GPU-operator convergence (driver/toolkit/device-plugin/DCGM) and
+# prometheus-adapter APIService aggregation. Fails closed if exceeded.
 READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-1200}" # 20 min
-
-# wait_for polls <check-cmd...> every 10s until it succeeds (exit 0) or
-# <timeout-seconds> elapses. Fail-closed: returns non-zero with diagnostics on
-# timeout, so a cluster that never converges fails the install loudly instead of
-# handing a not-ready cluster to `aicr validate`. The check command must tolerate
-# the target resource not existing yet (a missing resource is a normal early
-# state), which the kubectl jsonpath checks below do by comparing to "".
-wait_for() {
-  local desc="$1" timeout="$2"; shift 2
-  # Callers share one budget by passing the time remaining until a common
-  # deadline, which can reach 0 (or briefly go negative) once earlier checks
-  # consume it — clamp so the final check still gets one fail-closed attempt
-  # rather than a deadline in the past.
-  (( timeout < 0 )) && timeout=0
-  local deadline=$(( SECONDS + timeout ))
-  echo "::group::Wait: ${desc} (timeout ${timeout}s)"
-  until "$@" >/dev/null 2>&1; do
-    if (( SECONDS >= deadline )); then
-      echo "::error::timed out after ${timeout}s waiting for: ${desc}" >&2
-      echo "::endgroup::"
-      return 1
-    fi
-    sleep 10
-  done
-  echo "ok: ${desc}"
-  echo "::endgroup::"
-}
-
-# Readiness predicates for the post-install gate. Each is fail-closed: an absent
-# resource or unset status yields a non-matching value, so wait_for keeps polling.
-_clusterpolicy_ready() {
-  [[ "$(kubectl get clusterpolicy cluster-policy \
-    -o jsonpath='{.status.state}' 2>/dev/null)" == "ready" ]]
-}
-_apiservice_available() {
-  [[ "$(kubectl get apiservice "$1" \
-    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)" == "True" ]]
-}
-# _skyhook_complete is true when every nodewright (Skyhook) CR reports
-# status.status=complete. Skyhook node tuning REBOOTS the GPU node, which
-# re-initializes the gpu-operator operands AFTER ClusterPolicy first reports
-# ready — so this must clear before the GPU/metrics checks, else the gate passes
-# on a transient pre-reboot ready state and validate races the re-convergence.
-# Empty list (CR not created yet) => not complete => keep waiting. If the Skyhook
-# CRD is absent the recipe has no nodewright, so skip rather than block. Skyhook
-# CRs are cluster-scoped (see validators/deployment/expected_resources.go).
-_skyhook_complete() {
-  kubectl get crd skyhooks.skyhook.nvidia.com >/dev/null 2>&1 || return 0
-  local states
-  states="$(kubectl get skyhooks.skyhook.nvidia.com \
-    -o jsonpath='{range .items[*]}{.status.status}{"\n"}{end}' 2>/dev/null)"
-  [[ -n "$states" ]] && ! grep -qxv 'complete' <<<"$states"
-}
 
 # Per-run unique OCI repo suffix. The committed config carries the stable
 # prefix only; we append `-${RUN_ID}` once, idempotently, so re-running a
@@ -232,32 +179,39 @@ phase_install() {
   kubectl get pods -A | grep -Ev '\s+Running\s+|\s+Completed\s+' || true
   echo "::endgroup::"
 
-  # Readiness barrier the helmfile path lacks. The helm deploy.sh `kubectl wait`s
-  # on operator-driven convergence; `helmfile apply` returns once each release's
-  # own objects are Ready, leaving the GPU stack (ClusterPolicy -> DCGM exporter)
-  # and the prometheus-adapter metrics APIServices still reconciling. Gating here
-  # lets the stack converge before `aicr validate` runs, so deployment- and
-  # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
-  # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
-  # prometheus-adapter is serving custom/external metrics.
-  # All readiness checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute
-  # one deadline up front and pass each call the time remaining until it, so the
-  # combined barrier cannot run N x the per-check timeout.
+  # Readiness gate: run the deployment validation phase -- the authoritative
+  # expected-resources / ClusterPolicy / DRA / nodewright checks the later
+  # `--phase all` run gates on -- in a retry loop until it passes. `helmfile
+  # apply` returns before operator-driven convergence, and nodewright (skyhook)
+  # reboots the GPU node AFTER gpu-operator first reports ready, re-initing the
+  # operands; proxy signals (ClusterPolicy=ready, Skyhook status.status) read that
+  # transient state as "done" prematurely, so we gate on the real check. It rides
+  # through the reboot via expected-resources' own poll plus this outer retry.
+  # Fail-closed: the install fails if the phase never passes within the budget.
   #
-  # nodewright (skyhook) tuning is waited on FIRST: it reboots the GPU node to
-  # apply kernel tuning, re-initializing the gpu-operator operands after the
-  # operator first reports ClusterPolicy=ready. Checking ClusterPolicy/operands
-  # before that reboot lets the gate pass on a transient pre-reboot ready state,
-  # so wait for tuning to complete before the GPU/metrics checks.
+  # Run against a copy of the config with spec.validate.evidence stripped so the
+  # gate never emits/pushes an evidence bundle -- that is the conformance phase's
+  # job (phase_conformance, `--phase all`).
+  local gate_config; gate_config="$(mktemp)"
+  yq 'del(.spec.validate.evidence)' "${config}" > "${gate_config}"
   local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
-  wait_for "nodewright (skyhook) tuning complete" "$(( ready_deadline - SECONDS ))" \
-    _skyhook_complete
-  wait_for "gpu-operator ClusterPolicy state=ready" "$(( ready_deadline - SECONDS ))" \
-    _clusterpolicy_ready
-  wait_for "custom.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
-    _apiservice_available v1beta1.custom.metrics.k8s.io
-  wait_for "external.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
-    _apiservice_available v1beta1.external.metrics.k8s.io
+  local attempt=1
+  echo "::group::Readiness gate: validate --phase deployment (timeout ${READINESS_TIMEOUT_SECONDS}s)"
+  until "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null >/dev/null 2>&1; do
+    if (( SECONDS >= ready_deadline )); then
+      echo "::error::deployment readiness gate did not pass within ${READINESS_TIMEOUT_SECONDS}s; final attempt:" >&2
+      "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null 2>&1 || true
+      rm -f "${gate_config}"
+      echo "::endgroup::"
+      exit 1
+    fi
+    echo "deployment phase not ready (attempt ${attempt}); retrying in 15s..."
+    attempt=$(( attempt + 1 ))
+    sleep 15
+  done
+  rm -f "${gate_config}"
+  echo "deployment readiness gate passed (attempt ${attempt})"
+  echo "::endgroup::"
 }
 
 phase_conformance() {

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -63,66 +63,13 @@ TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
 TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
 TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
 HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
-# Convergence budget for the post-install readiness gate. Spans nodewright
-# (skyhook) node tuning -- which REBOOTS the GPU node and re-inits the operator
-# stack after gpu-operator first reports ready -- plus cold-boot GPU-operator
-# convergence (driver build/load -> toolkit -> device-plugin -> DCGM exporter)
-# and prometheus-adapter APIService aggregation. Generous; the gate fails closed
-# if exceeded.
+# Budget for the post-install readiness gate, which runs the deployment
+# validation phase until it passes (see phase_install). Generous: it must span
+# nodewright (skyhook) node tuning -- which REBOOTS the GPU node and re-inits the
+# gpu-operator operands after the operator first reports ready -- plus cold-boot
+# GPU-operator convergence (driver/toolkit/device-plugin/DCGM) and
+# prometheus-adapter APIService aggregation. Fails closed if exceeded.
 READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-1200}" # 20 min
-
-# wait_for polls <check-cmd...> every 10s until it succeeds (exit 0) or
-# <timeout-seconds> elapses. Fail-closed: returns non-zero with diagnostics on
-# timeout, so a cluster that never converges fails the install loudly instead of
-# handing a not-ready cluster to `aicr validate`. The check command must tolerate
-# the target resource not existing yet (a missing resource is a normal early
-# state), which the kubectl jsonpath checks below do by comparing to "".
-wait_for() {
-  local desc="$1" timeout="$2"; shift 2
-  # Callers share one budget by passing the time remaining until a common
-  # deadline, which can reach 0 (or briefly go negative) once earlier checks
-  # consume it — clamp so the final check still gets one fail-closed attempt
-  # rather than a deadline in the past.
-  (( timeout < 0 )) && timeout=0
-  local deadline=$(( SECONDS + timeout ))
-  echo "::group::Wait: ${desc} (timeout ${timeout}s)"
-  until "$@" >/dev/null 2>&1; do
-    if (( SECONDS >= deadline )); then
-      echo "::error::timed out after ${timeout}s waiting for: ${desc}" >&2
-      echo "::endgroup::"
-      return 1
-    fi
-    sleep 10
-  done
-  echo "ok: ${desc}"
-  echo "::endgroup::"
-}
-
-# Readiness predicates for the post-install gate. Each is fail-closed: an absent
-# resource or unset status yields a non-matching value, so wait_for keeps polling.
-_clusterpolicy_ready() {
-  [[ "$(kubectl get clusterpolicy cluster-policy \
-    -o jsonpath='{.status.state}' 2>/dev/null)" == "ready" ]]
-}
-_apiservice_available() {
-  [[ "$(kubectl get apiservice "$1" \
-    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)" == "True" ]]
-}
-# _skyhook_complete is true when every nodewright (Skyhook) CR reports
-# status.status=complete. Skyhook node tuning REBOOTS the GPU node, which
-# re-initializes the gpu-operator operands AFTER ClusterPolicy first reports
-# ready — so this must clear before the GPU/metrics checks, else the gate passes
-# on a transient pre-reboot ready state and validate races the re-convergence.
-# Empty list (CR not created yet) => not complete => keep waiting. If the Skyhook
-# CRD is absent the recipe has no nodewright, so skip rather than block. Skyhook
-# CRs are cluster-scoped (see validators/deployment/expected_resources.go).
-_skyhook_complete() {
-  kubectl get crd skyhooks.skyhook.nvidia.com >/dev/null 2>&1 || return 0
-  local states
-  states="$(kubectl get skyhooks.skyhook.nvidia.com \
-    -o jsonpath='{range .items[*]}{.status.status}{"\n"}{end}' 2>/dev/null)"
-  [[ -n "$states" ]] && ! grep -qxv 'complete' <<<"$states"
-}
 
 # Per-run unique OCI repo suffix. The committed config carries the stable
 # prefix only; we append `-${RUN_ID}` once, idempotently, so re-running a
@@ -232,32 +179,39 @@ phase_install() {
   kubectl get pods -A | grep -Ev '\s+Running\s+|\s+Completed\s+' || true
   echo "::endgroup::"
 
-  # Readiness barrier the helmfile path lacks. The helm deploy.sh `kubectl wait`s
-  # on operator-driven convergence; `helmfile apply` returns once each release's
-  # own objects are Ready, leaving the GPU stack (ClusterPolicy -> DCGM exporter)
-  # and the prometheus-adapter metrics APIServices still reconciling. Gating here
-  # lets the stack converge before `aicr validate` runs, so deployment- and
-  # conformance-phase checks evaluate a ready cluster. ClusterPolicy=ready implies
-  # the DCGM exporter operand is rolled out; the two aggregated APIServices imply
-  # prometheus-adapter is serving custom/external metrics.
-  # All readiness checks share a SINGLE READINESS_TIMEOUT_SECONDS budget: compute
-  # one deadline up front and pass each call the time remaining until it, so the
-  # combined barrier cannot run N x the per-check timeout.
+  # Readiness gate: run the deployment validation phase -- the authoritative
+  # expected-resources / ClusterPolicy / DRA / nodewright checks the later
+  # `--phase all` run gates on -- in a retry loop until it passes. `helmfile
+  # apply` returns before operator-driven convergence, and nodewright (skyhook)
+  # reboots the GPU node AFTER gpu-operator first reports ready, re-initing the
+  # operands; proxy signals (ClusterPolicy=ready, Skyhook status.status) read that
+  # transient state as "done" prematurely, so we gate on the real check. It rides
+  # through the reboot via expected-resources' own poll plus this outer retry.
+  # Fail-closed: the install fails if the phase never passes within the budget.
   #
-  # nodewright (skyhook) tuning is waited on FIRST: it reboots the GPU node to
-  # apply kernel tuning, re-initializing the gpu-operator operands after the
-  # operator first reports ClusterPolicy=ready. Checking ClusterPolicy/operands
-  # before that reboot lets the gate pass on a transient pre-reboot ready state,
-  # so wait for tuning to complete before the GPU/metrics checks.
+  # Run against a copy of the config with spec.validate.evidence stripped so the
+  # gate never emits/pushes an evidence bundle -- that is the conformance phase's
+  # job (phase_conformance, `--phase all`).
+  local gate_config; gate_config="$(mktemp)"
+  yq 'del(.spec.validate.evidence)' "${config}" > "${gate_config}"
   local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
-  wait_for "nodewright (skyhook) tuning complete" "$(( ready_deadline - SECONDS ))" \
-    _skyhook_complete
-  wait_for "gpu-operator ClusterPolicy state=ready" "$(( ready_deadline - SECONDS ))" \
-    _clusterpolicy_ready
-  wait_for "custom.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
-    _apiservice_available v1beta1.custom.metrics.k8s.io
-  wait_for "external.metrics.k8s.io APIService Available" "$(( ready_deadline - SECONDS ))" \
-    _apiservice_available v1beta1.external.metrics.k8s.io
+  local attempt=1
+  echo "::group::Readiness gate: validate --phase deployment (timeout ${READINESS_TIMEOUT_SECONDS}s)"
+  until "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null >/dev/null 2>&1; do
+    if (( SECONDS >= ready_deadline )); then
+      echo "::error::deployment readiness gate did not pass within ${READINESS_TIMEOUT_SECONDS}s; final attempt:" >&2
+      "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null 2>&1 || true
+      rm -f "${gate_config}"
+      echo "::endgroup::"
+      exit 1
+    fi
+    echo "deployment phase not ready (attempt ${attempt}); retrying in 15s..."
+    attempt=$(( attempt + 1 ))
+    sleep 15
+  done
+  rm -f "${gate_config}"
+  echo "deployment readiness gate passed (attempt ${attempt})"
+  echo "::endgroup::"
 }
 
 phase_conformance() {


### PR DESCRIPTION
## Summary

Replace the UAT post-install readiness gate's proxy signals with the authoritative check: run `aicr validate --phase deployment` in a retry loop until it passes, then proceed to `--phase all`.

## Motivation / Context

The readiness gate added in #1426/#1429 polled **proxy** signals — `Skyhook.status.status == complete`, `ClusterPolicy.state == ready`, and the metrics APIServices. On a fresh cluster those read "ready" during a *transient* window: nodewright (skyhook) reboots the GPU node for tuning **after** gpu-operator first reports ready, which re-inits the gpu-operator operands (their pods drop back to `Init`/`Pending`). The gate passed on that pre-reboot state, and the later `--phase all` run's deployment-phase `expected-resources` check then failed on the `Pending` pods.

Observed directly in run `28054511667`: the post-install snapshot showed the GPU node `Ready,SchedulingDisabled` (skyhook cordon) with the tuning pod at `Init:1/3`, yet the gate reported `nodewright (skyhook) tuning complete` and `ClusterPolicy state=ready` immediately after. Investigating `deploy.sh` confirmed it has no extra gpu-operator wait we were missing — its gpu-operator readiness is the same `ClusterPolicy.state=ready` assertion — so the fix is to stop proxying and gate on the real deployment phase.

Related: #1426, #1429 (this supersedes their proxy-signal gate)
Fixes: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT test harness (`tests/uat/{aws,gcp}`)

## Implementation Notes

- **Removed** the proxy predicates (`wait_for`, `_skyhook_complete`, `_clusterpolicy_ready`, `_apiservice_available`) from both runners.
- **Added** a retry loop running `aicr validate --phase deployment` until it passes, bounded by `READINESS_TIMEOUT_SECONDS` (20m). That phase *is* `expected-resources` (+ ClusterPolicy/DRA/nodewright), so it can't pass before the cluster genuinely converges, and it rides through the skyhook reboot via expected-resources' own poll plus the outer retry. Fail-closed: a final diagnostic run + `exit 1` if it never passes in budget (`failOnError` defaults true, so `validate` exits non-zero on phase failure).
- **Evidence-stripped gate config**: the loop runs against `yq 'del(.spec.validate.evidence)'` of the test config so the gate never emits/pushes an evidence bundle (emit fires whenever `cfg.evidence != nil`, `pkg/cli/validate.go:389`). The full bundle is still emitted once by the conformance phase (`--phase all`).
- **Timeouts**: install step `25→45`, job `110→130` — the gate runs inside the install step for up to `READINESS_TIMEOUT_SECONDS` on top of one helmfile attempt, and the job cap was the sum of step timeouts.

## Testing

```bash
bash -n tests/uat/aws/run tests/uat/gcp/run        # OK
shellcheck -S warning tests/uat/{aws,gcp}/run      # clean
```

- Gate-loop logic verified in isolation (stub failing twice then succeeding): retries, `set -e`-safe (the failing `until` condition doesn't exit the script), success and timeout paths both correct.
- Workflow YAML parses; `del(.spec.validate.evidence)` preserves the agent block.
- **Not** validated end-to-end on a live cluster — the UAT cluster was torn down before re-test. The proxy-gate's premature pass that this fixes was captured in run `28054511667` (above). yamllint/shellcheck also run in CI via `make qualify`.

## Risk Assessment

- [x] **Low** — UAT test harness only (`tests/uat`); no product/runtime code; fail-closed; revertable.

**Rollout notes:** The gate now deploys validator Jobs/RBAC during the install step (cleaned up after), and `--phase all` redeploys them in the conformance step — minor extra time; the deployment phase passes instantly there since the cluster is already converged. Budget overridable via `READINESS_TIMEOUT_SECONDS`.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [ ] Linter passes (`make lint`) — `bash -n` + shellcheck verified locally; yamllint/shellcheck also run in CI
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (shell harness; gate logic validated as above)
- [ ] I updated docs if user-facing behavior changed — N/A (internal UAT harness)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
