### PR TITLE
chore (validator): pin Trainer self-install JobSet image to promoted registry

### DIFF
--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -64,6 +65,17 @@ const (
 
 	// maxExtractedFileSize caps individual file sizes during tar extraction (50 MB).
 	maxExtractedFileSize = 50 * 1024 * 1024
+
+	// jobSetStagingImageRepo is the JobSet controller image repository referenced by the
+	// upstream Kubeflow Trainer v2.2.0 manifests. It points at the Kubernetes staging
+	// registry, whose tags are garbage-collected (MANIFEST_UNKNOWN/404), so jobset-controller-manager
+	// lands in ImagePullBackOff and its admission webhook has no endpoints.
+	jobSetStagingImageRepo = "us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset"
+
+	// jobSetPromotedImageRepo is the promoted, permanent JobSet image repository on the
+	// production registry. The same tag (e.g. v0.11.0) exists here, so rewriting the repo
+	// prefix is sufficient to make the controller pullable.
+	jobSetPromotedImageRepo = "registry.k8s.io/jobset/jobset"
 )
 
 // trainerResourceRef identifies a Kubernetes resource applied during Trainer installation,
@@ -127,6 +139,10 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 		if err != nil {
 			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to marshal Trainer resource to YAML", err)
 		}
+
+		// Repoint the JobSet controller image off the garbage-collected staging registry
+		// onto the promoted production registry before applying (see issue #1430).
+		yamlBytes = rewriteJobSetStagingImage(yamlBytes)
 
 		obj := &unstructured.Unstructured{}
 		if unmarshalErr := yaml.Unmarshal(yamlBytes, obj); unmarshalErr != nil {
@@ -192,6 +208,23 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 	}
 
 	return applied, nil
+}
+
+// rewriteJobSetStagingImage rewrites any reference to the garbage-collected JobSet
+// staging-registry image repository onto the promoted production registry, preserving
+// the tag/digest. The Kubeflow Trainer v2.2.0 manifests pin the JobSet controller image
+// to the Kubernetes staging registry, whose tags have been garbage-collected; left as-is
+// the jobset-controller-manager enters ImagePullBackOff and its admission webhook has no
+// endpoints, so the NCCL TrainJob cannot create pods (issue #1430). The replacement is a
+// repo-prefix swap only, so it is tag-agnostic and a no-op when the staging repo is absent.
+func rewriteJobSetStagingImage(yamlBytes []byte) []byte {
+	if !bytes.Contains(yamlBytes, []byte(jobSetStagingImageRepo)) {
+		return yamlBytes
+	}
+	rewritten := bytes.ReplaceAll(yamlBytes, []byte(jobSetStagingImageRepo), []byte(jobSetPromotedImageRepo))
+	slog.Info("Rewrote JobSet image off staging registry",
+		"from", jobSetStagingImageRepo, "to", jobSetPromotedImageRepo)
+	return rewritten
 }
 
 // deleteTrainer removes every resource that was created by installTrainer, in reverse

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteJobSetStagingImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantChanged bool
+	}{
+		{
+			name:        "staging image with v0.11.0 tag is repointed",
+			input:       "        image: us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:v0.11.0\n",
+			wantChanged: true,
+		},
+		{
+			name:        "staging image with arbitrary tag is repointed (tag-agnostic)",
+			input:       "image: us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:v0.99.9",
+			wantChanged: true,
+		},
+		{
+			name:        "already-promoted image is left untouched",
+			input:       "image: registry.k8s.io/jobset/jobset:v0.11.0",
+			wantChanged: false,
+		},
+		{
+			name:        "unrelated resource is left untouched",
+			input:       "image: nvcr.io/nvidia/some-image:latest",
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(rewriteJobSetStagingImage([]byte(tt.input)))
+
+			if strings.Contains(got, jobSetStagingImageRepo) {
+				t.Errorf("output still references staging repo %q: %s", jobSetStagingImageRepo, got)
+			}
+
+			changed := got != tt.input
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v (output: %s)", changed, tt.wantChanged, got)
+			}
+
+			if tt.wantChanged && !strings.Contains(got, jobSetPromotedImageRepo) {
+				t.Errorf("output does not reference promoted repo %q: %s", jobSetPromotedImageRepo, got)
+			}
+		})
+	}
+}
+
+// TestRewriteJobSetStagingImage_PreservesTag verifies the rewrite is a repo-prefix swap
+// that preserves the original tag.
+func TestRewriteJobSetStagingImage_PreservesTag(t *testing.T) {
+	in := "image: " + jobSetStagingImageRepo + ":v0.11.0"
+	want := "image: " + jobSetPromotedImageRepo + ":v0.11.0"
+	if got := string(rewriteJobSetStagingImage([]byte(in))); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Pin the JobSet controller image used by the NCCL performance validator's Kubeflow Trainer **self-install** to the promoted production registry (`registry.k8s.io/jobset/jobset`), aligning that path with AICR's `kubeflow-trainer` Helm chart and making the performance phase resilient on clusters that lack a pre-installed Trainer.

## Motivation / Context

The performance validator can install Kubeflow Trainer itself when the cluster lacks it — an **undocumented, ephemeral test fixture** in `validators/performance/trainer_lifecycle.go` (install-if-absent → run NCCL test → tear down; gated only by a CRD existence check, no flag). That self-install builds the upstream Trainer **v2.2.0 GitHub kustomize manifests**, which pin the JobSet controller image to the Kubernetes **staging** registry `us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:v0.11.0`. Staging tags are garbage-collected, so `jobset-controller-manager` enters `ImagePullBackOff`, its admission webhook (`mjobset.kb.io`) has no endpoints, and the NCCL TrainJob cannot start — the performance phase fails after a long timeout.

This is **not a regression** and is confined to one path. The supported, documented path — installing Trainer via AICR's `kubeflow-trainer` Helm component (`oci://ghcr.io/kubeflow/charts/kubeflow-trainer:2.2.0`) — already renders the **promoted** `registry.k8s.io/jobset/jobset:v0.11.0` and is unaffected. The defect is the inconsistency: the in-repo self-install fixture references an ephemeral registry that bit-rotted. This change hardens that fixture to match.

Fixes: #1430

## Type of Change

- [x] New feature / enhancement (hardening of the validator self-install fixture; aligns it with the Helm path)

> Note: `NVIDIA/aicr` has no `enhancement`/`bug` repo labels; the conventional-commit type (`feat`) carries the classification.

## Component(s) Affected

- [x] Validator (`pkg/validator` — `validators/performance`)

## Implementation Notes

- `installTrainer` passes each built manifest through a new `rewriteJobSetStagingImage` helper before applying — swaps the staging repo prefix for the promoted production repo.
- Repo-prefix swap only: **tag-agnostic** (works for any future v0.x tag) and a **no-op** when the staging repo is absent (e.g. an upstream-fixed manifest).
- Scoped strictly to the self-install path. The Helm/bundle path does not call this code, runs in a different process, and renders the promoted image already — **zero behavioral impact** there.

## Testing

Unit:
```bash
go test ./validators/performance/ -run TestRewriteJobSetStagingImage -v   # PASS
golangci-lint run -c .golangci.yaml ./validators/performance/...          # 0 issues
```

Live A/B on GKE `aicr-demo5` (H100, COS), clean-cluster self-install path, same recipe (`gke/h100/cos/training/kubeflow`), only the validator image differs:

| | Unfixed (`:edge`) | Fixed (this PR) |
|---|---|---|
| JobSet image deployed | `…/k8s-staging-images/jobset/jobset:v0.11.0` | `registry.k8s.io/jobset/jobset:v0.11.0` |
| `jobset-controller-manager` | `ImagePullBackOff` (`NotFound`) | `Running 1/1` |
| TrainJob | never created (webhook no endpoints) | launched: launcher + 2 workers on GPU nodes |
| Verdict | fails | **`passed` — 338.22 GB/s** (threshold 225, `>= 250 → true`), phase 2m34s |

Validator emitted `Rewrote JobSet image off staging registry from=…/k8s-staging-images/… to=registry.k8s.io/jobset/jobset`. Result matches the issue's manual repro (~338 GB/s after hand-patching), confirming the image path was the sole defect.

## Risk Assessment

- [x] **Low** — Isolated change on the validator's self-install path, covered by unit tests and a live A/B, trivially revertible. No effect on the bundle/Helm path.

**Rollout notes:** N/A — no API, recipe, or user-facing surface change.

## Follow-ups (out of scope, noted on #1430)

- `deleteTrainer` doesn't clean up cluster-scoped resources (ClusterRoles/Bindings, webhook configs), which then collide with a later Helm install of the `kubeflow-trainer` component.
- Design question: whether the self-install fixture should exist at all vs. failing fast when Trainer is absent (consistent with the deployment-phase recommendation), and/or hardening `isTrainerInstalled` to check controller readiness.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed (N/A — internal validator fixture)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
