### PR TITLE
fix(lke): add provider ID mapping for Akamai Cloud / Linode LKE

### DIFF
--- a/.claude/skills/aicr-analyzing-snapshots/SKILL.md
+++ b/.claude/skills/aicr-analyzing-snapshots/SKILL.md
@@ -51,8 +51,8 @@ Key fields for provider identification:
 | Field Path | What It Reveals |
 |------------|----------------|
 | `K8s.server.version` | K8s version + vendor suffix (`-eks-`, `-gke`, `-aks`, `+lke`) |
-| `K8s.node.provider` | Mapped provider: eks, gke, aks, oke, metal3, kind |
-| `K8s.node.provider-id` | Raw provider URI (`aws://`, `gce://`, `azure://`, `oci://`, `metal3://`) |
+| `K8s.node.provider` | Mapped provider: eks, gke, aks, oke, lke, metal3, kind |
+| `K8s.node.provider-id` | Raw provider URI (`aws://`, `gce://`, `azure://`, `oci://`, `linode://`, `metal3://`) |
 | `K8s.node.kernel-version` | Kernel + arch indicator (e.g., `-64k` = ARM 64K pages) |
 | `K8s.node.container-runtime-*` | Runtime name and version |
 | `K8s.node.kubelet-version` | Kubelet version |
@@ -66,6 +66,7 @@ Key fields for provider identification:
 | `gce://` | gke | Google GKE |
 | `azure://` | aks | Azure AKS |
 | `oci://` | oke | Oracle OKE |
+| `linode://` | lke | Akamai Cloud / Linode LKE |
 | `metal3://` | bare-metal | Metal3/Ironic, self-managed |
 | `kind://` | kind | Local dev cluster |
 | *(none/other)* | any | Self-managed, check version string |

--- a/pkg/collector/k8s/doc.go
+++ b/pkg/collector/k8s/doc.go
@@ -85,6 +85,7 @@
 //   - GKE: cloud.google.com/gke-nodepool
 //   - AKS: kubernetes.azure.com/cluster
 //   - OKE: node.info.ds.oke
+//   - LKE: lke.linode.com/pool-id
 //   - Self-managed: No provider-specific labels
 //
 // # Context Support

--- a/pkg/collector/k8s/node.go
+++ b/pkg/collector/k8s/node.go
@@ -93,6 +93,7 @@ func (k *Collector) collectNode(ctx context.Context) (map[string]measurement.Rea
 //   - gce://my-project/us-central1-a/gke-cluster-node → "gke"
 //   - azure:///subscriptions/.../virtualMachines/... → "aks"
 //   - ocid1.instance.oc1... → "oke" (OKE emits a raw OCID, no scheme prefix)
+//   - linode://58291 → "lke" (Akamai Cloud / Linode LKE)
 //
 // If the format is unrecognized, it returns the raw provider prefix.
 func parseProvider(providerID string) string {
@@ -121,6 +122,8 @@ func parseProvider(providerID string) string {
 		return "aks"
 	case "oci":
 		return "oke"
+	case "linode":
+		return "lke"
 	default:
 		return provider
 	}

--- a/pkg/collector/k8s/node_test.go
+++ b/pkg/collector/k8s/node_test.go
@@ -229,6 +229,16 @@ func TestParseProvider(t *testing.T) {
 			want:       "oke",
 		},
 		{
+			name:       "Akamai Cloud LKE",
+			providerID: "linode://58291",
+			want:       "lke",
+		},
+		{
+			name:       "Akamai Cloud LKE uppercase normalized",
+			providerID: "LINODE://58291",
+			want:       "lke",
+		},
+		{
 			name:       "unknown format",
 			providerID: "custom-provider://some-id",
 			want:       "custom-provider",

--- a/pkg/fingerprint/from_measurements.go
+++ b/pkg/fingerprint/from_measurements.go
@@ -54,8 +54,7 @@ const (
 	noteUnknownSKU          = "unknown-sku"
 )
 
-//	FromMeasurements builds a Fingerprint from a snapshot's measurement
-//
+// FromMeasurements builds a Fingerprint from a snapshot's measurement
 // slice. Dimensions whose source signal is missing keep their zero
 // value (empty string for Dimension/OSDimension, 0 for IntDimension);
 // callers compare those against criteria using Match, which treats

--- a/pkg/fingerprint/from_measurements.go
+++ b/pkg/fingerprint/from_measurements.go
@@ -28,6 +28,7 @@ import (
 // don't want to import them just for the names.
 const (
 	serviceOKE              = "oke"
+	serviceLKE              = "lke"
 	subtypeK8sServer        = "server"
 	subtypeK8sNode          = "node"
 	subtypeGPUHardware      = "hardware"
@@ -53,7 +54,8 @@ const (
 	noteUnknownSKU          = "unknown-sku"
 )
 
-// FromMeasurements builds a Fingerprint from a snapshot's measurement
+//	FromMeasurements builds a Fingerprint from a snapshot's measurement
+//
 // slice. Dimensions whose source signal is missing keep their zero
 // value (empty string for Dimension/OSDimension, 0 for IntDimension);
 // callers compare those against criteria using Match, which treats
@@ -330,6 +332,10 @@ func extractRegion(m *measurement.Measurement) (region string, multi bool) {
 //   - "oci" — bare string stored by the collector before the "oci://" → "oke"
 //     mapping existed
 //   - "oke" — already normalized; pass through
+//
+// Akamai Cloud / Linode LKE nodes carry "linode://<instance-id>"; the collector
+// normalizes this to "lke" via parseProvider, but hand-crafted snapshots may
+// carry the raw "linode://..." URL or the bare "linode" string.
 func normalizeProviderID(v string) string {
 	if strings.HasPrefix(v, "ocid1.") {
 		return serviceOKE
@@ -339,6 +345,12 @@ func normalizeProviderID(v string) string {
 	}
 	if v == "oci" {
 		return serviceOKE
+	}
+	if strings.HasPrefix(v, "linode://") {
+		return serviceLKE
+	}
+	if v == "linode" {
+		return serviceLKE
 	}
 	return v
 }

--- a/pkg/fingerprint/from_measurements_test.go
+++ b/pkg/fingerprint/from_measurements_test.go
@@ -351,6 +351,9 @@ func TestFromMeasurements_ServiceDetection(t *testing.T) {
 		{"oci", "oke"},
 		{"oci://ocid1.instance.oc1.us-chicago-1.example", "oke"},
 		{"ocid1.instance.oc1.us-chicago-1.anxxeljsaqwjupqcb4pa5kzxy4hef5dtclbkqsnmu6kedbkrne3s2bz5nwzq", "oke"},
+		{"lke", "lke"},
+		{"linode", "lke"},
+		{"linode://58291", "lke"},
 		{"kind", "kind"},
 		{"", ""},
 	}


### PR DESCRIPTION
## Summary

Map Akamai Cloud / Linode LKE nodes (`linode://<instance-id>` provider IDs) to the `lke` service in the K8s collector and fingerprint paths, so live LKE clusters are correctly detected, and the correct overlays are chosen.

## Motivation / Context

The `lke` service criteria, overlays, and docs already existed, but real LKE clusters were never detected as `lke`: the collector's `parseProvider` fell through to the raw `linode` prefix, and the fingerprint's `normalizeProviderID` had no Linode case. This closes that gap end-to-end (snapshot collection and fingerprint-based service detection).

Fixes: N/A
Related: N/A

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)


## Component(s) Affected

- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Other: `pkg/fingerprint`

## Implementation Notes

Provider normalization happens in two layers and both are updated:

- **Collector** (`pkg/collector/k8s/node.go`): `parseProvider` adds `case "linode": return "lke"`. The scheme is lowercased first, so `LINODE://` normalizes too. This is the live-cluster path.
- **Fingerprint** (`pkg/fingerprint/from_measurements.go`): adds a `serviceLKE` constant and teaches `normalizeProviderID` to handle both the raw `linode://<id>` URL and the bare `linode` string. This is defensive for hand-crafted snapshots that carry the unnormalized value (mirrors the existing OKE `oci`/`ocid1.` handling).

Also updates the `aicr-analyzing-snapshots` skill doc and package godoc (`doc.go`) with the `linode://` → `lke` mapping and the `lke.linode.com/pool-id` node label. No new service enum value is introduced — `CriteriaServiceLKE` and the LKE recipes already existed.


## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
  Additive single-case mapping in two well-isolated functions, fully covered by unit tests. Nodes that previously surfaced the raw linode prefix now resolve to lke; no other provider behavior changes.

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->
 N/A — backwards compatible, no migration required.
## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
