### PR TITLE
feat(evidence): auto-sign evidence pointers on push

### DIFF
--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -34,12 +34,21 @@
 # predictable (no surprise commits) and avoids the loop-guards an automatic
 # push trigger would require.
 #
-# Follow-up — Option B (auto-trigger on push). Lower friction but needs:
-#   * skip the run entirely when no unsigned pointer is present;
-#   * a loop-guard so the workflow's own signing commit does not re-trigger
-#     it (e.g. gate on the actor / commit message, or [skip ci]);
-#   * graceful handling on forks where Actions or id-token are disabled.
-# Land Option A first; add B once the discover-and-patch path is proven.
+# Two triggers:
+#   * workflow_dispatch — manual, works anywhere (incl. upstream).
+#   * push to recipes/evidence/** — auto-sign (Option B), forks only.
+#
+# Loop / scope guards for the auto-trigger (it commits back to the branch):
+#   * GitHub does not re-run workflows for pushes made with the default
+#     GITHUB_TOKEN, so the commit-back below does not re-trigger this on its
+#     own. The job `if:` also skips a push whose head commit is our own
+#     signing commit — belt-and-suspenders for forks pushing via a PAT.
+#   * The job `if:` restricts the push path to forks (github.repository !=
+#     'NVIDIA/aicr') and `branches-ignore: [main]` keeps it off any default
+#     branch, so it never auto-commits to the canonical repo.
+#   * The signer script no-ops cleanly when no unsigned pointer is present.
+#   * On forks with Actions or id-token disabled, the workflow simply does
+#     not run / the sign step fails closed with a clear message.
 #
 # Security note: this runs in the *contributor's fork* on a branch they
 # control, signing with the fork's own GitHub Actions OIDC identity. The
@@ -56,6 +65,11 @@ name: "Recipe Evidence: Sign"
 
 on:
   workflow_dispatch: {}
+  push:
+    paths:
+      - 'recipes/evidence/**'
+    branches-ignore:
+      - main
 
 permissions:
   contents: write   # commit the patched pointer(s) back to the branch
@@ -72,6 +86,14 @@ jobs:
     name: Sign unsigned evidence pointers
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Manual dispatch runs anywhere. The push auto-trigger runs only in forks
+    # (never the canonical repo) and skips our own signing commit so the
+    # commit-back can't loop (GITHUB_TOKEN pushes already don't re-trigger;
+    # this also covers forks pushing via a PAT).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.repository != 'NVIDIA/aicr' &&
+       !startsWith(github.event.head_commit.message, 'chore(evidence): sign pending evidence pointers'))
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -44,8 +44,9 @@
 #     own. The job `if:` also skips a push whose head commit is our own
 #     signing commit — belt-and-suspenders for forks pushing via a PAT.
 #   * The job `if:` restricts the push path to forks (github.repository !=
-#     'NVIDIA/aicr') and `branches-ignore: [main]` keeps it off any default
-#     branch, so it never auto-commits to the canonical repo.
+#     'NVIDIA/aicr') and skips the fork's default branch (matched dynamically
+#     via github.event.repository.default_branch, so a non-`main` default is
+#     still covered), so it never auto-commits to a default branch.
 #   * The signer script no-ops cleanly when no unsigned pointer is present.
 #   * On forks with Actions or id-token disabled, the workflow simply does
 #     not run / the sign step fails closed with a clear message.
@@ -68,8 +69,6 @@ on:
   push:
     paths:
       - 'recipes/evidence/**'
-    branches-ignore:
-      - main
 
 permissions:
   contents: write   # commit the patched pointer(s) back to the branch
@@ -87,12 +86,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Manual dispatch runs anywhere. The push auto-trigger runs only in forks
-    # (never the canonical repo) and skips our own signing commit so the
-    # commit-back can't loop (GITHUB_TOKEN pushes already don't re-trigger;
-    # this also covers forks pushing via a PAT).
+    # (never the canonical repo), never on the fork's default branch (matched
+    # dynamically so a renamed default is still covered), and skips our own
+    # signing commit so the commit-back can't loop (GITHUB_TOKEN pushes already
+    # don't re-trigger; this also covers forks pushing via a PAT).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.repository != 'NVIDIA/aicr' &&
+       github.ref_name != github.event.repository.default_branch &&
        !startsWith(github.event.head_commit.message, 'chore(evidence): sign pending evidence pointers'))
     steps:
       - name: Checkout

--- a/docs/contributor/evidence-publishing.md
+++ b/docs/contributor/evidence-publishing.md
@@ -76,11 +76,17 @@ git push
 
 ### 3. Sign in your fork via GitHub Actions
 
-Run the **Recipe Evidence: Sign** workflow
-(`.github/workflows/evidence-publish.yaml`) from your fork's *Actions* tab
-(it is `workflow_dispatch` — no inputs). The filename says *publish* because it
-anticipates a future auto-publish leg (see the workflow header); today it only
-signs. The workflow:
+The **Recipe Evidence: Sign** workflow (`.github/workflows/evidence-publish.yaml`)
+runs two ways in your fork:
+
+- **Automatically** when you push a change under `recipes/evidence/**` to any
+  branch other than your default — so step 2's push usually triggers it for you.
+- **Manually** from your fork's *Actions* tab (`workflow_dispatch`, no inputs) —
+  use this to re-run after making the registry package public, or if the auto-run
+  didn't fire.
+
+The auto-trigger is fork-only (it never runs on the canonical repo) and skips its
+own signing commit, so it can't loop. The workflow:
 
 - discovers every pointer in `recipes/evidence/*.yaml` with an empty
   `signer` (i.e. unsigned),


### PR DESCRIPTION
## Summary

Adds the push-triggered variant of the fork-based evidence signing workflow — "Option B", the follow-up flagged in `evidence-publish.yaml`'s header when #1433 landed Option A (manual `workflow_dispatch`). A push under `recipes/evidence/**` now auto-runs the signer, so a contributor's "commit the unsigned pointer and push" step signs without a manual Actions click.

## Motivation / Context

#1433 deliberately shipped Option A first and documented Option B's loop-guard requirements as a fast-follow. This implements it.

Fixes: N/A
Related: #1433, #1431

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling
- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions workflow

## Implementation Notes

Trigger: added `push` (paths `recipes/evidence/**`, `branches-ignore: [main]`) alongside the existing `workflow_dispatch`.

Loop / scope guards (the workflow commits the patched pointer back):
- **No loop:** GitHub doesn't re-run workflows for pushes made with the default `GITHUB_TOKEN`, so the commit-back doesn't re-trigger. The job `if:` *also* skips a push whose head commit is our own signing commit (`startsWith(... 'chore(evidence): sign pending evidence pointers')`) — belt-and-suspenders for forks that push via a PAT.
- **Fork-only:** the push path runs only when `github.repository \!= 'NVIDIA/aicr'`, and `branches-ignore: [main]` keeps it off any default branch — it never auto-commits to the canonical repo. `workflow_dispatch` still works anywhere (incl. upstream).
- **Graceful:** the signer script already no-ops when nothing is unsigned and fails closed with a clear message when a bundle can't be pulled.

## Testing

```bash
actionlint .github/workflows/evidence-publish.yaml   # OK
yamllint   .github/workflows/evidence-publish.yaml   # OK
```

Workflow logic is trigger/guard wiring (no unit-test surface); the signer script itself was tested in #1451. The guard expression is exercised by the existing dispatch path plus the new push path.

## Risk Assessment

- [x] **Low** — Additive trigger on an existing fork-only helper; guarded against loops and against running on the canonical repo. No effect on upstream CI or merge gates.

**Rollout notes:** Forks with Actions enabled get auto-signing on pointer pushes; everyone retains the manual dispatch. Upstream behavior unchanged.

## Checklist

- [x] Linter passes (`actionlint`, `yamllint`)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs (contributor publishing guide)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)