### PR TITLE
feat(evidence): fork-based signing workflow + publishing docs

### DIFF
--- a/.github/scripts/evidence-sign-unsigned.sh
+++ b/.github/scripts/evidence-sign-unsigned.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Discover committed-but-unsigned evidence pointers and sign each in place.
+# Consumed by .github/workflows/evidence-publish.yaml (the fork-based
+# signing leg): a contributor pushes an unsigned bundle and commits the
+# pointer locally (`aicr ... --no-sign`), then this signs the bundle each
+# pointer references using the runner's ambient OIDC token and patches the
+# pointer's signer block in place.
+#
+# A pointer is "unsigned" iff its first attestation has no `signer` block —
+# the state `--no-sign` produces. Already-signed pointers are skipped, so
+# re-running is idempotent and safe.
+#
+# Required env:
+#   AICR   path to the aicr binary (built from a trusted source)
+#
+# Requires the mikefarah `yq` (v4) — the same `yq` the rest of the repo's
+# scripts assume. The kislyuk/python `yq` has incompatible syntax and is not
+# supported. On GitHub-hosted runners mikefarah yq is preinstalled.
+#
+# Any extra arguments are forwarded to `aicr evidence sign` (e.g.
+# --plain-http / --insecure-tls for local-registry tests).
+#
+# Outputs (and, when set, appends to $GITHUB_OUTPUT):
+#   skipped=<n>  pointers already signed (no-op)
+#   signed=<n>   pointers signed this run
+#   failed=<n>   pointers whose signing (or parsing) failed
+#
+# Exit status is non-zero when any signing failed, so the workflow surfaces
+# the cause (commonly a private fork registry returning HTTP 403 on the
+# pre-sign pull — make the aicr-evidence package public).
+
+set -euo pipefail
+
+: "${AICR:?AICR is required (path to aicr binary)}"
+
+extra_args=("$@")
+
+signed=0
+failed=0
+skipped=0
+
+shopt -s nullglob
+for pointer in recipes/evidence/*.yaml; do
+  # signer absent => unsigned (the --no-sign state). A signed-without-Rekor
+  # pointer still has a signer block, so it is correctly skipped.
+  #
+  # Fail closed on a yq error: a missing yq or malformed YAML must NOT look
+  # like an unsigned pointer (which would resign an already-signed bundle and
+  # break rerun idempotence). Treat a parse failure as a hard failure.
+  if ! signer=$(yq eval '.attestations[0].signer // "null"' "$pointer" 2>/dev/null); then
+    echo "::error::failed to parse ${pointer} with yq — invalid YAML, or mikefarah yq (v4) not installed"
+    failed=$((failed + 1))
+    continue
+  fi
+  if [[ "$signer" != "null" ]]; then
+    echo "skip (already signed): ${pointer}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  echo "signing unsigned pointer: ${pointer}"
+  # --yes: never pause for the interactive identity-disclosure prompt in CI
+  # (ambient OIDC does not prompt, but this is belt-and-suspenders).
+  if "$AICR" evidence sign "$pointer" --yes "${extra_args[@]}"; then
+    signed=$((signed + 1))
+  else
+    echo "::error::failed to sign ${pointer} — is the bundle's registry package public? (a private fork package returns HTTP 403 on the pre-sign pull)"
+    failed=$((failed + 1))
+  fi
+done
+
+echo "skipped=${skipped}"
+echo "signed=${signed}"
+echo "failed=${failed}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "skipped=${skipped}"
+    echo "signed=${signed}"
+    echo "failed=${failed}"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+# Fail closed if any pointer could not be signed.
+[[ "$failed" -eq 0 ]]

--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fork-based evidence signing — the Fulcio-bound leg of two-phase publish.
+#
+# A contributor publishes an UNSIGNED evidence bundle locally (where the
+# cluster lives, often behind a VPN that blocks Sigstore) and commits the
+# pointer:
+#
+#   aicr validate -r recipes/overlays/<slug>.yaml -s snapshot.yaml \
+#     --emit-attestation ./out --push ghcr.io/<owner>/aicr-evidence --no-sign
+#   cp ./out/pointer.yaml recipes/evidence/<slug>.yaml
+#
+# They then run THIS workflow from their fork's Actions tab. It discovers
+# every committed pointer with an empty signer block, signs the bundle each
+# one references with the runner's ambient OIDC identity (where Sigstore IS
+# reachable), patches the pointer's signer block in place, and commits it
+# back to the branch. Clean no-op when there is nothing unsigned.
+#
+# Why workflow_dispatch (Option A): no recipe-name or bundle-ref inputs to
+# thread through — the committed pointer is the work item, and it already
+# carries bundle.oci + bundle.digest. Manual dispatch keeps the commit-back
+# predictable (no surprise commits) and avoids the loop-guards an automatic
+# push trigger would require.
+#
+# Follow-up — Option B (auto-trigger on push). Lower friction but needs:
+#   * skip the run entirely when no unsigned pointer is present;
+#   * a loop-guard so the workflow's own signing commit does not re-trigger
+#     it (e.g. gate on the actor / commit message, or [skip ci]);
+#   * graceful handling on forks where Actions or id-token are disabled.
+# Land Option A first; add B once the discover-and-patch path is proven.
+#
+# Security note: this runs in the *contributor's fork* on a branch they
+# control, signing with the fork's own GitHub Actions OIDC identity. The
+# id-token:write / contents:write grants act on the fork, not upstream —
+# there is no pull_request_target / untrusted-ref exposure (it is manual
+# dispatch on the fork's own code).
+#
+# The fork's aicr-evidence registry package must be PUBLIC: the pre-sign
+# pull (and the upstream evidence gate) fetch the bundle, and a private
+# package returns HTTP 403. The signing step fails with a clear message
+# pointing at this when it can't pull.
+
+name: "Recipe Evidence: Sign"
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # commit the patched pointer(s) back to the branch
+  id-token: write   # ambient OIDC for keyless Fulcio/Rekor signing
+
+concurrency:
+  # Serialize per branch; do NOT cancel in progress — a cancel mid-sign
+  # could leave a bundle signed in the registry but its pointer un-patched.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sign:
+    name: Sign unsigned evidence pointers
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # Do not persist the push token in .git/config: it would sit there
+          # across the fork-controlled `go build` step. The push step below
+          # supplies the token explicitly only when it needs it.
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: ${{ steps.versions.outputs.go }}
+          cache: false
+
+      - name: Build aicr
+        env:
+          GOFLAGS: -mod=vendor
+        run: |
+          # Verify the vendored dependency tree against go.sum before building
+          # the binary that will sign with the runner's OIDC identity.
+          go mod verify
+          go build -o ./bin/aicr ./cmd/aicr
+
+      - name: Sign unsigned evidence pointers
+        id: sign
+        env:
+          AICR: ${{ github.workspace }}/bin/aicr
+        run: .github/scripts/evidence-sign-unsigned.sh
+
+      - name: Commit signed pointers
+        # always() so that if one pointer fails to sign, the ones that DID
+        # sign are still committed — otherwise the registry would hold a signed
+        # bundle whose committed pointer stays unsigned. The job still fails
+        # (the sign step exited non-zero), surfacing the failure.
+        if: ${{ always() && steps.sign.outputs.signed != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- recipes/evidence/; then
+            echo "No pointer changes to commit (nothing to sign)."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add recipes/evidence/
+          # -s adds a `Signed-off-by:` (DCO) trailer matching the bot author,
+          # so the DCO bot passes on the commit-back. The commit is NOT
+          # cryptographically signed (no -S) — it fills in the evidence
+          # pointer's signer block (the bundle signature); repo commit-signing
+          # policy is satisfied by the eventual squash-merge.
+          git commit -s -m "chore(evidence): sign pending evidence pointers"
+          # Push with the token supplied inline (credentials are not persisted
+          # in .git/config). A non-fast-forward here is a clear, recoverable
+          # failure: re-dispatch after pulling.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${GITHUB_REF_NAME}"

--- a/docs/contributor/evidence-publishing.md
+++ b/docs/contributor/evidence-publishing.md
@@ -1,0 +1,127 @@
+# Publishing Recipe Evidence
+
+Recipe evidence is a signed bundle that proves a recipe's validators passed
+on hardware matching its `criteria`. Producing it has two legs:
+
+1. **Validate + push (network-light).** Runs where the cluster lives —
+   often a corporate VPN. Captures a snapshot, runs the validators, builds
+   the bundle, and pushes it to an OCI registry.
+2. **Sign (Fulcio-bound).** Signs the pushed bundle with keyless OIDC
+   (Sigstore Fulcio + Rekor) and records the signature in the committed
+   pointer.
+
+The two legs need different network access, and the signing leg is the one
+contributors most often can't complete locally.
+
+## The Fulcio connectivity problem
+
+Keyless signing reaches `fulcio.sigstore.dev` and `rekor.sigstore.dev`.
+**Corporate VPNs and some home networks block TLS to these hosts** — the
+connection is rejected at the IP level upstream, not by AICR. The symptom
+is a hang or a TLS/connection-reset error during the sign step, even though
+`aicr validate` and the registry push succeed.
+
+This is not an AICR bug and AICR cannot work around it; the block is on the
+path to Sigstore's public-good infrastructure. Contributors have reported
+needing a phone hotspot to sign from a laptop.
+
+## Recommended path: split the legs, sign in CI
+
+The fix is to keep the network-light leg local and move only the
+Fulcio-bound leg to GitHub Actions, where Sigstore is reachable. The signer
+identity becomes your fork's GitHub Actions OIDC identity rather than a
+personal one.
+
+### 1. Validate and push an unsigned bundle (local, on VPN)
+
+```shell
+aicr snapshot -o snapshot.yaml
+aicr validate \
+  -r recipes/overlays/<slug>.yaml \
+  -s snapshot.yaml \
+  --emit-attestation ./out \
+  --push ghcr.io/<your-fork-owner>/aicr-evidence \
+  --no-sign
+cp ./out/pointer.yaml recipes/evidence/<slug>.yaml
+```
+
+`--no-sign` skips all OIDC/Fulcio/Rekor work, so this runs even where
+Sigstore egress is blocked. It pushes the content-addressed bundle and
+writes a pointer with an empty `signer` block. See
+[`aicr validate`](../user/cli-reference.md#aicr-validate) and
+[`aicr evidence publish`](../user/cli-reference.md#aicr-evidence-publish)
+(which also accepts `--no-sign` if you push as a separate step).
+
+> **Make the registry package public.** The signing step (and the
+> repository's evidence gate) pull the bundle back to sign and verify it.
+> If your fork's `aicr-evidence` package is private, the pull fails with an
+> HTTP **403** and the gate reports `registry-forbidden`. On GHCR, set the
+> `aicr-evidence` package visibility to **public** under your account's
+> *Packages* settings. Any OCI-1.1 registry works; it just has to be
+> readable.
+
+### 2. Commit the unsigned pointer and push your branch
+
+```shell
+git add recipes/evidence/<slug>.yaml
+# Use -s (DCO sign-off) — required for all contributors. NVIDIA org members
+# additionally use -S (cryptographic signing); external contributors use -s
+# alone. See CONTRIBUTING.md.
+git commit -s -m "evidence: <slug> (unsigned; sign in CI)"
+git push
+```
+
+`aicr evidence verify` reports an unsigned pointer as a non-failing
+**pending signature** state, so an in-flight PR is not flagged as broken.
+
+### 3. Sign in your fork via GitHub Actions
+
+Run the **Recipe Evidence: Sign** workflow
+(`.github/workflows/evidence-publish.yaml`) from your fork's *Actions* tab
+(it is `workflow_dispatch` — no inputs). The filename says *publish* because it
+anticipates a future auto-publish leg (see the workflow header); today it only
+signs. The workflow:
+
+- discovers every pointer in `recipes/evidence/*.yaml` with an empty
+  `signer` (i.e. unsigned),
+- signs the bundle each one already references using the runner's ambient
+  OIDC token ([`aicr evidence sign`](../user/cli-reference.md#aicr-evidence-sign)),
+- patches the pointer's `signer` block in place and commits it back to the
+  branch.
+
+It is a clean no-op when there are no unsigned pointers, and it fails with a
+clear message if it cannot pull a bundle (the public-package requirement
+above). Pull the commit it pushes (`git pull`) — your PR now carries a pointer
+whose `signer` block is filled in (the *bundle* is signed; the commit-back
+itself is a normal, unsigned GitHub Actions commit, which the eventual
+squash-merge re-signs under the repo's policy).
+
+> The workflow declares `id-token: write` in its own `permissions:` block —
+> it is not a default. Your fork must have GitHub Actions enabled and not
+> restrict workflow OIDC token issuance (the default fork setting allows it).
+>
+> Avoid pushing other commits to the branch while the workflow runs: it
+> commits the patched pointers back, and a concurrent push would cause a
+> non-fast-forward — re-dispatch after `git pull` if that happens.
+
+## Fallback: split the legs locally
+
+If you have a host with Sigstore egress (a jump box, CI runner, or
+hotspot), you can run the signing leg there instead of in Actions:
+
+```shell
+# On VPN, where the cluster is: produce an unsigned bundle.
+aicr validate -r recipes/overlays/<slug>.yaml -s snapshot.yaml --emit-attestation ./out
+
+# Off VPN, where Sigstore is reachable: sign, push, and write the pointer.
+aicr evidence publish ./out --push ghcr.io/<your-fork-owner>/aicr-evidence
+cp ./out/pointer.yaml recipes/evidence/<slug>.yaml
+```
+
+The signed artifact is content-addressed, so the result is identical
+regardless of which host ran which leg.
+
+## See also
+
+- [ADR-007: Verifiable Recipe Test Evidence](../design/007-recipe-evidence.md) — trust model and bundle format.
+- [`aicr evidence` CLI reference](../user/cli-reference.md#aicr-evidence-sign) — `sign`, `publish`, `verify`.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -90,3 +90,5 @@ navigation:
         path: contributor/skills.md
       - page: Maintaining AICR
         path: contributor/maintaining.md
+      - page: Publishing Recipe Evidence
+        path: contributor/evidence-publishing.md


### PR DESCRIPTION
## Summary

Adds the Fulcio-bound signing leg of two-phase evidence publish: a `workflow_dispatch` workflow a contributor runs in their fork to sign committed-but-unsigned evidence pointers, plus a contributor doc explaining the Sigstore connectivity problem this works around.

## Motivation / Context

Final piece of the evidence-gate pilot epic. Keyless signing reaches `fulcio.sigstore.dev`/`rekor.sigstore.dev`, which corporate VPNs and some home networks block at the IP level. The fix is to keep the network-light push leg local (`--no-sign`, merged in #1445) and move only the signing leg to CI, where Sigstore is reachable. This consumes the `aicr evidence sign` CLI merged in #1446.

Fixes: #1433, #1436
Related: #1431, #1434

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions workflow + script

## Implementation Notes

- **`.github/workflows/evidence-publish.yaml`** — `workflow_dispatch`, no inputs (the committed pointer is the work item). `id-token: write` (ambient keyless OIDC) + `contents: write` (commit the patched pointer back). Builds aicr, runs the discovery script, commits signed pointers back. Clean no-op when nothing is unsigned. **Option B (auto-trigger on push) is documented in the header as a follow-up** with its loop-guard requirements; Option A (manual) lands first per the issue.
- **`.github/scripts/evidence-sign-unsigned.sh`** — "unsigned" = first attestation has no `signer` block (the `--no-sign` state); already-signed pointers are skipped (idempotent re-runs). Fails closed with an actionable message when a bundle can't be pulled (a private fork package → HTTP 403 on the pre-sign pull).
- **`docs/contributor/evidence-publishing.md`** (+ nav entry) — the Fulcio block, the split-leg path, the **public-package requirement**, and the local-only fallback.
- **Security:** runs in the contributor's fork on a branch they control, signing with the fork's own OIDC identity. The write grants act on the fork, not upstream — no `pull_request_target`/untrusted-ref exposure (manual dispatch on the fork's own code).

## Testing

Local smoke tests (built aicr, ran the discovery script):

| Scenario | Result |
|---|---|
| Both committed pointers (signed) | skipped → `signed=0`, clean no-op |
| Temp unsigned pointer | detected → routed to `aicr evidence sign` → fails closed with the public-package hint when the bundle can't be pulled |

`shellcheck -S warning` + `actionlint` + `yamllint` all clean.

## Risk Assessment

- [x] **Low** — New, manually-triggered workflow + script + docs; nothing wired into existing PR/merge gates. No effect unless a contributor dispatches it in their fork.

**Rollout notes:** Contributors enable Actions in their fork and make their `aicr-evidence` package public (documented). Upstream behavior is unchanged.

## Checklist

- [x] Linter passes (`shellcheck`, `actionlint`, `yamllint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (local smoke tests; no unit-test surface for a dispatch workflow)
- [x] I updated docs (new contributor page + nav entry)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)