### PR TITLE
chore(scan): suppress unfixed oras-go tar-extraction CVE (GHSA-fxhp-mv3v-67qp)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -34,3 +34,29 @@ exclude:
 # suppressed CVEs are all in Python / glibc / libcap2 / ncurses /
 # pillow and never surface against Go source.
 # Reviewed: 2026-06-01
+
+# Go-source suppressions (accepted risk, not "not affected").
+#
+# Unlike the aiperf-bench image CVEs above, these Go-module findings are
+# REACHABLE in AICR source and are suppressed only because no fixed
+# release exists upstream yet. Each entry MUST record the reachable path,
+# the no-fix status, the target fixed version, and a review date. Drop the
+# entry the moment a fixed version is vendored — do not let it linger.
+ignore:
+  # GHSA-fxhp-mv3v-67qp (CVE-2026-50163) — oras-go tar extraction: a
+  # hardlink entry with a relative Linkname escapes the extract dir via
+  # process-CWD resolution. REACHABLE: `aicr evidence verify` pulls an OCI
+  # bundle via oras.Copy into a file.Store that unpacks the gzip-tar layer
+  # to disk (pkg/evidence/verifier/fetch.go). Exploiting it requires an
+  # operator to verify a hostile/attacker-crafted bundle (CVSS UI:R).
+  # No fixed v2 release exists: latest tag is v2.6.1 (affected); the fix
+  # (b11f777) is only on the v3 module line (github.com/oras-project/oras-go/v3),
+  # which itself has only a v3.0.0-dev pre-release. Advisory declares the
+  # v2 patch as v2.7.0 but it is not yet tagged.
+  # ACTION: bump oras.land/oras-go/v2 to v2.7.0 and delete this entry.
+  # Review: 2026-08-01
+  - vulnerability: GHSA-fxhp-mv3v-67qp
+    reason: >-
+      Reachable but no fixed v2 release exists yet; fix is v3-only
+      (unstable v3.0.0-dev). Track upstream v2.7.0 tag, then bump and
+      remove. See CVE-2026-50163.


### PR DESCRIPTION
## Summary

Add a documented, dated grype `ignore` for **GHSA-fxhp-mv3v-67qp / CVE-2026-50163** (oras-go tar-extraction hardlink escape, High) so `make scan` / `make qualify` is unblocked while no fixed upstream release exists.

## Motivation / Context

`make scan` (`grype dir:.`) fails on GHSA-fxhp-mv3v-67qp in `oras.land/oras-go/v2 v2.6.1`. Investigation:

- **Reachable in AICR** — `aicr evidence verify` pulls an OCI bundle via `oras.Copy` into a `file.Store` that unpacks the gzip-tar layer to disk (`pkg/evidence/verifier/fetch.go`). This is the exact hardlink/relative-`Linkname` CWD-escape path the advisory describes, so a `not_affected` suppression would be false. Exploiting it requires an operator to verify a hostile/attacker-crafted bundle (CVSS `UI:R`).
- **No fixed v2 release exists** — `v2.6.1` is the latest tag and is affected; the fix (`b11f777`) is only on the `main`/**v3** module line (`github.com/oras-project/oras-go/v3`), which itself has only a `v3.0.0-dev` pre-release. The advisory declares the v2 patch as `v2.7.0`, but it is not tagged yet.

Given no fixed v2 artifact and no drop-in v2 commit, an accepted-risk-with-tracking grype `ignore` is the correct mechanism. **OpenVEX is not usable here**: `.openvex.json` is only wired into the image scans (via the `vex:` input), not `grype dir:.`, and all its statements are `not_affected`, whereas this CVE is reachable/affected.

Fixes: N/A
Related: GHSA-fxhp-mv3v-67qp, CVE-2026-50163

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: vulnerability scan config (`.grype.yaml`)

## Implementation Notes

- The `ignore` entry records the reachable path, the no-fix status, the target fixed version (`v2.7.0`), and a **2026-08-01 review date**, under a new "Go-source suppressions (accepted risk, not not_affected)" header.
- **Action to remove:** bump `oras.land/oras-go/v2` to `v2.7.0` once tagged and delete the entry.

## Testing

```bash
make scan   # Running vulnerability scan... No vulnerabilities found
yamllint .grype.yaml   # clean
```

No Go source changed, so the Go lint/coverage gates do not apply.

## Risk Assessment

- [x] **Low** — Scan-config only; trivially reversible.

**Rollout notes:** Delete the ignore entry when `oras-go` v2.7.0 is tagged and vendored. Review date 2026-08-01.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`) — yamllint clean; no Go changes
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
