### PR TITLE
ci(pages): pin custom domain via CNAME in Pages artifact

### DIFF
--- a/.github/workflows/evidence-dashboard-publish.yaml
+++ b/.github/workflows/evidence-dashboard-publish.yaml
@@ -135,6 +135,14 @@ jobs:
           fi
           rm -rf _site_check
 
+      # Reassert the custom domain on every publish. With the GitHub Actions
+      # source the domain set in repo settings is authoritative, but a deploy
+      # whose artifact omits CNAME can silently clear it; writing the file makes
+      # the domain self-healing. Placed AFTER the determinism diff so the extra
+      # file never trips the byte-identical gate above.
+      - name: Assert custom domain
+        run: echo 'validation.aicr.run' > _site/CNAME
+
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
 


### PR DESCRIPTION
## Summary

Write a `CNAME` file into the GitHub Pages artifact so the evidence dashboard's custom domain (`validation.aicr.run`) is reasserted on every publish.

## Motivation / Context

The evidence dashboard (`evidence-dashboard-publish.yaml`, GP5 / #1405) deploys to GitHub Pages using the **GitHub Actions** source. In that mode the custom domain is stored in repo settings, but a deploy whose artifact omits a `CNAME` file can silently clear that setting — flapping the domain off the live site and forcing a manual re-add + DNS re-check. Writing the file on each build makes the domain self-healing.

Discovered while bringing `validation.aicr.run` online: DNS was correct but the artifact carried no `CNAME`, leaving the custom-domain state dependent solely on the settings value.

Fixes: N/A
Related: #1405

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/evidence-dashboard-publish.yaml` (GitHub Pages deploy)

## Implementation Notes

- The step runs **after** the determinism diff (`diff -r _site _site_check`) so the extra `CNAME` file cannot trip the byte-identical reproducibility gate.
- Domain is a literal (`validation.aicr.run`), matching the repo's preference for explicit, self-documenting values in workflows.
- No change to job permissions, credentials, or the fork-safety gates.

## Testing

```bash
yamllint .github/workflows/evidence-dashboard-publish.yaml   # clean
```

Workflow-only change (one added step); no Go sources touched, so the test/coverage and e2e/scan portions of `make qualify` are not applicable. Full `make qualify` equivalent runs in CI.

## Risk Assessment

- [x] **Low** — Single added step, isolated to the Pages publish path, trivially reversible.

**Rollout notes:** Takes effect on the next publish to `main`. No migration; if reverted, the domain simply reverts to relying on the settings value.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A (no Go changes)
- [x] Linter passes (`yamllint` clean)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI workflow)
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
