### PR TITLE
fix(recipe): align H100 NCCL bandwidth gate across services

### DIFF
--- a/demos/cuj1-training.md
+++ b/demos/cuj1-training.md
@@ -159,7 +159,7 @@ aicr validate \
     --recipe recipe.yaml \
     --toleration dedicated=gpu-workload:NoSchedule \
     --toleration nvidia.com/gpu=present:NoSchedule \
-    --phase conformance \
+    --phase all \
     --output report.json
 ```
 
@@ -206,12 +206,14 @@ kubectl logs -f -n kubeflow -l trainer.kubeflow.org/job-name=pytorch-mnist
 
 ## Performance Validation (GKE)
 
-> **Note:** `aicr validate --phase performance` is not yet automated for GKE.
-> The GKE NCCL test uses raw Pods with a TCPXO daemon sidecar (required for
-> GPUDirect), which differs from the EKS TrainJob-based approach. Run the test
-> manually — see [GKE TCPXO Networking](../docs/integrator/gke-tcpxo-networking.md#running-the-nccl-benchmark)
-> for the runnable NCCL benchmark, prerequisites, TCPXO runtime requirements,
-> and result expectations.
+> **Note:** `aicr validate --phase performance` runs the NCCL all-reduce
+> benchmark automatically for `h100-gke-cos-training` — it deploys the
+> TrainJob and injects the GKE multi-NIC / TCPXO annotations for you. It
+> requires at least 2 *discovered* schedulable GPU nodes (fewer than 2 returns
+> a successful *skipped* result); the selected nodes also need free GPU capacity
+> or the TrainJob stays Pending and the check times out — it does not skip. See [GKE TCPXO Networking](../docs/integrator/gke-tcpxo-networking.md#running-the-nccl-benchmark)
+> for prerequisites, TCPXO runtime requirements, result expectations, and a
+> manual standalone benchmark for debugging the data path directly.
 
 ## Success
 
@@ -320,7 +322,7 @@ EOF
 ```
 
 > CLI flags always win over the same field in `--config`, so the same config
-> drives both the pre-deploy dry-run validate and the post-deploy conformance
+> drives both the pre-deploy dry-run validate and the post-deploy `--phase all`
 > validate — phase and `--no-cluster` are toggled on the command line.
 
 ### Snapshot
@@ -351,7 +353,7 @@ aicr validate --config aicr-config.yaml \
 ```
 
 `--phase deployment` and `--no-cluster` are CLI overrides — neither is pinned
-in the config so the same file works for the conformance run below.
+in the config so the same file works for the post-deploy `--phase all` run below.
 
 ### Generate Bundle
 
@@ -387,7 +389,7 @@ cd ..
 
 ```shell
 aicr validate --config aicr-config.yaml \
-    --phase conformance \
+    --phase all \
     --output report.json
 ```
 
@@ -404,7 +406,8 @@ present) to `ghcr.io/<owner>/aicr-evidence`.
     ├── bom.cdx.json                 # CycloneDX SBOM
     ├── ctrf/                        # per-phase CTRF test results
     │   ├── conformance.json
-    │   └── deployment.json
+    │   ├── deployment.json
+    │   └── performance.json
     ├── manifest.json                # per-file sha256 inventory
     ├── recipe.yaml                  # canonical post-resolution recipe
     ├── snapshot.yaml                # cluster snapshot at validate-time
@@ -454,5 +457,5 @@ so no `podTemplateOverrides` are needed.
 ### Success
 
 Job success + signed evidence verifies (`exit 0`) + fabric bandwidth within
-range from the manual NCCL run (see
+range from the automated post-deploy `aicr validate --phase all` run's included performance phase (see
 [GKE TCPXO Networking](../docs/integrator/gke-tcpxo-networking.md#running-the-nccl-benchmark)).

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -117,42 +117,48 @@ Update the `nccl-plugin-gpudirecttcpx-dev` image tag in your workload to match.
 
 ## Running the NCCL Benchmark
 
-The GKE H100 training recipe (`h100-gke-cos-training`) already selects the
-automated `nccl-all-reduce-bw` performance check (floor `>= 250` GB/s), so
-`aicr validate --phase performance` runs the NCCL all-reduce benchmark for you.
-If you want to run the benchmark by hand — for example to debug the GPUDirect
-TCPX data path directly with raw Pods and a TCPXO daemon sidecar, which differs
-from the EKS TrainJob-based approach — use either of the two profiles below.
-Each pod runs a `tcpxo-daemon` sidecar (manages the GPUDirect TCPXO data path)
-plus the `nccl-test` container.
+### Automated (recommended): `aicr validate`
 
-### Option 1: testdata manifests (matches validator framework)
+The GKE H100 training recipe (`h100-gke-cos-training`) already selects the
+automated `nccl-all-reduce-bw` performance check (floor `>= 300` GB/s), so the
+benchmark is fully driven for you:
 
 ```shell
-export NAMESPACE=nccl-perf
-export GPU_COUNT_PER_NODE=8
-export GPU_COUNT=16
-export WORKER_COUNT=2
-export TEST_TYPE=all_reduce_perf
-export MIN_MESSAGE_SIZE=1M
-export MAX_MESSAGE_SIZE=8G
-
-kubectl create ns $NAMESPACE
-envsubst < validators/performance/testdata/h100/gke/runtime.yaml | kubectl apply -f -
-
-# Wait for pods to be 2/2 Running
-kubectl get pods -n $NAMESPACE -o wide -w
-
-# Trigger the AllReduce benchmark from host-1
-kubectl exec nccl-test-host-1 -n $NAMESPACE -c nccl-test -- \
-  /scripts/allreduce.sh nccl-host-1 nccl-host-2
-
-# Expected: ~340 GB/s busBW at 16 GB (AllReduce), ~100 GB/s avg
-# Clean up
-kubectl delete ns $NAMESPACE
+aicr validate --recipe recipes/overlays/h100-gke-cos-training.yaml \
+  --phase performance
 ```
 
-### Option 2: standalone demo manifests
+The validator runs the all-reduce sweep over the validator-fixed `1K`–`16G`
+message-size range and asserts the busBW floor. It deploys the
+`TrainingRuntime` (`validators/performance/testdata/h100/gke/runtime.yaml`)
+**plus** the shared `TrainJob` (`validators/performance/testdata/trainjob.yaml`)
+that actually launches the worker Pods. The runtime template carries the GKE
+multi-NIC and NRI device annotation keys (`networking.gke.io/interfaces` and
+`devices.gke.io/container.tcpxo-daemon`) as `${...}` placeholders, and the
+validator **discovers and substitutes their concrete values dynamically** at
+apply time — the interface list from the cluster's discovered GPU NIC networks
+and the NRI device annotation sized to the per-node GPU count. Because those
+values are resolved at runtime, the framework manifest cannot be reproduced by a
+plain `kubectl apply` / `envsubst` of `runtime.yaml` alone, so running the
+framework path by hand is not supported. Use `aicr validate` for the
+framework-equivalent benchmark.
+
+**Prerequisites:** the automated check needs at least **2 schedulable GPU nodes**
+with allocatable GPUs — the all-reduce measures East-West fabric between nodes.
+The validator counts *discovered* schedulable GPU nodes: with fewer than 2 it
+returns a successful *skipped* result without measuring bandwidth. The selected
+nodes also need **free** GPU capacity (the TrainJob places a full GPU node per
+worker); if the GPUs are already occupied the workers stay Pending and the check
+times out — it does not skip. If Kubeflow Trainer is not already installed, the validator
+downloads and installs it (Trainer v2.2.0 from GitHub, then removes it
+afterward), so the validator environment needs GitHub egress.
+
+### Manual standalone benchmark
+
+To exercise the GPUDirect TCPXO data path directly with raw Pods and a TCPXO
+daemon sidecar (independent of the validator framework — useful for debugging),
+use the standalone demo manifest. Each pod runs a `tcpxo-daemon` sidecar
+(manages the GPUDirect TCPXO data path) plus the `nccl-test` container.
 
 NRI profile (recommended, no `hostNetwork`):
 

--- a/pkg/recipe/nccl_bandwidth_floor_test.go
+++ b/pkg/recipe/nccl_bandwidth_floor_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nccl_bandwidth_floor_test.go pins the production-resolved value of the
+// H100 GKE COS `nccl-all-reduce-bw` performance gate. The K8s-native check
+// runs on the parent leaf and its kubeflow sibling at a fixed busBW floor;
+// the Slinky (slurm) leaf intentionally clears the performance phase
+// (checks/constraints empty) because the K8s-launched check bypasses
+// slurmd and measures the wrong path. Exact-value coverage so a future
+// floor edit cannot silently drift these three overlays apart.
+
+package recipe
+
+import (
+	"context"
+	"testing"
+)
+
+// findPerformanceConstraint returns the value of the named constraint in the
+// resolved performance phase, plus whether it was found.
+func findPerformanceConstraint(v *ValidationConfig, name string) (string, bool) {
+	if v == nil || v.Performance == nil {
+		return "", false
+	}
+	for _, c := range v.Performance.Constraints {
+		if c.Name == name {
+			return c.Value, true
+		}
+	}
+	return "", false
+}
+
+// performanceCheckPresent reports whether the named check appears in the
+// resolved performance phase's checks list.
+func performanceCheckPresent(v *ValidationConfig, name string) bool {
+	if v == nil || v.Performance == nil {
+		return false
+	}
+	for _, ch := range v.Performance.Checks {
+		if ch == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestH100GKENCCLBandwidthFloor asserts the production resolver yields the
+// expected nccl-all-reduce-bw floor for the H100 GKE COS training family.
+func TestH100GKENCCLBandwidthFloor(t *testing.T) {
+	const checkName = "nccl-all-reduce-bw"
+
+	tests := []struct {
+		name string
+		// criteria selects the overlay through the production resolver.
+		criteria *Criteria
+		// wantValue is the expected resolved constraint value when wantPerf
+		// is true.
+		wantValue string
+		// wantPerf is true when the overlay should resolve the K8s-native
+		// nccl-all-reduce-bw check + constraint; false when the performance
+		// phase is cleared (no check, no constraint).
+		wantPerf bool
+	}{
+		{
+			name: "h100-gke-cos-training",
+			criteria: &Criteria{
+				Service:     CriteriaServiceGKE,
+				Accelerator: CriteriaAcceleratorH100,
+				OS:          CriteriaOSCOS,
+				Intent:      CriteriaIntentTraining,
+				Platform:    CriteriaPlatformAny,
+			},
+			wantValue: ">= 300",
+			wantPerf:  true,
+		},
+		{
+			name: "h100-gke-cos-training-kubeflow",
+			criteria: &Criteria{
+				Service:     CriteriaServiceGKE,
+				Accelerator: CriteriaAcceleratorH100,
+				OS:          CriteriaOSCOS,
+				Intent:      CriteriaIntentTraining,
+				Platform:    CriteriaPlatformKubeflow,
+			},
+			wantValue: ">= 300",
+			wantPerf:  true,
+		},
+		{
+			name: "h100-gke-cos-training-slurm",
+			criteria: &Criteria{
+				Service:     CriteriaServiceGKE,
+				Accelerator: CriteriaAcceleratorH100,
+				OS:          CriteriaOSCOS,
+				Intent:      CriteriaIntentTraining,
+				Platform:    CriteriaPlatformSlurm,
+			},
+			wantPerf: false,
+		},
+	}
+
+	ctx := context.Background()
+	store, err := loadMetadataStore(ctx)
+	if err != nil {
+		t.Fatalf("loadMetadataStore: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := store.BuildRecipeResult(ctx, tt.criteria)
+			if err != nil {
+				t.Fatalf("BuildRecipeResult: %v", err)
+			}
+
+			gotValue, found := findPerformanceConstraint(result.Validation, checkName)
+			checkPresent := performanceCheckPresent(result.Validation, checkName)
+
+			if tt.wantPerf {
+				if !checkPresent {
+					t.Errorf("performance check %q not present in resolved checks", checkName)
+				}
+				if !found {
+					t.Fatalf("performance constraint %q not found; expected value %q", checkName, tt.wantValue)
+				}
+				if gotValue != tt.wantValue {
+					t.Errorf("nccl-all-reduce-bw = %q, want %q", gotValue, tt.wantValue)
+				}
+			} else {
+				if checkPresent {
+					t.Errorf("performance check %q should be cleared but is present", checkName)
+				}
+				if found {
+					t.Errorf("performance constraint %q should be cleared but resolved to %q", checkName, gotValue)
+				}
+			}
+		})
+	}
+}

--- a/recipes/evidence/h100-gke-cos-training/7c4c0edc8c765a95a0f3afdb3bbb8e91/sha256-be4680f26ad9ebeb57145f1953f18311ca00e81a4edb37773e0ec1060c6bd261.yaml
+++ b/recipes/evidence/h100-gke-cos-training/7c4c0edc8c765a95a0f3afdb3bbb8e91/sha256-be4680f26ad9ebeb57145f1953f18311ca00e81a4edb37773e0ec1060c6bd261.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-06-30T22:17:15Z
+    bundle:
+      digest: sha256:be4680f26ad9ebeb57145f1953f18311ca00e81a4edb37773e0ec1060c6bd261
+      oci: ghcr.io/nvidia/aicr-evidence:h100-gke-cos-training-cb0800ddf394
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: yuanchen97@gmail.com
+      issuer: https://github.com/login/oauth
+      rekorLogIndex: 2027401692
+recipe: h100-gke-cos-training
+schemaVersion: 1.0.0

--- a/recipes/overlays/a100-aks-training.yaml
+++ b/recipes/overlays/a100-aks-training.yaml
@@ -63,10 +63,12 @@ spec:
   # here.
   #
   # Performance gating is intentionally omitted until an empirical A100-on-Azure
-  # NCCL baseline is established. The H100 AKS training overlay pins an absolute
-  # nccl-all-reduce-bw floor (>= 100); that value is calibrated for H100 ND-series
-  # nodes and is neither fabric-class aware (https://github.com/NVIDIA/aicr/issues/1256)
-  # nor valid for A100, so carrying it would only false-fail healthy runs.
+  # NCCL baseline is established. AKS has no validator NCCL runtime template or
+  # scheduling path (it is not in the support table), so even the H100 AKS
+  # training overlay leaves the performance phase undeclared rather than gate on
+  # an unmeasured floor (see issue #1337). A100 on Azure is likewise unmeasured
+  # and would need its own fabric-aware baseline (#1256), so carrying any floor
+  # here would only false-fail healthy runs.
   validation:
     conformance:
       checks:

--- a/recipes/overlays/a100-gke-cos-training.yaml
+++ b/recipes/overlays/a100-gke-cos-training.yaml
@@ -84,7 +84,7 @@ spec:
   #
   # Performance gating is intentionally omitted until an empirical A100-on-GKE
   # NCCL baseline is established. The H100 GKE training overlay pins an absolute
-  # nccl-all-reduce-bw floor (>= 250) calibrated on 8-GPU H100 NVLink nodes;
+  # nccl-all-reduce-bw floor (>= 300) calibrated on 8-GPU H100 NVLink nodes;
   # that value is neither fabric-class aware (https://github.com/NVIDIA/aicr/issues/1256)
   # nor valid for A100, so carrying it would only false-fail healthy runs.
   validation:

--- a/recipes/overlays/h100-gke-cos-training.yaml
+++ b/recipes/overlays/h100-gke-cos-training.yaml
@@ -96,17 +96,26 @@ spec:
       # https://github.com/NVIDIA/aicr/issues/1256.
       constraints:
         # Fixed absolute floor calibrated on a3-megagpu-8g (8x H100,
-        # 8x GPUDirect TCPXO NICs). This recipe is SKU-agnostic — it
-        # matches all GKE/H100 instance types, including small shapes
-        # (e.g. a3-highgpu-1g: 1 GPU, 1 gVNIC ~100 Gbps) whose pure
-        # inter-node NIC path measures single-digit GB/s and cannot
-        # clear this floor. See #1256. The proper fix is either a
-        # weakest-in-scope liveness floor (option a) or a per-fabric
-        # criteria dimension (option b); both need measured numbers
-        # from the small SKUs that we don't have yet. Keeping the
-        # calibrated value here until then.
+        # 8x GPUDirect TCPXO NICs). >= 300 is grounded in GKE's own
+        # measured all-reduce busbw on this fabric: a3-megagpu-8g over
+        # TCPXO sustains ~338-340 GB/s busbw (validated on 2 nodes /
+        # 16 GPUs — see the committed h100-gke-cos-training evidence run
+        # and docs/integrator/gke-tcpxo-networking.md). With the
+        # validator's 10% tolerance a >= 300 floor has an effective cutoff
+        # of 270 GB/s, leaving ample headroom over that measurement. NCCL
+        # busbw is fabric/transport dependent (GKE TCPXO vs EKS EFA), so
+        # this is NOT derived from the EKS floor — it independently lands
+        # at the same >= 300 value because both fabrics clear it.
+        # This recipe is SKU-agnostic — it matches all GKE/H100 instance
+        # types, including small shapes (e.g. a3-highgpu-1g: 1 GPU, 1 gVNIC
+        # ~100 Gbps) whose pure inter-node NIC path measures single-digit
+        # GB/s and cannot clear this floor. See #1256. The proper fix is
+        # either a weakest-in-scope liveness floor (option a) or a per-fabric
+        # criteria dimension (option b); both need measured numbers from the
+        # small SKUs that we don't have yet. Keeping the calibrated value
+        # here until then.
         - name: nccl-all-reduce-bw
-          value: ">= 250"
+          value: ">= 300"
     conformance:
       checks:
         - platform-health


### PR DESCRIPTION
## Summary

Align the H100 training NCCL all-reduce bandwidth gate across service types by raising the GKE floor from `>= 250` to `>= 300` GB/s (matching EKS), and fix a stale comment in the A100 AKS overlay. Touches 7 files: 3 overlays (h100-gke-cos-training floor 250→300 + rationale comment, a100-gke-cos-training and a100-aks-training stale-comment fixes), 2 docs (`docs/integrator/gke-tcpxo-networking.md` floor + benchmark rewrite, `demos/cuj1-training.md` performance-validation updates), a new `pkg/recipe/nccl_bandwidth_floor_test.go` exact-value resolution test, and an add-only refreshed evidence pointer (`sha256-be4680f2…` added alongside the retained `sha256-f2573e7f…`; bundle in `ghcr.io/nvidia/aicr-evidence`).

## Motivation / Context

The H100 training performance gate (`nccl-all-reduce-bw`) diverged by service provider: `h100-eks-training` pinned `>= 300` GB/s while `h100-gke-cos-training` pinned `>= 250` GB/s. GKE's own measured all-reduce busbw on a3-megagpu-8g over GPUDirect TCPXO is ~338-340 GB/s (validated on 2 nodes / 16 GPUs) (per the committed h100-gke-cos-training evidence run and docs/integrator/gke-tcpxo-networking.md), so a 300 GB/s floor leaves ~12% headroom and is justified on GKE's own merits. NCCL busbw is fabric/transport dependent (GKE TCPXO vs EKS EFA), so the new value is not *derived* from the EKS floor — it independently coincides with the EKS/H100 >= 300 value because both fabrics clear that bar on a full 8-GPU node. The prior >= 250 was conservative relative to GKE's measured number.

It also fixes a stale comment in `a100-aks-training.yaml` that claimed the H100 AKS overlay pins a `>= 100` NCCL floor — H100 on AKS actually leaves the performance phase undeclared (no validator NCCL runtime/scheduling path; AKS is not in the support table, see #1337).

Fixes: N/A
Related: #1256 (fabric-class-aware NCCL gates), #1337 (AKS NCCL runtime), #1564 (make self-installed Kubeflow Trainer version configurable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- `h100-gke-cos-training.yaml`: `nccl-all-reduce-bw` floor `>= 250` → `>= 300`; comment updated to ground the floor in GKE's measured ~338-340 GB/s TCPXO busbw (not the EKS floor or inference throughput).
- `a100-gke-cos-training.yaml`: comment-only fix — updated the cross-reference to the H100 GKE floor (`>= 250` → `>= 300`); A100-on-GKE performance gating remains intentionally omitted.
- `a100-aks-training.yaml`: comment-only fix — corrected the false claim about an H100 AKS `>= 100` floor.
- `docs/integrator/gke-tcpxo-networking.md`: floor reference updated to `>= 300`. Reworked the "Running the NCCL Benchmark" section: removed the non-runnable "Option 1: testdata manifests" block (it applied only the `TrainingRuntime`, which creates no pods, then waited for standalone-demo pod names and ran a script the runtime never creates, and could not reproduce the GKE multi-NIC / NRI device annotations the validator injects dynamically) and replaced it with an "Automated (recommended): `aicr validate`" subsection that documents the real flow (validator applies `runtime.yaml` + shared `trainjob.yaml`, injects `networking.gke.io/interfaces` + NRI device annotations at apply time, sweeps the fixed 1K–16G range). The standalone demo (formerly Option 2) is retained as "Manual standalone benchmark".
- `demos/cuj1-training.md`: updated the GKE "Performance Validation" note and success criterion to reflect that `aicr validate --phase performance` now runs the NCCL all-reduce automatically for `h100-gke-cos-training` (was: "not yet automated for GKE, run manually").
- `recipes/evidence/h100-gke-cos-training/7c4c0edc.../`: refreshed evidence pointer for the tightened gate (see Risk Assessment).
- `pkg/recipe/nccl_bandwidth_floor_test.go` (new): table-driven exact-value resolution coverage through the production `BuildRecipeResult` resolver.
- No change to GB200 gates: EKS gates both `nccl-all-reduce-bw-net` (>= 40) + `-nvls` (>= 500), OKE gates `-nvls` (>= 500) only. The OKE NET variant is intentionally deferred — there is no OKE NET runtime template and OCI pod RDMA exposure is not yet testbed-verified — so it is out of scope here and tracked separately.

## Testing

```bash
make qualify                    # pass (see note below)
go test ./pkg/recipe/...        # ok
golangci-lint run ./pkg/recipe/...  # 0 issues
```

Added exact-value resolution coverage in `pkg/recipe/nccl_bandwidth_floor_test.go`: asserts `h100-gke-cos-training` and `h100-gke-cos-training-kubeflow` resolve `nccl-all-reduce-bw` to `>= 300`, and `h100-gke-cos-training-slurm` resolves to a cleared performance phase (no check, no constraint).

Coverage (per-package gate, current vs `origin/main`):

```
pkg/recipe: 87.1% → 87.1% (+0.0%)   # held; new test exercises already-covered BuildRecipeResult paths
make test-coverage: 78.3% total (threshold 75%) — passed
```

`make qualify` passes. The only `make test` failures in the local sandbox are environmental — packages needing TCP bind / TUF (sigstore) CDN access / live HTTP test servers (`pkg/server`, `pkg/trust`, `pkg/cli`, `pkg/config`, `pkg/oci`, `pkg/serializer`) fail with `bind: operation not permitted` under the network sandbox; all pass when re-run with network access. None are attributable to this PR.

## Risk Assessment

- [x] **Low** — Isolated change to 3 recipe overlays + 2 docs + 1 test + refreshed evidence pointer, easy to revert.

**Evidence refreshed in this PR:** re-validated on a GKE H100 a3-megagpu cluster (measured 338.1 GB/s, clears the new >= 300 floor) and added a refreshed, keyless-signed pointer (`sha256-be4680f2…`, bundle in `ghcr.io/nvidia/aicr-evidence`, recipe digest 3dd9929 matches). Add-only: the prior `sha256-f2573e7f…` pointer is retained per the immutable evidence model (ADR-007). Signer is the allowlisted community identity for this source.



**Rollout notes:** Raises the GKE H100 training performance floor. The validator applies a 10% tolerance (`bandwidth >= threshold * 0.9`), so the effective cutoff moves from 225 GB/s (old 250) to 270 GB/s (new 300). A GKE H100 run measuring 225-269 GB/s that previously passed would now fail; the committed evidence run (~338 GB/s) still clears the new floor with headroom.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)








