### PR TITLE
chore(recipes): update nodewright to v0.17.1 (fixes immutable selector)

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -19,7 +19,7 @@ A machine-readable **CycloneDX 1.6 JSON** companion to this page is produced by 
 <!-- BEGIN AICR-BOM -->
 ## Summary
 
-- Components: **27**
+- Components: **33**
 - Unique images: **82**
 - Distinct registries: **11**
 
@@ -38,6 +38,8 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | gatekeeper | helm | gatekeeper/gatekeeper | 3.22.2 | 3 |
 | gke-nccl-tcpxo | manifest | — | — | 4 |
 | gpu-operator | helm | nvidia/gpu-operator | v26.3.2 | 14 |
+| gpu-operator-ocp | manifest | — | — | 0 |
+| gpu-operator-ocp-olm | manifest | — | — | 0 |
 | grove | helm | grove-charts | v0.1.0-alpha.8 | 1 |
 | k8s-ephemeral-storage-metrics | helm | k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics | 1.19.2 | 1 |
 | k8s-nim-operator | helm | k8s-nim-operator | 3.1.0 | 1 |
@@ -46,9 +48,13 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | kubeflow-trainer | helm | kubeflow-trainer | 2.2.0 | 3 |
 | kueue | helm | kueue | 0.17.1 | 1 |
 | network-operator | helm | nvidia/network-operator | 26.1.1 | 5 |
+| network-operator-ocp | manifest | — | — | 0 |
+| network-operator-ocp-olm | manifest | — | — | 0 |
 | nfd | helm | node-feature-discovery | 0.18.3 | 1 |
+| nfd-ocp | manifest | — | — | 0 |
+| nfd-ocp-olm | manifest | — | — | 0 |
 | nodewright-customizations | manifest | — | — | 5 |
-| nodewright-operator | helm | nodewright | v0.17.0 | 3 |
+| nodewright-operator | helm | nodewright | v0.17.1 | 3 |
 | nvidia-dra-driver-gpu | helm | dra-driver-nvidia-gpu | 0.4.1-rc.1 | 1 |
 | nvsentinel | helm | nvsentinel | v1.9.0 | 6 |
 | prometheus-adapter | helm | prometheus-community/prometheus-adapter | 5.3.0 | 1 |
@@ -123,6 +129,14 @@ _No images extracted._
 - `nvcr.io/nvidia/k8s/dcgm-exporter:4.5.3-4.8.2-distroless`
 - `nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0`
 
+### gpu-operator-ocp
+
+_No images extracted._
+
+### gpu-operator-ocp-olm
+
+_No images extracted._
+
 ### grove
 
 - `ghcr.io/ai-dynamo/grove/grove-operator:v0.1.0-alpha.8`
@@ -169,9 +183,25 @@ _No images extracted._
 - `nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2`
 - `nvcr.io/nvidia/mellanox/k8s-rdma-shared-dev-plugin:network-operator-v26.1.0`
 
+### network-operator-ocp
+
+_No images extracted._
+
+### network-operator-ocp-olm
+
+_No images extracted._
+
 ### nfd
 
 - `registry.k8s.io/nfd/node-feature-discovery:v0.18.3`
+
+### nfd-ocp
+
+_No images extracted._
+
+### nfd-ocp-olm
+
+_No images extracted._
 
 ### nodewright-customizations
 
@@ -183,7 +213,7 @@ _No images extracted._
 
 ### nodewright-operator
 
-- `bitnami/kubectl:latest@sha256:1bc359beb3ae3982591349df11db50b0917b0596e8bed8ab9cf0c8a84a3502d1`
+- `alpine/kubectl:1.36.2@sha256:01d138ce994b684abc62d9cfdff44de42a4c8996dcc12626dd0193afc3fb5a95`
 - `ghcr.io/nvidia/nodewright/operator:v0.17.0@sha256:1511449bf51f2844b6bb3a03bde3d5590caf2ca283e3e39c0745a8016af2132f`
 - `quay.io/brancz/kube-rbac-proxy:v0.15.0@sha256:2c7b120590cbe9f634f5099f2cbb91d0b668569023a81505ca124a5c437e7663`
 

--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -145,7 +145,7 @@ componentRefs:
     chart: nodewright
     type: Helm
     source: oci://ghcr.io/nvidia/nodewright/charts
-    version: v0.17.0
+    version: v0.17.1
     valuesFile: components/nodewright-operator/values.yaml
 deploymentOrder:
   - cert-manager

--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -150,7 +150,7 @@ componentRefs:
     chart: nodewright
     type: Helm
     source: oci://ghcr.io/nvidia/nodewright/charts
-    version: v0.17.0
+    version: v0.17.1
     valuesFile: components/nodewright-operator/values.yaml
     overrides:
       customization: ubuntu

--- a/examples/recipes/eks-training.yaml
+++ b/examples/recipes/eks-training.yaml
@@ -59,7 +59,7 @@ componentRefs:
     chart: nodewright
     type: Helm
     source: oci://ghcr.io/nvidia/nodewright/charts
-    version: v0.17.0
+    version: v0.17.1
     valuesFile: components/nodewright-operator/values.yaml
   - name: prometheus-operator-crds
     namespace: monitoring

--- a/examples/recipes/kind.yaml
+++ b/examples/recipes/kind.yaml
@@ -37,7 +37,7 @@ componentRefs:
     chart: nodewright
     type: Helm
     source: oci://ghcr.io/nvidia/nodewright/charts
-    version: v0.17.0
+    version: v0.17.1
     valuesFile: components/nodewright-operator/values.yaml
   - name: prometheus-operator-crds
     namespace: nvidia-system

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -64,7 +64,7 @@ spec:
     - name: nodewright-operator
       type: Helm
       source: oci://ghcr.io/nvidia/nodewright/charts
-      version: v0.17.0
+      version: v0.17.1
       valuesFile: components/nodewright-operator/values.yaml
 
     - name: prometheus-operator-crds

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -203,7 +203,7 @@ components:
     helm:
       defaultRepository: oci://ghcr.io/nvidia/nodewright/charts
       defaultChart: nodewright
-      defaultVersion: v0.17.0
+      defaultVersion: v0.17.1
       defaultNamespace: skyhook
     nodeScheduling:
       nodeCountPaths:


### PR DESCRIPTION
## Summary

Bump the `nodewright-operator` Helm chart pin from `v0.17.0` to `v0.17.1` across the registry, base overlay, and example recipes, and regenerate the container-images BOM.

## Motivation / Context

`deploy.sh` could not upgrade `nodewright-operator` over a pre-rename install: the chart's controller-manager Deployment has an immutable `spec.selector` that changed across the skyhook to nodewright rename, so `helm upgrade` failed with `field is immutable` and the retry loop could not recover (manual `kubectl delete` was required).

The `v0.17.1` chart fixes this upstream by shipping a `selector-migration` **pre-upgrade hook** (ServiceAccount + Role + Job, `hook-weight: -10`) that deletes the stale Deployment before the upgrade so `helm upgrade` recreates it cleanly. AICR's generated `install.sh` runs `helm upgrade --install` with no `--no-hooks`, so the hook executes as part of the normal deploy.

Fixes: #1382
Related: #1361

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `v0.17.1` is a chart-only patch: its `appVersion` is still `v0.17.0`, so the rendered operator image legitimately remains `ghcr.io/nvidia/nodewright/operator:v0.17.0`. The regenerated BOM reflects this.
- The BOM regen also folds in pre-existing OCP manifest-component drift (empty `*-ocp` entries from #1380 that were never regenerated). These are zero-image manifest entries and harmless.

## Testing

```bash
make qualify
```

`make qualify` passed: 23 chainsaw tests passed / 0 failed, golangci-lint + yamllint clean, Grype found no vulnerabilities, license headers OK. No Go source changed, so the coverage gate does not apply.

## Risk Assessment

- [x] **Low** — Isolated chart-version pin bump, well-tested, easy to revert

**Rollout notes:** Patch chart upgrade; the new pre-upgrade hook recovers stuck pre-rename installs automatically. Backwards compatible.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
