### PR TITLE
docs(#1533): fix bundle-layout, validator, and GPU constraint-path drift

### DIFF
--- a/demos/cuj2-demo.md
+++ b/demos/cuj2-demo.md
@@ -17,7 +17,7 @@
   │  base ─▶ eks ─▶ eks-inference ─▶ h100-eks-inference ─▶                 │
   │          h100-eks-ubuntu-inference ─▶ h100-eks-ubuntu-inference-dynamo │
   │                                                                        │
-  │  Output: 16 components, constraints, deployment order                  │
+  │  Output: 18 components, constraints, deployment order                  │
   └────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -35,24 +35,30 @@
   │      --storage-class <storage-class>                                   │
   │                                                                        │
   │  recipe.yaml ──▶ bundle/                                               │
-  │    ├── deploy.sh                                                       │
-  │    ├── cert-manager/             (TLS certificates)                    │
-  │    ├── prometheus-operator-crds/ (CRDs for monitoring stack)           │
-  │    ├── kube-prometheus-stack/    (Prometheus, Grafana, alerting)       │
-  │    ├── prometheus-adapter/       (custom metrics API for HPA)          │
-  │    ├── k8s-ephemeral-storage-metrics/  (storage monitoring)            │
-  │    ├── gpu-operator/             (GPU driver, device-plugin, DCGM)     │
-  │    ├── nvidia-dra-driver-gpu/    (Dynamic Resource Allocation)         │
-  │    ├── kai-scheduler/            (gang scheduling)                     │
-  │    ├── agentgateway-crds/        (Gateway API + inference CRDs)        │
-  │    ├── agentgateway/             (inference gateway controller)        │
-  │    ├── nvsentinel/               (security/compliance)                 │
-  │    ├── nodewright-operator/      (node configuration)                  │
-  │    ├── nodewright-customizations/ (H100 tuning)                        │
-  │    ├── aws-ebs-csi-driver/       (EBS storage)                         │
-  │    ├── aws-efa/                  (Elastic Fabric Adapter)              │
-  │    ├── dynamo-crds/              (Dynamo CRDs)                         │
-  │    └── dynamo-platform/          (inference serving platform)          │
+  │    ├── deploy.sh        (root automation script)                       │
+  │    ├── README.md        (root deployment guide)                        │
+  │    ├── checksums.txt    (SHA256 of listed files; excludes recipe.yaml) │
+  │    ├── recipe.yaml      (resolved recipe; not yet in checksums, #1549) │
+  │    ├── 001-agentgateway-crds/              (agentgateway.dev CRDs)     │
+  │    ├── 002-agentgateway-crds-post/         (Gateway API + Inf-Ext CRDs)│
+  │    ├── 003-aws-ebs-csi-driver/             (EBS storage)               │
+  │    ├── 004-aws-efa/                        (Elastic Fabric Adapter)    │
+  │    ├── 005-cert-manager/                   (TLS certificates)          │
+  │    ├── 006-agentgateway/                   (inference gateway)         │
+  │    ├── 007-agentgateway-post/              (post-chart manifests)      │
+  │    ├── 008-grove/                          (multinode inference)       │
+  │    ├── 009-nfd/                            (node feature discovery)    │
+  │    ├── 010-nodewright-operator/            (node configuration)        │
+  │    ├── 011-nodewright-customizations/      (H100 tuning)               │
+  │    ├── 012-prometheus-operator-crds/       (monitoring CRDs)           │
+  │    ├── 013-kube-prometheus-stack/          (Prometheus, Grafana)       │
+  │    ├── 014-gpu-operator/                   (driver, plugin, DCGM)      │
+  │    ├── 015-k8s-ephemeral-storage-metrics/  (storage metrics)           │
+  │    ├── 016-kai-scheduler/                  (gang scheduling)           │
+  │    ├── 017-dynamo-platform/                (inference serving)         │
+  │    ├── 018-nvidia-dra-driver-gpu/          (DRA driver)                │
+  │    ├── 019-nvsentinel/                     (GPU health/remediation)    │
+  │    └── 020-prometheus-adapter/             (custom metrics API (HPA))  │
   └────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -61,9 +67,9 @@
   │                                                                        │
   │  $ cd bundle && ./deploy.sh                                            │
   │                                                                        │
-  │  cert-manager ──▶ kube-prometheus-stack ──▶ gpu-operator ──▶           │
-  │  kai-scheduler ──▶ agentgateway ──▶ nvidia-dra-driver ──▶              │
-  │  dynamo-platform ──▶ nodewright ──▶ nvsentinel ──▶ ...                 │
+  │  selected components in deployment order (post-folders &               │
+  │  some steps omitted): agentgateway-crds ──▶ ... ──▶ cert-manager       │
+  │  ──▶ agentgateway ──▶ ... ──▶ gpu-operator ──▶ dynamo-platform ──▶ ... │
   │                                                                        │
   │  Result: Fully configured GPU cluster                                  │
   │    • 8x H100 GPUs advertised via DRA                                   │
@@ -98,47 +104,49 @@
 ```
 ┌─────────────────────────────────────┬─────────────────────────────────────┐
 │      TRAINING (kubeflow)            │      INFERENCE (dynamo)             │
-│      13 components, 7 overlays      │      16 components, 7 overlays      │
+│  15 components, 8 overlays +mixins  │  18 components, 8 overlays +mixins  │
 ├─────────────────────────────────────┼─────────────────────────────────────┤
 │                                     │                                     │
 │  base.yaml                          │  base.yaml                          │
+│  ├── nfd                            │  ├── nfd                            │
 │  ├── cert-manager                   │  ├── cert-manager                   │
+│  ├── gpu-operator                   │  ├── gpu-operator                   │
+│  ├── nvsentinel                     │  ├── nvsentinel                     │
+│  ├── nodewright-operator            │  ├── nodewright-operator            │
+│  ├── prometheus-operator-crds       │  ├── prometheus-operator-crds       │
 │  ├── kube-prometheus-stack          │  ├── kube-prometheus-stack          │
 │  ├── k8s-ephemeral-storage-metrics  │  ├── k8s-ephemeral-storage-metrics  │
-│  ├── gpu-operator                   │  ├── gpu-operator                   │
 │  ├── nvidia-dra-driver-gpu          │  ├── nvidia-dra-driver-gpu          │
-│  ├── kai-scheduler                  │  ├── kai-scheduler                  │
-│  ├── nvsentinel                     │  ├── nvsentinel                     │
-│  └── nodewright-operator               │  └── nodewright-operator               │
-│      │                              │      │                              │
+│  └── kai-scheduler                  │  └── kai-scheduler                  │
+│  monitoring-hpa (metadata)          │  monitoring-hpa (metadata)          │
+│  └── prometheus-adapter             │  └── prometheus-adapter             │
+│  h100-any (validation floor)        │  h100-any (validation floor)        │
 │  eks.yaml                           │  eks.yaml                           │
 │  ├── aws-ebs-csi-driver             │  ├── aws-ebs-csi-driver             │
 │  └── aws-efa                        │  └── aws-efa                        │
-│      │                              │      │                              │
 │  eks-training.yaml                  │  eks-inference.yaml                 │
-│  (no new components)                │  ├── agentgateway-crds      ◀── NEW │
-│      │                              │  └── agentgateway           ◀── NEW │
-│      │                              │      │                              │
+│  (gpu-operator overrides)           │  (inference constraints)            │
 │  h100-eks-training.yaml             │  h100-eks-inference.yaml            │
-│  ├── gpu-operator (CDI, gdrcopy)    │  └── nodewright-customizations         │
-│  └── nodewright-customizations         │      │                              │
-│      │                              │  h100-eks-ubuntu-inference.yaml     │
-│  h100-eks-ubuntu-training.yaml      │  (Ubuntu constraints)               │
-│  (Ubuntu constraints)               │      │                              │
-│      │                              │  h100-eks-ubuntu-inference-dynamo   │
-│  h100-eks-ubuntu-training-kubeflow  │  ├── gpu-operator (v26.3.2, CDI)    │
-│  └── kubeflow-trainer       ◀── NEW │  ├── nvidia-dra-driver (gpuRes)◀─NEW│
-│                                     │  ├── dynamo-crds             ◀─ NEW │
-│                                     │  └── dynamo-platform         ◀─ NEW │
-│                                     │                                     │
-├─────────────────────────────────────┼─────────────────────────────────────┤
-│  Unique: kubeflow-trainer           │  Unique: agentgateway-crds,         │
-│                                     │          agentgateway,              │
-│                                     │    dynamo-crds, dynamo-platform     │
+│  └── nodewright-customizations      │  └── nodewright-customizations      │
+│  h100-eks-ubuntu-training.yaml      │  h100-eks-ubuntu-inference.yaml     │
+│  (Ubuntu constraints)               │  (Ubuntu constraints)               │
+│  h100-eks-ubuntu-training-kubeflow  │  h100-eks-ubuntu-inference-dynamo   │
+│  mixins (merged separately):        │  ├── grove                          │
+│  + os-ubuntu, platform-kubeflow     │  └── dynamo-platform                │
+│  └── kubeflow-trainer (via mixin)   │  mixins (merged separately):        │
+│                                     │  + os-ubuntu, platform-inference    │
+│                                     │  ├── agentgateway-crds (via mixin)  │
+│                                     │  └── agentgateway (via mixin)       │
 ├─────────────────────────────────────┴─────────────────────────────────────┤
-│  Shared (base + eks): cert-manager, kube-prometheus-stack, gpu-operator,  │
-│    kai-scheduler, nvidia-dra-driver-gpu, nvsentinel, nodewright-operator,    │
-│    k8s-ephemeral-storage-metrics, aws-ebs-csi-driver, aws-efa             │
+│  Unique training: kubeflow-trainer                                        │
+│  Unique inference: agentgateway-crds, agentgateway, grove, dynamo-platform│
+├───────────────────────────────────────────────────────────────────────────┤
+│  Shared (base/eks/h100/hpa layers):                                       │
+│    cert-manager, kube-prometheus-stack, gpu-operator, kai-scheduler,      │
+│    nvidia-dra-driver-gpu, nvsentinel, nfd, nodewright-operator,           │
+│    nodewright-customizations, prometheus-adapter,                         │
+│    prometheus-operator-crds, k8s-ephemeral-storage-metrics,               │
+│    aws-ebs-csi-driver, aws-efa                                            │
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -259,7 +267,7 @@ http://127.0.0.1:9090/chat.html
 │ 4 │ accelerator_metrics        │ gpu-operator (DCGM exporter)             │ base    │
 │ 5 │ ai_service_metrics         │ kube-prometheus-stack, prometheus-adapter│ base    │
 │ 6 │ ai_inference               │ agentgateway-crds, agentgateway          │ eks-inf │
-│ 7 │ robust_controller          │ dynamo-crds, dynamo-platform             │ dynamo  │
+│ 7 │ robust_controller          │ dynamo-platform                          │ dynamo  │
 │ 8 │ pod_autoscaling            │ prometheus-adapter + HPA                 │ base    │
 │ 9 │ cluster_autoscaling        │ EKS Auto Scaling Group (ASG)             │ infra   │
 ├───┴────────────────────────────┴──────────────────────────────────────────┴─────────┤

--- a/demos/images/data.md
+++ b/demos/images/data.md
@@ -39,15 +39,23 @@ Caption: "Single YAML response with optimal configurations for runtime criteria"
 Visual: File system tree structure showing multiple component folders
 
 ```shell
-bundles/
-├── gpu-operator/
-│   ├── checksums.txt
+bundle/
+├── deploy.sh                     # root automation script (executable)
+├── README.md                     # root deployment guide
+├── checksums.txt                 # SHA256 of the listed bundle files (recipe.yaml is written
+│                                 # afterward and is not yet covered — see issue #1549)
+├── recipe.yaml                   # canonical post-resolution recipe
+├── NNN-cert-manager/             # each folder is prefixed with its NNN deployment-order
+│   ├── install.sh                # index (computed from the dependency graph — e.g. cert-manager
+│   ├── values.yaml               # and NFD sort ahead of gpu-operator, which depends on them)
+│   ├── cluster-values.yaml
+│   └── upstream.env              # CHART/REPO/VERSION (every upstream-helm folder)
+├── NNN-gpu-operator/
+│   ├── install.sh
 │   ├── values.yaml
-│   └── scripts/install.sh
-├── network-operator/
-│   ├── checksums.txt
-│   └── argocd/application.yaml
-└── cert-manager/
+│   ├── cluster-values.yaml
+│   └── upstream.env
+└── NNN-<component>/
     └── ...
 ```
 

--- a/demos/images/meta.md
+++ b/demos/images/meta.md
@@ -9,23 +9,23 @@ Visual: Vertical stack of 6 stat cards, each with a large bold number and muted 
 
 ```
 ┌─────────────────────────────────────────────┐
-│  18  Registered Components                  │
+│  33  Registered Components                  │
 │  Helm and Kustomize charts in the registry  │
 ├─────────────────────────────────────────────┤
-│  23  Overlay Layers                         │
+│  97  Overlay Files                          │
 │  Specialization overlays across all         │
 │  criteria combinations                      │
 ├─────────────────────────────────────────────┤
-│  427  Config Values                         │
-│  Total leaf configuration values across     │
-│  all component value files                  │
+│  31  values.yaml Files                      │
+│  Files named exactly values.yaml            │
+│  under recipes/components/                  │
 ├─────────────────────────────────────────────┤
 │  5  Criteria Dimensions                     │
 │  service, accelerator, intent, os, platform │
 ├─────────────────────────────────────────────┤
-│  15  Max Components per Recipe              │
+│  18  Max Components per Recipe              │
 │  Most specialized inference recipe          │
-│  (H100 + EKS + Dynamo)                     │
+│  (H100 + EKS + Ubuntu + Dynamo)             │
 ├─────────────────────────────────────────────┤
 │  6  Overlay Chain Depth                     │
 │  base > service > intent > accelerator      │
@@ -43,20 +43,20 @@ Visual: Left-to-right horizontal pipeline, boxes connected by labeled arrows
 ```
 ┌──────────────┐  +SERVICE=EKS  ┌──────────────┐  +INTENT=TRAINING  ┌──────────────┐
 │   GENERIC    │───────────────▶│   + EKS      │──────────────────▶│  + TRAINING  │
-│   (Base)     │                │              │                   │              │
-│ 9 components │                │ +2 components│                   │ gpu-operator  │
-│ 427 values   │                │ aws-ebs-csi  │                   │ overrides:    │
-│              │                │ aws-efa      │                   │ CDI, gdrcopy  │
-└──────────────┘                │ +70 values   │                   └──────────────┘
+│   (base+wild)│                │              │                   │              │
+│ 11 components│                │ +2 components│                   │ gpu-operator  │
+│              │                │ aws-ebs-csi  │                   │ overrides:    │
+│              │                │ aws-efa      │                   │ CDI           │
+└──────────────┘                │              │                   └──────────────┘
                                 └──────────────┘                          │
                                                                           ▼
 ┌──────────────┐  +PLATFORM=    ┌──────────────┐  +ACCELERATOR=    ┌──────────────┐
 │   RESOLVED   │◀──────────────│  + UBUNTU    │◀────────────────│  + H100      │
 │   RECIPE     │   KUBEFLOW    │              │   H100           │              │
 │              │                │ OS kernel    │                   │ +nodewright- │
-│ 12 unique    │  +kubeflow-   │ constraint   │                   │ customizations │
+│ 15 unique    │  +kubeflow-   │ constraint   │                   │ customizations │
 │ components   │  trainer      │ >= 6.8       │                   │ behavior     │
-│              │  +36 values   │              │                   │ mutations    │
+│              │               │              │                   │ mutations    │
 └──────────────┘                └──────────────┘                   └──────────────┘
 ```
 
@@ -77,10 +77,10 @@ Visual: Single input forking into two divergent paths
 ┌───────────────────────┐       ┌───────────────────────┐
 │  TRAINING (Kubeflow)  │       │  INFERENCE (Dynamo)   │
 │                       │       │                       │
-│  12 components        │       │  15 components        │
+│  15 components        │       │  18 components        │
 │                       │       │                       │
 │  Unique:              │       │  Unique:              │
-│    kubeflow-trainer   │       │    dynamo-crds        │
+│    kubeflow-trainer   │       │    grove              │
 │                       │       │    dynamo-platform    │
 │  GPU Operator:        │       │    agentgateway-crds  │
 │    CDI=true           │       │    agentgateway       │
@@ -99,13 +99,14 @@ Caption: "intent=training vs intent=inference produces divergent component graph
 ---
 
 **Section 4: Cross-Service Comparison** (Right Panel, Bottom)
-Visual: Horizontal bar chart, 3 bars for same generic workload across services
+Visual: Horizontal bar chart, 3 bars for the same workload across services
+(criteria: `--accelerator h100 --intent training`; GKE additionally needs `--os cos`)
 
-| Service  | Components | Service-Specific Additions            |
-|----------|------------|---------------------------------------|
-| EKS      | 14         | aws-efa, aws-ebs-csi-driver           |
-| GKE/COS  | 10         | COS-specific GPU Operator overrides   |
-| Kind     | 16         | network-operator, DRA driver, local   |
+| Service  | Components | Service-Specific Additions / Omissions        |
+|----------|------------|-----------------------------------------------|
+| EKS      | 14         | aws-efa, aws-ebs-csi-driver, nodewright-customizations |
+| GKE/COS  | 13         | gke-nccl-tcpxo, nodewright-customizations, COS GPU overrides |
+| Kind     | 12         | network-operator; no cloud CSI/EFA            |
 
 Caption: "Same intent, different service = different component sets and values"
 
@@ -117,7 +118,7 @@ Caption: "Same intent, different service = different component sets and values"
 - Header: Dark bg, "AI Cluster Runtime" bold NVIDIA Green
 - Footer: Dark bg, white text
 - NVIDIA Green for active/matching/passing elements
-- Orange for delta callouts (+N components, +N values)
+- Orange for delta callouts (+N components)
 - Grey for muted subtitles and secondary text
 - Component names in monospace font
 - Numbers large and bold in stat cards

--- a/demos/validation-acceptance.md
+++ b/demos/validation-acceptance.md
@@ -46,7 +46,7 @@ Expected:
 - Completes in <10s
 - `recipe.yaml` created
 - Criteria matching flags
-- 13 components, 7 overlays
+- 15 components, 8 overlays
 
 ## Bundle
 

--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -642,8 +642,9 @@ type ValidationFunc func(
 
 ### Common pitfalls
 
-- **Function name typo in YAML.** Silently skipped — no error raised.
-  Add a test that calls `Get("...")` (or `RegistryHas(...)`) for every
+- **Function name typo in YAML.** Fails closed — `RunValidations` raises
+  `ErrCodeInvalidRequest` ("unknown validation function") rather than
+  skipping the check. Add a test that calls `Get("...")` for every
   shipping check.
 - **Returning an error when you mean a warning.** Errors stop the
   bundle. If the user can ship through it, return a warning.
@@ -812,7 +813,8 @@ Patterns common to all four surfaces.
   error.** Masquerades broken YAML as passing. Fail closed — return
   `ErrCodeInvalidRequest`. (CLAUDE.md anti-pattern.)
 - **Function-name typo in `registry.yaml` `validations:` block.**
-  Silently skipped, no error. Add a registry-lookup test for every
+  Fails closed — `RunValidations` raises `ErrCodeInvalidRequest`
+  ("unknown validation function"). Add a registry-lookup test for every
   shipping function.
 - **`yaml.Marshal` on `map[string]any` for output that feeds CTRF or
   a digest.** `yaml.v3` walks randomized Go map order. Use

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -880,7 +880,7 @@ Constraints use fully qualified measurement paths: `{Type}.{Subtype}.{Key}`
 | `OS.release.ID` | Operating system identifier (ubuntu, rhel) |
 | `OS.release.VERSION_ID` | OS version (24.04, 22.04) |
 | `OS.sysctl./proc/sys/kernel/osrelease` | Kernel version |
-| `GPU.info.type` | GPU hardware type |
+| `GPU.hardware.model` | GPU model (e.g. `h100`, `l40s`) |
 
 Supported operators:
 


### PR DESCRIPTION
## Summary

Fix the doc-only items in the #1533 P2/P3 documentation-drift tail: stale bundle-layout examples, an inaccurate "silently skipped" validator description, and an impossible GPU constraint path.

## Motivation / Context

#1528 fixed the P1s and most P2 prose; #1533 tracks the remaining tail. This PR closes the doc-only subset and is a **partial** close — other #1533 items remain, both code/cluster work (#1529, #1531, #1532, #1549, #1550) and additional doc-only drift still open (e.g. the `cli-reference.md` cross-cloud query block, tracked in a follow-up comment on #1533). Items already resolved on `main` (data-flow.md, `recipe --criteria` demos, the cuj2 conformance link, SBOM/`wget` wording, saved-recipe `--data`) were verified and left unchanged.

Fixes: N/A
Related: #1533, #1528

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `demos/images/data.md`, `demos/cuj2-demo.md`: bundle trees now use the real `NNN-<component>/` layout with root `checksums.txt`/`recipe.yaml`/`README.md`/`deploy.sh`. cuj2 lists the actual 20 emitted folders (incl. the agentgateway post-chart manifest folders); `checksums.txt` is described as covering only the listed files (`recipe.yaml` is written afterward, not yet covered — #1549). `data.md` uses `NNN-` placeholders (the index is dependency-graph-derived) and shows `upstream.env` for every upstream-helm folder incl. cert-manager.
- `demos/cuj2-demo.md`, `demos/images/meta.md`, `demos/validation-acceptance.md`: corrected component counts and overlay/mixin attribution — inference **18** / training **15** components, **8 applied overlays, plus 2 separately merged mixins** (`platform-inference`/`platform-kubeflow` + `os-ubuntu`); included the `h100-any` (validation floor) and `monitoring-hpa` wildcard overlays; attributed `nodewright-customizations` to the H100 layer. Dropped the removed `dynamo-crds`, added `grove`/`nfd`; robust_controller conformance row maps to `dynamo-platform`. meta.md core metrics refreshed (33 registered components, 97 overlay files, 31 `values.yaml` files) and the cross-service comparison regenerated (EKS 14 / GKE-COS 13 / Kind 12 for h100+training). All counts/order/folders taken from a freshly built `aicr recipe` + `aicr bundle`, not estimated.
- `docs/contributor/validator.md`: unknown `ValidationFunc` names **fail closed** (`ErrCodeInvalidRequest`), not silently skipped (`pkg/bundler/validations/registry.go`).
- `docs/user/cli-reference.md`: `GPU.info.type` → `GPU.hardware.model` (the real collector path; `pkg/collector/gpu/gpu.go`).

## Testing

```bash
make qualify   # full gate: test (-race) + lint + e2e + scan + coverage + doc checks
```

`make qualify` passes: tests green, coverage 78.1% (threshold 75%), go vet, golangci-lint + yamllint, e2e, scan, and the AGENTS-sync / doc-filename / MDX-safe / chart-pin checks all pass. Component counts/order/bundle folders additionally cross-checked against a locally built binary.

## Risk Assessment

- [x] **Low** — Documentation only, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Linter passes (`make lint`)
- [x] `make qualify` passes locally
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
