### PR TITLE
fix(ci): make helm v4.2.2 pin effective, verify helm-diff provenance

### DIFF
--- a/.github/actions/setup-build-tools/action.yml
+++ b/.github/actions/setup-build-tools/action.yml
@@ -244,9 +244,23 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        if [[ -x /usr/local/bin/helm ]]; then echo "helm already installed"; helm version; exit 0; fi
         HELM_VERSION="${{ inputs.helm_version }}"
         HELM_VERSION="${HELM_VERSION#v}"
+        # The runner image may ship a preinstalled helm (ubuntu-latest bundles
+        # Helm 3 at /usr/local/bin/helm). Only skip installation when the
+        # existing binary already matches the pinned version; a bare presence
+        # check silently ignores the .settings.yaml pin and leaves jobs running
+        # the runner's stock Helm 3 instead of the pinned Helm 4.
+        if [[ -x /usr/local/bin/helm ]]; then
+          INSTALLED="$(/usr/local/bin/helm version --template '{{.Version}}' 2>/dev/null || true)"
+          INSTALLED="${INSTALLED#v}"
+          if [[ "${INSTALLED}" == "${HELM_VERSION}" ]]; then
+            echo "helm ${HELM_VERSION} already installed"
+            helm version
+            exit 0
+          fi
+          echo "helm ${INSTALLED:-unknown} present; replacing with pinned ${HELM_VERSION}"
+        fi
         HELM_BASE="https://get.helm.sh"
         HELM_TAR="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
         HELM_TMP="$(mktemp -d)"

--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -167,9 +167,26 @@ phase_install() {
       helm plugin remove diff
     fi
     # Install from the signed release tarball (helm-diff's recommended Helm 4
-    # method). The git-URL form requires --verify=false under Helm 4; the
-    # tarball form works without it and carries the upstream release signature.
-    helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz"
+    # method). Helm 4 verifies plugin provenance by default (--verify=true):
+    # the .prov signature is checked against a keyring. Import the maintainer's
+    # release key, pin it to the published fingerprint (fail closed on
+    # mismatch), export it to a legacy keyring, and verify against it.
+    local HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
+    local HELM_DIFF_GNUPGHOME HELM_DIFF_KEYRING
+    HELM_DIFF_GNUPGHOME="$(mktemp -d)"
+    HELM_DIFF_KEYRING="$(mktemp)"
+    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" curl -fsSL "https://github.com/databus23.gpg" \
+      | GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --import
+    if ! GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --with-colons --fingerprint \
+        | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
+      echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
+      rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
+      exit 1
+    fi
+    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
+    helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
+      --keyring "${HELM_DIFF_KEYRING}"
+    rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
   fi
   echo "::endgroup::"
 

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -167,9 +167,26 @@ phase_install() {
       helm plugin remove diff
     fi
     # Install from the signed release tarball (helm-diff's recommended Helm 4
-    # method). The git-URL form requires --verify=false under Helm 4; the
-    # tarball form works without it and carries the upstream release signature.
-    helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz"
+    # method). Helm 4 verifies plugin provenance by default (--verify=true):
+    # the .prov signature is checked against a keyring. Import the maintainer's
+    # release key, pin it to the published fingerprint (fail closed on
+    # mismatch), export it to a legacy keyring, and verify against it.
+    local HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
+    local HELM_DIFF_GNUPGHOME HELM_DIFF_KEYRING
+    HELM_DIFF_GNUPGHOME="$(mktemp -d)"
+    HELM_DIFF_KEYRING="$(mktemp)"
+    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" curl -fsSL "https://github.com/databus23.gpg" \
+      | GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --import
+    if ! GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --with-colons --fingerprint \
+        | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
+      echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
+      rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
+      exit 1
+    fi
+    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
+    helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
+      --keyring "${HELM_DIFF_KEYRING}"
+    rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
   fi
   echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

Make the pinned Helm `v4.2.2` actually install on GitHub-hosted runners, and verify helm-diff plugin provenance so the UAT install step (`uat-aws`, `uat-gcp`) stops failing with `remote: Not Found`.

## Motivation / Context

UAT failed at **Install helm-diff plugin (v3.15.10)** with a `git clone` of the `.tgz` URL → `remote: Not Found`. Two compounding bugs:

1. **The `helm: v4.2.2` pin was a no-op.** `setup-build-tools` skipped Helm install whenever `/usr/local/bin/helm` merely existed. `ubuntu-latest` (ubuntu-24.04) **preinstalls Helm 3.21.2** at that path, so every job silently ran Helm 3.
2. **#1510 switched helm-diff to a tarball-URL install that only works under Helm 4.** Under the actually-running Helm 3, that GitHub release-download URL is routed to the git VCS installer and `git clone` fails. The prior git-repo install form worked on Helm 3, which is why UAT was green before #1510.

Even after fixing (1), Helm 4 verifies plugin provenance by default (`--verify=true`) and the install fails unless the maintainer's signing key is available in a keyring — so (2)'s install path also needed provenance wiring.

Fixes: #1574
Related: #1510

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI (`.github/actions/setup-build-tools`, `tests/uat/{aws,gcp}/run`)

## Implementation Notes

- **`setup-build-tools`**: reinstall Helm unless the existing binary's version already matches the pin (`helm version --template '{{.Version}}'`), instead of skipping on mere presence. This makes the `.settings.yaml` pin effective everywhere the action runs.
- **`tests/uat/{aws,gcp}/run`**: import the helm-diff maintainer's release key into an isolated `GNUPGHOME`, **pin it to the published fingerprint `C5645EF47482257A1F806D2BEA17A2A206AFF8CD` and fail closed on mismatch**, export it to a legacy keyring, and run `helm plugin install … --keyring …` so Helm 4 provenance verification passes. Temp keyring/GNUPGHOME are cleaned up in all paths.

**Blast radius (intentional):** making the pin real flips these jobs from the runner's Helm 3.21.2 to the pinned Helm 4.2.2: `gpu-cluster-setup` (gpu-h100 tests), `integration`, `kwok-test`, `mirror-e2e`, `sigstore-scaffolding-e2e`, `uat-aws`, `uat-gcp`. helmfile v1.6.0 supports Helm 4.

## Testing

Verified the full plugin-install flow end-to-end against a local Helm 4.2.0 (close to the pinned 4.2.2): fingerprint pin check passes, provenance verifies (`Plugin Hash Verified …`), `helm diff version` → `3.15.10`. `bash -n` and `yamllint` clean on the edited files. actionlint (merge-gate) lints the action YAML; no new `${{ }}` expressions were introduced.

```bash
bash -n tests/uat/aws/run tests/uat/gcp/run   # syntax OK
yamllint .github/actions/setup-build-tools/action.yml   # clean
```

## Risk Assessment

- [x] **Medium** — Touches a shared composite action; several CI jobs move from Helm 3 to the pinned Helm 4.

**Rollout notes:** No user-facing/runtime behavior change (CI-only). Easily reverted. Watch the first run of the affected workflows for any latent Helm 3→4 incompatibilities.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, CI-only shell/YAML change
- [x] Linter passes (`bash -n`, `yamllint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [ ] I updated docs if user-facing behavior changed — N/A (internal CI)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
