### PR TITLE
fix(evidence): make unsigned-commit CI-sign flow coherent (#1530)

### DIFF
--- a/.github/scripts/evidence-sign-unsigned.sh
+++ b/.github/scripts/evidence-sign-unsigned.sh
@@ -2,33 +2,42 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Discover committed-but-unsigned evidence pointers and sign each in place.
-# Consumed by .github/workflows/evidence-publish.yaml (the fork-based
-# signing leg): a contributor pushes an unsigned bundle and commits the
-# pointer locally (`aicr ... --no-sign`), then this signs the bundle each
-# pointer references using the runner's ambient OIDC token and patches the
-# pointer's signer block in place.
+# Discover committed-but-unsigned evidence pointers, sign each, and relocate
+# it to its canonical per-source path. Consumed by
+# .github/workflows/evidence-publish.yaml (the fork-based signing leg).
 #
-# A pointer is "unsigned" iff its first attestation has no `signer` block —
-# the state `--no-sign` produces. Already-signed pointers are skipped, so
-# re-running is idempotent and safe.
+# The two-phase publish flow (#1530): a contributor pushes an unsigned bundle
+# and commits the pointer FLAT at recipes/evidence/<recipe>.yaml
+# (`aicr ... --no-sign`). A flat path is the only committable state for an
+# unsigned pointer — the nested <source> path segment derives from the signer,
+# which a `--no-sign` pointer does not have. This script then:
+#
+#   1. signs the bundle each flat pointer references with the runner's ambient
+#      OIDC token (patching the pointer's signer block in place), and
+#   2. relocates the now-signed pointer to its canonical per-source path
+#      recipes/evidence/<recipe>/<source>/<digest>.yaml — the layout the
+#      per-source contract gate requires.
+#
+# Both steps run inside `aicr evidence sign --relocate`, so the SourceSlug
+# derivation stays in one place (Go) rather than being reimplemented here.
+# `--relocate` is idempotent: an already-signed flat pointer (a prior run
+# signed it but the relocation didn't land) is moved without re-signing, so
+# re-running is safe.
+#
+# Pointers already relocated under <recipe>/<source>/ are not scanned (the
+# glob is flat), so they are never re-processed. allowlist.yaml is skipped.
 #
 # Required env:
 #   AICR   path to the aicr binary (built from a trusted source)
-#
-# Requires the mikefarah `yq` (v4) — the same `yq` the rest of the repo's
-# scripts assume. The kislyuk/python `yq` has incompatible syntax and is not
-# supported. On GitHub-hosted runners mikefarah yq is preinstalled.
 #
 # Any extra arguments are forwarded to `aicr evidence sign` (e.g.
 # --plain-http / --insecure-tls for local-registry tests).
 #
 # Outputs (and, when set, appends to $GITHUB_OUTPUT):
-#   skipped=<n>  pointers already signed (no-op)
-#   signed=<n>   pointers signed this run
-#   failed=<n>   pointers whose signing (or parsing) failed
+#   signed=<n>   flat pointers signed and/or relocated this run
+#   failed=<n>   flat pointers whose signing/relocation failed
 #
-# Exit status is non-zero when any signing failed, so the workflow surfaces
+# Exit status is non-zero when any pointer failed, so the workflow surfaces
 # the cause (commonly a private fork registry returning HTTP 403 on the
 # pre-sign pull — make the aicr-evidence package public).
 
@@ -40,49 +49,38 @@ extra_args=("$@")
 
 signed=0
 failed=0
-skipped=0
 
 shopt -s nullglob
+# The evidence root is also defined in Go as verifier.EvidenceDirName
+# ("recipes/evidence"); a shell script can't import the constant, so keep this
+# glob in sync if that path ever changes.
 for pointer in recipes/evidence/*.yaml; do
-  # signer absent => unsigned (the --no-sign state). A signed-without-Rekor
-  # pointer still has a signer block, so it is correctly skipped.
-  #
-  # Fail closed on a yq error: a missing yq or malformed YAML must NOT look
-  # like an unsigned pointer (which would resign an already-signed bundle and
-  # break rerun idempotence). Treat a parse failure as a hard failure.
-  if ! signer=$(yq eval '.attestations[0].signer // "null"' "$pointer" 2>/dev/null); then
-    echo "::error::failed to parse ${pointer} with yq — invalid YAML, or mikefarah yq (v4) not installed"
-    failed=$((failed + 1))
-    continue
-  fi
-  if [[ "$signer" != "null" ]]; then
-    echo "skip (already signed): ${pointer}"
-    skipped=$((skipped + 1))
+  # allowlist.yaml is not a pointer; never feed it to `evidence sign`.
+  if [[ "${pointer##*/}" == "allowlist.yaml" ]]; then
     continue
   fi
 
-  echo "signing unsigned pointer: ${pointer}"
+  echo "signing + relocating flat pending pointer: ${pointer}"
+  # --relocate: sign in place, then move to the canonical per-source path.
   # --yes: never pause for the interactive identity-disclosure prompt in CI
   # (ambient OIDC does not prompt, but this is belt-and-suspenders).
-  if "$AICR" evidence sign "$pointer" --yes "${extra_args[@]}"; then
+  if "$AICR" evidence sign "$pointer" --relocate --yes "${extra_args[@]}"; then
     signed=$((signed + 1))
   else
-    echo "::error::failed to sign ${pointer} — is the bundle's registry package public? (a private fork package returns HTTP 403 on the pre-sign pull)"
+    echo "::error::failed to sign/relocate ${pointer} — is the bundle's registry package public? (a private fork package returns HTTP 403 on the pre-sign pull)"
     failed=$((failed + 1))
   fi
 done
 
-echo "skipped=${skipped}"
 echo "signed=${signed}"
 echo "failed=${failed}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
-    echo "skipped=${skipped}"
     echo "signed=${signed}"
     echo "failed=${failed}"
   } >> "$GITHUB_OUTPUT"
 fi
 
-# Fail closed if any pointer could not be signed.
+# Fail closed if any pointer could not be signed/relocated.
 [[ "$failed" -eq 0 ]]

--- a/.github/workflows/evidence-pointer-contract.yaml
+++ b/.github/workflows/evidence-pointer-contract.yaml
@@ -62,4 +62,8 @@ jobs:
       - name: Check evidence pointer contract
         env:
           GOFLAGS: -mod=vendor
+        # No --allow-pending: this is the merge gate, so a flat unsigned pending
+        # pointer is rejected. It must be signed and relocated under
+        # <recipe>/<source>/ (the fork-based sign leg does this) before merge —
+        # an unsigned pointer must never land on main, where that leg never runs.
         run: go run ./tools/evidence-pointercheck -root recipes/evidence

--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -16,17 +16,22 @@
 #
 # A contributor publishes an UNSIGNED evidence bundle locally (where the
 # cluster lives, often behind a VPN that blocks Sigstore) and commits the
-# pointer:
+# pointer FLAT — recipes/evidence/<recipe>.yaml — because the nested
+# <source> path segment derives from the signer a `--no-sign` pointer does
+# not yet have:
 #
 #   aicr validate -r recipes/overlays/<slug>.yaml -s snapshot.yaml \
 #     --emit-attestation ./out --push ghcr.io/<owner>/aicr-evidence --no-sign
-#   cp ./out/pointer.yaml recipes/evidence/<slug>.yaml
+#   cp ./out/pointer.yaml recipes/evidence/<recipe>.yaml
 #
 # They then run THIS workflow from their fork's Actions tab. It discovers
-# every committed pointer with an empty signer block, signs the bundle each
-# one references with the runner's ambient OIDC identity (where Sigstore IS
-# reachable), patches the pointer's signer block in place, and commits it
-# back to the branch. Clean no-op when there is nothing unsigned.
+# every flat pointer with an empty signer block, signs the bundle each one
+# references with the runner's ambient OIDC identity (where Sigstore IS
+# reachable), patches the pointer's signer block in place, RELOCATES it to
+# its canonical per-source path recipes/evidence/<recipe>/<source>/<digest>.yaml
+# (the layout the per-source contract gate requires), and commits the move
+# back to the branch. Clean no-op when there is nothing unsigned. This is the
+# commit-flat -> CI-sign -> CI-relocate-to-nested flow (#1530).
 #
 # Why workflow_dispatch (Option A): no recipe-name or bundle-ref inputs to
 # thread through — the committed pointer is the work item, and it already
@@ -138,13 +143,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if git diff --quiet -- recipes/evidence/; then
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # -A stages the relocation as a delete (flat pointer) + add (nested
+          # pointer) plus any in-place signer patch, so the moved files commit
+          # correctly. Check the STAGED set after `git add` so an untracked
+          # relocated file is still counted as a change.
+          git add -A recipes/evidence/
+          if git diff --cached --quiet -- recipes/evidence/; then
             echo "No pointer changes to commit (nothing to sign)."
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add recipes/evidence/
           # -s adds a `Signed-off-by:` (DCO) trailer matching the bot author,
           # so the DCO bot passes on the commit-back. The commit is NOT
           # cryptographically signed (no -S) — it fills in the evidence

--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -24,13 +24,15 @@
 #     --emit-attestation ./out --push ghcr.io/<owner>/aicr-evidence --no-sign
 #   cp ./out/pointer.yaml recipes/evidence/<recipe>.yaml
 #
-# They then run THIS workflow from their fork's Actions tab. It discovers
-# every flat pointer with an empty signer block, signs the bundle each one
-# references with the runner's ambient OIDC identity (where Sigstore IS
-# reachable), patches the pointer's signer block in place, RELOCATES it to
-# its canonical per-source path recipes/evidence/<recipe>/<source>/<digest>.yaml
-# (the layout the per-source contract gate requires), and commits the move
-# back to the branch. Clean no-op when there is nothing unsigned. This is the
+# They then run THIS workflow from their fork's Actions tab. It scans every
+# flat pointer under recipes/evidence/ except allowlist.yaml and runs
+# `aicr evidence sign --relocate` on each: an unsigned pointer is signed with
+# the runner's ambient OIDC identity (where Sigstore IS reachable) and then
+# relocated; an already-signed flat pointer left by a partial prior run is
+# relocated without re-signing (idempotent). The destination is the canonical
+# per-source path recipes/evidence/<recipe>/<source>/<digest>.yaml (the layout
+# the per-source contract gate requires), and the move is committed back to the
+# branch. Clean no-op when there are no flat pointers. This is the
 # commit-flat -> CI-sign -> CI-relocate-to-nested flow (#1530).
 #
 # Why workflow_dispatch (Option A): no recipe-name or bundle-ref inputs to

--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -137,11 +137,16 @@ jobs:
         run: .github/scripts/evidence-sign-unsigned.sh
 
       - name: Commit signed pointers
-        # always() so that if one pointer fails to sign, the ones that DID
-        # sign are still committed — otherwise the registry would hold a signed
-        # bundle whose committed pointer stays unsigned. The job still fails
-        # (the sign step exited non-zero), surfacing the failure.
-        if: ${{ always() && steps.sign.outputs.signed != '0' }}
+        # always(), with no signed-count guard: the git-diff check below decides
+        # whether there is anything to commit. This is load-bearing for partial
+        # failure — `aicr evidence sign` patches the signer block into the flat
+        # pointer BEFORE the relocation step, so if relocation then fails the
+        # bundle is already signed in the registry. Committing the signed (but
+        # not-yet-relocated) pointer persists that work, so the next dispatch
+        # takes the idempotent relocate-only path instead of re-signing and
+        # attaching a duplicate referrer. The job still fails (the sign step
+        # exited non-zero), surfacing the failure.
+        if: ${{ always() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/evidence-publish.yaml
+++ b/.github/workflows/evidence-publish.yaml
@@ -64,10 +64,12 @@
 # there is no pull_request_target / untrusted-ref exposure (it is manual
 # dispatch on the fork's own code).
 #
-# The fork's aicr-evidence registry package must be PUBLIC: the pre-sign
-# pull (and the upstream evidence gate) fetch the bundle, and a private
-# package returns HTTP 403. The signing step fails with a clear message
-# pointing at this when it can't pull.
+# The fork's aicr-evidence registry package must be PUBLIC: the upstream
+# evidence gate fetches the bundle anonymously, and a private package returns
+# HTTP 403. The signing step fails with a clear message pointing at this when
+# it can't pull. The signature ATTACH (a referrer write) is authenticated
+# separately by the ghcr-login step + packages:write below — public visibility
+# alone does not grant write.
 
 name: "Recipe Evidence: Sign"
 
@@ -80,6 +82,10 @@ on:
 permissions:
   contents: write   # commit the patched pointer(s) back to the branch
   id-token: write   # ambient OIDC for keyless Fulcio/Rekor signing
+  # packages:write attaches the Sigstore bundle as an OCI referrer of the
+  # already-pushed artifact (a registry write — making the package public only
+  # enables the anonymous pre-sign pull, not the signature attach).
+  packages: write
 
 concurrency:
   # Serialize per branch; do NOT cancel in progress — a cancel mid-sign
@@ -129,6 +135,13 @@ jobs:
           # the binary that will sign with the runner's OIDC identity.
           go mod verify
           go build -o ./bin/aicr ./cmd/aicr
+
+      # `aicr evidence sign` attaches the Sigstore bundle as an OCI referrer —
+      # a registry write — so authenticate first (ORAS reads Docker creds). The
+      # public-package setting only enables the anonymous pre-sign pull. For a
+      # non-GHCR registry, swap this for that registry's login.
+      - name: Authenticate to GHCR
+        uses: ./.github/actions/ghcr-login
 
       - name: Sign unsigned evidence pointers
         id: sign

--- a/docs/contributor/evidence-publishing.md
+++ b/docs/contributor/evidence-publishing.md
@@ -42,12 +42,20 @@ aicr validate \
   --emit-attestation ./out \
   --push ghcr.io/<your-fork-owner>/aicr-evidence \
   --no-sign
-cp ./out/pointer.yaml recipes/evidence/<slug>.yaml
+cp ./out/pointer.yaml recipes/evidence/<recipe>.yaml
 ```
 
 `--no-sign` skips all OIDC/Fulcio/Rekor work, so this runs even where
 Sigstore egress is blocked. It pushes the content-addressed bundle and
-writes a pointer with an empty `signer` block. See
+writes a pointer with an empty `signer` block.
+
+Commit it **flat** at `recipes/evidence/<recipe>.yaml` (where `<recipe>` is
+the pointer's `recipe:` field). This is the *only* committable location for
+an unsigned pointer: the nested per-source path
+`recipes/evidence/<recipe>/<src>/<digest>.yaml` includes a `<src>`
+segment derived from the **signer**, which a `--no-sign` pointer does not yet
+have. The signing leg below relocates the pointer to that nested path once it
+is signed. See
 [`aicr validate`](../user/cli-reference.md#aicr-validate) and
 [`aicr evidence publish`](../user/cli-reference.md#aicr-evidence-publish)
 (which also accepts `--no-sign` if you push as a separate step).
@@ -63,11 +71,11 @@ writes a pointer with an empty `signer` block. See
 ### 2. Commit the unsigned pointer and push your branch
 
 ```shell
-git add recipes/evidence/<slug>.yaml
+git add recipes/evidence/<recipe>.yaml
 # Use -s (DCO sign-off) — required for all contributors. NVIDIA org members
 # additionally use -S (cryptographic signing); external contributors use -s
 # alone. See CONTRIBUTING.md.
-git commit -s -m "evidence: <slug> (unsigned; sign in CI)"
+git commit -s -m "evidence: <recipe> (unsigned; sign in CI)"
 git push
 ```
 
@@ -88,19 +96,22 @@ runs two ways in your fork:
 The auto-trigger is fork-only (it never runs on the canonical repo) and skips its
 own signing commit, so it can't loop. The workflow:
 
-- discovers every pointer in `recipes/evidence/*.yaml` with an empty
+- discovers every flat pointer in `recipes/evidence/*.yaml` with an empty
   `signer` (i.e. unsigned),
 - signs the bundle each one already references using the runner's ambient
-  OIDC token ([`aicr evidence sign`](../user/cli-reference.md#aicr-evidence-sign)),
-- patches the pointer's `signer` block in place and commits it back to the
-  branch.
+  OIDC token and **relocates** the now-signed pointer to its canonical
+  per-source path `recipes/evidence/<recipe>/<src>/<digest>.yaml`
+  ([`aicr evidence sign --relocate`](../user/cli-reference.md#aicr-evidence-sign)),
+- commits the move back to the branch.
 
 It is a clean no-op when there are no unsigned pointers, and it fails with a
 clear message if it cannot pull a bundle (the public-package requirement
-above). Pull the commit it pushes (`git pull`) — your PR now carries a pointer
-whose `signer` block is filled in (the *bundle* is signed; the commit-back
-itself is a normal, unsigned GitHub Actions commit, which the eventual
-squash-merge re-signs under the repo's policy).
+above). Pull the commit it pushes (`git pull`) — your PR now carries a
+**signed, nested** pointer (the flat pending file is gone). The *bundle* is
+signed; the commit-back itself is a normal, unsigned GitHub Actions commit,
+which the eventual squash-merge re-signs under the repo's policy. The
+per-source contract gate accepts the flat pending pointer while the PR is in
+flight and requires the signed, nested pointer once the signing leg has run.
 
 > The workflow declares `id-token: write` in its own `permissions:` block —
 > it is not a default. Your fork must have GitHub Actions enabled and not
@@ -121,11 +132,24 @@ aicr validate -r recipes/overlays/<slug>.yaml -s snapshot.yaml --emit-attestatio
 
 # Off VPN, where Sigstore is reachable: sign, push, and write the pointer.
 aicr evidence publish ./out --push ghcr.io/<your-fork-owner>/aicr-evidence
-cp ./out/pointer.yaml recipes/evidence/<slug>.yaml
 ```
 
-The signed artifact is content-addressed, so the result is identical
-regardless of which host ran which leg.
+`aicr evidence publish` signs the pointer, so commit it directly at its
+**canonical per-source path**, not flat. The command logs the exact
+destination (`copyTo=…`) — copy the pointer there:
+
+```shell
+# The path is recipes/evidence/<recipe>/<src>/<digest>.yaml; <src> is
+# derived from your signer identity. Use the copyTo path the command printed.
+mkdir -p recipes/evidence/<recipe>/<src>
+cp ./out/pointer.yaml recipes/evidence/<recipe>/<src>/<digest>.yaml
+```
+
+The flat commit-then-CI-sign flow above is only for the unsigned case: a
+signed pointer already has the signer the `<src>` segment derives from, so
+it goes straight to its nested path and needs no relocation. The signed
+artifact is content-addressed, so the result is identical regardless of which
+host ran which leg.
 
 ## See also
 

--- a/docs/contributor/evidence-publishing.md
+++ b/docs/contributor/evidence-publishing.md
@@ -72,10 +72,9 @@ is signed. See
 
 ```shell
 git add recipes/evidence/<recipe>.yaml
-# Use -s (DCO sign-off) — required for all contributors. NVIDIA org members
-# additionally use -S (cryptographic signing); external contributors use -s
-# alone. See CONTRIBUTING.md.
-git commit -s -m "evidence: <recipe> (unsigned; sign in CI)"
+# Every commit from every contributor must be both signed off (-s, DCO) and
+# cryptographically signed (-S). See CONTRIBUTING.md.
+git commit -s -S -m "evidence: <recipe> (unsigned; sign in CI)"
 git push
 ```
 
@@ -104,14 +103,21 @@ own signing commit, so it can't loop. The workflow:
   ([`aicr evidence sign --relocate`](../user/cli-reference.md#aicr-evidence-sign)),
 - commits the move back to the branch.
 
-It is a clean no-op when there are no unsigned pointers, and it fails with a
+It is a clean no-op when there are no flat pointers, and it fails with a
 clear message if it cannot pull a bundle (the public-package requirement
 above). Pull the commit it pushes (`git pull`) — your PR now carries a
 **signed, nested** pointer (the flat pending file is gone). The *bundle* is
 signed; the commit-back itself is a normal, unsigned GitHub Actions commit,
-which the eventual squash-merge re-signs under the repo's policy. The
-per-source contract gate accepts the flat pending pointer while the PR is in
-flight and requires the signed, nested pointer once the signing leg has run.
+which the eventual squash-merge re-signs under the repo's policy.
+
+> **Run this leg before merge.** The blocking per-source contract gate
+> requires a **signed, nested** pointer; it rejects a flat pending pointer
+> still sitting at the evidence root. That is deliberate — an unsigned pointer
+> must not merge to `main`, where the fork-only sign workflow would never run
+> to complete it. So a PR whose pointer is still flat stays red until this leg
+> signs and relocates it (and you `git pull` the commit-back). Local tooling
+> can validate the transient flat state with
+> `evidence-pointercheck --allow-pending`, but the merge gate does not set it.
 
 > The workflow declares `id-token: write` in its own `permissions:` block —
 > it is not a default. Your fork must have GitHub Actions enabled and not

--- a/docs/contributor/evidence-publishing.md
+++ b/docs/contributor/evidence-publishing.md
@@ -127,6 +127,32 @@ which the eventual squash-merge re-signs under the repo's policy.
 > commits the patched pointers back, and a concurrent push would cause a
 > non-fast-forward — re-dispatch after `git pull` if that happens.
 
+### 4. Add your signer to the allowlist
+
+A signed, nested pointer is **not** sufficient on its own. The contract gate
+also requires the pointer's verified signer to be listed in
+[`recipes/evidence/allowlist.yaml`](../../recipes/evidence/allowlist.yaml) as a
+`community` or `partner` entry; an unlisted signer is rejected (it would only
+ever count as "reported", never corroborating). Your fork's GitHub Actions OIDC
+identity is a **new signer** that the existing entries do not cover, so you must
+add it in the same PR.
+
+The entry is keyed by the one-way `source` slug — the exact `<src>` directory
+the signing leg just created under `recipes/evidence/<recipe>/<src>/`. Add it
+under the `community` class (no cleartext identity; an optional `label` may
+carry a non-PII handle):
+
+```yaml
+# recipes/evidence/allowlist.yaml
+community:
+  - source: <src>          # the <src> directory segment from step 3
+    label: <your-gh-handle> # optional, non-PII
+```
+
+See the header of `recipes/evidence/allowlist.yaml` and
+[artifact verification](../user/artifact-verification.md) for the anti-sybil
+rules; maintainer review of this entry is the trust gate.
+
 ## Fallback: split the legs locally
 
 If you have a host with Sigstore egress (a jump box, CI runner, or

--- a/docs/contributor/evidence-publishing.md
+++ b/docs/contributor/evidence-publishing.md
@@ -153,9 +153,11 @@ cp ./out/pointer.yaml recipes/evidence/<recipe>/<src>/<digest>.yaml
 
 The flat commit-then-CI-sign flow above is only for the unsigned case: a
 signed pointer already has the signer the `<src>` segment derives from, so
-it goes straight to its nested path and needs no relocation. The signed
-artifact is content-addressed, so the result is identical regardless of which
-host ran which leg.
+it goes straight to its nested path and needs no relocation. The *bundle* is
+content-addressed, so its bytes (and `bundle.digest`) are identical regardless
+of which host ran which leg — but the committed *pointer path* still depends on
+the signer: `<src>` is derived from your signing identity, so a different
+signer lands the pointer under a different `<src>` directory.
 
 ## See also
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2667,7 +2667,9 @@ Signing is the only leg that needs Fulcio/Rekor egress, so this command is desig
 aicr evidence sign <pointer> [flags]
 ```
 
-The positional `<pointer>` is the committed `recipes/evidence/<recipe>.yaml`. The pointer must carry exactly one attestation that is already pushed (`bundle.oci`/`bundle.digest` set) and not yet signed (empty `signer`); otherwise the command fails closed (an already-signed pointer is never re-signed).
+The positional `<pointer>` is the committed flat pending pointer `recipes/evidence/<recipe>.yaml`. The pointer must carry exactly one attestation that is already pushed (`bundle.oci`/`bundle.digest` set) and not yet signed (empty `signer`); otherwise the command fails closed (an already-signed pointer is never re-signed, except under `--relocate`, which moves an already-signed pointer without re-signing).
+
+With `--relocate`, the now-signed pointer is moved from its flat pending path to its canonical per-source path `recipes/evidence/<recipe>/<src>/<digest>.yaml` — the layout the per-source contract gate requires. A flat pointer is the only committable state for an unsigned pointer, because the `<src>` segment derives from the signer it does not yet have. This is the step the fork-based CI signing leg runs.
 
 **Flags:**
 
@@ -2678,6 +2680,7 @@ The positional `<pointer>` is the committed `recipes/evidence/<recipe>.yaml`. Th
 | `--yes` | `--assume-yes` | bool | `false` | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. |
 | `--plain-http` | | bool | `false` | Use HTTP instead of HTTPS for the registry (pull + referrer attach; local-registry tests). |
 | `--insecure-tls` | | bool | `false` | Skip TLS verification for the registry (pull + referrer attach; self-signed registries). |
+| `--relocate` | | bool | `false` | After signing, move the pointer from its flat pending path (`recipes/evidence/<recipe>.yaml`) to its canonical per-source path (`recipes/evidence/<recipe>/<src>/<digest>.yaml`). Used by the fork-based CI signing leg to complete the commit-flat → sign → relocate flow. Idempotent: an already-signed flat pointer is moved without re-signing, and a pointer already at its canonical path is a no-op. If a **different** file already occupies the canonical path, the command fails closed with a conflict error rather than overwriting it (per-source pointers are immutable) — resolve by removing the duplicate, or `git pull` to sync a prior relocation, then re-run. |
 
 **Exit codes:**
 
@@ -2690,7 +2693,8 @@ The positional `<pointer>` is the committed `recipes/evidence/<recipe>.yaml`. Th
 
 ```shell
 # In CI (ambient OIDC), after a contributor committed an unsigned pointer:
-aicr evidence sign recipes/evidence/h100-eks-ubuntu-training.yaml
+# sign and relocate it to its canonical per-source path.
+aicr evidence sign recipes/evidence/h100-eks-ubuntu-training.yaml --relocate
 ```
 
 ---

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -67,6 +67,13 @@ const (
 	// disclosure prompt (see confirmKeylessSigningDisclosure). The banner is
 	// still emitted; only the y/N pause is skipped.
 	flagAssumeYes = "yes"
+	// flagRelocate moves the pointer to its canonical per-source path after
+	// `aicr evidence sign` fills in the signer block. It completes the
+	// commit-flat -> CI-sign -> CI-relocate-to-nested flow (#1530): a flat
+	// pending pointer cannot be committed at its nested <source>/ path because
+	// that segment derives from the signer it does not yet have, so the
+	// fork-based CI leg relocates it once it is signed.
+	flagRelocate = "relocate"
 )
 
 // Category labels (urfave/cli flag.Category values, grouping flags in help output).

--- a/pkg/cli/evidence_sign.go
+++ b/pkg/cli/evidence_sign.go
@@ -138,8 +138,15 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 		if rerr != nil {
 			return rerr
 		}
-		slog.Info("evidence pointer already signed; relocated to canonical path",
-			"from", path, "to", dest, "recipe", pointer.Recipe)
+		if dest == path {
+			// RelocatePointerToCanonical no-ops when the pointer is already at
+			// its canonical path; don't claim a move that didn't happen.
+			slog.Info("evidence pointer already signed and at its canonical path; nothing to do",
+				"path", path, "recipe", pointer.Recipe)
+		} else {
+			slog.Info("evidence pointer already signed; relocated to canonical path",
+				"from", path, "to", dest, "recipe", pointer.Recipe)
+		}
 		return nil
 	}
 

--- a/pkg/cli/evidence_sign.go
+++ b/pkg/cli/evidence_sign.go
@@ -133,6 +133,12 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 	// falls through to ValidateSignablePointer, which fails closed on an
 	// already-signed pointer rather than re-signing it. LoadAndValidatePointer
 	// already guarantees exactly one attestation, so [0] is safe.
+	//
+	// This trusts the on-disk signer block without re-materializing or
+	// cryptographically verifying the bundle — the same metadata-only trust the
+	// contract gate applies, and not a new escalation (a contributor can write
+	// the nested path directly). Closing that gap (verify the signature before
+	// honoring a committed signer) is tracked repo-wide in #1535.
 	if relocate && pointer.Attestations[0].Signer != nil {
 		dest, rerr := attestation.RelocatePointerToCanonical(path, pointer)
 		if rerr != nil {

--- a/pkg/cli/evidence_sign.go
+++ b/pkg/cli/evidence_sign.go
@@ -57,10 +57,18 @@ Keyless OIDC signing uses the same precedence chain as ` + "`aicr evidence publi
 --identity-token > COSIGN_IDENTITY_TOKEN env > GitHub Actions ambient OIDC >
 --oidc-device-flow > interactive browser flow.
 
+With --relocate, the now-signed pointer is moved from its flat pending path
+(` + "`recipes/evidence/<recipe>.yaml`" + `) to its canonical per-source path
+(` + "`recipes/evidence/<recipe>/<source>/<digest>.yaml`" + `) — the layout the
+per-source contract gate requires. A flat pointer is the only committable
+state for an unsigned pointer, since the ` + "`<source>`" + ` segment derives from the
+signer it does not yet have. --relocate is idempotent: an already-signed flat
+pointer is moved without re-signing.
+
 Example:
 
   # In CI (ambient OIDC), after a contributor committed an unsigned pointer:
-  aicr evidence sign recipes/evidence/h100-eks-ubuntu-training.yaml`,
+  aicr evidence sign recipes/evidence/h100-eks-ubuntu-training.yaml --relocate`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     flagIdentityToken,
@@ -82,6 +90,11 @@ Example:
 			&cli.BoolFlag{
 				Name:     flagInsecureTLS,
 				Usage:    "Skip TLS verification for the registry (pull + referrer attach; self-signed registries).",
+				Category: catEvidence,
+			},
+			&cli.BoolFlag{
+				Name:     flagRelocate,
+				Usage:    "After signing, move the pointer from its flat pending path (recipes/evidence/<recipe>.yaml) to its canonical per-source path recipes/evidence/<recipe>/<source>/<digest>.yaml. Used by the fork-based CI signing leg to complete the commit-flat -> sign -> relocate flow.",
 				Category: catEvidence,
 			},
 			assumeYesFlag(catEvidence),
@@ -107,10 +120,29 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 			"exactly one pointer file is allowed: aicr evidence sign <pointer>")
 	}
 
+	relocate := cmd.Bool(flagRelocate)
+
 	pointer, err := verifier.LoadAndValidatePointer(path)
 	if err != nil {
 		return err
 	}
+
+	// Idempotent recovery: with --relocate, an already-signed flat pointer
+	// (signing succeeded on a prior run but the relocation didn't land) is
+	// moved to its canonical path without re-signing. Without --relocate this
+	// falls through to ValidateSignablePointer, which fails closed on an
+	// already-signed pointer rather than re-signing it. LoadAndValidatePointer
+	// already guarantees exactly one attestation, so [0] is safe.
+	if relocate && pointer.Attestations[0].Signer != nil {
+		dest, rerr := attestation.RelocatePointerToCanonical(path, pointer)
+		if rerr != nil {
+			return rerr
+		}
+		slog.Info("evidence pointer already signed; relocated to canonical path",
+			"from", path, "to", dest, "recipe", pointer.Recipe)
+		return nil
+	}
+
 	// Fail fast (before the registry pull) unless the pointer is in the exact
 	// state we sign. The rule lives in pkg/evidence/attestation — SignExisting
 	// enforces it too — so the CLI cannot drift from the domain contract.
@@ -159,6 +191,28 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 		OIDCResolve: oidcResolve,
 	}); err != nil {
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to sign existing evidence bundle")
+	}
+
+	// SignExisting patched the in-memory pointer's signer block, so its
+	// canonical <source> path is now derivable. Relocate it home to satisfy
+	// the per-source contract gate.
+	if relocate {
+		dest, rerr := attestation.RelocatePointerToCanonical(path, pointer)
+		if rerr != nil {
+			// The bundle is already signed in the registry; only the local move
+			// failed. Surface that explicitly: PropagateOrWrap returns the inner
+			// coded error verbatim (no double-wrap), so this operator-critical
+			// context would otherwise be lost. Recovery is to relocate manually
+			// (re-running `aicr evidence sign --relocate` no-ops the already-done
+			// signing and just moves the file), or resolve a canonical-path
+			// conflict — never re-sign.
+			slog.Error("bundle signed but pointer relocation failed; relocate the pointer (no re-sign needed)",
+				"path", path, "recipe", pointer.Recipe, "error", rerr)
+			return errors.PropagateOrWrap(rerr, errors.ErrCodeInternal,
+				"signed the bundle but failed to relocate the pointer to its canonical path")
+		}
+		slog.Info("evidence pointer signed and relocated", "from", path, "to", dest, "recipe", pointer.Recipe)
+		return nil
 	}
 
 	slog.Info("evidence pointer signed", "path", path, "recipe", pointer.Recipe)

--- a/pkg/cli/evidence_sign_test.go
+++ b/pkg/cli/evidence_sign_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+)
+
+func TestEvidenceSignCmd_HasRelocateFlag(t *testing.T) {
+	cmd := evidenceSignCmd()
+	found := false
+	for _, f := range cmd.Flags {
+		if f.Names()[0] == flagRelocate {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing expected flag: --%s", flagRelocate)
+	}
+}
+
+// signedFlatPointerYAML is a valid, already-signed single-attestation pointer
+// for the recipe, as committed flat at recipes/evidence/<recipe>.yaml before
+// relocation.
+func signedFlatPointerYAML(recipe string) string {
+	return "schemaVersion: 1.0.0\n" +
+		"recipe: " + recipe + "\n" +
+		"attestations:\n  - bundle:\n      oci: ghcr.io/yuanchen8911/aicr-evidence:x\n" +
+		"      digest: sha256:33d4cf36\n" +
+		"      predicateType: " + attestation.PredicateTypeV1 + "\n" +
+		"    signer:\n      identity: yuanchen97@gmail.com\n" +
+		"      issuer: https://github.com/login/oauth\n" +
+		"    attestedAt: 2026-06-23T18:24:27Z\n"
+}
+
+// TestEvidenceSignCmd_RelocateOnlyForAlreadySigned exercises the idempotent
+// recovery path: `aicr evidence sign --relocate` on a pointer that is already
+// signed must move it to its canonical per-source path without re-signing (no
+// network, no Fulcio), so a prior run that signed but failed to relocate can
+// be re-driven cleanly.
+func TestEvidenceSignCmd_RelocateOnlyForAlreadySigned(t *testing.T) {
+	const recipe = "h100-gke-cos-training"
+	root := t.TempDir()
+	flat := filepath.Join(root, recipe+".yaml")
+	if err := os.WriteFile(flat, []byte(signedFlatPointerYAML(recipe)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+	if err := cmd.Run(context.Background(),
+		[]string{"aicr", "evidence", "sign", flat, "--relocate", "--yes"}); err != nil {
+		t.Fatalf("evidence sign --relocate (already signed): %v", err)
+	}
+
+	// 7c4c0edc8c765a95a0f3afdb3bbb8e91 is SourceSlug(issuer, identity).
+	want := filepath.Join(root, recipe, "7c4c0edc8c765a95a0f3afdb3bbb8e91", "sha256-33d4cf36.yaml")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("pointer not relocated to canonical path %q: %v", want, err)
+	}
+	if _, err := os.Stat(flat); !os.IsNotExist(err) {
+		t.Errorf("flat pending pointer should be gone, stat err = %v", err)
+	}
+}
+
+// TestEvidenceSignCmd_RejectsAlreadySignedWithoutRelocate confirms the guard
+// is unchanged without --relocate: an already-signed pointer is never
+// re-signed (it fails closed before any network work).
+func TestEvidenceSignCmd_RejectsAlreadySignedWithoutRelocate(t *testing.T) {
+	const recipe = "h100-gke-cos-training"
+	flat := filepath.Join(t.TempDir(), recipe+".yaml")
+	if err := os.WriteFile(flat, []byte(signedFlatPointerYAML(recipe)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+	if err := cmd.Run(context.Background(),
+		[]string{"aicr", "evidence", "sign", flat, "--yes"}); err == nil {
+		t.Fatal("expected an error signing an already-signed pointer without --relocate")
+	}
+}

--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -170,20 +170,27 @@ func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) 
 		return currentPath, nil
 	}
 	dest := filepath.Join(filepath.Dir(currentPath), relSuffix)
-	// Fail closed on a pre-existing destination rather than clobber it (the
-	// per-source pointer is immutable, so a collision is a real conflict).
-	// Checked before MkdirAll so a rejected relocation creates no directories.
-	if _, statErr := os.Stat(dest); statErr == nil {
-		return "", errors.New(errors.ErrCodeConflict,
-			"canonical pointer path already exists, refusing to overwrite: "+dest)
-	} else if !os.IsNotExist(statErr) {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to stat canonical pointer path", statErr)
-	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
 		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create canonical pointer directory", err)
 	}
-	if err := os.Rename(currentPath, dest); err != nil {
-		return "", errors.Wrap(errors.ErrCodeInternal, "failed to move pointer to canonical path", err)
+	// Move with an atomic no-clobber guarantee: os.Link fails with EEXIST if
+	// dest already exists, so the exclusivity check and the placement are a
+	// single operation — no TOCTOU gap (a Stat+Rename would let another writer
+	// create dest after the Stat, and Rename silently clobbers it on Unix). The
+	// per-source pointer is immutable, so a pre-existing dest is a real conflict
+	// for the operator to resolve, not something to overwrite.
+	if err := os.Link(currentPath, dest); err != nil {
+		if os.IsExist(err) {
+			return "", errors.New(errors.ErrCodeConflict,
+				"canonical pointer path already exists, refusing to overwrite: "+dest)
+		}
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to link pointer to canonical path", err)
+	}
+	// The link now holds dest; drop the flat source to complete the move. If
+	// this fails, dest is already correct — surface the leftover source.
+	if err := os.Remove(currentPath); err != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal,
+			"relocated pointer to canonical path but failed to remove the flat source: "+currentPath, err)
 	}
 	return dest, nil
 }

--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -88,20 +88,104 @@ func MarshalPointer(p *Pointer) ([]byte, error) {
 // destination — only signed, pushed bundles earn a place in the tree — so
 // the hint returns guidance instead of a path.
 func PointerCopyToHint(p *Pointer) string {
-	const unpushed = "(sign and push the bundle, then commit under recipes/evidence/<recipe>/<source>/)"
+	suffix, err := canonicalPointerSuffix(p)
+	if err != nil {
+		return "(sign and push the bundle, then commit under recipes/evidence/<recipe>/<source>/)"
+	}
+	return "recipes/evidence/" + filepath.ToSlash(suffix)
+}
+
+// canonicalPointerSuffix returns the <recipe>/<source>/<bundle-digest>.yaml
+// path (relative to the evidence root) a signed, pushed pointer belongs at —
+// the single source of truth for the #1347 Option A per-source layout, shared
+// by PointerCopyToHint and RelocatePointerToCanonical. The <source> segment is
+// SourceSlug(signer), so an unsigned or unpushed pointer has no canonical
+// suffix and yields an error.
+func canonicalPointerSuffix(p *Pointer) (string, error) {
 	if p == nil || len(p.Attestations) == 0 {
-		return unpushed
+		return "", errors.New(errors.ErrCodeInvalidRequest, "pointer with at least one attestation is required")
 	}
 	att := p.Attestations[0]
-	if att.Signer == nil || att.Bundle.Digest == "" {
-		return unpushed
+	if att.Signer == nil {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			"pointer has no signer; its canonical <source> path is underivable")
+	}
+	if att.Bundle.Digest == "" {
+		return "", errors.New(errors.ErrCodeInvalidRequest, "pointer has no pushed bundle digest")
+	}
+	// recipe is the only attacker-influenced segment that reaches a filesystem
+	// path in RelocatePointerToCanonical (source is hex; the digest filename is
+	// validated sha256:<hex>). Reject anything that isn't a clean local path so
+	// a recipe like "../../etc" cannot escape the evidence tree on os.Rename —
+	// defense in depth that does not rely on the CI contract gate, which a
+	// direct `aicr evidence sign --relocate <file>` invocation bypasses.
+	// filepath.IsLocal also rejects "" and absolute paths.
+	if !filepath.IsLocal(p.Recipe) {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			"pointer.recipe is not a local path segment: "+p.Recipe)
 	}
 	source, err := SourceSlug(att.Signer.Issuer, att.Signer.Identity)
 	if err != nil {
-		return unpushed
+		return "", err
 	}
 	file := strings.ReplaceAll(att.Bundle.Digest, ":", "-") + ".yaml"
-	return "recipes/evidence/" + p.Recipe + "/" + source + "/" + file
+	return filepath.Join(p.Recipe, source, file), nil
+}
+
+// RelocatePointerToCanonical moves a freshly-signed pointer from its flat
+// pending location to its canonical per-source path, returning the
+// destination. The flat location is the only place an unsigned pointer can be
+// committed: the nested <source> path segment derives from the signer
+// (SourceSlug), which a `--no-sign` pointer does not have. Once the
+// fork-based CI leg signs it (`aicr evidence sign`), this completes the
+// commit-flat -> CI-sign -> CI-relocate-to-nested flow (#1530) by moving the
+// now-signed pointer under <recipe>/<source>/<bundle-digest>.yaml, where the
+// per-source contract gate (verifier.CheckEvidenceTree) requires it.
+//
+// The destination root is the directory currentPath sits in, so a flat
+// pointer at recipes/evidence/<recipe>.yaml lands under
+// recipes/evidence/<recipe>/<source>/. Parent directories are created. It is
+// a no-op (returns currentPath) when the pointer already lives at its
+// canonical path. It fails closed — without moving anything — when the
+// pointer is unsigned, has no pushed digest, or a different file already
+// occupies the canonical path (the per-source pointer is immutable, so a
+// collision is a genuine conflict for the operator to resolve, not something
+// to overwrite).
+func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) {
+	// canonicalPointerSuffix fails closed when the pointer is unsigned or has
+	// no pushed digest — the two states with no derivable canonical home.
+	relSuffix, err := canonicalPointerSuffix(p)
+	if err != nil {
+		return "", err
+	}
+	// The canonical layout is the <recipe>/<source>/<digest>.yaml suffix under
+	// the evidence root. When currentPath already ends in that suffix the
+	// pointer is at its canonical path — a no-op. Detecting it by suffix
+	// (rather than recomputing from filepath.Dir) is what keeps a flat pointer
+	// at <root>/<recipe>.yaml distinguishable from a nested one at
+	// <root>/<recipe>/<source>/<digest>.yaml: only the latter ends in the
+	// suffix, so the flat root is filepath.Dir, not a doubly-nested path.
+	cp := filepath.Clean(currentPath)
+	if cp == relSuffix || strings.HasSuffix(filepath.ToSlash(cp), "/"+filepath.ToSlash(relSuffix)) {
+		return currentPath, nil
+	}
+	dest := filepath.Join(filepath.Dir(currentPath), relSuffix)
+	// Fail closed on a pre-existing destination rather than clobber it (the
+	// per-source pointer is immutable, so a collision is a real conflict).
+	// Checked before MkdirAll so a rejected relocation creates no directories.
+	if _, statErr := os.Stat(dest); statErr == nil {
+		return "", errors.New(errors.ErrCodeConflict,
+			"canonical pointer path already exists, refusing to overwrite: "+dest)
+	} else if !os.IsNotExist(statErr) {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to stat canonical pointer path", statErr)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to create canonical pointer directory", err)
+	}
+	if err := os.Rename(currentPath, dest); err != nil {
+		return "", errors.Wrap(errors.ErrCodeInternal, "failed to move pointer to canonical path", err)
+	}
+	return dest, nil
 }
 
 // WritePointer writes the pointer file to outputDir/pointer.yaml.

--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -124,19 +124,43 @@ func canonicalPointerSuffix(p *Pointer) (string, error) {
 		return "", errors.New(errors.ErrCodeInvalidRequest,
 			"pointer.recipe is not a local path segment: "+p.Recipe)
 	}
+	// The digest becomes a path leaf. validatePointer only enforces the
+	// sha256: prefix when bundle.oci is set (not the hex body), so a digest like
+	// "sha256:x/../../escaped" would survive and traverse on filepath.Join.
+	// Require the canonical sha256:<hex> shape here: hex carries no path
+	// separator or ".", so the derived filename cannot escape <recipe>/<source>/.
+	if !isHexDigest(att.Bundle.Digest) {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			"pointer bundle digest is not a canonical sha256:<hex> value: "+att.Bundle.Digest)
+	}
 	source, err := SourceSlug(att.Signer.Issuer, att.Signer.Identity)
 	if err != nil {
 		return "", err
 	}
-	// The digest becomes a path leaf. validatePointer only enforces the
-	// sha256:<hex> shape when bundle.oci is set, so guard it here too: require a
-	// single, local element (no separator, no "..") before joining.
 	file := strings.ReplaceAll(att.Bundle.Digest, ":", "-") + ".yaml"
-	if file != filepath.Base(file) || !filepath.IsLocal(file) {
-		return "", errors.New(errors.ErrCodeInvalidRequest,
-			"pointer bundle digest is not safe as a filename: "+att.Bundle.Digest)
-	}
 	return filepath.Join(p.Recipe, source, file), nil
+}
+
+// isHexDigest reports whether d is a "sha256:"-prefixed, non-empty,
+// lowercase-hex digest — the only shape a bundle digest takes. It is the
+// fail-closed check before the digest is turned into a path leaf: hex contains
+// no path separator or ".", so a value that passes cannot traverse out of the
+// canonical pointer directory.
+func isHexDigest(d string) bool {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(d, prefix) {
+		return false
+	}
+	hex := d[len(prefix):]
+	if hex == "" {
+		return false
+	}
+	for _, c := range hex {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // RelocatePointerToCanonical moves a freshly-signed pointer from its flat
@@ -188,6 +212,19 @@ func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) 
 	// for the operator to resolve, not something to overwrite.
 	if err := os.Link(currentPath, dest); err != nil {
 		if os.IsExist(err) {
+			// dest already exists. If it is the SAME inode as the source, a
+			// prior run linked it but stopped before removing the source — a
+			// completed placement, not a conflict. Finish it (idempotent
+			// recovery) rather than fail with a spurious clobber error. Only a
+			// dest backed by a DIFFERENT file is a real immutable-pointer
+			// conflict for the operator to resolve.
+			if sameInode(currentPath, dest) {
+				if rmErr := os.Remove(currentPath); rmErr != nil {
+					return "", errors.Wrap(errors.ErrCodeInternal,
+						"canonical pointer already placed but failed to remove the flat source: "+currentPath, rmErr)
+				}
+				return dest, nil
+			}
 			return "", errors.New(errors.ErrCodeConflict,
 				"canonical pointer path already exists, refusing to overwrite: "+dest)
 		}
@@ -200,6 +237,22 @@ func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) 
 			"relocated pointer to canonical path but failed to remove the flat source: "+currentPath, err)
 	}
 	return dest, nil
+}
+
+// sameInode reports whether a and b are the same underlying file (e.g. two
+// hard links to one inode). Used to recognize a partially-completed relocation
+// — source still linked to dest — as already placed rather than a conflict. A
+// stat failure on either path reports false (treat as not-same; fail safe).
+func sameInode(a, b string) bool {
+	fa, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fa, fb)
 }
 
 // WritePointer writes the pointer file to outputDir/pointer.yaml.

--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -113,13 +113,13 @@ func canonicalPointerSuffix(p *Pointer) (string, error) {
 	if att.Bundle.Digest == "" {
 		return "", errors.New(errors.ErrCodeInvalidRequest, "pointer has no pushed bundle digest")
 	}
-	// recipe is the only attacker-influenced segment that reaches a filesystem
-	// path in RelocatePointerToCanonical (source is hex; the digest filename is
-	// validated sha256:<hex>). Reject anything that isn't a clean local path so
-	// a recipe like "../../etc" cannot escape the evidence tree on os.Rename —
-	// defense in depth that does not rely on the CI contract gate, which a
-	// direct `aicr evidence sign --relocate <file>` invocation bypasses.
-	// filepath.IsLocal also rejects "" and absolute paths.
+	// recipe and the bundle digest are the attacker-influenced segments that
+	// reach a filesystem path in RelocatePointerToCanonical (source is hex).
+	// Fail closed at this sink so a malicious value can't escape the evidence
+	// tree on the os.Link relocation — defense in depth that does not depend on
+	// the CI contract gate, which a direct `aicr evidence sign --relocate
+	// <file>` invocation bypasses. filepath.IsLocal rejects "", "..", and
+	// absolute paths.
 	if !filepath.IsLocal(p.Recipe) {
 		return "", errors.New(errors.ErrCodeInvalidRequest,
 			"pointer.recipe is not a local path segment: "+p.Recipe)
@@ -128,7 +128,14 @@ func canonicalPointerSuffix(p *Pointer) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// The digest becomes a path leaf. validatePointer only enforces the
+	// sha256:<hex> shape when bundle.oci is set, so guard it here too: require a
+	// single, local element (no separator, no "..") before joining.
 	file := strings.ReplaceAll(att.Bundle.Digest, ":", "-") + ".yaml"
+	if file != filepath.Base(file) || !filepath.IsLocal(file) {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			"pointer bundle digest is not safe as a filename: "+att.Bundle.Digest)
+	}
 	return filepath.Join(p.Recipe, source, file), nil
 }
 

--- a/pkg/evidence/attestation/pointer_test.go
+++ b/pkg/evidence/attestation/pointer_test.go
@@ -208,6 +208,39 @@ func TestRelocatePointerToCanonical(t *testing.T) {
 		}
 	})
 
+	t.Run("recovers a partial move where dest is the same inode", func(t *testing.T) {
+		// Simulate a prior run that linked dest but stopped before removing the
+		// flat source (os.Link ok, os.Remove not yet). Retry must finish the
+		// move (remove the stale source, return dest) — not fail with a
+		// spurious clobber conflict.
+		root := t.TempDir()
+		flat := filepath.Join(root, "h100-gke-cos-training.yaml")
+		if _, err := WritePointerFile(flat, signed()); err != nil {
+			t.Fatalf("write flat: %v", err)
+		}
+		canonical := filepath.Join(root, "h100-gke-cos-training",
+			"7c4c0edc8c765a95a0f3afdb3bbb8e91", "sha256-33d4cf36.yaml")
+		if err := os.MkdirAll(filepath.Dir(canonical), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Link(flat, canonical); err != nil {
+			t.Fatalf("simulate prior link: %v", err)
+		}
+		dest, err := RelocatePointerToCanonical(flat, signed())
+		if err != nil {
+			t.Fatalf("expected idempotent recovery, got error: %v", err)
+		}
+		if dest != canonical {
+			t.Errorf("dest = %q, want %q", dest, canonical)
+		}
+		if _, err := os.Stat(flat); !os.IsNotExist(err) {
+			t.Errorf("flat source should be removed after recovery, stat err = %v", err)
+		}
+		if _, err := os.Stat(canonical); err != nil {
+			t.Errorf("canonical should remain after recovery: %v", err)
+		}
+	})
+
 	t.Run("rejects an unsigned pointer", func(t *testing.T) {
 		unsigned := signed()
 		unsigned.Attestations[0].Signer = nil

--- a/pkg/evidence/attestation/pointer_test.go
+++ b/pkg/evidence/attestation/pointer_test.go
@@ -15,6 +15,8 @@
 package attestation
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -115,6 +117,133 @@ func TestPointerCopyToHint(t *testing.T) {
 	if got := PointerCopyToHint(unsigned); strings.HasPrefix(got, "recipes/evidence/") {
 		t.Errorf("unsigned hint should not be a path, got %q", got)
 	}
+}
+
+func TestRelocatePointerToCanonical(t *testing.T) {
+	signed := func() *Pointer {
+		return &Pointer{
+			SchemaVersion: PointerSchemaVersion,
+			Recipe:        "h100-gke-cos-training",
+			Attestations: []PointerAttestation{{
+				Bundle: PointerBundle{
+					OCI:           "ghcr.io/yuanchen8911/aicr-evidence:x",
+					Digest:        "sha256:33d4cf36",
+					PredicateType: PredicateTypeV1,
+				},
+				Signer: &PointerSigner{
+					Identity: "yuanchen97@gmail.com",
+					Issuer:   "https://github.com/login/oauth",
+				},
+			}},
+		}
+	}
+
+	t.Run("moves flat pending pointer to nested canonical path", func(t *testing.T) {
+		root := t.TempDir()
+		flat := filepath.Join(root, "h100-gke-cos-training.yaml")
+		if _, err := WritePointerFile(flat, signed()); err != nil {
+			t.Fatalf("write flat: %v", err)
+		}
+
+		dest, err := RelocatePointerToCanonical(flat, signed())
+		if err != nil {
+			t.Fatalf("RelocatePointerToCanonical: %v", err)
+		}
+		// 7c4c0edc8c765a95a0f3afdb3bbb8e91 is SourceSlug(issuer, identity).
+		want := filepath.Join(root, "h100-gke-cos-training",
+			"7c4c0edc8c765a95a0f3afdb3bbb8e91", "sha256-33d4cf36.yaml")
+		if dest != want {
+			t.Errorf("dest = %q, want %q", dest, want)
+		}
+		if _, err := os.Stat(dest); err != nil {
+			t.Errorf("destination not written: %v", err)
+		}
+		if _, err := os.Stat(flat); !os.IsNotExist(err) {
+			t.Errorf("flat source should be gone, stat err = %v", err)
+		}
+	})
+
+	t.Run("is a no-op when already at canonical path", func(t *testing.T) {
+		root := t.TempDir()
+		canonical := filepath.Join(root, "h100-gke-cos-training",
+			"7c4c0edc8c765a95a0f3afdb3bbb8e91", "sha256-33d4cf36.yaml")
+		if err := os.MkdirAll(filepath.Dir(canonical), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := WritePointerFile(canonical, signed()); err != nil {
+			t.Fatalf("write canonical: %v", err)
+		}
+		dest, err := RelocatePointerToCanonical(canonical, signed())
+		if err != nil {
+			t.Fatalf("RelocatePointerToCanonical: %v", err)
+		}
+		if dest != canonical {
+			t.Errorf("dest = %q, want unchanged %q", dest, canonical)
+		}
+		if _, err := os.Stat(canonical); err != nil {
+			t.Errorf("canonical file should still exist: %v", err)
+		}
+	})
+
+	t.Run("refuses to clobber an existing canonical pointer", func(t *testing.T) {
+		root := t.TempDir()
+		flat := filepath.Join(root, "h100-gke-cos-training.yaml")
+		if _, err := WritePointerFile(flat, signed()); err != nil {
+			t.Fatalf("write flat: %v", err)
+		}
+		canonical := filepath.Join(root, "h100-gke-cos-training",
+			"7c4c0edc8c765a95a0f3afdb3bbb8e91", "sha256-33d4cf36.yaml")
+		if err := os.MkdirAll(filepath.Dir(canonical), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := WritePointerFile(canonical, signed()); err != nil {
+			t.Fatalf("write canonical: %v", err)
+		}
+		if _, err := RelocatePointerToCanonical(flat, signed()); err == nil {
+			t.Error("expected a conflict error when the canonical path already exists")
+		}
+		// The flat source must be left in place on a refusal (no move happened).
+		if _, err := os.Stat(flat); err != nil {
+			t.Errorf("flat source should remain after refusal: %v", err)
+		}
+	})
+
+	t.Run("rejects an unsigned pointer", func(t *testing.T) {
+		unsigned := signed()
+		unsigned.Attestations[0].Signer = nil
+		if _, err := RelocatePointerToCanonical(filepath.Join(t.TempDir(), "x.yaml"), unsigned); err == nil {
+			t.Error("expected an error for an unsigned pointer")
+		}
+	})
+
+	t.Run("rejects a pointer with no digest", func(t *testing.T) {
+		noDigest := signed()
+		noDigest.Attestations[0].Bundle.Digest = ""
+		if _, err := RelocatePointerToCanonical(filepath.Join(t.TempDir(), "x.yaml"), noDigest); err == nil {
+			t.Error("expected an error for a pointer with no pushed digest")
+		}
+	})
+
+	t.Run("rejects a recipe with path traversal", func(t *testing.T) {
+		// defense-in-depth: a recipe escaping the evidence tree must never
+		// reach os.Rename, even when called directly (no CI gate in front).
+		for _, recipe := range []string{"../../etc/evil", "/abs/evil", ".."} {
+			evil := signed()
+			evil.Recipe = recipe
+			root := t.TempDir()
+			flat := filepath.Join(root, "x.yaml")
+			if err := os.WriteFile(flat, []byte("x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := RelocatePointerToCanonical(flat, evil); err == nil {
+				t.Errorf("recipe %q: expected a rejection, got nil", recipe)
+			}
+			// The flat source must be untouched (no move attempted).
+			if _, err := os.Stat(flat); err != nil {
+				t.Errorf("recipe %q: flat source should be untouched: %v", recipe, err)
+			}
+		}
+	})
 }
 
 func TestBuildPointer_ProducesSingleAttestation(t *testing.T) {

--- a/pkg/evidence/attestation/pointer_test.go
+++ b/pkg/evidence/attestation/pointer_test.go
@@ -224,6 +224,19 @@ func TestRelocatePointerToCanonical(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects a digest that is unsafe as a filename", func(t *testing.T) {
+		// defense-in-depth: a digest carrying a separator or ".." must not
+		// reach os.Link as a path leaf (e.g. an OCI-empty pointer that skipped
+		// the sha256: shape check in validatePointer).
+		for _, digest := range []string{"sha256:../../etc/evil", "sha256:a/b", "sha256:.."} {
+			evil := signed()
+			evil.Attestations[0].Bundle.Digest = digest
+			if _, err := RelocatePointerToCanonical(filepath.Join(t.TempDir(), "x.yaml"), evil); err == nil {
+				t.Errorf("digest %q: expected a rejection, got nil", digest)
+			}
+		}
+	})
+
 	t.Run("rejects a recipe with path traversal", func(t *testing.T) {
 		// defense-in-depth: a recipe escaping the evidence tree must never
 		// reach os.Rename, even when called directly (no CI gate in front).

--- a/pkg/evidence/verifier/discover.go
+++ b/pkg/evidence/verifier/discover.go
@@ -74,16 +74,19 @@ func (p TreeProblem) String() string { return p.Path + ": " + p.Message }
 //   - that verified signer is allowlisted as community or partner (first-party
 //     ingests directly and must not commit per-run pointers).
 //
-// One exception: a flat root-level <recipe>.yaml is accepted as a *pending*
-// pointer (unsigned, single-attestation, bundle-referencing) — the transient
+// allowPending controls the flat root-level <recipe>.yaml *pending* pointer
+// (unsigned, single-attestation, bundle-referencing) — the transient
 // commit-flat state of the two-phase publish flow (#1530), which the
-// fork-based CI leg signs and relocates under <recipe>/<source>/. See
-// checkPendingPointer.
+// fork-based CI leg signs and relocates under <recipe>/<source>/. When true it
+// is accepted as a valid intermediate; when false (the merge gate's posture) a
+// flat root file is rejected just like any other unexpected root file, so an
+// unsigned pointer cannot land on a protected branch — the relocation must
+// have run first. See checkPendingPointer.
 //
 // It returns the list of problems (empty when the tree is clean) plus a
 // non-nil error only for an operational failure (unreadable allowlist, etc.),
 // keeping policy violations distinct from infrastructure errors.
-func CheckEvidenceTree(root, allowlistPath string) ([]TreeProblem, error) {
+func CheckEvidenceTree(root, allowlistPath string, allowPending bool) ([]TreeProblem, error) {
 	al, err := allowlist.Load(allowlistPath)
 	if err != nil {
 		// allowlist.Load already returns coded errors (NotFound for a missing
@@ -104,14 +107,26 @@ func CheckEvidenceTree(root, allowlistPath string) ([]TreeProblem, error) {
 			if rd.Name() == AllowlistFileName {
 				continue
 			}
-			// Any other root-level .yaml is a flat *pending* pointer — the
+			path := filepath.Join(root, rd.Name())
+			if !allowPending {
+				// Merge-gate posture: a flat pointer must have been signed and
+				// relocated under <recipe>/<source>/ before it can land here.
+				// Reject any root-level file so an unsigned (unverifiable,
+				// potentially squatting) pointer cannot merge to a protected
+				// branch while the fork-based sign+relocate leg has not run.
+				problems = append(problems, TreeProblem{
+					Path:    path,
+					Message: "unexpected file at evidence root (pointers live under <recipe>/<source>/; a flat pending pointer must be signed and relocated before merge)",
+				})
+				continue
+			}
+			// allowPending: a root-level .yaml is a flat *pending* pointer — the
 			// transient commit-flat state of the two-phase publish flow
 			// (#1530). An unsigned pointer cannot live at its nested
 			// <source>/ path because that segment derives from the signer it
 			// does not yet have; the fork-based CI leg signs it and relocates
 			// it under <recipe>/<source>/. Accept it only as a valid, unsigned
 			// pending pointer named <recipe>.yaml; reject anything else.
-			path := filepath.Join(root, rd.Name())
 			if msg := checkPendingPointer(path); msg != "" {
 				problems = append(problems, TreeProblem{Path: path, Message: msg})
 			}

--- a/pkg/evidence/verifier/discover.go
+++ b/pkg/evidence/verifier/discover.go
@@ -74,6 +74,12 @@ func (p TreeProblem) String() string { return p.Path + ": " + p.Message }
 //   - that verified signer is allowlisted as community or partner (first-party
 //     ingests directly and must not commit per-run pointers).
 //
+// One exception: a flat root-level <recipe>.yaml is accepted as a *pending*
+// pointer (unsigned, single-attestation, bundle-referencing) — the transient
+// commit-flat state of the two-phase publish flow (#1530), which the
+// fork-based CI leg signs and relocates under <recipe>/<source>/. See
+// checkPendingPointer.
+//
 // It returns the list of problems (empty when the tree is clean) plus a
 // non-nil error only for an operational failure (unreadable allowlist, etc.),
 // keeping policy violations distinct from infrastructure errors.
@@ -94,18 +100,64 @@ func CheckEvidenceTree(root, allowlistPath string) ([]TreeProblem, error) {
 	var problems []TreeProblem
 	for _, rd := range recipeDirs {
 		if !rd.IsDir() {
-			// Only allowlist.yaml is expected as a non-directory at the root.
-			if rd.Name() != AllowlistFileName {
-				problems = append(problems, TreeProblem{
-					Path:    filepath.Join(root, rd.Name()),
-					Message: "unexpected file at evidence root (pointers live under <recipe>/<source>/)",
-				})
+			// allowlist.yaml is the one expected non-directory at the root.
+			if rd.Name() == AllowlistFileName {
+				continue
+			}
+			// Any other root-level .yaml is a flat *pending* pointer — the
+			// transient commit-flat state of the two-phase publish flow
+			// (#1530). An unsigned pointer cannot live at its nested
+			// <source>/ path because that segment derives from the signer it
+			// does not yet have; the fork-based CI leg signs it and relocates
+			// it under <recipe>/<source>/. Accept it only as a valid, unsigned
+			// pending pointer named <recipe>.yaml; reject anything else.
+			path := filepath.Join(root, rd.Name())
+			if msg := checkPendingPointer(path); msg != "" {
+				problems = append(problems, TreeProblem{Path: path, Message: msg})
 			}
 			continue
 		}
 		problems = append(problems, checkRecipeDir(root, rd.Name(), al)...)
 	}
 	return problems, nil
+}
+
+// checkPendingPointer validates a flat root-level pointer as a pending
+// intermediate of the commit-flat -> CI-sign -> CI-relocate flow (#1530) and
+// returns a non-empty message describing the first violation, or "" when it
+// is an acceptable pending pointer. A pending pointer must:
+//
+//   - be named <recipe>.yaml (a deterministic flat name; arbitrary files are
+//     rejected here, preserving the old "unexpected file at root" behavior);
+//   - parse and validate as a single-attestation V1 pointer;
+//   - reference a pushed bundle (bundle.oci + bundle.digest) so it is
+//     actually signable later; and
+//   - be UNSIGNED — a signed pointer has a derivable <source> and must live
+//     under <recipe>/<source>/, never flat.
+//
+// No path-ownership or allowlist check applies: an unsigned pointer carries
+// no verified signer to anchor those checks. They are enforced on the
+// signed, relocated pointer once CI moves it into <recipe>/<source>/.
+func checkPendingPointer(path string) string {
+	base := filepath.Base(path)
+	if !strings.HasSuffix(base, ".yaml") {
+		return "unexpected file at evidence root (only allowlist.yaml and flat <recipe>.yaml pending pointers are allowed)"
+	}
+	ptr, err := LoadAndValidatePointer(path)
+	if err != nil {
+		return "invalid pending pointer at evidence root: " + err.Error()
+	}
+	if want := ptr.Recipe + ".yaml"; base != want {
+		return "flat pending pointer must be named <recipe>.yaml (expected " + want + ", got " + base + ")"
+	}
+	att := ptr.Attestations[0]
+	if att.Signer != nil {
+		return "signed pointer must live under <recipe>/<source>/, not flat at the evidence root"
+	}
+	if att.Bundle.OCI == "" || att.Bundle.Digest == "" {
+		return "pending pointer must reference a pushed bundle (bundle.oci + bundle.digest) to be signable"
+	}
+	return ""
 }
 
 // checkRecipeDir walks one <recipe>/ directory: every pointer must sit two

--- a/pkg/evidence/verifier/discover_test.go
+++ b/pkg/evidence/verifier/discover_test.go
@@ -220,6 +220,91 @@ func TestCheckEvidenceTree_RejectsLooseFiles(t *testing.T) {
 	}
 }
 
+// flatPendingYAML renders an unsigned single-attestation pointer for
+// testRecipe that references a pushed bundle — the commit-flat intermediate
+// of the two-phase publish flow (#1530).
+func flatPendingYAML(recipe string) string {
+	return "schemaVersion: 1.0.0\n" +
+		"recipe: " + recipe + "\n" +
+		"attestations:\n  - bundle:\n      oci: ghcr.io/x/aicr-evidence:v1\n" +
+		"      digest: sha256:abc\n" +
+		"      predicateType: " + attestation.PredicateTypeV1 + "\n" +
+		"    attestedAt: 2026-06-23T18:24:27Z\n"
+}
+
+// TestCheckEvidenceTree_AcceptsFlatPendingPointer accepts a flat, unsigned
+// <recipe>.yaml at the root — the transient commit-flat state CI signs and
+// relocates. The per-source contract gate must not reject it on the PR before
+// the signing leg can run.
+func TestCheckEvidenceTree_AcceptsFlatPendingPointer(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, testRecipe+".yaml"),
+		[]byte(flatPendingYAML(testRecipe)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	if err != nil {
+		t.Fatalf("CheckEvidenceTree: %v", err)
+	}
+	for _, p := range problems {
+		t.Errorf("unexpected problem for a valid flat pending pointer: %s", p)
+	}
+}
+
+// TestCheckEvidenceTree_RejectsSignedFlatPointer rejects a SIGNED pointer left
+// flat at the root: a signed pointer has a derivable <source> and must live
+// nested under <recipe>/<source>/.
+func TestCheckEvidenceTree_RejectsSignedFlatPointer(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, testRecipe+".yaml"),
+		[]byte(pointerYAML("ghcr.io/x/e:v1", "sha256:abc", "alice@example.com")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	if err != nil {
+		t.Fatalf("CheckEvidenceTree: %v", err)
+	}
+	if len(problems) == 0 {
+		t.Fatal("expected a signed flat pointer to be rejected (must be nested)")
+	}
+}
+
+// TestCheckEvidenceTree_RejectsMisnamedFlatPointer rejects a flat pending
+// pointer whose filename does not match its recipe field.
+func TestCheckEvidenceTree_RejectsMisnamedFlatPointer(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "wrong-name.yaml"),
+		[]byte(flatPendingYAML(testRecipe)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	if err != nil {
+		t.Fatalf("CheckEvidenceTree: %v", err)
+	}
+	if len(problems) == 0 {
+		t.Fatal("expected a misnamed flat pending pointer to be rejected")
+	}
+}
+
+// TestCheckEvidenceTree_RejectsUnpushedFlatPointer rejects a flat pending
+// pointer that references no pushed bundle (nothing to sign later).
+func TestCheckEvidenceTree_RejectsUnpushedFlatPointer(t *testing.T) {
+	root := t.TempDir()
+	body := "schemaVersion: 1.0.0\nrecipe: " + testRecipe + "\n" +
+		"attestations:\n  - bundle:\n      predicateType: " + attestation.PredicateTypeV1 + "\n" +
+		"    attestedAt: 2026-06-23T18:24:27Z\n"
+	if err := os.WriteFile(filepath.Join(root, testRecipe+".yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	if err != nil {
+		t.Fatalf("CheckEvidenceTree: %v", err)
+	}
+	if len(problems) == 0 {
+		t.Fatal("expected a flat pending pointer with no pushed bundle to be rejected")
+	}
+}
+
 // TestCheckEvidenceTree_MissingAllowlist surfaces an operational error
 // (distinct from a contract violation) when the allowlist is unreadable.
 func TestCheckEvidenceTree_MissingAllowlist(t *testing.T) {

--- a/pkg/evidence/verifier/discover_test.go
+++ b/pkg/evidence/verifier/discover_test.go
@@ -124,7 +124,7 @@ func TestDiscoverPointers_EmptyRecipe(t *testing.T) {
 // TestCheckEvidenceTree_CommittedTreeClean asserts the real committed
 // recipes/evidence/ tree passes the contract against the committed allowlist.
 func TestCheckEvidenceTree_CommittedTreeClean(t *testing.T) {
-	problems, err := CheckEvidenceTree(repoEvidenceRoot, repoAllowlist)
+	problems, err := CheckEvidenceTree(repoEvidenceRoot, repoAllowlist, false)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestCheckEvidenceTree_RejectsSquat(t *testing.T) {
 	writePointer(t, root, testRecipe, victimSource, "sha256-evil.yaml",
 		pointerYAML("ghcr.io/attacker/e:v1", "sha256:evil", attackerID))
 
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, false)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestCheckEvidenceTree_RejectsUnsigned(t *testing.T) {
 		"      predicateType: " + attestation.PredicateTypeV1 + "\n    attestedAt: 2026-06-23T18:24:27Z\n"
 	writePointer(t, root, testRecipe, "7c4c0edc8c765a95a0f3afdb3bbb8e91", "sha256-abc.yaml", body)
 
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, false)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestCheckEvidenceTree_RejectsUnlisted(t *testing.T) {
 	writePointer(t, root, testRecipe, src, "sha256-abc.yaml",
 		pointerYAML("ghcr.io/x/e:v1", "sha256:abc", id))
 
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, false)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestCheckEvidenceTree_RejectsLooseFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, false)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -242,12 +242,31 @@ func TestCheckEvidenceTree_AcceptsFlatPendingPointer(t *testing.T) {
 		[]byte(flatPendingYAML(testRecipe)), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, true)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
 	for _, p := range problems {
 		t.Errorf("unexpected problem for a valid flat pending pointer: %s", p)
+	}
+}
+
+// TestCheckEvidenceTree_RejectsFlatPendingWhenNotAllowed is the merge-gate
+// guard (mchmarny, #1538): with allowPending=false — the posture the blocking
+// contract gate runs under — a flat unsigned pending pointer is rejected, so it
+// cannot merge to a protected branch before the sign+relocate leg has run.
+func TestCheckEvidenceTree_RejectsFlatPendingWhenNotAllowed(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, testRecipe+".yaml"),
+		[]byte(flatPendingYAML(testRecipe)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	problems, err := CheckEvidenceTree(root, repoAllowlist, false)
+	if err != nil {
+		t.Fatalf("CheckEvidenceTree: %v", err)
+	}
+	if len(problems) == 0 {
+		t.Fatal("expected a flat pending pointer to be rejected when allowPending=false")
 	}
 }
 
@@ -260,7 +279,7 @@ func TestCheckEvidenceTree_RejectsSignedFlatPointer(t *testing.T) {
 		[]byte(pointerYAML("ghcr.io/x/e:v1", "sha256:abc", "alice@example.com")), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, true)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -277,7 +296,7 @@ func TestCheckEvidenceTree_RejectsMisnamedFlatPointer(t *testing.T) {
 		[]byte(flatPendingYAML(testRecipe)), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, true)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -296,7 +315,7 @@ func TestCheckEvidenceTree_RejectsUnpushedFlatPointer(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, testRecipe+".yaml"), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, true)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}
@@ -308,7 +327,7 @@ func TestCheckEvidenceTree_RejectsUnpushedFlatPointer(t *testing.T) {
 // TestCheckEvidenceTree_MissingAllowlist surfaces an operational error
 // (distinct from a contract violation) when the allowlist is unreadable.
 func TestCheckEvidenceTree_MissingAllowlist(t *testing.T) {
-	if _, err := CheckEvidenceTree(t.TempDir(), filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
+	if _, err := CheckEvidenceTree(t.TempDir(), filepath.Join(t.TempDir(), "nope.yaml"), false); err == nil {
 		t.Error("expected an error for a missing allowlist")
 	}
 }
@@ -323,7 +342,7 @@ func TestCheckEvidenceTree_RejectsRecipeMismatch(t *testing.T) {
 	writePointer(t, root, "gb200-eks-ubuntu-training", src, "sha256-abc.yaml",
 		pointerYAML("ghcr.io/x/e:v1", "sha256:abc", id))
 
-	problems, err := CheckEvidenceTree(root, repoAllowlist)
+	problems, err := CheckEvidenceTree(root, repoAllowlist, false)
 	if err != nil {
 		t.Fatalf("CheckEvidenceTree: %v", err)
 	}

--- a/tools/evidence-pointercheck/main.go
+++ b/tools/evidence-pointercheck/main.go
@@ -36,15 +36,19 @@ import (
 
 func main() {
 	var root, allowlistPath string
+	var allowPending bool
 	flag.StringVar(&root, "root", verifier.EvidenceDirName, "path to the committed evidence root")
 	flag.StringVar(&allowlistPath, "allowlist", "", "path to allowlist.yaml (default: <root>/allowlist.yaml)")
+	flag.BoolVar(&allowPending, "allow-pending", false,
+		"accept a flat <recipe>.yaml unsigned pending pointer (the transient commit-flat state) instead of rejecting it; "+
+			"off by default so the merge gate refuses an unsigned pointer that has not been signed and relocated")
 	flag.Parse()
 
 	if allowlistPath == "" {
 		allowlistPath = filepath.Join(root, verifier.AllowlistFileName)
 	}
 
-	problems, err := verifier.CheckEvidenceTree(root, allowlistPath)
+	problems, err := verifier.CheckEvidenceTree(root, allowlistPath, allowPending)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "evidence-pointercheck: "+err.Error())
 		os.Exit(2)


### PR DESCRIPTION
## Summary

Make the commit-unsigned-then-CI-sign evidence-publishing flow internally coherent: a contributor commits an unsigned pointer **flat**, the fork-based CI leg signs it and **relocates** it to its canonical per-source path, and the contract gate accepts the flat pending pointer as a valid intermediate.

## Motivation / Context

The unsigned-commit flow was broken three ways: `evidence-sign-unsigned.sh` globbed a flat path that matched no committed pointer (and mis-fired on `allowlist.yaml`); an unsigned pointer could not be placed at its nested `<source>` path because that segment derives from the signer it lacks; and the blocking contract gate rejected the flat intermediate before signing could run. The only coherent design is **commit-flat → CI-sign → CI-relocate-to-nested**, and the relocate step did not exist.

Fixes: #1530
Related: #1401 (per-source pointer contract), #1402 (GP2 ingest)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/evidence`
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.github/` (evidence signing workflow + script)

## Implementation Notes

- **attestation**: `RelocatePointerToCanonical` moves a signed flat pointer to `recipes/evidence/<recipe>/<source>/<digest>.yaml`; `canonicalPointerSuffix` is the single source of truth for the per-source layout, shared with `PointerCopyToHint`. A `filepath.IsLocal` guard on the recipe segment blocks path traversal even when the function is called directly (no CI gate in front).
- **cli**: `aicr evidence sign --relocate` — sign-then-relocate, with an idempotent relocate-only recovery path for an already-signed flat pointer (and a no-op when already canonical).
- **verifier**: `CheckEvidenceTree` accepts a flat `<recipe>.yaml` as an unsigned, single-attestation, bundle-referencing pending pointer; still rejects signed-flat, misnamed, and unpushed files. Path-ownership and allowlist remain enforced on the signed, relocated pointer — anti-squat is not weakened.
- **ci**: `evidence-sign-unsigned.sh` scans flat pointers, skips `allowlist.yaml`, calls `sign --relocate`; `evidence-publish.yaml` stages the move with `git add -A` and commits the relocation.

## Testing

```bash
make test    # -race, affected packages green
make lint    # golangci-lint: 0 issues
```

New tests cover relocation (move, no-op, clobber-refusal, unsigned/no-digest rejection, recipe path-traversal rejection), the flat-pending gate cases, and the CLI `--relocate` flag (relocate-only idempotence + already-signed-without-relocate fails closed).

## Risk Assessment

- [x] **Low** — Isolated to the evidence-publishing path; thoroughly tested; the contract gate's security invariants (path-ownership, allowlist) are unchanged for signed pointers.

**Rollout notes:** No migration. The flat-pending acceptance is additive; existing nested signed pointers are unaffected. `--relocate` is opt-in.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
