### PR TITLE
docs: fix supply-chain verify pinning, evidence semantics, drift

### DIFF
--- a/docs/contributor/evidence-ingest.md
+++ b/docs/contributor/evidence-ingest.md
@@ -169,8 +169,10 @@ used to manufacture consensus.
   verified against Rekor by digest" shape is not yet implemented, so such
   community bundles cannot be ingested — the producer fails closed rather
   than record an unverified signer.
-- Discovery currently walks the flat `recipes/evidence/<recipe>.yaml`
-  pointers. The per-source nested layout is forward-compatible.
+- Discovery walks the per-source nested layout
+  `recipes/evidence/<recipe>/<src>/<digest>.yaml` (the
+  `<recipe>/<src>/*.yaml` glob in `pkg/evidence/verifier/discover.go`); a
+  flat `recipes/evidence/<recipe>.yaml` is rejected as an unexpected root file.
 - The publish job writes to `gs://aicr-testgrid-staging/results` using the
   shared eidosx WIF service account from `uat-gcp.yaml`. GP3 will replace
   it with a dedicated `objectCreator`-only identity scoped to that prefix.


### PR DESCRIPTION
## Summary

Post-#1528 documentation-correctness follow-ups. Each fix was verified against the implementation on current `main`. Eight findings across docs, ADRs, demos, `SECURITY.md`, and one source comment:

1. **Provenance verification trusted any NVIDIA repo.** `gh attestation verify --owner nvidia` only proves *some* NVIDIA repo attested the digest. Pinned to `--repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml` across `supply-chain-verification.md`, `demos/provenance.md`/`.sh`/slides, and `SECURITY.md` (aligns the commands with the existing subject-narrowing guidance already in `supply-chain-verification.md`).
2. **ADR-007 reversed the verifier semantics.** Corrected the Update note: an *unsigned* bundle yields a `pending signature` (exit 0) result rather than always being signature-verified, and a pointer's *claimed* signer is **always** cross-checked against the cert — only external `expected-issuer`/`expected-identity-regexp` pinning is opt-in (`pkg/evidence/verifier/verify.go`).
3. **`attested` trust level overclaimed.** No longer says "Full chain cryptographically verified" when the binary attestation is missing — `pkg/bundler/verifier` classifies that state as an *incomplete chain* (`verifier.go:237`).
4. **Drift workflow uploaded no snapshot.** `automation.md` wrote `snapshot.yaml` but `upload-artifact` globbed `snapshot-*.yaml` (matches nothing). Fixed the path.
5. **Maintainer checklist mis-bucketed manual steps.** `maintaining.md` listed items 1–5 as automatic; items 3 (signer identity acceptable) and 4 (OCI ref matches) are maintainer judgement calls — the sticky comment surfaces them but does not accept them.
6. **evidence-ingest.md** — discovery walks the per-source nested layout (`<recipe>/<src>/*.yaml`), not the flat pointer (`discover.go`).
7. **ADR-014** — CR-template snippet now matches the real flat field-by-field mapping (no `$v.spec` key).
8. **pkg/server/doc.go** — `Cache-Control` comment `max-age=300` → `600` (`RecipeCacheTTL = 10m`).

## Motivation / Context

Surfaced by the post-merge cross-review of #1528 plus a follow-up review pass.

Related: #1528. Finding 5 (checklist) is the doc face of #1535 (closed); see note below.

> **Note on #1535:** #1535 ("pointer-contract gate trusts pointer-supplied
> signer") was closed COMPLETED on 2026-06-29 by #1544, which documented that
> the merge gate is *structural by design* and that cryptographic trust enters
> at **ingest** (`VerifySignature` + `CrossCheckPointerSigner`). This PR's
> ADR-007 edit touches the separate top-of-file verifier "Update" note and is
> consistent with #1544; it does not alter #1544's gate/ingest narrative or its
> #1535 references.

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `demos/`, `SECURITY.md`)
- [x] API server (comment-only: `pkg/server/doc.go`)

## Implementation Notes

`<src>` placeholder used throughout (the `<source>` HTML-void token fails `make check-docs-mdx`).

## Testing

```bash
make check-docs-mdx        # OK: all doc files are MDX-safe
make check-docs-filenames  # OK
golangci-lint run -c .golangci.yaml ./pkg/server/...   # 0 issues (doc.go comment-only)
```

Doc/comment-only change; full `make qualify` not required (no test/e2e-affecting code). The one `.go` edit is a comment; `golangci-lint` on `pkg/server` is clean.

## Risk Assessment

- [x] **Low** — documentation/comment corrections, no behavior change.

## Checklist

- [x] Linter passes (`golangci-lint` on the touched Go package)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
