### PR TITLE
feat(validation): exempt RTX Pro 6000 LKE training from NCCL performance floor

### DIFF
--- a/pkg/recipe/validation_phase_floor_test.go
+++ b/pkg/recipe/validation_phase_floor_test.go
@@ -99,6 +99,21 @@ func (c classification) requiresPerformance() bool {
 	if c.IsKind || !c.isAcceleratorBound() {
 		return false
 	}
+	// LKE RTX Pro 6000 training has no meaningful NCCL all-reduce gate at
+	// any node count: RTX Pro 6000 is a workstation-class card and Linode
+	// exposes no multi-node RDMA fabric, so an all-reduce would be
+	// Ethernet-bound with no empirically-grounded threshold to assert —
+	// even a multi-node request cannot run the bandwidth check meaningfully.
+	// Exempt these overlays rather than block on a Linode testbed that
+	// would only ever measure Ethernet-bound throughput. Scoped to lke so
+	// a future rtx-pro-6000 training overlay on a fabric-capable service
+	// is not silently exempted. See #1008.
+	lkeRTXProTraining := c.Service == CriteriaServiceLKE &&
+		c.Accelerator == CriteriaAcceleratorRTXPro6000 &&
+		c.Intent == CriteriaIntentTraining
+	if lkeRTXProTraining {
+		return false
+	}
 	if c.Intent == CriteriaIntentTraining {
 		return true
 	}
@@ -357,6 +372,10 @@ func TestClassifyOverlay(t *testing.T) {
 		{"training-eks-h100", CriteriaIntentTraining, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, true, true},
 		{"training-aks-h100-kubeflow", CriteriaIntentTraining, CriteriaServiceAKS, CriteriaPlatformKubeflow, CriteriaAcceleratorH100, false, true, true},
 		{"training-kind-h100", CriteriaIntentTraining, CriteriaServiceKind, CriteriaPlatformAny, CriteriaAcceleratorH100, true, true, false},
+		// RTX Pro 6000 is workstation-class (single-node, no multi-node
+		// RDMA fabric): deployment required, but the NCCL all-reduce
+		// performance floor is N/A. See requiresPerformance.
+		{"training-lke-rtx-pro-6000", CriteriaIntentTraining, CriteriaServiceLKE, CriteriaPlatformAny, CriteriaAcceleratorRTXPro6000, false, true, false},
 		{"inference-eks-h100-plain", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformAny, CriteriaAcceleratorH100, false, true, false},
 		{"inference-eks-h100-dynamo", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformDynamo, CriteriaAcceleratorH100, false, true, true},
 		{"inference-eks-h100-nim", CriteriaIntentInference, CriteriaServiceEKS, CriteriaPlatformNIM, CriteriaAcceleratorH100, false, true, true},

--- a/recipes/overlays/rtx-pro-6000-lke-training.yaml
+++ b/recipes/overlays/rtx-pro-6000-lke-training.yaml
@@ -26,6 +26,12 @@ spec:
     accelerator: rtx-pro-6000
     intent: training
 
+  # No performance phase: RTX Pro 6000 is a workstation-class card and LKE
+  # exposes no multi-node RDMA fabric, so the nccl-all-reduce-bw gate has no
+  # meaningful threshold at any node count (an all-reduce here is
+  # Ethernet-bound). The strict validation floor exempts LKE rtx-pro-6000
+  # training accordingly. See #1008.
+
   # Specific constraints for RTX PRO 6000 on LKE training workloads
   # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
   constraints:

--- a/recipes/overlays/rtx-pro-6000-lke-ubuntu-training.yaml
+++ b/recipes/overlays/rtx-pro-6000-lke-ubuntu-training.yaml
@@ -28,6 +28,12 @@ spec:
     os: ubuntu
     intent: training
 
+  # No performance phase: RTX Pro 6000 is a workstation-class card and LKE
+  # exposes no multi-node RDMA fabric, so the nccl-all-reduce-bw gate has no
+  # meaningful threshold at any node count (an all-reduce here is
+  # Ethernet-bound). The strict validation floor exempts LKE rtx-pro-6000
+  # training accordingly. See #1008.
+
   # Ubuntu OS constraints via mixin
   mixins:
     - os-ubuntu


### PR DESCRIPTION
## Summary

Exempt RTX Pro 6000 training overlays from the NCCL all-reduce-bw performance floor, since the card is workstation-class with no multi-node RDMA fabric. Resolves the strict-floor gap for the two LKE training overlays without blocking on a Linode testbed.

## Motivation / Context

The strict validation floor (`AICR_VALIDATION_FLOOR_STRICT=1`) flagged `rtx-pro-6000-lke-training` and `rtx-pro-6000-lke-ubuntu-training` as missing a performance phase. #1008 tracked adding an `nccl-all-reduce-bw` constraint once a Linode LKE testbed lands — but RTX Pro 6000 is a single-GPU workstation card with no multi-node RDMA fabric on LKE, so a multi-node NCCL bandwidth gate is **not applicable**, not merely pending a testbed (which would only ever measure Ethernet-bound throughput). This implements design-note option 2 from #1008: treat these overlays as single-node training and exempt them from the multi-node NCCL floor.

Fixes: #1008
Related: #1043 (performance-phase epic)

## Type of Change

- [x] Refactoring (no functional changes) / validation-contract update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Docs/examples (recipe overlays)

## Implementation Notes

- `pkg/recipe/validation_phase_floor_test.go`: `requiresPerformance()` returns false for `accelerator=rtx-pro-6000` + `intent=training`; added a `TestClassifyOverlay` case (`training-lke-rtx-pro-6000`) asserting deployment required / performance N/A. The only rtx-pro-6000 training overlays today are the two LKE ones, so the exemption is precisely scoped (all other rtx-pro-6000 overlays are inference and unaffected).
- `recipes/overlays/rtx-pro-6000-lke-training.yaml`, `...-ubuntu-training.yaml`: documented why no performance phase applies.

## Testing

```bash
make qualify
go test ./pkg/recipe/ -run 'TestOverlayValidationPhaseFloor|TestClassifyOverlay'
AICR_VALIDATION_FLOOR_STRICT=1 go test ./pkg/recipe/ -run TestOverlayValidationPhaseFloor   # rtx-pro-6000-lke-* no longer flagged
```

Default floor test (the CI gate) green; in strict mode the two LKE training overlays no longer appear as gaps. golangci-lint + yamllint clean on the changed paths.

## Risk Assessment

- [x] **Low** — Narrowly-scoped validation-floor classification change + overlay comments; no runtime/bundle behavior change.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
