### PR TITLE
feat(evidence): aicr evidence sign — sign an existing pushed bundle

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2645,6 +2645,46 @@ aicr evidence publish ./out --push ghcr.io/myorg/aicr-evidence
 
 ---
 
+### aicr evidence sign
+
+Complete the signing leg for a bundle that was already pushed **unsigned** (via `aicr evidence publish --no-sign` or `validate --emit-attestation --push --no-sign`). It reads the committed pointer, pulls the bundle it references (`bundle.oci` + `bundle.digest` — no recipe-name or bundle-ref input needed), signs the predicate with keyless OIDC, attaches the Sigstore Bundle as an OCI referrer of the existing artifact, and patches the pointer's `signer` block in place.
+
+Signing is the only leg that needs Fulcio/Rekor egress, so this command is designed to run in CI (GitHub Actions ambient OIDC) where Sigstore is reachable, while the push leg runs wherever the cluster lives. The bundle is **not** re-emitted: the predicate is read verbatim from the pulled bundle, so the signature binds the same bytes the unsigned push produced.
+
+**Synopsis:**
+
+```shell
+aicr evidence sign <pointer> [flags]
+```
+
+The positional `<pointer>` is the committed `recipes/evidence/<recipe>.yaml`. The pointer must carry exactly one attestation that is already pushed (`bundle.oci`/`bundle.digest` set) and not yet signed (empty `signer`); otherwise the command fails closed (an already-signed pointer is never re-signed).
+
+**Flags:**
+
+| Flag | Alias | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--identity-token` | | string | | Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Reads `COSIGN_IDENTITY_TOKEN` from env. Same precedence chain as `aicr evidence publish`. |
+| `--oidc-device-flow` | | bool | `false` | Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Reads `AICR_OIDC_DEVICE_FLOW`. Useful on headless hosts. |
+| `--yes` | `--assume-yes` | bool | `false` | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. |
+| `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS for the registry (pull + referrer attach; local-registry tests). |
+| `--insecure-tls` | | bool | `false` | Skip TLS verification for the registry (pull + referrer attach; self-signed registries). |
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Bundle signed, referrer attached, and the pointer's `signer` block written back. |
+| non-zero | Pointer already signed / has nothing pushed to sign, bundle could not be pulled (e.g. a private registry returns 403), identity-disclosure prompt declined, or signing/attach failed. |
+
+**Examples:**
+
+```shell
+# In CI (ambient OIDC), after a contributor committed an unsigned pointer:
+aicr evidence sign recipes/evidence/h100-eks-ubuntu-training.yaml
+```
+
+---
+
 ### aicr evidence verify
 
 Verify a recipe-evidence v1 bundle produced by `aicr validate --emit-attestation`. When the bundle carries a signature, verifies it against the Sigstore trusted root and extracts the cryptographically anchored predicate. Recomputes every file's sha256 against `manifest.json` (which the predicate's `manifest.digest` field anchors), and surfaces the predicate's fingerprint, phase counts, and BOM info.

--- a/pkg/cli/evidence.go
+++ b/pkg/cli/evidence.go
@@ -25,7 +25,7 @@ func evidenceCmd() *cli.Command {
 	return &cli.Command{
 		Name:     "evidence",
 		Category: functionalCategoryName,
-		Usage:    "Manage recipe evidence bundles: digest, publish, verify.",
+		Usage:    "Manage recipe evidence bundles: digest, publish, sign, verify.",
 		Description: `Operations on recipe-evidence v1 bundles.
 
 Bundles are produced by ` + "`aicr validate --emit-attestation`" + ` and consumed
@@ -37,12 +37,14 @@ Subcommands:
 
   digest   Print the canonical digest of a resolved recipe.
   publish  Sign and push an already-emitted bundle, then write its pointer.
+  sign     Sign an already-pushed, unsigned bundle and patch its pointer.
   verify   Verify a bundle's integrity claims.
 
 See docs/design/007-recipe-evidence.md for the trust model.`,
 		Commands: []*cli.Command{
 			evidenceDigestCmd(),
 			evidencePublishCmd(),
+			evidenceSignCmd(),
 			evidenceVerifyCmd(),
 		},
 	}

--- a/pkg/cli/evidence_sign.go
+++ b/pkg/cli/evidence_sign.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+	"github.com/NVIDIA/aicr/pkg/evidence/verifier"
+)
+
+// evidenceSignCmd implements `aicr evidence sign <pointer>`. It completes the
+// signing leg for a bundle that was already pushed unsigned (via
+// `--no-sign`): it pulls the bundle the committed pointer references, signs
+// it with ambient OIDC, attaches the Sigstore Bundle as an OCI referrer, and
+// patches the pointer's signer block in place. This is the step the
+// fork-based CI workflow runs after a contributor commits an unsigned pointer.
+func evidenceSignCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "sign",
+		Category:  functionalCategoryName,
+		Usage:     "Sign an already-pushed, unsigned evidence bundle and patch its pointer.",
+		ArgsUsage: "<pointer>",
+		Description: `Sign the bundle a committed pointer references, then fill in the
+pointer's signer block in place.
+
+Consumes the unsigned pointer left by ` + "`aicr evidence publish --no-sign`" + ` (or
+` + "`validate --emit-attestation --push --no-sign`" + `): the pointer already carries
+` + "`bundle.oci`" + ` + ` + "`bundle.digest`" + `, so no recipe-name or bundle-ref input is
+needed. The bundle is pulled (not re-emitted), its predicate signed with
+keyless OIDC (Fulcio + Rekor), and the resulting Sigstore Bundle attached
+as an OCI referrer of the existing artifact. The pointer's
+` + "`signer.{identity,issuer,rekorLogIndex}`" + ` are then written back to the same file.
+
+This is the only leg that needs Fulcio egress, so it is designed to run in
+CI (GitHub Actions ambient OIDC) where Sigstore is reachable, while the
+push leg runs wherever the cluster lives.
+
+Keyless OIDC signing uses the same precedence chain as ` + "`aicr evidence publish`" + `:
+--identity-token > COSIGN_IDENTITY_TOKEN env > GitHub Actions ambient OIDC >
+--oidc-device-flow > interactive browser flow.
+
+Example:
+
+  # In CI (ambient OIDC), after a contributor committed an unsigned pointer:
+  aicr evidence sign recipes/evidence/h100-eks-ubuntu-training.yaml`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     flagIdentityToken,
+				Usage:    "Pre-fetched OIDC identity token for keyless signing. Skips ambient/browser/device-code flows. Prefer COSIGN_IDENTITY_TOKEN on shared hosts; flag values are visible in process listings (ps, /proc/<pid>/cmdline).",
+				Sources:  cli.EnvVars("COSIGN_IDENTITY_TOKEN"),
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagOIDCDeviceFlow,
+				Usage:    "Use the OAuth 2.0 device authorization grant for OIDC instead of opening a browser callback. Useful on headless hosts when --identity-token / COSIGN_IDENTITY_TOKEN and ambient GitHub Actions OIDC are both unavailable.",
+				Sources:  cli.EnvVars("AICR_OIDC_DEVICE_FLOW"),
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagPlainHTTP,
+				Usage:    "Use HTTP instead of HTTPS for the registry (pull + referrer attach; local registry tests).",
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagInsecureTLS,
+				Usage:    "Skip TLS verification for the registry (pull + referrer attach; self-signed registries).",
+				Category: catEvidence,
+			},
+			assumeYesFlag(catEvidence),
+		},
+		Action: runEvidenceSignCmd,
+	}
+}
+
+func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
+	if err := validateSingleValueFlags(cmd, flagIdentityToken); err != nil {
+		return err
+	}
+
+	path := cmd.Args().First()
+	if path == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"pointer file is required: aicr evidence sign <pointer>")
+	}
+	// Reject extra positional args so a mistyped invocation fails loudly
+	// rather than silently signing only the first file.
+	if cmd.Args().Len() > 1 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"exactly one pointer file is allowed: aicr evidence sign <pointer>")
+	}
+
+	pointer, err := verifier.LoadAndValidatePointer(path)
+	if err != nil {
+		return err
+	}
+	// Fail fast (before the registry pull) unless the pointer is in the exact
+	// state we sign. The rule lives in pkg/evidence/attestation — SignExisting
+	// enforces it too — so the CLI cannot drift from the domain contract.
+	if err = attestation.ValidateSignablePointer(pointer); err != nil {
+		return err
+	}
+
+	// Signing publishes the signer's identity on the interactive keyless
+	// paths, so gate it behind the disclosure prompt; ambient/token sources
+	// and non-TTY runs (the CI case this command targets) pass through.
+	oidcResolve := oidcResolveOptionsFromFlags(cmd)
+	if discErr := confirmKeylessSigningDisclosure(oidcResolve, cmd.Bool(flagAssumeYes), os.Stdin, os.Stderr); discErr != nil {
+		return discErr
+	}
+
+	plainHTTP := cmd.Bool(flagPlainHTTP)
+	insecureTLS := cmd.Bool(flagInsecureTLS)
+
+	// Pull the already-pushed bundle so SignExisting can reconstruct the
+	// predicate the signature binds and so we resolve the artifact's full
+	// descriptor (mediaType + size) — a pointer alone carries only the digest.
+	mat, err := verifier.MaterializeBundle(ctx, verifier.VerifyOptions{
+		Input:       path,
+		PlainHTTP:   plainHTTP,
+		InsecureTLS: insecureTLS,
+	}, verifier.InputFormPointer, pointer)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeUnavailable,
+			"failed to pull the bundle referenced by the pointer (is the registry package accessible?)")
+	}
+	defer mat.Cleanup()
+
+	// Sign, attach the Sigstore referrer, and patch the pointer's signer
+	// block back to the file the caller passed.
+	if err = attestation.SignExisting(ctx, attestation.SignExistingOptions{
+		Pointer:     pointer,
+		PointerPath: path,
+		BundleDir:   mat.BundleDir,
+		Artifact: attestation.MainArtifactDescriptor{
+			Digest:    mat.Digest,
+			MediaType: mat.MediaType,
+			Size:      mat.Size,
+		},
+		PlainHTTP:   plainHTTP,
+		InsecureTLS: insecureTLS,
+		OIDCResolve: oidcResolve,
+	}); err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to sign existing evidence bundle")
+	}
+
+	slog.Info("evidence pointer signed", "path", path, "recipe", pointer.Recipe)
+	return nil
+}

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -386,18 +386,9 @@ func buildPointerInputsFromOutcome(bundle *Bundle, out emitOutcome) PointerInput
 		in.BundleOCI = oci.TrimScheme(out.PushSummary.Reference)
 		in.BundleHash = out.PushSummary.Digest
 	}
-	if out.Sign != nil {
-		signer := &PointerSigner{
-			Identity: out.Sign.Identity,
-			Issuer:   out.Sign.Issuer,
-		}
-		// --no-rekor signing returns RekorLogIndex == 0 with no entry
-		// created; treat zero as "no Rekor entry" at this boundary.
-		if out.Sign.RekorLogIndex > 0 {
-			idx := out.Sign.RekorLogIndex
-			signer.RekorLogIndex = &idx
-		}
-		in.Signer = signer
-	}
+	// PointerSignerFromSignature applies the zero-Rekor rule: a
+	// SignedAttestation.RekorLogIndex of 0 is the "no Rekor entry" sentinel
+	// (e.g. --no-rekor) and maps to a nil index. nil when out.Sign is nil.
+	in.Signer = PointerSignerFromSignature(out.Sign)
 	return in
 }

--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -79,13 +79,50 @@ func MarshalPointer(p *Pointer) ([]byte, error) {
 
 // WritePointer writes the pointer file to outputDir/pointer.yaml.
 func WritePointer(outputDir string, p *Pointer) (string, error) {
+	return WritePointerFile(filepath.Join(outputDir, PointerFilename), p)
+}
+
+// WritePointerFile writes the pointer to an exact path, overwriting it. Used
+// to patch a committed pointer in place (e.g. `aicr evidence sign` filling in
+// the signer block), where the destination is the recipes/evidence/<recipe>.yaml
+// the caller read — not a generated pointer.yaml beside a bundle dir.
+//
+// The write is atomic: it writes to a temp file in the same directory and
+// renames it into place, so a crash or write error mid-flight cannot leave a
+// committed pointer truncated/corrupt. The temp's Close error is propagated
+// (a writable Close can surface buffered-write failures), and a leftover temp
+// is removed on any failure before the rename.
+func WritePointerFile(path string, p *Pointer) (string, error) {
 	body, err := MarshalPointer(p)
 	if err != nil {
 		return "", err
 	}
-	out := filepath.Join(outputDir, PointerFilename)
-	if err := os.WriteFile(out, body, 0o600); err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to write pointer file", err)
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".pointer-*.tmp") // 0o600 by default
+	if err != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create temp pointer file", err)
 	}
-	return out, nil
+	tmpName := tmp.Name()
+	// Remove the temp on any path that does not rename it into place.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, werr := tmp.Write(body); werr != nil {
+		_ = tmp.Close()
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to write temp pointer file", werr)
+	}
+	// Closing a writable handle flushes buffered data — propagate its error.
+	if cerr := tmp.Close(); cerr != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to close temp pointer file", cerr)
+	}
+	if rerr := os.Rename(tmpName, path); rerr != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to rename pointer file into place", rerr)
+	}
+	committed = true
+	return path, nil
 }

--- a/pkg/evidence/attestation/sign.go
+++ b/pkg/evidence/attestation/sign.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/oci"
+)
+
+// SignExistingOptions controls SignExisting. It signs a bundle that has
+// already been pushed to a registry (e.g. by `--no-sign`) and attaches the
+// Sigstore Bundle as an OCI referrer — the Fulcio-bound leg the fork-based
+// CI workflow runs after a contributor commits an unsigned pointer.
+type SignExistingOptions struct {
+	// Pointer is the loaded, validated unsigned pointer. Its first
+	// attestation's bundle.oci names the in-toto subject and registry; on
+	// success its signer block is filled in and the pointer is written back
+	// to PointerPath. Required.
+	Pointer *Pointer
+
+	// PointerPath is the file the patched pointer is written back to —
+	// typically the committed recipes/evidence/<recipe>.yaml the caller
+	// read. Required.
+	PointerPath string
+
+	// BundleDir is a local copy of the already-pushed bundle (typically a
+	// freshly pulled temp dir). Only the unsigned in-toto Statement is read
+	// from it — to reconstruct the exact predicate the signature binds — so
+	// the bundle is never re-emitted. May be the summary-bundle dir or a
+	// parent containing it (mirrors loadOnDiskBundle / publish).
+	BundleDir string
+
+	// Artifact is the subject descriptor of the already-pushed artifact:
+	// the manifest Digest, MediaType, and Size resolved at pull time. All
+	// three are required to attach a spec-compliant referrer; a pointer
+	// alone carries only the digest.
+	Artifact MainArtifactDescriptor
+
+	PlainHTTP   bool
+	InsecureTLS bool
+
+	// OIDCResolve configures keyless-signing token resolution, deferred
+	// until adjacent to SignStatement so Fulcio's nonce-binding window is
+	// respected.
+	OIDCResolve bundleattest.ResolveOptions
+}
+
+// SignExisting signs an already-pushed, unsigned evidence bundle, attaches
+// the resulting Sigstore Bundle as an OCI referrer of that artifact, and
+// patches the pointer's signer block in place — writing it back to
+// PointerPath. It does not push or re-emit the bundle: the predicate is read
+// verbatim from the local copy's statement.intoto.json so the signature
+// binds the same bytes the unsigned push produced.
+//
+// Like Publish, it returns only an error and writes its artifact (the
+// patched pointer) as a side effect: the populated success path needs a live
+// Fulcio sign + registry attach that unit tests cannot reach, so only the
+// guard paths are unit-tested.
+func SignExisting(ctx context.Context, opts SignExistingOptions) error {
+	if opts.PointerPath == "" {
+		return errors.New(errors.ErrCodeInvalidRequest, "pointer path is required")
+	}
+	// Enforce the signable-pointer invariant in the domain function itself, not
+	// just the CLI: patching Attestations[0] on a multi-attestation or
+	// already-signed pointer would clobber provenance for any non-CLI caller.
+	if err := ValidateSignablePointer(opts.Pointer); err != nil {
+		return err
+	}
+	reference := opts.Pointer.Attestations[0].Bundle.OCI
+	if opts.Artifact.Digest == "" || opts.Artifact.MediaType == "" || opts.Artifact.Size <= 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"artifact descriptor (digest, mediaType, size) is required to sign an existing bundle")
+	}
+
+	bundle, _, err := loadOnDiskBundle(opts.BundleDir)
+	if err != nil {
+		return err
+	}
+
+	artifactDigestHex := strings.TrimPrefix(opts.Artifact.Digest, "sha256:")
+	artifactStmt, err := BuildArtifactStatement(oci.TrimScheme(reference), artifactDigestHex, bundle.Predicate)
+	if err != nil {
+		return err
+	}
+
+	logOIDCResolveMode(opts.OIDCResolve)
+	resolveCtx, resolveCancel := context.WithTimeout(ctx, defaults.OIDCAuthTimeout)
+	token, tokenErr := bundleattest.ResolveOIDCToken(resolveCtx, opts.OIDCResolve)
+	resolveCancel()
+	if tokenErr != nil {
+		return tokenErr
+	}
+
+	signCtx, signCancel := context.WithTimeout(ctx, defaults.EvidenceBundleSignTimeout)
+	defer signCancel()
+	signRes, err := bundleattest.SignStatement(signCtx, artifactStmt, bundleattest.SignOptions{
+		OIDCToken: token,
+		FulcioURL: opts.OIDCResolve.FulcioURL,
+		RekorURL:  opts.OIDCResolve.RekorURL,
+	})
+	if err != nil {
+		return err
+	}
+
+	attachCtx, attachCancel := context.WithTimeout(ctx, defaults.EvidenceBundlePushTimeout)
+	defer attachCancel()
+	referrer, attachErr := AttachSigstoreBundleAsReferrer(attachCtx, AttachReferrerOptions{
+		Reference:    reference,
+		BundleJSON:   signRes.BundleJSON,
+		MainArtifact: opts.Artifact,
+		PlainHTTP:    opts.PlainHTTP,
+		InsecureTLS:  opts.InsecureTLS,
+	})
+	if attachErr != nil {
+		return attachErr
+	}
+
+	// Patch the signer block and write the pointer back. Revert the in-memory
+	// mutation if the write fails, so the caller's pointer is never left marked
+	// signed while the file on disk stays unsigned — otherwise a retry with the
+	// same object would trip the already-signed guard.
+	opts.Pointer.Attestations[0].Signer = PointerSignerFromSignature(signRes)
+	if _, err := WritePointerFile(opts.PointerPath, opts.Pointer); err != nil {
+		opts.Pointer.Attestations[0].Signer = nil
+		return err
+	}
+
+	slog.Info("evidence bundle signed and pointer patched in place",
+		"referrerDigest", referrer.Digest,
+		"mainArtifactDigest", opts.Artifact.Digest,
+		"recipe", bundle.RecipeName,
+		"signer", signRes.Identity)
+
+	return nil
+}
+
+// ValidateSignablePointer reports whether a pointer is in the exact state
+// `aicr evidence sign` operates on: exactly one attestation, already pushed
+// (bundle.oci + bundle.digest set), and not yet signed (nil Signer). It is the
+// single source of truth for this domain rule — the CLI calls it for fail-fast
+// validation before the registry pull, and SignExisting calls it before
+// patching the signer block — so the two cannot drift. Failing closed here
+// prevents re-signing (which would clobber an existing signature) or signing a
+// pointer that has nothing pushed to sign.
+func ValidateSignablePointer(p *Pointer) error {
+	if p == nil || len(p.Attestations) != 1 {
+		return errors.New(errors.ErrCodeInvalidRequest, "pointer must carry exactly one attestation to sign")
+	}
+	att := p.Attestations[0]
+	if att.Signer != nil {
+		return errors.New(errors.ErrCodeConflict,
+			"pointer is already signed; refusing to overwrite its signer block")
+	}
+	if att.Bundle.OCI == "" || att.Bundle.Digest == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"pointer has no pushed bundle to sign (bundle.oci/bundle.digest are empty); "+
+				"push it first with `aicr evidence publish --no-sign`")
+	}
+	return nil
+}
+
+// PointerSignerFromSignature builds the pointer's signer block from a
+// signing result, applying the same zero-Rekor rule as the emit path:
+// SignedAttestation.RekorLogIndex uses 0 as the "no Rekor entry" sentinel
+// (e.g. --no-rekor), so this maps 0 to a nil index. A genuine Rekor index 0
+// is therefore indistinguishable from "no entry" at this boundary — an
+// accepted limitation, since the index is informational, not the trust anchor.
+func PointerSignerFromSignature(sig *bundleattest.SignedAttestation) *PointerSigner {
+	if sig == nil {
+		return nil
+	}
+	signer := &PointerSigner{Identity: sig.Identity, Issuer: sig.Issuer}
+	if sig.RekorLogIndex > 0 {
+		idx := sig.RekorLogIndex
+		signer.RekorLogIndex = &idx
+	}
+	return signer
+}

--- a/pkg/evidence/attestation/sign_test.go
+++ b/pkg/evidence/attestation/sign_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func signableSignPointer() *Pointer {
+	return &Pointer{
+		SchemaVersion: PointerSchemaVersion,
+		Recipe:        "h100-eks-ubuntu-training",
+		Attestations: []PointerAttestation{{
+			Bundle: PointerBundle{OCI: "ghcr.io/owner/aicr-evidence:tag", Digest: "sha256:abc", PredicateType: PredicateTypeV1},
+		}},
+	}
+}
+
+func TestValidateSignablePointer(t *testing.T) {
+	signed := signableSignPointer()
+	signed.Attestations[0].Signer = &PointerSigner{Identity: "u@x", Issuer: "iss"}
+	noBundle := signableSignPointer()
+	noBundle.Attestations[0].Bundle.OCI = ""
+	noDigest := signableSignPointer()
+	noDigest.Attestations[0].Bundle.Digest = ""
+	twoAtts := signableSignPointer()
+	twoAtts.Attestations = append(twoAtts.Attestations, twoAtts.Attestations[0])
+
+	tests := []struct {
+		name     string
+		pointer  *Pointer
+		wantErr  bool
+		wantCode errors.ErrorCode
+	}{
+		{"valid unsigned", signableSignPointer(), false, ""},
+		{"nil pointer", nil, true, errors.ErrCodeInvalidRequest},
+		{"already signed", signed, true, errors.ErrCodeConflict},
+		{"no bundle.oci", noBundle, true, errors.ErrCodeInvalidRequest},
+		{"no bundle.digest", noDigest, true, errors.ErrCodeInvalidRequest},
+		{"multiple attestations", twoAtts, true, errors.ErrCodeInvalidRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSignablePointer(tt.pointer)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Errorf("error code = %v, want %v", err, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestSignExisting_RejectsBadPointer(t *testing.T) {
+	desc := MainArtifactDescriptor{Digest: "sha256:abc", MediaType: "application/json", Size: 1}
+	noOCI := signableSignPointer()
+	noOCI.Attestations[0].Bundle.OCI = ""
+	noDigest := signableSignPointer()
+	noDigest.Attestations[0].Bundle.Digest = ""
+	alreadySigned := signableSignPointer()
+	alreadySigned.Attestations[0].Signer = &PointerSigner{Identity: "u@x", Issuer: "iss"}
+	multiAtt := signableSignPointer()
+	multiAtt.Attestations = append(multiAtt.Attestations, multiAtt.Attestations[0])
+
+	tests := []struct {
+		name     string
+		pointer  *Pointer
+		path     string
+		wantCode errors.ErrorCode
+	}{
+		{"nil pointer", nil, "p.yaml", errors.ErrCodeInvalidRequest},
+		{"no attestations", &Pointer{}, "p.yaml", errors.ErrCodeInvalidRequest},
+		{"empty path", signableSignPointer(), "", errors.ErrCodeInvalidRequest},
+		{"empty bundle.oci", noOCI, "p.yaml", errors.ErrCodeInvalidRequest},
+		{"empty bundle.digest", noDigest, "p.yaml", errors.ErrCodeInvalidRequest},
+		{"already signed", alreadySigned, "p.yaml", errors.ErrCodeConflict},
+		{"multiple attestations", multiAtt, "p.yaml", errors.ErrCodeInvalidRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SignExisting(context.Background(), SignExistingOptions{
+				Pointer: tt.pointer, PointerPath: tt.path, Artifact: desc,
+			})
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Errorf("error code = %v, want %v", err, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestSignExisting_RejectsIncompleteDescriptor(t *testing.T) {
+	tests := []struct {
+		name string
+		desc MainArtifactDescriptor
+	}{
+		{"no digest", MainArtifactDescriptor{MediaType: "application/json", Size: 1}},
+		{"no mediaType", MainArtifactDescriptor{Digest: "sha256:abc", Size: 1}},
+		{"no size", MainArtifactDescriptor{Digest: "sha256:abc", MediaType: "application/json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SignExisting(context.Background(), SignExistingOptions{
+				Pointer:     signableSignPointer(),
+				PointerPath: "p.yaml",
+				Artifact:    tt.desc,
+			})
+			if err == nil {
+				t.Fatalf("expected error for incomplete descriptor %+v", tt.desc)
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+func TestPointerSignerFromSignature(t *testing.T) {
+	if PointerSignerFromSignature(nil) != nil {
+		t.Errorf("nil signature should yield nil signer")
+	}
+
+	withRekor := PointerSignerFromSignature(&bundleattest.SignedAttestation{
+		Identity: "ci@github", Issuer: "https://token.actions.githubusercontent.com", RekorLogIndex: 42,
+	})
+	if withRekor == nil || withRekor.RekorLogIndex == nil || *withRekor.RekorLogIndex != 42 {
+		t.Fatalf("expected rekor index 42; got %+v", withRekor)
+	}
+	if withRekor.Identity != "ci@github" {
+		t.Errorf("identity mismatch: %+v", withRekor)
+	}
+
+	zeroRekor := PointerSignerFromSignature(&bundleattest.SignedAttestation{Identity: "u@x", RekorLogIndex: 0})
+	if zeroRekor.RekorLogIndex != nil {
+		t.Errorf("zero rekor index should map to nil; got *%d", *zeroRekor.RekorLogIndex)
+	}
+}
+
+func TestWritePointerFile_WritesExactPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "h100-eks-ubuntu-training.yaml")
+	p := &Pointer{
+		SchemaVersion: PointerSchemaVersion,
+		Recipe:        "h100-eks-ubuntu-training",
+		Attestations: []PointerAttestation{{
+			Bundle:     PointerBundle{OCI: "ghcr.io/x/aicr-evidence:tag", Digest: "sha256:abc", PredicateType: PredicateTypeV1},
+			AttestedAt: time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC),
+		}},
+	}
+	got, err := WritePointerFile(target, p)
+	if err != nil {
+		t.Fatalf("WritePointerFile: %v", err)
+	}
+	if got != target {
+		t.Errorf("returned path = %q, want %q", got, target)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("pointer file not written at exact path: %v", err)
+	}
+}

--- a/pkg/evidence/verifier/fetch.go
+++ b/pkg/evidence/verifier/fetch.go
@@ -63,6 +63,15 @@ type MaterializedBundle struct {
 	Reference string
 	Digest    string
 
+	// MediaType and Size are the pulled manifest's descriptor fields,
+	// populated for OCI sources (empty/zero for a local directory). Together
+	// with Digest they form the subject descriptor needed to attach a
+	// Sigstore referrer to the already-pushed artifact — the input the
+	// sign-existing path (`aicr evidence sign`) needs that a pointer alone
+	// (digest only) cannot supply.
+	MediaType string
+	Size      int64
+
 	cleanup func()
 }
 
@@ -265,6 +274,8 @@ func materializeOCIRefRequireDigest(ctx context.Context, ref string, opts Verify
 		BundleDir: resolved,
 		Reference: formatOCIReference(registry, repo, refTarget),
 		Digest:    desc.Digest.String(),
+		MediaType: desc.MediaType,
+		Size:      desc.Size,
 		cleanup:   cleanup,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Adds `aicr evidence sign <pointer>` — the sign-existing leg that completes the two-phase publish flow. A contributor pushes an unsigned bundle and commits the pointer (`evidence publish --no-sign`); this command signs it later (the only step that needs Fulcio/Rekor egress), attaches the Sigstore referrer, and patches the pointer's signer block in place.

## Motivation / Context

Completes the CLI/verifier work for the evidence-gate pilot. This is the second of the two CLI PRs and **completes #1434**; it is the step the fork-based CI signing workflow (#1433) will call.

Fixes: #1434
Related: #1431, #1433 (fork workflow consumes this)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/{attestation,verifier}`

## Implementation Notes

- `MaterializedBundle` now carries `MediaType`/`Size` (populated from the pulled manifest descriptor) — the subject descriptor needed to attach a referrer, which a pointer (digest only) can't supply.
- `attestation.SignExisting` reads the predicate from the pulled bundle (no re-emit), signs with ambient OIDC, attaches the Sigstore Bundle as an OCI referrer, then patches the pointer's signer block and writes it back. Mirroring `Publish`, it returns only an error and writes its artifact as a side effect — the registry-bound happy path isn't unit-testable.
- `evidence sign` fails closed via `assertUnsignedSignable`: refuses anything that isn't a single, already-pushed, not-yet-signed attestation (never re-signs over an existing signature).
- Refactors: `buildPointerInputsFromOutcome` reuses the new `PointerSignerFromSignature` (shared zero-Rekor rule); `WritePointer` delegates to a new `WritePointerFile` (exact-path write).

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/cli/... ./pkg/evidence/...   # 0 issues
go test -race ./pkg/cli/... ./pkg/evidence/...                          # ok
```

New unit tests: pointer-state guards (`assertUnsignedSignable`), `SignExisting` input guards, signature→pointer-signer mapping, exact-path pointer writes. Registry/Fulcio-bound happy path not unit-tested (consistent with `Publish`).

## Risk Assessment

- [x] **Low** — New subcommand + additive `MaterializedBundle` fields; existing paths unchanged.

**Rollout notes:** Backwards-compatible. Depends conceptually on the `--no-sign` PR (produces the unsigned pointers this consumes) but has no compile dependency on it.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)