### PR TITLE
docs: expand SECURITY.md with SLA, scope, embargo, and versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,65 @@ To report a potential security vulnerability in any NVIDIA product:
 
 NVIDIA offers acknowledgement for externally reported security issues under our coordinated vulnerability disclosure policy. Visit [PSIRT Policies](https://www.nvidia.com/en-us/security/psirt-policies/) for details.
 
+## Acknowledgement and Response
+
+Reports submitted through the channels above are received by NVIDIA PSIRT.
+PSIRT acknowledges receipt of each report, coordinates with the reporter
+throughout the investigation, and provides progress updates as the issue moves
+toward remediation. The expectations for acknowledgement, ongoing
+communication, and reporter credit are defined in the
+[PSIRT Policies](https://www.nvidia.com/en-us/security/psirt-policies/), which
+set the response timeline for AICR. If you do not receive an acknowledgement,
+re-send your report to psirt@nvidia.com rather than opening a public issue.
+
+## Embargo, Coordinated Disclosure, and CVEs
+
+Confirmed vulnerabilities are handled under embargo. NVIDIA PSIRT manages the
+coordinated disclosure timeline: the issue is kept confidential while a fix is
+prepared, affected downstream consumers are notified where appropriate, and a
+security advisory is published when the embargo lifts. NVIDIA is a CVE Numbering
+Authority (CNA) and assigns CVE identifiers for resolved issues that require
+user action, so downstream users can track and patch them through standard
+vulnerability databases.
+
+AICR maintainers support this process by developing fixes privately and holding
+public discussion of an issue until PSIRT lifts the embargo. Please keep any
+reported vulnerability confidential until then.
+
+## Out of Scope
+
+The following generally do **not** qualify as security vulnerabilities in AICR.
+Reviewing this list before reporting helps PSIRT focus on real issues:
+
+- Findings that require physical access to a node or control-plane host.
+- Social engineering, phishing, or attacks that depend on an already-compromised
+  operator credential or workstation.
+- Theoretical weaknesses with no demonstrated, practical exploit path.
+- Vulnerabilities in upstream components that AICR only deploys (for example the
+  GPU Operator, Network Operator, or other Helm chart sub-images) — report those
+  to the owning project. We will help coordinate when an AICR default is involved.
+- Missing cluster hardening that is the operator's responsibility, such as
+  network policy, secrets management, or RBAC tightening covered by the
+  deployment documentation.
+
+When in doubt, report it — PSIRT would rather triage an out-of-scope report than
+miss a real one.
+
+## Supported Versions
+
+AICR is pre-1.0 and ships from a single active release line. Only the latest
+released minor receives security fixes; earlier minors are end-of-life and
+should be upgraded.
+
+| Version | Supported |
+|---------|-----------|
+| `0.15.x` (latest released minor) | ✅ Receives security fixes |
+| `< 0.15` | ❌ End-of-life — upgrade to the latest release |
+
+Security fixes ship in a new patch or minor release rather than as backports to
+end-of-life versions. When AICR reaches 1.0 this policy will be revised and a
+longer support window published here.
+
 ## Product Security Resources
 
 For all security-related concerns: https://www.nvidia.com/en-us/security


### PR DESCRIPTION
## Summary

Expands `SECURITY.md` with an acknowledgement-and-response section, an embargo and coordinated-disclosure section, an out-of-scope list, and a supported-version matrix.

## Motivation / Context

The NVIDIA OSS Health Scorecard (Security Policy dimension) flagged that `SECURITY.md` gives a private reporting path and PGP key but does not document several details reviewers expect: an acknowledgement and response timeline, out-of-scope criteria, an embargo and pre-disclosure process, and a supported-version matrix. This change adds those details while keeping NVIDIA PSIRT as the single point of contact, so the project does not invent a process that conflicts with PSIRT.

Fixes: #1422
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: Root security policy doc (`SECURITY.md`)

## Implementation Notes

- **Acknowledgement and response:** the new section states that PSIRT acknowledges receipt and coordinates with the reporter, and points to the PSIRT Policies that set the response timeline. NVIDIA PSIRT does not publish a fixed number of days, so the section references the published policy rather than inventing a project-specific window.
- **Embargo, coordinated disclosure, and CVEs:** describes how confirmed issues are held under embargo and how NVIDIA, as a CVE Numbering Authority, assigns CVE identifiers.
- **Out of scope:** lists report types that do not qualify, including upstream components that AICR only deploys (those go to the owning project).
- **Supported versions:** adds a matrix showing that the latest released minor (`0.15.x`) receives security fixes and earlier minors are end-of-life. AICR is pre-1.0; the policy is noted as one to revisit at 1.0.

No existing headings were renamed, so inbound anchor links to `SECURITY.md` are unaffected.

## Testing

Verified by running the NVIDIA OSS Health Scorecard's Security Policy evaluation against the edited `SECURITY.md`. The four items this issue calls out now pass — acknowledgement SLA, out-of-scope criteria, supported-version matrix, and embargo / pre-disclosure — and the dimension reaches Level 4 on documented content.

Two findings are intentionally not addressed here: a malware-scan-on-release-binaries signal, which is a CI step rather than a documentation gap; and the "signed release tags" finding, which is a scorecard false positive (release tags verify as signed) noted in the issue itself.

## Risk Assessment

- [x] **Low** — Documentation-only change, easy to revert

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go code changed
- [ ] Linter passes (`make lint`) — N/A, no Go or YAML changed
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, documentation only
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

