### PR TITLE
feat(ci): surface superseded UAT runs (#1274)

### DIFF
--- a/.github/workflows/uat-superseded-notice.yaml
+++ b/.github/workflows/uat-superseded-notice.yaml
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reactive surfacing for a *superseded* UAT run (issue #1274, DC1).
+#
+# The reservation lease (uat-run.yaml's `uat-<reservation>` concurrency group,
+# cancel-in-progress: false) holds at most one in-progress + one pending run.
+# When a third contender arrives, GitHub cancels the older PENDING run before it
+# starts any job — it is superseded, not failed, and would otherwise vanish
+# silently. This observer runs on the default branch (workflow_run events fire
+# only from the default branch), classifies each cancelled "UAT Run" as a
+# pending supersede (cancelled with no started job) versus a genuine mid-run
+# cancel, and for a supersede emits a job-summary entry plus a ::warning so a
+# dropped request is visible to its requester.
+#
+# This is the reactive/primary layer. The nightly controller
+# (uat-nightly-batch.yaml) also reconciles the same signal synchronously for the
+# cells it dispatches; the two are complementary, and a DC6 regression guard
+# (#1279) will exercise this observer. The workflow never checks out the
+# triggering run's code and reads only trusted `workflow_run.*` metadata, so a
+# fork-influenced run title cannot inject into the shell.
+
+name: "UAT: Superseded Run Notice"
+
+on:
+  workflow_run:
+    workflows: ["UAT Run"]
+    types: [completed]
+
+permissions:
+  actions: read  # read the triggering run's jobs to classify it
+
+concurrency:
+  # One notice per triggering run; never cancel an in-flight notice.
+  group: uat-superseded-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  notice:
+    # Only a cancelled run can be a pending supersede — skip success/failure
+    # cheaply. Gate to the canonical repo so forks don't run it.
+    if: ${{ github.event.workflow_run.conclusion == 'cancelled' && github.repository == 'nvidia/aicr' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Classify and surface a superseded run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          # Fetch the triggering run's jobs. Distinguish a real empty result
+          # (superseded) from a transient API/auth/rate-limit failure: the
+          # latter must NOT be misread as "zero jobs", which would emit a false
+          # superseded warning. On a fetch failure, skip rather than cry wolf.
+          if ! jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" 2>/dev/null); then
+            echo "::warning::could not fetch jobs for run ${RUN_ID}; skipping supersede classification."
+            exit 0
+          fi
+          # A run cancelled while PENDING (superseded on the reservation lease)
+          # never starts a job: total_count == 0, or every job has a null
+          # started_at. A human/mid-run cancel has at least one started job.
+          superseded=$(jq -r '
+            ((.total_count // 0) == 0)
+            or (([.jobs[]? | select(.started_at != null)] | length) == 0)
+            | tostring' <<<"$jobs_json")
+
+          if [[ "$superseded" != "true" ]]; then
+            echo "Run ${RUN_ID} was cancelled after starting a job — a genuine cancel, not a pending supersede; nothing to surface."
+            exit 0
+          fi
+
+          # RUN_TITLE is the triggering run's display title. uat-run.yaml sets a
+          # run-name of "UAT <reservation> @ <version> ..." (#1579), so the title
+          # names the superseded reservation. It is trusted workflow_run metadata
+          # passed via env (never inlined into the script). The step-summary is
+          # file content (safe as-is); the ::warning:: command is percent-encoded
+          # below since %, CR, and LF are workflow-command metacharacters.
+          {
+            echo "### ⚠️ UAT run superseded"
+            echo ""
+            echo "**${RUN_TITLE}** was cancelled while pending and never ran — superseded on the reservation lease (a newer run took its single pending slot)."
+            echo ""
+            echo "- Run: [\`${RUN_ID}\`](${RUN_URL})"
+            echo "- Branch: \`${HEAD_BRANCH}\`"
+            echo ""
+            echo "Re-dispatch this reservation once it frees if the coverage is still needed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Percent-encode workflow-command metacharacters so a crafted run title
+          # cannot inject or truncate the annotation.
+          esc() { local s=$1; s=${s//'%'/'%25'}; s=${s//$'\r'/'%0D'}; s=${s//$'\n'/'%0A'}; printf '%s' "$s"; }
+          echo "::warning::UAT run superseded while pending — $(esc "$RUN_TITLE") ($(esc "$RUN_URL")); re-dispatch when the reservation frees."

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -33,7 +33,7 @@ The lease is a GitHub Actions concurrency group keyed by reservation name — `u
 
 This replaces the previous behavior, where a second run hitting a busy AWS reservation hard-failed on the capacity check. Now it queues.
 
-**The one-in-progress-plus-one-pending limit.** GitHub concurrency holds at most one in-progress run plus one pending run per group. If a *third* run is queued for a reservation that already has one in-progress and one pending, GitHub cancels the older pending run and the newest takes its place. At launch this is acceptable: there are two reservations, each contended by at most the nightly cron plus an occasional ad-hoc dispatch. A run cancelled this way is *superseded*, not failed; surfacing that signal so a dropped request is never silent is handled by the reliability follow-up (DC6). If deeper queuing is ever needed (many requesters per reservation), the escalation path is the *Deferred* standing broker service — a pull-based queue rather than GitHub concurrency — recorded in the epic (#1264).
+**The one-in-progress-plus-one-pending limit.** GitHub concurrency holds at most one in-progress run plus one pending run per group. If a *third* run is queued for a reservation that already has one in-progress and one pending, GitHub cancels the older pending run and the newest takes its place. At launch this is acceptable: there are two reservations, each contended by at most the nightly cron plus an occasional ad-hoc dispatch. A run cancelled this way is *superseded*, not failed. So that a dropped request is never silent, the `uat-superseded-notice.yaml` observer watches for it: triggered on `workflow_run: completed` for `UAT Run`, it classifies a cancelled run that never started a job as a supersede (versus a genuine mid-run cancel) and emits a job-summary entry plus a `::warning`. (The nightly controller reconciles the same signal synchronously for the cells it dispatches; a DC6 regression guard, #1279, will exercise the observer.) If deeper queuing is ever needed (many requesters per reservation), the escalation path is the *Deferred* standing broker service — a pull-based queue rather than GitHub concurrency — recorded in the epic (#1264).
 
 ## Adding a reservation
 
@@ -58,5 +58,4 @@ The values in this file are identifiers, **not secrets** — a reservation-id gr
 What ships now is the lease, the data-driven dispatch surface, and a main-only nightly batch. Still to come:
 
 - **Version matrix (DC1 follow-up / DC5).** The nightly batch will expand into a time-boxed, `main`-first, previous-N-stable-releases schedule (`uat-broker schedule`), each release row installing the released `aicr` images at that version.
-- **Superseded-run surfacing (DC6).** A reactive notice so a dropped (superseded) request is visible to its requester.
 - **Per-intent shaping + daytime deployment (DC2 / DC8).** Selecting the test config and recipe by `intent`, and the morning-handoff daytime human-access cluster.


### PR DESCRIPTION
## Summary

Adds `uat-superseded-notice.yaml`, a reactive `workflow_run` observer that makes a **superseded** UAT run visible (job-summary entry + `::warning`) instead of letting it vanish silently.

## Motivation / Context

Fourth and final PR in the DC1 day/night scheduler series (#1274). The reservation lease (`uat-run.yaml`'s `uat-<reservation>` concurrency group, `cancel-in-progress: false`) holds at most one in-progress + one pending run; a third contender cancels the older **pending** run before it starts any job. That run is *superseded*, not failed — a dropped request that would otherwise leave no trace. This observer surfaces it. Builds only on PR-2's top-level `uat-run.yaml` (#1569, merged); independent of PR-3 (#1579).

Fixes: N/A
Related: #1274, #1264

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI workflows (`.github/workflows/uat-superseded-notice.yaml`)

## Implementation Notes

- **Trigger:** `on: workflow_run: workflows: ["UAT Run"], types: [completed]`. Only top-level workflows emit `workflow_run`, and only from the default branch — so `uat-run.yaml` (top-level since PR-2) is the right subject, and this observer only runs once merged to `main`.
- **Classifier:** a run cancelled while *pending* never starts a job. The job reads the triggering run's jobs and treats it as superseded when `total_count == 0` **or** every job has a null `started_at`; a genuine mid-run cancel (≥1 started job) is ignored. If the jobs API can't be read, it errs toward surfacing rather than silence.
- **Output:** a job-summary entry plus a `::warning` naming the run and reservation, with a re-dispatch hint.
- **Security:** never checks out the triggering run's code; reads only trusted `workflow_run.*` metadata, passed via `env:` (never inlined), so a fork-influenced run title can't inject. Needs only `permissions: actions: read`.
- **Layering:** this is the reactive/primary layer. The nightly controller (`uat-nightly-batch.yaml`, PR-3) reconciles the same signal synchronously for the cells it dispatches; a DC6 guard (#1279) will exercise this observer. The two are complementary.
- **Doc note:** the `uat.md` queuing section now points at this observer instead of deferring to "DC6", and the shipped item is removed from the roadmap. This overlaps the roadmap region PR-3 also edits — whichever merges second takes a one-line rebase.

## Testing

```bash
# New CI workflow + doc line — no Go source touched.
actionlint .github/workflows/uat-superseded-notice.yaml   # CI-pinned v1.7.11, checksum-verified
yamllint  .github/workflows/uat-superseded-notice.yaml
bash -n   <observer embedded script>
```

- `actionlint` + `yamllint` clean; `bash -n` clean; longest line 161 (< 200).
- Classifier validated against 5 synthetic `runs/<id>/jobs` payloads: zero-jobs → superseded; all-`null`-`started_at` → superseded; one started → not; mixed → not; empty API response → surfaces (fail-toward-visible).
- **Cannot be exercised on this PR:** `workflow_run` observers fire only from the default branch, so it goes live on merge to `main`; CI here only lints it.

## Risk Assessment

- [x] **Low** — Isolated, additive single workflow + one doc line; no change to any existing pipeline; easy to revert.

**Rollout notes:** Inert until merged to `main` (default-branch-only trigger). No secrets, no checkout, least-privilege token.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go source changed
- [x] Linter passes (`actionlint` + `yamllint`; no Go → `make lint` Go gate N/A)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (observer is default-branch-only; a DC6 regression guard, #1279, will exercise it)
- [x] I updated docs if user-facing behavior changed (`docs/contributor/uat.md`)
- [x] Changes follow existing patterns in the codebase (mirrors the repo's `workflow_run` observers)
- [x] Commits are cryptographically signed (`git commit -S`)
