### PR TITLE
docs(testgrid): public TestGrid page + Fern nav (TG6)

### DIFF
--- a/docs/design/012-recipe-coordinate-mapping.md
+++ b/docs/design/012-recipe-coordinate-mapping.md
@@ -48,10 +48,10 @@ column-metadata schema that its consumers share.
   They *import* this mapping; their internals are owned by their own issues.
 - The API and UI that render the board (GP5).
 - The live board / hosting / navigation host.
-- The user-facing `docs/user/` TestGrid page. It is **deferred**: it has a soft
-  dependency on TG4a's served URL form, so it is authored alongside that work
-  rather than here. This design spec is the internal contract that unblocks the
-  dependent workstreams in the meantime.
+
+The user-facing TestGrid page ([`docs/user/testgrid.md`](../user/testgrid.md))
+presents this contract for end users; this ADR remains the internal source of
+truth that the page and the dependent workstreams derive from.
 
 ## Taxonomy
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -36,6 +36,8 @@ navigation:
         path: user/component-catalog.md
       - page: Recipe Health
         path: user/recipe-health.md
+      - page: TestGrid
+        path: user/testgrid.md
       - page: Validation
         path: user/validation.md
       - page: Coverage Matrix

--- a/docs/user/testgrid.md
+++ b/docs/user/testgrid.md
@@ -1,0 +1,86 @@
+{/*
+Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/}
+
+# AICR TestGrid
+
+The AICR TestGrid is the **live validation-posture** board: it shows the actual pass/fail of AICR recipes from real validation runs against real clusters, organized so you can navigate straight from a cloud service provider down to a single check. It answers *"is this recipe passing right now, against which Kubernetes version, and who signed the result?"*
+
+It is the live complement to two **offline, structural** surfaces:
+
+- [Recipe Health](./recipe-health.md) — the catalog-wide structural state of every recipe, computed hermetically with no cluster.
+- [Recipe & CLI Coverage Matrix](./coverage-matrix.md) — which journeys and CLI verbs are exercised in-repo, and how often.
+
+Neither of those reports live pass/fail; the TestGrid does. The three surfaces coexist and never duplicate each other — see [How it relates to recipe health](#how-it-relates-to-recipe-health) below. The full design contract is recorded in [ADR-012](../design/012-recipe-coordinate-mapping.md).
+
+## How to read it — CSP-first navigation
+
+The board is a five-level addressing space. You navigate it the way you reason about a deployment: start from your cloud, narrow to your hardware and OS, then your workload.
+
+| Level | Value | Example |
+|-------|-------|---------|
+| **Group** | service (the CSP) | `eks` |
+| **Dashboard** | accelerator + OS | `h100-ubuntu` |
+| **Tab** | intent, optionally with platform | `training-kubeflow` |
+| **Row** | validation `<phase>/<check>` | `conformance/gpu-operator-ready` |
+| **Column** | one build | one validation run |
+
+The first three levels (group, dashboard, tab) come from the **recipe** — they identify *which cell* a result belongs in. The last two (row, column) come from the **validation run** — they describe *what is in that cell*: which checks ran, in which build. A recipe never decides its own rows or columns.
+
+This split is why the board is CSP-first even though recipe names are accelerator-first: the recipe `h100-eks-ubuntu-training-kubeflow` lands at the coordinate `eks/h100-ubuntu/training-kubeflow`. The mapping is derived from the recipe's resolved criteria, never from string-parsing its name, so the two stay independently correct.
+
+### The coordinate
+
+Every cell has a stable, canonical address:
+
+```text
+<group>/<dashboard>/<tab>
+```
+
+For example `eks/h100-ubuntu/training-kubeflow` (with a platform) or `eks/h100-ubuntu/training` (bare intent — when a recipe declares no platform, the segment is dropped, never filled with a placeholder).
+
+Treat the coordinate as a **stable opaque identity**, not a key you take apart: a dimension value can itself contain `-` (for example `rtx-pro-6000`), so the path has no reliable positional split point. It is something to link to and compare for equality, not to decompose.
+
+## The Kubernetes version facet
+
+The Kubernetes version is deliberately **not** part of the coordinate. It lives **in the column** — one build is one K8s version. This keeps a coordinate (`eks/h100-ubuntu/training`) invariant as clusters upgrade, so links into the board do not churn every time a new K8s minor ships.
+
+The trade-off is that one tab can hold columns for the *same* coordinate at *different* K8s versions. Two countermeasures keep a stale result from being read as a current one:
+
+- a **K8s-version facet / filter**, so you can scope the view to a version; and
+- a **latest-per-signer default scope**, so the default view does not mix stale and current results from the same signer.
+
+Each column also carries the recipe's declared K8s constraint alongside the observed version, so you can tell at a glance whether the cluster the build ran on actually satisfied what the recipe asked for.
+
+## Provenance columns — who produced the result
+
+Trust in a column comes from its provenance metadata. Each build column carries a fixed set of keys so you can weigh a result before relying on it:
+
+| Key | Meaning |
+|-----|---------|
+| `aicr_version` | the `aicr` release that produced the result |
+| `k8s_version` | the cluster version actually observed (`major.minor`) |
+| `k8s_constraint` | the K8s version the recipe declared it needs |
+| `signer_identity` | the signing identity (workflow / subject) that attested the result |
+| `signer_issuer` | the OIDC issuer that vouched for that identity |
+| `source_class` | how the result was produced (for example `ci` versus ad-hoc) |
+| `evidence_digest` | the digest of the underlying signed evidence artifact |
+
+`signer_identity` and `signer_issuer` together are what let you distinguish **community-submitted** results from **NVIDIA UAT** runs, and they key the latest-per-signer default scope. `evidence_digest` is the verifiable anchor: every cell traces back to a signed [conformance evidence](../design/007-recipe-evidence.md) artifact you can verify independently with [artifact verification](./artifact-verification.md).
+
+## How it relates to recipe health
+
+The TestGrid and the [Recipe Health](./recipe-health.md) matrix are **two surfaces that coexist; neither is a richer rendering of the other**:
+
+- **Recipe Health** owns the **offline structural / freshness** signal — does the recipe resolve cleanly, are its charts pinned — computed without a live cluster.
+- **The TestGrid** owns the **live validation-posture** signal — derived from real runs against real clusters.
+
+AICR keeps these axes deliberately separate so a "resolves cleanly" verdict never gets fused with a "validated and performant" one. The two surfaces share exactly one thing: the recipe's `metadata.name`, the identity by which both address the same recipe.
+
+The Recipe Health **Evidence** column is the cross-link between them. Today it reads `pending` for every recipe. Once a recipe has signed evidence, that column will **link** into the recipe's TestGrid coordinate — it links, it never copies the board's content — and the link is automatically checkable so it can never point at a coordinate that does not exist on the board.


### PR DESCRIPTION
## Summary

Adds the public-facing **AICR TestGrid** docs page (`docs/user/testgrid.md`) and registers it in the Fern nav, completing the user-facing deliverable for TG6. The CSP-first taxonomy, the recipe→coordinate mapping (`pkg/recipe.CoordinateFor`), the pinned column-metadata schema, the ADR-009 reconciliation, and the #1224 cross-link contract already shipped in [ADR-012](../design/012-recipe-coordinate-mapping.md); this PR presents that contract for end users.

## Motivation / Context

TG6 asks for the canonical taxonomy/mapping/metadata schema to be documented and a public TestGrid page published. The engineering (shared Go function + golden test) and the design ADR-012 already landed; the remaining gap was the user docs page + nav registration. ADR-012's "Out of scope" note (page deferred to TG4a) is updated to reflect that the page now exists, with ADR-012 remaining the internal source of truth.

Fixes: #1272
Related: #1224, #1263

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New page covers: what the TestGrid is, CSP-first navigation (group/dashboard/tab/row/column), the coordinate / stable URL form, the K8s-version-in-column facet, the provenance/signer/source metadata columns (community vs UAT), and how it coexists with the offline Recipe Health and Coverage matrices (link-only Evidence cross-link, never duplication).
- Registered under **User Guide** in `docs/index.yml` (Latest nav). Released-version navs under `fern/versions/*.yml` are publish-time snapshots and are intentionally not edited for an unreleased page.
- No Go changes — the shared mapping function and its golden test already exist.

## Testing

```bash
make lint   # check-docs-filenames + check-docs-mdx
```

- `check-docs-filenames`: OK
- `check-docs-mdx`: OK
- All intra-doc and cross-doc links verified to resolve (lychee anchor check runs in `fern-docs-ci`).

## Risk Assessment

- [x] **Low** — Docs-only, additive, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, docs-only; doc lints pass
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (no code change)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
