### PR TITLE
feat(evidence-gate): protected/other partition + component-scoped cascade

### DIFF
--- a/.github/scripts/recipe-evidence-check.sh
+++ b/.github/scripts/recipe-evidence-check.sh
@@ -8,9 +8,16 @@
 # canonical digest. Writes a Markdown report; never blocks the PR.
 #
 # A recipe is "affected" when the PR touches its overlay, an ancestor
-# overlay in its base chain, a referenced component values file, or its
-# own evidence pointer (recipes/evidence/<slug>.yaml) — so a pointer-only
+# overlay in its base chain, a referenced component values file, a
+# *changed* registry component it transitively references, or its own
+# evidence pointer (recipes/evidence/<slug>.yaml) — so a pointer-only
 # "refresh evidence" PR is verified rather than silently skipped.
+#
+# The report separates "protected" recipes — those with a committed
+# pointer in recipes/evidence/, the set the gate actively verifies — from
+# "other affected" recipes that have no evidence yet (best-effort, not a
+# warning). This keeps a broad-impact PR from rendering dozens of alarming
+# "missing" rows for recipes nobody has produced evidence for.
 #
 # Required env:
 #   AICR        path to the aicr binary (built from a trusted source)
@@ -22,8 +29,8 @@
 #   REPO_URL    base URL for absolute links in the report (e.g.
 #               https://github.com/NVIDIA/aicr); when unset, the
 #               trust-model link in the trailer is omitted
-#   MAX_ROWS    cap on per-recipe rows (default 80) to keep the report
-#               under GitHub's ~65KB comment-body cap on broad-impact PRs
+#   MAX_ROWS    cap on protected-recipe rows (default 80) to keep the
+#               report under GitHub's ~65KB comment-body cap
 #
 # Local invocation:
 #   make build  # or `go build -o ./bin/aicr ./cmd/aicr`
@@ -38,10 +45,6 @@
 #     `aicr validate --emit-attestation` writes pointers named after
 #     the criteria-derived slug (RecipeNameFor). Overlays not following
 #     the canonical naming will be reported as missing-pointer.
-#   * Discovery walks `spec.base` ancestors but not `spec.mixins`, and
-#     promote-all only matches recipes/registry.yaml or recipes/
-#     overlays/base.yaml. Mixin/check/component edits outside literal
-#     valuesFile refs are not promoted. Parity with kwok-recipes.
 #   * `aicr evidence verify` fetches OCI artifacts from PR-controlled
 #     URLs; an allow-list of trusted registries is a follow-up.
 
@@ -54,6 +57,25 @@ set -euo pipefail
 
 REPO_URL="${REPO_URL:-}"
 MAX_ROWS="${MAX_ROWS:-80}"
+# Cap on the collapsed "other affected" list so a broad PR can't blow past
+# GitHub's ~65KB comment-body limit.
+OTHER_MAX="${OTHER_MAX:-200}"
+
+# md_escape sanitizes a value rendered into a Markdown table cell. Slugs and
+# verifier-supplied hints can in principle carry characters that break the
+# table or the surrounding backticks; collapse newlines, escape pipes, and
+# drop backticks so a value can't break out of a code span.
+md_escape() {
+  printf '%s' "$1" | tr '\n' ' ' | sed 's/|/\\|/g; s/`//g'
+}
+
+# log_sanitize strips characters from PR-controlled text before it is echoed
+# into a `::warning::`/`::error::` workflow command, so the text cannot inject
+# its own workflow commands. Collapses newlines and carriage returns, and
+# neutralizes `::`.
+log_sanitize() {
+  printf '%s' "$1" | tr '\n\r' '  ' | sed 's/::/:_:/g'
+}
 
 # Three-dot range so we only see what the PR actually changed (relative
 # to its merge base) — not main commits that landed after PR open.
@@ -63,10 +85,89 @@ if ! changed_files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>&1); the
   exit 1
 fi
 
+# A change to recipes/overlays/base.yaml is genuinely broad — it sits at
+# the root of (almost) every base chain — so it still promotes all leaf
+# recipes. A registry.yaml change is NOT treated as broad: instead we
+# compute which component *entries* changed and promote only the recipes
+# that transitively reference one of them (see changed_components + Rule 5).
 promote_all=false
-if echo "$changed_files" | grep -qE '^recipes/(registry\.yaml|overlays/base\.yaml)$'; then
+if printf '%s\n' "$changed_files" | grep -qxF 'recipes/overlays/base.yaml'; then
   promote_all=true
 fi
+
+# Component-level registry scoping (#1435). When recipes/registry.yaml
+# changes, diff it at the component-entry level between BASE and HEAD and
+# collect the names whose entry was added, removed, or modified. An
+# `aws-efa`-only edit then flags only recipes that reference `aws-efa`,
+# not every leaf. Empty when registry.yaml is unchanged or only changed
+# cosmetically (no entry differs).
+registry_changed=false
+changed_components=""
+if printf '%s\n' "$changed_files" | grep -qxF 'recipes/registry.yaml'; then
+  registry_changed=true
+  reg_base=$(mktemp)
+  reg_head=$(mktemp)
+  # A revision missing the file (e.g. registry.yaml newly added) yields an
+  # empty doc, so every HEAD component reads as added — fail-open to broad
+  # for that recipe set, which is the safe direction for a warning gate.
+  git show "${BASE_SHA}:recipes/registry.yaml" >"$reg_base" 2>/dev/null || : >"$reg_base"
+  git show "${HEAD_SHA}:recipes/registry.yaml" >"$reg_head" 2>/dev/null || : >"$reg_head"
+  comp_names=$( { yq eval '.components[].name // ""' "$reg_base" 2>/dev/null || true; \
+                  yq eval '.components[].name // ""' "$reg_head" 2>/dev/null || true; } \
+                | grep -v '^$' | sort -u )
+  while IFS= read -r cn; do
+    [[ -z "$cn" ]] && continue
+    # Pass the name via strenv() rather than string-interpolating it into the
+    # yq expression: a PR-controlled component name must be data, not code.
+    # strenv (not env) keeps it a string so a scalar-looking name (`true`,
+    # `null`, `123`) isn't YAML-typed and made to miss its registry entry.
+    b=$(CN="$cn" yq eval '.components[] | select(.name == strenv(CN))' "$reg_base" 2>/dev/null || true)
+    h=$(CN="$cn" yq eval '.components[] | select(.name == strenv(CN))' "$reg_head" 2>/dev/null || true)
+    if [[ "$b" != "$h" ]]; then
+      changed_components="${changed_components}${cn}"$'\n'
+    fi
+  done <<<"$comp_names"
+  changed_components=$(printf '%s' "$changed_components" | grep -v '^$' | sort -u || true)
+  rm -f "$reg_base" "$reg_head"
+  cc_count=$(printf '%s\n' "$changed_components" | grep -c . || true)
+  echo "Changed registry components: ${cc_count}"
+fi
+
+# recipe_components <overlay-path> — print the sorted, unique set of
+# component names a recipe resolves to, using the *same* engine the digest
+# uses: `aicr recipe` resolves by criteria across all overlays, with an
+# unconditional base.yaml merge and criteria-matched wildcard overlays
+# (e.g. monitoring-hpa injecting prometheus-adapter). Hand-walking
+# spec.base/spec.mixins misses base.yaml and wildcard injections, which
+# would make Rule 5 a false-negative for base/wildcard components — exactly
+# the registry entries this scoping targets. Resolving via aicr keeps the
+# affected-set consistent with the digest comparison downstream.
+recipe_components() {
+  local overlay="$1" service accel os intent platform
+  service=$(yq eval '.spec.criteria.service // ""' "$overlay" 2>/dev/null || true)
+  accel=$(yq eval '.spec.criteria.accelerator // ""' "$overlay" 2>/dev/null || true)
+  os=$(yq eval '.spec.criteria.os // ""' "$overlay" 2>/dev/null || true)
+  intent=$(yq eval '.spec.criteria.intent // ""' "$overlay" 2>/dev/null || true)
+  platform=$(yq eval '.spec.criteria.platform // ""' "$overlay" 2>/dev/null || true)
+
+  local args=()
+  [[ -n "$service" && "$service" != "null" ]] && args+=(--service "$service")
+  [[ -n "$accel" && "$accel" != "null" ]] && args+=(--accelerator "$accel")
+  [[ -n "$os" && "$os" != "null" ]] && args+=(--os "$os")
+  [[ -n "$intent" && "$intent" != "null" ]] && args+=(--intent "$intent")
+  [[ -n "$platform" && "$platform" != "null" ]] && args+=(--platform "$platform")
+
+  : "${AICR_TIMEOUT:=30s}"
+  # Return non-zero when the resolver itself fails (timeout / error), so the
+  # caller can fail OPEN (include the recipe) rather than mistake a resolver
+  # hiccup for "references no changed component" — a false negative is the
+  # dangerous direction for a protection gate.
+  local out
+  if ! out=$(timeout "$AICR_TIMEOUT" "$AICR" recipe "${args[@]}" --format json 2>/dev/null); then
+    return 1
+  fi
+  printf '%s\n' "$out" | jq -r '.componentRefs[].name // empty' 2>/dev/null | sort -u
+}
 
 affected="[]"
 for overlay in recipes/overlays/*.yaml; do
@@ -108,7 +209,7 @@ for overlay in recipes/overlays/*.yaml; do
       parent=$(yq eval '.spec.base // ""' "$current" 2>/dev/null || true)
       if [[ -z "$parent" || "$parent" == "null" ]]; then break; fi
       if [[ -n "${visited_r2[$parent]:-}" ]]; then
-        echo "::warning::cyclic base chain detected at overlay '${name}' (re-visited '${parent}')"
+        echo "::warning::cyclic base chain detected at overlay '$(log_sanitize "$name")' (re-visited '$(log_sanitize "$parent")')"
         break
       fi
       visited_r2[$parent]=1
@@ -136,7 +237,7 @@ for overlay in recipes/overlays/*.yaml; do
       parent=$(yq eval '.spec.base // ""' "$current" 2>/dev/null || true)
       if [[ -z "$parent" || "$parent" == "null" ]]; then break; fi
       if [[ -n "${visited_r3[$parent]:-}" ]]; then
-        echo "::warning::cyclic base chain detected at overlay '${name}' (re-visited '${parent}')"
+        echo "::warning::cyclic base chain detected at overlay '$(log_sanitize "$name")' (re-visited '$(log_sanitize "$parent")')"
         break
       fi
       visited_r3[$parent]=1
@@ -165,6 +266,25 @@ for overlay in recipes/overlays/*.yaml; do
     fi
   fi
 
+  # Rule 5: a changed registry component entry that this recipe
+  # transitively references (component-level cascade scoping, #1435). Only
+  # the recipes that actually reference a changed component are promoted —
+  # not every leaf — so an `aws-efa`-only registry edit no longer flags
+  # non-AWS recipes.
+  if [[ "$include" == "false" && "$registry_changed" == "true" && -n "$changed_components" ]]; then
+    if rc=$(recipe_components "$overlay"); then
+      # Resolved cleanly: include only on a real intersection.
+      if [[ -n "$rc" ]] && comm -12 <(printf '%s\n' "$rc") <(printf '%s\n' "$changed_components") | grep -q .; then
+        include=true
+      fi
+    else
+      # Resolver failed (aicr recipe timeout/error). Fail open: include the
+      # recipe so a transient failure can't hide real drift on a protected one.
+      echo "::warning::component resolution failed for $(log_sanitize "$overlay"); including conservatively"
+      include=true
+    fi
+  fi
+
   if [[ "$include" == "true" ]]; then
     affected=$(echo "$affected" | jq -c --arg r "$name" '. + [$r]')
   fi
@@ -172,6 +292,31 @@ done
 
 count=$(echo "$affected" | jq 'length')
 echo "Affected leaf overlays: ${count}"
+
+# Partition affected recipes into "protected" (a committed pointer exists
+# in recipes/evidence/) and "other" (affected but no evidence yet). The
+# gate actively verifies the protected set; the others are surfaced as a
+# best-effort summary, not per-recipe warnings (#1432).
+#
+# A pointer present in BASE or HEAD counts as protected: a PR that *deletes*
+# a pointer leaves no file at HEAD, but removing evidence from a previously
+# protected recipe is a de-protection we must surface — not silently demote
+# it to "no evidence yet". The protected loop renders such a recipe as
+# "evidence pointer removed" rather than verifying it.
+protected="[]"
+others="[]"
+while IFS= read -r slug; do
+  [[ -z "$slug" ]] && continue
+  if [[ -f "recipes/evidence/${slug}.yaml" ]] \
+     || git cat-file -e "${BASE_SHA}:recipes/evidence/${slug}.yaml" 2>/dev/null; then
+    protected=$(echo "$protected" | jq -c --arg r "$slug" '. + [$r]')
+  else
+    others=$(echo "$others" | jq -c --arg r "$slug" '. + [$r]')
+  fi
+done < <(echo "$affected" | jq -r '.[]')
+protected_count=$(echo "$protected" | jq 'length')
+other_count=$(echo "$others" | jq 'length')
+echo "Protected (have pointers): ${protected_count}; other affected (no evidence yet): ${other_count}"
 
 # Orphan-pointer check. The loop above only iterates existing overlays,
 # so a pointer added/modified for a slug with no matching leaf overlay
@@ -206,9 +351,13 @@ mkdir -p "$(dirname "$REPORT_OUT")"
   echo "## Recipe evidence check"
   echo
   if [[ "$promote_all" == "true" ]]; then
-    echo "> **Broad impact:** \`recipes/registry.yaml\` or \`recipes/overlays/base.yaml\` changed;"
-    echo "> every leaf recipe is potentially affected. The list below covers all of them — each"
-    echo "> one would ideally have refreshed evidence before merge."
+    echo "> **Broad impact:** \`recipes/overlays/base.yaml\` changed; every leaf recipe is"
+    echo "> potentially affected. Recipes that carry committed evidence are verified below;"
+    echo "> the rest have no evidence yet (best-effort)."
+    echo
+  elif [[ "$registry_changed" == "true" && -n "$changed_components" ]]; then
+    echo "> **Registry change:** scoped to recipes that reference a changed component"
+    echo "> entry in \`recipes/registry.yaml\` (not every leaf)."
     echo
   fi
 } >> "$REPORT_OUT"
@@ -225,17 +374,19 @@ if [[ "$count" -eq 0 && "$orphan_count" -eq 0 ]]; then
   exit 0
 fi
 
-if [[ "$count" -gt 0 ]]; then
-  {
-    echo "Affected leaf overlays: **${count}**"
-    echo
-    echo "| Recipe | Pointer | Verify | Digest match |"
-    echo "|---|---|---|---|"
-  } >> "$REPORT_OUT"
-fi
-
 rows_written=0
 rows_truncated=0
+
+if [[ "$protected_count" -gt 0 ]]; then
+  {
+    echo "### Protected recipes"
+    echo
+    echo "Recipes with committed evidence (\`recipes/evidence/<slug>.yaml\`) that this PR affects: **${protected_count}**"
+    echo
+    echo "| Recipe | Verify | Digest match |"
+    echo "|---|---|---|"
+  } >> "$REPORT_OUT"
+fi
 
 # `while IFS= read -r` (not `for x in $(...)`) so slugs with shell
 # metachars don't word-split or glob-expand.
@@ -249,6 +400,16 @@ while IFS= read -r slug; do
   overlay="recipes/overlays/${slug}.yaml"
   pointer="recipes/evidence/${slug}.yaml"
 
+  # Protected via a BASE pointer that this PR deletes (absent at HEAD).
+  # Removing evidence from a previously protected recipe is a de-protection
+  # to surface, not a file to verify.
+  if [[ ! -f "$pointer" ]]; then
+    echo "| \`$(md_escape "$slug")\` | :warning: evidence pointer removed | — |" >> "$REPORT_OUT"
+    warnings=$((warnings + 1))
+    rows_written=$((rows_written + 1))
+    continue
+  fi
+
   # Wall-clock cap on aicr invocations so a hung / tarpit OCI registry
   # behind a PR-controlled pointer URL can't burn the whole job budget.
   # `timeout` exits 124 on timeout; the existing verify-exit default
@@ -258,21 +419,14 @@ while IFS= read -r slug; do
   digest_err=$(mktemp)
   current_digest=""
   if ! current_digest=$(timeout "$AICR_TIMEOUT" "$AICR" evidence digest -r "$overlay" 2>"$digest_err"); then
-    echo "::warning::digest failed for ${overlay}: $(head -c 500 "$digest_err")"
-    echo "| \`${slug}\` | — | — | :warning: could not compute current digest |" >> "$REPORT_OUT"
+    echo "::warning::digest failed for $(log_sanitize "$overlay"): $(log_sanitize "$(head -c 500 "$digest_err")")"
+    echo "| \`$(md_escape "$slug")\` | — | :warning: could not compute current digest |" >> "$REPORT_OUT"
     warnings=$((warnings + 1))
     rows_written=$((rows_written + 1))
     rm -f "$digest_err"
     continue
   fi
   rm -f "$digest_err"
-
-  if [[ ! -f "$pointer" ]]; then
-    echo "| \`${slug}\` | :warning: missing | — | — |" >> "$REPORT_OUT"
-    warnings=$((warnings + 1))
-    rows_written=$((rows_written + 1))
-    continue
-  fi
 
   verify_json=$(mktemp)
   verify_err=$(mktemp)
@@ -281,34 +435,80 @@ while IFS= read -r slug; do
   verify_exit=$?
   set -e
   if [[ "$verify_exit" -ne 0 && -s "$verify_err" ]]; then
-    echo "::warning::verify exit ${verify_exit} for ${pointer}: $(head -c 500 "$verify_err")"
+    # Echo the full stderr into the job log (not just the table) so a
+    # maintainer can see the underlying cause beyond the classified row.
+    echo "::warning::verify exit ${verify_exit} for $(log_sanitize "$pointer"): $(log_sanitize "$(head -c 1000 "$verify_err")")"
   fi
   rm -f "$verify_err"
 
-  # aicr maps both ErrCodeConflict (phase failures recorded; bundle
-  # valid) and ErrCodeInvalidRequest (bundle invalid) to OS exit 2 —
-  # see pkg/errors/exitcode.go. Disambiguate via whether the JSON
-  # payload contains a parseable predicate.
+  # Pull structured fields surfaced by `aicr evidence verify --format json`
+  # (see pkg/evidence/verifier): VerifyResult.Exit (0 valid, 1 valid with
+  # recorded phase failures, 2 invalid), the predicate digest, the
+  # pending-signature flag, and — on Exit 2 — the classified failureCause
+  # {class, httpStatus, hint}. We branch on the JSON `.exit`, not the OS exit
+  # code, because aicr collapses both Exit 1 (ErrCodeConflict) and Exit 2
+  # (ErrCodeInvalidRequest) to OS exit 2 (see pkg/errors/exitcode.go).
+  result_exit=""
   signed_digest=""
+  pending="false"
+  cause_class=""
+  cause_status=""
+  cause_hint=""
   if [[ -s "$verify_json" ]]; then
+    result_exit=$(jq -r '.exit // empty' "$verify_json" 2>/dev/null || true)
     signed_digest=$(jq -r '.predicate.recipe.digest // empty' "$verify_json" 2>/dev/null || true)
+    pending=$(jq -r '.pending // false' "$verify_json" 2>/dev/null || echo false)
+    cause_class=$(jq -r '.failureCause.class // empty' "$verify_json" 2>/dev/null || true)
+    cause_status=$(jq -r '.failureCause.httpStatus // empty' "$verify_json" 2>/dev/null || true)
+    cause_hint=$(jq -r '.failureCause.hint // empty' "$verify_json" 2>/dev/null || true)
   fi
+  rm -f "$verify_json"
 
-  case "$verify_exit" in
-    0)
-      verify_cell=":white_check_mark: passed"
-      ;;
-    2)
-      if [[ -n "$signed_digest" ]]; then
+  # verify_ok tracks whether the bundle itself verified (exit 0/1). When it
+  # did not, the verify cell already owns the single warning for this row, so
+  # the digest section must not add a second one (a broken bundle is one
+  # problem, not two).
+  verify_ok=true
+  if [[ -z "$result_exit" ]]; then
+    # No parseable VerifyResult — verify errored before producing output
+    # (bad input / early failure) or `timeout` killed it (exit 124).
+    verify_cell=":x: verify error (exit ${verify_exit})"
+    verify_ok=false
+    warnings=$((warnings + 1))
+  else
+    case "$result_exit" in
+      0)
+        if [[ "$pending" == "true" ]]; then
+          verify_cell=":hourglass: pending signature"
+        else
+          verify_cell=":white_check_mark: passed"
+        fi
+        ;;
+      1)
+        # Valid bundle whose recorded validator results show phase failures
+        # — informational, not a gate warning.
         verify_cell=":warning: phase failures recorded (informational)"
-      else
-        verify_cell=":x: bundle invalid"
-      fi
-      ;;
-    *)
-      verify_cell=":x: verify error (exit ${verify_exit})"
-      ;;
-  esac
+        ;;
+      2)
+        # Render the classified, actionable cause instead of a bare
+        # "invalid" (#1437): e.g. "invalid — registry-forbidden (HTTP 403):
+        # make the fork's aicr-evidence package public".
+        verify_cell=":x: invalid"
+        if [[ -n "$cause_class" ]]; then
+          verify_cell="${verify_cell} — ${cause_class}"
+          [[ -n "$cause_status" ]] && verify_cell="${verify_cell} (HTTP ${cause_status})"
+          [[ -n "$cause_hint" ]] && verify_cell="${verify_cell}: $(md_escape "$cause_hint")"
+        fi
+        verify_ok=false
+        warnings=$((warnings + 1))
+        ;;
+      *)
+        verify_cell=":x: verify error (result exit ${result_exit})"
+        verify_ok=false
+        warnings=$((warnings + 1))
+        ;;
+    esac
+  fi
 
   if [[ -n "$signed_digest" ]]; then
     if [[ "$signed_digest" == "$current_digest" ]]; then
@@ -318,17 +518,56 @@ while IFS= read -r slug; do
       warnings=$((warnings + 1))
     fi
   else
-    digest_cell=":warning: skipped (verify did not surface a signed digest)"
-    warnings=$((warnings + 1))
+    digest_cell=":warning: skipped (no signed digest)"
+    # Only a warning when the bundle otherwise verified — a failed verify
+    # already counted its single warning above.
+    if [[ "$verify_ok" == "true" ]]; then
+      warnings=$((warnings + 1))
+    fi
   fi
 
-  echo "| \`${slug}\` | :white_check_mark: present | ${verify_cell} | ${digest_cell} |" >> "$REPORT_OUT"
+  echo "| \`$(md_escape "$slug")\` | ${verify_cell} | ${digest_cell} |" >> "$REPORT_OUT"
   rows_written=$((rows_written + 1))
-  rm -f "$verify_json"
-done < <(echo "$affected" | jq -r '.[]')
+done < <(echo "$protected" | jq -r '.[]')
 
 if [[ "$rows_truncated" -gt 0 ]]; then
-  echo "| _… +${rows_truncated} more (truncated; raise MAX_ROWS or split the PR)_ | | | |" >> "$REPORT_OUT"
+  echo "| _… +${rows_truncated} more (truncated; raise MAX_ROWS or split the PR)_ | | |" >> "$REPORT_OUT"
+fi
+
+# Other affected recipes (no committed evidence). Surfaced as a collapsed
+# summary, not per-recipe warnings: evidence is hardware-gated and most
+# recipes have none yet, so flagging each as "missing" on a broad PR is
+# noise. The set grows naturally as evidence is added.
+if [[ "$other_count" -gt 0 ]]; then
+  {
+    echo
+    echo "<details><summary>Other affected recipes without evidence yet: <b>${other_count}</b></summary>"
+    echo
+    echo "These recipes are affected by this PR but carry no committed evidence pointer, so there is"
+    echo "nothing to verify. This is expected — evidence is hardware-gated and added over time."
+    echo
+  } >> "$REPORT_OUT"
+  # Cap the list (OTHER_MAX) so a broad PR's collapsed section can't push the
+  # comment past GitHub's ~65KB body limit; the count in the summary is still
+  # the full total.
+  other_listed=0
+  other_omitted=0
+  while IFS= read -r oslug; do
+    [[ -z "$oslug" ]] && continue
+    if [[ "$other_listed" -ge "$OTHER_MAX" ]]; then
+      other_omitted=$((other_omitted + 1))
+      continue
+    fi
+    echo "- \`$(md_escape "$oslug")\`" >> "$REPORT_OUT"
+    other_listed=$((other_listed + 1))
+  done < <(echo "$others" | jq -r '.[]')
+  if [[ "$other_omitted" -gt 0 ]]; then
+    echo "- _… +${other_omitted} more (list capped at ${OTHER_MAX})_" >> "$REPORT_OUT"
+  fi
+  {
+    echo
+    echo "</details>"
+  } >> "$REPORT_OUT"
 fi
 
 if [[ "$orphan_count" -gt 0 ]]; then
@@ -346,7 +585,8 @@ if [[ "$orphan_count" -gt 0 ]]; then
   } >> "$REPORT_OUT"
   while IFS= read -r oslug; do
     if [[ -z "$oslug" ]]; then continue; fi
-    echo "| \`recipes/evidence/${oslug}.yaml\` | :warning: no \`recipes/overlays/${oslug}.yaml\` |" >> "$REPORT_OUT"
+    oslug_md=$(md_escape "$oslug")
+    echo "| \`recipes/evidence/${oslug_md}.yaml\` | :warning: no \`recipes/overlays/${oslug_md}.yaml\` |" >> "$REPORT_OUT"
     warnings=$((warnings + 1))
   done < <(echo "$orphans" | jq -r '.[]')
 fi
@@ -379,4 +619,6 @@ fi
 echo "warnings=${warnings}"
 echo "rows_written=${rows_written}"
 echo "rows_truncated=${rows_truncated}"
+echo "protected=${protected_count}"
+echo "other_affected=${other_count}"
 echo "orphan_pointers=${orphan_count}"

--- a/docs/design/007-recipe-evidence.md
+++ b/docs/design/007-recipe-evidence.md
@@ -376,6 +376,41 @@ surface item 1 below for the full schema).
    since the field is additive metadata) but its motivation is the
    evidence lifecycle this ADR establishes.
 
+### Gate report structure (implemented)
+
+The CI gate (`.github/scripts/recipe-evidence-check.sh`) renders its
+warning-only Markdown comment around two ideas that keep it low-noise on
+broad-impact PRs:
+
+- **Protected vs. other affected.** A recipe is *protected* — implicitly —
+  iff it has a committed pointer at `recipes/evidence/<slug>.yaml`. The
+  protected set is what the gate actively verifies (pointer present →
+  verify → digest compare) and renders as a status table. Recipes that are
+  affected but carry no pointer are best-effort: evidence is
+  hardware-gated and most recipes have none yet, so they are collapsed
+  into a single `<details>` count rather than shown as alarming "missing"
+  rows. Adding a pointer is the only action that moves a recipe into the
+  protected set — there is no separate list to maintain, and it converges
+  with the recipes validated on real hardware.
+
+- **Component-scoped registry cascade.** A change to
+  `recipes/registry.yaml` does not promote every leaf recipe. The gate
+  diffs the registry at the component-*entry* level and marks a recipe
+  affected only if its resolved component set — walked across the base
+  chain and `spec.mixins` — intersects the changed entries, so an
+  `aws-efa`-only edit flags only recipes that reference `aws-efa`. A change
+  to `recipes/overlays/base.yaml` is still treated as broad (it sits at the
+  root of nearly every base chain). The recomputed digest remains the
+  ground truth: a protected recipe whose digest still matches its pointer
+  is reported as a match, never as drift, regardless of promotion.
+
+- **Classified verify failures.** When `aicr evidence verify` fails, the
+  gate surfaces the structured `failureCause` from its `--format json`
+  output (registry 401/403 → "make the fork's aicr-evidence package
+  public", 404, signature, integrity, schema) in the verify column and
+  echoes the full error into the job log — so a contributor can self-serve
+  the fix instead of seeing a bare "invalid".
+
 ### Material-slice canonicalization (proposed)
 
 The material slice is the projection of the recipe-resolution surface


### PR DESCRIPTION
## Summary

Tunes the warning-only recipe-evidence gate (`.github/scripts/recipe-evidence-check.sh`) so broad-impact PRs stop rendering an alarming wall of "missing"/"drifted" rows. Three changes: a protected-vs-other partition, a component-scoped registry cascade, and classified verify-failure causes in the comment.

## Motivation / Context

Part of the evidence-gate pilot epic. PR #1418 (an `aws-efa`-only registry bump) promoted ~all leaf recipes to "affected" and #1427 surfaced an unhelpful bare "invalid". This is the gate-report half of that tuning; it consumes the `failureCause` JSON contract added in #1445.

Fixes: #1432, #1435, #1437
Related: #1431

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI gate script (`.github/scripts/recipe-evidence-check.sh`) + ADR-007

## Implementation Notes

- **Protected vs. other (#1432):** "protected" = has a committed pointer in `recipes/evidence/`. The gate verifies the protected set (status table); affected-but-unevidenced recipes collapse into a single `<details>` count — no longer per-recipe "missing" warnings. No new files to maintain.
- **Component-scoped cascade (#1435):** `registry.yaml` changes are diffed at the component-entry level; a recipe is affected only if its resolved component set (walked across base chain + `spec.mixins`) intersects the changed entries. `base.yaml` stays broad. The recomputed digest remains ground truth (match ⇒ not drift).
- **Classified causes (#1437, script half):** parse `failureCause {class, httpStatus, hint}` + `pending` from `aicr evidence verify --format json`; render an actionable cause in the verify column and echo the full error to the job log.
- ADR-007 gains a "Gate report structure" subsection.

## Testing

Local smoke tests (built `aicr`, temp commits, `recipe-evidence-check.sh`):

| Scenario | Result |
|---|---|
| `aws-efa`-only registry edit | 23 affected = **1 protected** (`gb200-eks-ubuntu-training`) + **22 EKS collapsed**; GKE `h100-gke-cos-training` **not affected** |
| `base.yaml` edit (broad) | 63 affected → **2 protected + 61 collapsed**; warnings **63 → 4** |
| single overlay edit | Rules 1–4 still scope correctly (3 affected) |

`bash -n` + `shellcheck -S warning` clean. (No Go changed; the consumed `failureCause`/`pending` JSON shipped in #1445.)

## Risk Assessment

- [x] **Low** — Warning-only gate; never blocks merge. Changes only the CI script + a doc. Worst case is over/under-listing in a PR comment, with the digest comparison as ground truth.

**Rollout notes:** No config or workflow changes; the workflow invokes the same script with the same env contract.

## Checklist

- [x] Linter passes (`shellcheck`, `bash -n`)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed (ADR-007)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)