### PR TITLE
feat(ci): add UAT reservation registry and broker helper (#1274)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,15 @@ docs/user/recipe-health.md @nvidia/aicr-maintainer
 # Recipe-quality surfaces (RQ): the CUJ/CLI coverage matrix generator
 tools/coverage/** @nvidia/aicr-maintainer
 
+# UAT day/night broker (#1274, DC1): the reservation-registry parser and
+# nightly version-matrix schedule helper that arbitrates reserved GPU time.
+# infra/uat/reservations.yaml is intentionally left under the default owner so
+# onboarding a reservation stays a low-friction data edit ("new infra extends
+# by data edit", #1274); the IDs there are identifiers, not secrets (see the
+# NOTE in that file).
+pkg/uatbroker/** @nvidia/aicr-maintainer
+tools/uat-broker/** @nvidia/aicr-maintainer
+
 # CI/CD and automation
 /Makefile @nvidia/aicr-maintainer
 /.goreleaser.yaml @nvidia/aicr-maintainer

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,7 @@ area/ci:
           - 'tools/coverage/**'
           - 'tools/evidence-project/**'
           - 'tools/corroborate/**'
+          - 'tools/uat-broker/**'
 
 area/recipes:
   - changed-files:

--- a/infra/uat/reservations.yaml
+++ b/infra/uat/reservations.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# UAT reservation registry (#1274, DC1).
+#
+# Each row enumerates one reserved-capacity GPU pool the day/night UAT
+# broker arbitrates. The "name" is the lease key: the shared dispatch
+# surface (uat-run.yaml) holds a GitHub Actions concurrency group
+# "uat-<name>" so contending runs on the same reservation QUEUE instead of
+# racing the hardware. New infrastructure is onboarded by adding a row
+# here — no broker code change.
+#
+# NOTE — these values are identifiers, NOT secrets. A reservation-id (and the
+# GCP project path it embeds) grants no access on its own: access to the
+# reserved capacity — and to anything running on it — is governed by cloud
+# IAM/ACLs bound to the CI federation identity (see infra/uat-aws-account/
+# and infra/uat-gcp-account/), not by knowledge of the ID. They are safe to
+# commit; disclosure reveals only internal infra naming, not a way in.
+#
+# Fields:
+#   name                human-facing reservation / lease key (must be unique)
+#   cloud               aws | gcp
+#   reservation-id      the cloud capacity-reservation identifier; GCP uses
+#                       the fully-qualified resource path (matches the value
+#                       embedded in cluster-config-path verbatim)
+#   accelerator         GPU accelerator family on the reservation
+#   gpu-count           GPUs per reserved node (forward-looking metadata)
+#   cluster-config-path the github.com/mchmarny/cluster Cluster config the
+#                       actuator provisions from
+#   test-config-dir     directory holding the per-cloud AICRConfig test
+#                       files (the ./tests/uat/<cloud>/run phase runner roots
+#                       one level up, at the cluster-config)
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-0cbe491320188dfa6
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/aws/cluster-config.yaml
+    test-config-dir: tests/uat/aws/tests
+  - name: gcp-h100
+    cloud: gcp
+    reservation-id: projects/nv-dgxcloudprod-20240108/reservations/h100-a3-mega-phase-1-general-pool-384-us-c1-reservation
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/gcp/cluster-config.yaml
+    test-config-dir: tests/uat/gcp/tests

--- a/pkg/uatbroker/doc.go
+++ b/pkg/uatbroker/doc.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package uatbroker resolves the UAT reservation registry
+// (infra/uat/reservations.yaml) and expands the nightly version-matrix
+// schedule for the day/night UAT broker (#1274).
+//
+// The registry maps a human-facing reservation NAME — the key the broker
+// leases through the GitHub Actions concurrency group "uat-<name>" so
+// contending runs queue rather than race — to the cloud, capacity
+// reservation id, accelerator, and the on-disk cluster/test configuration a
+// UAT run consumes. LoadRegistryFile + Lookup back the `uat-broker
+// reservations` CLI; new infrastructure is onboarded by adding a row, with
+// no code change.
+//
+// ExpandSchedule builds the ordered nightly run list: the tip-of-main cell
+// first, then the previous N stable releases in descending semver order, per
+// reservation. Cells are ordered newest-first so the nightly controller
+// drops the OLDEST releases first when its time-box closes — it simply stops
+// at the cursor. Release cells carry their tag in AICRVersion for DC5's
+// version-parameterized install; until DC5 lands they install from source.
+//
+// The package performs no network or git I/O and holds no credentials: the
+// CLI feeds it the registry bytes and the raw `git tag` list.
+package uatbroker

--- a/pkg/uatbroker/model.go
+++ b/pkg/uatbroker/model.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uatbroker
+
+// Recognized cloud values for a reservation row.
+const (
+	CloudAWS = "aws"
+	CloudGCP = "gcp"
+)
+
+// validClouds is the set of accepted Reservation.Cloud values.
+var validClouds = map[string]bool{CloudAWS: true, CloudGCP: true}
+
+// Reservation is one row of the UAT reservation registry
+// (infra/uat/reservations.yaml). Each row maps a reservation Name — the key
+// the day/night broker leases via the GitHub Actions concurrency group
+// "uat-<Name>" — to the cloud-specific identifiers and the on-disk
+// cluster/test configuration a UAT run consumes.
+type Reservation struct {
+	Name              string `yaml:"name"`
+	Cloud             string `yaml:"cloud"`
+	ReservationID     string `yaml:"reservation-id"`
+	Accelerator       string `yaml:"accelerator"`
+	GPUCount          int    `yaml:"gpu-count"`
+	ClusterConfigPath string `yaml:"cluster-config-path"`
+	TestConfigDir     string `yaml:"test-config-dir"`
+}
+
+// Registry is the parsed reservations.yaml document.
+type Registry struct {
+	Reservations []Reservation `yaml:"reservations"`
+}
+
+// Cell is one unit of work in the nightly version matrix: a single UAT run
+// of one AICRVersion against one Reservation. IsMain marks the tip-of-main
+// cell, whose AICRVersion is empty (DC5 installs from source until it wires
+// version-parameterized install; a release cell carries its tag).
+type Cell struct {
+	Reservation string `json:"reservation"`
+	AICRVersion string `json:"aicr_version"`
+	IsMain      bool   `json:"is_main"`
+}

--- a/pkg/uatbroker/registry.go
+++ b/pkg/uatbroker/registry.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uatbroker
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// maxRegistryBytes bounds the registry file read so an attacker-influenced
+// path cannot OOM the process; the registry is a small hand-edited file.
+const maxRegistryBytes int64 = 1 << 20 // 1 MiB
+
+// ParseRegistry parses and validates a reservations.yaml document.
+func ParseRegistry(data []byte) (*Registry, error) {
+	var reg Registry
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "parse reservation registry", err)
+	}
+	if err := reg.Validate(); err != nil {
+		return nil, err
+	}
+	return &reg, nil
+}
+
+// LoadRegistryFile reads, size-bounds, parses, and validates the
+// reservation registry at path.
+func LoadRegistryFile(path string) (*Registry, error) {
+	f, err := os.Open(path) //nolint:gosec // operator-supplied registry path (CLI flag), size-bounded below
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "open reservation registry "+path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxRegistryBytes+1))
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "read reservation registry "+path, err)
+	}
+	if int64(len(data)) > maxRegistryBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "reservation registry "+path+" exceeds size limit")
+	}
+	return ParseRegistry(data)
+}
+
+// Validate enforces registry invariants: at least one row; every row has the
+// required fields; cloud is recognized; gpu-count is positive; and names are
+// unique (the name is the lease key, so a duplicate would make the lease
+// ambiguous).
+func (r *Registry) Validate() error {
+	if len(r.Reservations) == 0 {
+		return errors.New(errors.ErrCodeInvalidRequest, "reservation registry has no reservations")
+	}
+	seen := make(map[string]bool, len(r.Reservations))
+	for i := range r.Reservations {
+		res := &r.Reservations[i]
+		if strings.TrimSpace(res.Name) == "" {
+			return errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("reservation[%d] has an empty name", i))
+		}
+		if seen[res.Name] {
+			return errors.New(errors.ErrCodeInvalidRequest, "duplicate reservation name "+res.Name)
+		}
+		seen[res.Name] = true
+		if !validClouds[res.Cloud] {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("reservation %s has unknown cloud %q (want %s or %s)", res.Name, res.Cloud, CloudAWS, CloudGCP))
+		}
+		for _, f := range []struct{ key, val string }{
+			{"reservation-id", res.ReservationID},
+			{"accelerator", res.Accelerator},
+			{"cluster-config-path", res.ClusterConfigPath},
+			{"test-config-dir", res.TestConfigDir},
+		} {
+			if strings.TrimSpace(f.val) == "" {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("reservation %s has an empty %s", res.Name, f.key))
+			}
+		}
+		if res.GPUCount <= 0 {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("reservation %s has a non-positive gpu-count (%d)", res.Name, res.GPUCount))
+		}
+	}
+	return nil
+}
+
+// Lookup returns the reservation row with the given name, or an
+// ErrCodeNotFound error when no row matches.
+func (r *Registry) Lookup(name string) (*Reservation, error) {
+	for i := range r.Reservations {
+		if r.Reservations[i].Name == name {
+			// Return a copy so callers cannot mutate the registry's internal
+			// slice (and bypass Validate) through the returned pointer.
+			res := r.Reservations[i]
+			return &res, nil
+		}
+	}
+	return nil, errors.New(errors.ErrCodeNotFound, "reservation "+name+" not found in registry")
+}
+
+// Names returns the reservation names in registry (document) order.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.Reservations))
+	for i := range r.Reservations {
+		names = append(names, r.Reservations[i].Name)
+	}
+	return names
+}

--- a/pkg/uatbroker/registry_test.go
+++ b/pkg/uatbroker/registry_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uatbroker
+
+import (
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+const validRegistryYAML = `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-0cbe491320188dfa6
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/aws/cluster-config.yaml
+    test-config-dir: tests/uat/aws/tests
+  - name: gcp-h100
+    cloud: gcp
+    reservation-id: projects/p/reservations/r
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/gcp/cluster-config.yaml
+    test-config-dir: tests/uat/gcp/tests
+`
+
+func TestParseRegistry(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+		// code is the expected pkg/errors code when wantErr is true.
+		code errors.ErrorCode
+	}{
+		{name: "valid", yaml: validRegistryYAML},
+		{
+			name:    "empty document",
+			yaml:    "reservations: []",
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:    "malformed yaml",
+			yaml:    "reservations: [oops",
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "empty name",
+			yaml: `
+reservations:
+  - name: ""
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "unknown cloud",
+			yaml: `
+reservations:
+  - name: az-h100
+    cloud: azure
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "missing cluster-config-path",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    test-config-dir: t
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "non-positive gpu-count",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 0
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "duplicate name",
+			yaml: `
+reservations:
+  - name: dup
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+  - name: dup
+    cloud: gcp
+    reservation-id: cr-y
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c2.yaml
+    test-config-dir: t2
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg, err := ParseRegistry([]byte(tt.yaml))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseRegistry err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !stderrors.Is(err, errors.New(tt.code, "")) {
+					t.Errorf("error code = %v, want %v", err, tt.code)
+				}
+				return
+			}
+			if reg == nil {
+				t.Fatal("ParseRegistry returned nil registry without error")
+			}
+		})
+	}
+}
+
+func TestRegistryLookup(t *testing.T) {
+	reg, err := ParseRegistry([]byte(validRegistryYAML))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+
+	res, err := reg.Lookup("gcp-h100")
+	if err != nil {
+		t.Fatalf("Lookup(gcp-h100): %v", err)
+	}
+	if res.Cloud != CloudGCP || res.ReservationID != "projects/p/reservations/r" {
+		t.Errorf("Lookup(gcp-h100) = %+v, want cloud=gcp id=projects/p/reservations/r", res)
+	}
+
+	if _, missErr := reg.Lookup("does-not-exist"); !stderrors.Is(missErr, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("Lookup(missing) error = %v, want ErrCodeNotFound", missErr)
+	}
+
+	// Mutating the returned reservation must not leak into the registry.
+	res.Name = "mutated"
+	again, lookupErr := reg.Lookup("gcp-h100")
+	if lookupErr != nil {
+		t.Fatalf("re-Lookup(gcp-h100): %v", lookupErr)
+	}
+	if again.Name != "gcp-h100" {
+		t.Errorf("Lookup returned an aliased internal pointer; mutation leaked: %q", again.Name)
+	}
+}
+
+func TestRegistryNamesOrder(t *testing.T) {
+	reg, err := ParseRegistry([]byte(validRegistryYAML))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	got := reg.Names()
+	want := []string{"aws-h100", "gcp-h100"}
+	if len(got) != len(want) {
+		t.Fatalf("Names() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Names()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoadRegistryFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "reservations.yaml")
+	if err := os.WriteFile(path, []byte(validRegistryYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := LoadRegistryFile(path)
+	if err != nil {
+		t.Fatalf("LoadRegistryFile: %v", err)
+	}
+	if len(reg.Reservations) != 2 {
+		t.Errorf("loaded %d reservations, want 2", len(reg.Reservations))
+	}
+
+	if _, err := LoadRegistryFile(filepath.Join(dir, "nope.yaml")); !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("LoadRegistryFile(missing) error = %v, want ErrCodeInvalidRequest", err)
+	}
+}
+
+// TestCommittedRegistryValid guards the actual checked-in registry: it must
+// parse, validate, and carry the two launch reservations. A bad data edit
+// fails here before it can break the broker workflows.
+func TestCommittedRegistryValid(t *testing.T) {
+	reg, err := LoadRegistryFile(filepath.Join("..", "..", "infra", "uat", "reservations.yaml"))
+	if err != nil {
+		t.Fatalf("committed reservations.yaml invalid: %v", err)
+	}
+	want := map[string]string{"aws-h100": CloudAWS, "gcp-h100": CloudGCP}
+	for name, cloud := range want {
+		res, err := reg.Lookup(name)
+		if err != nil {
+			t.Errorf("committed registry missing %q: %v", name, err)
+			continue
+		}
+		if res.Cloud != cloud {
+			t.Errorf("%q cloud = %q, want %q", name, res.Cloud, cloud)
+		}
+	}
+}

--- a/pkg/uatbroker/schedule.go
+++ b/pkg/uatbroker/schedule.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uatbroker
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// ExpandSchedule builds the ordered per-reservation nightly run schedule.
+// For each reservation it emits, in order:
+//
+//  1. the tip-of-main cell (when includeMain is true), then
+//  2. up to previousN of the newest STABLE releases, in DESCENDING semver
+//     order.
+//
+// rawTags are unsorted tag strings (e.g. the output of `git tag -l 'v*'`);
+// pre-release tags (those with a semver pre-release segment) and tags that
+// do not parse as semver are dropped. Cells are ordered newest-first so the
+// nightly controller, when its time-box closes, simply stops at the cursor —
+// which drops the OLDEST releases first, as DC1 requires. A negative
+// previousN is treated as zero.
+func ExpandSchedule(reservations, rawTags []string, includeMain bool, previousN int) map[string][]Cell {
+	if previousN < 0 {
+		previousN = 0
+	}
+	stable := sortedStableDescending(rawTags)
+	if previousN < len(stable) {
+		stable = stable[:previousN]
+	}
+
+	out := make(map[string][]Cell, len(reservations))
+	for _, res := range reservations {
+		cells := make([]Cell, 0, len(stable)+1)
+		if includeMain {
+			cells = append(cells, Cell{Reservation: res, AICRVersion: "", IsMain: true})
+		}
+		for _, tag := range stable {
+			cells = append(cells, Cell{Reservation: res, AICRVersion: tag, IsMain: false})
+		}
+		out[res] = cells
+	}
+	return out
+}
+
+// sortedStableDescending parses rawTags, drops unparseable and pre-release
+// tags, and returns the remaining stable tags' ORIGINAL strings (e.g.
+// "v1.2.3") in descending semver order.
+func sortedStableDescending(rawTags []string) []string {
+	versions := make([]*semver.Version, 0, len(rawTags))
+	seen := make(map[string]bool, len(rawTags))
+	for _, t := range rawTags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		v, err := semver.NewVersion(t)
+		if err != nil {
+			continue // not semver — drop
+		}
+		if v.Prerelease() != "" {
+			continue // pre-release — drop
+		}
+		if seen[v.String()] {
+			continue // normalized duplicate (e.g. "v1.2" and "v1.2.0") — drop
+		}
+		seen[v.String()] = true
+		versions = append(versions, v)
+	}
+	sort.Sort(sort.Reverse(semver.Collection(versions)))
+
+	out := make([]string, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, v.Original())
+	}
+	return out
+}

--- a/pkg/uatbroker/schedule_test.go
+++ b/pkg/uatbroker/schedule_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uatbroker
+
+import (
+	"reflect"
+	"testing"
+)
+
+// versionsOf returns the ordered AICRVersion strings for a reservation's
+// cells, with the tip-of-main cell rendered as "main" so order is readable.
+func versionsOf(cells []Cell) []string {
+	out := make([]string, 0, len(cells))
+	for _, c := range cells {
+		if c.IsMain {
+			out = append(out, "main")
+			continue
+		}
+		out = append(out, c.AICRVersion)
+	}
+	return out
+}
+
+func TestExpandScheduleOrdering(t *testing.T) {
+	// Deliberately unsorted, with a pre-release and a non-semver tag mixed in.
+	rawTags := []string{"v1.5.0", "v2.0.0-rc1", "v1.2.0", "v2.0.0", "not-a-tag", "v1.10.0"}
+
+	tests := []struct {
+		name         string
+		reservations []string
+		includeMain  bool
+		previousN    int
+		// want maps reservation -> ordered version labels ("main" for the
+		// tip-of-main cell).
+		want map[string][]string
+	}{
+		{
+			name:         "main first then 2 newest stable descending",
+			reservations: []string{"aws-h100"},
+			includeMain:  true,
+			previousN:    2,
+			// Stable, descending: v2.0.0, v1.10.0, v1.5.0, v1.2.0. The rc1
+			// pre-release and "not-a-tag" are dropped. previousN=2 keeps the
+			// two newest; v1.5.0/v1.2.0 (oldest) are dropped.
+			want: map[string][]string{"aws-h100": {"main", "v2.0.0", "v1.10.0"}},
+		},
+		{
+			name:         "drop oldest first when previousN tight",
+			reservations: []string{"aws-h100"},
+			includeMain:  false,
+			previousN:    1,
+			want:         map[string][]string{"aws-h100": {"v2.0.0"}},
+		},
+		{
+			name:         "previousN zero is main only",
+			reservations: []string{"aws-h100"},
+			includeMain:  true,
+			previousN:    0,
+			want:         map[string][]string{"aws-h100": {"main"}},
+		},
+		{
+			name:         "previousN larger than available keeps all stable",
+			reservations: []string{"aws-h100"},
+			includeMain:  true,
+			previousN:    99,
+			want:         map[string][]string{"aws-h100": {"main", "v2.0.0", "v1.10.0", "v1.5.0", "v1.2.0"}},
+		},
+		{
+			name:         "multiple reservations get identical ordered cells",
+			reservations: []string{"aws-h100", "gcp-h100"},
+			includeMain:  true,
+			previousN:    2,
+			want: map[string][]string{
+				"aws-h100": {"main", "v2.0.0", "v1.10.0"},
+				"gcp-h100": {"main", "v2.0.0", "v1.10.0"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandSchedule(tt.reservations, rawTags, tt.includeMain, tt.previousN)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d reservations, want %d", len(got), len(tt.want))
+			}
+			for res, wantVers := range tt.want {
+				gotVers := versionsOf(got[res])
+				if !reflect.DeepEqual(gotVers, wantVers) {
+					t.Errorf("reservation %s = %v, want %v", res, gotVers, wantVers)
+				}
+			}
+			// The release cells must carry the tag, and only main is IsMain.
+			for res, cells := range got {
+				for i, c := range cells {
+					if c.Reservation != res {
+						t.Errorf("%s cell[%d].Reservation = %q, want %q", res, i, c.Reservation, res)
+					}
+					if c.IsMain && c.AICRVersion != "" {
+						t.Errorf("%s main cell[%d] has non-empty AICRVersion %q", res, i, c.AICRVersion)
+					}
+					if !c.IsMain && c.AICRVersion == "" {
+						t.Errorf("%s release cell[%d] has empty AICRVersion", res, i)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExpandScheduleEmptyTags(t *testing.T) {
+	got := ExpandSchedule([]string{"aws-h100"}, nil, true, 2)
+	if v := versionsOf(got["aws-h100"]); !reflect.DeepEqual(v, []string{"main"}) {
+		t.Errorf("empty tags = %v, want [main]", v)
+	}
+}
+
+func TestExpandScheduleNegativePreviousN(t *testing.T) {
+	// A negative previousN is clamped to zero (main only).
+	got := ExpandSchedule([]string{"aws-h100"}, []string{"v1.0.0"}, true, -3)
+	if v := versionsOf(got["aws-h100"]); !reflect.DeepEqual(v, []string{"main"}) {
+		t.Errorf("negative previousN = %v, want [main]", v)
+	}
+}
+
+func TestSortedStableDescending(t *testing.T) {
+	// "v1.0" normalizes to 1.0.0 (a duplicate of "v1.0.0") and must be dropped,
+	// not consume a second slot.
+	got := sortedStableDescending([]string{"v1.0.0", "v0.9.0", "v1.0.0-beta", "garbage", "v2.3.4", "  v1.10.0  ", "v1.0"})
+	want := []string{"v2.3.4", "v1.10.0", "v1.0.0", "v0.9.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortedStableDescending = %v, want %v", got, want)
+	}
+}

--- a/tools/uat-broker/README.md
+++ b/tools/uat-broker/README.md
@@ -1,0 +1,68 @@
+# uat-broker
+
+Day/night UAT broker helper (#1274, DC1). Reads the reservation registry
+(`infra/uat/reservations.yaml`) and expands the nightly version-matrix
+schedule. It holds no credentials and performs no network or git I/O — the
+calling workflow feeds it the registry path and the raw `git tag` list on
+stdin. Business logic lives in [`pkg/uatbroker`](../../pkg/uatbroker); this
+package is a thin CLI over it.
+
+## Build
+
+```sh
+GOFLAGS=-mod=vendor go build -o ./bin/uat-broker ./tools/uat-broker
+```
+
+## Subcommands
+
+### `reservations`
+
+Resolve one reservation row to `GITHUB_OUTPUT`-style `key=value` lines:
+
+```sh
+uat-broker reservations --name aws-h100 >> "$GITHUB_OUTPUT"
+# cloud=aws
+# reservation-id=cr-0cbe491320188dfa6
+# accelerator=h100
+# gpu-count=8
+# cluster-config-path=tests/uat/aws/cluster-config.yaml
+# test-config-dir=tests/uat/aws/tests
+```
+
+List every reservation name (one per line):
+
+```sh
+uat-broker reservations --list
+```
+
+### `schedule`
+
+Expand the ordered nightly version matrix as JSON — the tip-of-main cell
+first, then the previous N stable releases in descending semver order, per
+reservation. Candidate tags are read from stdin; pre-release and
+non-semver tags are dropped. Cells are ordered newest-first so the nightly
+controller drops the oldest releases first when its time-box closes.
+
+```sh
+git tag -l 'v*' | uat-broker schedule --previous-n 2
+# {
+#   "aws-h100": [
+#     { "reservation": "aws-h100", "aicr_version": "",       "is_main": true  },
+#     { "reservation": "aws-h100", "aicr_version": "v2.0.0",  "is_main": false },
+#     { "reservation": "aws-h100", "aicr_version": "v1.10.0", "is_main": false }
+#   ],
+#   "gcp-h100": [ ... ]
+# }
+```
+
+Flags: `--file` (registry path, default `infra/uat/reservations.yaml`),
+`--reservations a,b` (override the registry's reservation set),
+`--previous-n N` (default 2), `--include-main` (default true).
+
+## Exit codes
+
+Follows the `pkg/errors` coded contract: `0` success, `2` invalid
+request / bad flags, `3` reservation not found. Other coded failures map
+to their `pkg/errors` exit codes too — e.g. `5` (timeout) when a
+SIGINT/SIGTERM interrupts a blocking stdin read, and `8` (internal) on a
+stdout write or JSON-encode failure.

--- a/tools/uat-broker/main.go
+++ b/tools/uat-broker/main.go
@@ -1,0 +1,340 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command uat-broker is the day/night UAT broker helper (#1274, DC1). It
+// reads the reservation registry (infra/uat/reservations.yaml) and expands
+// the nightly version-matrix schedule. It holds no credentials and performs
+// no network or git I/O — the calling workflow feeds it the registry path
+// and the raw `git tag` list on stdin.
+//
+// Subcommands:
+//
+//	uat-broker reservations --name <name> [--file <registry>]
+//	    Resolve one reservation row and print its fields as
+//	    GITHUB_OUTPUT-style key=value lines (redirect to "$GITHUB_OUTPUT").
+//
+//	uat-broker reservations --list [--file <registry>]
+//	    Print every reservation name, one per line.
+//
+//	uat-broker schedule [--file <registry>] [--reservations a,b] \
+//	    [--previous-n N] [--include-main] < tags
+//	    Read candidate tags from stdin and print the ordered nightly
+//	    version-matrix schedule as JSON: main-first, then the previous N
+//	    stable releases in descending semver order, per reservation.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/uatbroker"
+)
+
+// defaultRegistryPath is the registry location relative to the repo root,
+// where the workflows invoke the tool.
+const defaultRegistryPath = "infra/uat/reservations.yaml"
+
+// maxTagsBytes bounds the stdin tag-list read so an oversized stream cannot
+// OOM the process.
+const maxTagsBytes int64 = 1 << 20 // 1 MiB
+
+const usage = `uat-broker — UAT reservation registry + nightly schedule helper (#1274)
+
+Usage:
+  uat-broker reservations --name <name> [--file <registry>]   resolve one row as key=value lines
+  uat-broker reservations --list [--file <registry>]          list reservation names
+  uat-broker schedule [--file <registry>] [--reservations a,b] [--previous-n N] [--include-main]
+                                                              expand the nightly version matrix (tags on stdin) as JSON`
+
+func main() {
+	os.Exit(realMain())
+}
+
+// realMain runs the CLI and returns the process exit code. It is split from
+// main so the signal-context teardown (defer stop()) runs before os.Exit,
+// which would otherwise skip deferred functions.
+func realMain() int {
+	// Cancel on Ctrl-C / SIGTERM (CI cancellation) rather than imposing an
+	// arbitrary deadline: the tool only does local file + stdin I/O.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return parseAndRun(ctx, os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
+}
+
+// parseAndRun dispatches the subcommand and returns a process exit code,
+// preserving the coded pkg/errors exit-code contract (2=INVALID_REQUEST,
+// 3=NOT_FOUND, etc.) rather than collapsing every failure into 1.
+func parseAndRun(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, usage)
+		return errors.ExitInvalidInput
+	}
+
+	sub, rest := args[0], args[1:]
+	var err error
+	switch sub {
+	case "reservations":
+		err = runReservations(rest, stdout, stderr)
+	case "schedule":
+		err = runSchedule(ctx, rest, stdin, stdout, stderr)
+	case "help", "-h", "--help":
+		fmt.Fprintln(stdout, usage)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "uat-broker: unknown subcommand %q\n%s\n", sub, usage)
+		return errors.ExitInvalidInput
+	}
+
+	if err != nil {
+		fmt.Fprintln(stderr, "uat-broker:", err)
+		return errors.ExitCodeFromError(err)
+	}
+	return 0
+}
+
+// runReservations resolves one reservation row (--name) into key=value lines
+// or lists every reservation name (--list).
+func runReservations(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("reservations", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		file string
+		name string
+		list bool
+	)
+	fs.StringVar(&file, "file", defaultRegistryPath, "path to the reservation registry")
+	fs.StringVar(&name, "name", "", "reservation name to resolve")
+	fs.BoolVar(&list, "list", false, "list all reservation names, one per line")
+	if err := fs.Parse(args); err != nil {
+		return flagParseErr(err, "reservations")
+	}
+	if fs.NArg() != 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"reservations: unexpected positional arguments: "+strings.Join(fs.Args(), " "))
+	}
+
+	reg, err := uatbroker.LoadRegistryFile(file)
+	if err != nil {
+		return err
+	}
+
+	// Build the output first, then write it in one checked call so a broken
+	// pipe or an unwritable $GITHUB_OUTPUT surfaces as a failure instead of a
+	// silent exit-0 that leaves downstream jobs without their inputs. Writes to
+	// the strings.Builder cannot fail.
+	var b strings.Builder
+	switch {
+	case list && name != "":
+		return errors.New(errors.ErrCodeInvalidRequest, "reservations: --list and --name are mutually exclusive")
+	case list:
+		for _, n := range reg.Names() {
+			fmt.Fprintln(&b, n)
+		}
+	case name == "":
+		return errors.New(errors.ErrCodeInvalidRequest, "reservations: --name is required (or pass --list)")
+	default:
+		res, lookupErr := reg.Lookup(name)
+		if lookupErr != nil {
+			return lookupErr
+		}
+		// GITHUB_OUTPUT-style key=value lines; every value is single-line.
+		fmt.Fprintf(&b, "cloud=%s\n", res.Cloud)
+		fmt.Fprintf(&b, "reservation-id=%s\n", res.ReservationID)
+		fmt.Fprintf(&b, "accelerator=%s\n", res.Accelerator)
+		fmt.Fprintf(&b, "gpu-count=%d\n", res.GPUCount)
+		fmt.Fprintf(&b, "cluster-config-path=%s\n", res.ClusterConfigPath)
+		fmt.Fprintf(&b, "test-config-dir=%s\n", res.TestConfigDir)
+	}
+
+	if _, err := io.WriteString(stdout, b.String()); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "write reservations output", err)
+	}
+	return nil
+}
+
+// runSchedule reads candidate tags from stdin and prints the ordered nightly
+// version-matrix schedule as JSON.
+func runSchedule(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("schedule", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		file        string
+		reservCSV   string
+		previousN   int
+		includeMain bool
+	)
+	fs.StringVar(&file, "file", defaultRegistryPath, "registry path (used to resolve reservations when --reservations is empty)")
+	fs.StringVar(&reservCSV, "reservations", "", "comma-separated reservation names (default: every row in --file)")
+	fs.IntVar(&previousN, "previous-n", 2, "number of previous stable releases below main to include")
+	fs.BoolVar(&includeMain, "include-main", true, "include the tip-of-main cell first")
+	if err := fs.Parse(args); err != nil {
+		return flagParseErr(err, "schedule")
+	}
+	if fs.NArg() != 0 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"schedule: unexpected positional arguments: "+strings.Join(fs.Args(), " "))
+	}
+
+	reservations, err := resolveReservations(file, reservCSV)
+	if err != nil {
+		return err
+	}
+	tags, err := readTags(ctx, stdin)
+	if err != nil {
+		return err
+	}
+
+	schedule := uatbroker.ExpandSchedule(reservations, tags, includeMain, previousN)
+
+	// Warn loudly (but do not fail) when the matrix degrades, so a shallow
+	// checkout with no tag history doesn't silently skip the release rows. The
+	// two degraded states are distinct: main still runs, vs nothing runs.
+	switch {
+	case previousN > 0 && includeMain && scheduleHasNoReleases(schedule):
+		fmt.Fprintln(stderr,
+			"uat-broker: warning: no stable release tags on stdin — schedule is main-only "+
+				"(shallow checkout? fetch full tag history)")
+	case scheduleIsEmpty(schedule):
+		fmt.Fprintln(stderr,
+			"uat-broker: warning: empty schedule — --include-main=false and no stable release tags, nothing to run")
+	}
+
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(schedule); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "encode schedule", err)
+	}
+	return nil
+}
+
+// resolveReservations returns the reservation names to schedule: the
+// --reservations list when given, otherwise every name in the registry.
+func resolveReservations(file, csv string) ([]string, error) {
+	if strings.TrimSpace(csv) != "" {
+		names := splitCSV(csv)
+		if len(names) == 0 {
+			return nil, errors.New(errors.ErrCodeInvalidRequest, "schedule: --reservations is empty after trimming")
+		}
+		// Reject duplicates so the input fails loudly rather than silently
+		// collapsing via the schedule's reservation-keyed output map — mirrors
+		// the registry's own name-uniqueness invariant.
+		seen := make(map[string]bool, len(names))
+		for _, n := range names {
+			if seen[n] {
+				return nil, errors.New(errors.ErrCodeInvalidRequest, "schedule: duplicate reservation name "+n+" in --reservations")
+			}
+			seen[n] = true
+		}
+		return names, nil
+	}
+	reg, err := uatbroker.LoadRegistryFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return reg.Names(), nil
+}
+
+// readTags reads the newline-separated candidate tag list from stdin,
+// size-bounded, returning the non-empty trimmed lines. The read runs in a
+// goroutine so a SIGINT/SIGTERM (ctx cancellation) interrupts a blocking
+// stdin read: an interactive invocation with no pipe, or a CI cancellation
+// mid-read, returns promptly instead of hanging until SIGKILL. The reader
+// goroutine is released when the process exits (or when stdin closes).
+func readTags(ctx context.Context, stdin io.Reader) ([]string, error) {
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		data, err := io.ReadAll(io.LimitReader(stdin, maxTagsBytes+1))
+		ch <- readResult{data, err}
+	}()
+
+	var data []byte
+	select {
+	case <-ctx.Done():
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "interrupted while reading tags from stdin", ctx.Err())
+	case r := <-ch:
+		if r.err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "read tags from stdin", r.err)
+		}
+		data = r.data
+	}
+	if int64(len(data)) > maxTagsBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "tag list on stdin exceeds size limit")
+	}
+	var tags []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			tags = append(tags, line)
+		}
+	}
+	return tags, nil
+}
+
+// scheduleHasNoReleases reports whether the schedule contains only
+// tip-of-main cells (no release rows).
+func scheduleHasNoReleases(schedule map[string][]uatbroker.Cell) bool {
+	for _, cells := range schedule {
+		for i := range cells {
+			if !cells[i].IsMain {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// scheduleIsEmpty reports whether the schedule has no cells at all (neither
+// main nor any release) — i.e. --include-main=false with no stable tags.
+func scheduleIsEmpty(schedule map[string][]uatbroker.Cell) bool {
+	for _, cells := range schedule {
+		if len(cells) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// splitCSV splits a comma-separated list, trimming whitespace and dropping
+// empties.
+func splitCSV(csv string) []string {
+	var out []string
+	for _, p := range strings.Split(csv, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// flagParseErr maps a FlagSet parse error to the coded exit contract: -h is
+// not an error (exit 0), anything else is an invalid-request (exit 2). The
+// FlagSet already wrote the message to stderr.
+func flagParseErr(err error, sub string) error {
+	if stderrors.Is(err, flag.ErrHelp) {
+		return nil
+	}
+	return errors.Wrap(errors.ErrCodeInvalidRequest, "parse "+sub+" flags", err)
+}

--- a/tools/uat-broker/main_test.go
+++ b/tools/uat-broker/main_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/uatbroker"
+)
+
+const testRegistry = `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-0cbe491320188dfa6
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/aws/cluster-config.yaml
+    test-config-dir: tests/uat/aws/tests
+  - name: gcp-h100
+    cloud: gcp
+    reservation-id: projects/p/reservations/r
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/gcp/cluster-config.yaml
+    test-config-dir: tests/uat/gcp/tests
+`
+
+func writeRegistry(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "reservations.yaml")
+	if err := os.WriteFile(p, []byte(testRegistry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func invoke(stdin string, args ...string) (code int, stdout, stderr string) {
+	var out, errb bytes.Buffer
+	code = parseAndRun(context.Background(), args, strings.NewReader(stdin), &out, &errb)
+	return code, out.String(), errb.String()
+}
+
+func TestReservationsResolve(t *testing.T) {
+	reg := writeRegistry(t)
+	code, stdout, stderr := invoke("", "reservations", "--file", reg, "--name", "aws-h100")
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr: %s)", code, stderr)
+	}
+	for _, want := range []string{
+		"cloud=aws",
+		"reservation-id=cr-0cbe491320188dfa6",
+		"accelerator=h100",
+		"gpu-count=8",
+		"cluster-config-path=tests/uat/aws/cluster-config.yaml",
+		"test-config-dir=tests/uat/aws/tests",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q\ngot:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestReservationsList(t *testing.T) {
+	reg := writeRegistry(t)
+	code, stdout, _ := invoke("", "reservations", "--file", reg, "--list")
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	got := strings.Fields(stdout)
+	if len(got) != 2 || got[0] != "aws-h100" || got[1] != "gcp-h100" {
+		t.Errorf("--list = %v, want [aws-h100 gcp-h100]", got)
+	}
+}
+
+func TestReservationsExitCodes(t *testing.T) {
+	reg := writeRegistry(t)
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"no name, no list", []string{"reservations", "--file", reg}, errors.ExitInvalidInput},
+		{"missing reservation", []string{"reservations", "--file", reg, "--name", "nope"}, errors.ExitNotFound},
+		{"unknown registry file", []string{"reservations", "--file", "/no/such.yaml", "--name", "aws-h100"}, errors.ExitInvalidInput},
+		{"bad flag", []string{"reservations", "--bogus"}, errors.ExitInvalidInput},
+		{"list and name conflict", []string{"reservations", "--file", reg, "--list", "--name", "aws-h100"}, errors.ExitInvalidInput},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _, _ := invoke("", tt.args...)
+			if code != tt.want {
+				t.Errorf("exit code = %d, want %d", code, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduleJSON(t *testing.T) {
+	reg := writeRegistry(t)
+	stdin := "v1.0.0\nv2.0.0\nv1.5.0-rc1\nv1.5.0\n"
+	code, stdout, stderr := invoke(stdin, "schedule", "--file", reg, "--previous-n", "2")
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr: %s)", code, stderr)
+	}
+
+	var schedule map[string][]uatbroker.Cell
+	if err := json.Unmarshal([]byte(stdout), &schedule); err != nil {
+		t.Fatalf("schedule output is not valid JSON: %v\ngot:\n%s", err, stdout)
+	}
+	for _, res := range []string{"aws-h100", "gcp-h100"} {
+		cells := schedule[res]
+		if len(cells) != 3 {
+			t.Fatalf("%s has %d cells, want 3 (main + 2)", res, len(cells))
+		}
+		if !cells[0].IsMain {
+			t.Errorf("%s cell[0] is not main", res)
+		}
+		if cells[1].AICRVersion != "v2.0.0" || cells[2].AICRVersion != "v1.5.0" {
+			t.Errorf("%s release order = [%s %s], want [v2.0.0 v1.5.0]", res, cells[1].AICRVersion, cells[2].AICRVersion)
+		}
+	}
+}
+
+func TestScheduleReservationsOverride(t *testing.T) {
+	// --reservations bypasses the registry entirely.
+	code, stdout, stderr := invoke("v1.0.0\n", "schedule", "--reservations", "aws-h100", "--previous-n", "1")
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr: %s)", code, stderr)
+	}
+	var schedule map[string][]uatbroker.Cell
+	if err := json.Unmarshal([]byte(stdout), &schedule); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, ok := schedule["aws-h100"]; !ok || len(schedule) != 1 {
+		t.Errorf("schedule keys = %v, want only aws-h100", schedule)
+	}
+}
+
+func TestScheduleRejectsDuplicateReservations(t *testing.T) {
+	// Duplicate --reservations must fail loudly rather than silently collapse.
+	code, _, _ := invoke("v1.0.0\n", "schedule", "--reservations", "aws-h100,aws-h100")
+	if code != errors.ExitInvalidInput {
+		t.Errorf("exit = %d, want %d for duplicate --reservations", code, errors.ExitInvalidInput)
+	}
+}
+
+func TestReadTagsRejectsOversizedInput(t *testing.T) {
+	// Exercise the OOM-safeguard branch: input larger than maxTagsBytes.
+	big := strings.Repeat("v1.0.0\n", int(maxTagsBytes/7)+1)
+	if _, err := readTags(context.Background(), strings.NewReader(big)); err == nil {
+		t.Fatal("expected an error for a tag list exceeding the size limit")
+	}
+}
+
+func TestReadTagsCanceledContext(t *testing.T) {
+	// A canceled context must interrupt a blocking stdin read rather than hang.
+	pr, pw := io.Pipe() // never written → Read blocks until ctx cancellation
+	defer pw.Close()    // release the reader goroutine when the test ends
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := readTags(ctx, pr); err == nil {
+		t.Fatal("expected an error when the context is canceled during the stdin read")
+	}
+}
+
+func TestScheduleWarnsOnNoReleases(t *testing.T) {
+	// previous-n>0 with no usable tags must warn (but still succeed main-only).
+	code, _, stderr := invoke("not-a-tag\n", "schedule", "--reservations", "aws-h100", "--previous-n", "2")
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stderr, "main-only") {
+		t.Errorf("expected a main-only warning on stderr, got: %s", stderr)
+	}
+}
+
+func TestScheduleEmptyWarning(t *testing.T) {
+	// --include-main=false with no usable tags yields an empty schedule, which
+	// must be reported as empty/nothing-to-run, NOT as "main-only".
+	code, _, stderr := invoke("not-a-tag\n", "schedule", "--reservations", "aws-h100", "--include-main=false", "--previous-n", "2")
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stderr, "empty schedule") {
+		t.Errorf("expected an empty-schedule warning, got: %s", stderr)
+	}
+	if strings.Contains(stderr, "main-only") {
+		t.Errorf("must not claim main-only when --include-main=false, got: %s", stderr)
+	}
+}
+
+func TestRejectsPositionalArgs(t *testing.T) {
+	reg := writeRegistry(t)
+	tests := [][]string{
+		{"reservations", "--file", reg, "--list", "extra"},
+		{"reservations", "--file", reg, "--name", "aws-h100", "stray"},
+		{"schedule", "--reservations", "aws-h100", "bogus"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			code, _, _ := invoke("", args...)
+			if code != errors.ExitInvalidInput {
+				t.Errorf("exit = %d, want %d for trailing positional args", code, errors.ExitInvalidInput)
+			}
+		})
+	}
+}
+
+// failingWriter fails every Write, simulating a broken pipe or an unwritable
+// $GITHUB_OUTPUT target.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestReservationsPropagatesWriteError(t *testing.T) {
+	reg := writeRegistry(t)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"resolve", []string{"reservations", "--file", reg, "--name", "aws-h100"}},
+		{"list", []string{"reservations", "--file", reg, "--list"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := parseAndRun(context.Background(), tt.args, strings.NewReader(""), failingWriter{}, io.Discard)
+			if code == 0 {
+				t.Error("expected a non-zero exit when the stdout write fails")
+			}
+		})
+	}
+}
+
+func TestTopLevelDispatch(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"no args", nil, errors.ExitInvalidInput},
+		{"unknown subcommand", []string{"frobnicate"}, errors.ExitInvalidInput},
+		{"help", []string{"help"}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _, _ := invoke("", tt.args...)
+			if code != tt.want {
+				t.Errorf("exit code = %d, want %d", code, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add the UAT reservation registry (`infra/uat/reservations.yaml`) and a `uat-broker` helper that resolves reservation rows and expands the nightly version-matrix schedule. Data + tooling only — no live workflow is changed.

## Motivation / Context

First of four PRs implementing **DC1 — day/night scheduler + reservation broker** (#1274), part of the comprehensive UAT epic (#1264). It establishes the data-driven foundation the rest of the broker builds on: the reservation registry is the lease's source of truth (each row's `name` becomes the GitHub Actions concurrency-group key `uat-<name>`), and the helper provides the two operations the later PRs consume — resolving a row for the dispatch surface (PR-2) and expanding the time-boxed version matrix for the nightly controller (PR-3). Onboarding new reserved capacity is a one-row data edit, no code change.

Fixes: N/A
Related: #1274, #1264

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `infra/uat/` reservation registry; new `pkg/uatbroker` + `tools/uat-broker`; `.github/labeler.yml` + `CODEOWNERS`

## Implementation Notes

- **Go helper, mirroring the `pkg/corroborate` + `tools/corroborate` precedent**: all logic lives in `pkg/uatbroker` (`ParseRegistry`/`LoadRegistryFile`/`Validate`/`Lookup`/`Names`, `ExpandSchedule`), with a thin `tools/uat-broker` CLI exposing `reservations` and `schedule` subcommands.
- **Schedule ordering is the testable core**: main-first, then the previous N stable releases in descending semver order (`Masterminds/semver/v3`, not shell `sort`), with pre-release and non-semver tags dropped and the oldest dropped first when truncating — so the nightly controller sheds the oldest releases when its time-box closes.
- **`reservations` emits `GITHUB_OUTPUT`-style `key=value` lines** so PR-2's resolve job is simply `uat-broker reservations --name … >> "$GITHUB_OUTPUT"`; `schedule` emits JSON from a stdin tag list.
- **Coded exits** (`0` ok / `2` invalid-request / `3` not-found) so workflows can branch on failure mode.
- `reservations.yaml` is intentionally **not** CODEOWNERS-gated (kept under the default owner) so "new infra extends by data edit" stays low-friction; only the Go helper is maintainer-owned. `gpu-count` is forward-looking metadata (consumed by DC2) and is validated positive.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
```

- `make qualify` green end-to-end: tests pass, **aggregate coverage 77.5% ≥ 75%**, lint clean (golangci-lint v2.12.2), e2e 23/0, grype reports no vulnerabilities.
- New-package coverage: `pkg/uatbroker` **95.9%**, `tools/uat-broker` **87.3%** — table-driven tests cover registry validation, lookup, schedule ordering/filtering/drop-oldest, the CLI subcommands and their exit codes, and a guard that the committed registry stays valid.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No runtime/behavior change — the helper is not wired into any workflow until PR-2 (the broker cutover). Safe to merge independently.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — no user-facing behavior; the broker docs page lands with PR-2)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
