### PR TITLE
feat(evidence): --no-sign push and pending/structured-cause verify

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -829,6 +829,7 @@ aicr validate [flags]
 | `--full` | | bool | false | Emit the full (unredacted) evidence bundle. By default the bundle is minimized: `snapshot.yaml` is reduced to an allowlisted set of fields (dropping node names, provider instance IDs, the node label/taint set, OS tuning, loaded modules, systemd config) and per-test CTRF `stdout`/`message` are omitted. `--full` ships the raw payloads. The cryptographic verification story holds either way; minimal bundles record the applied policy in `predicate.redaction` and self-verify with `aicr evidence verify`. |
 | `--bom` | | string | | Path to a CycloneDX BOM (`bom.cdx.json`) to embed. Optional with `--emit-attestation`; when omitted, aicr synthesizes a recipe-bound BOM from the recipe's component refs + validator catalog images. Pass `make bom`'s output for an exhaustive BOM. |
 | `--push` | | string | | OCI registry reference to push the signed summary bundle to. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. The `sha256:` digest is the canonical address, so the tag is only a human-readable label — tag choice never affects verification. Omit the tag and aicr derives a unique per-recipe one, `<recipe-slug>-<short-fingerprint>` (e.g. `ghcr.io/myorg/aicr-evidence:h100-eks-ubuntu-training-3f9a1c2b4d5e`), so distinct attestations never collide on a shared tag. Pass an explicit tag to override. |
+| `--no-sign` | | bool | false | Push the evidence bundle **unsigned** (requires `--emit-attestation` and `--push`) and write a `pointer.yaml` with an empty `signer` block. Defers Fulcio/Rekor signing to the fork-based CI workflow, so the network-light push can run where the cluster lives even when Sigstore egress is blocked. No-op unless both `--emit-attestation` and `--push` are set. `aicr evidence verify` reports the resulting pointer as a non-failing **pending signature** state. |
 | `--plain-http` | | bool | false | Use HTTP instead of HTTPS for evidence push (local registry tests). |
 | `--insecure-tls` | | bool | false | Skip TLS verification for evidence push (self-signed registries). |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for `--push` keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr bundle --attest`. |
@@ -2613,23 +2614,25 @@ The positional `<bundle-dir>` is either the directory `--emit-attestation` wrote
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--push` | | string | | OCI registry reference to push the signed summary bundle to. Required. Triggers Sigstore keyless signing via the precedence chain documented under `--identity-token`. Omit the tag and aicr derives a unique per-recipe one (`<recipe-slug>-<short-fingerprint>`); pass an explicit tag to override. See [`aicr validate --push`](#aicr-validate). |
+| `--no-sign` | | bool | `false` | Push the bundle **unsigned** and write a `pointer.yaml` with an empty `signer` block, instead of signing. Skips all OIDC/Fulcio/Rekor steps (and the identity-disclosure prompt), so it runs even where Sigstore egress is blocked. The bundle's content reference (`bundle.oci`/`bundle.digest`) is still recorded; complete the signing leg later with the fork-based CI workflow. `aicr evidence verify` reports such a pointer as a non-failing **pending signature** state. |
 | `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr validate --push`. |
 | `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
 | `--yes` | `--assume-yes` | bool | `false` | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. See [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures). |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS when pushing the OCI artifact (local-registry tests). |
 | `--insecure-tls` | | bool | `false` | Skip TLS verification when pushing the OCI artifact (self-signed registries). |
 
-> **Identity disclosure:** `evidence publish` always signs. On the interactive
-> (browser / device-code) keyless paths it publishes the signer's identity
-> (email + issuer) to the public Rekor log, so on a TTY it pauses for
-> confirmation first (`--yes` skips it). See
+> **Identity disclosure:** `evidence publish` signs unless `--no-sign` is set.
+> On the interactive (browser / device-code) keyless paths it publishes the
+> signer's identity (email + issuer) to the public Rekor log, so on a TTY it
+> pauses for confirmation first (`--yes` skips it). `--no-sign` runs no OIDC
+> flow, so the prompt is skipped entirely. See
 > [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures).
 
 **Exit codes:**
 
 | Code | Meaning |
 |------|---------|
-| 0 | Bundle signed, pushed, and `pointer.yaml` written. |
+| 0 | Bundle pushed and `pointer.yaml` written (signed, or unsigned with `--no-sign`). |
 | non-zero | Identity-disclosure prompt declined, or bundle could not be loaded, signed, or pushed. |
 
 **Examples:**
@@ -2681,10 +2684,15 @@ The positional argument is auto-detected as one of:
 
 | Code | Meaning |
 |------|---------|
-| 0 | Bundle valid; every check passed. |
-| 2 | Bundle invalid (signature, integrity, or predicate failure), OR recorded validator results show failures. |
+| 0 | Bundle valid; every check passed (or valid but **unsigned** — see pending below). |
+| 1 | Bundle valid, but recorded validator phase results show failures (informational). |
+| 2 | Bundle invalid. The `failureCause.class` field gives the specific reason — registry access (`registry-forbidden`/`not-found`/`registry`), `signature`, `integrity`, `schema`, or `unknown` (see Failure cause below). |
 
-The JSON/Markdown output's `exit` field (and `VerifyResult.Exit` from the library API) still distinguishes the two non-zero cases as `1` (recorded phase failures) vs `2` (bundle invalid). Shell consumers can branch via `jq '.exit'` on `--format json` output.
+The JSON/Markdown output's `exit` field mirrors `VerifyResult.Exit` from the library API. Shell consumers can branch via `jq '.exit'` on `--format json` output.
+
+**Pending signature.** An unsigned bundle whose pointer carries no `signer` (e.g. one published with `--no-sign`, awaiting the signing leg) is **not** a failure: it verifies at exit `0` with `pending: true` in the JSON output and a "pending signature" verdict in the Markdown summary. This lets an in-flight PR commit an unsigned pointer without the gate flagging it as broken.
+
+**Failure cause.** On a non-zero exit, the JSON output carries a structured `failureCause` object — `class` (one of `registry-forbidden`, `not-found`, `registry`, `signature`, `integrity`, `schema`, `unknown`), an optional `httpStatus`, and an actionable `hint`. For example, a private fork registry returns `class: registry-forbidden`, `httpStatus: 403` with a hint to make the package public — so the reason is self-serviceable rather than a bare "invalid". The Markdown summary renders the same as **Cause**/**Hint** lines.
 
 **Examples:**
 ```shell

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -54,6 +54,12 @@ const (
 	flagInsecureTLS    = "insecure-tls"
 	flagPlainHTTP      = "plain-http"
 	flagPush           = "push"
+	// flagNoSign pushes an unsigned evidence bundle and writes a pointer whose
+	// attestation has a nil Signer (the unsigned state — distinct from a
+	// signed-without-Rekor pointer, which has a Signer with a nil
+	// rekorLogIndex). Decouples the network-light push leg from the
+	// Fulcio-bound signing leg, which the fork-based CI workflow completes later.
+	flagNoSign = "no-sign"
 	// flagFull ships an unredacted evidence bundle. By default the bundle is
 	// minimized (sensitive snapshot fields and CTRF logs removed).
 	flagFull = "full"

--- a/pkg/cli/evidence_publish.go
+++ b/pkg/cli/evidence_publish.go
@@ -70,6 +70,11 @@ Example:
 				Category: catEvidence,
 			},
 			&cli.BoolFlag{
+				Name:     flagNoSign,
+				Usage:    "Push the bundle unsigned and write a pointer with an empty signer block, instead of signing. Sign it later via the fork-based CI workflow. Skips all OIDC/Fulcio/Rekor steps.",
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
 				Name:     flagPlainHTTP,
 				Usage:    "Use HTTP instead of HTTPS when pushing the evidence OCI artifact (local registry tests).",
 				Category: catEvidence,
@@ -112,13 +117,17 @@ func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
 		return errors.New(errors.ErrCodeInvalidRequest, "--push <oci-ref> is required")
 	}
 
-	// `evidence publish` always signs (push is required), so gate the
-	// interactive keyless login behind the identity-disclosure prompt before
-	// it can open a browser/device-code flow. Non-interactive token sources
-	// and non-TTY runs pass through inside the gate.
+	// Unless --no-sign is set, `evidence publish` signs (push is required), so
+	// gate the interactive keyless login behind the identity-disclosure prompt
+	// before it can open a browser/device-code flow. Non-interactive token
+	// sources and non-TTY runs pass through inside the gate. With --no-sign no
+	// OIDC flow runs, so the prompt is skipped entirely.
+	noSign := cmd.Bool(flagNoSign)
 	oidcResolve := oidcResolveOptionsFromFlags(cmd)
-	if err := confirmKeylessSigningDisclosure(oidcResolve, cmd.Bool(flagAssumeYes), os.Stdin, os.Stderr); err != nil {
-		return err
+	if !noSign {
+		if err := confirmKeylessSigningDisclosure(oidcResolve, cmd.Bool(flagAssumeYes), os.Stdin, os.Stderr); err != nil {
+			return err
+		}
 	}
 
 	err := attestation.Publish(ctx, attestation.PublishOptions{
@@ -126,6 +135,7 @@ func runEvidencePublishCmd(ctx context.Context, cmd *cli.Command) error {
 		Push:        push,
 		PlainHTTP:   cmd.Bool(flagPlainHTTP),
 		InsecureTLS: cmd.Bool(flagInsecureTLS),
+		NoSign:      noSign,
 		AICRVersion: version,
 		OIDCResolve: oidcResolve,
 	})

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -568,6 +568,13 @@ func validateCmdFlags() []cli.Flag {
 			Category: catEvidence,
 		},
 		&cli.BoolFlag{
+			Name: flagNoSign,
+			Usage: `Push the evidence bundle unsigned (requires --emit-attestation and --push) and write a pointer with an empty signer block.
+	Defers Fulcio/Rekor signing to a later step (the fork-based CI workflow), so the network-light push can run
+	where the cluster lives even when Sigstore egress is blocked. No-op unless both --emit-attestation and --push are set.`,
+			Category: catEvidence,
+		},
+		&cli.BoolFlag{
 			Name:     flagPlainHTTP,
 			Usage:    "Use HTTP instead of HTTPS when pushing the evidence OCI artifact (local registry tests).",
 			Category: catEvidence,

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -38,6 +38,12 @@ type recipeEvidenceConfig struct {
 	PlainHTTP   bool
 	InsecureTLS bool
 
+	// NoSign pushes an unsigned bundle and writes a pointer with an empty
+	// signer block (requires Push). Defers Fulcio/Rekor signing; see
+	// attestation.EmitOptions.NoSign. CLI-only — there is no config-file
+	// equivalent, mirroring Full.
+	NoSign bool
+
 	// Full disables evidence minimization. Default (false) ships a redacted
 	// snapshot and CTRF reports with stdout/message omitted; --full ships the
 	// raw payloads. CLI-only — there is no config-file equivalent.
@@ -73,6 +79,7 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 		Push:        stringFlagOrConfig(cmd, flagPush, att.Push),
 		PlainHTTP:   boolFlagOrConfig(cmd, flagPlainHTTP, att.PlainHTTP),
 		InsecureTLS: boolFlagOrConfig(cmd, flagInsecureTLS, att.InsecureTLS),
+		NoSign:      cmd.Bool(flagNoSign),
 		Full:        cmd.Bool(flagFull),
 		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
 		AssumeYes:   cmd.Bool(flagAssumeYes),
@@ -115,11 +122,13 @@ func emitRecipeEvidence(
 	cfg *recipeEvidenceConfig,
 ) error {
 
-	// Signing happens only when --push is set (see attestation.Emit). Gate the
-	// interactive keyless login behind the identity-disclosure prompt before
-	// the long validation-and-push run can open a browser/device-code flow.
-	// Non-interactive token sources and non-TTY runs pass through inside the gate.
-	if cfg.Push != "" {
+	// Signing happens only when --push is set without --no-sign (see
+	// attestation.Emit). Gate the interactive keyless login behind the
+	// identity-disclosure prompt before the long validation-and-push run can
+	// open a browser/device-code flow. Non-interactive token sources and
+	// non-TTY runs pass through inside the gate; --no-sign skips it entirely
+	// because no OIDC flow runs.
+	if cfg.Push != "" && !cfg.NoSign {
 		if err := confirmKeylessSigningDisclosure(cfg.OIDCResolve, cfg.AssumeYes, os.Stdin, os.Stderr); err != nil {
 			return err
 		}
@@ -136,6 +145,7 @@ func emitRecipeEvidence(
 		Push:         cfg.Push,
 		PlainHTTP:    cfg.PlainHTTP,
 		InsecureTLS:  cfg.InsecureTLS,
+		NoSign:       cfg.NoSign,
 		Full:         cfg.Full,
 		Recipe:       rec,
 		Snapshot:     snap,

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -51,6 +51,13 @@ type EmitOptions struct {
 	PlainHTTP   bool
 	InsecureTLS bool
 
+	// NoSign pushes the bundle unsigned and writes a pointer with an empty
+	// signer block. Consulted only when Push is set; with Push empty the
+	// bundle is already local-only and unsigned. Lets the network-light push
+	// run where the cluster lives and defers Fulcio/Rekor signing to the
+	// fork-based CI workflow.
+	NoSign bool
+
 	// Full disables minimization. By default (Full=false) the bundle ships a
 	// redacted snapshot and CTRF reports with stdout/message omitted, and the
 	// predicate records the redaction policy. Full=true ships the raw
@@ -164,6 +171,7 @@ func Emit(ctx context.Context, opts EmitOptions) (*EmitResult, error) {
 		InsecureTLS: opts.InsecureTLS,
 		AICRVersion: opts.AICRVersion,
 		OIDCResolve: opts.OIDCResolve,
+		NoSign:      opts.NoSign,
 	})
 	if err != nil {
 		return nil, err
@@ -255,6 +263,13 @@ type signPushOptions struct {
 	InsecureTLS bool
 	AICRVersion string
 	OIDCResolve bundleattest.ResolveOptions
+
+	// NoSign pushes the bundle but skips the Fulcio/Rekor signing and the
+	// Sigstore-referrer attach. The resulting pointer carries
+	// bundle.oci/digest with an empty signer block, to be signed later by
+	// the fork-based CI workflow. Decouples the network-light push leg from
+	// the Fulcio-bound signing leg.
+	NoSign bool
 }
 
 // signAndPush handles the optional sign+push pipeline. Returns a
@@ -292,6 +307,16 @@ func signAndPush(ctx context.Context, bundle *Bundle, opts signPushOptions) (emi
 	})
 	if err != nil {
 		return emitOutcome{}, err
+	}
+
+	// Push-without-sign: stop after the content-addressed push. The pointer
+	// built from this outcome carries bundle.oci/digest with a nil Signer,
+	// signaling "pending signature" to verifiers and the gate.
+	if opts.NoSign {
+		slog.Info("evidence bundle pushed unsigned (--no-sign); sign later via the fork-based CI workflow",
+			"reference", summary.Reference,
+			"digest", summary.Digest)
+		return emitOutcome{PushSummary: summary}, nil
 	}
 
 	artifactDigestHex := strings.TrimPrefix(summary.Digest, "sha256:")

--- a/pkg/evidence/attestation/emit_test.go
+++ b/pkg/evidence/attestation/emit_test.go
@@ -267,6 +267,30 @@ func TestBuildPointerInputsFromOutcome_SignedWithoutRekorLeavesIndexNil(t *testi
 	}
 }
 
+// TestBuildPointerInputsFromOutcome_PushedUnsigned covers the --no-sign
+// outcome: the bundle was pushed (so bundle.oci/digest are populated) but
+// not signed (Sign nil), so the resulting pointer carries a content
+// reference with an empty signer block — the "pending signature" state the
+// fork-based signing workflow later completes.
+func TestBuildPointerInputsFromOutcome_PushedUnsigned(t *testing.T) {
+	bundle := &Bundle{RecipeName: "x", Predicate: &Predicate{}}
+	in := buildPointerInputsFromOutcome(bundle, emitOutcome{
+		PushSummary: &PushResult{
+			Reference: "oci://ghcr.io/owner/aicr-evidence:tag",
+			Digest:    "sha256:abc",
+		},
+	})
+	if in.Signer != nil {
+		t.Errorf("pushed-unsigned outcome should leave Signer nil; got %+v", in.Signer)
+	}
+	if in.BundleOCI != "ghcr.io/owner/aicr-evidence:tag" {
+		t.Errorf("BundleOCI should be the scheme-trimmed push reference; got %q", in.BundleOCI)
+	}
+	if in.BundleHash != "sha256:abc" {
+		t.Errorf("BundleHash = %q, want sha256:abc", in.BundleHash)
+	}
+}
+
 func TestSignAndPush_NoPushReturnsZeroOutcome(t *testing.T) {
 	bundle := &Bundle{SummaryDir: "/tmp/x"}
 	out, err := signAndPush(context.Background(), bundle, signPushOptions{})

--- a/pkg/evidence/attestation/publish.go
+++ b/pkg/evidence/attestation/publish.go
@@ -46,6 +46,12 @@ type PublishOptions struct {
 	PlainHTTP   bool
 	InsecureTLS bool
 
+	// NoSign pushes the unsigned bundle and writes a pointer with an empty
+	// signer block instead of signing. The Fulcio/Rekor leg is deferred to
+	// `aicr evidence sign` (or the fork-based CI workflow). When false,
+	// Publish signs as before.
+	NoSign bool
+
 	// AICRVersion is stamped into the pushed OCI manifest's annotations.
 	// It does not alter the signed predicate, which is read verbatim from
 	// the bundle's statement.intoto.json — the bundle bytes (and their
@@ -101,6 +107,7 @@ func Publish(ctx context.Context, opts PublishOptions) error {
 		InsecureTLS: opts.InsecureTLS,
 		AICRVersion: opts.AICRVersion,
 		OIDCResolve: opts.OIDCResolve,
+		NoSign:      opts.NoSign,
 	})
 	if err != nil {
 		return err

--- a/pkg/evidence/verifier/failure.go
+++ b/pkg/evidence/verifier/failure.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifier
+
+import (
+	stderrors "errors"
+
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+// setFailureCause records the classified reason for a non-zero Exit, but
+// only the first one — verification runs steps in order, so the earliest
+// failure is the root cause and later steps' errors are usually fallout.
+func setFailureCause(r *VerifyResult, step int, err error) {
+	if r == nil || err == nil || r.FailureCause != nil {
+		return
+	}
+	r.FailureCause = classifyFailure(step, err)
+}
+
+// classifyFailure turns a step error into a structured, actionable cause.
+// A registry HTTP status (extracted from the oras error chain) takes
+// precedence over the step identity because a 403/404 pulling the bundle is
+// the same actionable problem regardless of which step surfaced it; absent a
+// status, the step that failed selects the class.
+func classifyFailure(step int, err error) *FailureCause {
+	if c := classifyRegistryError(err); c != nil {
+		return c
+	}
+	c := &FailureCause{Detail: err.Error()}
+	switch step {
+	case stepSignature:
+		c.Class = CauseSignature
+	case stepInventory:
+		c.Class = CauseIntegrity
+	case stepPredicate:
+		c.Class = CauseSchema
+	default:
+		// Includes stepMaterialize with no registry status: Verify also
+		// accepts unpacked local directories, so a status-less materialize
+		// failure (missing dir, malformed reference) is not necessarily a
+		// registry problem. Without registry evidence, leave it unknown rather
+		// than asserting a registry cause that would drive the wrong remediation.
+		c.Class = CauseUnknown
+	}
+	return c
+}
+
+// classifyRegistryError walks the error chain for an oras registry response
+// and maps its HTTP status to an actionable cause. Returns nil when no
+// registry status is present.
+func classifyRegistryError(err error) *FailureCause {
+	var respErr *errcode.ErrorResponse
+	if !stderrors.As(err, &respErr) {
+		return nil
+	}
+	c := &FailureCause{Detail: err.Error(), HTTPStatus: respErr.StatusCode}
+	switch respErr.StatusCode {
+	case 401, 403:
+		c.Class = CauseRegistryForbidden
+		c.Hint = "registry not accessible (make the fork's aicr-evidence package public, or provide registry credentials)"
+	case 404:
+		c.Class = CauseNotFound
+		c.Hint = "bundle not found at the referenced digest (was it pushed to this registry?)"
+	default:
+		c.Class = CauseRegistry
+	}
+	return c
+}

--- a/pkg/evidence/verifier/failure_test.go
+++ b/pkg/evidence/verifier/failure_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifier
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"oras.land/oras-go/v2/registry/remote/errcode"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestClassifyFailure_RegistryStatusTakesPrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		step       int
+		wantClass  string
+		wantStatus int
+		wantHint   bool
+	}{
+		{"forbidden", http.StatusForbidden, stepMaterialize, CauseRegistryForbidden, 403, true},
+		{"unauthorized", http.StatusUnauthorized, stepMaterialize, CauseRegistryForbidden, 401, true},
+		{"not found", http.StatusNotFound, stepMaterialize, CauseNotFound, 404, true},
+		{"other status", http.StatusInternalServerError, stepMaterialize, CauseRegistry, 500, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Wrap through pkg/errors to mimic the real chain MaterializeBundle
+			// produces (errors.Wrap over the oras response error).
+			err := errors.Wrap(errors.ErrCodeUnavailable, "OCI pull failed",
+				&errcode.ErrorResponse{StatusCode: tt.status})
+			c := classifyFailure(tt.step, err)
+			if c.Class != tt.wantClass {
+				t.Errorf("Class = %q, want %q", c.Class, tt.wantClass)
+			}
+			if c.HTTPStatus != tt.wantStatus {
+				t.Errorf("HTTPStatus = %d, want %d", c.HTTPStatus, tt.wantStatus)
+			}
+			switch {
+			case tt.wantHint && c.Hint == "":
+				t.Errorf("expected an actionable hint for status %d", tt.status)
+			case !tt.wantHint && c.Hint != "":
+				t.Errorf("status %d should carry no remediation hint; got %q", tt.status, c.Hint)
+			}
+		})
+	}
+}
+
+func TestClassifyFailure_StepWhenNoRegistryStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		step      int
+		wantClass string
+	}{
+		{"signature", stepSignature, CauseSignature},
+		{"inventory", stepInventory, CauseIntegrity},
+		{"predicate", stepPredicate, CauseSchema},
+		{"materialize (no registry status) is unknown, not registry", stepMaterialize, CauseUnknown},
+		{"unknown step", 99, CauseUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := classifyFailure(tt.step, errors.New(errors.ErrCodeInvalidRequest, "boom"))
+			if c.Class != tt.wantClass {
+				t.Errorf("Class = %q, want %q", c.Class, tt.wantClass)
+			}
+			if !strings.Contains(c.Detail, "boom") {
+				t.Errorf("Detail = %q, want it to contain %q", c.Detail, "boom")
+			}
+			if c.HTTPStatus != 0 {
+				t.Errorf("HTTPStatus should be 0 without a registry status; got %d", c.HTTPStatus)
+			}
+		})
+	}
+}
+
+func TestSetFailureCause_FirstWins(t *testing.T) {
+	r := &VerifyResult{}
+	setFailureCause(r, stepMaterialize, errors.New(errors.ErrCodeUnavailable, "first"))
+	setFailureCause(r, stepInventory, errors.New(errors.ErrCodeInternal, "second"))
+	if r.FailureCause == nil || !strings.Contains(r.FailureCause.Detail, "first") {
+		t.Fatalf("expected first failure to win; got %+v", r.FailureCause)
+	}
+}
+
+func TestSetFailureCause_IgnoresNil(t *testing.T) {
+	r := &VerifyResult{}
+	setFailureCause(r, stepMaterialize, nil)
+	if r.FailureCause != nil {
+		t.Errorf("nil error should not set a cause; got %+v", r.FailureCause)
+	}
+}
+
+func TestWriteVerdict_PendingAndCause(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *VerifyResult
+		wantText []string
+	}{
+		{
+			name:     "pending signature verdict",
+			result:   &VerifyResult{Exit: ExitValidPassed, Pending: true},
+			wantText: []string{"pending signature"},
+		},
+		{
+			name: "invalid verdict renders classified cause",
+			result: &VerifyResult{
+				Exit: ExitInvalid,
+				FailureCause: &FailureCause{
+					Class:      CauseRegistryForbidden,
+					HTTPStatus: 403,
+					Hint:       "make the fork's aicr-evidence package public",
+					Detail:     "OCI pull failed",
+				},
+			},
+			wantText: []string{CauseRegistryForbidden, "HTTP 403", "package public", "OCI pull failed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RenderMarkdown(tt.result)
+			for _, want := range tt.wantText {
+				if !strings.Contains(got, want) {
+					t.Errorf("verdict missing %q:\n%s", want, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/evidence/verifier/report.go
+++ b/pkg/evidence/verifier/report.go
@@ -196,11 +196,36 @@ func writeVerdict(b *strings.Builder, r *VerifyResult) {
 	b.WriteString("---\n")
 	switch r.Exit {
 	case ExitValidPassed:
-		b.WriteString("**Verdict:** bundle valid — all checks passed (exit 0)\n")
+		if r.Pending {
+			b.WriteString("**Verdict:** bundle valid but unsigned — pending signature (exit 0)\n")
+		} else {
+			b.WriteString("**Verdict:** bundle valid — all checks passed (exit 0)\n")
+		}
 	case ExitValidPhaseFailures:
 		b.WriteString("**Verdict:** bundle valid; recorded validator phase results show failures (exit 1, informational)\n")
 	case ExitInvalid:
-		b.WriteString("**Verdict:** bundle invalid — integrity check(s) failed (exit 2)\n")
+		b.WriteString("**Verdict:** bundle invalid — verification failed (exit 2)\n")
+		writeFailureCause(b, r.FailureCause)
+	}
+}
+
+// writeFailureCause appends a classified, actionable cause line so a reader
+// of the PR comment sees *why* verification failed (e.g. a registry 403),
+// not just "invalid".
+func writeFailureCause(b *strings.Builder, c *FailureCause) {
+	if c == nil {
+		return
+	}
+	fmt.Fprintf(b, "**Cause:** `%s`", c.Class)
+	if c.HTTPStatus != 0 {
+		fmt.Fprintf(b, " (HTTP %d)", c.HTTPStatus)
+	}
+	b.WriteString("\n")
+	if c.Hint != "" {
+		fmt.Fprintf(b, "**Hint:** %s\n", c.Hint)
+	}
+	if c.Detail != "" {
+		fmt.Fprintf(b, "\n> %s\n", escapeMD(c.Detail))
 	}
 }
 

--- a/pkg/evidence/verifier/testbundle_test.go
+++ b/pkg/evidence/verifier/testbundle_test.go
@@ -32,6 +32,19 @@ import (
 // bundle root (which contains summary-bundle/).
 func buildTestBundle(t *testing.T) string {
 	t.Helper()
+	return buildBundle(t, false)
+}
+
+// buildTestBundleFailedPhase is like buildTestBundle but records a failed
+// deployment phase, so the predicate's phase summary has Failed > 0 and
+// Verify reports the informational exit-1 (valid bundle, phase failures).
+func buildTestBundleFailedPhase(t *testing.T) string {
+	t.Helper()
+	return buildBundle(t, true)
+}
+
+func buildBundle(t *testing.T, withPhaseFailure bool) string {
+	t.Helper()
 	dir := t.TempDir()
 
 	rec := &recipe.RecipeResult{
@@ -46,9 +59,14 @@ func buildTestBundle(t *testing.T) string {
 	}
 	bom := []byte(`{"bomFormat":"CycloneDX","specVersion":"1.6","components":[{"name":"a"},{"name":"b"}]}`)
 	report := &ctrf.Report{}
+	status := "passed"
 	report.Results.Summary = ctrf.Summary{Tests: 1, Passed: 1, Failed: 0, Skipped: 0}
+	if withPhaseFailure {
+		status = "failed"
+		report.Results.Summary = ctrf.Summary{Tests: 1, Passed: 0, Failed: 1, Skipped: 0}
+	}
 	phaseResults := []*validator.PhaseResult{
-		{Phase: validator.PhaseDeployment, Status: "passed", Report: report, Duration: time.Second},
+		{Phase: validator.PhaseDeployment, Status: status, Report: report, Duration: time.Second},
 	}
 
 	_, err := attestation.Build(context.Background(), attestation.BuildOptions{

--- a/pkg/evidence/verifier/types.go
+++ b/pkg/evidence/verifier/types.go
@@ -105,6 +105,36 @@ type KV struct {
 	Value string `json:"value" yaml:"value"`
 }
 
+// Failure-cause classes recorded in FailureCause.Class. Stable strings so
+// the gate script (and future tooling) can branch on them without parsing
+// human prose. They classify *why* a verification failed, complementing the
+// coarse Exit code.
+const (
+	CauseRegistryForbidden = "registry-forbidden" // 401/403 pulling the bundle
+	CauseNotFound          = "not-found"          // 404 — bundle/referrer absent at ref
+	CauseRegistry          = "registry"           // other registry/transport failure
+	CauseSignature         = "signature"          // signature/cert/identity verification failed
+	CauseIntegrity         = "integrity"          // manifest hash-chain mismatch
+	CauseSchema            = "schema"             // predicate parse / schema / type error
+	CauseUnknown           = "unknown"            // unclassified
+)
+
+// FailureCause is the structured, machine-readable reason a verification
+// produced a non-zero Exit. The gate renders Class/Hint into the PR comment
+// so a contributor can self-serve the fix (e.g. a 403 → "make the fork's
+// aicr-evidence package public") instead of seeing a bare "invalid".
+type FailureCause struct {
+	// Class is one of the Cause* constants — a stable identifier.
+	Class string `json:"class" yaml:"class"`
+	// Detail is the underlying error message (sanitized).
+	Detail string `json:"detail" yaml:"detail"`
+	// HTTPStatus is the registry HTTP status when the failure was a
+	// registry response (0 otherwise).
+	HTTPStatus int `json:"httpStatus,omitempty" yaml:"httpStatus,omitempty"`
+	// Hint is an actionable, human-facing remediation when one is known.
+	Hint string `json:"hint,omitempty" yaml:"hint,omitempty"`
+}
+
 // VerifyResult is what Verify returns to its caller.
 type VerifyResult struct {
 	Input        InputForm              `json:"input" yaml:"input"`
@@ -115,4 +145,14 @@ type VerifyResult struct {
 	BundleDigest string                 `json:"bundleDigest,omitempty" yaml:"bundleDigest,omitempty"`
 	Steps        []StepResult           `json:"steps" yaml:"steps"`
 	Exit         int                    `json:"exit" yaml:"exit"`
+
+	// Pending is true when the bundle is unsigned — a "pending signature"
+	// state, not a failure. An in-flight PR that committed an unsigned
+	// pointer (via `--no-sign`) verifies with Exit 0 and Pending true, so
+	// the gate can render "pending signature" instead of a misleading
+	// "all checks passed" or a false "invalid".
+	Pending bool `json:"pending,omitempty" yaml:"pending,omitempty"`
+
+	// FailureCause classifies a non-zero Exit. nil when Exit is 0/1.
+	FailureCause *FailureCause `json:"failureCause,omitempty" yaml:"failureCause,omitempty"`
 }

--- a/pkg/evidence/verifier/types.go
+++ b/pkg/evidence/verifier/types.go
@@ -153,6 +153,9 @@ type VerifyResult struct {
 	// "all checks passed" or a false "invalid".
 	Pending bool `json:"pending,omitempty" yaml:"pending,omitempty"`
 
-	// FailureCause classifies a non-zero Exit. nil when Exit is 0/1.
+	// FailureCause classifies why the bundle was rejected. Set only when
+	// Exit is ExitInvalid (2); nil for Exit 0 (valid, possibly pending) and
+	// Exit 1 (valid bundle with recorded phase failures), which are not
+	// bundle-invalid outcomes.
 	FailureCause *FailureCause `json:"failureCause,omitempty" yaml:"failureCause,omitempty"`
 }

--- a/pkg/evidence/verifier/verify.go
+++ b/pkg/evidence/verifier/verify.go
@@ -76,6 +76,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	mat, err := MaterializeBundle(ctx, opts, form, pointer)
 	if err != nil {
 		record(r, stepMaterialize, StepFailed, err.Error(), nil)
+		setFailureCause(r, stepMaterialize, err)
 		r.Exit = ExitInvalid
 		return r, nil
 	}
@@ -89,7 +90,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	// present, sigstore-go anchors the DSSE-wrapped Statement to a
 	// Fulcio cert + optional Rekor entry. The predicate inside that
 	// verified Statement is the cryptographically authoritative value.
-	verifiedPredicate := stepSignatureCheck(ctx, r, mat, opts)
+	verifiedPredicate, pendingSignature := stepSignatureCheck(ctx, r, mat, opts)
 
 	// Step 3 — predicate parse. Prefer the predicate the signature
 	// step produced (cryptographically anchored); fall back to the
@@ -98,6 +99,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	pred, perr := resolvePredicate(verifiedPredicate, mat)
 	if perr != nil {
 		record(r, stepPredicate, StepFailed, perr.Error(), nil)
+		setFailureCause(r, stepPredicate, perr)
 		r.Exit = ExitInvalid
 		return r, nil
 	}
@@ -117,6 +119,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	mismatches, invErr := CheckInventory(ctx, mat, pred.Manifest.Digest)
 	if invErr != nil {
 		record(r, stepInventory, StepFailed, invErr.Error(), mismatches)
+		setFailureCause(r, stepInventory, invErr)
 		r.Exit = ExitInvalid
 	} else {
 		record(r, stepInventory, StepPassed,
@@ -128,19 +131,31 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 		r.Exit = ExitValidPhaseFailures
 	}
 
+	// "Pending signature" is strictly an exit-0 state. Set it only once the
+	// final exit is known, so an unsigned bundle that later failed predicate
+	// parsing, the manifest hash check, or carries phase failures is reported
+	// as that failure — never as a misleading pending result with a non-zero
+	// exit.
+	if r.Exit == ExitValidPassed && pendingSignature {
+		r.Pending = true
+	}
+
 	record(r, stepRender, StepInformational, "report assembled", nil)
 	return r, nil
 }
 
 // stepSignatureCheck runs step 2 and returns the cryptographically
-// anchored predicate when the bundle is signed (nil otherwise). Side
-// effects: records the step row, sets r.Signer, may update r.Exit.
+// anchored predicate when the bundle is signed (nil otherwise) plus whether
+// the bundle is unsigned (a candidate "pending signature" state). Side
+// effects: records the step row, sets r.Signer, may update r.Exit. The
+// caller decides whether to surface Pending, since that is only valid once
+// the final exit is known.
 //
 // When the input is a pointer file with a signer claim, this step also
 // cross-checks the pointer's claim against the actual cert. A
 // malicious pointer that names a different signer than the bundle
 // fails here.
-func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedBundle, opts VerifyOptions) *attestation.Predicate {
+func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedBundle, opts VerifyOptions) (*attestation.Predicate, bool) {
 	sig, sigErr := VerifySignature(ctx, mat, opts)
 
 	var claimedSigner *attestation.PointerSigner
@@ -154,22 +169,29 @@ func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedB
 		if claimedSigner != nil {
 			if ccErr := CrossCheckPointerSigner(claimedSigner, nil); ccErr != nil {
 				record(r, stepSignature, StepFailed, ccErr.Error(), nil)
+				setFailureCause(r, stepSignature, ccErr)
 				r.Exit = ExitInvalid
-				return nil
+				return nil, false
 			}
 		}
-		record(r, stepSignature, StepSkipped, "no signature attached (unsigned bundle)", nil)
-		return nil
+		// Unsigned with no signer claim: a candidate "pending signature"
+		// state, not a failure. The bundle was pushed (often via --no-sign)
+		// and awaits the signing leg; verification of the rest of the bundle
+		// continues. The caller sets r.Pending only if the final exit is 0.
+		record(r, stepSignature, StepSkipped, "no signature attached (unsigned bundle — pending signature)", nil)
+		return nil, true
 	case sigErr != nil:
 		record(r, stepSignature, StepFailed, sigErr.Error(), nil)
+		setFailureCause(r, stepSignature, sigErr)
 		r.Exit = ExitInvalid
-		return nil
+		return nil, false
 	default:
 		r.Signer = sig.Signer
 		if ccErr := CrossCheckPointerSigner(claimedSigner, sig.Signer); ccErr != nil {
 			record(r, stepSignature, StepFailed, ccErr.Error(), nil)
+			setFailureCause(r, stepSignature, ccErr)
 			r.Exit = ExitInvalid
-			return nil
+			return nil, false
 		}
 		detail := "signer " + sig.Signer.Identity + " (issuer " + sig.Signer.Issuer + ")"
 		var sub []KV
@@ -178,7 +200,7 @@ func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedB
 				Value: strconv.FormatInt(*sig.Signer.RekorLogIndex, 10)}}
 		}
 		record(r, stepSignature, StepPassed, detail, sub)
-		return sig.Predicate
+		return sig.Predicate, false
 	}
 }
 

--- a/pkg/evidence/verifier/verify_test.go
+++ b/pkg/evidence/verifier/verify_test.go
@@ -76,15 +76,23 @@ func TestVerify_DirectoryHappyPath(t *testing.T) {
 func TestVerify_PendingOnlyWhenExitZero(t *testing.T) {
 	tests := []struct {
 		name        string
+		build       func(t *testing.T) string             // bundle root; defaults to buildTestBundle
 		tamper      func(t *testing.T, summaryDir string) // nil = leave the bundle intact
 		wantExit    int
 		wantPending bool
 	}{
 		{
 			name:        "clean unsigned bundle is pending",
-			tamper:      nil,
 			wantExit:    ExitValidPassed,
 			wantPending: true,
+		},
+		{
+			name: "unsigned bundle with phase failures is not pending",
+			// An unsigned bundle that records a failed phase verifies as the
+			// informational exit-1, which must not be reported as pending.
+			build:       buildTestBundleFailedPhase,
+			wantExit:    ExitValidPhaseFailures,
+			wantPending: false,
 		},
 		{
 			name: "unsigned bundle that fails integrity is not pending",
@@ -102,7 +110,11 @@ func TestVerify_PendingOnlyWhenExitZero(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			summary := summaryDirOf(t, buildTestBundle(t))
+			build := tt.build
+			if build == nil {
+				build = buildTestBundle
+			}
+			summary := summaryDirOf(t, build(t))
 			if tt.tamper != nil {
 				tt.tamper(t, summary)
 			}

--- a/pkg/evidence/verifier/verify_test.go
+++ b/pkg/evidence/verifier/verify_test.go
@@ -69,6 +69,57 @@ func TestVerify_DirectoryHappyPath(t *testing.T) {
 	}
 }
 
+// TestVerify_PendingOnlyWhenExitZero guards the contract that "pending
+// signature" is strictly an exit-0 state: an unsigned bundle that verifies
+// cleanly is Pending, but one that also fails the manifest hash check is
+// reported as that failure (exit 2) and must NOT serialize as pending.
+func TestVerify_PendingOnlyWhenExitZero(t *testing.T) {
+	tests := []struct {
+		name        string
+		tamper      func(t *testing.T, summaryDir string) // nil = leave the bundle intact
+		wantExit    int
+		wantPending bool
+	}{
+		{
+			name:        "clean unsigned bundle is pending",
+			tamper:      nil,
+			wantExit:    ExitValidPassed,
+			wantPending: true,
+		},
+		{
+			name: "unsigned bundle that fails integrity is not pending",
+			// Tamper a bundle file so the manifest hash check fails (exit 2)
+			// while the signature step still skips as unsigned.
+			tamper: func(t *testing.T, summaryDir string) {
+				if err := os.WriteFile(filepath.Join(summaryDir, "recipe.yaml"),
+					[]byte("apiVersion: aicr.nvidia.com/v1alpha1\nkind: RecipeResult\nmaterialEdit: 1\n"), 0o600); err != nil {
+					t.Fatalf("write recipe: %v", err)
+				}
+			},
+			wantExit:    ExitInvalid,
+			wantPending: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := summaryDirOf(t, buildTestBundle(t))
+			if tt.tamper != nil {
+				tt.tamper(t, summary)
+			}
+			res, err := Verify(context.Background(), VerifyOptions{Input: summary})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if res.Exit != tt.wantExit {
+				t.Fatalf("Exit = %d, want %d", res.Exit, tt.wantExit)
+			}
+			if res.Pending != tt.wantPending {
+				t.Errorf("Pending = %v, want %v (exit %d)", res.Pending, tt.wantPending, res.Exit)
+			}
+		})
+	}
+}
+
 func TestVerify_TamperedFileFails(t *testing.T) {
 	bundleDir := buildTestBundle(t)
 	summary := summaryDirOf(t, bundleDir)


### PR DESCRIPTION
## Summary

Adds `--no-sign` (push-without-sign) to `validate --emit-attestation` / `evidence publish`, and teaches `evidence verify` to report unsigned pointers as a non-failing **pending signature** state and to emit a structured, classified `failureCause` (e.g. registry 403) on failures.

## Motivation / Context

Part of the evidence-gate pilot tuning epic. This is the first of two PRs for the CLI/verifier work: it decouples the network-light push leg from the Fulcio-bound signing leg (so contributors blocked from Sigstore egress can still push), and makes verify failures self-serviceable instead of a bare "invalid".

Fixes: N/A
Related: #1431, #1434 (push-without-sign + verify-pending; sign-existing follows up), #1437 (Go half — structured cause)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/{attestation,verifier}`

## Implementation Notes

- `--no-sign` short-circuits `signAndPush` after the content-addressed push: no artifact statement, no OIDC resolve, no Fulcio/Rekor, no identity-disclosure prompt. The pointer is written with `bundle.oci`/`bundle.digest` set and an empty `signer` block.
- `evidence verify`: an unsigned pointer with no signer claim sets `VerifyResult.Pending` (exit 0) — distinct from "all checks passed" and from "invalid". A pointer that *claims* a signer over an unsigned bundle still fails (cross-check), as before.
- Non-zero exits carry `VerifyResult.FailureCause {class, detail, httpStatus, hint}`, classified from the error chain (oras `errcode.ErrorResponse` status takes precedence over the failing step). Surfaced in `--format json` and the Markdown verdict.
- **Deferred to a follow-up:** `aicr evidence sign <pointer>` (sign-existing) — it needs registry main-artifact descriptor resolution and its happy path is registry-bound (not unit-testable), mirroring the existing `Publish` precedent. That PR completes #1434.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/cli/... ./pkg/evidence/...   # 0 issues
go test -race ./pkg/cli/... ./pkg/evidence/...                          # ok
```

New unit tests: unsigned-pushed outcome → pointer mapping; failure classifier (403/404/other + per-step) with first-wins semantics; pending/cause rendering. Registry-bound happy paths (`--no-sign` push, sign, attach) are not unit-testable, consistent with existing `Publish` coverage.

## Risk Assessment

- [x] **Low** — Additive flags + new result fields; existing signed/unsigned paths unchanged. The gate is warning-only.

**Rollout notes:** Backwards-compatible. New `pending`/`failureCause` JSON fields are `omitempty`; `--no-sign` defaults off.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)