### PR TITLE
feat(recipes): bump dynamo-platform and runtime to 1.2.1

### DIFF
--- a/demos/workloads/inference/vllm-agg.yaml
+++ b/demos/workloads/inference/vllm-agg.yaml
@@ -90,7 +90,7 @@ spec:
               effect: NoExecute
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               env:
                 - name: SERVED_MODEL_NAME
                   value: Qwen/Qwen3-0.6B
@@ -121,7 +121,7 @@ spec:
               resourceClaimName: vllm-gpu-claim
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               workingDir: /workspace/examples/backends/vllm
               command: ["python3", "-m", "dynamo.vllm"]
               args:

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -34,7 +34,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | aws-ebs-csi-driver | helm | aws-ebs-csi-driver/aws-ebs-csi-driver | 2.59.0 | 6 |
 | aws-efa | helm | aws-efa-k8s-device-plugin | v0.5.29 | 1 |
 | cert-manager | helm | jetstack/cert-manager | v1.20.2 | 4 |
-| dynamo-platform | helm | dynamo-platform | 1.2.0 | 3 |
+| dynamo-platform | helm | dynamo-platform | 1.2.1 | 3 |
 | gatekeeper | helm | gatekeeper/gatekeeper | 3.22.2 | 3 |
 | gke-nccl-tcpxo | manifest | — | — | 4 |
 | gpu-operator | helm | nvidia/gpu-operator | v26.3.2 | 14 |
@@ -97,7 +97,7 @@ _No images extracted._
 
 - `nats:2.10.21-alpine`
 - `natsio/nats-server-config-reloader:0.16.0`
-- `nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.2.0`
+- `nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.2.1`
 
 ### gatekeeper
 

--- a/pkg/evidence/cncf/scripts/manifests/dynamo-vllm-agg.yaml
+++ b/pkg/evidence/cncf/scripts/manifests/dynamo-vllm-agg.yaml
@@ -100,7 +100,7 @@ spec:
               effect: NoExecute
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               env:
                 - name: SERVED_MODEL_NAME
                   value: Qwen/Qwen3-0.6B
@@ -131,7 +131,7 @@ spec:
               resourceClaimName: vllm-gpu-claim
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               workingDir: /workspace/examples/backends/vllm
               command: ["python3", "-m", "dynamo.vllm"]
               args:

--- a/recipes/components/dynamo-platform/values.yaml
+++ b/recipes/components/dynamo-platform/values.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dynamo Platform Helm values (v1.2.0)
+# Dynamo Platform Helm values (v1.2.1)
 # NVIDIA Dynamo inference serving platform operator.
 # Provides OpenAI-compatible endpoints, KV-cache-aware routing,
 # disaggregated prefill/decode, and SLA-driven autoscaling.

--- a/recipes/overlays/b200-gke-cos-inference-dynamo.yaml
+++ b/recipes/overlays/b200-gke-cos-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/gb200-oke-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/gb200-oke-ubuntu-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/h100-aks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-aks-ubuntu-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/h100-eks-ubuntu-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
+++ b/recipes/overlays/h100-gke-cos-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/h100-kind-inference-dynamo.yaml
+++ b/recipes/overlays/h100-kind-inference-dynamo.yaml
@@ -43,7 +43,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
+++ b/recipes/overlays/rtx-pro-6000-eks-ubuntu-inference-dynamo.yaml
@@ -49,7 +49,7 @@ spec:
     - name: dynamo-platform
       type: Helm
       source: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
-      version: "1.2.0"
+      version: "1.2.1"
       valuesFile: components/dynamo-platform/values.yaml
       dependencyRefs:
         - grove

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -482,7 +482,7 @@ components:
     helm:
       defaultRepository: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
       defaultChart: dynamo-platform
-      defaultVersion: "1.2.0"
+      defaultVersion: "1.2.1"
       defaultNamespace: dynamo-system
     storageClassPaths:
       - nats.config.jetstream.fileStore.pvc.storageClassName

--- a/tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml
+++ b/tests/chainsaw/ai-conformance/cluster/assert-dynamo.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Assert Dynamo platform components are healthy.
-# Chart: dynamo-platform 1.2.0
+# Chart: dynamo-platform 1.2.1
 # Provides NVIDIA Dynamo inference serving: OpenAI-compatible endpoints,
 # KV-cache-aware routing, disaggregated prefill/decode, SLA-driven autoscaling.
 #

--- a/tests/manifests/dynamo-vllm-smoke-test.yaml
+++ b/tests/manifests/dynamo-vllm-smoke-test.yaml
@@ -60,7 +60,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               env:
                 - name: SERVED_MODEL_NAME
                   value: Qwen/Qwen3-0.6B
@@ -81,7 +81,7 @@ spec:
               resourceClaimName: vllm-smoke-gpu-claim
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               workingDir: /workspace/examples/backends/vllm
               command: ["python3", "-m", "dynamo.vllm"]
               args:

--- a/validators/performance/model_cache.go
+++ b/validators/performance/model_cache.go
@@ -92,7 +92,7 @@ const (
 	// ResolveImage for registry-override parity is tracked in #1159. Note that
 	// registry parity alone is not air-gap support: the populate Job's
 	// snapshot_download still reaches huggingface.co for the weights.
-	cacheWorkerImage = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0"
+	cacheWorkerImage = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1"
 
 	// Resource requests for the populate container. snapshot_download is
 	// network/IO-bound, not compute-bound, so requests stay small; they exist so

--- a/validators/performance/testdata/inference/dynamo-deployment-gateway-epp.yaml
+++ b/validators/performance/testdata/inference/dynamo-deployment-gateway-epp.yaml
@@ -38,7 +38,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.1
               env:
                 - name: DYN_KV_CACHE_BLOCK_SIZE
                   value: "128"
@@ -93,7 +93,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               workingDir: /workspace/examples/backends/vllm
               command: ["python3", "-m", "dynamo.vllm"]
               args:
@@ -120,7 +120,7 @@ spec:
                       key: token
                       optional: true
             - name: sidecar-frontend
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               args:
                 - -m
                 - dynamo.frontend

--- a/validators/performance/testdata/inference/dynamo-deployment.yaml
+++ b/validators/performance/testdata/inference/dynamo-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               env:
                 - name: SERVED_MODEL_NAME
                   # Quoted so a scalar-looking model ID (e.g. a pure-numeric or
@@ -79,7 +79,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
               workingDir: /workspace/examples/backends/vllm
               command: ["python3", "-m", "dynamo.vllm"]
               args:


### PR DESCRIPTION
## Summary

Bump the `dynamo-platform` Helm chart pin from `1.2.0` to `1.2.1` (registry default + all inference-dynamo overlays), and bump the Dynamo runtime worker image (`vllm-runtime`) in lockstep to avoid runtime-tag vs operator-chart drift.

## Motivation / Context

Pick up the latest `dynamo-platform` 1.2.1 chart release for the inference-dynamo recipes. The runtime worker image is versioned separately from the operator chart; `docs/contributor/inference-perf-fluctuation.md` documents a version-skew (issue #1193) caused by tag-vs-chart drift, so both are bumped together.

Fixes: N/A
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- `recipes/registry.yaml` `defaultVersion` and the pinned `version` in all 8 `*-inference-dynamo.yaml` overlays: `1.2.0` → `1.2.1`.
- `recipes/components/dynamo-platform/values.yaml` header comment updated to `v1.2.1`.
- `docs/user/container-images.md` regenerated via `make bom-docs` — BOM renders the 1.2.1 chart cleanly (`kubernetes-operator:1.2.1`), confirming the pin resolves.
- `vllm-runtime:1.2.0` → `1.2.1` in the `cacheWorkerImage` constant (`validators/performance/model_cache.go`), its validator testdata manifests, the smoke-test + CNCF-evidence manifests, and the demo workload. The `TestCacheWorkerImageMatchesTemplate` drift guard stays green (constant + templates bumped together).

## Testing

```bash
make lint    # 0 issues; includes ADR-006 chart-pin verification
make test    # all packages pass, total coverage 78.3%
golangci-lint run -c .golangci.yaml ./validators/performance/...   # 0 issues
```

## Risk Assessment

- [x] **Low** — Version-pin bump kept in sync across chart + runtime image; drift guard test covers the runtime constant.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
