### PR TITLE
fix(ci): trim UAT nightly matrix, quiet run-watch, run 2 GPU nodes

### DIFF
--- a/.github/workflows/uat-nightly-batch.yaml
+++ b/.github/workflows/uat-nightly-batch.yaml
@@ -37,7 +37,7 @@ on:
       previous_n:
         description: 'Previous stable releases below main to run per reservation (0 = main only).'
         type: string
-        default: '2'
+        default: '1'
       deadline_offset_hours:
         description: 'Time-box: hours after batch start to stop dispatching new cells. Keep below the drive job timeout (GitHub caps a hosted job at 6h) so the graceful drop-oldest is reachable.'
         type: string
@@ -143,7 +143,7 @@ jobs:
           REPO: ${{ github.repository }}
           REF: ${{ github.ref_name }}
           RESERVATION: ${{ matrix.reservation }}
-          PREVIOUS_N: ${{ inputs.previous_n || '2' }}
+          PREVIOUS_N: ${{ inputs.previous_n || '1' }}
           DEADLINE_OFFSET_HOURS: ${{ inputs.deadline_offset_hours || '5' }}
           BATCH_START: ${{ needs.enumerate.outputs.batch_start }}
         run: |
@@ -232,7 +232,13 @@ jobs:
             # --exit-status is intentionally not fatal here; classify the run's
             # conclusion below so we can distinguish a benign superseded run from
             # a real failure without aborting mid-loop.
-            gh run watch "$run_id" --repo "$REPO" --exit-status || true
+            # Output is discarded: in a non-TTY log `gh run watch` APPENDS a full
+            # status render every refresh (no in-place redraw), which flooded the
+            # drive log with tens of thousands of duplicate lines per multi-hour
+            # cell. We only need it to BLOCK until the run finishes; the
+            # conclusion is read from `gh run view` below, so the live render is
+            # redundant. --interval 60 keeps the polling gentle on the API.
+            gh run watch "$run_id" --repo "$REPO" --interval 60 --exit-status >/dev/null 2>&1 || true
 
             conclusion=$(gh run view "$run_id" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "")
             njobs=$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" --jq '.total_count' 2>/dev/null || echo "")

--- a/tests/uat/aws/cluster-config.yaml
+++ b/tests/uat/aws/cluster-config.yaml
@@ -91,7 +91,13 @@ compute:
         - name: gpu-worker
           instanceType: p5.48xlarge
           capacity:
-            desired: 1
+            # Two GPU nodes: activates the multi-node NCCL East-West fabric
+            # check (nccl-all-reduce-bw, which skips on a single GPU node) and
+            # lets the TrainJob (numNodes: 2) span both nodes. Requires the
+            # capacity reservation below to hold >=2 p5.48xlarge instances —
+            # the post-lease capacity assertion in uat-aws.yaml fails closed
+            # otherwise.
+            desired: 2
             reservation:
               preference: capacity-reservations-only
               target: cr-0cbe491320188dfa6

--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -282,8 +282,9 @@ phase_conformance() {
   # not-yet-converged cluster and failed. The deployment phase gates that
   # convergence deployer-agnostically. The performance phase's only check,
   # nccl-all-reduce-bw, needs >=2 GPU nodes for its East-West fabric test and
-  # skips gracefully on this single-GPU-node cluster (skip != fail); it
-  # activates automatically if the cluster ever scales to multiple GPU nodes.
+  # is now active: the cluster-config provisions 2 GPU nodes (gpu-worker
+  # capacity.desired: 2). If the pool is ever scaled back to a single GPU
+  # node, the check skips gracefully (skip != fail) rather than failing.
   # Evidence is rendered/attested from the merged multi-phase report, so the
   # signed bundle covers all phases.
   echo "::group::Validate (all phases) + emit signed evidence"
@@ -312,7 +313,7 @@ metadata:
   namespace: ${TRAINJOB_NAMESPACE}
 spec:
   trainer:
-    numNodes: 1
+    numNodes: 2
     image: ${TRAINJOB_IMAGE}
     command:
       - python3

--- a/tests/uat/gcp/cluster-config.yaml
+++ b/tests/uat/gcp/cluster-config.yaml
@@ -103,9 +103,13 @@ compute:
           zones:
             - us-central1-c
           autoscaling:
+            # Two GPU nodes: activates the multi-node NCCL East-West fabric
+            # check (nccl-all-reduce-bw, which skips on a single GPU node) and
+            # lets the TrainJob (numNodes: 2) span both nodes. Drawn from the
+            # 384-node general-pool reservation below, so no capacity gate.
             enabled: true
-            minNodes: 1
-            maxNodes: 1
+            minNodes: 2
+            maxNodes: 2
           guestAccelerator:
             type: nvidia-h100-mega-80gb
             count: 8

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -282,8 +282,9 @@ phase_conformance() {
   # not-yet-converged cluster and failed. The deployment phase gates that
   # convergence deployer-agnostically. The performance phase's only check,
   # nccl-all-reduce-bw, needs >=2 GPU nodes for its East-West fabric test and
-  # skips gracefully on this single-GPU-node cluster (skip != fail); it
-  # activates automatically if the cluster ever scales to multiple GPU nodes.
+  # is now active: the cluster-config provisions 2 GPU nodes (gpu-worker
+  # autoscaling min/maxNodes: 2). If the pool is ever scaled back to a single
+  # GPU node, the check skips gracefully (skip != fail) rather than failing.
   # Evidence is rendered/attested from the merged multi-phase report, so the
   # signed bundle covers all phases.
   echo "::group::Validate (all phases) + emit signed evidence"
@@ -312,7 +313,7 @@ metadata:
   namespace: ${TRAINJOB_NAMESPACE}
 spec:
   trainer:
-    numNodes: 1
+    numNodes: 2
     image: ${TRAINJOB_IMAGE}
     command:
       - python3


### PR DESCRIPTION
## Summary

UAT nightly-batch tuning observed during a live UAT session: trim the version matrix to main + latest stable, silence `gh run watch` log spam, and provision 2 GPU nodes per bringup so multi-node NCCL coverage actually runs.

## Motivation / Context

Observed running the nightly batch:

- The version matrix ran main + the previous **two** stable releases per reservation; main + latest stable is enough right now.
- The `drive` job's "Run version-matrix cells" step flooded the log — in a non-TTY Actions log `gh run watch` appends a full status render every refresh (no in-place redraw), so the 3s default emitted tens of thousands of duplicate status lines per multi-hour cell.
- Clusters brought up a single GPU node, so the performance phase's `nccl-all-reduce-bw` East-West fabric check skipped (needs ≥2 GPU nodes) and the TrainJob never spanned nodes — no multi-node coverage.

Fixes: N/A
Related: #1274

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT CI (`.github/workflows/uat-nightly-batch.yaml`, `tests/uat/{aws,gcp}`)

## Implementation Notes

- **Matrix trim:** `previous_n` default `2` → `1` (both the `workflow_dispatch` input default and the cron `|| '1'` fallback).
- **Log spam:** `gh run watch` output discarded (`--interval 60 --exit-status >/dev/null 2>&1`). It is used only to block until the cell finishes; the conclusion is still read from `gh run view` afterward, so nothing is lost.
- **2 GPU nodes:** AWS `gpu-worker` `capacity.desired: 2`; GCP `gpu-worker` autoscaling `min/maxNodes: 2`; TrainJob `numNodes: 2` in both run scripts. Conformance-phase comments refreshed — the NCCL check is now active and only skips if the pool is ever scaled back to a single node.

## Testing

```bash
yamllint .github/workflows/uat-nightly-batch.yaml tests/uat/aws/cluster-config.yaml tests/uat/gcp/cluster-config.yaml  # clean
bash -n tests/uat/aws/run tests/uat/gcp/run  # clean
```

YAML/shell-only change; validated with yamllint and `bash -n`. End-to-end verification happens in the nightly UAT run itself.

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

**Rollout notes:** AWS capacity reservation `cr-0cbe491320188dfa6` must hold **≥2 p5.48xlarge** instances or the post-lease capacity assertion in `uat-aws.yaml` fails closed. GCP draws from the 384-node general-pool reservation, so no capacity gate applies. 2 GPU nodes ≈ 2× GPU spend per cell (and for the long-lived daytime-up cluster). Easy to revert per commit.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
