### PR TITLE
docs(cli): list `any` as a supported --service value

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -386,7 +386,7 @@ Generate recipes using direct system parameters:
 **Flags:**
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
-| `--service` | | string | K8s service: eks, gke, aks, oke, ocp, kind, lke, bcm |
+| `--service` | | string | K8s service: eks, gke, aks, oke, ocp, kind, lke, bcm, any |
 | `--accelerator` | `--gpu` | string | Accelerator/GPU type: h100, h200, gb200, b200, a100, l40, rtx-pro-6000 |
 | `--intent` | | string | Workload intent: training, inference |
 | `--os` | | string | OS family: ubuntu, rhel, cos, amazonlinux, talos |


### PR DESCRIPTION
## Summary

List `any` as a supported value for the `recipe --service` flag in the CLI reference.

## Motivation / Context

`--service` accepts `any` (`CriteriaServiceAny`, parsed by `recipe.ParseService`), and the validation walkthrough already documents `service=any` for self-managed clusters (`docs/user/validation.md`). The CLI reference's exhaustive value list was the only place that omitted it, making a valid input look unsupported. The OpenAPI contract (`api/aicr/v1/server.yaml`) and `docs/user/api-reference.md` both already list `any`; this brings the CLI reference into agreement.

Surfaced by CodeRabbit review on #1485.

Fixes: N/A
Related: #1485

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

`any` is appended last to match the ordering in the OpenAPI `service` enum and `api-reference.md`. No code or behavior change.

## Testing

```bash
# Doc-only change; no code paths affected.
```

## Risk Assessment

- [x] **Low** — Isolated docs-only change, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, doc-only
- [x] Linter passes (`make lint`) — N/A, doc-only
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
