### PR TITLE
fix(corroborate): escape boot() error + fail-closed meta schema gate

### DIFF
--- a/pkg/corroborate/generate.go
+++ b/pkg/corroborate/generate.go
@@ -232,14 +232,49 @@ func collectRuns(ctx context.Context, inputDir string, allowlist *Allowlist) ([]
 	return runs, nil
 }
 
+// compatibleMetaSchema reports whether a meta.json schemaVersion is safe to parse
+// under the current rules. An empty version is tolerated (GP2 may omit it); a
+// non-empty version is compatible only when it shares RunMetaSchemaVersion's
+// major (so a backward-compatible future minor still loads, but a new major does
+// not). See the gate in loadRun for the fail-closed rationale.
+func compatibleMetaSchema(got string) bool {
+	if got == "" {
+		return true
+	}
+	return schemaMajor(got) == schemaMajor(RunMetaSchemaVersion)
+}
+
+// schemaMajor returns the "<family>/v<major>" portion of a meta schemaVersion,
+// stripping any ".<minor>[...]" suffix. A value with no minor suffix is returned
+// unchanged.
+func schemaMajor(v string) string {
+	if i := strings.IndexByte(v, '.'); i >= 0 {
+		return v[:i]
+	}
+	return v
+}
+
 // loadRun parses one run directory (the dir containing metaPath).
 func loadRun(metaPath string, allowlist *Allowlist) (*signerRun, error) {
 	meta, err := readRunMeta(metaPath)
 	if err != nil {
 		return nil, err
 	}
+	// Schema gate, fail-closed on an incompatible major — symmetric with
+	// LoadAllowlist (classify.go), which rejects an unsupported allowlist
+	// schemaVersion because a future schema may change the trust semantics. A
+	// meta/v2 that repurposes a field (e.g. signer/allowlisted) must not be parsed
+	// under v1 assumptions, so a different major is skipped (errSkipRun) rather
+	// than aborting the whole dashboard. An empty version is tolerated by design
+	// (GP2 may omit it); a same-major future minor still loads, with a warning.
+	if !compatibleMetaSchema(meta.SchemaVersion) {
+		slog.Warn("skipping run: incompatible meta.json schema major version",
+			"path", metaPath, "got", meta.SchemaVersion, "want", RunMetaSchemaVersion,
+			"signer", meta.Signer.Identity)
+		return nil, errSkipRun
+	}
 	if meta.SchemaVersion != "" && meta.SchemaVersion != RunMetaSchemaVersion {
-		slog.Warn("unexpected meta.json schema version",
+		slog.Warn("meta.json schema version differs within the supported major; parsing under current rules",
 			"path", metaPath, "got", meta.SchemaVersion, "want", RunMetaSchemaVersion)
 	}
 

--- a/pkg/corroborate/generate_test.go
+++ b/pkg/corroborate/generate_test.go
@@ -388,6 +388,55 @@ func TestGenerateSeries(t *testing.T) {
 	}
 }
 
+func TestCompatibleMetaSchema(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want bool
+	}{
+		{"empty tolerated", "", true},
+		{"exact match", "aicr-corroboration-meta/v1", true},
+		{"same major future minor", "aicr-corroboration-meta/v1.2", true},
+		{"incompatible major", "aicr-corroboration-meta/v2", false},
+		{"unrelated value", "something-else/v1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compatibleMetaSchema(tt.got); got != tt.want {
+				t.Errorf("compatibleMetaSchema(%q) = %v, want %v", tt.got, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateSkipsIncompatibleSchemaMajor(t *testing.T) {
+	// A meta.json declaring a different schema major is dropped fail-closed: a
+	// future major may repurpose fields this parser would misread, so it must not
+	// be classified under current assumptions (symmetric with LoadAllowlist).
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "results", "eks", "h100-ubuntu", "training", "s1", "run-1")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"schemaVersion":"aicr-corroboration-meta/v2",` +
+		`"coordinate":{"group":"eks","dashboard":"h100-ubuntu","tab":"training"},` +
+		`"recipe":"h100-eks-ubuntu-training",` +
+		`"signer":{"idHash":"s1","identity":"https://github.com/x/y/.github/workflows/a.yaml@refs/heads/main",` +
+		`"issuer":"https://token.actions.githubusercontent.com","class":"community","allowlisted":false},` +
+		`"runId":"run-1","attestedAt":"2026-06-20T03:14:07Z"}`
+	if err := os.WriteFile(filepath.Join(runDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Generate(context.Background(), Options{InputDir: dir, OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if res.Runs != 0 || res.Recipes != 0 {
+		t.Errorf("summary = %+v, want 0 runs / 0 recipes (incompatible-major run skipped)", res)
+	}
+}
+
 func TestSafeRecipeSlug(t *testing.T) {
 	tests := []struct {
 		slug string

--- a/pkg/corroborate/renderer/index.html
+++ b/pkg/corroborate/renderer/index.html
@@ -1815,7 +1815,7 @@ async function boot(){
     index = await res.json();
   } catch (err) {
     showError(
-      `<b>Could not load <span class="mono">data/index.json</span></b> (${err.message}).<br><br>` +
+      `<b>Could not load <span class="mono">data/index.json</span></b> (${esc(err.message)}).<br><br>` +
       `A page that <span class="mono">fetch()</span>es sibling files can't read them over <span class="mono">file://</span> ` +
       `(browser security). Serve it over HTTP instead:<br>` +
       `<span class="mono">python3 -m http.server 8000</span> from this directory → open <span class="mono">http://localhost:8000/</span>.`


### PR DESCRIPTION
## Summary

Two post-merge review follow-ups from #1483: escape the one unescaped error string in the dashboard renderer, and make the `meta.json` schema-version gate fail closed on an incompatible major (symmetric with the allowlist loader).

## Motivation / Context

#1483 merged with two non-blocking review threads still open. This addresses both.

Fixes: N/A
Related: #1483, #1404

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: corroboration dashboard generator (`pkg/corroborate`)

## Implementation Notes

- **Renderer (`renderer/index.html`):** `boot()`'s `catch` interpolated `err.message` into `innerHTML` unescaped — the one data-adjacent string bypassing the otherwise-universal `esc()` discipline (some browsers embed a snippet of the offending `index.json` into `SyntaxError` messages). CSP (`script-src 'self' 'unsafe-inline'`) blocks execution so it was not exploitable, but it is now wrapped with `esc(err.message)` to match the series error path.
- **`loadRun` schema gate:** a `meta.json` schema-version mismatch previously only warned and continued, asymmetric with `LoadAllowlist`, which fails closed on an unsupported `schemaVersion` because a future schema may change trust semantics. An incompatible major (e.g. `meta/v2` repurposing `signer`/`allowlisted`) is now skipped via `errSkipRun` rather than parsed under v1 assumptions. An empty version stays tolerated by design (GP2 may omit it); a same-major future minor still loads with a warning. New `compatibleMetaSchema`/`schemaMajor` helpers carry the logic.

## Testing

```bash
go test ./pkg/corroborate/... ./tools/corroborate/...
golangci-lint run -c .golangci.yaml ./pkg/corroborate/... ./tools/corroborate/...
```

All pass; lint reports 0 issues. Added a table test for `compatibleMetaSchema` and an integration test asserting a `meta/v2` run is skipped.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — behavior change only affects malformed/future-major evidence (skipped instead of mis-parsed) and an error-banner code path.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
