### PR TITLE
fix(bundler): honor bundlers query param; driver-managed cleanup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -559,6 +559,26 @@ Verify a bundle with `aicr verify <dir>`. Update the trusted root cache with
 | Build failures | Run `make tidy` to update dependencies |
 | K8s connection fails | Check `~/.kube/config` or `KUBECONFIG` env |
 
+### Redeploying on Driver-Managed Clusters
+
+On clusters where gpu-operator installs the NVIDIA kernel driver
+(`driver.enabled: true` — e.g. EKS; GKE COS is host-managed and unaffected),
+running `make cleanup` (`tools/cleanup`) can leave the `nvidia_uvm` kernel
+module wedged mid-unload on GPU nodes. The symptom appears on the *next*
+install: the driver validation init container crashes
+(`Init:CrashLoopBackOff`, logs show `failed to create device node
+nvidia-uvm`). The cleanup script detects driver-managed mode (via the
+`nvidia-driver-daemonset` or `driver.enabled` in the release values) and
+prints this guidance; the fix is to reboot the GPU nodes before reinstalling:
+
+```bash
+kubectl cordon <gpu-node>            # each GPU node
+# reboot the instances, e.g. on EKS:
+aws ec2 reboot-instances --instance-ids <ids>
+# wait for the nodes to report Ready, then
+kubectl uncordon <gpu-node>
+```
+
 ### Debugging Tests
 
 ```bash

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -742,8 +742,13 @@ paths:
           in: query
           required: false
           description: >
-            Comma-delimited list of bundler types to execute.
-            If not specified, all registered bundlers are executed.
+            Comma-delimited list of recipe component names to bundle.
+            If not specified, all enabled components are bundled.
+            Components not listed are skipped as if disabled (their
+            dependency edges are treated as satisfied externally).
+            A name the recipe does not declare, or one that is disabled
+            (by the recipe or by a "set" parameter enabled=false
+            override), is rejected with HTTP 400.
           schema:
             type: string
           examples:
@@ -1020,7 +1025,7 @@ paths:
                 type: string
                 format: binary
         "400":
-          description: Invalid request (invalid recipe or bundler type)
+          description: Invalid request (invalid recipe or bundlers filter)
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestIdResponse"
@@ -1037,15 +1042,19 @@ paths:
                     requestId: "550e8400-e29b-41d4-a716-446655440000"
                     timestamp: "2025-01-15T10:30:00Z"
                     retryable: false
-                invalidBundler:
-                  summary: Invalid bundler type
+                unknownBundler:
+                  summary: Bundlers filter names an undeclared component
                   value:
                     code: INVALID_REQUEST
-                    message: "Invalid bundler type"
-                    details:
-                      bundler: "invalid-bundler"
-                      error: "unsupported bundle type: invalid-bundler"
-                      valid: ["gpu-operator", "network-operator", "nodewright-operator", "nvsentinel", "cert-manager", "nvidia-dra-driver-gpu"]
+                    message: 'unknown component "invalid-bundler" in bundlers filter; recipe declares: gpu-operator, network-operator, cert-manager'
+                    requestId: "550e8400-e29b-41d4-a716-446655440000"
+                    timestamp: "2025-01-15T10:30:00Z"
+                    retryable: false
+                disabledBundler:
+                  summary: Bundlers filter names a disabled component
+                  value:
+                    code: INVALID_REQUEST
+                    message: 'component "cert-manager" is disabled and cannot be selected via the bundlers filter'
                     requestId: "550e8400-e29b-41d4-a716-446655440000"
                     timestamp: "2025-01-15T10:30:00Z"
                     retryable: false
@@ -1554,8 +1563,10 @@ components:
           type: array
           items:
             type: string
-            enum: [gpu-operator, network-operator, nodewright-operator, nvsentinel, cert-manager, nvidia-dra-driver-gpu]
           description: >
-            Optional list of bundler types to execute.
-            If not specified, all registered bundlers are executed.
+            Optional list of recipe component names to bundle.
+            If not specified, all enabled components are bundled.
+            Superseded by the "bundlers" query parameter, which accepts
+            enabled component names the recipe declares; unknown or
+            disabled names are rejected with HTTP 400.
           example: [gpu-operator, network-operator]

--- a/docs/integrator/index.md
+++ b/docs/integrator/index.md
@@ -54,10 +54,10 @@ curl "http://aicrd.aicr.svc/v1/recipe?service=eks&accelerator=h100"
 - name: Generate bundles
   # recipe.json is the fully-hydrated RecipeResult from the GET above; the
   # bundle endpoint adopts it as-is and bundles all of its componentRefs.
-  # (The `bundlers` query param is not currently honored — see
-  # https://github.com/NVIDIA/aicr/issues/1531. There is no supported way to
-  # bundle a subset via the API today; hand-trimming componentRefs drops
-  # required dependencies, so bundle the full result.)
+  # To bundle a subset, add the `bundlers` query parameter (comma-delimited
+  # component names, e.g. "?bundlers=gpu-operator,network-operator") rather
+  # than hand-trimming componentRefs, which drops required dependencies.
+  # Unknown or disabled component names are rejected with HTTP 400.
   run: |
     curl -X POST "http://aicrd.aicr.svc/v1/bundle" \
       -H "Content-Type: application/json" \

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -367,7 +367,7 @@ Generate deployment bundles from a recipe.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `bundlers` | string | (all) | Comma-delimited list of bundler types to execute. **Not currently honored — all bundlers run regardless ([#1531](https://github.com/NVIDIA/aicr/issues/1531)).** |
+| `bundlers` | string | (all) | Comma-delimited list of recipe component names to bundle (e.g. `gpu-operator,network-operator`). Whitespace around names is trimmed. Components not listed are skipped as if disabled (their dependency edges are treated as satisfied externally). A name the recipe does not declare, or one that is disabled (by the recipe or a `set` `enabled=false` override), is rejected with HTTP 400. |
 | `set` | string[] | | Value overrides (format: `bundler:path.to.field=value`). Repeat for multiple. |
 | `dynamic` | string[] | | Declare value paths as install-time parameters (format: `component:path.to.field`). Repeat for multiple. Supported with `deployer=helm`, `deployer=argocd-helm`, `deployer=flux`, and `deployer=helmfile`. |
 | `system-node-selector` | string[] | | Node selectors for system components (format: `key=value`). Repeat for multiple. |
@@ -386,7 +386,7 @@ The request body is the recipe (RecipeResult) directly. No wrapper object needed
 
 #### Components
 
-These are the recipe **components** in [`recipes/registry.yaml`](https://github.com/NVIDIA/aicr/blob/main/recipes/registry.yaml). (The `bundlers` query parameter that would select a subset is currently ignored — all run regardless, #1531.) The registry is the authoritative source — see the [component catalog](component-catalog.md) for the full, current list with detailed descriptions. The table below is illustrative of commonly used components:
+These are the recipe **components** in [`recipes/registry.yaml`](https://github.com/NVIDIA/aicr/blob/main/recipes/registry.yaml) — the names the `bundlers` query parameter accepts (a request may only name components the recipe declares). The registry is the authoritative source — see the [component catalog](component-catalog.md) for the full, current list with detailed descriptions. The table below is illustrative of commonly used components:
 
 | Component | Description |
 |-----------|-------------|
@@ -436,12 +436,13 @@ These are the recipe **components** in [`recipes/registry.yaml`](https://github.
 > a few component fields shown) — use a generated `RecipeResult`, not these
 > literals.
 >
-> The `bundlers` query parameter is **not currently honored** — all bundlers run
-> regardless ([#1531](https://github.com/NVIDIA/aicr/issues/1531)). There is no
-> supported way to bundle a subset via the API today: hand-trimming
-> `componentRefs` is unsafe (it silently drops required dependencies and breaks
-> deployers like Helmfile on dangling `dependencyRefs`). Bundle the full
-> hydrated result.
+> To bundle a subset of the recipe's components, use the `bundlers` query
+> parameter (e.g. `?bundlers=gpu-operator,network-operator`) rather than
+> hand-trimming `componentRefs` — trimming the body silently drops required
+> dependencies and breaks deployers like Helmfile on dangling
+> `dependencyRefs`. The filter prunes those edges safely (a filtered-out
+> dependency is assumed satisfied externally) and rejects unknown or disabled
+> component names with HTTP 400.
 
 ```shell
 # Basic: pipe recipe to bundle

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -798,7 +798,8 @@ func (b *DefaultBundler) getTypedValueOverridesForComponent(componentName string
 }
 
 // filterEnabledComponents resolves the set of components to bundle by applying
-// recipe-level overrides.enabled and bundle-time --set enabled toggles, then
+// recipe-level overrides.enabled, bundle-time --set enabled toggles, and the
+// positive bundlers component-name filter (config.WithBundlers, #1531), then
 // returns the enabled refs (with dangling dependency edges pruned) alongside
 // the deployment order filtered to those refs.
 //
@@ -843,6 +844,46 @@ func (b *DefaultBundler) filterEnabledComponents(recipeResult *recipe.RecipeResu
 		}
 		enabledRefs = append(enabledRefs, ref)
 		enabledSet[ref.Name] = struct{}{}
+	}
+
+	// Apply the positive component-name filter (POST /v1/bundle ?bundlers=…,
+	// config.WithBundlers). Requested names must be declared AND enabled —
+	// an unknown name is a typo the operator needs to hear about, and a
+	// disabled one mirrors the --set re-enable rejection above (the recipe
+	// author disabled it because the platform provides it). Enabled
+	// components outside the requested set are skipped exactly like
+	// disabled ones, so the dependency-edge pruning below treats them as
+	// satisfied externally. See #1531.
+	if b.Config != nil {
+		if requested := b.Config.Bundlers(); len(requested) > 0 {
+			requestedSet := make(map[string]struct{}, len(requested))
+			for _, name := range requested {
+				if _, declared := declaredSet[name]; !declared {
+					declaredNames := make([]string, 0, len(recipeResult.ComponentRefs))
+					for _, ref := range recipeResult.ComponentRefs {
+						declaredNames = append(declaredNames, ref.Name)
+					}
+					return nil, nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+						"unknown component %q in bundlers filter; recipe declares: %s",
+						name, strings.Join(declaredNames, ", ")))
+				}
+				if _, enabled := enabledSet[name]; !enabled {
+					return nil, nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+						"component %q is disabled and cannot be selected via the bundlers filter", name))
+				}
+				requestedSet[name] = struct{}{}
+			}
+			kept := make([]recipe.ComponentRef, 0, len(requestedSet))
+			for _, ref := range enabledRefs {
+				if _, ok := requestedSet[ref.Name]; !ok {
+					slog.Info("skipping component excluded by bundlers filter", "component", ref.Name)
+					delete(enabledSet, ref.Name)
+					continue
+				}
+				kept = append(kept, ref)
+			}
+			enabledRefs = kept
+		}
 	}
 
 	if len(enabledRefs) == 0 {

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -426,6 +426,153 @@ func TestMake_UndeclaredDependencyErrors(t *testing.T) {
 	}
 }
 
+// TestMake_BundlersFilter pins the semantics of the `bundlers` positive
+// component-name filter (POST /v1/bundle ?bundlers=…, config.WithBundlers):
+// a subset selection bundles only the named components, an unknown or
+// disabled name fails with ErrCodeInvalidRequest, and an empty filter
+// preserves current behavior (all enabled components). See #1531.
+func TestMake_BundlersFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		bundlers    []string
+		wantDirs    []string
+		wantAbsent  []string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:       "empty filter bundles all enabled components",
+			bundlers:   nil,
+			wantDirs:   []string{"001-gpu-operator", "002-aws-ebs-csi-driver"},
+			wantAbsent: []string{"cert-manager", "001-cert-manager", "003-cert-manager"},
+		},
+		{
+			name:     "filter selects subset",
+			bundlers: []string{"gpu-operator"},
+			wantDirs: []string{"001-gpu-operator"},
+			wantAbsent: []string{
+				"aws-ebs-csi-driver", "001-aws-ebs-csi-driver", "002-aws-ebs-csi-driver",
+			},
+		},
+		{
+			name:        "unknown name errors",
+			bundlers:    []string{"gpu-operator", "no-such-component"},
+			wantErr:     true,
+			wantErrText: "unknown component",
+		},
+		{
+			name:        "disabled component request errors",
+			bundlers:    []string{"cert-manager"},
+			wantErr:     true,
+			wantErrText: "disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var bundlerOpts []Option
+			if tt.bundlers != nil {
+				bundlerOpts = append(bundlerOpts,
+					WithConfig(config.NewConfig(config.WithBundlers(tt.bundlers))))
+			}
+			bundler, err := New(bundlerOpts...)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			recipeResult := &recipe.RecipeResult{
+				APIVersion: "aicr.run/v1alpha2",
+				Kind:       "Recipe",
+				Criteria:   &recipe.Criteria{Service: "eks", Accelerator: "h100", Intent: "training"},
+				ComponentRefs: []recipe.ComponentRef{
+					{Name: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia"},
+					{Name: "aws-ebs-csi-driver", Version: "2.55.0", Type: "helm", Source: "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"},
+					{Name: "cert-manager", Version: "v1.20.2", Type: "helm", Source: "https://charts.jetstack.io", Overrides: map[string]any{"enabled": false}},
+				},
+				DeploymentOrder: []string{"gpu-operator", "aws-ebs-csi-driver"},
+			}
+
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			_, makeErr := bundler.Make(ctx, recipeResult, tmpDir)
+			if tt.wantErr {
+				if makeErr == nil {
+					t.Fatal("Make() expected error, got nil")
+				}
+				if !stderrors.Is(makeErr, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("Make() error code = %v, want ErrCodeInvalidRequest", makeErr)
+				}
+				if !strings.Contains(makeErr.Error(), tt.wantErrText) {
+					t.Errorf("Make() error = %q, want substring %q", makeErr.Error(), tt.wantErrText)
+				}
+				return
+			}
+			if makeErr != nil {
+				t.Fatalf("Make() error = %v", makeErr)
+			}
+			for _, dir := range tt.wantDirs {
+				if _, statErr := os.Stat(filepath.Join(tmpDir, dir)); os.IsNotExist(statErr) {
+					t.Errorf("expected %s directory to be created", dir)
+				}
+			}
+			for _, dir := range tt.wantAbsent {
+				if _, statErr := os.Stat(filepath.Join(tmpDir, dir)); !os.IsNotExist(statErr) {
+					t.Errorf("expected %s directory to NOT be created", dir)
+				}
+			}
+		})
+	}
+}
+
+// TestMake_BundlersFilterDependencyPruned verifies that a dependency edge
+// pointing at an enabled-but-filtered-out component is pruned exactly like a
+// disabled one: the helmfile deployer (the only path that recomputes ordering
+// from dependency edges) must not fail with a false circular-dependency error
+// when the depended-upon component is excluded by the bundlers filter. See #1531.
+func TestMake_BundlersFilterDependencyPruned(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig(
+		config.WithDeployer(config.DeployerHelmfile),
+		config.WithBundlers([]string{"gpu-operator"}),
+	)
+	bundler, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.run/v1alpha2",
+		Kind:       "Recipe",
+		Criteria:   &recipe.Criteria{Service: "eks", Accelerator: "h100", Intent: "training"},
+		ComponentRefs: []recipe.ComponentRef{
+			// cert-manager is enabled but excluded by the bundlers filter;
+			// gpu-operator depends on it — assumed satisfied externally.
+			{Name: "cert-manager", Version: "v1.20.2", Type: "helm", Source: "https://charts.jetstack.io"},
+			{Name: "gpu-operator", Version: "v25.3.3", Type: "helm", Source: "https://helm.ngc.nvidia.com/nvidia", DependencyRefs: []string{"cert-manager"}},
+		},
+		DeploymentOrder: []string{"cert-manager", "gpu-operator"},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	if _, makeErr := bundler.Make(ctx, recipeResult, tmpDir); makeErr != nil {
+		t.Fatalf("Make() with filtered-out depended-upon component error = %v", makeErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "001-gpu-operator")); os.IsNotExist(statErr) {
+		t.Error("expected 001-gpu-operator to be created")
+	}
+	for _, dir := range []string{"cert-manager", "001-cert-manager", "002-cert-manager"} {
+		if _, statErr := os.Stat(filepath.Join(tmpDir, dir)); !os.IsNotExist(statErr) {
+			t.Errorf("expected %s directory to NOT be created", dir)
+		}
+	}
+}
+
 func TestMake_SetEnabledOverridesPrecedence(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -256,6 +256,15 @@ type Config struct {
 	// that Helm/Argo CD/Flux cannot assess natively. Off by default so
 	// existing bundle output is unchanged; opt-in via --readiness-hooks. See #904.
 	readinessHooks bool
+
+	// bundlers is a positive filter on recipe component names (the
+	// `bundlers` query parameter on POST /v1/bundle): when non-empty, only
+	// the named components are bundled; every other enabled component is
+	// skipped as if disabled (its dependency edges are treated as satisfied
+	// externally). Empty means all enabled components. A name the recipe
+	// does not declare, or one the recipe/--set disabled, is rejected with
+	// ErrCodeInvalidRequest at bundle time. See #1531.
+	bundlers []string
 }
 
 // Getter methods for read-only access
@@ -470,6 +479,17 @@ func (c *Config) AppName() string {
 // opt-in via --readiness-hooks on the CLI. See #904.
 func (c *Config) ReadinessHooks() bool {
 	return c.readinessHooks
+}
+
+// Bundlers returns a copy of the positive component-name filter. Empty means
+// all enabled components are bundled. See #1531.
+func (c *Config) Bundlers() []string {
+	if c.bundlers == nil {
+		return nil
+	}
+	result := make([]string, len(c.bundlers))
+	copy(result, c.bundlers)
+	return result
 }
 
 // Validate checks if the Config has valid settings.
@@ -747,6 +767,23 @@ func WithAppName(name string) Option {
 func WithReadinessHooks(enabled bool) Option {
 	return func(c *Config) {
 		c.readinessHooks = enabled
+	}
+}
+
+// WithBundlers sets the positive component-name filter: only recipe
+// components named here are bundled; every other enabled component is
+// skipped exactly like a disabled one, so its dependency edges are pruned
+// as satisfied externally. Empty (or nil) means all enabled components.
+// Names that the recipe does not declare, or that are disabled by the
+// recipe or --set, are rejected with ErrCodeInvalidRequest at bundle time
+// rather than silently ignored. See #1531.
+func WithBundlers(names []string) Option {
+	return func(c *Config) {
+		if len(names) == 0 {
+			return
+		}
+		c.bundlers = make([]string, len(names))
+		copy(c.bundlers, names)
 	}
 }
 

--- a/pkg/bundler/config/config_test.go
+++ b/pkg/bundler/config/config_test.go
@@ -1183,3 +1183,42 @@ func TestWithFluxNamespace(t *testing.T) {
 		}
 	})
 }
+
+func TestWithBundlers(t *testing.T) {
+	t.Run("set names", func(t *testing.T) {
+		names := []string{"gpu-operator", "network-operator"}
+		cfg := NewConfig(WithBundlers(names))
+		got := cfg.Bundlers()
+		if len(got) != 2 || got[0] != "gpu-operator" || got[1] != "network-operator" {
+			t.Errorf("Bundlers() = %v, want %v", got, names)
+		}
+	})
+
+	t.Run("default is nil", func(t *testing.T) {
+		cfg := NewConfig()
+		if got := cfg.Bundlers(); got != nil {
+			t.Errorf("default Bundlers() = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty slice means no filter", func(t *testing.T) {
+		cfg := NewConfig(WithBundlers([]string{}))
+		if got := cfg.Bundlers(); got != nil {
+			t.Errorf("Bundlers() with empty input = %v, want nil", got)
+		}
+	})
+
+	t.Run("input and output are defensively copied", func(t *testing.T) {
+		names := []string{"gpu-operator"}
+		cfg := NewConfig(WithBundlers(names))
+		names[0] = "mutated-input"
+		got := cfg.Bundlers()
+		if got[0] != "gpu-operator" {
+			t.Errorf("Bundlers()[0] = %q after input mutation, want %q", got[0], "gpu-operator")
+		}
+		got[0] = "mutated-output"
+		if again := cfg.Bundlers(); again[0] != "gpu-operator" {
+			t.Errorf("Bundlers()[0] = %q after output mutation, want %q", again[0], "gpu-operator")
+		}
+	})
+}

--- a/pkg/bundler/handler.go
+++ b/pkg/bundler/handler.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -63,6 +64,7 @@ func bundleConfigFromParams(params *bundleParams) *config.Config {
 		config.WithRepoURL(params.repoURL),
 		config.WithVendorCharts(params.vendorCharts),
 		config.WithAppName(params.appName),
+		config.WithBundlers(params.bundlers),
 	)
 }
 
@@ -156,6 +158,7 @@ type bundleParams struct {
 	repoURL                    string
 	vendorCharts               bool
 	appName                    string
+	bundlers                   []string
 }
 
 // parseQueryParams extracts and validates all query parameters from the request
@@ -261,6 +264,26 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 			return nil, validateErr
 		}
 		params.appName = v
+	}
+
+	// Parse bundlers (positive filter on recipe component names). Comma
+	// delimited and repeatable; whitespace around names is trimmed and empty
+	// segments are dropped so "a, b," parses as ["a", "b"]. Presence is
+	// keyed on the query map, not query.Get, so an explicit empty value
+	// ("bundlers=" or "bundlers=,,") is rejected rather than silently
+	// bundling everything — only an ABSENT parameter means no filter. See #1531.
+	if values, ok := query["bundlers"]; ok {
+		for _, v := range values {
+			for _, name := range strings.Split(v, ",") {
+				if name = strings.TrimSpace(name); name != "" {
+					params.bundlers = append(params.bundlers, name)
+				}
+			}
+		}
+		if len(params.bundlers) == 0 {
+			return nil, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				"bundlers must contain at least one component name")
+		}
 	}
 
 	return params, nil

--- a/pkg/bundler/handler_test.go
+++ b/pkg/bundler/handler_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundler
+
+import (
+	stderrors "errors"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestParseBundleConfig_Bundlers pins the query-param parsing of the
+// `bundlers` positive component-name filter on POST /v1/bundle: comma
+// delimited, whitespace trimmed, empty segments dropped, and an all-empty
+// value rejected with ErrCodeInvalidRequest. See #1531.
+func TestParseBundleConfig_Bundlers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		present  bool
+		bundlers string // raw query value, used only when present
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "absent param means no filter",
+			expected: nil,
+		},
+		{
+			name:     "single name",
+			present:  true,
+			bundlers: "gpu-operator",
+			expected: []string{"gpu-operator"},
+		},
+		{
+			name:     "multiple names with whitespace trimmed",
+			present:  true,
+			bundlers: "gpu-operator, network-operator ,cert-manager",
+			expected: []string{"gpu-operator", "network-operator", "cert-manager"},
+		},
+		{
+			name:     "empty segments dropped",
+			present:  true,
+			bundlers: "gpu-operator,,network-operator,",
+			expected: []string{"gpu-operator", "network-operator"},
+		},
+		{
+			name:     "all-empty value rejected",
+			present:  true,
+			bundlers: ",, ,",
+			wantErr:  true,
+		},
+		{
+			name:    "explicit empty value rejected",
+			present: true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := "/v1/bundle"
+			if tt.present {
+				target += "?bundlers=" + url.QueryEscape(tt.bundlers)
+			}
+			r := httptest.NewRequest("POST", target, nil)
+
+			cfg, err := ParseBundleConfig(r)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseBundleConfig() expected error, got nil")
+				}
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("ParseBundleConfig() error code = %v, want ErrCodeInvalidRequest", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseBundleConfig() error = %v", err)
+			}
+			if got := cfg.Bundlers(); !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("Bundlers() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/server/bundle_handler.go
+++ b/pkg/server/bundle_handler.go
@@ -52,9 +52,9 @@ func newBundleHandler(client *aicr.Client, allowLists *aicr.AllowLists) *bundleH
 
 // HandleBundles processes bundle generation requests. It accepts a POST
 // request with a JSON body containing the recipe (RecipeResult) and the same
-// query parameters as the legacy pkg/bundler handler (set, dynamic, deployer,
-// node selectors/tolerations, repo, workload-gate, workload-selector, nodes,
-// vendor-charts, app-name). The response is a zip archive of the bundle.
+// query parameters as the legacy pkg/bundler handler (bundlers, set, dynamic,
+// deployer, node selectors/tolerations, repo, workload-gate, workload-selector,
+// nodes, vendor-charts, app-name). The response is a zip archive of the bundle.
 func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 	logger := slog.With("requestID", RequestIDFromContext(r.Context()))
 

--- a/tools/cleanup
+++ b/tools/cleanup
@@ -66,7 +66,8 @@ has_tools kubectl
 
 # AICR-managed namespaces. Sourced from `defaultNamespace` entries in
 # recipes/registry.yaml plus child namespaces created at runtime by some
-# operators (e.g. kai-resource-reservation by kai-scheduler).
+# operators (e.g. kai-resource-reservation by kai-scheduler), and the
+# privileged-* variants Talos recipes install into (recipes/mixins/os-talos.yaml).
 AICR_NAMESPACES=(
     node-feature-discovery
     gpu-operator
@@ -84,6 +85,11 @@ AICR_NAMESPACES=(
     kueue-system
     kubeflow
     slinky
+    privileged-gpu-operator
+    privileged-network-operator
+    privileged-nvsentinel
+    privileged-nvidia-dra-driver-gpu
+    privileged-nodewright-operator
 )
 
 # CRD API-group suffixes owned by AICR components. Matched as substrings
@@ -113,6 +119,67 @@ ctx="$(kubectl config current-context 2>/dev/null || echo unknown)"
 msg "Target cluster context: ${ctx}"
 if $DRY_RUN; then
     msg "DRY-RUN mode — no changes will be applied."
+fi
+
+# Detect whether gpu-operator manages the NVIDIA kernel driver on this
+# cluster (driver.enabled=true — e.g. EKS; GKE COS is host-managed and
+# unaffected). The primary signal is the nvidia-driver-daemonset: it is the
+# concrete artifact of driver-managed mode, needs no extra tooling, and is
+# robust to release-name drift. Helm computed values (driver.enabled) are a
+# fallback for the window where the DaemonSet is not (yet) listable. Both
+# probes are read-only, so detection also runs under --dry-run. Fail-open:
+# if detection errors (no cluster access, apiserver timeout) the mode stays
+# unknown and cleanup proceeds without the warning. See #1553.
+DRIVER_MANAGED=false
+detect_driver_managed() {
+    local ds_ns rel_ns values
+    # Search cluster-wide by DaemonSet name (same discovery deploy.sh.tmpl
+    # uses): the operator namespace is not fixed — Talos recipes install
+    # gpu-operator into privileged-gpu-operator, not gpu-operator.
+    ds_ns="$(kubectl get daemonset -A \
+        -o jsonpath='{.items[?(@.metadata.name=="nvidia-driver-daemonset")].metadata.namespace}' \
+        --request-timeout=15s 2>/dev/null | awk '{print $1}' || true)"
+    if [[ -n "$ds_ns" ]]; then
+        DRIVER_MANAGED=true
+        return 0
+    fi
+    command -v helm >/dev/null 2>&1 || return 0
+    # Resolve the gpu-operator release namespace dynamically for the same reason.
+    rel_ns="$(helm list -A 2>/dev/null | awk '$1 == "gpu-operator" {print $2; exit}' || true)"
+    [[ -z "$rel_ns" ]] && return 0
+    values="$(helm get values gpu-operator -n "$rel_ns" -a 2>/dev/null || true)"
+    [[ -z "$values" ]] && return 0
+    if command -v yq >/dev/null 2>&1; then
+        [[ "$(echo "$values" | yq '.driver.enabled' 2>/dev/null)" == "true" ]] && DRIVER_MANAGED=true
+    else
+        # No yq: accept `enabled: true` only at the first nesting level under a
+        # top-level `driver:` block (helm renders values with 2-space indents),
+        # so nested keys like driver.rdma.enabled cannot false-positive.
+        if echo "$values" | awk '/^driver:/{d=1; next} /^[^[:space:]]/{d=0} d && /^  enabled:[[:space:]]*true[[:space:]]*$/{found=1; exit} {next} END{exit !found}'; then
+            DRIVER_MANAGED=true
+        fi
+    fi
+    return 0
+}
+detect_driver_managed
+
+# Operator guidance for driver-managed clusters: uninstalling gpu-operator
+# can leave the nvidia_uvm kernel module wedged mid-unload on GPU nodes,
+# which breaks the NEXT install (driver validation Init:CrashLoopBackOff,
+# "failed to create device node nvidia-uvm") until the nodes are rebooted.
+# Automated cordon/drain/reboot is cloud-specific and out of scope. See #1553.
+print_driver_managed_guidance() {
+    log_warning "DRIVER-MANAGED cluster detected: gpu-operator installs the NVIDIA kernel driver (driver.enabled=true)."
+    log_warning "Uninstalling gpu-operator can leave the nvidia_uvm kernel module wedged mid-unload on GPU nodes."
+    log_warning "A subsequent install then fails driver validation (Init:CrashLoopBackOff, 'failed to create device node nvidia-uvm')."
+    log_warning "After cleanup, reboot the GPU nodes BEFORE reinstalling:"
+    log_warning "  1. kubectl cordon <gpu-node>   # each GPU node"
+    log_warning "  2. reboot the instances        # e.g. 'aws ec2 reboot-instances' on EKS, or your platform's mechanism"
+    log_warning "  3. wait for Ready, then: kubectl uncordon <gpu-node>"
+}
+
+if $DRIVER_MANAGED; then
+    print_driver_managed_guidance
 fi
 
 if ! $ASSUME_YES && ! $DRY_RUN; then
@@ -264,4 +331,8 @@ if $DRY_RUN; then
     msg "(dry-run — no changes applied)"
 else
     msg "Verify: 'kubectl get ns' and 'helm ls -A' should show no AICR remnants."
+fi
+if $DRIVER_MANAGED; then
+    msg "ACTION REQUIRED before reinstalling on this driver-managed cluster:"
+    print_driver_managed_guidance
 fi


### PR DESCRIPTION
## Summary

Implements the documented `POST /v1/bundle` `bundlers` query parameter as a positive component-name filter, and makes `tools/cleanup` detect driver-managed clusters and print the GPU-node reboot guidance needed to avoid a wedged `nvidia_uvm` on redeploy.

## Motivation / Context

`bundlers` was documented in the OpenAPI spec and API reference but never read by the server — every request bundled all components. Separately, `tools/cleanup` on driver-managed clusters (gpu-operator `driver.enabled=true`, e.g. EKS) can leave `nvidia_uvm` wedged mid-unload, breaking the next install until the GPU nodes are rebooted; the script gave no warning.

Fixes: #1531
Fixes: #1553

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/cleanup`, `DEVELOPMENT.md`

## Implementation Notes

- The filter is applied in `filterEnabledComponents` after recipe-level `enabled` and `--set` toggles: unlisted enabled components are skipped exactly like disabled ones, so the existing dependency-edge pruning treats them as satisfied externally (no false circular-dependency in helmfile). An unknown name, or a name the recipe disables, is rejected with `ErrCodeInvalidRequest` (HTTP 400) rather than silently ignored.
- `tools/cleanup` detects driver-managed mode via the `nvidia-driver-daemonset` (primary; robust to release-name drift) with a `helm get values` `driver.enabled` fallback (yq, or a 2-space-indent-anchored awk that cannot false-positive on nested keys like `driver.rdma.enabled`). Detection is read-only, fail-open, and prints cordon → reboot → uncordon guidance both before the confirmation prompt and after completion. Automated drain/reboot is cloud-specific and out of scope per the issue.

## Testing

```bash
make qualify
```

`make qualify` passed locally (unit tests with `-race`, golangci-lint + yamllint, e2e incl. chainsaw 23/23, grype scan clean, license headers). `shellcheck -x tools/cleanup` clean. New table-driven tests: `TestMake_BundlersFilter`, `TestMake_BundlersFilterDependencyPruned`, `TestParseBundleConfig_Bundlers`, `TestWithBundlers`.

Coverage: `pkg/bundler/...` 78.3% → 79.3% (+1.0%).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No behavior change for requests that omit `bundlers` (previously-ignored values now take effect or return 400, which matches the documented contract). Cleanup-script change is output-only.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
