### PR TITLE
ci(uat): refresh cloud creds before teardown to prevent GPU leak

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -360,6 +360,23 @@ jobs:
             fi
           done
 
+      # Re-assume the role immediately before teardown. The `Configure AWS
+      # credentials` step at the top of the job mints a 1-hour session (the
+      # action's default with no role-duration-seconds), but the UAT phases
+      # (prep + install + conformance + train + verify) can run the full job
+      # timeout before teardown, so by the time `Destroy Cluster` runs the
+      # original session token has expired. Passing that stale token into the
+      # actuator made every retry fail with ExpiredToken and leaked the GPU
+      # node. The `id-token: write` permission is granted for the whole job,
+      # so configure-aws-credentials can mint a fresh session here.
+      - name: Refresh AWS credentials for teardown
+        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.GITHUB_ACTIONS_ROLE_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: GitHubActions-UAT-AICR-Teardown
+
       # Teardown (retry up to 3 times). Runs last so a slow destroy
       # cannot block evidence upload or summary rendering.
       #

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -331,6 +331,21 @@ jobs:
             fi
           done
 
+      # Re-authenticate to GCP immediately before teardown. The WIF credential
+      # file written by the `Authenticate to GCP` step at the top of the job
+      # references a short-lived GitHub OIDC token; the UAT phases can run the
+      # full job timeout before teardown, by which point that token has expired
+      # and the actuator's STS exchange fails. The `id-token: write` permission
+      # is granted for the whole job, so re-running auth mints a fresh token
+      # file. Mirrors the AWS teardown credential refresh.
+      - name: Re-authenticate to GCP for teardown
+        id: auth_teardown
+        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        with:
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_WIF_SERVICE_ACCOUNT }}
+
       # Teardown (retry up to 3 times). Runs last so a slow destroy
       # cannot block evidence upload or summary rendering.
       - name: Destroy Cluster
@@ -340,16 +355,24 @@ jobs:
           set -euxo pipefail
           yq -i '.deployment.destroy = true' "$CLUSTER_CONFIG"
           cat "$CLUSTER_CONFIG"
+          destroyed=false
           for attempt in 1 2 3; do
             echo "Destroy attempt ${attempt}..."
             if docker run \
               -e CONFIG_CONTENT="$(base64 < $CLUSTER_CONFIG)" \
               -e AUTO_APPROVE=true \
-              -e KEY_CONTENT="$(base64 < ${{ steps.auth.outputs.credentials_file_path }})" \
+              -e KEY_CONTENT="$(base64 < ${{ steps.auth_teardown.outputs.credentials_file_path }})" \
               ${{ env.GKE_ACTUATOR_IMAGE }} apply; then
               echo "Cluster destroyed successfully"
+              destroyed=true
               break
             fi
             echo "Destroy attempt ${attempt} failed, retrying..."
             sleep 30
           done
+          # Fail the step if every attempt failed; otherwise a genuine destroy
+          # failure exits 0 and the GPU node leaks silently.
+          if [ "$destroyed" != true ]; then
+            echo "::error::Cluster ${DEPLOYMENT_ID} destroy failed after 3 attempts; GPU node may be leaking"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Re-authenticate to the cloud provider immediately before UAT cluster teardown so `Destroy Cluster` always runs with fresh credentials, preventing leaked GPU nodes.

## Motivation / Context

A scheduled AWS UAT run failed teardown and leaked a p5.48xlarge GPU node (holding the H100 capacity reservation). Root cause: the workflow authenticates once at the top of the job, but the phases between auth and teardown — prep + install + conformance + train + verify — can run the full job timeout. By the time `Destroy Cluster` runs the session has expired:

- **AWS:** `configure-aws-credentials` mints a **1-hour** session by default (no `role-duration-seconds`). The expired `AWS_SESSION_TOKEN` was passed into the actuator on every retry, so all 3 attempts failed with `ExpiredTokenException`, the state `PutObject` to S3 also 403'd (terraform wrote `errored.tfstate` locally), and the GPU node leaked.
- **GCP:** the WIF credential file references a short-lived GitHub OIDC token that expires the same way.

The 3-attempt retry loop cannot recover from this — it reuses the same dead credential each time.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI (UAT GitHub Actions workflows)

## Implementation Notes

- Added a credential-refresh step immediately before `Destroy Cluster` in both `uat-aws.yaml` (re-assume role via `configure-aws-credentials`) and `uat-gcp.yaml` (re-run `google-github-actions/auth`, `id: auth_teardown`). The `id-token: write` permission is granted for the whole job, so both actions can mint fresh credentials late in the run.
- AWS: re-running the action re-exports the `AWS_*` env vars, so the Destroy step needs no reference change. GCP: the Destroy step's `KEY_CONTENT` is repointed to `steps.auth_teardown.outputs.credentials_file_path`.
- Also added the missing post-loop failure guard to the GCP teardown so a genuine destroy failure fails the step instead of exiting 0 and leaking silently (the AWS teardown already had this guard).

## Testing

```bash
yamllint .github/workflows/uat-aws.yaml .github/workflows/uat-gcp.yaml   # clean
# Structural parse verified with yq; step ordering confirmed.
```

Full validation is the next scheduled/manual UAT run, which exercises the teardown path.

## Risk Assessment

- [x] **Low** — CI-only change to the teardown path; adds an auth step and a fail-closed guard. Easy to revert.

**Rollout notes:** N/A — takes effect on the next UAT workflow run.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`) — yamllint clean
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
