### PR TITLE
feat(ci): per-intent + daytime-lifecycle UAT cluster acquisition

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -25,13 +25,21 @@ on:
   workflow_call:
     inputs:
       reservation:
-        description: 'Reservation name (lease key) this run targets; used for labeling.'
+        description: 'Reservation name (lease key) this run targets; used for labeling and the daytime cluster name.'
         type: string
         required: true
       aicr_version:
         description: 'Released aicr version to install (e.g. v1.2.3); empty = build from source (main tip).'
         type: string
         default: ''
+      intent:
+        description: 'Recipe intent — selects the per-intent test config (h100-<intent>-config.yaml).'
+        type: string
+        default: training
+      lifecycle:
+        description: 'nightly (provision→CUJ→teardown) | daytime-up (provision+deploy+HOLD) | daytime-down (tear down the held daytime cluster).'
+        type: string
+        default: nightly
       cluster_config_path:
         description: 'Cluster-config the EKS actuator provisions from (from infra/uat/reservations.yaml).'
         type: string
@@ -81,10 +89,20 @@ jobs:
       AWS_ACCOUNT_ID: "615299774277"
       AWS_REGION: "us-east-1"
       GITHUB_ACTIONS_ROLE_NAME: "github-actions-role-aicr"
-      DEPLOYMENT_ID: "aicr-uat-${{ github.run_id }}"
+      # Cluster name (EKS actuator derives it from .deployment.id). The nightly
+      # per-run lifecycle uses a run-scoped name for per-run OCI/state isolation;
+      # the daytime lifecycles use a STABLE, reservation-tagged name so the
+      # evening teardown (daytime-down) and the nightly pre-batch guard can find
+      # the held cluster. Reservation names are lowercase alnum+hyphen, so the
+      # derived name is a valid EKS cluster name.
+      DEPLOYMENT_ID: >-
+        ${{ (inputs.lifecycle == 'daytime-up' || inputs.lifecycle == 'daytime-down')
+        && format('aicr-uat-day-{0}', inputs.reservation)
+        || format('aicr-uat-{0}', github.run_id) }}
       CLUSTER_CONFIG: ${{ inputs.cluster_config_path }}
-      # Training is the DC1 launch intent; DC2 selects the file by intent.
-      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-training-config.yaml
+      # DC2 selects the AICRConfig by intent; both intents drive the same
+      # cluster-config (GPU pool from the reservation, system/CPU pools dynamic).
+      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-${{ inputs.intent }}-config.yaml
       # v0.4.23 — required for the .eks-nested cluster-config schema; the
       # prior pin (v0.2.6) read .compute.nodeGroups.* directly and failed
       # Terraform parse with "object with 1 attribute eks".
@@ -98,6 +116,30 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
+
+      # Fail closed on an unrecognized intent/lifecycle before any provisioning:
+      # workflow_dispatch constrains these to a choice, but workflow_call passes
+      # free strings, so a caller typo must surface as a clear error rather than
+      # a missing-file failure deep in a phase. Also assert the per-intent config
+      # exists so a missing sibling config fails here, not mid-run.
+      - name: Validate inputs
+        env:
+          INTENT: ${{ inputs.intent }}
+          LIFECYCLE: ${{ inputs.lifecycle }}
+        run: |
+          set -euo pipefail
+          case "${INTENT}" in
+            training|inference) ;;
+            *) echo "::error::unknown intent '${INTENT}' (want training|inference)"; exit 1 ;;
+          esac
+          case "${LIFECYCLE}" in
+            nightly|daytime-up|daytime-down) ;;
+            *) echo "::error::unknown lifecycle '${LIFECYCLE}' (want nightly|daytime-up|daytime-down)"; exit 1 ;;
+          esac
+          if [[ ! -f "${TEST_CONFIG}" ]]; then
+            echo "::error::test config not found: ${TEST_CONFIG}"; exit 1
+          fi
+          echo "intent=${INTENT} lifecycle=${LIFECYCLE} test-config=${TEST_CONFIG} cluster=${DEPLOYMENT_ID}"
 
       # Versions
       - name: Load versions
@@ -119,9 +161,10 @@ jobs:
 
       # Main cell (aicr_version empty): build the aicr binary from the
       # checked-out source (tip). Release cells install the released binary
-      # instead (next step).
+      # instead (next step). daytime-down tears down the held cluster only — it
+      # builds nothing and pushes no images.
       - name: Build aicr binary
-        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GOFLAGS: -mod=vendor
         run: |
@@ -134,7 +177,7 @@ jobs:
       # :<version>) and the snapshot-agent via ghcr.io/nvidia/aicr:<version> — so
       # the validator/agent build+push steps below are skipped for release cells.
       - name: Install released aicr
-        if: inputs.aicr_version != '' && inputs.skip_tests != true
+        if: inputs.aicr_version != '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         uses: ./.github/actions/install-aicr-release
         with:
           aicr-version: ${{ inputs.aicr_version }}
@@ -145,7 +188,7 @@ jobs:
       # Main cell only: release cells use the released validator images the
       # released binary self-resolves to (skipped when aicr_version is set).
       - name: Build and push validator images
-        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         run: |
           GO_VERSION="$(cat .go-version)"
           # CHAINSAW_* args dropped in #1236 — the deployment validator
@@ -168,13 +211,57 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-UAT-AICR
 
-      # Capacity check (reads desired count and reservation ID from cluster config).
+      # Pre-batch guard (#1275, DC2). The nightly lifecycle refuses to provision
+      # into a reservation that still holds an un-torn-down daytime cluster:
+      # a missed evening teardown must surface as a BLOCKED batch, not as silent
+      # contention with the daytime deployment. Detect by the stable daytime
+      # cluster name (aicr-uat-day-<reservation>); we already hold the
+      # reservation lease (uat-run.yaml) and are authenticated to the cloud, so
+      # this runs before Bringup and fails fast rather than racing. Only the
+      # nightly lifecycle guards — daytime-up creates that cluster, daytime-down
+      # removes it.
+      - name: Pre-batch guard — refuse if a daytime cluster still holds the reservation
+        id: guard
+        if: inputs.lifecycle == 'nightly'
+        env:
+          RESERVATION: ${{ inputs.reservation }}
+        run: |
+          set -euo pipefail
+          DAYTIME_NAME="aicr-uat-day-${RESERVATION}"
+          set +e
+          OUT=$(aws eks describe-cluster --name "${DAYTIME_NAME}" --region "${AWS_REGION}" 2>&1)
+          RC=$?
+          set -e
+          if [[ ${RC} -eq 0 ]]; then
+            echo "::error::daytime cluster ${DAYTIME_NAME} still holds reservation ${RESERVATION}; refusing to start the nightly batch. Tear it down first (uat-run lifecycle=daytime-down)."
+            exit 1
+          fi
+          # Fail closed on anything that is NOT a definitive "does not exist":
+          # a throttle/auth error must not be read as "clear to proceed".
+          if grep -q 'ResourceNotFoundException' <<<"${OUT}"; then
+            echo "no daytime cluster on reservation ${RESERVATION}; proceeding"
+          else
+            echo "::error::could not determine daytime-cluster state for ${DAYTIME_NAME}: ${OUT}"
+            exit 1
+          fi
+
+      # Post-lease capacity assertion (#1275, DC2). The reservation lease
+      # (uat-run.yaml) is now the contention gate, so this is no longer a
+      # race-and-fail pre-flight: by the time it runs we hold the lease and no
+      # other UAT run is consuming the reservation. It asserts the reservation
+      # is provisioned large enough for the desired GPU count — a genuinely
+      # exhausted/undersized reservation still fails, but transient contention
+      # (another run's not-yet-released nodes) no longer does, because we check
+      # the reservation's TOTAL size, not its momentary AvailableInstanceCount.
+      # Skipped for daytime-down, which provisions nothing.
+      #
       # Uses the runner-preinstalled yq because Install tools runs later; if the
       # cluster-config schema ever drifts, the explicit empty-value guard below
       # surfaces the mismatch immediately instead of letting yq return empty
       # silently and the AWS API reject a malformed reservation ID.
-      - name: Check EC2 capacity reservation
+      - name: Assert EC2 capacity reservation (post-lease)
         id: capacity
+        if: inputs.lifecycle != 'daytime-down'
         run: |
           set -euo pipefail
           GPU_WORKER='.compute.eks.nodeGroups.workers[] | select(.name == "gpu-worker")'
@@ -189,14 +276,25 @@ jobs:
           fi
           echo "Reservation: ${RESERVATION}, desired: ${DESIRED}"
 
-          AVAILABLE=$(aws ec2 describe-capacity-reservations \
+          # TotalInstanceCount = the reservation's provisioned size (fixed by the
+          # reservation, not by concurrent consumption). AvailableInstanceCount
+          # is logged for context but is intentionally NOT the assertion: with
+          # the lease held, "unavailable" means our own prior run, not a rival.
+          CAP=$(aws ec2 describe-capacity-reservations \
             --capacity-reservation-ids "${RESERVATION}" \
-            --query 'CapacityReservations[0].AvailableInstanceCount' \
+            --query 'CapacityReservations[0].[TotalInstanceCount,AvailableInstanceCount]' \
             --output text)
+          TOTAL=$(awk '{print $1}' <<<"${CAP}")
+          AVAILABLE=$(awk '{print $2}' <<<"${CAP}")
+          echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
           echo "available=${AVAILABLE}" >> "$GITHUB_OUTPUT"
-          echo "Available instances in reservation ${RESERVATION}: ${AVAILABLE}"
-          if [[ "${AVAILABLE}" -lt "${DESIRED}" ]]; then
-            echo "::error::Insufficient capacity: need ${DESIRED} instances, only ${AVAILABLE} available in reservation ${RESERVATION}"
+          echo "Reservation ${RESERVATION}: total=${TOTAL}, available=${AVAILABLE}, desired=${DESIRED}"
+          if [[ -z "${TOTAL}" || "${TOTAL}" == "None" ]]; then
+            echo "::error::could not read TotalInstanceCount for reservation ${RESERVATION}"
+            exit 1
+          fi
+          if [[ "${TOTAL}" -lt "${DESIRED}" ]]; then
+            echo "::error::Reservation ${RESERVATION} is undersized: need ${DESIRED} instances, reservation holds only ${TOTAL}"
             exit 1
           fi
 
@@ -230,7 +328,7 @@ jobs:
       # arch: the GPU worker (p5.48xlarge) is amd64. Lives in the aicr-validators
       # namespace (not the release ghcr.io/nvidia/aicr repo); cleaned up below.
       - name: Build and push snapshot-agent image
-        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GOFLAGS: -mod=vendor
           KO_DOCKER_REPO: ghcr.io/nvidia/aicr-validators/agent
@@ -253,9 +351,10 @@ jobs:
           yq -i '.deployment.id = strenv(DEPLOYMENT_ID)' "$CLUSTER_CONFIG"
           cat "$CLUSTER_CONFIG"
 
-      # Bringup
+      # Bringup — skipped for daytime-down (teardown-only; nothing to provision).
       - name: Bringup Infra
         id: infra
+        if: inputs.lifecycle != 'daytime-down'
         run: |
           set -euox pipefail
           docker run \
@@ -319,9 +418,12 @@ jobs:
       # until the GPU stack converges — the readiness barrier the helmfile
       # bundle lacks (the helm deploy.sh `kubectl wait`s instead). Step id stays
       # `conformance` so the train/verify gating below is unaffected.
+      # daytime-up provisions and deploys the stack, then HOLDS: the CUJ
+      # (conformance/train/verify + evidence) is a nightly-batch concern, so
+      # daytime-up stops after install and leaves the cluster up for handoff.
       - name: UAT - validate (all phases) + emit signed evidence
         id: conformance
-        if: steps.install.outcome == 'success'
+        if: steps.install.outcome == 'success' && inputs.lifecycle != 'daytime-up'
         # Larger budget than conformance-only: the deployment phase waits out
         # cold-start GPU bring-up (driver install/migration). (The performance
         # phase's NCCL benchmark skips on single-GPU-node clusters like this
@@ -333,9 +435,13 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: ./tests/uat/aws/run conformance "${TEST_CONFIG}"
 
+      # The TrainJob CUJ is training-intent-specific. For intent=inference the
+      # served-workload CUJ (phase_serve) is owned by DC3 and out of scope here,
+      # so the train step is skipped; verify/evidence still cover the deployed
+      # inference stack.
       - name: UAT - train (TrainJob)
         id: train
-        if: steps.conformance.outcome == 'success'
+        if: steps.conformance.outcome == 'success' && inputs.intent == 'training'
         timeout-minutes: 25
         shell: bash
         env:
@@ -407,16 +513,21 @@ jobs:
         env:
           SUMMARY_RESERVATION: ${{ inputs.reservation }}
           SUMMARY_AICR_VERSION: ${{ inputs.aicr_version }}
+          SUMMARY_INTENT: ${{ inputs.intent }}
+          SUMMARY_LIFECYCLE: ${{ inputs.lifecycle }}
         run: |
           {
             echo "## UAT Results (AWS)"
             echo ""
-            printf '**Reservation:** `%s`\n' "$SUMMARY_RESERVATION"
+            printf '**Reservation:** `%s` · **Intent:** `%s` · **Lifecycle:** `%s`\n' \
+              "$SUMMARY_RESERVATION" "$SUMMARY_INTENT" "$SUMMARY_LIFECYCLE"
+            printf '**Cluster:** `%s`\n' "$DEPLOYMENT_ID"
             printf '**AICR version:** `%s`\n' "${SUMMARY_AICR_VERSION:-main (build from source)}"
             echo "**Build:** \`${{ github.sha }}\` (branch: \`${{ github.ref_name }}\`)"
             echo ""
             echo "| Phase | Status |"
             echo "|-------|--------|"
+            echo "| Pre-batch guard | ${{ steps.guard.outcome }} |"
             echo "| Capacity | ${{ steps.capacity.outcome }} |"
             echo "| Dependencies | ${{ steps.deps.outcome }} |"
             echo "| Config | ${{ steps.config.outcome }} |"
@@ -437,7 +548,7 @@ jobs:
       # Main cell only — release cells reference shared, permanent released image
       # tags and must not delete them.
       - name: Cleanup validator image
-        if: always() && inputs.aicr_version == '' && inputs.skip_tests != true
+        if: always() && inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -461,8 +572,19 @@ jobs:
       # actuator made every retry fail with ExpiredToken and leaked the GPU
       # node. The `id-token: write` permission is granted for the whole job,
       # so configure-aws-credentials can mint a fresh session here.
+      #
+      # Teardown gating (#1275, DC2): tear down for the nightly lifecycle
+      # (unless skip_delete) and for daytime-down (the explicit evening
+      # teardown of the held cluster — daytime-down provisions nothing, so it
+      # does not gate on steps.infra). NEVER for daytime-up, which holds the
+      # cluster for handoff. skip_delete is a nightly-only debugging escape and
+      # is ignored for daytime-down.
       - name: Refresh AWS credentials for teardown
-        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
+        if: >-
+          always() && (
+            inputs.lifecycle == 'daytime-down' ||
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+          )
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
         with:
           role-to-assume: "arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.GITHUB_ACTIONS_ROLE_NAME }}"
@@ -486,7 +608,11 @@ jobs:
       # post-loop guard a genuine destroy failure (e.g. orphaned ENIs/SGs
       # blocking VPC deletion) would exit 0 and re-leak silently.
       - name: Destroy Cluster
-        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
+        if: >-
+          always() && (
+            inputs.lifecycle == 'daytime-down' ||
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+          )
         shell: bash
         run: |
           set -euxo pipefail
@@ -529,4 +655,4 @@ jobs:
     uses: ./.github/workflows/evidence-ingest.yaml
     with:
       bundle_ref: ${{ needs.uat-aws.outputs.bundle_ref }}
-      recipe: eks-h100-training
+      recipe: eks-h100-${{ inputs.intent }}

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -25,13 +25,21 @@ on:
   workflow_call:
     inputs:
       reservation:
-        description: 'Reservation name (lease key) this run targets; used for labeling.'
+        description: 'Reservation name (lease key) this run targets; used for labeling and the daytime cluster name.'
         type: string
         required: true
       aicr_version:
         description: 'Released aicr version to install (e.g. v1.2.3); empty = build from source (main tip).'
         type: string
         default: ''
+      intent:
+        description: 'Recipe intent — selects the per-intent test config (h100-<intent>-config.yaml).'
+        type: string
+        default: training
+      lifecycle:
+        description: 'nightly (provision→CUJ→teardown) | daytime-up (provision+deploy+HOLD) | daytime-down (tear down the held daytime cluster).'
+        type: string
+        default: nightly
       cluster_config_path:
         description: 'Cluster-config the GKE actuator provisions from (from infra/uat/reservations.yaml).'
         type: string
@@ -82,10 +90,20 @@ jobs:
       GCP_REGION: "us-central1"
       GCP_WIF_PROVIDER: "projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider"
       GCP_WIF_SERVICE_ACCOUNT: "github-actions@eidosx.iam.gserviceaccount.com"
-      DEPLOYMENT_ID: "aicr-${{ github.run_id }}"
+      # Cluster name (GKE actuator derives it from .deployment.id). The nightly
+      # per-run lifecycle uses a run-scoped name for per-run isolation; the
+      # daytime lifecycles use a STABLE, reservation-tagged name so the evening
+      # teardown (daytime-down) and the nightly pre-batch guard can find the
+      # held cluster. Reservation names are lowercase alnum+hyphen, so the
+      # derived name is a valid GKE cluster name.
+      DEPLOYMENT_ID: >-
+        ${{ (inputs.lifecycle == 'daytime-up' || inputs.lifecycle == 'daytime-down')
+        && format('aicr-day-{0}', inputs.reservation)
+        || format('aicr-{0}', github.run_id) }}
       CLUSTER_CONFIG: ${{ inputs.cluster_config_path }}
-      # Training is the DC1 launch intent; DC2 selects the file by intent.
-      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-training-config.yaml
+      # DC2 selects the AICRConfig by intent; both intents drive the same
+      # cluster-config (GPU pool from the reservation, system/CPU pools dynamic).
+      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-${{ inputs.intent }}-config.yaml
       GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:latest"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
@@ -96,6 +114,30 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
+
+      # Fail closed on an unrecognized intent/lifecycle before any provisioning:
+      # workflow_dispatch constrains these to a choice, but workflow_call passes
+      # free strings, so a caller typo must surface as a clear error rather than
+      # a missing-file failure deep in a phase. Also assert the per-intent config
+      # exists so a missing sibling config fails here, not mid-run.
+      - name: Validate inputs
+        env:
+          INTENT: ${{ inputs.intent }}
+          LIFECYCLE: ${{ inputs.lifecycle }}
+        run: |
+          set -euo pipefail
+          case "${INTENT}" in
+            training|inference) ;;
+            *) echo "::error::unknown intent '${INTENT}' (want training|inference)"; exit 1 ;;
+          esac
+          case "${LIFECYCLE}" in
+            nightly|daytime-up|daytime-down) ;;
+            *) echo "::error::unknown lifecycle '${LIFECYCLE}' (want nightly|daytime-up|daytime-down)"; exit 1 ;;
+          esac
+          if [[ ! -f "${TEST_CONFIG}" ]]; then
+            echo "::error::test config not found: ${TEST_CONFIG}"; exit 1
+          fi
+          echo "intent=${INTENT} lifecycle=${LIFECYCLE} test-config=${TEST_CONFIG} cluster=${DEPLOYMENT_ID}"
 
       # Versions
       - name: Load versions
@@ -117,9 +159,10 @@ jobs:
 
       # Main cell (aicr_version empty): build the aicr binary from the
       # checked-out source (tip). Release cells install the released binary
-      # instead (next step).
+      # instead (next step). daytime-down tears down the held cluster only — it
+      # builds nothing and pushes no images.
       - name: Build aicr binary
-        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GOFLAGS: -mod=vendor
         run: |
@@ -132,7 +175,7 @@ jobs:
       # :<version>) and the snapshot-agent via ghcr.io/nvidia/aicr:<version> — so
       # the validator/agent build+push steps below are skipped for release cells.
       - name: Install released aicr
-        if: inputs.aicr_version != '' && inputs.skip_tests != true
+        if: inputs.aicr_version != '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         uses: ./.github/actions/install-aicr-release
         with:
           aicr-version: ${{ inputs.aicr_version }}
@@ -143,7 +186,7 @@ jobs:
       # Main cell only: release cells use the released validator images the
       # released binary self-resolves to (skipped when aicr_version is set).
       - name: Build and push validator images
-        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         run: |
           GO_VERSION="$(cat .go-version)"
           # CHAINSAW_* args dropped in #1236 — the deployment validator
@@ -167,6 +210,49 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+
+      # GCP capacity posture (#1275, DC2). Unlike AWS, GCP has NO pre-flight
+      # capacity/quota assertion here — the decision (recorded in
+      # docs/contributor/uat.md) is to rely on the GKE actuator failing at
+      # provision time if the reservation is exhausted, rather than adding a
+      # symmetric gcloud reservation check. The reservation lease (uat-run.yaml)
+      # already serializes contending runs, so a provision-time failure means a
+      # genuinely undersized/exhausted reservation, not a race. There is
+      # intentionally no capacity step below.
+
+      # Pre-batch guard (#1275, DC2). The nightly lifecycle refuses to provision
+      # into a reservation that still holds an un-torn-down daytime cluster: a
+      # missed evening teardown must surface as a BLOCKED batch, not as silent
+      # contention. Detect by the stable daytime cluster name
+      # (aicr-day-<reservation>); we already hold the reservation lease
+      # (uat-run.yaml) and are authenticated, so this runs before Bringup and
+      # fails fast rather than racing. Only the nightly lifecycle guards —
+      # daytime-up creates that cluster, daytime-down removes it.
+      - name: Pre-batch guard — refuse if a daytime cluster still holds the reservation
+        id: guard
+        if: inputs.lifecycle == 'nightly'
+        env:
+          RESERVATION: ${{ inputs.reservation }}
+        run: |
+          set -euo pipefail
+          DAYTIME_NAME="aicr-day-${RESERVATION}"
+          set +e
+          OUT=$(gcloud container clusters describe "${DAYTIME_NAME}" \
+            --region "${GCP_REGION}" --project "${GCP_PROJECT_ID}" 2>&1)
+          RC=$?
+          set -e
+          if [[ ${RC} -eq 0 ]]; then
+            echo "::error::daytime cluster ${DAYTIME_NAME} still holds reservation ${RESERVATION}; refusing to start the nightly batch. Tear it down first (uat-run lifecycle=daytime-down)."
+            exit 1
+          fi
+          # Fail closed on anything that is NOT a definitive "does not exist":
+          # a throttle/auth error must not be read as "clear to proceed".
+          if grep -qE 'code=404|Not found|No cluster' <<<"${OUT}"; then
+            echo "no daytime cluster on reservation ${RESERVATION}; proceeding"
+          else
+            echo "::error::could not determine daytime-cluster state for ${DAYTIME_NAME}: ${OUT}"
+            exit 1
+          fi
 
       # Deps
       - name: Install tools
@@ -199,7 +285,7 @@ jobs:
       # aicr-validators namespace (not the release ghcr.io/nvidia/aicr repo);
       # cleaned up below.
       - name: Build and push snapshot-agent image
-        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GOFLAGS: -mod=vendor
           KO_DOCKER_REPO: ghcr.io/nvidia/aicr-validators/agent
@@ -219,9 +305,10 @@ jobs:
           yq -i '.deployment.id = strenv(DEPLOYMENT_ID)' "$CLUSTER_CONFIG"
           cat "$CLUSTER_CONFIG"
 
-      # Bringup
+      # Bringup — skipped for daytime-down (teardown-only; nothing to provision).
       - name: Bringup Infra
         id: infra
+        if: inputs.lifecycle != 'daytime-down'
         run: |
           set -euox pipefail
           docker run \
@@ -289,9 +376,12 @@ jobs:
       # until the GPU stack converges — the readiness barrier the helmfile
       # bundle lacks (the helm deploy.sh `kubectl wait`s instead). Step id stays
       # `conformance` so the train/verify gating below is unaffected.
+      # daytime-up provisions and deploys the stack, then HOLDS: the CUJ
+      # (conformance/train/verify + evidence) is a nightly-batch concern, so
+      # daytime-up stops after install and leaves the cluster up for handoff.
       - name: UAT - validate (all phases) + emit signed evidence
         id: conformance
-        if: steps.install.outcome == 'success'
+        if: steps.install.outcome == 'success' && inputs.lifecycle != 'daytime-up'
         # Larger budget than conformance-only: the deployment phase waits out
         # cold-start GPU bring-up (driver install/migration). (The performance
         # phase's NCCL benchmark skips on single-GPU-node clusters like this
@@ -303,9 +393,13 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: ./tests/uat/gcp/run conformance "${TEST_CONFIG}"
 
+      # The TrainJob CUJ is training-intent-specific. For intent=inference the
+      # served-workload CUJ (phase_serve) is owned by DC3 and out of scope here,
+      # so the train step is skipped; verify/evidence still cover the deployed
+      # inference stack.
       - name: UAT - train (TrainJob)
         id: train
-        if: steps.conformance.outcome == 'success'
+        if: steps.conformance.outcome == 'success' && inputs.intent == 'training'
         timeout-minutes: 25
         shell: bash
         env:
@@ -380,16 +474,21 @@ jobs:
         env:
           SUMMARY_RESERVATION: ${{ inputs.reservation }}
           SUMMARY_AICR_VERSION: ${{ inputs.aicr_version }}
+          SUMMARY_INTENT: ${{ inputs.intent }}
+          SUMMARY_LIFECYCLE: ${{ inputs.lifecycle }}
         run: |
           {
             echo "## UAT Results (GCP)"
             echo ""
-            printf '**Reservation:** `%s`\n' "$SUMMARY_RESERVATION"
+            printf '**Reservation:** `%s` · **Intent:** `%s` · **Lifecycle:** `%s`\n' \
+              "$SUMMARY_RESERVATION" "$SUMMARY_INTENT" "$SUMMARY_LIFECYCLE"
+            printf '**Cluster:** `%s`\n' "$DEPLOYMENT_ID"
             printf '**AICR version:** `%s`\n' "${SUMMARY_AICR_VERSION:-main (build from source)}"
             echo "**Build:** \`${{ github.sha }}\` (branch: \`${{ github.ref_name }}\`)"
             echo ""
             echo "| Phase | Status |"
             echo "|-------|--------|"
+            echo "| Pre-batch guard | ${{ steps.guard.outcome }} |"
             echo "| Dependencies | ${{ steps.deps.outcome }} |"
             echo "| Config | ${{ steps.config.outcome }} |"
             echo "| Cluster | ${{ steps.infra.outcome }} |"
@@ -409,7 +508,7 @@ jobs:
       # Main cell only — release cells reference shared, permanent released image
       # tags and must not delete them.
       - name: Cleanup validator image
-        if: always() && inputs.aicr_version == '' && inputs.skip_tests != true
+        if: always() && inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -431,9 +530,20 @@ jobs:
       # and the actuator's STS exchange fails. The `id-token: write` permission
       # is granted for the whole job, so re-running auth mints a fresh token
       # file. Mirrors the AWS teardown credential refresh.
+      #
+      # Teardown gating (#1275, DC2): tear down for the nightly lifecycle
+      # (unless skip_delete) and for daytime-down (the explicit evening
+      # teardown of the held cluster — daytime-down provisions nothing, so it
+      # does not gate on steps.infra). NEVER for daytime-up, which holds the
+      # cluster for handoff. skip_delete is a nightly-only debugging escape and
+      # is ignored for daytime-down.
       - name: Re-authenticate to GCP for teardown
         id: auth_teardown
-        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
+        if: >-
+          always() && (
+            inputs.lifecycle == 'daytime-down' ||
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+          )
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
@@ -442,7 +552,11 @@ jobs:
       # Teardown (retry up to 3 times). Runs last so a slow destroy
       # cannot block evidence upload or summary rendering.
       - name: Destroy Cluster
-        if: always() && steps.infra.outcome != 'skipped' && inputs.skip_delete != true
+        if: >-
+          always() && (
+            inputs.lifecycle == 'daytime-down' ||
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+          )
         shell: bash
         run: |
           set -euxo pipefail
@@ -485,4 +599,4 @@ jobs:
     uses: ./.github/workflows/evidence-ingest.yaml
     with:
       bundle_ref: ${{ needs.uat-gcp.outputs.bundle_ref }}
-      recipe: gke-h100-training
+      recipe: gke-h100-${{ inputs.intent }}

--- a/.github/workflows/uat-run.yaml
+++ b/.github/workflows/uat-run.yaml
@@ -31,6 +31,14 @@ run-name: "UAT ${{ inputs.reservation }} @ ${{ inputs.aicr_version || 'main' }}$
 # cloud-appropriate reusable pipeline. Because every run for a reservation
 # routes through here and shares the lease, contending runs QUEUE instead of
 # racing the hardware.
+#
+# DC2 (#1275) adds two orthogonal dials, both forwarded to the cloud pipeline:
+#   - intent (training|inference) selects the per-intent test config +
+#     recipe criteria.
+#   - lifecycle (nightly|daytime-up|daytime-down) selects the cluster
+#     lifecycle: the nightly provision→CUJ→teardown, the daytime
+#     provision-and-hold (stable lease-tagged name, no teardown), or the
+#     evening teardown of that held daytime cluster.
 on:
   workflow_dispatch:
     inputs:
@@ -46,8 +54,18 @@ on:
         description: 'Unique correlation key set by the nightly controller so it can find this run; leave empty for manual runs.'
         type: string
         default: ''
+      intent:
+        description: 'Recipe intent — selects the per-intent test config (h100-<intent>-config.yaml) and recipe criteria.'
+        type: choice
+        options: [training, inference]
+        default: training
+      lifecycle:
+        description: 'Cluster lifecycle. nightly: provision→CUJ→teardown. daytime-up: provision+deploy+HOLD (stable name, no teardown). daytime-down: tear down the held daytime cluster.'
+        type: choice
+        options: [nightly, daytime-up, daytime-down]
+        default: nightly
       skip_delete:
-        description: 'Skip cluster teardown (manual debugging only).'
+        description: 'Skip cluster teardown (manual debugging only; ignored for daytime lifecycles).'
         type: boolean
         default: false
       skip_tests:
@@ -65,6 +83,12 @@ on:
       dispatch_key:
         type: string
         default: ''
+      intent:
+        type: string
+        default: training
+      lifecycle:
+        type: string
+        default: nightly
       skip_delete:
         type: boolean
         default: false
@@ -153,6 +177,8 @@ jobs:
     with:
       reservation: ${{ inputs.reservation }}
       aicr_version: ${{ inputs.aicr_version }}
+      intent: ${{ inputs.intent }}
+      lifecycle: ${{ inputs.lifecycle }}
       cluster_config_path: ${{ needs.resolve.outputs.cluster_config_path }}
       test_config_dir: ${{ needs.resolve.outputs.test_config_dir }}
       skip_delete: ${{ inputs.skip_delete }}
@@ -172,6 +198,8 @@ jobs:
     with:
       reservation: ${{ inputs.reservation }}
       aicr_version: ${{ inputs.aicr_version }}
+      intent: ${{ inputs.intent }}
+      lifecycle: ${{ inputs.lifecycle }}
       cluster_config_path: ${{ needs.resolve.outputs.cluster_config_path }}
       test_config_dir: ${{ needs.resolve.outputs.test_config_dir }}
       skip_delete: ${{ inputs.skip_delete }}

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -6,14 +6,14 @@
 
 Each reserved GPU pool follows a daily cycle, with every phase acquiring the *same* per-reservation lease so CI and human use never overlap on one reservation:
 
-- **Night — the nightly batch.** On a cron, `uat-nightly-batch.yaml` runs the [version matrix](#the-version-matrix) per reservation — `main` plus the previous N stable releases — each cell a full provision → CUJ → evidence → publish → teardown.
-- **Morning — handoff.** Once the batch drains a reservation, the daytime human-access deployment is stood up on it (owned by DC2/DC8; not yet implemented).
+- **Night — the nightly batch.** On a cron, `uat-nightly-batch.yaml` runs the [version matrix](#the-version-matrix) per reservation — `main` plus the previous N stable releases — each cell a full provision → CUJ → evidence → publish → teardown. This is the `lifecycle=nightly` mode: provision-and-destroy under a run-scoped cluster name.
+- **Morning — handoff.** Once the batch drains a reservation, the daytime human-access deployment is stood up on it with `lifecycle=daytime-up`: provision, deploy the stack, and **hold** (no teardown) under a stable, reservation-tagged cluster name. DC2 owns this provision-and-hold mechanic; DC8 owns *what* is deployed and how access is shared.
 - **Day — human use.** The daytime cluster is used outside CI.
-- **Evening — teardown.** The daytime cluster is torn down before the next night batch.
+- **Evening — teardown.** The daytime cluster is torn down with `lifecycle=daytime-down` **before** the next night batch, releasing the reservation.
 
-The phases are independently scheduled (cron edges), not chained: the per-reservation lease — plus a pre-batch guard (DC2) — keeps them from overlapping, so a crashed or overrunning phase never orphans the reservation. A hosted GitHub Actions job is capped at the runner's timeout (hours, not a whole working day), so a single lease-holding run cannot span the day; the lease only needs to cover the brief transition windows, and the steady-state daytime cluster's existence is guarded by its lease-tag rather than a continuously held run.
+The phases are independently scheduled (cron edges), not chained: the per-reservation lease — plus a [pre-batch guard](#pre-batch-guard) — keeps them from overlapping, so a crashed or overrunning phase never orphans the reservation. A hosted GitHub Actions job is capped at the runner's timeout (hours, not a whole working day), so a single lease-holding run cannot span the day; the lease only needs to cover the brief transition windows, and the steady-state daytime cluster's existence is tracked by its stable, reservation-tagged name rather than a continuously held run.
 
-> The morning handoff, the daytime deployment, and the evening teardown are owned by sibling work (DC2 and DC8) and are not yet wired up. What ships today is the **night side** (the nightly batch) plus the **lease + dispatch surface** every phase builds on.
+> What ships today is the **night side** (the nightly batch), the **lease + dispatch surface** every phase builds on, and DC2's **per-intent selection**, **daytime provision-and-hold / teardown mechanics**, and **pre-batch guard**. The daytime deployment's *workload content* and out-of-band access distribution are owned by DC8 and layer on top of the `daytime-up` mechanic.
 
 ## Requesting a UAT run
 
@@ -25,7 +25,55 @@ gh workflow run uat-run.yaml --repo NVIDIA/aicr --ref main -f reservation=aws-h1
 
 `uat-run.yaml` resolves the reservation row, then invokes the cloud-appropriate reusable pipeline (`uat-aws.yaml` or `uat-gcp.yaml`). A typo'd reservation name fails fast in the resolve step (the `uat-broker` helper exits *not found*). For manual debugging, `skip_tests` and `skip_delete` inputs are available.
 
-The nightly batch and (later) the daytime handoff call this *same* surface, so every run for a reservation contends on one lease.
+Two further inputs shape the run (both default to the nightly-batch behavior, so the cron needs neither):
+
+```bash
+# Inference intent, nightly provision→CUJ→teardown
+gh workflow run uat-run.yaml --repo NVIDIA/aicr --ref main \
+  -f reservation=aws-h100 -f intent=inference
+
+# Morning handoff: stand up the daytime cluster and hold it
+gh workflow run uat-run.yaml --repo NVIDIA/aicr --ref main \
+  -f reservation=aws-h100 -f lifecycle=daytime-up
+
+# Evening teardown of the held daytime cluster
+gh workflow run uat-run.yaml --repo NVIDIA/aicr --ref main \
+  -f reservation=aws-h100 -f lifecycle=daytime-down
+```
+
+The nightly batch and the daytime handoff/teardown call this *same* surface, so every run for a reservation contends on one lease.
+
+## Selecting the intent
+
+The `intent` input (`training` — the default — or `inference`) selects both the recipe criteria and the per-intent test config the pipeline consumes: `tests/uat/<cloud>/tests/h100-<intent>-config.yaml`. The two configs are siblings with the same `AICRConfig` shape; they differ only in `spec.recipe.criteria.intent`/`platform` (`training`/`kubeflow` vs `inference`/`dynamo`) and the stable evidence push prefix. Both intents provision from the *same* `cluster-config.yaml` — the GPU pool count comes from the reservation row and the system/CPU pools stay per-run dynamic (GCP autoscales; AWS is fixed at `desired: 3`), so nothing about the cluster shape is hardcoded per intent.
+
+The nightly CUJ steps are intent-aware: the training TrainJob step runs only for `intent=training`. The served-inference workload (`phase_serve`) is owned by DC3 and out of scope here, so an `intent=inference` run stands up and validates the inference stack (Dynamo platform, KAI scheduler, DRA driver) and signs evidence, but does not yet exercise a served endpoint.
+
+An unrecognized `intent` (or a missing sibling config) fails closed in the pipeline's `Validate inputs` step before any provisioning.
+
+## Cluster lifecycles
+
+The `lifecycle` input selects one of three cluster lifecycles, all sharing the reservation lease:
+
+| Lifecycle | Cluster name | Provisions | Deploys | CUJ | Teardown at job end |
+|-----------|--------------|-----------|---------|-----|---------------------|
+| `nightly` (default) | `aicr-uat-<run_id>` (AWS) / `aicr-<run_id>` (GCP) — run-scoped | yes | yes | yes (prep→install→validate→train/verify) | yes (unless `skip_delete`) |
+| `daytime-up` | `aicr-uat-day-<reservation>` (AWS) / `aicr-day-<reservation>` (GCP) — **stable** | yes | yes (prep→install) | no | **no — holds** |
+| `daytime-down` | same stable name | no | no | no | yes (tears down the held cluster) |
+
+The nightly per-run name isolates concurrent history (OCI tags, Terraform state) per run. The daytime name is **stable and reservation-tagged** so the evening `daytime-down` teardown and the nightly pre-batch guard can find the held cluster without tracking a run id. `skip_delete` is a nightly-only debugging escape and is ignored by the daytime lifecycles.
+
+## Pre-batch guard
+
+A missed evening teardown must surface as a **blocked batch, never as silent contention** with the still-running daytime deployment. Before it provisions, every `nightly` run asserts that no daytime cluster (by the stable `aicr-uat-day-<reservation>` / `aicr-day-<reservation>` name) is still up on the target reservation. The check runs *after* the run has acquired the reservation lease and authenticated to the cloud, and *before* Bringup — so it fails fast rather than racing. It fails **closed**: only a definitive "cluster does not exist" (AWS `ResourceNotFoundException`, GCP `code=404`) clears the run to proceed; a throttle or auth error blocks the batch rather than being read as "clear."
+
+If the guard trips, tear the daytime cluster down with `lifecycle=daytime-down` (which releases the reservation), then re-run the batch.
+
+## Capacity assertions and the GCP posture
+
+**AWS — post-lease assertion.** `uat-aws.yaml` asserts the EC2 capacity reservation is provisioned large enough for the GPU pool's desired count. Because the reservation lease is now the contention gate, this is **not** a race-and-fail pre-flight: it checks the reservation's `TotalInstanceCount` (its fixed provisioned size), not the momentary `AvailableInstanceCount`. A genuinely undersized/exhausted reservation still fails; transient contention (another run's not-yet-released nodes) no longer does, because the lease already guaranteed we are the only run consuming the reservation.
+
+**GCP — actuator-time failure (decided posture).** `uat-gcp.yaml` has **no** pre-flight capacity/quota assertion, and DC2 deliberately did **not** add one. GCP relies on the GKE actuator failing at provision time if the reservation is exhausted. With the reservation lease serializing contending runs, a provision-time failure means a genuinely undersized/exhausted reservation, not a race — so a symmetric gcloud reservation check would add a second cloud API surface without changing the outcome. This is a recorded decision, not an oversight; there is intentionally no capacity step in the GCP pipeline.
 
 ## How queuing works (the reservation lease)
 
@@ -70,6 +118,7 @@ The values in this file are identifiers, **not secrets** — a reservation-id gr
 
 ## Roadmap
 
-What ships now is the lease, the data-driven dispatch surface, the time-boxed nightly version matrix (`main` + previous-N stable releases, release cells installing released artifacts), and superseded-run surfacing (the controller flags a dropped cell inline; the `uat-superseded-notice.yaml` observer catches ad-hoc dropped runs). Still to come:
+What ships now is the lease, the data-driven dispatch surface, the time-boxed nightly version matrix (`main` + previous-N stable releases, release cells installing released artifacts), superseded-run surfacing (the controller flags a dropped cell inline; the `uat-superseded-notice.yaml` observer catches ad-hoc dropped runs), per-intent selection, and the daytime provision-and-hold / teardown / pre-batch-guard mechanics. Still to come:
 
-- **Per-intent shaping + daytime deployment (DC2 / DC8).** Selecting the test config and recipe by `intent`, and the morning-handoff daytime human-access cluster.
+- **Served-inference CUJ (DC3).** The `phase_serve` step an `intent=inference` run will exercise on the deployed inference stack.
+- **Daytime workload + access (DC8).** *What* the daytime cluster deploys on top of DC2's `daytime-up` mechanic, the served-endpoint exposure, and out-of-band access distribution.

--- a/tests/uat/aws/tests/h100-inference-config.yaml
+++ b/tests/uat/aws/tests/h100-inference-config.yaml
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AICRConfig consumed by `aicr {snapshot,recipe,bundle,validate} --config`.
+#
+# The inference sibling of `h100-training-config.yaml` (#1275, DC2). The UAT
+# pipeline selects between the two by the `intent` input: an `intent=inference`
+# dispatch resolves this file, an `intent=training` (the default) dispatch the
+# training one. Both drive the SAME EKS cluster (`../cluster-config.yaml`) — the
+# GPU pool count comes from the reservation row and the system/CPU pools stay
+# per-run dynamic, so only the recipe criteria (and the evidence push target)
+# differ by intent.
+#
+# The served inference workload itself (phase_serve) is out of scope here and
+# owned by DC3; this config stands up and validates the inference stack
+# (dynamo platform + KAI scheduler + DRA driver) the way the training config
+# stands up the training stack.
+#
+# `spec.validate.evidence.attestation.push` carries the stable per-recipe
+# repo only; `../run` appends a `:run-${RUN_ID}` tag at runtime so each UAT
+# execution publishes a uniquely traceable, digest-addressed point under one
+# stable repo (`oras repo tags` lists run history). Consumers pin immutably
+# via `@sha256:…`.
+kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: eks-h100-inference-uat
+
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - dedicated=worker-workload:NoSchedule
+        - dedicated=worker-workload:NoExecute
+        - nvidia.com/gpu=present:NoSchedule
+
+  recipe:
+    criteria:
+      service: eks
+      accelerator: h100
+      os: ubuntu
+      intent: inference
+      platform: dynamo
+    output:
+      path: recipe.yaml
+
+  bundle:
+    input:
+      recipe: recipe.yaml
+    output:
+      target: ./bundle
+    deployment:
+      deployer: helmfile
+    scheduling:
+      acceleratedNodeSelector:
+        nodeGroup: gpu-worker
+      acceleratedNodeTolerations:
+        - dedicated=worker-workload:NoSchedule
+        - dedicated=worker-workload:NoExecute
+        - nvidia.com/gpu=present:NoSchedule
+      systemNodeSelector:
+        nodeGroup: system-worker
+      systemNodeTolerations:
+        - dedicated=system-workload:NoSchedule
+        - dedicated=system-workload:NoExecute
+      # Consume the cluster's default StorageClass rather than hardcoding a
+      # name. The aws-ebs-csi-driver component provisions a gp3-backed default
+      # named "ebs-csi-default-sc" (annotated is-default-class=true), so an
+      # empty value binds PVCs to it automatically. Pinning a literal "gp3"
+      # only works on clusters using the AWS managed EBS CSI addon (which
+      # auto-creates a class named "gp3") — not on an aicr-bundle-deployed
+      # cluster, where the StatefulSet would otherwise never be created.
+      storageClass: ""
+
+  validate:
+    execution:
+      # The deployment phase is the readiness barrier (gpu-operator ClusterPolicy
+      # reaches state=ready, the DRA kubelet-plugin DaemonSet rolls out, nodewright
+      # node tuning completes). failFast stops the run if that phase fails, so the
+      # conformance/performance phases are not evaluated against a not-yet-converged
+      # cluster — which previously surfaced as misleading accelerator-metrics /
+      # ai-service-metrics / pod-autoscaling failures. The `../run` readiness gate
+      # gives the operator-driven stack time to converge before validate, so on a
+      # healthy cluster the deployment phase passes and all phases still run.
+      failFast: true
+    input:
+      recipe: recipe.yaml
+      snapshot: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      tolerations:
+        - dedicated=worker-workload:NoSchedule
+        - dedicated=worker-workload:NoExecute
+        - nvidia.com/gpu=present:NoSchedule
+    evidence:
+      attestation:
+        # Setting `out` enables emit. The push target below is the stable
+        # per-recipe repo; ../run appends a `:run-${RUN_ID}` tag for per-run
+        # isolation. Consumers pin immutably via the artifact digest.
+        out: ./evidence
+        push: ghcr.io/nvidia/aicr-evidence/h100-eks-ubuntu-inference-dynamo

--- a/tests/uat/gcp/tests/h100-inference-config.yaml
+++ b/tests/uat/gcp/tests/h100-inference-config.yaml
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AICRConfig consumed by `aicr {snapshot,recipe,bundle,validate} --config`.
+#
+# The inference sibling of `h100-training-config.yaml` (#1275, DC2). The UAT
+# pipeline selects between the two by the `intent` input: an `intent=inference`
+# dispatch resolves this file, an `intent=training` (the default) dispatch the
+# training one. Both drive the SAME GKE cluster (`../cluster-config.yaml`) — the
+# GPU pool count comes from the reservation row and the system/CPU pools stay
+# per-run dynamic (GKE autoscales), so only the recipe criteria (and the
+# evidence push target) differ by intent.
+#
+# The served inference workload itself (phase_serve) is out of scope here and
+# owned by DC3; this config stands up and validates the inference stack
+# (dynamo platform + KAI scheduler + DRA driver) the way the training config
+# stands up the training stack.
+#
+# `spec.validate.evidence.attestation.push` carries the stable per-recipe
+# repo only; `../run` appends a `:run-${RUN_ID}` tag at runtime so each UAT
+# execution publishes a uniquely traceable, digest-addressed point under one
+# stable repo (`oras repo tags` lists run history). Consumers pin immutably
+# via `@sha256:…`.
+kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: gke-h100-inference-uat
+
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - dedicated=gpu-workload:NoSchedule
+        - nvidia.com/gpu=present:NoSchedule
+
+  recipe:
+    criteria:
+      service: gke
+      accelerator: h100
+      os: cos
+      intent: inference
+      platform: dynamo
+    output:
+      path: recipe.yaml
+
+  bundle:
+    input:
+      recipe: recipe.yaml
+    output:
+      target: ./bundle
+    deployment:
+      deployer: helmfile
+    scheduling:
+      acceleratedNodeSelector:
+        nodeGroup: gpu-worker
+      acceleratedNodeTolerations:
+        - dedicated=gpu-workload:NoSchedule
+        - nvidia.com/gpu=present:NoSchedule
+      systemNodeSelector:
+        nodeGroup: system-worker
+      # GKE pd-ssd-backed default; matches the UAT GPU node disk type.
+      storageClass: premium-rwo
+
+  validate:
+    execution:
+      # The deployment phase is the readiness barrier (gpu-operator ClusterPolicy
+      # reaches state=ready, the DRA kubelet-plugin DaemonSet rolls out, nodewright
+      # node tuning completes). failFast stops the run if that phase fails, so the
+      # conformance/performance phases are not evaluated against a not-yet-converged
+      # cluster — which previously surfaced as misleading accelerator-metrics /
+      # ai-service-metrics / pod-autoscaling failures. The `../run` readiness gate
+      # gives the operator-driven stack time to converge before validate, so on a
+      # healthy cluster the deployment phase passes and all phases still run.
+      failFast: true
+    input:
+      recipe: recipe.yaml
+      snapshot: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      tolerations:
+        - dedicated=gpu-workload:NoSchedule
+        - nvidia.com/gpu=present:NoSchedule
+    evidence:
+      attestation:
+        # Setting `out` enables emit. The push target below is the stable
+        # per-recipe repo; ../run appends a `:run-${RUN_ID}` tag for per-run
+        # isolation. Consumers pin immutably via the artifact digest.
+        out: ./evidence
+        push: ghcr.io/nvidia/aicr-evidence/h100-gke-cos-inference-dynamo


### PR DESCRIPTION
## Summary

Acquire a UAT cluster shaped by `{reservation, intent}` through the reservation lease, and add the two cluster lifecycles a reservation can carry — the nightly per-run cluster and the long-lived daytime deployment — with an enforced cleanup boundary between them.

## Motivation / Context

Implements DC2. AWS previously hard-failed on a busy reservation in a race-and-fail pre-flight; the test config and recipe intent were hard-coded to training; and there was no mechanism for the morning-handoff daytime cluster or a guard preventing the nightly batch from racing an un-torn-down daytime deployment. This builds on DC1's reservation lease and dispatch surface.

Fixes: #1275
Related: #1264, #1274

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT CI workflows (`.github/workflows/uat-*.yaml`) and UAT test configs (`tests/uat/**`)

## Implementation Notes

- **Per-intent selection.** `intent` input (`training`|`inference`) on `uat-run.yaml`, forwarded to the cloud pipelines, selects `tests/uat/<cloud>/tests/h100-<intent>-config.yaml` and the evidence-ingest recipe name. New inference sibling configs (`intent: inference` / `platform: dynamo`). Both intents drive the *same* `cluster-config.yaml` (GPU pool from the reservation, system/CPU pools dynamic). The training TrainJob CUJ is gated to `intent=training`; served inference (`phase_serve`) is DC3's.
- **AWS capacity → post-lease assertion.** Now asserts `TotalInstanceCount >= desired` (the reservation's fixed size) rather than `AvailableInstanceCount`, so contention no longer hard-fails (the lease is the gate) but a genuinely undersized reservation still does.
- **GCP capacity — decided posture.** No symmetric pre-flight check; GCP relies on the GKE actuator failing at provision time. Documented in `docs/contributor/uat.md` and noted in `uat-gcp.yaml` (no phantom step).
- **Daytime lifecycle.** `lifecycle` input (`nightly`|`daytime-up`|`daytime-down`). Daytime modes use a stable, reservation-tagged `deployment.id` so teardown and the guard find the held cluster across runs (Terraform state is remote, keyed by `deployment.id`). `daytime-up` provisions + deploys + holds; `daytime-down` tears the held cluster down.
- **Pre-batch guard.** Every `nightly` run refuses to provision into a reservation that still holds an un-torn-down daytime cluster (detected by the stable cluster name), failing fast and fail-closed rather than racing.

## Testing

```bash
# Config resolution (recipe + bundle) for both new inference configs
aicr recipe --config tests/uat/aws/tests/h100-inference-config.yaml
aicr bundle --config tests/uat/aws/tests/h100-inference-config.yaml   # + gcp
# Workflow + docs lint
yamllint -c .yamllint.yaml .github/workflows/uat-*.yaml
actionlint -shellcheck= .github/workflows/uat-*.yaml
./tools/check-docs-filenames && ./tools/check-docs-mdx
```

Both inference configs resolve (recipe + bundle produce a valid `bundle/helmfile.yaml`); `validate --no-cluster` only needs a runtime snapshot. yamllint, actionlint (pinned v1.7.11, matching the merge gate's `-shellcheck=`), and the docs filename/MDX checks pass. No Go changes. Real UAT (provision on live GPU hardware) is not runnable locally and is exercised by dispatching the workflow.

## Risk Assessment

- [x] **Low** — CI/config/docs only, no Go changes, easy to revert; new lifecycles default to the existing nightly behavior.

**Rollout notes:** `intent` and `lifecycle` default to `training`/`nightly`, so the nightly cron and existing dispatches are unchanged. The daytime lifecycle's *workload content* and access distribution are DC8's and layer on top of the `daytime-up` mechanic shipped here.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`) — yamllint + actionlint + docs checks pass
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — new inference AICRConfigs (validated via recipe/bundle resolution + existing cuj2-inference chainsaw tests)
- [x] I updated docs if user-facing behavior changed — `docs/contributor/uat.md`
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
