### PR TITLE
refactor(ci): unify daytime UAT cluster name prefix across clouds

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -98,8 +98,8 @@ jobs:
       # derived name is a valid GKE cluster name.
       DEPLOYMENT_ID: >-
         ${{ (inputs.lifecycle == 'daytime-up' || inputs.lifecycle == 'daytime-down')
-        && format('aicr-day-{0}', inputs.reservation)
-        || format('aicr-{0}', github.run_id) }}
+        && format('aicr-uat-day-{0}', inputs.reservation)
+        || format('aicr-uat-{0}', github.run_id) }}
       CLUSTER_CONFIG: ${{ inputs.cluster_config_path }}
       # DC2 selects the AICRConfig by intent; both intents drive the same
       # cluster-config (GPU pool from the reservation, system/CPU pools dynamic).
@@ -224,7 +224,7 @@ jobs:
       # into a reservation that still holds an un-torn-down daytime cluster: a
       # missed evening teardown must surface as a BLOCKED batch, not as silent
       # contention. Detect by the stable daytime cluster name
-      # (aicr-day-<reservation>); we already hold the reservation lease
+      # (aicr-uat-day-<reservation>); we already hold the reservation lease
       # (uat-run.yaml) and are authenticated, so this runs before Bringup and
       # fails fast rather than racing. Only the nightly lifecycle guards —
       # daytime-up creates that cluster, daytime-down removes it.
@@ -235,7 +235,7 @@ jobs:
           RESERVATION: ${{ inputs.reservation }}
         run: |
           set -euo pipefail
-          DAYTIME_NAME="aicr-day-${RESERVATION}"
+          DAYTIME_NAME="aicr-uat-day-${RESERVATION}"
           set +e
           OUT=$(gcloud container clusters describe "${DAYTIME_NAME}" \
             --region "${GCP_REGION}" --project "${GCP_PROJECT_ID}" 2>&1)

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -58,7 +58,7 @@ The `lifecycle` input selects one of three cluster lifecycles, all sharing the r
 | Lifecycle | Cluster name | Provisions | Deploys | CUJ | Teardown at job end |
 |-----------|--------------|-----------|---------|-----|---------------------|
 | `nightly` (default) | `aicr-uat-<run_id>` (AWS) / `aicr-<run_id>` (GCP) — run-scoped | yes | yes | yes (prep→install→validate→train/verify) | yes (unless `skip_delete`) |
-| `daytime-up` | `aicr-uat-day-<reservation>` (AWS) / `aicr-day-<reservation>` (GCP) — **stable** | yes | yes (prep→install) | no | **no — holds** |
+| `daytime-up` | `aicr-uat-day-<reservation>` — **stable** | yes | yes (prep→install) | no | **no — holds** |
 | `daytime-down` | same stable name | no | no | no | yes (tears down the held cluster) |
 
 The nightly per-run name isolates concurrent history (OCI tags, Terraform state) per run. The daytime name is **stable and reservation-tagged** so the evening `daytime-down` teardown and the nightly pre-batch guard can find the held cluster without tracking a run id. `skip_delete` is a nightly-only debugging escape and is ignored by the daytime lifecycles.
@@ -110,8 +110,8 @@ Access is **out-of-band by design**: nothing here routes a kubeconfig or endpoin
 # AWS — training cluster (aicr-uat-day-aws-h100)
 aws eks update-kubeconfig --region us-east-1 --name aicr-uat-day-aws-h100
 
-# GCP — inference cluster (aicr-day-gcp-h100)
-gcloud container clusters get-credentials aicr-day-gcp-h100 --region <region>
+# GCP — inference cluster (aicr-uat-day-gcp-h100)
+gcloud container clusters get-credentials aicr-uat-day-gcp-h100 --region <region>
 ```
 
 **Training (AWS).** Submit Kubeflow `TrainJob`s against the held cluster — the same CUJ the nightly `intent=training` run exercises (see `demos/cuj1-training.md`).
@@ -130,7 +130,7 @@ Once DC3's `phase_serve` lands, the served workload is deployed automatically as
 
 ## Pre-batch guard
 
-A missed evening teardown must surface as a **blocked batch, never as silent contention** with the still-running daytime deployment. Before it provisions, every `nightly` run asserts that no daytime cluster (by the stable `aicr-uat-day-<reservation>` / `aicr-day-<reservation>` name) is still up on the target reservation. The check runs *after* the run has acquired the reservation lease and authenticated to the cloud, and *before* Bringup — so it fails fast rather than racing. It fails **closed**: only a definitive "cluster does not exist" (AWS `ResourceNotFoundException`, GCP `code=404`) clears the run to proceed; a throttle or auth error blocks the batch rather than being read as "clear."
+A missed evening teardown must surface as a **blocked batch, never as silent contention** with the still-running daytime deployment. Before it provisions, every `nightly` run asserts that no daytime cluster (by the stable, cross-cloud `aicr-uat-day-<reservation>` name) is still up on the target reservation. The check runs *after* the run has acquired the reservation lease and authenticated to the cloud, and *before* Bringup — so it fails fast rather than racing. It fails **closed**: only a definitive "cluster does not exist" (AWS `ResourceNotFoundException`, GCP `code=404`) clears the run to proceed; a throttle or auth error blocks the batch rather than being read as "clear."
 
 If the guard trips, tear the daytime cluster down with `lifecycle=daytime-down` (which releases the reservation), then re-run the batch.
 


### PR DESCRIPTION
## Summary

Unify the daytime human-access UAT cluster name prefix across clouds. GCP now uses the same `aicr-uat-…` convention as AWS.

## Motivation / Context

The daytime cluster name diverged by cloud: AWS used `aicr-uat-day-<reservation>` (nightly `aicr-uat-<run_id>`) while GCP used `aicr-day-<reservation>` (nightly `aicr-<run_id>`). Within each cloud the `DEPLOYMENT_ID` and its pre-batch guard agreed, so it was cosmetic rather than a bug — but the asymmetry is easy to trip over when reasoning across both pipelines. Noticed while reviewing the daytime cluster naming.

Fixes: N/A
Related: #1274, #1281, #1592

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT CI (`.github/workflows/uat-gcp.yaml`)

## Implementation Notes

- `uat-gcp.yaml`: `DEPLOYMENT_ID` for both lifecycles (`aicr-day-<res>` → `aicr-uat-day-<res>`, `aicr-<run_id>` → `aicr-uat-<run_id>`), the pre-batch guard's `DAYTIME_NAME`, and the accompanying comment.
- `docs/contributor/uat.md`: lifecycle table, the `get-credentials` example, and the pre-batch-guard paragraph collapse the dual AWS/GCP names to the single cross-cloud `aicr-uat-day-<reservation>` name.

## Testing

```bash
yamllint .github/workflows/uat-gcp.yaml  # clean
grep -rnE 'aicr-day-' .github/ docs/ tests/   # no matches remain
```

No functional change to provisioning — only the derived cluster-name string changes on GCP. Verified no stale `aicr-day-` references remain.

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

**Rollout notes — one migration caveat:** this renames the GCP daytime cluster. If a GCP daytime cluster is **currently held** under the old `aicr-day-<reservation>` name, tear it down **before** this merges — afterward `daytime-down` and the nightly pre-batch guard look for `aicr-uat-day-<reservation>` and will not find the old one (it would leak and could silently hold the reservation). UAT-GCP has been failing at Bringup for days, so a live daytime GCP cluster is unlikely, but confirm with `gcloud container clusters list` first.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
