### PR TITLE
refactor(client,cli): move CTRF merge + evidence emit behind facade

### DIFF
--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -34,11 +34,9 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/cncf"
 	k8sclient "github.com/NVIDIA/aicr/pkg/k8s/client"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 	"github.com/NVIDIA/aicr/pkg/validator"
-	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
 	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 )
@@ -231,41 +229,16 @@ type validationConfig struct {
 	evidence *recipeEvidenceConfig
 }
 
-// validateDataProvider builds the recipe.DataProvider matching the source
-// the validate Action handed to aicr.NewClient. It is constructed
-// separately (rather than reaching into the Client) so it can be threaded
-// into evidence emission, whose catalog.Load takes a DataProvider directly.
-// It mirrors the Client's own buildDataProvider so the evidence catalog
-// resolves against exactly the source the validator run used:
-//
-//   - empty dataDir → embedded provider only.
-//   - non-empty dataDir → the external dir layered over the embedded data.
-func validateDataProvider(dataDir string) (recipe.DataProvider, error) {
-	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), ".")
-	if dataDir == "" {
-		return embedded, nil
-	}
-	layered, err := recipe.NewLayeredDataProvider(embedded, recipe.LayeredProviderConfig{
-		ExternalDir: dataDir,
-	})
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to initialize external data", err)
-	}
-	return layered, nil
-}
-
 // runValidation runs validation using the container-per-validator engine.
 //
-// The validator run is now driven through the aicr.Client facade
-// (ValidateState), which owns the per-command DataProvider and threads it
-// into the validator catalog load. The evidence path still needs the raw
-// pkg/recipe.RecipeResult (via rec.Resolved()) and the same DataProvider
-// (dataProvider) so the attestation catalog resolves against the command's
-// source rather than the package global.
+// The validator run is driven through the aicr.Client facade (ValidateState),
+// which owns the per-command DataProvider. Report merging and recipe-evidence
+// emission also go through the facade (Client.MergeReports /
+// Client.EmitRecipeEvidence), so the catalog resolves against the Client's
+// source and no internal validator types are reconstructed CLI-side.
 func runValidation(
 	ctx context.Context,
 	client *aicr.Client,
-	dataProvider recipe.DataProvider,
 	rec *aicr.RecipeResult,
 	snap *snapshotter.Snapshot,
 	cfg validationConfig,
@@ -323,12 +296,10 @@ func runValidation(
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "validation failed")
 	}
 
-	// Extract CTRF reports from phase results and merge into a single report.
-	reports := make([]*ctrf.Report, 0, len(results))
-	for _, pr := range results {
-		reports = append(reports, pr.Report)
-	}
-	combined := ctrf.MergeReports("aicr", version, reports)
+	// Merge the per-phase CTRF reports into a single combined report via the
+	// facade, so a library/server caller of ValidateState produces the same
+	// combined document without reimplementing the merge.
+	combined := client.MergeReports(results)
 
 	// Serialize combined report; thread kubeconfig so ConfigMap writes
 	// target the same cluster used for snapshot/recipe reads.
@@ -383,27 +354,12 @@ func runValidation(
 	}
 
 	// Emit even on failure: failed runs document hardware-specific limits.
-	// emitRecipeEvidence needs the full pkg/recipe.RecipeResult (via
-	// Resolved()) for the predicate/BOM, and the command's DataProvider so
-	// the validator catalog used for evidence resolves against the same
-	// source as the run rather than the package global.
+	// The facade (Client.EmitRecipeEvidence) owns the facade→internal
+	// PhaseResult conversion, catalog load (against this Client's data
+	// source), and attestation.Emit; the CLI shim only adds the interactive
+	// signing-disclosure prompt.
 	if cfg.evidence != nil {
-		// emitRecipeEvidence takes []*validator.PhaseResult for downstream
-		// attestation.Emit. Convert each facade PhaseResult; Report is
-		// preserved as a typed pointer.
-		internalResults := make([]*validator.PhaseResult, len(results))
-		for i, pr := range results {
-			if pr == nil {
-				continue
-			}
-			internalResults[i] = &validator.PhaseResult{
-				Phase:    validator.Phase(pr.Phase),
-				Status:   pr.Status,
-				Report:   pr.Report,
-				Duration: pr.Duration,
-			}
-		}
-		if err := emitRecipeEvidence(ctx, dataProvider, rec.Resolved(), snap, internalResults, cfg.evidence); err != nil {
+		if err := emitRecipeEvidence(ctx, client, rec, snap, results, cfg.evidence); err != nil {
 			return err
 		}
 	}
@@ -736,26 +692,6 @@ Run validation without failing on check errors (informational mode):
 			}
 			defer func() { _ = client.Close() }()
 
-			// dataDir is the resolved external-data root. Mirror the same
-			// resolution recipeClientFromCmd performs internally so the
-			// evidence-side provider points at the same directory as the
-			// Client's recipe source.
-			dataDir := cmd.String("data")
-			if dataDir == "" {
-				dataDir = cfg.Recipe().DataDir()
-			}
-
-			// Second provider, separate from the Client's: this one is handed to
-			// evidence emission so conformance/SLSA evidence resolves files
-			// against the command's data source (the resolved --data dir), not
-			// the package global. The Client owns its own provider for recipe
-			// resolution and validation; evidence emission lives outside the
-			// Client surface and needs its own handle to the same directory.
-			dataProvider, err := validateDataProvider(dataDir)
-			if err != nil {
-				return err
-			}
-
 			slog.Info("loading recipe", "uri", recipeFilePath)
 
 			rec, err := client.LoadRecipe(ctx, recipeFilePath, kubeconfig)
@@ -814,7 +750,7 @@ Run validation without failing on check errors (informational mode):
 
 			evidenceCfg := buildRecipeEvidenceConfig(cmd, resolved)
 
-			return runValidation(ctx, client, dataProvider, rec, snap, validationConfig{
+			return runValidation(ctx, client, rec, snap, validationConfig{
 				phases:                phases,
 				kubeconfig:            kubeconfig,
 				output:                cmd.String("output"),

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -21,13 +21,9 @@ import (
 	"github.com/urfave/cli/v3"
 
 	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	"github.com/NVIDIA/aicr/pkg/config"
-	"github.com/NVIDIA/aicr/pkg/errors"
-	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
-	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
-	"github.com/NVIDIA/aicr/pkg/validator"
-	"github.com/NVIDIA/aicr/pkg/validator/catalog"
 )
 
 // recipeEvidenceConfig groups the inputs to `aicr validate --emit-attestation`.
@@ -101,58 +97,42 @@ func oidcResolveOptionsFromFlags(cmd *cli.Command) bundleattest.ResolveOptions {
 	}
 }
 
-// emitRecipeEvidence is the CLI shim over attestation.Emit. It loads the
-// validator catalog (a CLI-side concern keyed by the binary's build-time
-// version), builds an EmitOptions value from the parsed flag config, and
-// delegates the orchestration to the evidence package so the same code
-// path is reachable from the future API surface.
-//
-// dp is the command's DataProvider (built once in the validate Action and
-// shared with the aicr.Client driving the run). Threading it into
-// catalog.LoadWithDataProvider means a --data overlay resolves the validator
-// catalog against the command's source rather than the package-global provider —
-// closing the last global dependency on the validate evidence path. A nil
-// dp falls back to the package global inside catalog.LoadWithDataProvider.
+// emitRecipeEvidence is the CLI shim over Client.EmitRecipeEvidence. The
+// catalog load, facade→internal PhaseResult conversion, and attestation.Emit
+// orchestration now live behind the Client facade so a non-CLI caller can emit
+// recipe evidence with facade types alone. The CLI retains only the
+// interactive keyless-signing disclosure (a UI concern) and the flag→options
+// mapping, then delegates.
 func emitRecipeEvidence(
 	ctx context.Context,
-	dp recipe.DataProvider,
-	rec *recipe.RecipeResult,
+	client *aicr.Client,
+	rec *aicr.RecipeResult,
 	snap *snapshotter.Snapshot,
-	results []*validator.PhaseResult,
+	results []*aicr.PhaseResult,
 	cfg *recipeEvidenceConfig,
 ) error {
 
 	// Signing happens only when --push is set without --no-sign (see
 	// attestation.Emit). Gate the interactive keyless login behind the
-	// identity-disclosure prompt before the long validation-and-push run can
-	// open a browser/device-code flow. Non-interactive token sources and
-	// non-TTY runs pass through inside the gate; --no-sign skips it entirely
-	// because no OIDC flow runs.
+	// identity-disclosure prompt before the long push run can open a
+	// browser/device-code flow. Non-interactive token sources and non-TTY runs
+	// pass through inside the gate; --no-sign skips it entirely because no OIDC
+	// flow runs.
 	if cfg.Push != "" && !cfg.NoSign {
 		if err := confirmKeylessSigningDisclosure(cfg.OIDCResolve, cfg.AssumeYes, os.Stdin, os.Stderr); err != nil {
 			return err
 		}
 	}
 
-	cat, err := catalog.LoadWithDataProvider(ctx, dp, version, commit)
-	if err != nil {
-		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load validator catalog for evidence")
-	}
-
-	_, err = attestation.Emit(ctx, attestation.EmitOptions{
-		OutDir:       cfg.OutDir,
-		BOMPath:      cfg.BOMPath,
-		Push:         cfg.Push,
-		PlainHTTP:    cfg.PlainHTTP,
-		InsecureTLS:  cfg.InsecureTLS,
-		NoSign:       cfg.NoSign,
-		Full:         cfg.Full,
-		Recipe:       rec,
-		Snapshot:     snap,
-		PhaseResults: results,
-		Catalog:      cat,
-		AICRVersion:  version,
-		OIDCResolve:  cfg.OIDCResolve,
+	return client.EmitRecipeEvidence(ctx, rec, aicr.WrapSnapshot(snap), results, aicr.EvidenceOptions{
+		OutDir:      cfg.OutDir,
+		BOMPath:     cfg.BOMPath,
+		Push:        cfg.Push,
+		PlainHTTP:   cfg.PlainHTTP,
+		InsecureTLS: cfg.InsecureTLS,
+		NoSign:      cfg.NoSign,
+		Full:        cfg.Full,
+		Commit:      commit,
+		OIDCResolve: cfg.OIDCResolve,
 	})
-	return err
 }

--- a/pkg/client/v1/evidence.go
+++ b/pkg/client/v1/evidence.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"context"
+
+	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	evattest "github.com/NVIDIA/aicr/pkg/evidence/attestation"
+	"github.com/NVIDIA/aicr/pkg/validator/catalog"
+	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
+)
+
+// OIDCResolveOptions configures keyless-signing OIDC token resolution for a
+// pushed evidence bundle. Transparent alias of
+// pkg/bundler/attestation.ResolveOptions, mirroring how BundleOptions exposes
+// BundleAttester: the caller (CLI/server) builds the resolution inputs and the
+// facade threads them through to attestation.Emit, which resolves the token
+// adjacent to signing. The zero value is valid (no token sources → ambient or
+// interactive flows handled by the caller before invoking the facade).
+type OIDCResolveOptions = bundleattest.ResolveOptions
+
+// EvidenceOptions configures Client.EmitRecipeEvidence. It is the facade-owned
+// mirror of the inputs the CLI used to assemble inline, minus the interactive
+// signing-disclosure prompt, which is a UI concern the caller owns.
+type EvidenceOptions struct {
+	// OutDir is the directory to write the recipe-evidence v1 bundle to
+	// (summary-bundle/, optionally logs-bundle/, and pointer.yaml). Required.
+	OutDir string
+
+	// BOMPath optionally embeds a CycloneDX BOM; when empty a recipe-bound
+	// BOM is synthesized from the recipe's component refs and the validator
+	// catalog images that ran.
+	BOMPath string
+
+	// Push, when set, is the OCI reference to push the (optionally signed)
+	// summary bundle to.
+	Push string
+
+	// PlainHTTP / InsecureTLS control the OCI transport for Push (local /
+	// self-signed registries).
+	PlainHTTP   bool
+	InsecureTLS bool
+
+	// NoSign pushes an unsigned bundle and writes a pointer with an empty
+	// signer block (requires Push); defers Fulcio/Rekor signing.
+	NoSign bool
+
+	// Full disables evidence minimization (ships the raw snapshot and CTRF
+	// payloads instead of the redacted defaults).
+	Full bool
+
+	// Commit is the build commit used to resolve the validator catalog for
+	// the bundle's BOM. The Client's version is used for the catalog version
+	// and stamped as AICRVersion; commit has no Client-level home, so it is
+	// supplied per call.
+	Commit string
+
+	// OIDCResolve carries keyless-signing token-resolution inputs, consumed
+	// only when Push is set and NoSign is false.
+	OIDCResolve OIDCResolveOptions
+}
+
+// MergeReports merges the per-phase CTRF reports from a ValidateState run into
+// a single combined report, stamped with the tool name "aicr" and this
+// Client's version. Library and server callers use it to produce the same
+// combined CTRF document the CLI writes, without reaching into
+// pkg/validator/ctrf merge internals. Nil results and phases with a nil Report
+// contribute nothing.
+func (c *Client) MergeReports(results []*PhaseResult) *ctrf.Report {
+	reports := make([]*ctrf.Report, 0, len(results))
+	for _, pr := range results {
+		if pr == nil {
+			continue
+		}
+		reports = append(reports, pr.Report)
+	}
+	var version string
+	if c != nil {
+		version = c.version
+	}
+	return ctrf.MergeReports("aicr", version, reports)
+}
+
+// EmitRecipeEvidence builds (and optionally pushes) a recipe-evidence v1
+// attestation bundle from a completed validation run. It is the facade
+// counterpart to the logic the CLI previously assembled inline: it converts
+// the facade PhaseResults back to the internal shape, loads the validator
+// catalog against THIS Client's data source and version, and delegates to the
+// evidence attestation package.
+//
+// Interactive keyless-signing disclosure is intentionally NOT performed here —
+// that is a UI concern the caller handles (the CLI prompts before calling).
+// This method does no prompting and can run unattended from a server/library.
+func (c *Client) EmitRecipeEvidence(
+	ctx context.Context,
+	rec *RecipeResult,
+	snap *Snapshot,
+	results []*PhaseResult,
+	opts EvidenceOptions,
+) error {
+
+	if c == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
+	}
+	if ctx == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
+	if rec == nil || rec.internal == nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"nil or unresolved RecipeResult — call Client.ResolveRecipe to obtain an evidence-emittable RecipeResult")
+	}
+	if err := c.assertOwns(rec); err != nil {
+		return err
+	}
+	if snap == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, "nil Snapshot")
+	}
+	if opts.OutDir == "" {
+		return errors.New(errors.ErrCodeInvalidRequest, "evidence OutDir is required")
+	}
+
+	c.mu.RLock()
+	if c.builder == nil {
+		c.mu.RUnlock()
+		return errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
+	}
+	// Snapshot the per-Client provider + version so the validator catalog
+	// resolves against THIS Client's recipe source, matching the run.
+	dp := c.dp
+	clientVersion := c.version
+	c.inflight.Add(1)
+	c.mu.RUnlock()
+	defer c.inflight.Done()
+
+	cat, err := catalog.LoadWithDataProvider(ctx, dp, clientVersion, opts.Commit)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load validator catalog for evidence")
+	}
+
+	_, err = evattest.Emit(ctx, evattest.EmitOptions{
+		OutDir:       opts.OutDir,
+		BOMPath:      opts.BOMPath,
+		Push:         opts.Push,
+		PlainHTTP:    opts.PlainHTTP,
+		InsecureTLS:  opts.InsecureTLS,
+		NoSign:       opts.NoSign,
+		Full:         opts.Full,
+		Recipe:       rec.Resolved(),
+		Snapshot:     toInternalSnapshot(snap),
+		PhaseResults: toInternalPhaseResults(results),
+		Catalog:      cat,
+		AICRVersion:  clientVersion,
+		OIDCResolve:  opts.OIDCResolve,
+	})
+	return err
+}

--- a/pkg/client/v1/evidence_test.go
+++ b/pkg/client/v1/evidence_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
+)
+
+func TestMergeReports(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{version: "v1.2.3"}
+
+	r1 := &ctrf.Report{}
+	r1.Results.Summary = ctrf.Summary{Tests: 2, Passed: 2}
+	r2 := &ctrf.Report{}
+	r2.Results.Summary = ctrf.Summary{Tests: 3, Passed: 1, Failed: 2}
+
+	results := []*PhaseResult{
+		{Phase: "deployment", Report: r1},
+		nil,                                 // nil result skipped
+		{Phase: "performance", Report: r2},  // counts merged
+		{Phase: "conformance", Report: nil}, // nil report contributes nothing
+	}
+
+	merged := c.MergeReports(results)
+	if merged == nil {
+		t.Fatal("MergeReports returned nil")
+	}
+	if merged.Results.Tool.Name != "aicr" {
+		t.Errorf("tool name = %q, want aicr", merged.Results.Tool.Name)
+	}
+	if merged.Results.Tool.Version != "v1.2.3" {
+		t.Errorf("tool version = %q, want v1.2.3", merged.Results.Tool.Version)
+	}
+	if got := merged.Results.Summary.Tests; got != 5 {
+		t.Errorf("merged tests = %d, want 5", got)
+	}
+	if got := merged.Results.Summary.Passed; got != 3 {
+		t.Errorf("merged passed = %d, want 3", got)
+	}
+	if got := merged.Results.Summary.Failed; got != 2 {
+		t.Errorf("merged failed = %d, want 2", got)
+	}
+}
+
+// TestMergeReports_NilReceiver locks in that MergeReports tolerates a nil
+// Client (empty version), so a caller cannot panic on it.
+func TestMergeReports_NilReceiver(t *testing.T) {
+	t.Parallel()
+	var c *Client
+	merged := c.MergeReports(nil)
+	if merged == nil {
+		t.Fatal("MergeReports(nil) returned nil")
+	}
+	if merged.Results.Tool.Version != "" {
+		t.Errorf("version = %q, want empty for nil client", merged.Results.Tool.Version)
+	}
+}
+
+func TestEmitRecipeEvidence_RejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	validClient := newClientForBundleTest(t)
+	validRecipe := newRecipeResultForBundleTest(validClient,
+		[]recipe.ComponentRef{{Name: "c1", Type: recipe.ComponentTypeHelm}},
+		[]ComponentRef{{Name: "c1", Kind: "Helm"}},
+	)
+	validSnap := &Snapshot{}
+
+	tests := []struct {
+		name   string
+		client *Client
+		recipe *RecipeResult
+		snap   *Snapshot
+		opts   EvidenceOptions
+	}{
+		{"nil client", nil, validRecipe, validSnap, EvidenceOptions{OutDir: "out"}},
+		{"nil recipe", validClient, nil, validSnap, EvidenceOptions{OutDir: "out"}},
+		{"recipe missing internal", validClient, &RecipeResult{Name: "no-internal"}, validSnap, EvidenceOptions{OutDir: "out"}},
+		{"nil snapshot", validClient, validRecipe, nil, EvidenceOptions{OutDir: "out"}},
+		{"empty outdir", validClient, validRecipe, validSnap, EvidenceOptions{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.client.EmitRecipeEvidence(context.Background(), tt.recipe, tt.snap, nil, tt.opts)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			var se *aicrerrors.StructuredError
+			if !stderrors.As(err, &se) {
+				t.Fatalf("expected *aicrerrors.StructuredError, got %T: %v", err, err)
+			}
+			if se.Code != aicrerrors.ErrCodeInvalidRequest {
+				t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+			}
+		})
+	}
+}
+
+// TestEmitRecipeEvidence_RejectsClosedClient locks in the closed-Client guard:
+// after Close() clears the builder, evidence emission must fail closed rather
+// than loading a catalog from a half-torn-down Client.
+func TestEmitRecipeEvidence_RejectsClosedClient(t *testing.T) {
+	t.Parallel()
+
+	c := newClientForBundleTest(t)
+	r := newRecipeResultForBundleTest(c,
+		[]recipe.ComponentRef{{Name: "c1", Type: recipe.ComponentTypeHelm}},
+		[]ComponentRef{{Name: "c1", Kind: "Helm"}},
+	)
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	err := c.EmitRecipeEvidence(context.Background(), r, &Snapshot{}, nil, EvidenceOptions{OutDir: "out"})
+	if err == nil {
+		t.Fatalf("expected error from closed Client, got nil")
+	}
+	var se *aicrerrors.StructuredError
+	if !stderrors.As(err, &se) || se.Code != aicrerrors.ErrCodeInvalidRequest {
+		t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+	}
+}

--- a/pkg/client/v1/translate.go
+++ b/pkg/client/v1/translate.go
@@ -155,6 +155,30 @@ func fromInternalPhaseResult(p *validator.PhaseResult) *PhaseResult {
 	return out
 }
 
+// toInternalPhaseResults translates facade PhaseResults back into the
+// validator slice for evidence emission. The typed *ctrf.Report is carried
+// through so attestation.Emit receives the full per-phase report. nil/empty
+// input returns nil; nil elements are skipped (the attestation builder
+// iterates rather than indexes, so dropping nils is loss-free).
+func toInternalPhaseResults(in []*PhaseResult) []*validator.PhaseResult {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*validator.PhaseResult, 0, len(in))
+	for _, p := range in {
+		if p == nil {
+			continue
+		}
+		out = append(out, &validator.PhaseResult{
+			Phase:    validator.Phase(p.Phase),
+			Status:   p.Status,
+			Report:   p.Report,
+			Duration: p.Duration,
+		})
+	}
+	return out
+}
+
 // fromInternalPhase is the typed lift from validator.Phase to facade Phase.
 func fromInternalPhase(p validator.Phase) Phase { return Phase(p) }
 


### PR DESCRIPTION
## Summary

Moves the per-phase CTRF report merge and recipe-evidence emission out of `pkg/cli` and behind the `pkg/client/v1` facade, so non-CLI (library/server) callers of `ValidateState` get the same combined report and evidence bundle without reimplementing the merge or reconstructing internal `validator.PhaseResult` types.

## Motivation / Context

Follow-up to #1511, where these two items were flagged (CodeRabbit, "logic above the facade") and deliberately deferred because they change the `pkg/client/v1` public API surface. `runValidation` previously called `ctrf.MergeReports(...)` directly and rebuilt `[]*validator.PhaseResult` to reach the internal `attestation.Emit` path — neither reachable from a library caller holding only facade types.

Fixes: N/A
Related: #1511

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] `pkg/client/v1` facade
- [x] Other: `pkg/validator/ctrf`, `pkg/evidence/attestation` (consumed, not changed)

## Implementation Notes

New facade surface (additive, non-breaking):
- **`Client.MergeReports([]*PhaseResult) *ctrf.Report`** — merges per-phase reports into a combined report stamped with the Client's version + tool name `aicr`. The CLI now calls this instead of `ctrf.MergeReports("aicr", version, ...)`.
- **`Client.EmitRecipeEvidence(ctx, rec, snap, results, EvidenceOptions) error`** — converts facade `PhaseResult`s internally (new `toInternalPhaseResults`), loads the validator catalog against **this Client's** data source + version, and delegates to `attestation.Emit`.
- **`EvidenceOptions`** mirrors the inline inputs; **`OIDCResolveOptions`** is a transparent alias of `pkg/bundler/attestation.ResolveOptions`, mirroring how `BundleOptions` exposes `BundleAttester`.

Boundary decisions:
- The interactive keyless-signing **disclosure prompt stays CLI-side** (a UI concern); the facade method performs no prompting and is safe to call unattended.
- The CLI's separate evidence-only `DataProvider` (and the `validateDataProvider` helper) is **removed** — the Client's own provider is built from the same `--data` source, so it's the single source of truth now. This closes the last duplicated-provider seam on the validate path.

CLI behavior is unchanged (same merged report, same bundle, same prompts, same exit codes).

## Testing

```bash
make qualify
```

Added facade unit tests: `TestMergeReports` (merge math + version/tool stamping + nil handling), `TestMergeReports_NilReceiver`, `TestEmitRecipeEvidence_RejectsBadInput` (nil/closed/empty-OutDir guards), `TestEmitRecipeEvidence_RejectsClosedClient`. `pkg/client/v1` and `pkg/cli` tests pass; `go build ./...` clean; golangci-lint 0 issues on both packages.

## Risk Assessment

- [x] **Low** — Additive facade methods; CLI path delegates to them with identical observable behavior; well covered and easy to revert.

**Rollout notes:** No migration. Purely additive SDK surface; no CLI flags, endpoints, recipe fields, env vars, or error codes changed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (no user-facing CLI/API change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
