### PR TITLE
fix(ci): link digest-pinned evidence ref in UAT summaries

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -350,9 +350,9 @@ jobs:
             echo "| Validate (all phases) | ${{ steps.conformance.outcome }} |"
             echo "| Train | ${{ steps.train.outcome }} |"
             echo "| Verify | ${{ steps.verify.outcome }} |"
-            if [[ "${{ steps.conformance.outcome }}" == "success" ]]; then
+            if [[ -n "${{ steps.evidence_ref.outputs.ref }}" ]]; then
               echo ""
-              echo "**Evidence (OCI):** \`ghcr.io/nvidia/aicr-evidence/h100-eks-ubuntu-training-kubeflow:run-${{ github.run_id }}\`"
+              echo "**Evidence (OCI):** \`${{ steps.evidence_ref.outputs.ref }}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -321,9 +321,9 @@ jobs:
             echo "| Validate (all phases) | ${{ steps.conformance.outcome }} |"
             echo "| Train | ${{ steps.train.outcome }} |"
             echo "| Verify | ${{ steps.verify.outcome }} |"
-            if [[ "${{ steps.conformance.outcome }}" == "success" ]]; then
+            if [[ -n "${{ steps.evidence_ref.outputs.ref }}" ]]; then
               echo ""
-              echo "**Evidence (OCI):** \`ghcr.io/nvidia/aicr-evidence/h100-gke-cos-training-kubeflow:run-${{ github.run_id }}\`"
+              echo "**Evidence (OCI):** \`${{ steps.evidence_ref.outputs.ref }}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary

Print the digest-pinned evidence bundle ref in the UAT (AWS + GCP) Actions summaries instead of a reconstructed mutable `:run-<run_id>` OCI tag.

## Motivation / Context

Follow-up to the GP2 evidence-ingest work (#1402 / #1484). CodeRabbit flagged that the UAT summaries rebuilt a mutable `…aicr-evidence/<recipe>:run-${{ github.run_id }}` tag for the human-facing "Evidence (OCI)" link. That tag can drift from the actual bundle if the naming scheme changes or the tag is later repointed, sending reviewers to the wrong artifact — while ingest itself already uses the verified digest. Both jobs already export the validated, digest-pinned ref via `steps.evidence_ref.outputs.ref` (the same value fed to the `ingest-evidence` job), so the summary should use it too.

Fixes: N/A
Related: #1484, #1402

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: GitHub Actions UAT workflows (`.github/workflows/uat-aws.yaml`, `.github/workflows/uat-gcp.yaml`)

## Implementation Notes

- Replace the hand-built `…:run-${{ github.run_id }}` string with `${{ steps.evidence_ref.outputs.ref }}` in both summary steps.
- Tighten the guard from `conformance.outcome == 'success'` to `-n <ref>`: the ref is non-empty only when conformance succeeded *and* a bundle was produced, so the summary degrades cleanly (no empty `**Evidence (OCI):** ``) when no bundle exists.
- The explanatory comment blocks that document the conformance step's push tag are left unchanged — they accurately describe the push naming, not the reviewer-facing link.

## Testing

```bash
yamllint .github/workflows/uat-aws.yaml .github/workflows/uat-gcp.yaml  # clean
```

No Go changes; this is a workflow-summary string fix only. The summaries render at runtime, exercised by the scheduled UAT runs.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — cosmetic/summary-only; ingest behavior is unchanged.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`) — yamllint clean on both files
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
