### PR TITLE
ci(uat): build snapshot-agent image from PR source

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -173,6 +173,30 @@ jobs:
           install_helmfile: 'true'
           helmfile_version: '${{ steps.versions.outputs.helmfile }}'
           helmfile_sha256: '${{ steps.versions.outputs.helmfile_sha256_linux_amd64 }}'
+          install_ko: 'true'
+          ko_version: ${{ steps.versions.outputs.ko }}
+
+      # The snapshot agent runs in-cluster as its own image, separate from the
+      # locally-built aicr binary that drives the UAT phases. Left at the
+      # default (ghcr.io/nvidia/aicr:latest), it would be the last *released*
+      # build — so any artifact-schema change in the PR under test (e.g. an
+      # apiVersion bump) produces a snapshot the freshly-built binary rejects.
+      # Build the agent from the PR source and point AICR_IMAGE at it so the
+      # snapshot is stamped by the code under test, not a stale release. Single
+      # arch: the GPU worker (p5.48xlarge) is amd64. Lives in the aicr-validators
+      # namespace (not the release ghcr.io/nvidia/aicr repo); cleaned up below.
+      - name: Build and push snapshot-agent image
+        if: inputs.skip_tests != true
+        env:
+          GOFLAGS: -mod=vendor
+          KO_DOCKER_REPO: ghcr.io/nvidia/aicr-validators/agent
+        run: |
+          set -euo pipefail
+          ko build ./cmd/aicr \
+            --bare \
+            --platform=linux/amd64 \
+            --image-label="org.opencontainers.image.revision=${{ github.sha }}" \
+            --tags="${VALIDATOR_TAG}"
 
       # Config — v0.4.23+ of the EKS actuator derives the cluster name from
       # .deployment.id (same as GKE); the previous yq write to .cluster.name
@@ -225,6 +249,9 @@ jobs:
         env:
           AICR_BIN: ${{ github.workspace }}/aicr
           RUN_ID: ${{ github.run_id }}
+          # Snapshot agent = PR-built image (see "Build and push snapshot-agent
+          # image"), not the stale released default. Honored by `aicr snapshot`.
+          AICR_IMAGE: ghcr.io/nvidia/aicr-validators/agent:${{ env.VALIDATOR_TAG }}
         run: ./tests/uat/aws/run prep "${TEST_CONFIG}"
 
       - name: UAT - install (helmfile apply)
@@ -362,8 +389,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Delete UAT-tagged validator images to avoid GHCR clutter
-          for phase in deployment performance conformance; do
+          # Delete UAT-tagged validator + snapshot-agent images to avoid GHCR clutter
+          for phase in deployment performance conformance agent; do
             VERSION_ID=$(gh api \
               "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions" \
               --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -141,6 +141,31 @@ jobs:
           install_helmfile: 'true'
           helmfile_version: '${{ steps.versions.outputs.helmfile }}'
           helmfile_sha256: '${{ steps.versions.outputs.helmfile_sha256_linux_amd64 }}'
+          install_ko: 'true'
+          ko_version: ${{ steps.versions.outputs.ko }}
+
+      # The snapshot agent runs in-cluster as its own image, separate from the
+      # locally-built aicr binary that drives the UAT phases. Left at the
+      # default (ghcr.io/nvidia/aicr:latest), it would be the last *released*
+      # build — so any artifact-schema change in the PR under test (e.g. an
+      # apiVersion bump) produces a snapshot the freshly-built binary rejects.
+      # Build the agent from the PR source and point AICR_IMAGE at it so the
+      # snapshot is stamped by the code under test, not a stale release. Single
+      # arch: the GPU worker (a3-highgpu, H100) is amd64. Lives in the
+      # aicr-validators namespace (not the release ghcr.io/nvidia/aicr repo);
+      # cleaned up below.
+      - name: Build and push snapshot-agent image
+        if: inputs.skip_tests != true
+        env:
+          GOFLAGS: -mod=vendor
+          KO_DOCKER_REPO: ghcr.io/nvidia/aicr-validators/agent
+        run: |
+          set -euo pipefail
+          ko build ./cmd/aicr \
+            --bare \
+            --platform=linux/amd64 \
+            --image-label="org.opencontainers.image.revision=${{ github.sha }}" \
+            --tags="${VALIDATOR_TAG}"
 
       # Config
       - name: Update Config
@@ -194,6 +219,9 @@ jobs:
         env:
           AICR_BIN: ${{ github.workspace }}/aicr
           RUN_ID: ${{ github.run_id }}
+          # Snapshot agent = PR-built image (see "Build and push snapshot-agent
+          # image"), not the stale released default. Honored by `aicr snapshot`.
+          AICR_IMAGE: ghcr.io/nvidia/aicr-validators/agent:${{ env.VALIDATOR_TAG }}
         run: ./tests/uat/gcp/run prep "${TEST_CONFIG}"
 
       - name: UAT - install (helmfile apply)
@@ -333,8 +361,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Delete UAT-tagged validator images to avoid GHCR clutter
-          for phase in deployment performance conformance; do
+          # Delete UAT-tagged validator + snapshot-agent images to avoid GHCR clutter
+          for phase in deployment performance conformance agent; do
             VERSION_ID=$(gh api \
               "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions" \
               --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true


### PR DESCRIPTION
## Summary

Build the UAT snapshot-agent image from PR source (like the validator images already are) so the in-cluster agent stamps the same artifact apiVersion the freshly-built `aicr` binary expects.

## Motivation / Context

UAT's snapshot is captured by an in-cluster agent Job, whose **image** stamps the artifact `apiVersion`. The workflows built fresh validator images from the PR but left the agent at its default — `ghcr.io/nvidia/aicr:latest`, the last *released* build. Any artifact-schema change in the PR under test (e.g. the `aicr.run/v1alpha2` apiVersion bump in #1499) produced a snapshot the PR-built binary then **hard-rejected**:

```
snapshot file has apiVersion "aicr.nvidia.com/v1alpha1", which this aicr build
does not support (expected "aicr.run/v1alpha2")
```

…breaking the `prep` phase before the cluster was even exercised. This closes the agent↔binary version skew for *any* artifact-schema change, not just this one.

Fixes: N/A
Related: #1499 (aicr.run/v1alpha2 migration that surfaced this)

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT workflows (`.github/workflows/uat-aws.yaml`, `.github/workflows/uat-gcp.yaml`)

## Implementation Notes

- New `Build and push snapshot-agent image` step in both AWS and GCP UAT jobs: `ko build ./cmd/aicr --bare --platform=linux/amd64 --tags=$VALIDATOR_TAG` into `ghcr.io/nvidia/aicr-validators/agent` — kept in the existing validators namespace (reuses GHCR perms + cleanup), **not** the release `ghcr.io/nvidia/aicr` repo.
- Single-arch amd64: both GPU workers (p5.48xlarge, a3-highgpu) are x86.
- `prep` phase sets `AICR_IMAGE` to the per-run tag; `aicr snapshot` honors it (env-sourced flag beats the `:latest` default; the test config sets no `snapshot.agent.image`).
- ko installed via the existing `setup-build-tools` (`install_ko`, pinned `ko` version from `.settings.yaml`).
- Per-run agent tag deleted alongside the validator tags in the cleanup step.
- Note (out of scope here): the product-side UX cliff — a user upgrading the CLI past the migration with an existing snapshot — remains; the durable fix would be a transition window in `header.IsSupportedAPIVersion`. Tracked separately.

## Testing

```bash
# CI-only change; validated YAML locally
yq -e '.' .github/workflows/uat-aws.yaml .github/workflows/uat-gcp.yaml
```

The end-to-end exercise is the UAT workflows themselves.

## Risk Assessment

- [x] **Low** — Isolated CI change, mirrors the existing validator-image build pattern, easy to revert.

**Rollout notes:** No backwards-compat concerns; affects only the UAT workflows.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
