### PR TITLE
feat(ci): route UAT through the reservation broker (#1274)

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -14,27 +14,44 @@
 
 name: UAT - AWS
 
+# Reusable per-cloud UAT pipeline — invoked by uat-run.yaml, the shared
+# dispatch surface that owns the per-reservation concurrency lease (#1274,
+# DC1). It is intentionally NOT directly dispatchable or scheduled: the
+# nightly cron lives in uat-nightly-batch.yaml and ad-hoc runs go through
+# uat-run.yaml, so every run on the AWS reservation serializes on the same
+# lease. The filename is kept so the keyless-cosign signing identity (and the
+# EXPECTED_IDENTITY_REGEXP pins) stay `uat-aws.yaml@…` unchanged.
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      reservation:
+        description: 'Reservation name (lease key) this run targets; used for labeling.'
+        type: string
+        required: true
+      cluster_config_path:
+        description: 'Cluster-config the EKS actuator provisions from (from infra/uat/reservations.yaml).'
+        type: string
+        required: true
+      test_config_dir:
+        description: 'Directory holding the AICRConfig test files (from infra/uat/reservations.yaml).'
+        type: string
+        required: true
       skip_delete:
-        description: 'Skip cluster teardown (manual runs only; schedule always deletes)'
+        description: 'Skip cluster teardown (manual runs only; the nightly batch always deletes).'
         type: boolean
         default: false
       skip_tests:
-        description: 'Skip UAT test execution (manual runs only; schedule always tests)'
+        description: 'Skip UAT test execution (manual runs only; the nightly batch always tests).'
         type: boolean
         default: false
-  schedule:
-    - cron: '0 4 * * *' # daily at midnight PST, runs on default branch only
 
 permissions:
   contents: read
 
-# Long-running cloud provisioning — never cancel mid-teardown.
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+# NOTE: the per-reservation concurrency lease is owned by the caller
+# (uat-run.yaml). A reusable workflow must not declare its own concurrency
+# here, or every reservation would serialize against one group instead of
+# queueing per reservation.
 
 jobs:
   uat-aws:
@@ -61,8 +78,9 @@ jobs:
       AWS_REGION: "us-east-1"
       GITHUB_ACTIONS_ROLE_NAME: "github-actions-role-aicr"
       DEPLOYMENT_ID: "aicr-uat-${{ github.run_id }}"
-      CLUSTER_CONFIG: tests/uat/aws/cluster-config.yaml
-      TEST_CONFIG: tests/uat/aws/tests/h100-training-config.yaml
+      CLUSTER_CONFIG: ${{ inputs.cluster_config_path }}
+      # Training is the DC1 launch intent; DC2 selects the file by intent.
+      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-training-config.yaml
       # v0.4.23 — required for the .eks-nested cluster-config schema; the
       # prior pin (v0.2.6) read .compute.nodeGroups.* directly and failed
       # Terraform parse with "object with 1 attribute eks".
@@ -359,10 +377,13 @@ jobs:
       # Summary
       - name: Test Summary
         if: always()
+        env:
+          SUMMARY_RESERVATION: ${{ inputs.reservation }}
         run: |
           {
             echo "## UAT Results (AWS)"
             echo ""
+            printf '**Reservation:** `%s`\n' "$SUMMARY_RESERVATION"
             echo "**Build:** \`${{ github.sha }}\` (branch: \`${{ github.ref_name }}\`)"
             echo ""
             echo "| Phase | Status |"

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -14,27 +14,44 @@
 
 name: UAT - GCP
 
+# Reusable per-cloud UAT pipeline — invoked by uat-run.yaml, the shared
+# dispatch surface that owns the per-reservation concurrency lease (#1274,
+# DC1). It is intentionally NOT directly dispatchable or scheduled: the
+# nightly cron lives in uat-nightly-batch.yaml and ad-hoc runs go through
+# uat-run.yaml, so every run on the GCP reservation serializes on the same
+# lease. The filename is kept so the keyless-cosign signing identity (and the
+# EXPECTED_IDENTITY_REGEXP pins) stay `uat-gcp.yaml@…` unchanged.
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      reservation:
+        description: 'Reservation name (lease key) this run targets; used for labeling.'
+        type: string
+        required: true
+      cluster_config_path:
+        description: 'Cluster-config the GKE actuator provisions from (from infra/uat/reservations.yaml).'
+        type: string
+        required: true
+      test_config_dir:
+        description: 'Directory holding the AICRConfig test files (from infra/uat/reservations.yaml).'
+        type: string
+        required: true
       skip_delete:
-        description: 'Skip cluster teardown (manual runs only; schedule always deletes)'
+        description: 'Skip cluster teardown (manual runs only; the nightly batch always deletes).'
         type: boolean
         default: false
       skip_tests:
-        description: 'Skip UAT test execution (manual runs only; schedule always tests)'
+        description: 'Skip UAT test execution (manual runs only; the nightly batch always tests).'
         type: boolean
         default: false
-  schedule:
-    - cron: '0 4 * * *' # daily at midnight PST, runs on default branch only
 
 permissions:
   contents: read
 
-# Long-running cloud provisioning — never cancel mid-teardown.
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+# NOTE: the per-reservation concurrency lease is owned by the caller
+# (uat-run.yaml). A reusable workflow must not declare its own concurrency
+# here, or every reservation would serialize against one group instead of
+# queueing per reservation.
 
 jobs:
   uat-gcp:
@@ -62,8 +79,9 @@ jobs:
       GCP_WIF_PROVIDER: "projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider"
       GCP_WIF_SERVICE_ACCOUNT: "github-actions@eidosx.iam.gserviceaccount.com"
       DEPLOYMENT_ID: "aicr-${{ github.run_id }}"
-      CLUSTER_CONFIG: tests/uat/gcp/cluster-config.yaml
-      TEST_CONFIG: tests/uat/gcp/tests/h100-training-config.yaml
+      CLUSTER_CONFIG: ${{ inputs.cluster_config_path }}
+      # Training is the DC1 launch intent; DC2 selects the file by intent.
+      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-training-config.yaml
       GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:latest"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
@@ -181,7 +199,7 @@ jobs:
         run: |
           set -euox pipefail
           docker run \
-            -e CONFIG_CONTENT="$(base64 < $CLUSTER_CONFIG)" \
+            -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
             -e AUTO_APPROVE=true \
             -e KEY_CONTENT="$(base64 < ${{ steps.auth.outputs.credentials_file_path }})" \
             ${{ env.GKE_ACTUATOR_IMAGE }} apply
@@ -332,10 +350,13 @@ jobs:
       # Summary
       - name: Test Summary
         if: always()
+        env:
+          SUMMARY_RESERVATION: ${{ inputs.reservation }}
         run: |
           {
             echo "## UAT Results (GCP)"
             echo ""
+            printf '**Reservation:** `%s`\n' "$SUMMARY_RESERVATION"
             echo "**Build:** \`${{ github.sha }}\` (branch: \`${{ github.ref_name }}\`)"
             echo ""
             echo "| Phase | Status |"
@@ -400,7 +421,7 @@ jobs:
           for attempt in 1 2 3; do
             echo "Destroy attempt ${attempt}..."
             if docker run \
-              -e CONFIG_CONTENT="$(base64 < $CLUSTER_CONFIG)" \
+              -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
               -e AUTO_APPROVE=true \
               -e KEY_CONTENT="$(base64 < ${{ steps.auth_teardown.outputs.credentials_file_path }})" \
               ${{ env.GKE_ACTUATOR_IMAGE }} apply; then

--- a/.github/workflows/uat-nightly-batch.yaml
+++ b/.github/workflows/uat-nightly-batch.yaml
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: UAT Nightly Batch
+
+# The night side of the day/night cycle (#1274, DC1): on a nightly cron, run
+# one UAT pass per reservation. Reservations are enumerated from the
+# checked-in registry (infra/uat/reservations.yaml) so adding a reservation
+# needs no change here. Each cell invokes the shared uat-run.yaml, which holds
+# the per-reservation lease — so different reservations (independent hardware)
+# run in parallel while runs on the SAME reservation serialize.
+#
+# PR-2 scope: one main (build-from-source) pass per reservation. The
+# time-boxed, main-first, previous-N-stable version matrix (uat-broker
+# schedule) lands in the follow-up (DC1 PR-3 / DC5's versioned install).
+on:
+  schedule:
+    - cron: '0 4 * * *' # 04:00 UTC daily (evening in US Pacific); default branch only
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Serialize batch runs: a manual dispatch should not fan out a second batch
+# alongside the cron one. (The per-reservation leases in uat-run.yaml would
+# queue the duplicates anyway, but there is no reason to start them.)
+concurrency:
+  group: uat-nightly-batch
+  cancel-in-progress: false
+
+jobs:
+  # Enumerate reservation names from the registry into a JSON array for the
+  # matrix below — keeps the batch data-driven (no per-reservation YAML).
+  enumerate:
+    if: github.repository == 'nvidia/aicr'
+    runs-on: ubuntu-latest
+    outputs:
+      reservations: ${{ steps.list.outputs.reservations }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: '${{ steps.versions.outputs.go }}'
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            vendor/modules.txt
+      - name: Enumerate reservations
+        id: list
+        env:
+          GOFLAGS: -mod=vendor
+        run: |
+          set -euo pipefail
+          go build -o ./bin/uat-broker ./tools/uat-broker
+          mapfile -t names < <(./bin/uat-broker reservations --list)
+          if [ "${#names[@]}" -eq 0 ]; then
+            echo "::error::no reservations found in infra/uat/reservations.yaml"
+            exit 1
+          fi
+          json=$(printf '%s\n' "${names[@]}" | jq -R . | jq -cs .)
+          echo "reservations=${json}" >> "$GITHUB_OUTPUT"
+          echo "Reservations: ${json}"
+
+  # One UAT pass per reservation. Different reservations are independent
+  # hardware, so they run in parallel; uat-run.yaml's per-reservation lease
+  # serializes any run that shares a reservation (e.g. a concurrent ad-hoc
+  # dispatch). The caller grants the permission superset uat-run.yaml's nested
+  # pipeline + evidence-ingest need.
+  run:
+    needs: enumerate
+    strategy:
+      fail-fast: false
+      matrix:
+        reservation: ${{ fromJSON(needs.enumerate.outputs.reservations) }}
+    # Superset ceiling for the nested pipeline (uat-run.yaml → uat-{aws,gcp}
+    # → evidence-ingest); a reusable workflow's jobs cannot exceed it.
+    permissions:
+      contents: read  # checkout inside the called pipeline
+      actions: read  # required by the nested uat-{aws,gcp} + evidence-ingest jobs
+      id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
+      packages: write  # push validator + snapshot-agent images to GHCR
+    uses: ./.github/workflows/uat-run.yaml
+    with:
+      reservation: ${{ matrix.reservation }}

--- a/.github/workflows/uat-run.yaml
+++ b/.github/workflows/uat-run.yaml
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: UAT Run
+
+# The shared UAT dispatch surface and reservation-lease owner (#1274, DC1).
+# A human (workflow_dispatch) or the nightly batch (workflow_call) requests a
+# run against a named reservation; this workflow holds the per-reservation
+# concurrency lease, resolves the reservation row from the checked-in registry
+# (infra/uat/reservations.yaml) via the uat-broker helper, and dispatches the
+# cloud-appropriate reusable pipeline. Because every run for a reservation
+# routes through here and shares the lease, contending runs QUEUE instead of
+# racing the hardware.
+on:
+  workflow_dispatch:
+    inputs:
+      reservation:
+        description: 'Reservation name from infra/uat/reservations.yaml (e.g. aws-h100, gcp-h100).'
+        type: string
+        required: true
+      skip_delete:
+        description: 'Skip cluster teardown (manual debugging only).'
+        type: boolean
+        default: false
+      skip_tests:
+        description: 'Skip UAT test execution (manual debugging only).'
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      reservation:
+        type: string
+        required: true
+      skip_delete:
+        type: boolean
+        default: false
+      skip_tests:
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# The reservation lease. Every run targeting a given reservation serializes on
+# this group, so a contender waits rather than racing the reservation;
+# cancel-in-progress:false keeps an in-progress run (and its teardown) from
+# being killed.
+#
+# NOTE: this is a single-slot lease, not a full queue. GitHub concurrency holds
+# at most one in-progress + one PENDING run per group; a third contender
+# supersedes (cancels) the older pending one — cancel-in-progress:false only
+# protects the in-progress run, not the pending slot. Acceptable at launch (two
+# reservations, at most cron + one ad-hoc each); preserving every request would
+# need the deferred standing broker (see docs/contributor/uat.md, #1264).
+#
+# github.event.inputs is used for the dispatch path because the inputs context
+# is unreliable in a top-level concurrency group on workflow_dispatch
+# (community #45734/#35341); inputs.* covers the workflow_call path, where
+# github.event.inputs is empty.
+concurrency:
+  group: uat-${{ github.event.inputs.reservation || inputs.reservation }}
+  cancel-in-progress: false
+
+jobs:
+  # Resolve the reservation row to the cloud + on-disk config paths the
+  # cloud-specific pipeline consumes. A typo'd reservation name fails here
+  # (uat-broker exits NOT_FOUND), so the registry is the single source of truth.
+  resolve:
+    if: github.repository == 'nvidia/aicr'
+    runs-on: ubuntu-latest
+    outputs:
+      cloud: ${{ steps.row.outputs.cloud }}
+      cluster_config_path: ${{ steps.row.outputs['cluster-config-path'] }}
+      test_config_dir: ${{ steps.row.outputs['test-config-dir'] }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: '${{ steps.versions.outputs.go }}'
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            vendor/modules.txt
+      - name: Resolve reservation row
+        id: row
+        env:
+          GOFLAGS: -mod=vendor
+          # Pass via env (not inline interpolation) to avoid expression
+          # injection through the dispatch input.
+          RESERVATION: ${{ inputs.reservation }}
+        run: |
+          set -euo pipefail
+          go build -o ./bin/uat-broker ./tools/uat-broker
+          ./bin/uat-broker reservations --name "$RESERVATION" >> "$GITHUB_OUTPUT"
+
+  # One of run-aws / run-gcp fires based on the resolved cloud (the registry
+  # validates cloud ∈ {aws,gcp}, so exactly one matches). The caller job grants
+  # the permission SUPERSET its callee needs — a reusable workflow's jobs are
+  # ceilinged by the calling job's permissions, and the called pipeline does
+  # OIDC, GHCR push, and (nested) evidence-ingest GCS WIF.
+  run-aws:
+    needs: resolve
+    if: needs.resolve.outputs.cloud == 'aws'
+    # Superset ceiling for the nested pipeline (a reusable workflow's jobs
+    # cannot exceed the caller's permissions).
+    permissions:
+      contents: read  # checkout inside the called pipeline
+      actions: read  # required by the nested uat-{aws,gcp} + evidence-ingest jobs
+      id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
+      packages: write  # push validator + snapshot-agent images to GHCR
+    uses: ./.github/workflows/uat-aws.yaml
+    with:
+      reservation: ${{ inputs.reservation }}
+      cluster_config_path: ${{ needs.resolve.outputs.cluster_config_path }}
+      test_config_dir: ${{ needs.resolve.outputs.test_config_dir }}
+      skip_delete: ${{ inputs.skip_delete }}
+      skip_tests: ${{ inputs.skip_tests }}
+
+  run-gcp:
+    needs: resolve
+    if: needs.resolve.outputs.cloud == 'gcp'
+    # Superset ceiling for the nested pipeline (a reusable workflow's jobs
+    # cannot exceed the caller's permissions).
+    permissions:
+      contents: read  # checkout inside the called pipeline
+      actions: read  # required by the nested uat-{aws,gcp} + evidence-ingest jobs
+      id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
+      packages: write  # push validator + snapshot-agent images to GHCR
+    uses: ./.github/workflows/uat-gcp.yaml
+    with:
+      reservation: ${{ inputs.reservation }}
+      cluster_config_path: ${{ needs.resolve.outputs.cluster_config_path }}
+      test_config_dir: ${{ needs.resolve.outputs.test_config_dir }}
+      skip_delete: ${{ inputs.skip_delete }}
+      skip_tests: ${{ inputs.skip_tests }}

--- a/demos/cuj1-training.md
+++ b/demos/cuj1-training.md
@@ -229,12 +229,15 @@ recipe-evidence bundle out.
 
 ### Assumptions
 
-* Target cluster is the UAT GKE cluster provisioned by
-  [`.github/workflows/uat-gcp.yaml`](../.github/workflows/uat-gcp.yaml). To
-  bring it up without running the UAT suite or tearing it down:
+* Target cluster is the UAT GKE cluster provisioned by the
+  [`.github/workflows/uat-gcp.yaml`](../.github/workflows/uat-gcp.yaml)
+  pipeline. It is now invoked through the shared dispatch surface
+  [`uat-run.yaml`](../.github/workflows/uat-run.yaml) keyed by reservation
+  (#1274); to bring the cluster up without running the UAT suite or tearing it
+  down:
 
   ```shell
-  gh workflow run uat-gcp.yaml -f skip_delete=true -f skip_tests=true
+  gh workflow run uat-run.yaml -f reservation=gcp-h100 -f skip_delete=true -f skip_tests=true
   ```
 
   > Make sure to cleanup after yourself

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -1,0 +1,62 @@
+# UAT Day/Night Cycle and Reservation Broker
+
+**AICR's real-hardware UAT runs on a small set of reserved GPU pools that must be time-shared.** The day/night broker (issue #1274) arbitrates that scarce capacity so contending runs *queue* instead of racing the hardware, driven entirely by a checked-in registry. This page explains the operating model, how to request a run, how queuing behaves, and how to add a reservation.
+
+## The day/night cycle
+
+Each reserved GPU pool follows a daily cycle, with every phase acquiring the *same* per-reservation lease so CI and human use never overlap on one reservation:
+
+- **Night — the nightly batch.** On a cron, `uat-nightly-batch.yaml` runs one UAT pass per reservation (provision → CUJ → evidence → publish → teardown).
+- **Morning — handoff.** Once the batch drains a reservation, the daytime human-access deployment is stood up on it (owned by DC2/DC8; not yet implemented).
+- **Day — human use.** The daytime cluster is used outside CI.
+- **Evening — teardown.** The daytime cluster is torn down before the next night batch.
+
+The phases are independently scheduled (cron edges), not chained: the per-reservation lease — plus a pre-batch guard (DC2) — keeps them from overlapping, so a crashed or overrunning phase never orphans the reservation. A hosted GitHub Actions job is capped at the runner's timeout (hours, not a whole working day), so a single lease-holding run cannot span the day; the lease only needs to cover the brief transition windows, and the steady-state daytime cluster's existence is guarded by its lease-tag rather than a continuously held run.
+
+> The morning handoff, the daytime deployment, and the evening teardown are owned by sibling work (DC2 and DC8) and are not yet wired up. What ships today is the **night side** (the nightly batch) plus the **lease + dispatch surface** every phase builds on.
+
+## Requesting a UAT run
+
+All UAT runs go through one entry point, `uat-run.yaml` — the shared dispatch surface that owns the reservation lease. To request a run, dispatch it with a reservation name from the registry:
+
+```bash
+gh workflow run uat-run.yaml --repo NVIDIA/aicr --ref main -f reservation=aws-h100
+```
+
+`uat-run.yaml` resolves the reservation row, then invokes the cloud-appropriate reusable pipeline (`uat-aws.yaml` or `uat-gcp.yaml`). A typo'd reservation name fails fast in the resolve step (the `uat-broker` helper exits *not found*). For manual debugging, `skip_tests` and `skip_delete` inputs are available.
+
+The nightly batch and (later) the daytime handoff call this *same* surface, so every run for a reservation contends on one lease.
+
+## How queuing works (the reservation lease)
+
+The lease is a GitHub Actions concurrency group keyed by reservation name — `uat-<reservation>` (for example `uat-aws-h100`) — declared on `uat-run.yaml` with `cancel-in-progress: false`. Two runs that target the *same* reservation serialize: the second waits until the first (including its teardown) finishes. Two runs that target *different* reservations share no group and run in parallel, because they are independent hardware.
+
+This replaces the previous behavior, where a second run hitting a busy AWS reservation hard-failed on the capacity check. Now it queues.
+
+**The one-in-progress-plus-one-pending limit.** GitHub concurrency holds at most one in-progress run plus one pending run per group. If a *third* run is queued for a reservation that already has one in-progress and one pending, GitHub cancels the older pending run and the newest takes its place. At launch this is acceptable: there are two reservations, each contended by at most the nightly cron plus an occasional ad-hoc dispatch. A run cancelled this way is *superseded*, not failed; surfacing that signal so a dropped request is never silent is handled by the reliability follow-up (DC6). If deeper queuing is ever needed (many requesters per reservation), the escalation path is the *Deferred* standing broker service — a pull-based queue rather than GitHub concurrency — recorded in the epic (#1264).
+
+## Adding a reservation
+
+Reservations are data, not code. To onboard a new reserved pool, add a row to `infra/uat/reservations.yaml`:
+
+```yaml
+- name: aws-b200          # the lease key; becomes concurrency group uat-aws-b200
+  cloud: aws              # aws | gcp — selects which pipeline (EKS vs GKE) provisions
+  reservation-id: cr-...  # the cloud capacity-reservation id (GCP uses the full path)
+  accelerator: b200
+  gpu-count: 8
+  cluster-config-path: tests/uat/aws/cluster-config-b200.yaml
+  test-config-dir: tests/uat/aws/tests
+```
+
+No broker, workflow, or Go change is needed — the nightly batch enumerates rows from the registry, and `uat-run.yaml` resolves them. The unit of sequencing is the *reservation*, so a new GPU type in an existing cloud simply runs in parallel with the others on its own lease. (Provisioning is per *cloud*: the same `uat-aws.yaml` pipeline provisions any AWS accelerator from the row's `cluster-config-path`; you do not add a per-accelerator workflow.)
+
+The values in this file are identifiers, **not secrets** — a reservation-id grants no access on its own; access to the reserved capacity is governed by cloud IAM/ACLs bound to the CI federation identity (see `infra/uat-aws-account/` and `infra/uat-gcp-account/`). They are safe to commit.
+
+## Roadmap
+
+What ships now is the lease, the data-driven dispatch surface, and a main-only nightly batch. Still to come:
+
+- **Version matrix (DC1 follow-up / DC5).** The nightly batch will expand into a time-boxed, `main`-first, previous-N-stable-releases schedule (`uat-broker schedule`), each release row installing the released `aicr` images at that version.
+- **Superseded-run surfacing (DC6).** A reactive notice so a dropped (superseded) request is visible to its requester.
+- **Per-intent shaping + daytime deployment (DC2 / DC8).** Selecting the test config and recipe by `intent`, and the morning-handoff daytime human-access cluster.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -108,3 +108,5 @@ navigation:
         path: contributor/maintaining.md
       - page: Publishing Recipe Evidence
         path: contributor/evidence-publishing.md
+      - page: UAT Day/Night Cycle
+        path: contributor/uat.md

--- a/infra/uat-aws-account/README.md
+++ b/infra/uat-aws-account/README.md
@@ -1,6 +1,6 @@
 # AWS Account OIDC Setup for GitHub Actions
 
-Terraform configuration for AWS IAM OIDC federation enabling keyless GitHub Actions auth for the daily UAT workflow ([`.github/workflows/uat-aws.yaml`](../../.github/workflows/uat-aws.yaml)) that creates ephemeral EKS clusters.
+Terraform configuration for AWS IAM OIDC federation enabling keyless GitHub Actions auth for the UAT pipeline ([`.github/workflows/uat-aws.yaml`](../../.github/workflows/uat-aws.yaml)) that creates ephemeral EKS clusters. The pipeline is invoked through the shared dispatch surface (`uat-run.yaml`) — for ad-hoc runs and via the nightly batch (`uat-nightly-batch.yaml`) on a cron.
 
 ## Prerequisites
 

--- a/infra/uat-gcp-account/README.md
+++ b/infra/uat-gcp-account/README.md
@@ -1,6 +1,6 @@
 # UAT GCP Account Setup
 
-IAM configuration for the nightly GKE UAT workflow (`.github/workflows/uat-gcp.yaml`).
+IAM configuration for the GKE UAT pipeline (`.github/workflows/uat-gcp.yaml`), invoked through the shared dispatch surface (`uat-run.yaml`) for ad-hoc runs and via the nightly batch (`uat-nightly-batch.yaml`) on a cron.
 
 ## Relationship to demo-api-server
 


### PR DESCRIPTION
## Summary

DC1 PR-2 — the broker cutover: route all real-hardware UAT through a shared dispatch surface that holds a per-reservation concurrency lease, so contending runs *queue* instead of racing the reserved GPU hardware. Registry-driven; behavior is otherwise the existing UAT lane, rewired.

## Motivation / Context

Second of four PRs implementing **DC1 — day/night scheduler + reservation broker** (#1274), part of the UAT epic (#1264), building on the reservation registry + `uat-broker` helper merged in #1559. Today each per-cloud UAT workflow serializes only against itself, and AWS hard-fails when its reservation is busy; this PR replaces that with a reservation-keyed lease so a contending run queues rather than racing (or failing).

Fixes: N/A
Related: #1274, #1264, #1559

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.github/workflows/` (UAT lane), `infra/uat-*-account/` READMEs

## Implementation Notes

- **New `uat-run.yaml`** — the lease owner + dispatch surface. Top-level `concurrency: uat-${{ github.event.inputs.reservation || inputs.reservation }}` (`cancel-in-progress: false`); a `resolve` job builds the `uat-broker` helper and resolves the reservation row from `infra/uat/reservations.yaml`; `run-aws`/`run-gcp` invoke the cloud pipeline with the permission superset the nested pipeline + evidence-ingest need. Both `workflow_dispatch` (human) and `workflow_call` (batch).
- **`uat-aws.yaml` / `uat-gcp.yaml` converted in place** to `workflow_call`-only: dropped the per-workflow `schedule` cron and self-`concurrency`; `CLUSTER_CONFIG`/`TEST_CONFIG` now come from the registry via inputs. **Filenames kept**, so the keyless-cosign identity pins stay valid; the pipeline bodies are otherwise untouched and `ingest-evidence` stays nested.
- **New `uat-nightly-batch.yaml`** — the cron night side: enumerate reservations from the registry into a `fromJSON` matrix that `uses: uat-run.yaml` (mirrors the existing `kwok-recipes.yaml` dynamic-matrix pattern, so no `gh workflow run` token dependency). Different reservations run in parallel; same-reservation runs serialize on the lease.
- **Docs** — `docs/contributor/uat.md` (day/night model, requesting a run, queuing + the one-in-progress-plus-one-pending limit + standing-broker escalation, adding a reservation, and the ACL/non-secret note), registered in `docs/index.yml`. Also fixes the now-stale `gh workflow run uat-gcp.yaml` command in `demos/cuj1-training.md` and clarifies the two infra-account READMEs.

### Scope / boundaries

Exercises the **`main` × training** cell on **both reservations** (`aws-h100`, `gcp-h100`). Deferred to their consuming work to avoid dead pass-through inputs:

- the time-boxed `main`-first version matrix → **PR-3 / DC5** (`uat-broker schedule` + versioned install)
- `intent` → test-config / recipe selection → **DC2 / DC3** (inference)
- superseded-run surfacing → **DC6**

`reservation` is a free-form string validated against the registry (not a hardcoded `choice`), so adding a GPU pool stays a one-row data edit.

## Testing

```bash
actionlint .github/workflows/uat-run.yaml .github/workflows/uat-nightly-batch.yaml \
           .github/workflows/uat-aws.yaml .github/workflows/uat-gcp.yaml
yamllint -c .yamllint.yaml <the four workflows> docs/index.yml
./tools/check-docs-mdx && ./tools/check-docs-filenames
```

- `actionlint` clean on all four workflows (this validates the reusable-workflow input wiring between `uat-run.yaml` and the per-cloud pipelines).
- `yamllint` clean; `check-docs-mdx` + `check-docs-filenames` pass.
- No Go changes — the `uat-broker` helper (with its unit tests) landed in #1559.

## Risk Assessment

- [x] **Medium** — Touches the live UAT lane (a rewiring), though isolated to that lane and straightforward to revert.

**Rollout notes:** The cutover is atomic — the per-cloud crons move to `uat-nightly-batch.yaml` in the same change, so there is no window without nightly coverage and no window where two triggers can hit a reservation without sharing the lease. Real-hardware behavior can only be validated post-merge (the nightly cron fires on the default branch); the smoke test is a manual `gh workflow run uat-run.yaml -f reservation=aws-h100`. One watch-item: the nightly path nests four reusable-workflow levels (batch → uat-run → uat-aws → evidence-ingest), which is GitHub's documented maximum.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A (no Go changes; helper tested in #1559)
- [x] Linter passes (`make lint`) — actionlint + yamllint + doc checks green
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — workflow-level; `actionlint` is the merge gate
- [x] I updated docs if user-facing behavior changed — new `uat.md` + demo/README fixes
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
