### PR TITLE
docs(recipes): note b200-any-training retirement (#1053) in wildcard guide

### DIFF
--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -148,7 +148,7 @@ spec:
           value: ">= v25.10.0"
 ```
 
-Only use this pattern when the content is truly uniform across the wildcard dimension — if values diverge per service, keep them inline in each service-specific overlay. NCCL performance thresholds, for example, are explicitly **not** a good fit for this pattern: each service has a different network fabric (EFA, TCPXO, RoCE, etc.) and the same bandwidth number is rarely correct across two fabrics. The intent-scoped `gb200-any-training.yaml` shape that previously carried a cross-service NCCL threshold was retired in #1052 in favor of per-leaf performance blocks. See [Data Architecture](../contributor/recipe.md#criteria-wildcard-overlays) for when to use wildcard overlays vs mixins.
+Only use this pattern when the content is truly uniform across the wildcard dimension — if values diverge per service, keep them inline in each service-specific overlay. NCCL performance thresholds, for example, are explicitly **not** a good fit for this pattern: each service has a different network fabric (EFA, TCPXO, RoCE, etc.) and the same bandwidth number is rarely correct across two fabrics. The intent-scoped `gb200-any-training.yaml` and `b200-any-training.yaml` shapes that previously carried cross-service NCCL thresholds were retired (`gb200-any-training` in #1052, `b200-any-training` in #1053) in favor of per-leaf performance blocks. See [Data Architecture](../contributor/recipe.md#criteria-wildcard-overlays) for when to use wildcard overlays vs mixins.
 
 **Merge order:** `base.yaml` (lowest) → intermediate → leaf → mixins (highest)
 


### PR DESCRIPTION
## Summary

Fix a stale sentence in the criteria-wildcard section of the recipe development guide: it credited only the `gb200-any-training.yaml` retirement (#1052) but `b200-any-training.yaml` was likewise retired (#1053). Both `-any-training` wildcards are already gone on `main`.

## Motivation / Context

On `main`, `recipes/overlays/b200-any.yaml` and `gb200-any.yaml` are the live deployment-floor wildcards — the intent-scoped `*-any-training.yaml` variants that previously carried cross-service NCCL thresholds were both retired. The integrator guide still named only the GB200 retirement, which risks a recipe author copying the retired B200 cross-service NCCL-threshold pattern back in. This names both.

Fixes: N/A
Related: #1052, #1053, #1004

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

One-line edit to `docs/integrator/recipe-development.md`. Wording mirrors the contributor-side guidance. The anchor link target (`recipe.md#criteria-wildcard-overlays`) is unchanged and verified present.

## Testing

```bash
# Doc-only change — no code paths affected; full `make qualify` not run.
# Verified: both -any-training overlays are absent on main (b200-any.yaml /
# gb200-any.yaml present), and the referenced anchor heading exists.
```

Doc-only: tests, e2e, and Go lint cannot regress from this change. CI lychee link-check covers the touched `docs/**` file.

## Risk Assessment

- [x] **Low** — Isolated doc wording fix, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
