### PR TITLE
feat(evidence): regenerate signed demo evidence under aicr.run

### DIFF
--- a/pkg/evidence/allowlist/allowlist_test.go
+++ b/pkg/evidence/allowlist/allowlist_test.go
@@ -78,13 +78,12 @@ func TestClassify(t *testing.T) {
 		wantOK    bool
 	}{
 		{
-			// Community is empty (the demo signer's evidence was removed in the
-			// #1499 follow-up), so a community-issuer signer is admitted as
-			// "reported" only, not classified.
-			name:     "community-issuer signer admitted as reported (no community entries)",
-			issuer:   "https://github.com/login/oauth",
-			identity: "community-signer@example.com",
-			wantOK:   false,
+			// Slug 7c4c0edc8c765a95a0f3afdb3bbb8e91 = SourceSlug(issuer, identity) for this signer.
+			name:      "community by slug",
+			issuer:    "https://github.com/login/oauth",
+			identity:  "yuanchen97@gmail.com",
+			wantClass: ClassCommunity,
+			wantOK:    true,
 		},
 		{
 			name:      "first-party pattern on main",

--- a/recipes/evidence/allowlist.yaml
+++ b/recipes/evidence/allowlist.yaml
@@ -51,10 +51,10 @@ firstParty:
 
 # Community: individual external contributors, keyed by source slug only.
 # Each commits pointers under recipes/evidence/<recipe>/<src>/ where <src> is
-# the slug below. None onboarded yet — the prior entry anchored the
-# demo evidence removed in this PR (see #1499 follow-up); re-add alongside
-# regenerated, signed pointers.
-community: []
+# the slug below.
+community:
+  - issuer: https://github.com/login/oauth
+    source: 7c4c0edc8c765a95a0f3afdb3bbb8e91
 
 # Partner: vetted partner organizations. None onboarded yet.
 partner: []

--- a/recipes/evidence/gb200-eks-ubuntu-training/7c4c0edc8c765a95a0f3afdb3bbb8e91/sha256-93fac974407a873d5b6a52a72bafcaa18b019190545a23d03031680d6aabd2bc.yaml
+++ b/recipes/evidence/gb200-eks-ubuntu-training/7c4c0edc8c765a95a0f3afdb3bbb8e91/sha256-93fac974407a873d5b6a52a72bafcaa18b019190545a23d03031680d6aabd2bc.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-06-27T14:40:14Z
+    bundle:
+      digest: sha256:93fac974407a873d5b6a52a72bafcaa18b019190545a23d03031680d6aabd2bc
+      oci: ghcr.io/nvidia/aicr-evidence:gb200-eks-ubuntu-training-788a1bf8955a
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: yuanchen97@gmail.com
+      issuer: https://github.com/login/oauth
+      rekorLogIndex: 1982171931
+recipe: gb200-eks-ubuntu-training
+schemaVersion: 1.0.0

--- a/recipes/evidence/h100-gke-cos-training/7c4c0edc8c765a95a0f3afdb3bbb8e91/sha256-f2573e7f2496cc895e6a780604645f7c24ed4d7e0edf4c4845c0d341a3a6326e.yaml
+++ b/recipes/evidence/h100-gke-cos-training/7c4c0edc8c765a95a0f3afdb3bbb8e91/sha256-f2573e7f2496cc895e6a780604645f7c24ed4d7e0edf4c4845c0d341a3a6326e.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-06-27T14:13:46Z
+    bundle:
+      digest: sha256:f2573e7f2496cc895e6a780604645f7c24ed4d7e0edf4c4845c0d341a3a6326e
+      oci: ghcr.io/nvidia/aicr-evidence:h100-gke-cos-training-3619d2b8a5ba
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: yuanchen97@gmail.com
+      issuer: https://github.com/login/oauth
+      rekorLogIndex: 1981934662
+recipe: h100-gke-cos-training
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Regenerate verifiable, signed demo evidence for the two training recipes under the canonical `aicr.run` predicate type, pushed to the NVIDIA-org registry. Follow-up to #1507, which removed the stale pre-migration pointers that could no longer verify.

## Motivation / Context

Addresses @mchmarny's review note on #1507 (https://github.com/NVIDIA/aicr/pull/1507#discussion_r3486015757) asking whether the evidence could be regenerated under a canonical NVIDIA org rather than landing with `community: []` + a follow-up. This PR is that regeneration.

#1499 migrated the artifact domain to `aicr.run`, which bumped `PredicateTypeV1` to `https://aicr.run/recipe-evidence/v1`. The two committed demo evidence pointers had only their `predicateType` string edited in place, while still pinning the pre-migration, immutable signed OCI bundles — so `aicr evidence verify` failed on them. #1507 removed them (the correct immediate fix) and left regeneration as a follow-up. This PR is that regeneration.

Each bundle was produced by `aicr validate --emit-attestation` against a **live cluster**, then signed keyless (Sigstore) and pushed via `aicr evidence publish --push ghcr.io/nvidia/aicr-evidence`:

| Recipe | Cluster | NCCL result | OCI tag | Rekor index |
|---|---|---|---|---|
| `h100-gke-cos-training` | GKE a3-megagpu-8g (H100) | busbw 338 GB/s ≥ 250 | `…:h100-gke-cos-training-3619d2b8a5ba` | 1981934662 |
| `gb200-eks-ubuntu-training` | EKS p6e-gb200 (GB200) | nvls 841 GB/s ≥ 500 | `…:gb200-eks-ubuntu-training-788a1bf8955a` | 1982171931 |

Both carry `predicateType: https://aicr.run/recipe-evidence/v1` and **verify clean** (`aicr evidence verify` → exit 0: signature-verify, predicate-parse, and manifest-hash all pass).

The signer is unchanged from the original demo evidence (same `7c4c0edc…` community source slug), so this PR also restores the `community` allowlist entry and the allowlist `TestClassify` "community by slug" case — both had been removed in #1507 when the evidence was deleted.

Fixes: N/A (regeneration follow-up to #1507)
Related: #1507, #1499

## Type of Change

- [x] Bug fix (restores verifiable evidence removed in #1507)

## Component(s) Affected

- [x] Other: `recipes/evidence/` (signed pointers + signer allowlist), `pkg/evidence/allowlist` (test)

## Implementation Notes

- Both clusters' GPU nodes were fully occupied by a standing `slinky-slurm` NodeSet; freeing it (scale to 0 → validate → restore to 2) let the NCCL all-reduce workers schedule. No recipe/IMEX changes were needed — the earlier performance failures were pure capacity contention.
- The snapshots were captured with the released agent image (pre-migration) and restamped `aicr.nvidia.com/v1alpha1 → aicr.run/v1alpha2`; the #1499 bump is signal-only (no schema change), so the restamp is equivalent to a post-migration agent's output.
- Pointers live under the same `recipes/evidence/<recipe>/7c4c0edc…/` dirs as the originals (signer identity unchanged); only the digest-named filenames differ.

## Testing

```bash
go test ./pkg/evidence/allowlist/...                                  # ok
aicr evidence verify recipes/evidence/h100-gke-cos-training/...       # exit 0
aicr evidence verify recipes/evidence/gb200-eks-ubuntu-training/...   # exit 0
```

Both committed pointers verify end-to-end against their pushed OCI bundles (signature + predicate + manifest hash). Scope is evidence pointers + allowlist + one test; no production Go logic changed.

## Risk Assessment

- [x] **Low** — Restores demo/sample evidence; no production code paths. The pointer-contract gate validates the committed pointers against the allowlist in CI.

**Rollout notes:** Demo evidence is restored to a verifiable state. No runtime/API impact.

## Checklist

- [x] Tests pass locally (allowlist package)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
