### PR TITLE
fix(ci): restore SLSA Build L3 image provenance (reusable workflow)

### DIFF
--- a/.github/workflows/attest-images.yaml
+++ b/.github/workflows/attest-images.yaml
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable workflow that generates SLSA build-provenance + SBOM attestations
+# for the released container images.
+#
+# Running attestation generation from a *reusable* workflow is what makes the
+# provenance SLSA Build Level 3: the attestation's builder identity becomes this
+# workflow (`.github/workflows/attest-images.yaml`), a vetted, isolated builder
+# that callers cannot tamper with — verifiable with:
+#
+#   gh attestation verify oci://<image>@<digest> --repo NVIDIA/aicr \
+#     --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml
+#
+# Generating attestations directly in a top-level (caller) workflow only yields
+# Build Level 2. See:
+#   https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3
+
+name: Attest Images (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Image tag to resolve and attest (e.g. v1.2.3)'
+        required: true
+        type: string
+
+env:
+  # Keep in sync with on-tag.yaml. The validator phase images live under
+  # aicr-validators/<phase>; the readiness gate under its own repo path.
+  VALIDATOR_IMAGE_PREFIX: ghcr.io/nvidia/aicr-validators
+  GATE_IMAGE: ghcr.io/nvidia/aicr-gate
+
+jobs:
+  attest:
+    name: Attest Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Attest aicr image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ghcr.io/nvidia/aicr
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}
+
+      - name: Attest aicrd image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ghcr.io/nvidia/aicrd
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}
+
+      - name: Attest deployment validator image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/deployment
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}
+
+      - name: Attest performance validator image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/performance
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}
+
+      - name: Attest conformance validator image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/conformance
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}
+
+      - name: Attest aiperf-bench image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/aiperf-bench
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}
+
+      - name: Attest gate image
+        uses: ./.github/actions/attest-image-from-tag
+        with:
+          image_name: ${{ env.GATE_IMAGE }}
+          tag: ${{ inputs.tag }}
+          crane_version: ${{ steps.versions.outputs.crane }}

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -442,74 +442,22 @@ jobs:
   # Attestation Job (runs after all images are pushed and scanned)
   # =============================================================================
 
+  # Attestation is generated from a REUSABLE workflow on purpose: that is what
+  # makes the image provenance SLSA Build Level 3 (the builder identity becomes
+  # attest-images.yaml, verifiable via `gh attestation verify --signer-workflow`).
+  # Generating it inline in this caller workflow would only be Build Level 2.
+  # See #1536.
   attest:
     name: Attest Images
-    runs-on: ubuntu-latest
     needs: [image-vuln-scan]
-    timeout-minutes: 10
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Load versions
-        id: versions
-        uses: ./.github/actions/load-versions
-
-      - name: Attest aicr image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ghcr.io/nvidia/aicr
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
-
-      - name: Attest aicrd image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ghcr.io/nvidia/aicrd
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
-
-      - name: Attest deployment validator image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/deployment
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
-
-      - name: Attest performance validator image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/performance
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
-
-      - name: Attest conformance validator image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/conformance
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
-
-      - name: Attest aiperf-bench image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ${{ env.VALIDATOR_IMAGE_PREFIX }}/aiperf-bench
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
-
-      - name: Attest gate image
-        uses: ./.github/actions/attest-image-from-tag
-        with:
-          image_name: ${{ env.GATE_IMAGE }}
-          tag: ${{ github.ref_name }}
-          crane_version: ${{ steps.versions.outputs.crane }}
+    uses: ./.github/workflows/attest-images.yaml
+    with:
+      tag: ${{ github.ref_name }}
 
 
   # =============================================================================

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See the [Installation Guide](docs/user/installation.md) for manual installation,
 | **Multi-Deployer Bundles** | Render the same recipe into Helm, Argo CD (App of Apps or Helm chart variant), Flux, or Helmfile artifacts — pick whichever fits your GitOps pipeline. |
 | **Multi-Phase Validation** | Deployment, performance (training and inference), and conformance phases — run all or one at a time. |
 | **Drift Detection** | `aicr diff` compares two snapshots to surface configuration drift between clusters or over time. |
-| **Supply Chain Security** | SLSA build provenance (level under review, #1536), signed image SBOMs, image attestations (Cosign / Sigstore), and `aicr verify` for offline bundle verification. |
+| **Supply Chain Security** | SLSA Build Level 3 image provenance, signed image SBOMs, image attestations (Cosign / Sigstore), and `aicr verify` for offline bundle verification. |
 
 ## Supported Components
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -136,7 +136,7 @@ Tags: `latest`, `vX.Y.Z`
 
 Every release includes:
 
-- **SLSA Build Provenance v1** — verifiable build attestations (build level under review, #1536)
+- **SLSA Build Level 3 Provenance** — verifiable image build attestations (provenance v1), generated from a reusable workflow
 - **SBOM** — Software Bill of Materials (SPDX format)
 - **Sigstore Signatures** — keyless signing via Fulcio + Rekor
 - **Checksums** — SHA256 for all binaries
@@ -160,20 +160,20 @@ Every release includes:
 export TAG=$(curl -s https://api.github.com/repos/NVIDIA/aicr/releases/latest | jq -r '.tag_name')
 
 # GitHub CLI (core images)
-gh attestation verify oci://ghcr.io/nvidia/aicr:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
-gh attestation verify oci://ghcr.io/nvidia/aicrd:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicr:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicrd:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 
 # GitHub CLI (validator images)
-gh attestation verify oci://ghcr.io/nvidia/aicr-validators/deployment:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
-gh attestation verify oci://ghcr.io/nvidia/aicr-validators/performance:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
-gh attestation verify oci://ghcr.io/nvidia/aicr-validators/conformance:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
-gh attestation verify oci://ghcr.io/nvidia/aicr-validators/aiperf-bench:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicr-validators/deployment:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicr-validators/performance:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicr-validators/conformance:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicr-validators/aiperf-bench:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 
 # Cosign
 cosign verify-attestation \
   --type spdxjson \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$' \
   ghcr.io/nvidia/aicr:${TAG}
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,12 +147,35 @@ and how it is signed:
 
 | Guarantee | Artifact | Format / Standard | Signing |
 |-----------|----------|-------------------|---------|
-| Build provenance | Container images | SLSA Build Provenance v1 (build level under review — #1536) | Sigstore keyless via GitHub Actions OIDC |
+| Build provenance | Container images | SLSA Build Level 3 (provenance v1) | Sigstore keyless via GitHub Actions OIDC, generated from a reusable workflow |
 | Build provenance | CLI binaries | SLSA Build Provenance v1 (Sigstore bundle) | Cosign keyless, logged to public Rekor |
 | Signed SBOM | Container images | SPDX v2.3 JSON attestation | Cosign keyless (Fulcio + Rekor) |
 | Binary SBOM | CLI binaries | SPDX v2.3 JSON (via GoReleaser) | Separate release asset (`*.sbom.json`), not embedded |
 | Bundle attestation | `aicr bundle` output | SLSA Build Provenance v1 | Sigstore keyless OIDC (opt-in `--attest`) |
 | Recipe / bundle validity | `aicr verify` trust levels | `verified` / `attested` / `unverified` / `unknown` | Checksums + Sigstore trusted root |
+
+**Why image provenance is Build Level 3.** Image attestations are generated
+from a dedicated *reusable* workflow
+([`.github/workflows/attest-images.yaml`](.github/workflows/attest-images.yaml)),
+not inline in the release job. That reusable workflow is what raises the level
+from 2 to 3: it isolates provenance generation from the build, so the signing
+identity (the Fulcio certificate's subject) is the reusable workflow itself —
+which the calling workflow cannot alter. Because the build steps cannot forge or
+tamper with the provenance, it satisfies the defining requirement of SLSA Build
+Level 3 ([SLSA v1.0 levels](https://slsa.dev/spec/v1.0/levels)). GitHub issues
+Build Level 2 for attestations generated directly in a caller workflow and Build
+Level 3 only when they are produced by a reusable workflow
+([GitHub docs](https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3)).
+Confirm the trusted builder by pinning verification to it:
+
+```shell
+gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo NVIDIA/aicr \
+  --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml
+```
+
+CLI binaries remain SLSA Build Provenance v1 (Build Level 2): they are signed
+with `cosign attest-blob` from the release job (`on-tag.yaml`), which does not
+provide the reusable-workflow isolation.
 
 `aicr verify` reports one of four trust levels for a bundle: `verified`
 (full chain verified, binary identity pinned to NVIDIA CI), `attested`
@@ -173,7 +196,8 @@ export IMAGE="ghcr.io/nvidia/aicr"
 export DIGEST=$(crane digest "${IMAGE}:${TAG}")
 
 # Verify build provenance (the SPDX SBOM uses the Cosign flow in docs/integrator/supply-chain-verification.md)
-gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+# --signer-workflow pins the trusted reusable builder; passing it is the SLSA Build Level 3 check.
+gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 # ✓ Verification succeeded!
 #   • Build provenance (SLSA v1.0)
 ```

--- a/demos/provenance-demo-slides.html
+++ b/demos/provenance-demo-slides.html
@@ -300,7 +300,7 @@
     <div class="note">
       <span class="t info">Why keyless</span>
       No long-lived signing key to leak. The signer&rsquo;s identity is the workflow ref
-      (<code class="inl">https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/vX.Y.Z</code>) — verifiable against Fulcio&rsquo;s cert chain and Rekor&rsquo;s transparency log without contacting NVIDIA.
+      (<code class="inl">https://github.com/NVIDIA/aicr/.github/workflows/attest-images.yaml@refs/tags/vX.Y.Z</code>) — verifiable against Fulcio&rsquo;s cert chain and Rekor&rsquo;s transparency log without contacting NVIDIA.
     </div>
   </div>
 </section>
@@ -320,7 +320,7 @@
 <span class="d">ghcr.io/nvidia/aicr@sha256:f0c1abc…</span>
 
 <span class="c"># 2. Verify the SLSA provenance attestation against NVIDIA's identity.</span>
-<span class="p">$</span> gh attestation verify oci://"$IMAGE@$DIGEST" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+<span class="p">$</span> gh attestation verify oci://"$IMAGE@$DIGEST" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 <span class="g">Loaded digest sha256:f0c1abc… for oci://ghcr.io/nvidia/aicr@…</span>
 <span class="g">✓ Verification succeeded!</span>
 

--- a/demos/provenance-demo.sh
+++ b/demos/provenance-demo.sh
@@ -145,16 +145,16 @@ banner "Verify the image: SLSA Provenance v1 (via gh)"
 note "Requires GitHub auth: run 'gh auth login' or set GH_TOKEN first."
 note "gh attestation verify fetches the attestation from the GitHub attestations API, validates the Sigstore"
 note "signature against Fulcio's cert chain + Rekor's inclusion proof, and asserts the"
-note "artifact comes from --repo $OWNER/aicr and was signed by the on-tag.yaml release workflow."
+note "artifact comes from --repo $OWNER/aicr and was signed by the attest-images.yaml reusable workflow (the SLSA Build L3 trusted builder)."
 pause "Press Enter to verify provenance"
-run gh attestation verify "oci://$IMAGE_DIGEST" --repo "$OWNER/aicr" --signer-workflow "$OWNER/aicr/.github/workflows/on-tag.yaml" --source-ref "refs/tags/$TAG"
+run gh attestation verify "oci://$IMAGE_DIGEST" --repo "$OWNER/aicr" --signer-workflow "$OWNER/aicr/.github/workflows/attest-images.yaml" --source-ref "refs/tags/$TAG"
 
 banner "Verify the aicrd server image"
 note "Same flow, second subject. Resolve its own digest first — tags can drift independently."
 pause "Press Enter to resolve + verify aicrd"
 DIGEST_AICRD="$(crane digest "$IMAGE_AICRD:$TAG")"
 note "aicrd digest: $DIGEST_AICRD"
-run gh attestation verify "oci://$IMAGE_AICRD@$DIGEST_AICRD" --repo "$OWNER/aicr" --signer-workflow "$OWNER/aicr/.github/workflows/on-tag.yaml" --source-ref "refs/tags/$TAG"
+run gh attestation verify "oci://$IMAGE_AICRD@$DIGEST_AICRD" --repo "$OWNER/aicr" --signer-workflow "$OWNER/aicr/.github/workflows/attest-images.yaml" --source-ref "refs/tags/$TAG"
 
 # --- verify the SBOM attestation ---------------------------------------------
 
@@ -165,7 +165,7 @@ pause "Press Enter to verify the SBOM attestation"
 run cosign verify-attestation \
   --type spdxjson \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$' \
   "$IMAGE_DIGEST" \
   --output-file "$PREDICATE"
 

--- a/demos/provenance.md
+++ b/demos/provenance.md
@@ -68,7 +68,7 @@ and was signed by the exact release workflow named in `--signer-workflow`
 (pinning `--owner` alone would trust any workflow in any NVIDIA repository).
 
 ```shell
-gh attestation verify "oci://${IMAGE_DIGEST}" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify "oci://${IMAGE_DIGEST}" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 ```
 
 Expected output:
@@ -81,14 +81,14 @@ Loaded 1 attestation from GitHub API
 The following policy criteria will be enforced:
   - OIDC Issuer must match: https://token.actions.githubusercontent.com
   - Source Repository URI must match: https://github.com/NVIDIA/aicr
-  - Build signer workflow must match: NVIDIA/aicr/.github/workflows/on-tag.yaml
+  - Build signer workflow must match: NVIDIA/aicr/.github/workflows/attest-images.yaml
   - Predicate type must match: https://slsa.dev/provenance/v1
 ```
 
 Same for `aicrd`:
 
 ```shell
-gh attestation verify "oci://${IMAGE_AICRD}@${DIGEST_AICRD}" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify "oci://${IMAGE_AICRD}@${DIGEST_AICRD}" --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 ```
 
 ### Why pin to the digest
@@ -107,7 +107,7 @@ envelope to disk:
 cosign verify-attestation \
   --type spdxjson \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$' \
   "${IMAGE_DIGEST}" \
   --output-file predicate.json
 ```
@@ -209,7 +209,7 @@ policy must verify the Sigstore bundle format:
 
 Verify against AICR's release identity — issuer
 `https://token.actions.githubusercontent.com`, subject
-`https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/*`.
+`https://github.com/NVIDIA/aicr/.github/workflows/attest-images.yaml@refs/tags/*`.
 
 > Validated, cluster-tested copy-paste policies are tracked in
 > [#1537](https://github.com/NVIDIA/aicr/issues/1537). Earlier inline examples

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ configuration artifacts for GPU-accelerated Kubernetes clusters.
 Given a description of your environment — cloud, accelerator, OS,
 intent — AICR emits the Helm, Argo CD, Flux, or Helmfile artifacts
 your deployment tool consumes. The output is hardware-aware,
-version-locked, and backed by SLSA build provenance (level under review, #1536).
+version-locked, and backed by SLSA Build Level 3 image provenance.
 
 For the project pitch, supported environments, and a feature
 overview, see the [repository README](https://github.com/NVIDIA/aicr).
@@ -104,7 +104,7 @@ Reference for the terms used across the docs site.
 | **Specificity** | A score counting non-`any` criteria fields. More-specific overlays merge later. |
 | **Asymmetric matching** | Criteria-matching rule: recipe `any` is a wildcard; query `any` does not match a specific recipe. |
 | **ConfigMap URI** | `cm://namespace/name` — read or write snapshots and recipes directly to Kubernetes ConfigMaps. |
-| **SLSA / SBOM** | Supply-chain Levels for Software Artifacts (releases ship SLSA build provenance; build level under review in #1536) and Software Bill of Materials shipped with binaries and images. |
+| **SLSA / SBOM** | Supply-chain Levels for Software Artifacts (release images reach Build Level 3) and Software Bill of Materials shipped with binaries and images. |
 
 ## Links
 

--- a/docs/integrator/supply-chain-verification.md
+++ b/docs/integrator/supply-chain-verification.md
@@ -52,16 +52,18 @@ rather than self-asserted, then logged to the public Rekor transparency log.
 
 > **Note on the SLSA Build Level.** GitHub's attestation service yields Build
 > Level 2 by default; Build Level 3 additionally requires build **isolation**
-> via a dedicated reusable workflow. AICR currently attests from its release
-> job using composite actions (not an isolated reusable workflow), so the exact
-> level claimed elsewhere in the docs is being reconciled with the build
-> architecture in [#1536](https://github.com/NVIDIA/aicr/issues/1536).
+> via a dedicated reusable workflow. AICR generates image attestations from the
+> reusable [`attest-images.yaml`](https://github.com/NVIDIA/aicr/blob/main/.github/workflows/attest-images.yaml)
+> workflow, so the image provenance is **Build Level 3** — its signer identity is
+> that reusable workflow, which the caller cannot tamper with. Verify it by
+> pinning `--signer-workflow .../attest-images.yaml` (below). CLI binaries are
+> signed with `cosign attest-blob` from the release job and remain Build Level 2.
 
 **Method 1: GitHub CLI**
 
 ```shell
 # Verify provenance exists and is valid (using digest)
-gh attestation verify oci://${IMAGE_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://${IMAGE_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 
 # Output shows:
 # ✓ Verification succeeded!
@@ -76,7 +78,7 @@ gh attestation verify oci://${IMAGE_DIGEST} --repo NVIDIA/aicr --signer-workflow
 ```shell
 # Get full provenance data (using digest)
 gh attestation verify oci://${IMAGE_DIGEST} \
-  --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}" \
+  --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}" \
   --format json | jq '.[] | select(.verificationResult.statement.predicateType | contains("slsa"))'
 
 # Key fields in provenance:
@@ -95,7 +97,7 @@ commit SHA, workflow, and run. A representative slice:
   "verificationResult": {
     "signature": {
       "certificate": {
-        "subjectAlternativeName": "https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/v0.8.12",
+        "subjectAlternativeName": "https://github.com/NVIDIA/aicr/.github/workflows/attest-images.yaml@refs/tags/v0.8.12",
         "issuer": "https://token.actions.githubusercontent.com",
         "githubWorkflowName": "on_tag",
         "githubWorkflowRepository": "NVIDIA/aicr",
@@ -115,7 +117,7 @@ commit SHA, workflow, and run. A representative slice:
 All AICR releases are built using GitHub Actions with full transparency:
 
 1. **Source Code** — Public GitHub repository
-2. **Build Workflow** — `.github/workflows/on-tag.yaml` (version controlled)
+2. **Build & Attest Workflows** — `.github/workflows/on-tag.yaml` builds and calls the reusable `.github/workflows/attest-images.yaml`, which signs the image attestations (both version controlled)
 3. **Build Logs** — Public GitHub Actions run logs
 4. **Attestations** — Signed and stored in the public transparency log (Rekor)
 5. **Artifacts** — Published to GitHub Releases and GHCR
@@ -176,12 +178,12 @@ cat aicr_${VERSION}_${OS}_${ARCH}.sbom.json
 cosign verify-attestation \
   --type spdxjson \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$' \
   ${IMAGE_API_DIGEST} | \
   jq -r '.payload' | base64 -d | jq '.predicate' > sbom.json
 
 # Method 2: GitHub CLI (build provenance only; the SPDX SBOM needs Method 1's Cosign flow)
-gh attestation verify oci://${IMAGE_API_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}" --format json
+gh attestation verify oci://${IMAGE_API_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}" --format json
 ```
 
 ### SBOM format
@@ -237,13 +239,13 @@ jq '.creationInfo.created' sbom.json
 
 ```shell
 # Verify using digest (preferred - no warnings)
-gh attestation verify oci://${IMAGE_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://${IMAGE_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 
 # Verify the aicrd image
-gh attestation verify oci://${IMAGE_API_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://${IMAGE_API_DIGEST} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 
 # Note: You can still use tags, but tools may show warnings about mutability
-# gh attestation verify oci://ghcr.io/nvidia/aicr:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/on-tag.yaml --source-ref "refs/tags/${TAG}"
+# gh attestation verify oci://ghcr.io/nvidia/aicr:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 ```
 
 **Method 2: Cosign (SBOM attestations)**
@@ -253,14 +255,14 @@ gh attestation verify oci://${IMAGE_API_DIGEST} --repo NVIDIA/aicr --signer-work
 cosign verify-attestation \
   --type spdxjson \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$' \
   ${IMAGE_DIGEST}
 
 # Extract and view the SBOM predicate
 cosign verify-attestation \
   --type spdxjson \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$' \
   ${IMAGE_DIGEST} | jq -r '.payload' | base64 -d | jq '.predicate'
 ```
 
@@ -325,7 +327,7 @@ Sigstore *bundle* format (not the legacy Cosign signature format):
 Pin every policy to AICR's release identity:
 
 - **issuer:** `https://token.actions.githubusercontent.com`
-- **subject:** `https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/*` (the release workflow; narrow to the release pattern rather than trusting every workflow/ref)
+- **subject:** `https://github.com/NVIDIA/aicr/.github/workflows/attest-images.yaml@refs/tags/*` (the reusable attestation workflow that signs image provenance/SBOMs; narrow to the release pattern rather than trusting every workflow/ref)
 
 ### Kyverno
 
@@ -365,7 +367,7 @@ spec:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
-            subjectRegExp: '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.+$'
+            subjectRegExp: '^https://github\.com/NVIDIA/aicr/\.github/workflows/attest-images\.yaml@refs/tags/.+$'
       ctlog:
         url: https://rekor.sigstore.dev
       attestations:

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -44,7 +44,7 @@ This script:
 - Verifies the installation
 - Uses `GITHUB_TOKEN` environment variable for authenticated API calls (avoids rate limits)
 
-> **Supply Chain Security**: AICR includes SLSA build provenance (build level under review, #1536) with signed image SBOMs and verifiable attestations. See [SECURITY](https://github.com/NVIDIA/aicr/blob/main/SECURITY.md#supply-chain-security) for verification instructions.
+> **Supply Chain Security**: AICR includes SLSA Build Level 3 image provenance with signed image SBOMs and verifiable attestations. See [SECURITY](https://github.com/NVIDIA/aicr/blob/main/SECURITY.md#supply-chain-security) for verification instructions.
 
 ### Option 3: Manual Installation
 


### PR DESCRIPTION
## Summary

Restore **SLSA Build Level 3** for AICR container-image provenance by generating the attestation from a dedicated reusable workflow, and re-assert the (previously qualified) L3 wording across the docs.

## Motivation / Context

Image attestations regressed to **Build L2** when the `attest` step was inlined into the `on-tag.yaml` release job. GitHub issues Build L2 for attestations generated in a *caller* workflow and Build L3 only when they are generated from a **reusable** workflow (the isolated, vetted builder identity). This was diagnosed on #1536: the v0.16.0 `ghcr.io/nvidia/aicr` provenance has `builder.id = .../on-tag.yaml` (the caller), and `gh attestation verify --signer-workflow .../build.yaml` fails — both confirming L2.

Fixes: #1536
Related: #1547 (qualified the L3 docs to "build level under review" pending this fix)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: release CI (`.github/workflows/on-tag.yaml`, new `.github/workflows/attest-images.yaml`)

## Implementation Notes

- New reusable workflow **`.github/workflows/attest-images.yaml`** (`on: workflow_call`, input `tag`) holds the image-attestation steps. `on-tag.yaml`'s `attest` job now calls it via `uses:`. The provenance builder identity becomes the reusable workflow, so `gh attestation verify --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml` is the L3 acceptance test.
- Because `sbom-and-attest` (image SBOM Cosign attestation **and** `attest-build-provenance`) runs inside the reusable workflow, **both** the image build-provenance signer and the image SBOM Cosign `--certificate-identity-regexp` move to `attest-images.yaml`. All image-verification references across `SECURITY.md`, `RELEASING.md`, `docs/integrator/supply-chain-verification.md`, and the provenance demos were repointed accordingly.
- **Binary attestations are unchanged** (Build L2, `cosign attest-blob` signed from `on-tag.yaml`). Their verification references (`cli-reference.md`, `bundle-attestation.*`, and the `aicr` `verify-blob-attestation`) intentionally still pin `on-tag.yaml`. The `SECURITY.md` table reflects this split: images = Build Level 3, binaries = Build Provenance v1.
- Added a **"Why image provenance is Build Level 3"** explanation to `SECURITY.md`.

## Testing

```bash
actionlint .github/workflows/attest-images.yaml .github/workflows/on-tag.yaml   # exit 0
yamllint   .github/workflows/attest-images.yaml .github/workflows/on-tag.yaml   # exit 0
bash -n    demos/provenance-demo.sh                                             # syntax OK
```

No Go sources changed. The end-to-end L3 outcome can only be confirmed by a tagged release (attestations are produced on tag); the documented acceptance test is:

```bash
gh attestation verify "oci://ghcr.io/nvidia/aicr@<digest>" --repo NVIDIA/aicr \
  --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml
```

## Risk Assessment

- [x] **Medium** — Touches the release pipeline; fully verifiable only at the next tag.

**Rollout notes:** The restored L3 wording is accurate **as of the first release built with this workflow**; v0.16.0 and earlier image attestations remain L2 (signed by `on-tag.yaml`) and will not verify against the new `--signer-workflow`. No consumer migration required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A (no Go changes); workflows lint clean
- [x] Linter passes (`make lint`) — `actionlint` + `yamllint` clean on changed workflows
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (CI workflow; verified by `gh attestation verify` at release)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
