### PR TITLE
docs(agents): correct coverage floor to 75% (matches .settings.yaml)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -581,7 +581,7 @@ Follow the heading conventions in the `## Documentation Style` section above. Do
 Before pushing a PR that changes Go source, check coverage on affected packages. Set `pkg` to the narrowest changed root — `$pkg/...` includes descendants (e.g. use `pkg=pkg/collector/topology`, not `pkg=pkg/collector`, unless you want a combined delta).
 1. Current: `GOFLAGS="-mod=vendor" go test -coverprofile=cover.out ./$pkg/...` on each changed package.
 2. Baseline (skip for new packages; commit changes first): `(git worktree add $TMPDIR/baseline origin/main && (cd $TMPDIR/baseline && GOFLAGS="-mod=vendor" go test -coverprofile=$TMPDIR/base.out ./$pkg/...); rc=$?; git worktree remove --force $TMPDIR/baseline; return $rc 2>/dev/null || (exit $rc))` — `$TMPDIR/base.out` survives cleanup and `rc` preserves test status. Compare with `go tool cover -func`.
-3. **Block** if `make test-coverage` fails (enforces the project-wide 70% floor from `.settings.yaml`; do not use per-package profiles for this check).
+3. **Block** if `make test-coverage` fails (enforces the project-wide 75% floor from `.settings.yaml`; do not use per-package profiles for this check).
 4. **Flag** any package with per-package decrease > 0.5% (step 1 vs 2).
 5. **Block** if any new exported func/method (`git diff origin/main -- $pkg/`, added uppercase `func` lines) has 0% coverage — add tests first.
 6. Report the delta in the PR's Testing section (e.g. `pkg/recipe: 90.4% → 90.3% (-0.1%)`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,7 +581,7 @@ Follow the heading conventions in the `## Documentation Style` section above. Do
 Before pushing a PR that changes Go source, check coverage on affected packages. Set `pkg` to the narrowest changed root — `$pkg/...` includes descendants (e.g. use `pkg=pkg/collector/topology`, not `pkg=pkg/collector`, unless you want a combined delta).
 1. Current: `GOFLAGS="-mod=vendor" go test -coverprofile=cover.out ./$pkg/...` on each changed package.
 2. Baseline (skip for new packages; commit changes first): `(git worktree add $TMPDIR/baseline origin/main && (cd $TMPDIR/baseline && GOFLAGS="-mod=vendor" go test -coverprofile=$TMPDIR/base.out ./$pkg/...); rc=$?; git worktree remove --force $TMPDIR/baseline; return $rc 2>/dev/null || (exit $rc))` — `$TMPDIR/base.out` survives cleanup and `rc` preserves test status. Compare with `go tool cover -func`.
-3. **Block** if `make test-coverage` fails (enforces the project-wide 70% floor from `.settings.yaml`; do not use per-package profiles for this check).
+3. **Block** if `make test-coverage` fails (enforces the project-wide 75% floor from `.settings.yaml`; do not use per-package profiles for this check).
 4. **Flag** any package with per-package decrease > 0.5% (step 1 vs 2).
 5. **Block** if any new exported func/method (`git diff origin/main -- $pkg/`, added uppercase `func` lines) has 0% coverage — add tests first.
 6. Report the delta in the PR's Testing section (e.g. `pkg/recipe: 90.4% → 90.3% (-0.1%)`).


### PR DESCRIPTION
## Summary

`.claude/CLAUDE.md` (and its CI-synced `AGENTS.md` mirror) stated the test-coverage gate enforces a **70%** floor. The enforced value is **75%**: `make test-coverage` reads `quality.coverage_threshold: '75'` from `.settings.yaml` via `yq` (Makefile:19); the `70` at Makefile:21 is only a fallback when that read returns empty.

Fixes the line in both files (line 584) from 70% → 75%.

## Type of Change
- [x] Documentation update

## Testing
```
make check-agents-sync   # OK (CLAUDE.md and AGENTS.md mirror in sync)
```
Doc-only change to the agent-rules files; `check-agents-sync` confirms the mirror stays consistent.

## Checklist
- [x] Changes follow existing patterns
- [x] Commit is signed (`-S -s`)