### PR TITLE
fix(ci): guarantee helm-diff keyring cleanup on all paths

### DIFF
--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -171,22 +171,26 @@ phase_install() {
     # the .prov signature is checked against a keyring. Import the maintainer's
     # release key, pin it to the published fingerprint (fail closed on
     # mismatch), export it to a legacy keyring, and verify against it.
-    local HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
-    local HELM_DIFF_GNUPGHOME HELM_DIFF_KEYRING
-    HELM_DIFF_GNUPGHOME="$(mktemp -d)"
-    HELM_DIFF_KEYRING="$(mktemp)"
-    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" curl -fsSL "https://github.com/databus23.gpg" \
-      | GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --import
-    if ! GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --with-colons --fingerprint \
-        | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
-      echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
-      rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
-      exit 1
-    fi
-    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
-    helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
-      --keyring "${HELM_DIFF_KEYRING}"
-    rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
+    #
+    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/keyring are
+    # removed on every path — including a set -e (L41) abort, where a RETURN
+    # trap would not fire. The subshell keeps the trap and temp vars scoped to
+    # this block without disturbing the parent shell's traps.
+    (
+      HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
+      GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
+      HELM_DIFF_KEYRING="$(mktemp)"
+      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_KEYRING}"' EXIT
+      curl -fsSL "https://github.com/databus23.gpg" | gpg --import
+      if ! gpg --with-colons --fingerprint \
+          | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
+        echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
+        exit 1
+      fi
+      gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
+      helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
+        --keyring "${HELM_DIFF_KEYRING}"
+    )
   fi
   echo "::endgroup::"
 

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -171,22 +171,26 @@ phase_install() {
     # the .prov signature is checked against a keyring. Import the maintainer's
     # release key, pin it to the published fingerprint (fail closed on
     # mismatch), export it to a legacy keyring, and verify against it.
-    local HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
-    local HELM_DIFF_GNUPGHOME HELM_DIFF_KEYRING
-    HELM_DIFF_GNUPGHOME="$(mktemp -d)"
-    HELM_DIFF_KEYRING="$(mktemp)"
-    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" curl -fsSL "https://github.com/databus23.gpg" \
-      | GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --import
-    if ! GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --with-colons --fingerprint \
-        | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
-      echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
-      rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
-      exit 1
-    fi
-    GNUPGHOME="${HELM_DIFF_GNUPGHOME}" gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
-    helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
-      --keyring "${HELM_DIFF_KEYRING}"
-    rm -rf "${HELM_DIFF_GNUPGHOME}" "${HELM_DIFF_KEYRING}"
+    #
+    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/keyring are
+    # removed on every path — including a set -e (L41) abort, where a RETURN
+    # trap would not fire. The subshell keeps the trap and temp vars scoped to
+    # this block without disturbing the parent shell's traps.
+    (
+      HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
+      GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
+      HELM_DIFF_KEYRING="$(mktemp)"
+      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_KEYRING}"' EXIT
+      curl -fsSL "https://github.com/databus23.gpg" | gpg --import
+      if ! gpg --with-colons --fingerprint \
+          | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
+        echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
+        exit 1
+      fi
+      gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
+      helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
+        --keyring "${HELM_DIFF_KEYRING}"
+    )
   fi
   echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

Follow-up to #1575 addressing the non-blocking review nits from @mchmarny's approval ([review](https://github.com/NVIDIA/aicr/pull/1575#pullrequestreview-4611759863)).

## Motivation / Context

Two cleanup items from the #1575 review of the helm-diff provenance block in `tests/uat/{aws,gcp}/run`:

1. **Temp cleanup not guaranteed on all paths.** Under `set -e`, if `helm plugin install` failed the script aborted before the explicit `rm -rf`, leaking the temp `GNUPGHOME` + keyring — so the "cleaned up in all paths" claim didn't hold on the install-failure path.
2. **No-op `GNUPGHOME=` prefix on `curl`.** curl doesn't read it; only the piped `gpg --import` needs it.

The dedup nit (block duplicated across `aws/run` and `gcp/run`) is intentionally left as-is: the two run scripts are near-identical in their entirety, so extracting only this block would be inconsistent with the existing pattern — deduplicating the whole script is a separate, larger effort.

Fixes: N/A
Related: #1575

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI (`tests/uat/{aws,gcp}/run`)

## Implementation Notes

The reviewer suggested a `trap … RETURN`, but **a RETURN trap does not fire when `set -e` aborts on a failed command** (verified: the trap body never runs and temps leak). So the block now runs in a **subshell with an `EXIT` trap**, which fires on every exit path — normal completion *and* errexit abort — with the temp vars still in scope, and without disturbing the parent shell's traps or needing a disarm. The explicit `rm` lines are dropped; `GNUPGHOME` is exported once inside the subshell so the gpg calls (and no longer curl) pick it up.

## Testing

Verified end-to-end against local Helm 4.2.0: provenance verifies (`Plugin Hash Verified …`), `helm diff version` → `3.15.10`, subshell exits 0, temp dir/keyring removed. Also confirmed empirically that a RETURN trap does **not** fire under `set -e` on failure while the subshell EXIT trap does (both failure and success paths). `bash -n` clean on both scripts.

```bash
bash -n tests/uat/aws/run tests/uat/gcp/run   # syntax OK
```

## Risk Assessment

- [x] **Low** — CI-only shell hygiene; no runtime/behavior change to the install itself. Easily reverted.

**Rollout notes:** N/A.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, CI-only shell change
- [x] Linter passes (`bash -n`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [ ] I updated docs if user-facing behavior changed — N/A (internal CI)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
