### PR TITLE
CUJ2 inference E2E in the UAT runner + nightly both-intent (#1276)

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -71,8 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     # Covers the uncapped non-UAT steps (build, validator image push, EKS
     # provisioning, evidence upload) + the UAT phase steps (prep 15 + install 45
-    # + validate 40 + train 25 + verify 5 = 130) + the always()-run Destroy
-    # Cluster teardown. The teardown MUST fit in this budget: a job-level timeout
+    # + validate 40 + the intent-selected CUJ (train 25 OR serve 40) + verify 5
+    # = up to 145) + the always()-run Destroy Cluster teardown. Only one of
+    # train/serve runs per intent, so the budget counts the larger (serve).
+    # The teardown MUST fit in this budget: a job-level timeout
     # cancels pending always() steps, so an undersized cap would skip teardown
     # and leak the GPU node / capacity reservation.
     timeout-minutes: 180
@@ -109,6 +111,16 @@ jobs:
       EKS_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:57fd2bf77055f8e0090bd7b8e099e7f11fd874f0b5764057439d11f1cd32a8b1"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
+      # Pin validator-image resolution for MAIN cells to this run's freshly
+      # built+pushed validators (the `Build and push validator images` step
+      # tags them `:uat-<run_id>`), mirroring how AICR_IMAGE pins the agent — so
+      # the validators pair with the binary under test rather than a stale
+      # :latest. The main binary is stamped version=main (below), which the
+      # catalog would otherwise leave on the :latest path. Empty for release
+      # cells (aicr_version set): they use the released :<version> validators the
+      # released binary self-resolves, and an empty AICR_VALIDATOR_IMAGE_TAG is
+      # a no-op (the catalog ignores an empty override).
+      AICR_VALIDATOR_IMAGE_TAG: ${{ inputs.aicr_version == '' && format('uat-{0}', github.run_id) || '' }}
 
     steps:
       # Checkout
@@ -167,9 +179,34 @@ jobs:
         if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GOFLAGS: -mod=vendor
+          # github.sha via env (never inline ${{ }} in a shell run — expression
+          # injection). It is a 40-hex commit, so no real risk, but env is the
+          # repo norm and keeps zizmor/CodeRabbit quiet.
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          go build -o ./aicr ./cmd/aicr
-          ./aicr --version
+          set -euo pipefail
+          # Stamp the main-cell binary's version metadata via ldflags (mirroring
+          # goreleaser's pkg/cli.{version,commit,date} targets) so the emitted
+          # recipe/evidence report "main" + the commit instead of the un-stamped
+          # "dev"/"unknown" defaults. version="main" is deliberately NOT a
+          # release-shaped string, so it does not trip the catalog's
+          # :latest→:<version> validator-image rewrite; validator resolution is
+          # pinned explicitly below (AICR_VALIDATOR_IMAGE_TAG). Release cells
+          # install a goreleaser-built binary already stamped with its tag, so
+          # this step is main-only.
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          go build \
+            -ldflags "-X github.com/NVIDIA/aicr/pkg/cli.version=main -X github.com/NVIDIA/aicr/pkg/cli.commit=${COMMIT_SHA} -X github.com/NVIDIA/aicr/pkg/cli.date=${BUILD_DATE}" \
+            -o ./aicr ./cmd/aicr
+          # Assert the stamp actually landed — a broken ldflags target path would
+          # otherwise silently leave the binary on the default dev/unknown
+          # metadata (which then propagates to the evidence/TestGrid version).
+          VER_OUT="$(./aicr --version)"
+          echo "${VER_OUT}"
+          if ! printf '%s' "${VER_OUT}" | grep -qF "main (commit: ${COMMIT_SHA}"; then
+            echo "::error::aicr binary not stamped (want 'main (commit: ${COMMIT_SHA}…'); got: ${VER_OUT}" >&2
+            exit 1
+          fi
 
       # Release cell (aicr_version set): install the RELEASED aicr binary at that
       # version instead of building. The released binary self-resolves its own
@@ -435,10 +472,11 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: ./tests/uat/aws/run conformance "${TEST_CONFIG}"
 
-      # The TrainJob CUJ is training-intent-specific. For intent=inference the
-      # served-workload CUJ (phase_serve) is owned by DC3 and out of scope here,
-      # so the train step is skipped; verify/evidence still cover the deployed
-      # inference stack.
+      # The CUJ phase is intent-selected, mirroring the runner's intent-aware
+      # `all`: training runs the Kubeflow TrainJob; inference runs the served
+      # DynamoGraphDeployment (phase_serve, DC3) — deploy, wait for readiness,
+      # hit the OpenAI-compatible endpoint, assert a completion. Exactly one
+      # fires per run; verify/evidence cover the deployed stack either way.
       - name: UAT - train (TrainJob)
         id: train
         if: steps.conformance.outcome == 'success' && inputs.intent == 'training'
@@ -448,6 +486,19 @@ jobs:
           AICR_BIN: ${{ github.workspace }}/aicr
           RUN_ID: ${{ github.run_id }}
         run: ./tests/uat/aws/run train "${TEST_CONFIG}"
+
+      - name: UAT - serve (DynamoGraphDeployment + endpoint)
+        id: serve
+        if: steps.conformance.outcome == 'success' && inputs.intent == 'inference'
+        # Larger budget than train: a cold pull of the multi-GB vllm-runtime
+        # image + model download + engine warmup precedes the first served
+        # token (phase_serve's SERVE_READY_TIMEOUT_SECONDS is 30m).
+        timeout-minutes: 40
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+        run: ./tests/uat/aws/run serve "${TEST_CONFIG}"
 
       - name: UAT - verify (evidence verify)
         id: verify
@@ -504,6 +555,7 @@ jobs:
             evidence-result.json
             evidence/pointer.yaml
             train-logs/**
+            serve-logs/**
           retention-days: 30
           if-no-files-found: ignore
 
@@ -537,6 +589,7 @@ jobs:
             echo "| Install | ${{ steps.install.outcome }} |"
             echo "| Validate (all phases) | ${{ steps.conformance.outcome }} |"
             echo "| Train | ${{ steps.train.outcome }} |"
+            echo "| Serve | ${{ steps.serve.outcome }} |"
             echo "| Verify | ${{ steps.verify.outcome }} |"
             if [[ -n "${{ steps.evidence_ref.outputs.ref }}" ]]; then
               echo ""

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -71,8 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     # Covers the uncapped non-UAT steps (build, validator image push, GKE
     # provisioning, evidence upload) + the UAT phase steps (prep 15 + install 45
-    # + validate 40 + train 25 + verify 5 = 130) + the always()-run Destroy
-    # Cluster teardown. The teardown MUST fit in this budget: a job-level timeout
+    # + validate 40 + the intent-selected CUJ (train 25 OR serve 40) + verify 5
+    # = up to 145) + the always()-run Destroy Cluster teardown. Only one of
+    # train/serve runs per intent, so the budget counts the larger (serve).
+    # The teardown MUST fit in this budget: a job-level timeout
     # cancels pending always() steps, so an undersized cap would skip teardown
     # and leak the GPU node.
     timeout-minutes: 180
@@ -107,6 +109,16 @@ jobs:
       GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:latest"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
+      # Pin validator-image resolution for MAIN cells to this run's freshly
+      # built+pushed validators (the `Build and push validator images` step
+      # tags them `:uat-<run_id>`), mirroring how AICR_IMAGE pins the agent — so
+      # the validators pair with the binary under test rather than a stale
+      # :latest. The main binary is stamped version=main (below), which the
+      # catalog would otherwise leave on the :latest path. Empty for release
+      # cells (aicr_version set): they use the released :<version> validators the
+      # released binary self-resolves, and an empty AICR_VALIDATOR_IMAGE_TAG is
+      # a no-op (the catalog ignores an empty override).
+      AICR_VALIDATOR_IMAGE_TAG: ${{ inputs.aicr_version == '' && format('uat-{0}', github.run_id) || '' }}
 
     steps:
       # Checkout
@@ -165,9 +177,34 @@ jobs:
         if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
         env:
           GOFLAGS: -mod=vendor
+          # github.sha via env (never inline ${{ }} in a shell run — expression
+          # injection). It is a 40-hex commit, so no real risk, but env is the
+          # repo norm and keeps zizmor/CodeRabbit quiet.
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          go build -o ./aicr ./cmd/aicr
-          ./aicr --version
+          set -euo pipefail
+          # Stamp the main-cell binary's version metadata via ldflags (mirroring
+          # goreleaser's pkg/cli.{version,commit,date} targets) so the emitted
+          # recipe/evidence report "main" + the commit instead of the un-stamped
+          # "dev"/"unknown" defaults. version="main" is deliberately NOT a
+          # release-shaped string, so it does not trip the catalog's
+          # :latest→:<version> validator-image rewrite; validator resolution is
+          # pinned explicitly below (AICR_VALIDATOR_IMAGE_TAG). Release cells
+          # install a goreleaser-built binary already stamped with its tag, so
+          # this step is main-only.
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          go build \
+            -ldflags "-X github.com/NVIDIA/aicr/pkg/cli.version=main -X github.com/NVIDIA/aicr/pkg/cli.commit=${COMMIT_SHA} -X github.com/NVIDIA/aicr/pkg/cli.date=${BUILD_DATE}" \
+            -o ./aicr ./cmd/aicr
+          # Assert the stamp actually landed — a broken ldflags target path would
+          # otherwise silently leave the binary on the default dev/unknown
+          # metadata (which then propagates to the evidence/TestGrid version).
+          VER_OUT="$(./aicr --version)"
+          echo "${VER_OUT}"
+          if ! printf '%s' "${VER_OUT}" | grep -qF "main (commit: ${COMMIT_SHA}"; then
+            echo "::error::aicr binary not stamped (want 'main (commit: ${COMMIT_SHA}…'); got: ${VER_OUT}" >&2
+            exit 1
+          fi
 
       # Release cell (aicr_version set): install the RELEASED aicr binary at that
       # version instead of building. The released binary self-resolves its own
@@ -393,10 +430,11 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: ./tests/uat/gcp/run conformance "${TEST_CONFIG}"
 
-      # The TrainJob CUJ is training-intent-specific. For intent=inference the
-      # served-workload CUJ (phase_serve) is owned by DC3 and out of scope here,
-      # so the train step is skipped; verify/evidence still cover the deployed
-      # inference stack.
+      # The CUJ phase is intent-selected, mirroring the runner's intent-aware
+      # `all`: training runs the Kubeflow TrainJob; inference runs the served
+      # DynamoGraphDeployment (phase_serve, DC3) — deploy, wait for readiness,
+      # hit the OpenAI-compatible endpoint, assert a completion. Exactly one
+      # fires per run; verify/evidence cover the deployed stack either way.
       - name: UAT - train (TrainJob)
         id: train
         if: steps.conformance.outcome == 'success' && inputs.intent == 'training'
@@ -406,6 +444,19 @@ jobs:
           AICR_BIN: ${{ github.workspace }}/aicr
           RUN_ID: ${{ github.run_id }}
         run: ./tests/uat/gcp/run train "${TEST_CONFIG}"
+
+      - name: UAT - serve (DynamoGraphDeployment + endpoint)
+        id: serve
+        if: steps.conformance.outcome == 'success' && inputs.intent == 'inference'
+        # Larger budget than train: a cold pull of the multi-GB vllm-runtime
+        # image + model download + engine warmup precedes the first served
+        # token (phase_serve's SERVE_READY_TIMEOUT_SECONDS is 30m).
+        timeout-minutes: 40
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+        run: ./tests/uat/gcp/run serve "${TEST_CONFIG}"
 
       - name: UAT - verify (evidence verify)
         id: verify
@@ -465,6 +516,7 @@ jobs:
             evidence-result.json
             evidence/pointer.yaml
             train-logs/**
+            serve-logs/**
           retention-days: 30
           if-no-files-found: ignore
 
@@ -497,6 +549,7 @@ jobs:
             echo "| Install | ${{ steps.install.outcome }} |"
             echo "| Validate (all phases) | ${{ steps.conformance.outcome }} |"
             echo "| Train | ${{ steps.train.outcome }} |"
+            echo "| Serve | ${{ steps.serve.outcome }} |"
             echo "| Verify | ${{ steps.verify.outcome }} |"
             if [[ -n "${{ steps.evidence_ref.outputs.ref }}" ]]; then
               echo ""

--- a/.github/workflows/uat-nightly-batch.yaml
+++ b/.github/workflows/uat-nightly-batch.yaml
@@ -154,6 +154,21 @@ jobs:
           POLL_INTERVAL_SECONDS=5
           go build -o ./bin/uat-broker ./tools/uat-broker
 
+          # Nightly intents for this reservation (#1276, DC3). The batch runs
+          # EACH listed intent (training and/or inference) as its own full CUJ
+          # cell per version, dispatched SEQUENTIALLY through the shared
+          # per-reservation lease — so both intents run nightly with no
+          # contention and no second cron. The broker resolves an empty list to
+          # the training default, so this is always non-empty; fail closed if it
+          # somehow is not (a broker/registry regression).
+          NIGHTLY_INTENTS_CSV=$(./bin/uat-broker reservations --name "$RESERVATION" | sed -n 's/^nightly-intents=//p')
+          if [[ -z "$NIGHTLY_INTENTS_CSV" ]]; then
+            echo "::error::could not resolve nightly-intents for ${RESERVATION}" >&2
+            exit 1
+          fi
+          IFS=',' read -r -a intents <<< "$NIGHTLY_INTENTS_CSV"
+          echo "Nightly intents for ${RESERVATION}: ${intents[*]}"
+
           # Validate previous_n before the broker consumes it. `--previous-n` is
           # an int flag so it rejects non-integers, but it would accept a
           # negative and mis-shape the schedule; reject non-integer or negative
@@ -185,75 +200,85 @@ jobs:
           deadline=$(( BATCH_START + DEADLINE_OFFSET_HOURS * 3600 ))
           cell=0
           leg_failed=""
+          # Version outer-loop, intent inner-loop: `main` runs every intent
+          # before any release cell, so a time-box drop always sheds the OLDEST
+          # release cells first — never main's inference. Each (version × intent)
+          # is a full provision→CUJ→teardown dispatched through the shared lease,
+          # so the intents serialize automatically (no contention).
           for ver in "${versions[@]}"; do
-            if (( $(date +%s) >= deadline )); then
-              echo "::notice::Time-box reached — dropping remaining cells for ${RESERVATION} (oldest release first)."
-              break
-            fi
-            cell=$((cell + 1))
-            label="${ver:-main}"
-            # Unique per-dispatch key (controller run id + attempt + reservation
-            # + cell index) so the resolver below watches THIS run and never a
-            # concurrent manual dispatch of the same reservation/version.
-            dispatch_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RESERVATION}-${cell}"
-            title="UAT ${RESERVATION} @ ${label} #${dispatch_key}"
-            echo "::group::${title}"
+            for intent in "${intents[@]}"; do
+              if (( $(date +%s) >= deadline )); then
+                echo "::notice::Time-box reached — dropping remaining cells for ${RESERVATION} (oldest release first)."
+                break 2
+              fi
+              cell=$((cell + 1))
+              label="${ver:-main}"
+              # Unique per-dispatch key (controller run id + attempt + reservation
+              # + cell index) so the resolver below watches THIS run and never a
+              # concurrent manual dispatch of the same reservation/version. The
+              # cell index increments per (version × intent), so the two intents
+              # of one version get distinct keys and distinct run titles.
+              dispatch_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RESERVATION}-${cell}"
+              title="UAT ${RESERVATION} @ ${label} #${dispatch_key}"
+              echo "::group::${title} [intent=${intent}]"
 
-            gh workflow run uat-run.yaml --repo "$REPO" --ref "$REF" \
-              -f reservation="$RESERVATION" -f aicr_version="$ver" \
-              -f dispatch_key="$dispatch_key"
+              gh workflow run uat-run.yaml --repo "$REPO" --ref "$REF" \
+                -f reservation="$RESERVATION" -f aicr_version="$ver" \
+                -f intent="$intent" \
+                -f dispatch_key="$dispatch_key"
 
-            # Resolve the dispatched run by its run-name — this title MUST match
-            # uat-run.yaml's `run-name:` (which appends the same dispatch_key).
-            # dispatch_key makes the title globally unique, so an exact title
-            # match is unambiguous; no createdAt filter (a runner clock running
-            # ahead of GitHub's API clock would falsely reject this dispatch).
-            run_id=""
-            for _ in $(seq 1 "$POLL_MAX_ATTEMPTS"); do
-              sleep "$POLL_INTERVAL_SECONDS"
-              run_id=$(gh run list --repo "$REPO" --workflow uat-run.yaml \
-                --event workflow_dispatch --limit 50 \
-                --json databaseId,displayTitle,createdAt 2>/dev/null \
-                | jq -r --arg t "$title" \
-                    'map(select(.displayTitle == $t))
-                     | sort_by(.createdAt) | .[-1].databaseId // empty' || true)
-              [[ -n "$run_id" ]] && break
-            done
-            if [[ -z "$run_id" ]]; then
-              # Fail the leg rather than continue: an unwatched run can still
-              # hold the reservation's pending slot and let a later (lower-
-              # priority) cell supersede it, breaking version ordering.
-              echo "::error::Dispatched ${title} but could not resolve its run id; stopping this reservation leg to preserve version ordering."
+              # Resolve the dispatched run by its run-name — this title MUST match
+              # uat-run.yaml's `run-name:` (which appends the same dispatch_key).
+              # dispatch_key makes the title globally unique, so an exact title
+              # match is unambiguous; no createdAt filter (a runner clock running
+              # ahead of GitHub's API clock would falsely reject this dispatch).
+              run_id=""
+              for _ in $(seq 1 "$POLL_MAX_ATTEMPTS"); do
+                sleep "$POLL_INTERVAL_SECONDS"
+                run_id=$(gh run list --repo "$REPO" --workflow uat-run.yaml \
+                  --event workflow_dispatch --limit 50 \
+                  --json databaseId,displayTitle,createdAt 2>/dev/null \
+                  | jq -r --arg t "$title" \
+                      'map(select(.displayTitle == $t))
+                       | sort_by(.createdAt) | .[-1].databaseId // empty' || true)
+                [[ -n "$run_id" ]] && break
+              done
+              if [[ -z "$run_id" ]]; then
+                # Fail the leg rather than continue: an unwatched run can still
+                # hold the reservation's pending slot and let a later (lower-
+                # priority) cell supersede it, breaking version ordering.
+                echo "::error::Dispatched ${title} but could not resolve its run id; stopping this reservation leg to preserve version ordering."
+                echo "::endgroup::"
+                exit 1
+              fi
+
+              echo "Waiting on run ${run_id} ..."
+              # --exit-status is intentionally not fatal here; classify the run's
+              # conclusion below so we can distinguish a benign superseded run from
+              # a real failure without aborting mid-loop.
+              # Output is discarded: in a non-TTY log `gh run watch` APPENDS a full
+              # status render every refresh (no in-place redraw), which flooded the
+              # drive log with tens of thousands of duplicate lines per multi-hour
+              # cell. We only need it to BLOCK until the run finishes; the
+              # conclusion is read from `gh run view` below, so the live render is
+              # redundant. --interval 60 keeps the polling gentle on the API.
+              gh run watch "$run_id" --repo "$REPO" --interval 60 --exit-status >/dev/null 2>&1 || true
+
+              conclusion=$(gh run view "$run_id" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "")
+              njobs=$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" --jq '.total_count' 2>/dev/null || echo "")
+              if [[ "$conclusion" == "cancelled" && "$njobs" == "0" ]]; then
+                # Benign: the single-slot reservation lease dropped a pending run.
+                # Surface it (must not be silent) but do not fail the leg — the
+                # superseded-run observer complements this (DC1 superseded surfacing).
+                echo "::warning::${title} [intent=${intent}] was superseded while pending (dropped by the reservation lease); re-dispatch when the reservation frees."
+              elif [[ "$conclusion" != "success" ]]; then
+                # Real cell failure/timeout — record it so the leg (and thus the
+                # nightly batch) fails, but keep testing the remaining cells.
+                echo "::error::${title} [intent=${intent}] finished with conclusion '${conclusion:-unknown}'."
+                leg_failed=1
+              fi
               echo "::endgroup::"
-              exit 1
-            fi
-
-            echo "Waiting on run ${run_id} ..."
-            # --exit-status is intentionally not fatal here; classify the run's
-            # conclusion below so we can distinguish a benign superseded run from
-            # a real failure without aborting mid-loop.
-            # Output is discarded: in a non-TTY log `gh run watch` APPENDS a full
-            # status render every refresh (no in-place redraw), which flooded the
-            # drive log with tens of thousands of duplicate lines per multi-hour
-            # cell. We only need it to BLOCK until the run finishes; the
-            # conclusion is read from `gh run view` below, so the live render is
-            # redundant. --interval 60 keeps the polling gentle on the API.
-            gh run watch "$run_id" --repo "$REPO" --interval 60 --exit-status >/dev/null 2>&1 || true
-
-            conclusion=$(gh run view "$run_id" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "")
-            njobs=$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" --jq '.total_count' 2>/dev/null || echo "")
-            if [[ "$conclusion" == "cancelled" && "$njobs" == "0" ]]; then
-              # Benign: the single-slot reservation lease dropped a pending run.
-              # Surface it (must not be silent) but do not fail the leg — the
-              # superseded-run observer complements this (DC1 superseded surfacing).
-              echo "::warning::${title} was superseded while pending (dropped by the reservation lease); re-dispatch when the reservation frees."
-            elif [[ "$conclusion" != "success" ]]; then
-              # Real cell failure/timeout — record it so the leg (and thus the
-              # nightly batch) fails, but keep testing the remaining versions.
-              echo "::error::${title} finished with conclusion '${conclusion:-unknown}'."
-              leg_failed=1
-            fi
-            echo "::endgroup::"
+            done
           done
 
           if [[ -n "$leg_failed" ]]; then

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -13,7 +13,7 @@ Each reserved GPU pool follows a daily cycle, with every phase acquiring the *sa
 
 The phases are independently scheduled (cron edges), not chained: the per-reservation lease — plus a [pre-batch guard](#pre-batch-guard) — keeps them from overlapping, so a crashed or overrunning phase never orphans the reservation. A hosted GitHub Actions job is capped at the runner's timeout (hours, not a whole working day), so a single lease-holding run cannot span the day; the lease only needs to cover the brief transition windows, and the steady-state daytime cluster's existence is tracked by its stable, reservation-tagged name rather than a continuously held run.
 
-> What ships today is the **night side** (the nightly batch), the **lease + dispatch surface** every phase builds on, DC2's **per-intent selection**, **daytime provision-and-hold / teardown mechanics**, and **pre-batch guard**, and DC8's **day side** — the `uat-daytime.yaml` scheduler that stands up one human-facing deployment per cloud each morning and tears it down each evening. The served-inference *workload* an `intent=inference` cluster runs (`phase_serve`) is still owned by DC3.
+> What ships today is the **night side** (the nightly batch), the **lease + dispatch surface** every phase builds on, DC2's **per-intent selection**, **daytime provision-and-hold / teardown mechanics**, and **pre-batch guard**, DC8's **day side** — the `uat-daytime.yaml` scheduler that stands up one human-facing deployment per cloud each morning and tears it down each evening, and DC3's **served-inference CUJ** — the `phase_serve` step an `intent=inference` run now exercises on the deployed inference stack (deploy a `DynamoGraphDeployment`, hit its OpenAI-compatible endpoint, assert a completion).
 
 ## Requesting a UAT run
 
@@ -47,9 +47,27 @@ The nightly batch and the daytime handoff/teardown call this *same* surface, so 
 
 The `intent` input (`training` — the default — or `inference`) selects both the recipe criteria and the per-intent test config the pipeline consumes: `tests/uat/<cloud>/tests/h100-<intent>-config.yaml`. The two configs are siblings with the same `AICRConfig` shape; they differ only in `spec.recipe.criteria.intent`/`platform` (`training`/`kubeflow` vs `inference`/`dynamo`) and the stable evidence push prefix. Both intents provision from the *same* `cluster-config.yaml` — the GPU pool count comes from the reservation row and the system/CPU pools stay per-run dynamic (GCP autoscales; AWS is fixed at `desired: 3`), so nothing about the cluster shape is hardcoded per intent.
 
-The nightly CUJ steps are intent-aware: the training TrainJob step runs only for `intent=training`. The served-inference workload (`phase_serve`) is owned by DC3 and out of scope here, so an `intent=inference` run stands up and validates the inference stack (Dynamo platform, KAI scheduler, DRA driver) and signs evidence, but does not yet exercise a served endpoint.
+The CUJ phase is intent-selected — exactly one of `phase_train` / `phase_serve` runs, mirroring the runner's intent-aware `run all`:
+
+- **`intent=training` → `phase_train`.** Submits a Kubeflow `TrainJob`, waits for completion, captures logs (`demos/cuj1-training.md`).
+- **`intent=inference` → `phase_serve`** (DC3, #1276). Deploys a Dynamo `DynamoGraphDeployment` (KAI queue + DRA `ResourceClaim` + Frontend/decode-Worker graph) onto the already-validated inference stack, waits for the pods to become ready, port-forwards the frontend, issues a sample OpenAI-compatible `/v1/chat/completions` request, and asserts a non-empty completion — the inference counterpart of `phase_train`, at CUJ1 parity (`demos/cuj2-inference.md`). It **fails closed** (non-zero exit, captured pod logs/events under `serve-logs/`) on a non-ready deployment or an invalid completion, mirroring `phase_train`'s `Failed=True` handling. The served workload's node scheduling and model are overridable via `SERVE_*` env vars; the defaults track `demos/workloads/inference/vllm-agg.yaml`.
+
+In both cases the signed evidence bundle is emitted by the earlier conformance step (which validates the full deployed stack), so the CUJ step exercises the deployment while evidence already covers it. `phase_conformance` also cross-checks that the recipe's declared `platform` matches the deployed component set — the platform operator's workload CRD (`dynamographdeployments.nvidia.com` for `dynamo`, `trainjobs.trainer.kubeflow.org` for `kubeflow`) must be installed — because the emitted bundle's TestGrid tab coordinate is derived from the author-declared platform and is otherwise cluster-unverifiable (the fingerprint does not capture the platform dimension).
 
 An unrecognized `intent` (or a missing sibling config) fails closed in the pipeline's `Validate inputs` step before any provisioning.
+
+### Nightly intent cadence (both intents, both clouds)
+
+The single nightly cron (`uat-nightly-batch.yaml`, `0 4 * * *`) runs **both intents on every reservation**, so training *and* inference are exercised nightly on both AWS and GCP. The set of intents per reservation is data — the `nightly-intents` list in `infra/uat/reservations.yaml` (empty defaults to `[training]`):
+
+| Reservation | Cloud | `nightly-intents` | Nightly CUJs |
+|-------------|-------|-------------------|--------------|
+| `aws-h100` | AWS | `[training, inference]` | `phase_train` + `phase_serve` |
+| `gcp-h100` | GCP | `[training, inference]` | `phase_train` + `phase_serve` |
+
+**How it stays contention-free — serialize, don't add a second cron.** The intents are folded into the existing [version matrix](#the-version-matrix) as extra cells rather than a second scheduled job. The controller's drive loop is **version outer / intent inner**: for each version it dispatches one intent's full provision→CUJ→teardown, waits for it (`gh run watch`), then dispatches the next — all through the *same* per-reservation lease. So the intents serialize naturally, and because `main` runs every intent before any release cell, a time-box drop only ever sheds the oldest *release* cells (never `main`'s inference). This is the deliberate DC3 cadence decision: **never schedule two daily crons against one reservation** — the lease is a single-slot queue (one in-progress + one pending), so a second cron plus an occasional human dispatch on the same reservation is a routine three-contender case whose loser is silently [superseded](#how-queuing-works-the-reservation-lease). One cron dispatching serialized cells sidesteps that entirely.
+
+**Cost / tuning.** Listing both intents roughly **doubles a reservation's nightly cell count** (each version now runs two full cluster lifecycles). If the batch [time-box](#the-version-matrix) is exceeded the oldest cells are dropped first, so `main`+freshest always land; tune `previous_n` (fewer release versions) or `deadline_offset_hours` to fit the window. A released version that predates a platform (e.g. `dynamo`) fails its inference cell's recipe resolution as a genuine regression signal — drop `previous_n` if that coverage is premature. Changing which intents a reservation runs is a registry edit — no workflow change; the `uatbroker` committed-registry test pins the launch set.
 
 ## Cluster lifecycles
 
@@ -57,7 +75,7 @@ The `lifecycle` input selects one of three cluster lifecycles, all sharing the r
 
 | Lifecycle | Cluster name | Provisions | Deploys | CUJ | Teardown at job end |
 |-----------|--------------|-----------|---------|-----|---------------------|
-| `nightly` (default) | `aicr-uat-<run_id>` (AWS) / `aicr-<run_id>` (GCP) — run-scoped | yes | yes | yes (prep→install→validate→train/verify) | yes (unless `skip_delete`) |
+| `nightly` (default) | `aicr-uat-<run_id>` (AWS) / `aicr-<run_id>` (GCP) — run-scoped | yes | yes | yes (prep→install→validate→train\|serve→verify) | yes (unless `skip_delete`) |
 | `daytime-up` | `aicr-uat-day-<reservation>` (AWS) / `aicr-day-<reservation>` (GCP) — **stable** | yes | yes (prep→install) | no | **no — holds** |
 | `daytime-down` | same stable name | no | no | no | yes (tears down the held cluster) |
 
@@ -126,7 +144,7 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model":"<model>","messages":[{"role":"user","content":"hello"}]}'
 ```
 
-Once DC3's `phase_serve` lands, the served workload is deployed automatically as part of `daytime-up`; until then it is a one-command manual apply on the held cluster.
+On the held daytime cluster this served workload is a one-command manual apply (above): `daytime-up` deploys the inference *platform* and holds, so a human drives the serve step by hand. The automated `phase_serve` (DC3) runs in the **nightly** `intent=inference` CUJ, not `daytime-up`, which by design stops after install to hand the cluster off.
 
 ## Pre-batch guard
 
@@ -183,7 +201,6 @@ The values in this file are identifiers, **not secrets** — a reservation-id gr
 
 ## Roadmap
 
-What ships now is the lease, the data-driven dispatch surface, the time-boxed nightly version matrix (`main` + previous-N stable releases, release cells installing released artifacts), superseded-run surfacing (the controller flags a dropped cell inline; the `uat-superseded-notice.yaml` observer catches ad-hoc dropped runs), per-intent selection, the daytime provision-and-hold / teardown / pre-batch-guard mechanics, and the DC8 [daytime human-access scheduler](#daytime-human-access-deployment) (`uat-daytime.yaml`) — one held deployment per cloud each working day, torn down before the batch, with out-of-band access. Still to come:
+What ships now is the lease, the data-driven dispatch surface, the time-boxed nightly version matrix (`main` + previous-N stable releases, release cells installing released artifacts), superseded-run surfacing (the controller flags a dropped cell inline; the `uat-superseded-notice.yaml` observer catches ad-hoc dropped runs), per-intent selection, the DC3 [served-inference CUJ](#selecting-the-intent) (`phase_serve` — deploys a `DynamoGraphDeployment` and asserts a served completion; both training and inference run nightly on both clouds, serialized as extra version-matrix cells under the one cron), the daytime provision-and-hold / teardown / pre-batch-guard mechanics, and the DC8 [daytime human-access scheduler](#daytime-human-access-deployment) (`uat-daytime.yaml`) — one held deployment per cloud each working day, torn down before the batch, with out-of-band access. Still to come:
 
-- **Served-inference CUJ (DC3).** The `phase_serve` step an `intent=inference` run — nightly *and* the daytime inference cluster — will exercise on the deployed inference stack, deploying the served `DynamoGraphDeployment` automatically instead of the current manual apply.
 - **Both flavors per cloud during the day.** Blocked on capacity — one reservation cannot hold both a daytime cluster and the nightly batch at once. Pulls once more infra lands.

--- a/infra/uat/reservations.yaml
+++ b/infra/uat/reservations.yaml
@@ -41,6 +41,23 @@
 #   test-config-dir     directory holding the per-cloud AICRConfig test
 #                       files (the ./tests/uat/<cloud>/run phase runner roots
 #                       one level up, at the cluster-config)
+#   nightly-intents     (optional) the recipe intents the NIGHTLY version-matrix
+#                       batch (#1274, DC1) runs on this reservation, as a YAML
+#                       list — [training], [inference], or [training,
+#                       inference]. Empty/absent defaults to [training] (the
+#                       pre-DC3 behavior). DC3 (#1276) sets it to [training,
+#                       inference] on BOTH reservations so training and inference
+#                       both run nightly on both clouds. The batch runs the
+#                       intents SEQUENTIALLY within each version cell, through
+#                       the same per-reservation lease (intent inner-loop,
+#                       version outer-loop) — no second cron, no contention, and
+#                       `main` lands both intents before any release cell. Each
+#                       (version × intent) is a full provision→CUJ→teardown cell,
+#                       so listing both intents roughly doubles a reservation's
+#                       nightly cell count; the batch time-box drops the oldest
+#                       cells first if the budget is exceeded (tune previous_n /
+#                       deadline_offset_hours). Entries must be recognized and
+#                       unique. Not one-per-cloud (unlike daytime-intent).
 #   daytime-intent      (optional) opts this reservation into the daytime
 #                       human-access rotation (#1281, DC8) and picks the
 #                       flavor stood up during the working day: training |
@@ -59,6 +76,7 @@ reservations:
     gpu-count: 8
     cluster-config-path: tests/uat/aws/cluster-config.yaml
     test-config-dir: tests/uat/aws/tests
+    nightly-intents: [training, inference]
     daytime-intent: training
   - name: gcp-h100
     cloud: gcp
@@ -67,4 +85,5 @@ reservations:
     gpu-count: 8
     cluster-config-path: tests/uat/gcp/cluster-config.yaml
     test-config-dir: tests/uat/gcp/tests
+    nightly-intents: [training, inference]
     daytime-intent: inference

--- a/pkg/uatbroker/model.go
+++ b/pkg/uatbroker/model.go
@@ -48,6 +48,17 @@ type Reservation struct {
 	GPUCount          int    `yaml:"gpu-count"`
 	ClusterConfigPath string `yaml:"cluster-config-path"`
 	TestConfigDir     string `yaml:"test-config-dir"`
+	// NightlyIntents lists the recipe intents the nightly version-matrix batch
+	// (#1274, DC1) runs on this reservation, each a full CUJ per version cell:
+	// "training", "inference", or both. Empty defaults to ["training"] (the
+	// pre-DC3 behavior) — see NightlyIntentsOrDefault. DC3 (#1276) sets it to
+	// [training, inference] on every reservation so both CUJs run nightly on
+	// both clouds; the batch dispatches them SEQUENTIALLY through the shared
+	// per-reservation lease (intent inner-loop, version outer-loop), so there is
+	// never contention and `main` lands both intents before any release cell.
+	// Entries must be recognized intents and unique (a duplicate would
+	// double-run the same cell).
+	NightlyIntents []string `yaml:"nightly-intents"`
 	// DaytimeIntent opts this reservation into the daytime human-access
 	// rotation (#1281, DC8) and picks the flavor stood up on it during the
 	// working day: "training" or "inference". Empty means the reservation is
@@ -55,6 +66,20 @@ type Reservation struct {
 	// configurable cloud→flavor default — data, not code — so the split
 	// (AWS=training, GCP=inference at launch) can change without a workflow edit.
 	DaytimeIntent string `yaml:"daytime-intent"`
+}
+
+// NightlyIntentsOrDefault returns the reservation's nightly-batch intents,
+// defaulting an empty list to [IntentTraining] — the pre-DC3 behavior, so an
+// un-annotated reservation keeps running only the training CUJ nightly. Validate
+// guarantees any listed value is a recognized, non-duplicate intent. The
+// returned slice is a fresh copy the caller may mutate freely.
+func (r *Reservation) NightlyIntentsOrDefault() []string {
+	if len(r.NightlyIntents) == 0 {
+		return []string{IntentTraining}
+	}
+	out := make([]string, len(r.NightlyIntents))
+	copy(out, r.NightlyIntents)
+	return out
 }
 
 // DaytimeAssignment is one reservation's slot in the daytime human-access

--- a/pkg/uatbroker/registry.go
+++ b/pkg/uatbroker/registry.go
@@ -100,6 +100,25 @@ func (r *Registry) Validate() error {
 			return errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("reservation %s has a non-positive gpu-count (%d)", res.Name, res.GPUCount))
 		}
+		// nightly-intents is optional (empty defaults to [training]), but every
+		// listed value must be a recognized intent — a typo would otherwise
+		// dispatch a nonexistent per-intent config in the nightly batch — and
+		// must be unique, since a duplicate would double-run the same cell. There
+		// is no one-per-cloud limit (unlike daytime-intent): every reservation
+		// runs the nightly batch, and each may run any subset of the intents.
+		seenIntent := make(map[string]bool, len(res.NightlyIntents))
+		for _, intent := range res.NightlyIntents {
+			if !validIntents[intent] {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("reservation %s has unknown nightly-intent %q (want %s or %s)",
+						res.Name, intent, IntentTraining, IntentInference))
+			}
+			if seenIntent[intent] {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("reservation %s lists duplicate nightly-intent %q", res.Name, intent))
+			}
+			seenIntent[intent] = true
+		}
 		// daytime-intent is optional (empty = not in the daytime rotation), but
 		// when set it must be a recognized intent — a typo would otherwise
 		// silently drop the reservation from the daytime rotation or dispatch a

--- a/pkg/uatbroker/registry_test.go
+++ b/pkg/uatbroker/registry_test.go
@@ -18,6 +18,7 @@ import (
 	stderrors "errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -184,6 +185,67 @@ reservations:
     cluster-config-path: c.yaml
     test-config-dir: t
     daytime-intent: serving
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			// Empty/absent nightly-intents is valid — it defaults to [training].
+			name: "empty nightly-intents ok",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`,
+		},
+		{
+			name: "valid nightly-intents both",
+			yaml: `
+reservations:
+  - name: gcp-h100
+    cloud: gcp
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+    nightly-intents: [training, inference]
+`,
+		},
+		{
+			name: "unknown nightly-intent in list",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+    nightly-intents: [training, serving]
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			// A duplicate would double-run the same cell — reject it.
+			name: "duplicate nightly-intent in list",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+    nightly-intents: [training, training]
 `,
 			wantErr: true,
 			code:    errors.ErrCodeInvalidRequest,
@@ -431,5 +493,56 @@ func TestCommittedRegistryValid(t *testing.T) {
 		if n > 1 {
 			t.Errorf("cloud %q has %d daytime reservations, want at most 1 (both flavors per cloud is out of scope at launch)", cloud, n)
 		}
+	}
+
+	// The launch nightly intents (#1276, DC3): BOTH training and inference run
+	// nightly on BOTH reservations, serialized through the shared lease. A
+	// future change to the per-reservation intent set changes this deliberately.
+	wantNightly := map[string][]string{
+		"aws-h100": {IntentTraining, IntentInference},
+		"gcp-h100": {IntentTraining, IntentInference},
+	}
+	for name, want := range wantNightly {
+		res, lookupErr := reg.Lookup(name)
+		if lookupErr != nil {
+			t.Errorf("committed registry missing %q: %v", name, lookupErr)
+			continue
+		}
+		got := res.NightlyIntentsOrDefault()
+		if !slices.Equal(got, want) {
+			t.Errorf("committed registry nightly-intents[%q] = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestNightlyIntentsOrDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		set  []string
+		want []string
+	}{
+		{"empty defaults to training", nil, []string{IntentTraining}},
+		{"explicit training only", []string{IntentTraining}, []string{IntentTraining}},
+		{"both intents", []string{IntentTraining, IntentInference}, []string{IntentTraining, IntentInference}},
+		{"inference only", []string{IntentInference}, []string{IntentInference}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Reservation{NightlyIntents: tt.set}
+			if got := r.NightlyIntentsOrDefault(); !slices.Equal(got, tt.want) {
+				t.Errorf("NightlyIntentsOrDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNightlyIntentsOrDefaultCopies verifies the returned slice is a copy —
+// mutating it must not corrupt the registry's backing array.
+func TestNightlyIntentsOrDefaultCopies(t *testing.T) {
+	r := Reservation{NightlyIntents: []string{IntentTraining, IntentInference}}
+	got := r.NightlyIntentsOrDefault()
+	got[0] = "mutated"
+	if r.NightlyIntents[0] != IntentTraining {
+		t.Errorf("mutating the returned slice corrupted the reservation: %v", r.NightlyIntents)
 	}
 }

--- a/tests/uat/aws/run
+++ b/tests/uat/aws/run
@@ -23,12 +23,18 @@
 #
 # Phases:
 #   prep         snapshot + recipe + dry-run validate + bundle
-#   install      helmfile apply (deploys gpu-operator, kubeflow, ...)
+#   install      helmfile apply (deploys gpu-operator, kubeflow/dynamo, ...)
 #   conformance  validate ALL phases (deployment + conformance + performance)
 #                + emit signed evidence bundle
 #   train        submit TrainJob, wait for completion, capture logs
+#                (intent=training CUJ)
+#   serve        deploy a DynamoGraphDeployment, wait for readiness, hit the
+#                OpenAI-compatible endpoint, assert a completion, capture logs
+#                (intent=inference CUJ — the DC3 counterpart of `train`)
 #   verify       aicr evidence verify against the signed bundle
-#   all          run every phase in order (for local reproduction)
+#   all          run every phase in order (for local reproduction); the CUJ
+#                phase is chosen by the config's recipe intent — `train` for
+#                training, `serve` for inference
 #
 # Required env:
 #   AICR_BIN    Path to the aicr binary
@@ -45,7 +51,7 @@ config="${2:-}"
 
 if [[ -z "${phase}" || -z "${config}" ]]; then
   echo "Usage: $0 <phase> <test-config.yaml>" >&2
-  echo "Phases: prep | install | conformance | train | verify | all" >&2
+  echo "Phases: prep | install | conformance | train | serve | verify | all" >&2
   exit 2
 fi
 
@@ -70,6 +76,25 @@ HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
 # p5.48xlarge GPU-operator convergence (driver/toolkit/device-plugin/DCGM) and
 # prometheus-adapter APIService aggregation. Fails closed if exceeded.
 READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-1200}" # 20 min
+
+# Inference-serve knobs (phase_serve; overridable for local reproduction). The
+# defaults mirror the served DynamoGraphDeployment in demos/cuj2-inference.md
+# (demos/workloads/inference/vllm-agg.yaml) so CI and the demo stay in lockstep.
+SERVE_NAMESPACE="${SERVE_NAMESPACE:-dynamo-workload}"
+SERVE_NAME="${SERVE_NAME:-vllm-agg}"
+SERVE_QUEUE="${SERVE_QUEUE:-dynamo}"
+SERVE_MODEL="${SERVE_MODEL:-Qwen/Qwen3-0.6B}"
+SERVE_RUNTIME_IMAGE="${SERVE_RUNTIME_IMAGE:-nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1}"
+# GPU worker placement. The demo pins nodeGroup=gpu-worker; both UAT clusters
+# label their GPU pool the same way (tests/uat/*/cluster-config.yaml), so the
+# default lands the decode worker on the GPU node on either cloud.
+SERVE_GPU_NODE_SELECTOR_KEY="${SERVE_GPU_NODE_SELECTOR_KEY:-nodeGroup}"
+SERVE_GPU_NODE_SELECTOR_VALUE="${SERVE_GPU_NODE_SELECTOR_VALUE:-gpu-worker}"
+SERVE_FRONTEND_PORT="${SERVE_FRONTEND_PORT:-8000}"
+# Readiness budget: image pull of the multi-GB vllm-runtime + model download +
+# engine warmup on a cold GPU node. Generous; fails closed if exceeded.
+SERVE_READY_TIMEOUT_SECONDS="${SERVE_READY_TIMEOUT_SECONDS:-1800}" # 30 min
+SERVE_REQUEST_TIMEOUT_SECONDS="${SERVE_REQUEST_TIMEOUT_SECONDS:-120}" # 2 min
 
 # Per-run OCI tag. The committed config carries the stable per-recipe repo
 # only; we apply a `:run-${RUN_ID}` tag idempotently, stripping any existing
@@ -301,6 +326,35 @@ phase_conformance() {
   fi
   echo "evidence pointer:"
   cat ./evidence/pointer.yaml
+
+  # First-party platform sanity check. The emitted bundle's TestGrid tab
+  # coordinate is derived from the recipe's author-declared `platform`
+  # (inference→dynamo, training→kubeflow) and is NOT captured by the
+  # fingerprint — pkg/fingerprint/match.go treats the platform dimension as
+  # uncaptured — so a mis-declared platform would silently route evidence to
+  # the wrong tab. Cross-check that the platform operator's workload CRD is
+  # actually installed on the cluster the bundle deployed, so the declared
+  # coordinate matches the deployed component set. Unknown/other platforms are
+  # skipped (no false failure), a known platform whose CRD is absent fails closed.
+  echo "::group::Platform coordinate sanity check"
+  local platform crd
+  platform="$(yq -r '.criteria.platform // ""' recipe.yaml)"
+  case "${platform}" in
+    dynamo)   crd="dynamographdeployments.nvidia.com" ;;
+    kubeflow) crd="trainjobs.trainer.kubeflow.org" ;;
+    *)
+      echo "recipe declares platform '${platform}': no workload-CRD cross-check wired for it (skipping)"
+      echo "::endgroup::"
+      return 0
+      ;;
+  esac
+  if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
+    echo "::error::recipe declares platform=${platform} but its workload CRD ${crd} is not installed — the emitted evidence would map to the wrong TestGrid tab" >&2
+    kubectl get crd 2>&1 | head -50 >&2 || true
+    exit 1
+  fi
+  echo "platform=${platform}: workload CRD ${crd} present"
+  echo "::endgroup::"
 }
 
 phase_train() {
@@ -368,6 +422,234 @@ EOF
   echo "::endgroup::"
 }
 
+# serve_debug dumps the served-workload state (DGD, pods, describe, events,
+# logs) into serve-logs/ and the step log so a failed or successful phase_serve
+# is diagnosable from the uploaded artifacts. Best-effort; never fails the run.
+serve_debug() {
+  mkdir -p serve-logs
+  {
+    echo "--- dynamographdeployments ---"
+    kubectl get dynamographdeployments -n "${SERVE_NAMESPACE}" -o yaml 2>&1 || true
+    echo "--- pods ---"
+    kubectl get pods -n "${SERVE_NAMESPACE}" -o wide 2>&1 || true
+    echo "--- describe pods ---"
+    kubectl describe pods -n "${SERVE_NAMESPACE}" 2>&1 || true
+    echo "--- events ---"
+    kubectl get events -n "${SERVE_NAMESPACE}" --sort-by=.lastTimestamp 2>&1 || true
+    echo "--- logs (all pods, all containers, last 200 lines) ---"
+    for p in $(kubectl get pods -n "${SERVE_NAMESPACE}" -o name 2>/dev/null); do
+      echo "=== ${p} ==="
+      kubectl logs -n "${SERVE_NAMESPACE}" "${p#pod/}" --all-containers --tail=200 2>&1 || true
+    done
+  } | tee serve-logs/"${SERVE_NAME}".log
+}
+
+phase_serve() {
+  # Deploy the served inference graph (Dynamo) — the intent=inference CUJ, the
+  # DC3 counterpart of phase_train. Mirrors the DynamoGraphDeployment in
+  # demos/cuj2-inference.md (demos/workloads/inference/vllm-agg.yaml): the KAI
+  # queue, a DRA ResourceClaim, and a two-component (Frontend + decode Worker)
+  # graph serving an OpenAI-compatible endpoint.
+  #
+  # Tolerations are a portable SUPERSET of the taints across BOTH UAT clusters
+  # (AWS and GKE GPU pools use different `dedicated` values; the DRA/gpu-operator
+  # adds nvidia.com/gpu). Tolerating a taint a node does not carry is a no-op, so
+  # one list schedules correctly on either cloud. The Frontend deliberately omits
+  # the nvidia.com/gpu toleration so it stays OFF the scarce GPU nodes.
+  echo "::group::Deploy DynamoGraphDeployment (${SERVE_NAME} in ${SERVE_NAMESPACE})"
+  kubectl apply -f - <<EOF
+apiVersion: scheduling.run.ai/v2
+kind: Queue
+metadata:
+  name: ${SERVE_QUEUE}
+spec:
+  parentQueue: default-parent-queue
+  resources:
+    gpu: {limit: -1, overQuotaWeight: 1, quota: 0}
+    cpu: {limit: -1, overQuotaWeight: 1, quota: 0}
+    memory: {limit: -1, overQuotaWeight: 1, quota: 0}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${SERVE_NAMESPACE}
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: ${SERVE_NAME}-gpu-claim
+  namespace: ${SERVE_NAMESPACE}
+  labels:
+    kai.scheduler/queue: ${SERVE_QUEUE}
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${SERVE_NAME}
+  namespace: ${SERVE_NAMESPACE}
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          tolerations:
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoExecute}
+            - {key: dedicated, operator: Equal, value: gpu-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: system-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: system-workload, effect: NoExecute}
+          containers:
+            - name: main
+              image: ${SERVE_RUNTIME_IMAGE}
+              env:
+                - {name: SERVED_MODEL_NAME, value: ${SERVE_MODEL}}
+                - {name: DYN_ROUTER_MODE, value: kv}
+    - name: VllmDecodeWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 2Gi
+      podTemplate:
+        spec:
+          nodeSelector:
+            ${SERVE_GPU_NODE_SELECTOR_KEY}: ${SERVE_GPU_NODE_SELECTOR_VALUE}
+          tolerations:
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoExecute}
+            - {key: dedicated, operator: Equal, value: gpu-workload, effect: NoSchedule}
+            - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+          resourceClaims:
+            - name: gpu
+              resourceClaimName: ${SERVE_NAME}-gpu-claim
+          containers:
+            - name: main
+              image: ${SERVE_RUNTIME_IMAGE}
+              workingDir: /workspace/examples/backends/vllm
+              command: ["python3", "-m", "dynamo.vllm"]
+              args:
+                - --model
+                - ${SERVE_MODEL}
+                - --kv-events-config
+                - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}'
+              resources:
+                claims:
+                  - name: gpu
+EOF
+  echo "::endgroup::"
+
+  echo "::group::Wait for DynamoGraphDeployment readiness (timeout ${SERVE_READY_TIMEOUT_SECONDS}s)"
+  local deadline=$(( SECONDS + SERVE_READY_TIMEOUT_SECONDS ))
+  local ready=false pods_json total ready_count
+  while (( SECONDS < deadline )); do
+    pods_json="$(kubectl get pods -n "${SERVE_NAMESPACE}" -o json 2>/dev/null || echo '{}')"
+    # Fail closed as soon as a workload pod is unrecoverable so a bad image or
+    # crash loop surfaces immediately instead of burning the whole readiness
+    # budget. Two cases: a terminal phase=Failed, OR a container wedged in an
+    # image-pull / crash-loop / config-error waiting state — the latter keep the
+    # pod in phase=Running/Pending, so they must be checked explicitly (a
+    # multi-GB vllm-runtime pull that 404s would otherwise wait out the full
+    # SERVE_READY_TIMEOUT_SECONDS).
+    bad="$(echo "${pods_json}" | jq -r '
+      .items[]? as $p
+      | ( [ ($p.status.containerStatuses // [])[]?, ($p.status.initContainerStatuses // [])[]?
+            | .state.waiting.reason // empty ]
+          + (if $p.status.phase == "Failed" then ["phase=Failed"] else [] end) )[]
+      | select(. == "phase=Failed" or . == "ImagePullBackOff" or . == "ErrImagePull"
+               or . == "CrashLoopBackOff" or . == "InvalidImageName"
+               or . == "CreateContainerConfigError")' 2>/dev/null | head -n1)"
+    if [[ -n "${bad}" ]]; then
+      echo "a workload pod is unrecoverable (${bad}); not waiting out the readiness budget" >&2
+      break
+    fi
+    # Ready when at least one pod exists and every pod reports Ready=True.
+    total="$(echo "${pods_json}" | jq '[.items[]?] | length')"
+    ready_count="$(echo "${pods_json}" | jq '[.items[]? | select(.status.conditions[]? | select(.type=="Ready" and .status=="True"))] | length')"
+    if [[ "${total}" -gt 0 && "${total}" == "${ready_count}" ]]; then
+      ready=true
+      break
+    fi
+    echo "workload not ready (${ready_count}/${total} pods Ready); retrying in 15s..."
+    sleep 15
+  done
+  echo "::endgroup::"
+
+  if [[ "${ready}" != true ]]; then
+    echo "::error::DynamoGraphDeployment ${SERVE_NAME} did not become ready within ${SERVE_READY_TIMEOUT_SECONDS}s" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+
+  echo "::group::Query the OpenAI-compatible endpoint"
+  local svc="${SERVE_NAME}-frontend"
+  if ! kubectl get svc -n "${SERVE_NAMESPACE}" "${svc}" >/dev/null 2>&1; then
+    echo "::error::frontend service ${svc} not found in ${SERVE_NAMESPACE}" >&2
+    kubectl get svc -n "${SERVE_NAMESPACE}" >&2 || true
+    echo "::endgroup::"
+    exit 1
+  fi
+  # Port-forward the frontend and issue a sample chat completion. The forwarder
+  # is a background child; kill it on every exit path so a failing assertion
+  # does not leak the port-forward (belt-and-braces to the script exit, which
+  # would also reap it).
+  kubectl port-forward -n "${SERVE_NAMESPACE}" "svc/${svc}" \
+    "${SERVE_FRONTEND_PORT}:${SERVE_FRONTEND_PORT}" >/dev/null 2>&1 &
+  local pf_pid=$!
+  local up=false resp="" rc=0
+  for _ in $(seq 1 30); do
+    if curl -fsS "http://localhost:${SERVE_FRONTEND_PORT}/v1/models" >/dev/null 2>&1; then
+      up=true
+      break
+    fi
+    sleep 2
+  done
+  if [[ "${up}" == true ]]; then
+    resp="$(curl -sS --max-time "${SERVE_REQUEST_TIMEOUT_SECONDS}" \
+      -X POST "http://localhost:${SERVE_FRONTEND_PORT}/v1/chat/completions" \
+      -H 'Content-Type: application/json' \
+      -d "{\"model\":\"${SERVE_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"What is Kubernetes?\"}],\"max_tokens\":64}")" || rc=$?
+  fi
+  kill "${pf_pid}" 2>/dev/null || true
+  wait "${pf_pid}" 2>/dev/null || true
+  echo "::endgroup::"
+
+  if [[ "${up}" != true ]]; then
+    echo "::error::frontend endpoint ${svc} did not accept connections within the port-forward window" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+  echo "completion response:"
+  echo "${resp}"
+  # Assert a valid, non-empty OpenAI-compatible chat completion.
+  if [[ "${rc}" -ne 0 ]] || \
+     ! echo "${resp}" | jq -e '.choices[0].message.content | type == "string" and (length > 0)' >/dev/null 2>&1; then
+    echo "::error::inference request did not return a valid chat completion (curl rc=${rc})" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+  echo "served inference OK: /v1/chat/completions returned a non-empty completion"
+
+  echo "::group::Capture serve logs"
+  serve_debug >/dev/null
+  wc -l serve-logs/"${SERVE_NAME}".log || true
+  echo "::endgroup::"
+}
+
 phase_verify() {
   echo "::group::Bootstrap Sigstore TUF root"
   "${AICR_BIN}" trust update
@@ -404,11 +686,23 @@ case "${phase}" in
   install)     phase_install ;;
   conformance) phase_conformance ;;
   train)       phase_train ;;
+  serve)       phase_serve ;;
   verify)      phase_verify ;;
-  all)         phase_prep; phase_install; phase_conformance; phase_train; phase_verify ;;
+  all)
+    # The CUJ phase is chosen by the config's recipe intent so `run all`
+    # reproduces the right end-to-end flow: serve for inference, train
+    # otherwise. Defaults to training if the intent is unset.
+    phase_prep; phase_install; phase_conformance
+    intent="$(yq -r '.spec.recipe.criteria.intent // "training"' "${config}")"
+    case "${intent}" in
+      inference) phase_serve ;;
+      *)         phase_train ;;
+    esac
+    phase_verify
+    ;;
   *)
     echo "unknown phase: ${phase}" >&2
-    echo "Phases: prep | install | conformance | train | verify | all" >&2
+    echo "Phases: prep | install | conformance | train | serve | verify | all" >&2
     exit 2
     ;;
 esac

--- a/tests/uat/aws/tests/cuj2-inference/chainsaw-test.yaml
+++ b/tests/uat/aws/tests/cuj2-inference/chainsaw-test.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   description: |
     UAT CUJ2: Inference workload on live EKS cluster with GPU nodes.
-    Tests the aicr workflow from demos/cuj2.md against a real cluster:
+    Tests the aicr workflow from demos/cuj2-inference.md against a real cluster:
       Step 1: Snapshot the live cluster
       Step 2: Generate recipe (EKS/H100/inference/dynamo)
       Step 3: Validate deployment against live snapshot

--- a/tests/uat/gcp/run
+++ b/tests/uat/gcp/run
@@ -23,12 +23,18 @@
 #
 # Phases:
 #   prep         snapshot + recipe + dry-run validate + bundle
-#   install      helmfile apply (deploys gpu-operator, kubeflow, ...)
+#   install      helmfile apply (deploys gpu-operator, kubeflow/dynamo, ...)
 #   conformance  validate ALL phases (deployment + conformance + performance)
 #                + emit signed evidence bundle
 #   train        submit TrainJob, wait for completion, capture logs
+#                (intent=training CUJ)
+#   serve        deploy a DynamoGraphDeployment, wait for readiness, hit the
+#                OpenAI-compatible endpoint, assert a completion, capture logs
+#                (intent=inference CUJ — the DC3 counterpart of `train`)
 #   verify       aicr evidence verify against the signed bundle
-#   all          run every phase in order (for local reproduction)
+#   all          run every phase in order (for local reproduction); the CUJ
+#                phase is chosen by the config's recipe intent — `train` for
+#                training, `serve` for inference
 #
 # Required env:
 #   AICR_BIN    Path to the aicr binary
@@ -45,7 +51,7 @@ config="${2:-}"
 
 if [[ -z "${phase}" || -z "${config}" ]]; then
   echo "Usage: $0 <phase> <test-config.yaml>" >&2
-  echo "Phases: prep | install | conformance | train | verify | all" >&2
+  echo "Phases: prep | install | conformance | train | serve | verify | all" >&2
   exit 2
 fi
 
@@ -70,6 +76,25 @@ HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
 # GPU-operator convergence (driver/toolkit/device-plugin/DCGM) and
 # prometheus-adapter APIService aggregation. Fails closed if exceeded.
 READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-1200}" # 20 min
+
+# Inference-serve knobs (phase_serve; overridable for local reproduction). The
+# defaults mirror the served DynamoGraphDeployment in demos/cuj2-inference.md
+# (demos/workloads/inference/vllm-agg.yaml) so CI and the demo stay in lockstep.
+SERVE_NAMESPACE="${SERVE_NAMESPACE:-dynamo-workload}"
+SERVE_NAME="${SERVE_NAME:-vllm-agg}"
+SERVE_QUEUE="${SERVE_QUEUE:-dynamo}"
+SERVE_MODEL="${SERVE_MODEL:-Qwen/Qwen3-0.6B}"
+SERVE_RUNTIME_IMAGE="${SERVE_RUNTIME_IMAGE:-nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1}"
+# GPU worker placement. The demo pins nodeGroup=gpu-worker; both UAT clusters
+# label their GPU pool the same way (tests/uat/*/cluster-config.yaml), so the
+# default lands the decode worker on the GPU node on either cloud.
+SERVE_GPU_NODE_SELECTOR_KEY="${SERVE_GPU_NODE_SELECTOR_KEY:-nodeGroup}"
+SERVE_GPU_NODE_SELECTOR_VALUE="${SERVE_GPU_NODE_SELECTOR_VALUE:-gpu-worker}"
+SERVE_FRONTEND_PORT="${SERVE_FRONTEND_PORT:-8000}"
+# Readiness budget: image pull of the multi-GB vllm-runtime + model download +
+# engine warmup on a cold GPU node. Generous; fails closed if exceeded.
+SERVE_READY_TIMEOUT_SECONDS="${SERVE_READY_TIMEOUT_SECONDS:-1800}" # 30 min
+SERVE_REQUEST_TIMEOUT_SECONDS="${SERVE_REQUEST_TIMEOUT_SECONDS:-120}" # 2 min
 
 # Per-run OCI tag. The committed config carries the stable per-recipe repo
 # only; we apply a `:run-${RUN_ID}` tag idempotently, stripping any existing
@@ -301,6 +326,35 @@ phase_conformance() {
   fi
   echo "evidence pointer:"
   cat ./evidence/pointer.yaml
+
+  # First-party platform sanity check. The emitted bundle's TestGrid tab
+  # coordinate is derived from the recipe's author-declared `platform`
+  # (inference→dynamo, training→kubeflow) and is NOT captured by the
+  # fingerprint — pkg/fingerprint/match.go treats the platform dimension as
+  # uncaptured — so a mis-declared platform would silently route evidence to
+  # the wrong tab. Cross-check that the platform operator's workload CRD is
+  # actually installed on the cluster the bundle deployed, so the declared
+  # coordinate matches the deployed component set. Unknown/other platforms are
+  # skipped (no false failure), a known platform whose CRD is absent fails closed.
+  echo "::group::Platform coordinate sanity check"
+  local platform crd
+  platform="$(yq -r '.criteria.platform // ""' recipe.yaml)"
+  case "${platform}" in
+    dynamo)   crd="dynamographdeployments.nvidia.com" ;;
+    kubeflow) crd="trainjobs.trainer.kubeflow.org" ;;
+    *)
+      echo "recipe declares platform '${platform}': no workload-CRD cross-check wired for it (skipping)"
+      echo "::endgroup::"
+      return 0
+      ;;
+  esac
+  if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
+    echo "::error::recipe declares platform=${platform} but its workload CRD ${crd} is not installed — the emitted evidence would map to the wrong TestGrid tab" >&2
+    kubectl get crd 2>&1 | head -50 >&2 || true
+    exit 1
+  fi
+  echo "platform=${platform}: workload CRD ${crd} present"
+  echo "::endgroup::"
 }
 
 phase_train() {
@@ -368,6 +422,234 @@ EOF
   echo "::endgroup::"
 }
 
+# serve_debug dumps the served-workload state (DGD, pods, describe, events,
+# logs) into serve-logs/ and the step log so a failed or successful phase_serve
+# is diagnosable from the uploaded artifacts. Best-effort; never fails the run.
+serve_debug() {
+  mkdir -p serve-logs
+  {
+    echo "--- dynamographdeployments ---"
+    kubectl get dynamographdeployments -n "${SERVE_NAMESPACE}" -o yaml 2>&1 || true
+    echo "--- pods ---"
+    kubectl get pods -n "${SERVE_NAMESPACE}" -o wide 2>&1 || true
+    echo "--- describe pods ---"
+    kubectl describe pods -n "${SERVE_NAMESPACE}" 2>&1 || true
+    echo "--- events ---"
+    kubectl get events -n "${SERVE_NAMESPACE}" --sort-by=.lastTimestamp 2>&1 || true
+    echo "--- logs (all pods, all containers, last 200 lines) ---"
+    for p in $(kubectl get pods -n "${SERVE_NAMESPACE}" -o name 2>/dev/null); do
+      echo "=== ${p} ==="
+      kubectl logs -n "${SERVE_NAMESPACE}" "${p#pod/}" --all-containers --tail=200 2>&1 || true
+    done
+  } | tee serve-logs/"${SERVE_NAME}".log
+}
+
+phase_serve() {
+  # Deploy the served inference graph (Dynamo) — the intent=inference CUJ, the
+  # DC3 counterpart of phase_train. Mirrors the DynamoGraphDeployment in
+  # demos/cuj2-inference.md (demos/workloads/inference/vllm-agg.yaml): the KAI
+  # queue, a DRA ResourceClaim, and a two-component (Frontend + decode Worker)
+  # graph serving an OpenAI-compatible endpoint.
+  #
+  # Tolerations are a portable SUPERSET of the taints across BOTH UAT clusters
+  # (AWS and GKE GPU pools use different `dedicated` values; the DRA/gpu-operator
+  # adds nvidia.com/gpu). Tolerating a taint a node does not carry is a no-op, so
+  # one list schedules correctly on either cloud. The Frontend deliberately omits
+  # the nvidia.com/gpu toleration so it stays OFF the scarce GPU nodes.
+  echo "::group::Deploy DynamoGraphDeployment (${SERVE_NAME} in ${SERVE_NAMESPACE})"
+  kubectl apply -f - <<EOF
+apiVersion: scheduling.run.ai/v2
+kind: Queue
+metadata:
+  name: ${SERVE_QUEUE}
+spec:
+  parentQueue: default-parent-queue
+  resources:
+    gpu: {limit: -1, overQuotaWeight: 1, quota: 0}
+    cpu: {limit: -1, overQuotaWeight: 1, quota: 0}
+    memory: {limit: -1, overQuotaWeight: 1, quota: 0}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${SERVE_NAMESPACE}
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: ${SERVE_NAME}-gpu-claim
+  namespace: ${SERVE_NAMESPACE}
+  labels:
+    kai.scheduler/queue: ${SERVE_QUEUE}
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${SERVE_NAME}
+  namespace: ${SERVE_NAMESPACE}
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          tolerations:
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoExecute}
+            - {key: dedicated, operator: Equal, value: gpu-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: system-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: system-workload, effect: NoExecute}
+          containers:
+            - name: main
+              image: ${SERVE_RUNTIME_IMAGE}
+              env:
+                - {name: SERVED_MODEL_NAME, value: ${SERVE_MODEL}}
+                - {name: DYN_ROUTER_MODE, value: kv}
+    - name: VllmDecodeWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 2Gi
+      podTemplate:
+        spec:
+          nodeSelector:
+            ${SERVE_GPU_NODE_SELECTOR_KEY}: ${SERVE_GPU_NODE_SELECTOR_VALUE}
+          tolerations:
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoExecute}
+            - {key: dedicated, operator: Equal, value: gpu-workload, effect: NoSchedule}
+            - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+          resourceClaims:
+            - name: gpu
+              resourceClaimName: ${SERVE_NAME}-gpu-claim
+          containers:
+            - name: main
+              image: ${SERVE_RUNTIME_IMAGE}
+              workingDir: /workspace/examples/backends/vllm
+              command: ["python3", "-m", "dynamo.vllm"]
+              args:
+                - --model
+                - ${SERVE_MODEL}
+                - --kv-events-config
+                - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}'
+              resources:
+                claims:
+                  - name: gpu
+EOF
+  echo "::endgroup::"
+
+  echo "::group::Wait for DynamoGraphDeployment readiness (timeout ${SERVE_READY_TIMEOUT_SECONDS}s)"
+  local deadline=$(( SECONDS + SERVE_READY_TIMEOUT_SECONDS ))
+  local ready=false pods_json total ready_count
+  while (( SECONDS < deadline )); do
+    pods_json="$(kubectl get pods -n "${SERVE_NAMESPACE}" -o json 2>/dev/null || echo '{}')"
+    # Fail closed as soon as a workload pod is unrecoverable so a bad image or
+    # crash loop surfaces immediately instead of burning the whole readiness
+    # budget. Two cases: a terminal phase=Failed, OR a container wedged in an
+    # image-pull / crash-loop / config-error waiting state — the latter keep the
+    # pod in phase=Running/Pending, so they must be checked explicitly (a
+    # multi-GB vllm-runtime pull that 404s would otherwise wait out the full
+    # SERVE_READY_TIMEOUT_SECONDS).
+    bad="$(echo "${pods_json}" | jq -r '
+      .items[]? as $p
+      | ( [ ($p.status.containerStatuses // [])[]?, ($p.status.initContainerStatuses // [])[]?
+            | .state.waiting.reason // empty ]
+          + (if $p.status.phase == "Failed" then ["phase=Failed"] else [] end) )[]
+      | select(. == "phase=Failed" or . == "ImagePullBackOff" or . == "ErrImagePull"
+               or . == "CrashLoopBackOff" or . == "InvalidImageName"
+               or . == "CreateContainerConfigError")' 2>/dev/null | head -n1)"
+    if [[ -n "${bad}" ]]; then
+      echo "a workload pod is unrecoverable (${bad}); not waiting out the readiness budget" >&2
+      break
+    fi
+    # Ready when at least one pod exists and every pod reports Ready=True.
+    total="$(echo "${pods_json}" | jq '[.items[]?] | length')"
+    ready_count="$(echo "${pods_json}" | jq '[.items[]? | select(.status.conditions[]? | select(.type=="Ready" and .status=="True"))] | length')"
+    if [[ "${total}" -gt 0 && "${total}" == "${ready_count}" ]]; then
+      ready=true
+      break
+    fi
+    echo "workload not ready (${ready_count}/${total} pods Ready); retrying in 15s..."
+    sleep 15
+  done
+  echo "::endgroup::"
+
+  if [[ "${ready}" != true ]]; then
+    echo "::error::DynamoGraphDeployment ${SERVE_NAME} did not become ready within ${SERVE_READY_TIMEOUT_SECONDS}s" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+
+  echo "::group::Query the OpenAI-compatible endpoint"
+  local svc="${SERVE_NAME}-frontend"
+  if ! kubectl get svc -n "${SERVE_NAMESPACE}" "${svc}" >/dev/null 2>&1; then
+    echo "::error::frontend service ${svc} not found in ${SERVE_NAMESPACE}" >&2
+    kubectl get svc -n "${SERVE_NAMESPACE}" >&2 || true
+    echo "::endgroup::"
+    exit 1
+  fi
+  # Port-forward the frontend and issue a sample chat completion. The forwarder
+  # is a background child; kill it on every exit path so a failing assertion
+  # does not leak the port-forward (belt-and-braces to the script exit, which
+  # would also reap it).
+  kubectl port-forward -n "${SERVE_NAMESPACE}" "svc/${svc}" \
+    "${SERVE_FRONTEND_PORT}:${SERVE_FRONTEND_PORT}" >/dev/null 2>&1 &
+  local pf_pid=$!
+  local up=false resp="" rc=0
+  for _ in $(seq 1 30); do
+    if curl -fsS "http://localhost:${SERVE_FRONTEND_PORT}/v1/models" >/dev/null 2>&1; then
+      up=true
+      break
+    fi
+    sleep 2
+  done
+  if [[ "${up}" == true ]]; then
+    resp="$(curl -sS --max-time "${SERVE_REQUEST_TIMEOUT_SECONDS}" \
+      -X POST "http://localhost:${SERVE_FRONTEND_PORT}/v1/chat/completions" \
+      -H 'Content-Type: application/json' \
+      -d "{\"model\":\"${SERVE_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"What is Kubernetes?\"}],\"max_tokens\":64}")" || rc=$?
+  fi
+  kill "${pf_pid}" 2>/dev/null || true
+  wait "${pf_pid}" 2>/dev/null || true
+  echo "::endgroup::"
+
+  if [[ "${up}" != true ]]; then
+    echo "::error::frontend endpoint ${svc} did not accept connections within the port-forward window" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+  echo "completion response:"
+  echo "${resp}"
+  # Assert a valid, non-empty OpenAI-compatible chat completion.
+  if [[ "${rc}" -ne 0 ]] || \
+     ! echo "${resp}" | jq -e '.choices[0].message.content | type == "string" and (length > 0)' >/dev/null 2>&1; then
+    echo "::error::inference request did not return a valid chat completion (curl rc=${rc})" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+  echo "served inference OK: /v1/chat/completions returned a non-empty completion"
+
+  echo "::group::Capture serve logs"
+  serve_debug >/dev/null
+  wc -l serve-logs/"${SERVE_NAME}".log || true
+  echo "::endgroup::"
+}
+
 phase_verify() {
   echo "::group::Bootstrap Sigstore TUF root"
   "${AICR_BIN}" trust update
@@ -404,11 +686,23 @@ case "${phase}" in
   install)     phase_install ;;
   conformance) phase_conformance ;;
   train)       phase_train ;;
+  serve)       phase_serve ;;
   verify)      phase_verify ;;
-  all)         phase_prep; phase_install; phase_conformance; phase_train; phase_verify ;;
+  all)
+    # The CUJ phase is chosen by the config's recipe intent so `run all`
+    # reproduces the right end-to-end flow: serve for inference, train
+    # otherwise. Defaults to training if the intent is unset.
+    phase_prep; phase_install; phase_conformance
+    intent="$(yq -r '.spec.recipe.criteria.intent // "training"' "${config}")"
+    case "${intent}" in
+      inference) phase_serve ;;
+      *)         phase_train ;;
+    esac
+    phase_verify
+    ;;
   *)
     echo "unknown phase: ${phase}" >&2
-    echo "Phases: prep | install | conformance | train | verify | all" >&2
+    echo "Phases: prep | install | conformance | train | serve | verify | all" >&2
     exit 2
     ;;
 esac

--- a/tools/uat-broker/README.md
+++ b/tools/uat-broker/README.md
@@ -27,8 +27,16 @@ uat-broker reservations --name aws-h100 >> "$GITHUB_OUTPUT"
 # gpu-count=8
 # cluster-config-path=tests/uat/aws/cluster-config.yaml
 # test-config-dir=tests/uat/aws/tests
+# nightly-intents=training,inference
 # daytime-intent=training
 ```
+
+`nightly-intents` is the comma-separated list of intents the nightly batch runs
+on this reservation (#1276, DC3); it is emitted **resolved** (an un-annotated
+reservation reports the `training` default rather than an empty value). The
+launch set is `training,inference` on both reservations, so both CUJs run
+nightly on both clouds — the controller splits on comma and dispatches one
+serialized cell per intent per version.
 
 List every reservation name (one per line):
 

--- a/tools/uat-broker/main.go
+++ b/tools/uat-broker/main.go
@@ -188,6 +188,11 @@ func runReservations(args []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(&b, "gpu-count=%d\n", res.GPUCount)
 		fmt.Fprintf(&b, "cluster-config-path=%s\n", res.ClusterConfigPath)
 		fmt.Fprintf(&b, "test-config-dir=%s\n", res.TestConfigDir)
+		// The nightly batch's intents for this reservation, comma-joined and
+		// resolved (not raw) so an un-annotated reservation reports the training
+		// default rather than an empty value the caller must re-default. The
+		// nightly controller splits on comma and dispatches one cell per intent.
+		fmt.Fprintf(&b, "nightly-intents=%s\n", strings.Join(res.NightlyIntentsOrDefault(), ","))
 		// Empty when the reservation is not in the daytime rotation; callers
 		// that don't consume this key simply ignore the line.
 		fmt.Fprintf(&b, "daytime-intent=%s\n", res.DaytimeIntent)

--- a/tools/uat-broker/main_test.go
+++ b/tools/uat-broker/main_test.go
@@ -37,6 +37,7 @@ reservations:
     gpu-count: 8
     cluster-config-path: tests/uat/aws/cluster-config.yaml
     test-config-dir: tests/uat/aws/tests
+    nightly-intents: [training, inference]
     daytime-intent: training
   - name: gcp-h100
     cloud: gcp
@@ -45,6 +46,7 @@ reservations:
     gpu-count: 8
     cluster-config-path: tests/uat/gcp/cluster-config.yaml
     test-config-dir: tests/uat/gcp/tests
+    nightly-intents: [training, inference]
     daytime-intent: inference
 `
 
@@ -76,10 +78,38 @@ func TestReservationsResolve(t *testing.T) {
 		"gpu-count=8",
 		"cluster-config-path=tests/uat/aws/cluster-config.yaml",
 		"test-config-dir=tests/uat/aws/tests",
+		"nightly-intents=training,inference",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("stdout missing %q\ngot:\n%s", want, stdout)
 		}
+	}
+}
+
+// TestReservationsResolveNightlyIntentsDefaults verifies the resolved output
+// reports the training default when a row omits nightly-intents, so the nightly
+// batch's intent loop is never handed an empty list.
+func TestReservationsResolveNightlyIntentsDefaults(t *testing.T) {
+	const reg = `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`
+	p := filepath.Join(t.TempDir(), "reservations.yaml")
+	if err := os.WriteFile(p, []byte(reg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, stderr := invoke("", "reservations", "--file", p, "--name", "aws-h100")
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr: %s)", code, stderr)
+	}
+	if !strings.Contains(stdout, "nightly-intents=training") {
+		t.Errorf("stdout missing resolved default nightly-intents=training\ngot:\n%s", stdout)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bring real-cluster inference to CUJ1 parity (DC3): a `phase_serve` step deploys a Dynamo `DynamoGraphDeployment`, hits its OpenAI-compatible endpoint, and asserts a completion; and the nightly batch now runs **both** training and inference on **both** clouds, serialized through the shared reservation lease.

## Motivation / Context

Inference was only a `--no-cluster` dry-run that no workflow invoked — no inference column existed on any cloud. This makes inference a real cluster phase, the counterpart of `phase_train`, and wires it end-to-end so nightly runs exercise a served endpoint and emit a signed bundle whose criteria map to `inference-dynamo`.

Fixes: #1276
Related: #1596 (follow-up: surface the build commit on the corroboration dashboard)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT runner + workflows (`tests/uat/**`, `.github/workflows/uat-*`), reservation broker (`pkg/uatbroker`, `tools/uat-broker`)

## Implementation Notes

- **`phase_serve`** (`tests/uat/{aws,gcp}/run`): deploys the KAI queue + DRA `ResourceClaim` + Frontend/decode-Worker `DynamoGraphDeployment` (inlined from `demos/workloads/inference/vllm-agg.yaml`), waits for pod readiness, port-forwards the frontend, `POST /v1/chat/completions`, asserts a non-empty completion. **Fails closed** (captured pod logs/events under `serve-logs/`) on a non-ready deployment or invalid completion, mirroring `phase_train`. Node scheduling/model are `SERVE_*`-overridable; tolerations are a portable superset across both clouds.
- **Intent selection**: `run all` picks train vs serve from the config's recipe intent; the workflows add an intent-gated `UAT - serve` step mirroring `train`.
- **Platform cross-check** in `phase_conformance`: the declared `platform` must match the deployed workload CRD (`dynamographdeployments.nvidia.com` / `trainjobs.trainer.kubeflow.org`), since the TestGrid coordinate is author-declared and otherwise cluster-unverifiable.
- **Nightly cadence decision**: both intents run nightly on both clouds, folded into the version matrix as serialized cells (version outer-loop / intent inner-loop) through the shared per-reservation lease — **no second cron, no contention**, and `main` lands both intents before any release cell. Data-driven via a new `nightly-intents` list in `infra/uat/reservations.yaml` (`pkg/uatbroker`). Trade-off: this ~doubles a reservation's cell count; the batch time-box drops oldest cells first (tune `previous_n` / `deadline_offset_hours`), documented in `docs/contributor/uat.md`.
- **Version stamping**: the main-cell binary is stamped `version=main` + commit + date via ldflags so evidence/results read `main` instead of the un-stamped `dev`. Because a real `commit` would otherwise redirect validator images `:latest` → `:sha-<commit>` (which may not exist for a feature-branch ref), main-cell validator images are pinned to the run's own `:uat-<run_id>` build — mirroring the existing agent pin. Release cells are unaffected (empty override → released `:vX.Y.Z`).

## Testing

```bash
# Targeted gates (Go changes are scoped to the broker):
go test -race ./pkg/uatbroker/... ./tools/uat-broker/...   # ok, 96.9% / 91.5%
golangci-lint run -c .golangci.yaml ./pkg/uatbroker/... ./tools/uat-broker/...  # 0 issues
yamllint -c .yamllint.yaml .github/workflows/uat-*.yaml infra/uat/reservations.yaml  # clean
shellcheck tests/uat/aws/run tests/uat/gcp/run   # clean
# ldflags verified: `aicr --version` -> "main (commit: <sha>, date: ...)"
```

Full `make qualify` (e2e/grype) was **not** run — its e2e leg provisions real infrastructure. Per the issue's test plan, the real-hardware inference run is a manual `workflow_dispatch intent=inference` during bring-up; the `--no-cluster` chainsaw dry-run continues to validate the inference AICRConfig resolves.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No breaking changes. One behavior change to flag: main-cell validator images now resolve to the run's `:uat-<run_id>` build instead of `:latest` (consistent with the agent pin; removes known `:latest` staleness). `nightly-intents` defaults to `[training]` when absent, so the change is backward-compatible. The nightly cell count roughly doubles — see the time-box tuning note in `docs/contributor/uat.md`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — ran `-race` on the changed Go packages (`pkg/uatbroker`, `tools/uat-broker`)
- [x] Linter passes (`make lint`) — `golangci-lint` (affected pkgs, 0 issues) + `yamllint` + `shellcheck`
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
