### PR TITLE
feat(ci): GP5 GitHub Pages publish for evidence dashboard

### DIFF
--- a/.github/workflows/evidence-dashboard-publish.yaml
+++ b/.github/workflows/evidence-dashboard-publish.yaml
@@ -1,0 +1,168 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GP5 — Evidence dashboard publish to GitHub Pages (#1405).
+#
+# The repo's FIRST GitHub Pages pipeline. On merge to main (and on demand),
+# it syncs the source-keyed corroboration evidence tree from GCS read-only,
+# runs the GP4 generator (tools/corroborate) to emit the deterministic static
+# site, verifies the build is reproducible, then publishes via the canonical
+# configure-pages -> upload-pages-artifact -> deploy-pages chain.
+#
+# (Fern publishes the product docs to docs.nvidia.com via publish-fern-docs.yml,
+# a separate surface; this is the only workflow that deploys to GitHub Pages.)
+#
+# Identity & fork safety, per hippo:reviewer-cicd norms:
+#   - The build job authenticates to GCS with a READ-ONLY identity (objectViewer
+#     only) impersonated through the existing github-actions-pool federation. It
+#     is NOT the GP2 write/publish SA and NOT the shared project-wide SA. GP3
+#     provisions the dedicated read SA; the name is overridable via the
+#     EVIDENCE_READ_SERVICE_ACCOUNT repo var so it can be retargeted without a
+#     code change.
+#   - Every job is gated to the canonical repo, so a fork PR never obtains GCS
+#     credentials or Pages write.
+#   - The credentialed build job (id-token for GCS WIF) is separate from the
+#     deploy job (pages: write); neither grants the other's scope.
+
+name: "Evidence: Dashboard Publish"
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+# Least privilege at the top level; jobs widen only what they need.
+permissions:
+  contents: read
+
+# Serialize deploys to the single Pages environment and let an in-flight
+# publish finish (do not cancel — a half-deployed site is worse than a stale
+# one for the few extra seconds a queued run waits).
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Build: holds the GCS READ-ONLY credentials. Syncs the evidence tree,
+  # runs the deterministic generator twice and diffs the output (the
+  # determinism gate), then uploads the site as a Pages artifact. Holds NO
+  # pages: write.
+  # ---------------------------------------------------------------------
+  build:
+    name: Build site
+    if: github.repository == 'nvidia/aicr'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write  # GCS Workload Identity Federation only
+    env:
+      GCP_WIF_PROVIDER: "projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider"
+      # Read-only (objectViewer) SA, scoped to the evidence bucket by
+      # infra/uat-gcp-account/evidence-dashboard.tf. Deliberately NOT the shared
+      # github-actions@eidosx SA and NOT the GP2 evidence-publish writer.
+      GCS_READ_SERVICE_ACCOUNT: "evidence-read@eidosx.iam.gserviceaccount.com"
+      BUCKET: "aicr-testgrid-staging"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version: ${{ steps.versions.outputs.go }}
+          cache: false
+
+      - name: Build corroborate generator
+        env:
+          GOFLAGS: -mod=vendor
+        run: go build -o ./bin/corroborate ./tools/corroborate
+
+      - name: Authenticate to GCP (read-only)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        with:
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCS_READ_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+
+      - name: Sync evidence tree from GCS
+        run: |
+          set -euo pipefail
+          mkdir -p evidence/results
+          # Mirror the source-keyed tree to disk; the generator has no embedded
+          # cloud client and reads from a local directory. Read-only: rsync here
+          # only pulls (the SA cannot write back).
+          gcloud storage rsync -r "gs://${BUCKET}/results" evidence/results
+
+      - name: Generate site (with determinism gate)
+        run: |
+          set -euo pipefail
+          # Two independent builds from the same inputs must be byte-identical
+          # (the generator carries no clock/random). A drift here means a
+          # non-reproducible build — fail loudly rather than publish it.
+          #
+          # No -allowlist: each source's class is already re-derived from its
+          # VERIFIED signer at GP2 ingest time and baked into meta.json, which
+          # is the trust gate. The generator's own -allowlist re-derivation is
+          # deferred until its loader (pkg/corroborate) is reconciled with the
+          # GP1 allowlist schema (recipes/evidence/allowlist.yaml uses
+          # identityPattern/source; the loader still expects identity).
+          ./bin/corroborate -in evidence -out _site
+          ./bin/corroborate -in evidence -out _site_check
+          if ! diff -r _site _site_check; then
+            echo "::error::corroborate output is not reproducible (determinism gate failed)"
+            exit 1
+          fi
+          rm -rf _site_check
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: _site
+
+  # ---------------------------------------------------------------------
+  # Deploy: holds pages: write and deploys the artifact to the github-pages
+  # environment. Holds NO GCS credentials.
+  # ---------------------------------------------------------------------
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    # Publish only from main. A workflow_dispatch run on a non-main branch still
+    # builds (a credential-free preview of the generator output), but must never
+    # overwrite the single live Pages site with a branch build.
+    if: github.repository == 'nvidia/aicr' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write     # deploy to the Pages environment
+      id-token: write  # OIDC verification for deploy-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/docs/contributor/evidence-dashboard-publish.md
+++ b/docs/contributor/evidence-dashboard-publish.md
@@ -1,0 +1,88 @@
+# Evidence Dashboard Publish (GP5)
+
+The dashboard-publish pipeline is the repo's **first GitHub Pages** surface.
+On every merge to `main` (and on demand) it regenerates the interim-evidence
+dashboard from the source-keyed evidence tree in GCS and deploys the static
+site to GitHub Pages. It is the consumer end of the chain whose producer is
+[evidence-ingest (GP2)](evidence-ingest.md): ingest writes the tree, publish
+renders and serves it.
+
+Fern publishes the product docs to docs.nvidia.com via `publish-fern-docs.yml`;
+that is a separate surface. This workflow is the only one that deploys to
+GitHub Pages.
+
+## Pipeline
+
+```
+GCS source-keyed tree (read-only)
+        │
+        ▼
+  rsync  gs://<bucket>/results → evidence/results
+        │
+        ▼
+  generate  corroborate -in evidence -out _site   (×2, byte-identical)
+        │
+        ▼
+  determinism gate  diff -r _site _site_check  (fails closed)
+        │
+        ▼
+  upload-pages-artifact (_site)
+        │
+        ▼
+  deploy-pages → github-pages environment
+```
+
+The byte-deterministic generator (no clock, no random — see
+[`tools/corroborate`](../../tools/corroborate/README.md)) makes the publish a
+straight deploy: there is no drift-PR for the site. The in-job determinism
+gate runs the generator twice and diffs the output, so a non-reproducible
+build fails loudly instead of shipping.
+
+## Identity and fork safety
+
+Two jobs, neither holding the other's scope:
+
+- **`build`** authenticates to GCS with a **read-only** (`objectViewer`)
+  identity impersonated through the existing `github-actions-pool` WIF
+  federation, syncs the tree, runs the generator, and uploads the Pages
+  artifact. It holds `id-token: write` (for GCS WIF) but **not** `pages: write`.
+  The read SA (`evidence-read@eidosx`, provisioned by
+  `infra/uat-gcp-account/evidence-dashboard.tf`) is deliberately **not** the
+  shared project-wide `github-actions@eidosx` SA and **not** the GP2
+  `evidence-publish` write SA; a Pages publish must never run with GCS write or
+  admin scope.
+- **`deploy`** holds `pages: write` + `id-token: write` and deploys the
+  artifact to the `github-pages` environment. It holds **no** GCS credentials,
+  and additionally runs only on `refs/heads/main` — a `workflow_dispatch` run
+  on a branch still builds (a preview) but never publishes a branch build over
+  the single live site.
+
+Every job is gated `if: github.repository == 'nvidia/aicr'`, so a fork never
+obtains GCS credentials or Pages write.
+
+## Tests
+
+`tools/corroborate/publish_workflow_test.go` pins the contract that
+actionlint cannot express: the deploy job declares `pages: write` +
+`id-token: write` and targets the `github-pages` environment; the canonical
+publish chain (`configure-pages` → `upload-pages-artifact` → `deploy-pages`)
+is present; the build job uses the read-only identity (never the shared or
+write SA); the determinism gate is wired; and every job carries the
+canonical-repo guard. Workflow syntax is covered by the repo actionlint gate
+in `merge-gate.yaml`.
+
+## Forward limitations
+
+- The read SA's impersonation is repository-scoped (the shared
+  `github-actions-pool` provider, owned by `infra/demo-api-server`, maps only
+  the repository attribute). It is least-privilege on the resource side
+  (`objectViewer` on one bucket); GP3's `infra/evidence-dashboard` may tighten
+  the subject condition further.
+- The build does not pass `-allowlist` to the generator. Each source's class
+  is already re-derived from its verified signer at GP2 ingest time and baked
+  into `meta.json` (the trust gate); the generator's own allowlist
+  re-derivation is deferred until `pkg/corroborate`'s loader is reconciled with
+  the GP1 allowlist schema (`recipes/evidence/allowlist.yaml` uses
+  `identityPattern`/`source`; the loader still expects an `identity` field).
+- A custom domain for the Pages site is deferred; the site is served at the
+  default `github.io` coordinate.

--- a/docs/contributor/evidence-ingest.md
+++ b/docs/contributor/evidence-ingest.md
@@ -5,7 +5,8 @@ bundle into the **source-keyed tree** that the corroboration dashboard
 generator consumes. It is the bridge between the per-run attestation
 bundles produced by `aicr validate --emit-attestation --push` (see
 [ADR-007](../design/007-recipe-evidence.md)) and the aggregated,
-consensus view.
+consensus view. The tree it writes is rendered and served by
+[dashboard-publish (GP5)](evidence-dashboard-publish.md).
 
 Its defining property is **verify-before-count**: a bundle's signature,
 issuer, identity, and source registry are all checked in a step that

--- a/infra/uat-gcp-account/README.md
+++ b/infra/uat-gcp-account/README.md
@@ -26,6 +26,25 @@ cluster lifecycle management (create, connect, destroy):
 All bindings use `google_project_iam_member` (additive), so they cannot conflict
 with `demo-api-server`'s bindings on the same service account.
 
+## Evidence-dashboard read SA (GP5)
+
+`evidence-dashboard.tf` adds a dedicated **read-only** service account,
+`evidence-read`, for the GP5 Pages publish workflow
+(`.github/workflows/evidence-dashboard-publish.yaml`). Its only grant is
+`roles/storage.objectViewer` on the UAT evidence bucket
+(`var.evidence_bucket`, default `aicr-testgrid-staging`) -- a bucket-scoped,
+additive `google_storage_bucket_iam_member` binding; the bucket itself is
+managed elsewhere and is **not** created or owned here. It is impersonated
+through the existing `github-actions-pool` federation (repository-scoped) and
+is deliberately separate from the shared `github-actions` SA and the GP2
+evidence-publish writer, so a Pages build can only read published evidence.
+
+The publish workflow inlines this SA email directly (matching the repo norm for
+`GCP_WIF_SERVICE_ACCOUNT`); the `EVIDENCE_READ_SERVICE_ACCOUNT` output exists so
+the value can be confirmed against what the workflow hardcodes. GP3
+(`infra/evidence-dashboard`) still owns the hardened data bucket and the
+dedicated `objectCreator` writer.
+
 ## State
 
 Backend: `gs://eidos-tf-state/uat-gcp` (separate prefix from `demo`).

--- a/infra/uat-gcp-account/evidence-dashboard.tf
+++ b/infra/uat-gcp-account/evidence-dashboard.tf
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Read-only service account for the GP5 evidence-dashboard publish workflow
+# (.github/workflows/evidence-dashboard-publish.yaml).
+#
+# The publish job syncs the source-keyed evidence tree out of the UAT evidence
+# bucket and renders it to GitHub Pages. It only ever READS the bucket, so it
+# gets a dedicated identity whose ONLY grant is objectViewer on that one bucket
+# -- deliberately not the shared `github-actions` SA (project-wide objectAdmin)
+# and not the GP2 evidence-publish writer. A compromise of the Pages build can
+# read published evidence and nothing else.
+#
+# This is the read-only slice GP5 needs. GP3 (infra/evidence-dashboard) still
+# owns the hardened data bucket and the dedicated objectCreator writer SA.
+
+resource "google_service_account" "evidence_read" {
+  account_id   = "evidence-read"
+  display_name = "Read-only evidence-tree reader for the GP5 Pages dashboard build"
+}
+
+# Bucket-scoped (not project-scoped) read. Additive member binding so it never
+# fights any other IAM on the bucket, and confined to this single bucket.
+resource "google_storage_bucket_iam_member" "evidence_read_viewer" {
+  bucket = var.evidence_bucket
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.evidence_read.email}"
+}
+
+# Let the existing github-actions-pool federation impersonate the read SA from
+# NVIDIA/aicr workflow runs. Scoped per-SA via the repository attribute (the
+# shared provider, owned by demo-api-server, already pins the repo + main/tag
+# refs); the resource grant above keeps this least-privilege regardless.
+resource "google_service_account_iam_member" "evidence_read_impersonation" {
+  service_account_id = google_service_account.evidence_read.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/github-actions-pool/attribute.repository/${var.git_repo}"
+}

--- a/infra/uat-gcp-account/outputs.tf
+++ b/infra/uat-gcp-account/outputs.tf
@@ -26,3 +26,8 @@ output "SERVICE_ACCOUNT" {
   value       = data.google_service_account.github_actions.email
   description = "Service account email for GitHub Actions federated auth."
 }
+
+output "EVIDENCE_READ_SERVICE_ACCOUNT" {
+  value       = google_service_account.evidence_read.email
+  description = "Read-only SA the GP5 dashboard build impersonates (set as the EVIDENCE_READ_SERVICE_ACCOUNT repo var)."
+}

--- a/infra/uat-gcp-account/variables.tf
+++ b/infra/uat-gcp-account/variables.tf
@@ -29,3 +29,9 @@ variable "region" {
   type        = string
   default     = "us-central1"
 }
+
+variable "evidence_bucket" {
+  description = "GCS bucket holding the source-keyed evidence tree the GP5 dashboard build reads (read-only)."
+  type        = string
+  default     = "aicr-testgrid-staging"
+}

--- a/tools/corroborate/publish_workflow_test.go
+++ b/tools/corroborate/publish_workflow_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// shaPinned matches a third-party action ref pinned to a full 40-hex commit SHA
+// (repo[/path]@<sha>), the repo norm — a tag or branch ref must NOT match.
+var shaPinned = regexp.MustCompile(`@[0-9a-fA-F]{40}$`)
+
+// workflowPath is the GP5 Pages publish workflow relative to this package.
+const workflowPath = "../../.github/workflows/evidence-dashboard-publish.yaml"
+
+// siteDir is the generator output dir the workflow publishes as the Pages
+// artifact; the build step's -out and upload-pages-artifact path must agree.
+const siteDir = "_site"
+
+// publishWorkflow is the subset of the workflow YAML the security-critical
+// invariants are asserted against. The full file is linted for syntax by the
+// repo actionlint gate (merge-gate.yaml); this test pins the contract the
+// linter cannot express: the publish identity is read-only and the Pages
+// permissions are scoped to the job that needs them.
+type publishWorkflow struct {
+	Permissions map[string]string      `yaml:"permissions"`
+	Jobs        map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	If          string            `yaml:"if"`
+	Permissions map[string]string `yaml:"permissions"`
+	Environment struct {
+		Name string `yaml:"name"`
+	} `yaml:"environment"`
+	Env   map[string]string `yaml:"env"`
+	Steps []workflowStep    `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Uses string            `yaml:"uses"`
+	Run  string            `yaml:"run"`
+	With map[string]string `yaml:"with"`
+}
+
+func loadPublishWorkflow(t *testing.T) publishWorkflow {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(workflowPath))
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	var wf publishWorkflow
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+	return wf
+}
+
+// job returns the named job or fails the test if it is absent.
+func (wf publishWorkflow) job(t *testing.T, name string) workflowJob {
+	t.Helper()
+	j, ok := wf.Jobs[name]
+	if !ok {
+		t.Fatalf("missing %s job", name)
+	}
+	return j
+}
+
+// TestPublishWorkflowPagesPermissions asserts the deploy job declares the
+// Pages write + OIDC permissions the deploy-pages action requires, and that
+// the top-level default stays least-privilege (contents: read).
+func TestPublishWorkflowPagesPermissions(t *testing.T) {
+	wf := loadPublishWorkflow(t)
+
+	// Exact maps, not selected keys: an accidentally-added scope (e.g. a stray
+	// contents: write or packages: write) must fail the least-privilege split.
+	if want := (map[string]string{"contents": "read"}); !reflect.DeepEqual(wf.Permissions, want) {
+		t.Errorf("top-level permissions = %v, want %v", wf.Permissions, want)
+	}
+
+	build := wf.job(t, "build")
+	if want := (map[string]string{"contents": "read", "id-token": "write"}); !reflect.DeepEqual(build.Permissions, want) {
+		t.Errorf("build job permissions = %v, want %v", build.Permissions, want)
+	}
+
+	deploy := wf.job(t, "deploy")
+	if want := (map[string]string{"pages": "write", "id-token": "write"}); !reflect.DeepEqual(deploy.Permissions, want) {
+		t.Errorf("deploy job permissions = %v, want %v", deploy.Permissions, want)
+	}
+	if deploy.Environment.Name != "github-pages" {
+		t.Errorf("deploy environment = %q, want github-pages", deploy.Environment.Name)
+	}
+}
+
+// TestPublishWorkflowUsesPagesActions asserts the canonical Pages publish
+// chain is present and the build job does not silently hold pages: write.
+func TestPublishWorkflowUsesPagesActions(t *testing.T) {
+	wf := loadPublishWorkflow(t)
+
+	// Map each third-party action's repo path to its full uses ref so we can
+	// assert both presence and that it is pinned to a commit SHA (not a tag or
+	// branch, which are mutable). Local ./ actions are exempt.
+	uses := map[string]string{}
+	for _, job := range wf.Jobs {
+		for _, step := range job.Steps {
+			if step.Uses == "" || strings.HasPrefix(step.Uses, "./") {
+				continue
+			}
+			uses[strings.SplitN(step.Uses, "@", 2)[0]] = step.Uses
+		}
+	}
+	for _, want := range []string{
+		"actions/configure-pages",
+		"actions/upload-pages-artifact",
+		"actions/deploy-pages",
+	} {
+		ref, ok := uses[want]
+		if !ok {
+			t.Errorf("workflow does not use %s", want)
+			continue
+		}
+		if !shaPinned.MatchString(ref) {
+			t.Errorf("%s must be pinned to a full commit SHA, got %q", want, ref)
+		}
+	}
+
+	build := wf.job(t, "build")
+
+	// The build job carries GCS read creds and must NOT also hold pages: write.
+	if _, has := build.Permissions["pages"]; has {
+		t.Error("build job must not declare pages permission (separation of duties)")
+	}
+
+	// The generator must write to exactly the dir upload-pages-artifact
+	// publishes, so the deployed site is the freshly generated one.
+	var genWritesSite bool
+	var artifactPath string
+	for _, step := range build.Steps {
+		if strings.Contains(step.Run, "./bin/corroborate -in") && stepWritesTo(step.Run, siteDir) {
+			genWritesSite = true
+		}
+		if strings.HasPrefix(step.Uses, "actions/upload-pages-artifact@") {
+			artifactPath = step.With["path"]
+		}
+	}
+	if !genWritesSite {
+		t.Errorf("generator must write to %s", siteDir)
+	}
+	if artifactPath != siteDir {
+		t.Errorf("upload-pages-artifact path = %q, want generator output %q", artifactPath, siteDir)
+	}
+}
+
+// stepWritesTo reports whether a run script passes `-out <dir>` as an exact
+// token (so `_site` does not spuriously match `_site_check`).
+func stepWritesTo(run, dir string) bool {
+	fields := strings.Fields(run)
+	for i, f := range fields {
+		if f == "-out" && i+1 < len(fields) && fields[i+1] == dir {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPublishWorkflowReadOnlyIdentity asserts the build job authenticates to
+// GCS with a read-only identity — not the GP2 write SA, not the shared
+// project-wide SA.
+func TestPublishWorkflowReadOnlyIdentity(t *testing.T) {
+	wf := loadPublishWorkflow(t)
+
+	build := wf.job(t, "build")
+	sa := build.Env["GCS_READ_SERVICE_ACCOUNT"]
+	if sa == "" {
+		t.Fatal("build job missing GCS_READ_SERVICE_ACCOUNT env")
+	}
+	// Must be the dedicated read SA.
+	if !strings.Contains(sa, "evidence-read@") {
+		t.Errorf("read SA = %q, want an evidence-read@ identity", sa)
+	}
+	// The shared project-wide SA and the GP2 publish SA are forbidden here:
+	// a Pages publish must never run with write/admin GCS scope.
+	for _, forbidden := range []string{
+		"github-actions@eidosx",
+		"evidence-publish@eidosx",
+	} {
+		if strings.Contains(sa, forbidden) {
+			t.Errorf("read SA %q must not reference the privileged identity %q", sa, forbidden)
+		}
+	}
+
+	// The auth step must impersonate exactly this env var, not a literal.
+	var authed bool
+	for _, step := range build.Steps {
+		if strings.HasPrefix(step.Uses, "google-github-actions/auth@") {
+			authed = true
+			if got := step.With["service_account"]; got != "${{ env.GCS_READ_SERVICE_ACCOUNT }}" {
+				t.Errorf("auth service_account = %q, want ${{ env.GCS_READ_SERVICE_ACCOUNT }}", got)
+			}
+		}
+	}
+	if !authed {
+		t.Error("build job has no google-github-actions/auth step")
+	}
+}
+
+// TestPublishWorkflowDeterminismGate asserts the in-job determinism gate is
+// wired: the generator runs twice and the outputs are diffed so a
+// non-reproducible build fails loudly instead of publishing.
+func TestPublishWorkflowDeterminismGate(t *testing.T) {
+	wf := loadPublishWorkflow(t)
+
+	build := wf.job(t, "build")
+	var gen string
+	for _, step := range build.Steps {
+		if strings.Contains(step.Run, "corroborate") {
+			gen += step.Run
+		}
+	}
+	if strings.Count(gen, "./bin/corroborate -in") < 2 {
+		t.Error("determinism gate requires two generator builds")
+	}
+	if !strings.Contains(gen, "diff -r") {
+		t.Error("determinism gate must diff the two builds")
+	}
+}
+
+// TestPublishWorkflowForkSafety asserts every job is gated to the canonical
+// repo so a fork never obtains GCS creds or Pages write.
+func TestPublishWorkflowForkSafety(t *testing.T) {
+	wf := loadPublishWorkflow(t)
+
+	for name, job := range wf.Jobs {
+		if !strings.Contains(job.If, "github.repository == 'nvidia/aicr'") {
+			t.Errorf("job %q missing canonical-repo guard (fork safety)", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add the repo's **first GitHub Pages pipeline**: on merge to `main` (and `workflow_dispatch`) it syncs the source-keyed corroboration evidence tree from GCS read-only, runs the GP4 `corroborate` generator to emit the deterministic static site, verifies reproducibility, and publishes via `configure-pages` → `upload-pages-artifact` → `deploy-pages`.

## Motivation / Context

GP5 of the interim evidence-dashboard epic: stand up the public surface for the corroboration dashboard. Fern publishes product docs to docs.nvidia.com via `publish-fern-docs.yml`; this is the only workflow that deploys to GitHub Pages.

Fixes: #1405
Related: #1400 (epic), #1404 (GP4 generator), #1402 (GP2 ingest), #1403 (GP3 infra)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`)
- [x] Other: CI workflow (`.github/workflows`), infra (`infra/uat-gcp-account`), generator test (`tools/corroborate`)

## Implementation Notes

- **Two-job, least-privilege split.** `build` holds only `id-token: write` (GCS WIF, read-only SA) and runs an in-job determinism gate (two generator builds, `diff -r`); `deploy` holds `pages: write` on the `github-pages` environment. Neither grants the other's scope. Every job is gated `if: github.repository == 'nvidia/aicr'` for fork safety.
- **Read-only identity.** A dedicated `evidence-read@eidosx` SA (objectViewer on the evidence bucket only, repository-scoped WIF impersonation), added in `infra/uat-gcp-account/evidence-dashboard.tf` — deliberately not the shared `github-actions` SA and not the GP2 writer. **Already applied** in `eidosx` (`terraform plan` = 3 add / 0 change / 0 destroy; SA + bindings verified live).
- **No `-allowlist` for now.** Each source's class is already re-derived from its verified signer at GP2 ingest and baked into `meta.json` (the trust gate). The generator's own allowlist re-derivation is deferred until `pkg/corroborate`'s loader is reconciled with the GP1 allowlist schema (`recipes/evidence/allowlist.yaml` uses `identityPattern`/`source`; the loader still expects `identity`). Documented in the contributor doc.
- `tools/corroborate/publish_workflow_test.go` pins the security contract actionlint cannot express (Pages perms + environment, the publish chain, the read-only identity, the determinism gate, per-job repo guard).
- All action SHAs pinned; bounded `timeout-minutes`.

## Testing

```bash
go test -race ./tools/corroborate/...                 # PASS (incl. workflow-contract test)
golangci-lint run -c .golangci.yaml ./tools/corroborate/...   # 0 issues
actionlint .github/workflows/evidence-dashboard-publish.yaml  # OK (v1.7.11)
./tools/check-docs-filenames && ./tools/check-docs-mdx        # OK
terraform -chdir=infra/uat-gcp-account fmt -check && validate # OK; plan = 3 add/0 change/0 destroy
```

Local end-to-end of the build half (build generator → `gcloud storage rsync` evidence → generate) ran clean and byte-deterministic.

## Risk Assessment

- [x] **Medium** — New CI surface (first Pages workflow) + new GCS IAM, but additive and fork-safe.

**Rollout notes:** Before the first main-merge run, enable Pages in repo settings (Settings → Pages → source "GitHub Actions"); the `github-pages` environment is created on first deploy. The read-only SA is already provisioned. No data migration.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — ran `go test -race ./tools/corroborate/...`
- [x] Linter passes (`make lint`) — `golangci-lint` clean on the changed package; `actionlint` + docs checks pass
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — `publish_workflow_test.go`
- [x] I updated docs if user-facing behavior changed — new contributor doc + cross-link
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
