### PR TITLE
chore(license): header hand-authored files, skip generated evidence pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,13 +174,23 @@ LICENSE_IGNORES = \
 	-ignore 'dist/**' \
 	-ignore 'vendor/**' \
 	-ignore '**/testdata/**' \
+	-ignore 'recipes/evidence/*.yaml' \
+	-ignore 'recipes/evidence/*/*/*.yaml' \
 	-ignore 'THIRD_PARTY_NOTICES.md' \
 	-ignore '.licenses-cache/**'
 
+# The two recipes/evidence patterns in LICENSE_IGNORES match exactly the
+# generated, header-less pointer shapes MarshalPointer emits — the transient
+# flat <recipe>.yaml pending state and the final <recipe>/<source>/sha256-*.yaml
+# (any committed header is stripped on the next publish/sign). They are kept
+# narrow (not a recursive **) so unrelated YAML added under the tree still gets
+# header enforcement. The flat glob also covers the hand-maintained
+# allowlist.yaml, so the license target headers it explicitly below.
 .PHONY: license
 license: ## Add/verify license headers in source files
 	@echo "Ensuring license headers..."
 	@addlicense -f .github/headers/LICENSE $(LICENSE_IGNORES) .
+	@addlicense -f .github/headers/LICENSE recipes/evidence/allowlist.yaml
 
 #### DO NOT CHANGE THIS SET OF ALLOWED LICENSES, DO NOT ADD IGNORES
 license-check: ## Check license is approved

--- a/pkg/corroborate/renderer/index.html
+++ b/pkg/corroborate/renderer/index.html
@@ -1,4 +1,20 @@
 <!DOCTYPE html>
+<!--
+ Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <html lang="en">
 <head>
 <meta charset="utf-8">

--- a/recipes/evidence/allowlist.yaml
+++ b/recipes/evidence/allowlist.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Maintained signer allowlist for recipe-evidence corroboration.
 #
 # This file is the trust root for the interim evidence-corroboration


### PR DESCRIPTION
## Summary

Stop `make license` from repeatedly re-injecting Apache headers into header-less files: add headers to the two hand-authored files, and exclude the generated evidence pointers from `addlicense` so they stop churning.

## Motivation / Context

`make lint` runs `make license` (addlicense in add-mode), which kept adding headers to files that lack them. Two are hand-authored source that should carry a header permanently; the evidence pointer YAMLs are written header-less by `MarshalPointer` (`serializer.MarshalYAMLDeterministic`), so any committed header is stripped on the next `aicr evidence publish` / signing step — churn that never converges.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: build tooling (`Makefile`), license headers

## Implementation Notes

- Add the standard Apache header to:
  - `pkg/corroborate/renderer/index.html` — a `//go:embed`-ed static dashboard asset (hand-authored).
  - `recipes/evidence/allowlist.yaml` — the hand-maintained evidence trust root (no generator writes it).
- Ignore exactly the two generated pointer shapes in `LICENSE_IGNORES` so `make license` no longer targets them:
  - `recipes/evidence/*.yaml` — the transient flat `<recipe>.yaml` pending pointer (the `--no-sign` / commit-flat state CI later signs and relocates).
  - `recipes/evidence/*/*/*.yaml` — the final `<recipe>/<source>/sha256-*.yaml` pointers.
  The patterns are deliberately narrow (not a recursive `**`) so any unrelated YAML added under `recipes/evidence/` still gets header enforcement.
- The flat glob also covers `allowlist.yaml`, so `make license` re-headers it with an explicit second `addlicense` pass.
- The `DO NOT ADD IGNORES` note in the Makefile governs `go-licenses` `--allowed_licenses`/`--ignore` in `license-check` (dependency licensing), not `addlicense`'s file-glob ignores.

## Testing

```bash
# make license is now idempotent and correctly scoped:
#  - flat pending pointer + nested sha256 pointer: stay header-less
#  - an unrelated YAML placed under recipes/evidence/: DOES get a header (enforcement retained)
#  - allowlist.yaml: re-headered by the explicit pass
make license
go run ./tools/evidence-pointercheck -root recipes/evidence   # OK — all pointers honor the contract
yamllint recipes/evidence/allowlist.yaml                       # clean
```

Infra/tooling-only change (Makefile ignore globs + license-comment headers); no Go logic touched, so tests/e2e/Go-lint cannot regress. The evidence verifier `yaml.Unmarshal`s pointer bodies (comments ignored) and the pointer filename digest is the bundle digest (a field value), not the file's own bytes — so headers on the YAML/HTML files are parse- and verification-safe.

## Risk Assessment

- [x] **Low** — Comment-only header additions plus two narrow build-ignore globs; trivially reversible.

**Rollout notes:** N/A

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] I did not skip/disable tests to make CI green
- [x] Commits are cryptographically signed (`git commit -S`)
