### PR TITLE
fix(uat): gate on Prometheus readiness; retry conformance metric APIs

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -40,12 +40,13 @@ jobs:
   uat-aws:
     if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
-    # Bumped from 90 to 110 for the validate step running all phases (deployment
-    # readiness gate + conformance + NCCL performance), then to 130 so the
-    # install step's deployment-phase readiness gate (up to
-    # READINESS_TIMEOUT_SECONDS, spanning a nodewright reboot) fits on top of
-    # helmfile apply without the job cap truncating later steps.
-    timeout-minutes: 130
+    # Covers the uncapped non-UAT steps (build, validator image push, EKS
+    # provisioning, evidence upload) + the UAT phase steps (prep 15 + install 45
+    # + validate 40 + train 25 + verify 5 = 130) + the always()-run Destroy
+    # Cluster teardown. The teardown MUST fit in this budget: a job-level timeout
+    # cancels pending always() steps, so an undersized cap would skip teardown
+    # and leak the GPU node / capacity reservation.
+    timeout-minutes: 180
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -40,12 +40,13 @@ jobs:
   uat-gcp:
     if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
-    # Bumped from 90 to 110 for the validate step running all phases (deployment
-    # readiness gate + conformance + NCCL performance), then to 130 so the
-    # install step's deployment-phase readiness gate (up to
-    # READINESS_TIMEOUT_SECONDS, spanning a nodewright reboot) fits on top of
-    # helmfile apply without the job cap truncating later steps.
-    timeout-minutes: 130
+    # Covers the uncapped non-UAT steps (build, validator image push, GKE
+    # provisioning, evidence upload) + the UAT phase steps (prep 15 + install 45
+    # + validate 40 + train 25 + verify 5 = 130) + the always()-run Destroy
+    # Cluster teardown. The teardown MUST fit in this budget: a job-level timeout
+    # cancels pending always() steps, so an undersized cap would skip teardown
+    # and leak the GPU node.
+    timeout-minutes: 180
     permissions:
       contents: read
       actions: read

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -454,6 +454,14 @@ const (
 
 	// HPAPollInterval is the interval for polling HPA status during behavioral tests.
 	HPAPollInterval = 10 * time.Second
+
+	// MetricsAPIWarmupTimeout bounds the retry while the aggregated metrics APIs
+	// (custom/external.metrics.k8s.io) warm up: prometheus-adapter registers its
+	// APIServices before its first Prometheus relist populates metric data, so a
+	// single-shot GET right after the deployment phase can race that window. Kept
+	// short so the pod-autoscaling metric-API steps plus the HPA behavioral test
+	// stay within the validator's catalog timeout.
+	MetricsAPIWarmupTimeout = 60 * time.Second
 )
 
 // Karpenter behavioral test timeouts for conformance validation.

--- a/recipes/checks/kube-prometheus-stack/health-check.yaml
+++ b/recipes/checks/kube-prometheus-stack/health-check.yaml
@@ -40,6 +40,26 @@ spec:
                 namespace: monitoring
               status:
                 (availableReplicas > `0`): true
+    - name: validate-prometheus-server-ready
+      try:
+        # The operator-only check above passes as soon as the prometheus-operator
+        # Deployment is up -- BEFORE the operator has created and started the
+        # Prometheus server StatefulSet. Gate on the server itself being Ready so
+        # the deployment phase does not hand a not-yet-serving Prometheus to the
+        # conformance metric checks (ai-service-metrics / pod-autoscaling), which
+        # query Prometheus and the prometheus-adapter metrics APIs. The StatefulSet
+        # name derives from the chart fullnameOverride (kube-prometheus) + the
+        # Prometheus CR: prometheus-kube-prometheus-prometheus (matches the
+        # prometheus-kube-prometheus-prometheus-0 pod).
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: prometheus-kube-prometheus-prometheus
+                namespace: monitoring
+              status:
+                (readyReplicas > `0`): true
     - name: validate-all-pods-healthy
       try:
         # Assert no prometheus stack pods are in unhealthy phases

--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -192,24 +192,34 @@ phase_install() {
   # Run against a copy of the config with spec.validate.evidence stripped so the
   # gate never emits/pushes an evidence bundle -- that is the conformance phase's
   # job (phase_conformance, `--phase all`).
-  local gate_config; gate_config="$(mktemp)"
+  local gate_config gate_log
+  gate_config="$(mktemp)"
+  gate_log="$(mktemp)"
   yq 'del(.spec.validate.evidence)' "${config}" > "${gate_config}"
   local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
-  local attempt=1
+  local attempt=1 ready=false
   echo "::group::Readiness gate: validate --phase deployment (timeout ${READINESS_TIMEOUT_SECONDS}s)"
-  until "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null >/dev/null 2>&1; do
-    if (( SECONDS >= ready_deadline )); then
-      echo "::error::deployment readiness gate did not pass within ${READINESS_TIMEOUT_SECONDS}s; final attempt:" >&2
-      "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null 2>&1 || true
-      rm -f "${gate_config}"
-      echo "::endgroup::"
-      exit 1
+  # Check the deadline BEFORE each attempt so no validation run is launched once
+  # the budget is spent (a single run can itself take minutes). The last
+  # attempt's output is captured in gate_log for the failure diagnostic rather
+  # than re-running validate past the deadline.
+  while (( SECONDS < ready_deadline )); do
+    if "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null > "${gate_log}" 2>&1; then
+      ready=true
+      break
     fi
     echo "deployment phase not ready (attempt ${attempt}); retrying in 15s..."
     attempt=$(( attempt + 1 ))
     sleep 15
   done
-  rm -f "${gate_config}"
+  if [[ "${ready}" != true ]]; then
+    echo "::error::deployment readiness gate did not pass within ${READINESS_TIMEOUT_SECONDS}s; last attempt output:" >&2
+    cat "${gate_log}" >&2 || true
+    rm -f "${gate_config}" "${gate_log}"
+    echo "::endgroup::"
+    exit 1
+  fi
+  rm -f "${gate_config}" "${gate_log}"
   echo "deployment readiness gate passed (attempt ${attempt})"
   echo "::endgroup::"
 }

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -192,24 +192,34 @@ phase_install() {
   # Run against a copy of the config with spec.validate.evidence stripped so the
   # gate never emits/pushes an evidence bundle -- that is the conformance phase's
   # job (phase_conformance, `--phase all`).
-  local gate_config; gate_config="$(mktemp)"
+  local gate_config gate_log
+  gate_config="$(mktemp)"
+  gate_log="$(mktemp)"
   yq 'del(.spec.validate.evidence)' "${config}" > "${gate_config}"
   local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
-  local attempt=1
+  local attempt=1 ready=false
   echo "::group::Readiness gate: validate --phase deployment (timeout ${READINESS_TIMEOUT_SECONDS}s)"
-  until "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null >/dev/null 2>&1; do
-    if (( SECONDS >= ready_deadline )); then
-      echo "::error::deployment readiness gate did not pass within ${READINESS_TIMEOUT_SECONDS}s; final attempt:" >&2
-      "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null 2>&1 || true
-      rm -f "${gate_config}"
-      echo "::endgroup::"
-      exit 1
+  # Check the deadline BEFORE each attempt so no validation run is launched once
+  # the budget is spent (a single run can itself take minutes). The last
+  # attempt's output is captured in gate_log for the failure diagnostic rather
+  # than re-running validate past the deadline.
+  while (( SECONDS < ready_deadline )); do
+    if "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null > "${gate_log}" 2>&1; then
+      ready=true
+      break
     fi
     echo "deployment phase not ready (attempt ${attempt}); retrying in 15s..."
     attempt=$(( attempt + 1 ))
     sleep 15
   done
-  rm -f "${gate_config}"
+  if [[ "${ready}" != true ]]; then
+    echo "::error::deployment readiness gate did not pass within ${READINESS_TIMEOUT_SECONDS}s; last attempt output:" >&2
+    cat "${gate_log}" >&2 || true
+    rm -f "${gate_config}" "${gate_log}"
+    echo "::endgroup::"
+    exit 1
+  fi
+  rm -f "${gate_config}" "${gate_log}"
   echo "deployment readiness gate passed (attempt ${attempt})"
   echo "::endgroup::"
 }

--- a/validators/conformance/pod_autoscaling_check.go
+++ b/validators/conformance/pod_autoscaling_check.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -85,10 +86,17 @@ func CheckPodAutoscaling(ctx *validators.Context) error {
 		return errors.New(errors.ErrCodeInternal, "discovery REST client is not available")
 	}
 	rawURL := "/apis/custom.metrics.k8s.io/v1beta1"
-	result := restClient.Get().AbsPath(rawURL).Do(ctx.Ctx)
-	if err := result.Error(); err != nil {
+	// Retry: the aggregated APIService can be registered but not yet serving
+	// (prometheus-adapter relist) right after the deployment phase. Fail closed
+	// after the warmup budget.
+	var result rest.Result
+	if pollErr := waitForMetricsAPI(ctx.Ctx, defaults.MetricsAPIWarmupTimeout, defaults.HPAPollInterval,
+		func(c context.Context) error {
+			result = restClient.Get().AbsPath(rawURL).Do(c)
+			return result.Error()
+		}); pollErr != nil {
 		return errors.Wrap(errors.ErrCodeNotFound,
-			"custom metrics API not available (prometheus-adapter not ready)", err)
+			"custom metrics API not available (prometheus-adapter not ready)", pollErr)
 	}
 	var statusCode int
 	result.StatusCode(&statusCode)
@@ -193,26 +201,39 @@ pollLoop:
 				"the HPA behavioral test below.")
 	}
 
-	// 3. External metrics API has GPU metrics
+	// 3. External metrics API has GPU metrics. Retry: the adapter may have
+	// registered the APIService but not yet relisted the metric, or Prometheus
+	// may not hold a DCGM sample yet, right after the deployment phase. Fail
+	// closed (unreachable / no data) after the warmup budget.
 	extPath := "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/dcgm_gpu_power_usage"
-	extResult := restClient.Get().AbsPath(extPath).Do(ctx.Ctx)
-	if extErr := extResult.Error(); extErr != nil {
-		return errors.Wrap(errors.ErrCodeNotFound,
-			"external metric dcgm_gpu_power_usage not available", extErr)
-	}
-	var extStatusCode int
-	extResult.StatusCode(&extStatusCode)
-	extRaw, err := extResult.Raw()
-	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed reading external metric response", err)
-	}
+	var extResult rest.Result
 	var extResp struct {
 		Items []json.RawMessage `json:"items"`
 	}
-	if json.Unmarshal(extRaw, &extResp) == nil && len(extResp.Items) == 0 {
-		return errors.New(errors.ErrCodeNotFound,
-			"external metric dcgm_gpu_power_usage has no data")
+	if pollErr := waitForMetricsAPI(ctx.Ctx, defaults.MetricsAPIWarmupTimeout, defaults.HPAPollInterval,
+		func(c context.Context) error {
+			extResult = restClient.Get().AbsPath(extPath).Do(c)
+			if extErr := extResult.Error(); extErr != nil {
+				return extErr
+			}
+			extRaw, rawErr := extResult.Raw()
+			if rawErr != nil {
+				return rawErr
+			}
+			extResp.Items = nil
+			if unmarshalErr := json.Unmarshal(extRaw, &extResp); unmarshalErr != nil {
+				return errors.Wrap(errors.ErrCodeInternal, "failed reading external metric response", unmarshalErr)
+			}
+			if len(extResp.Items) == 0 {
+				return errors.New(errors.ErrCodeNotFound, "external metric dcgm_gpu_power_usage has no data")
+			}
+			return nil
+		}); pollErr != nil {
+		return errors.Wrap(errors.ErrCodeNotFound,
+			"external metric dcgm_gpu_power_usage not available", pollErr)
 	}
+	var extStatusCode int
+	extResult.StatusCode(&extStatusCode)
 
 	recordRawTextArtifact(ctx, "External Metrics API",
 		fmt.Sprintf("kubectl get --raw %s", extPath),
@@ -236,6 +257,29 @@ pollLoop:
 	recordRawTextArtifact(ctx, "Delete test namespace",
 		"kubectl delete namespace hpa-test --ignore-not-found",
 		fmt.Sprintf("Deleted namespace %s after HPA behavioral test.", hpaReport.Namespace))
+	return nil
+}
+
+// waitForMetricsAPI polls probe until it returns nil or the budget elapses,
+// returning the last probe error on timeout. prometheus-adapter registers its
+// aggregated APIServices before its first Prometheus relist populates metric
+// data, so a single-shot GET right after the deployment phase can race that
+// warm-up; this bounds the wait and fails closed. probe runs immediately, then
+// every interval.
+func waitForMetricsAPI(ctx context.Context, timeout, interval time.Duration, probe func(context.Context) error) error {
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var lastErr error
+	if err := wait.PollUntilContextCancel(pollCtx, interval, true,
+		func(c context.Context) (bool, error) {
+			lastErr = probe(c)
+			return lastErr == nil, nil
+		}); err != nil {
+		if lastErr != nil {
+			return lastErr
+		}
+		return err
+	}
 	return nil
 }
 

--- a/validators/conformance/pod_autoscaling_check_test.go
+++ b/validators/conformance/pod_autoscaling_check_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestWaitForMetricsAPI covers the bounded-retry helper that wraps the
+// pod-autoscaling metric-API probes (custom/external.metrics.k8s.io), which can
+// race the prometheus-adapter relist right after the deployment phase. A tiny
+// interval keeps the test fast.
+func TestWaitForMetricsAPI(t *testing.T) {
+	t.Run("immediate success runs the probe once", func(t *testing.T) {
+		calls := 0
+		err := waitForMetricsAPI(context.Background(), time.Second, time.Millisecond,
+			func(context.Context) error { calls++; return nil })
+		if err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("want 1 probe call, got %d", calls)
+		}
+	})
+
+	t.Run("retries until the probe succeeds", func(t *testing.T) {
+		calls := 0
+		err := waitForMetricsAPI(context.Background(), 5*time.Second, time.Millisecond,
+			func(context.Context) error {
+				calls++
+				if calls < 3 {
+					return errors.New("not ready")
+				}
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("want success after retries, got %v", err)
+		}
+		if calls < 3 {
+			t.Errorf("want >=3 probe calls, got %d", calls)
+		}
+	})
+
+	t.Run("returns the last probe error on timeout (fail closed)", func(t *testing.T) {
+		sentinel := errors.New("still not ready")
+		err := waitForMetricsAPI(context.Background(), 30*time.Millisecond, time.Millisecond,
+			func(context.Context) error { return sentinel })
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("want last probe error %v, got %v", sentinel, err)
+		}
+	})
+
+	t.Run("returns when the parent context is already canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := waitForMetricsAPI(ctx, time.Second, time.Millisecond,
+			func(context.Context) error { calls++; return errors.New("not ready") })
+		if err == nil {
+			t.Fatal("want non-nil error when parent context is canceled")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Make the UAT conformance metric checks (`ai-service-metrics`, `pod-autoscaling`) pass reliably: gate the deployment phase on the Prometheus **server** being Ready, and give the pod-autoscaling metric-API probes a bounded, fail-closed retry. Also folds in the #1439 review fixes (gate-deadline + UAT job timeout).

## Motivation / Context

After the deployment-phase readiness gate (#1439), `ai-service-metrics` and `pod-autoscaling` still failed — but not because of the single-GPU-node count. The deployment gate's `kube-prometheus-stack` health-check only asserted the prometheus-**operator** Deployment, and its pod selector (`app.kubernetes.io/name=kube-prometheus-stack`) matches **zero** pods on chart 84.4.0 (the real pods are labeled `prometheus`, `grafana`, etc.), so the negative pod-health asserts were vacuous. The gate therefore passed before the Prometheus **server** StatefulSet was serving, and conformance ran against a cold Prometheus / prometheus-adapter pipeline. The pod-autoscaling metric-API probes compounded it by being single-shot, racing the adapter's first relist.

Confirmed on a live cluster that the corrected health-check gates on the Prometheus server as intended.

Fixes/Closes: #1425
Related: #1439, #1426, #1429

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`validators/conformance`, `pkg/defaults`)
- [x] Recipe engine / data (`recipes/checks`)
- [x] Other: UAT test harness (`tests/uat/{aws,gcp}`, workflows)

## Implementation Notes

- **Health-check gates on the Prometheus server** (`recipes/checks/kube-prometheus-stack/health-check.yaml`): add a positive assert that the `prometheus-kube-prometheus-prometheus` StatefulSet has `readyReplicas > 0`, so the deployment phase waits for the server itself, not just the operator. (Hydrated into the recipe by `aicr` and run from the validation data — no validator-image rebuild required for this part.)
- **pod-autoscaling bounded retries** (#1425) (`validators/conformance/pod_autoscaling_check.go`, `pkg/defaults/timeouts.go`): wrap the single-shot custom- and external-metrics API probes in a fail-closed retry (new `MetricsAPIWarmupTimeout`, default 60s) via a testable `waitForMetricsAPI` helper; also fail closed on an unparseable external-metrics response (previously a vacuous pass).
- **#1439 review fixes** (`tests/uat/{aws,gcp}/run`, `.github/workflows/uat-{aws,gcp}.yaml`): check the readiness-gate deadline before each attempt (no run launched past the budget); raise the UAT job `timeout-minutes` to 180 so the `always()`-run Destroy Cluster teardown isn't cancelled by a job-level timeout.

## Testing

```bash
go build ./validators/conformance/... ./pkg/defaults/...      # OK
go vet  ./validators/conformance/...                          # OK
go test ./validators/conformance/... -run TestWaitForMetricsAPI -v   # PASS (4 subtests)
go test -cover ./validators/conformance/...                   # ok, 27.0%
golangci-lint run -c .golangci.yaml ./validators/conformance/... ./pkg/defaults/...   # 0 issues (v2.12.2, repo-pinned)
bash -n tests/uat/{aws,gcp}/run && shellcheck -S warning tests/uat/{aws,gcp}/run      # clean
```

- New `waitForMetricsAPI` unit test (immediate-success / retry-then-success / fail-closed timeout / canceled-context).
- Coverage `validators/conformance`: **26.8% → 27.0%** (no decrease).
- Health-check confirmed on a live cluster.
- `-race` requires cgo (no compiler in the dev env); CI runs it.

## Risk Assessment

- [x] **Low** — validator change is a fail-closed retry (no fail-open); the health-check adds a stricter readiness assert; UAT-harness/workflow changes are CI-only. Worst case is a slower gate, not a masked failure.

**Rollout notes:** `MetricsAPIWarmupTimeout` and `READINESS_TIMEOUT_SECONDS` are tunable; the metric-API retries are bounded to stay within the pod-autoscaling catalog timeout.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — unit tests pass; `-race` runs in CI (no local cgo)
- [x] Linter passes (`make lint`) — golangci-lint v2.12.2 (pinned): 0 issues; bash -n + shellcheck clean
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — `TestWaitForMetricsAPI`
- [ ] I updated docs if user-facing behavior changed — N/A (internal UAT/validator behavior)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
