### PR TITLE
chore(tuning): bump nvidia-setup to 0.4.0 for EKS nodes

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -205,8 +205,8 @@ _No images extracted._
 
 ### nodewright-customizations
 
-- `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.2.2@sha256:76913a5deff9513f348dd4b7d66cbca9ea1dd22df63baa4ac2f6b2fa7e93664e`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.3.0@sha256:f17c951d60b519d097c20a3d9f49668f043a996adb31b9bb4db24a112a8f60a2`
+- `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.4.0@sha256:187c56c6d2104d48c7632c293def79c714b04dd85c587b7793818ceba9d4fb04`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-tuned:0.3.0@sha256:cc99c8c0675f3752f5081f0978ae57174368952ca0bb5fcac07640fe62c156c7`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-tuning-gke:0.1.2@sha256:6671d49f006afdbeefd8858f1fa1216f7748205bc42edab3340210a2cc459a81`
 - `ghcr.io/nvidia/skyhook-packages/shellscript:1.1.1`

--- a/recipes/components/nodewright-customizations/manifests/tuning.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning.yaml
@@ -65,11 +65,11 @@ spec:
   {{- end }}
   # Tuning
   packages:
-    # Check for kernel being >= to 6.14.0-1018 and if not install
+    # Check for kernel being >= to 6.17.0-1019 and if not install
     nvidia-setup-kernel:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-setup
-      version: "0.2.2"
-      containerSHA: sha256:76913a5deff9513f348dd4b7d66cbca9ea1dd22df63baa4ac2f6b2fa7e93664e
+      version: "0.4.0"
+      containerSHA: sha256:187c56c6d2104d48c7632c293def79c714b04dd85c587b7793818ceba9d4fb04
       configMap:
         {{- if $cust.service }}
         service: {{ $cust.service }}
@@ -104,13 +104,13 @@ spec:
         service: {{ $cust.service }}
         {{- end }}
       dependsOn:
-        nvidia-setup-kernel: "0.2.2"
+        nvidia-setup-kernel: "0.4.0"
 
     # Full setup after kernel is in place
     nvidia-setup-full:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-setup
-      version: "0.2.2"
-      containerSHA: sha256:76913a5deff9513f348dd4b7d66cbca9ea1dd22df63baa4ac2f6b2fa7e93664e
+      version: "0.4.0"
+      containerSHA: sha256:187c56c6d2104d48c7632c293def79c714b04dd85c587b7793818ceba9d4fb04
       interrupt:
         type: reboot
       resources:


### PR DESCRIPTION
## Summary

Bumps `nvidia-setup` from 0.2.2 to 0.4.0 in the EKS nodewright tuning manifest (both the kernel and full-setup Skyhook packages, plus the `dependsOn` pin), pinned to the cosign-signed 0.4.0 digest.

## Motivation / Context

[nodewright-packages#83](https://github.com/NVIDIA/nodewright-packages/pull/83) released nvidia-setup 0.4.0, which:

- Bumps EKS h100/gb200 defaults to kernel `6.17.0-1019-aws` and EFA `1.48.0`
- Resolves the 64k-page kernel flavor on arm64 (`resolve_full_kernel` now appends `-64k` on aarch64, so GB200 installs `6.17.0-1019-aws-64k` instead of the non-64k flavor)
- Self-heals half-configured dpkg state during kernel install (`dpkg --configure -a` + one retry)


Fixes: N/A
Related: NVIDIA/nodewright-packages#83, NVIDIA/nodewright-packages#84

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling
- [x] Update to recipe

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Scope is the EKS manifest (`tuning.yaml`) only; the BCM manifest (`bcm-setup.yaml`) stays on 0.3.0.
- The kernel comment on `nvidia-setup-kernel` is updated from `6.14.0-1018` to `6.17.0-1019` to match 0.4.0's new EKS defaults.

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make test
make lint
yamllint recipes/components/nodewright-customizations/manifests/tuning.yaml
go test ./tools/bom/... ./pkg/bom/...
```

- `make test` passes with `-race` (coverage 77.8%, above the 75% floor); `make lint` passes.
- `go test ./tools/bom/... ./pkg/bom/...` passes, including the `TestCommittedBOMVersionsMatchRegistry` BOM-freshness gate.
- No Go source changes, so the coverage gate does not apply.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Nodes provisioned with the EKS tuning Skyhook will install kernel `6.17.0-1019-aws` (arm64: `-64k` flavor) and EFA 1.48.0 on next reconcile; the package interrupt is a reboot, as before. Revert = restore the previous version/digest pins.

## Checklist

- [x] Tests pass locally (`make test` with `-race`; e2e helmfile lane not runnable in this environment, see Testing)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
