### PR TITLE
fix(verifier): fail closed on invalid attestation; unify allowlist

### DIFF
--- a/.github/workflows/evidence-dashboard-publish.yaml
+++ b/.github/workflows/evidence-dashboard-publish.yaml
@@ -121,14 +121,16 @@ jobs:
           # (the generator carries no clock/random). A drift here means a
           # non-reproducible build — fail loudly rather than publish it.
           #
-          # No -allowlist: each source's class is already re-derived from its
-          # VERIFIED signer at GP2 ingest time and baked into meta.json, which
-          # is the trust gate. The generator's own -allowlist re-derivation is
-          # deferred until its loader (pkg/corroborate) is reconciled with the
-          # GP1 allowlist schema (recipes/evidence/allowlist.yaml uses
-          # identityPattern/source; the loader still expects identity).
-          ./bin/corroborate -in evidence -out _site
-          ./bin/corroborate -in evidence -out _site_check
+          # -allowlist re-derives each source's class from its VERIFIED signer
+          # against the in-tree GP1 allowlist — defense in depth on top of the
+          # class GP2 baked into meta.json at ingest time. The generator's
+          # loader (pkg/corroborate) delegates to the shared
+          # pkg/evidence/allowlist parser, so it reads the canonical
+          # identityPattern/source schema directly (#1505).
+          ./bin/corroborate -in evidence -out _site \
+            -allowlist recipes/evidence/allowlist.yaml
+          ./bin/corroborate -in evidence -out _site_check \
+            -allowlist recipes/evidence/allowlist.yaml
           if ! diff -r _site _site_check; then
             echo "::error::corroborate output is not reproducible (determinism gate failed)"
             exit 1

--- a/docs/contributor/evidence-dashboard-publish.md
+++ b/docs/contributor/evidence-dashboard-publish.md
@@ -80,12 +80,12 @@ in `merge-gate.yaml`.
   the repository attribute). It is least-privilege on the resource side
   (`objectViewer` on one bucket); GP3's `infra/evidence-dashboard` may tighten
   the subject condition further.
-- The build does not pass `-allowlist` to the generator. Each source's class
-  is already re-derived from its verified signer at GP2 ingest time and baked
-  into `meta.json` (the trust gate); the generator's own allowlist
-  re-derivation is deferred until `pkg/corroborate`'s loader is reconciled with
-  the GP1 allowlist schema (`recipes/evidence/allowlist.yaml` uses
-  `identityPattern`/`source`; the loader still expects an `identity` field).
+- The build passes `-allowlist recipes/evidence/allowlist.yaml` to the
+  generator, re-deriving each source's class from its verified signer against
+  the in-tree GP1 allowlist — defense in depth on top of the class GP2 baked
+  into `meta.json` at ingest time. `pkg/corroborate`'s loader delegates to
+  the shared `pkg/evidence/allowlist` parser, so it reads the canonical
+  `identityPattern`/`source` schema directly (#1505).
 - The Pages site is served at the custom domain `validation.aicr.run`: the
   publish workflow reasserts it on every run by writing a `CNAME` file into
   the site artifact (a deploy whose artifact omits `CNAME` would otherwise

--- a/docs/contributor/evidence-ingest.md
+++ b/docs/contributor/evidence-ingest.md
@@ -118,14 +118,12 @@ consumer.
 `project.Allowlist.Classify` derives a signer's trust tier from the
 **verified** `(issuer, identity)`, never a raw pointer string:
 
-1. The first matching `--allowlist` entry wins, `allowlisted=true`.
-2. When no allowlist file is loaded — the interim state before GP1 ships
-   `recipes/evidence/allowlist.yaml` — a built-in heuristic admits AICR's
-   own UAT identity (GitHub Actions OIDC + `NVIDIA/aicr`) as `first-party`
-   so it is not mislabeled. Once the file exists this branch is never
-   taken. (Note: GP2 and GP4 do not yet parse the canonical
-   `identityPattern`/`source` schema identically — see the reconciliation note
-   below — so this is the intended end-state, not current full parity.)
+1. With an allowlist loaded, the shared loader (`pkg/evidence/allowlist`,
+   the same one the GP4 consumer `pkg/corroborate` uses) decides: a slug or
+   pattern match wins, `allowlisted=true`.
+2. When no allowlist file is loaded (no `--allowlist` flag), a built-in
+   heuristic admits AICR's own UAT identity (GitHub Actions OIDC +
+   `NVIDIA/aicr`) as `first-party` so it is not mislabeled.
 3. Otherwise `community`, `allowlisted=false` — the fail-closed default.
    Reported, but never counted toward consensus.
 
@@ -149,17 +147,16 @@ partner: []
 ```
 
 `identityPattern` is a `^…$`-anchored regex (full-string match); the loader
-rejects an over-broad regex (unbounded `*`/`+`/`{n,}` that could span an
-org/repo segment) and overlapping entries, so the allowlist cannot itself be
-used to manufacture consensus.
+rejects an over-broad pattern (any wildcard left of the OIDC subject's `@` —
+only the ref may vary) and overlapping entries, so the allowlist cannot
+itself be used to manufacture consensus.
 
-> **Loaders not yet reconciled with the canonical schema.** Neither
-> loader parses the `identityPattern`/`source` allowlist above yet. Both
-> the GP2 ingest loader (`pkg/evidence/project`) and the GP4 consumer
-> (`pkg/corroborate`) still carry a single `Identity` field (and the GP1
-> canonical loader deliberately rejects a cleartext `identity`), so neither
-> can parse the canonical `recipes/evidence/allowlist.yaml`. Reconciling
-> both loaders with the GP1 allowlist schema is still outstanding.
+Both the GP2 ingest loader (`pkg/evidence/project`) and the GP4 consumer
+(`pkg/corroborate`) delegate to the shared canonical loader in
+`pkg/evidence/allowlist` (#1505), so producer and consumer parse the
+identical `identityPattern`/`source` schema and classify a verified signer
+identically. The shared loader rejects a cleartext `identity:` field, so
+personal emails cannot be reintroduced by accident.
 
 ## Forward limitations
 

--- a/docs/user/artifact-verification.md
+++ b/docs/user/artifact-verification.md
@@ -30,9 +30,9 @@ each one subsumes the guarantees of the levels beneath it.
 | Level | Name | What it guarantees |
 |-------|------|--------------------|
 | 4 | `verified` | Checksums valid, bundle attestation verified, binary attestation verified with identity pinned to NVIDIA CI, and no external data |
-| 3 | `attested` | Bundle attestation cryptographically verified, but the chain is incomplete — the binary attestation is missing or external `--data` was used. A binary attestation that *fails* verification also reports `attested` diagnostically but makes `aicr verify` exit nonzero |
+| 3 | `attested` | Bundle attestation cryptographically verified, but the chain is incomplete — the binary attestation is missing or external `--data` was used |
 | 2 | `unverified` | Checksums valid, but no attestation files exist (the bundle was created without `--attest`) |
-| 1 | `unknown` | Checksums are missing/invalid, or the bundle attestation fails verification |
+| 1 | `unknown` | Checksums are missing/invalid, or an attestation (bundle or binary) is present but *fails* verification — a present binary attestation that does not verify is a hard failure, not a degraded `attested` |
 
 The ordering matters for enforcement: `verified` > `attested` > `unverified` >
 `unknown`. A bundle that uses external data can never exceed `attested`, and a

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2521,9 +2521,9 @@ aicr verify <bundle-dir> [flags]
 | Level | Name | Criteria |
 |-------|------|----------|
 | 4 | `verified` | Full chain: checksums + bundle attestation + binary attestation pinned to NVIDIA CI |
-| 3 | `attested` | Bundle attestation verified; binary attestation missing/unverified, or external data (`--data`) used. A *failed* binary attestation also reports attested but exits nonzero (#1550) |
+| 3 | `attested` | Bundle attestation verified; binary attestation missing, or external data (`--data`) used |
 | 2 | `unverified` | Checksums valid, `--attest` was not used when creating the bundle |
-| 1 | `unknown` | Missing/invalid checksums, or bundle attestation fails verification |
+| 1 | `unknown` | Missing/invalid checksums, or an attestation (bundle or binary) present but failing verification |
 
 #### Verification steps
 

--- a/pkg/bundler/verifier/trust.go
+++ b/pkg/bundler/verifier/trust.go
@@ -27,7 +27,10 @@ import (
 type TrustLevel string
 
 const (
-	// TrustUnknown indicates missing attestation or checksum files.
+	// TrustUnknown indicates missing checksum files, or an attestation
+	// (bundle or binary) that is present but fails verification. A present
+	// binary attestation whose digest cannot be extracted, or that does not
+	// verify, is a hard failure — unknown, never a degraded attested (#1550).
 	TrustUnknown TrustLevel = "unknown"
 
 	// TrustUnverified indicates checksums are valid but no attestation files exist
@@ -202,8 +205,13 @@ func (r *VerifyResult) CheckPolicy(p Policy) (string, error) {
 // that verification reached the expected level:
 //   - verified: standard bundle with both attestations, no external data
 //   - attested: external data present (caps trust regardless of attestation chain)
-//   - unverified: no attestation files (--attest not used was used)
+//   - unverified: no attestation files (bundle created without --attest)
 //   - unknown: checksums failed or missing
+//
+// Note the max is computed from what the bundle CONTAINS, not what verified:
+// a bundle whose binary attestation is present but fails verification reports
+// TrustUnknown while its max achievable stays verified, so
+// --min-trust-level max correctly fails it.
 func (r *VerifyResult) MaxAchievableTrustLevel() TrustLevel {
 	if r == nil || !r.ChecksumsPassed {
 		return TrustUnknown

--- a/pkg/bundler/verifier/verifier.go
+++ b/pkg/bundler/verifier/verifier.go
@@ -228,39 +228,14 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 
 	slog.Debug("bundle attestation verified", "creator", bundleCreator, "toolVersion", result.ToolVersion)
 
-	// Step 4: Check for binary attestation
-	binaryAttestPath, joinErr := deployer.SafeJoin(bundleDir, attestation.BinaryAttestationFile)
-	if joinErr != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "unsafe binary attestation path", joinErr)
+	// Steps 4-5: Check for and verify the binary attestation.
+	done, stepErr := verifyBinaryStep(ctx, bundleDir, bundleAttestPath, identityPattern, result)
+	if stepErr != nil {
+		return nil, stepErr
 	}
-	if _, statErr := os.Stat(binaryAttestPath); os.IsNotExist(statErr) {
-		// Bundle attested but no binary attestation — chain incomplete
-		result.setTrust(TrustAttested, "bundle attested but binary attestation not found (incomplete chain)")
+	if done {
 		return result, nil
 	}
-
-	// Step 5: Verify binary attestation with identity pinning.
-	// Extract the binary digest from the bundle attestation's resolvedDependencies
-	// rather than hashing the running binary — the verifying binary may be a
-	// different version than the one that created the bundle.
-	binaryDigest, err := extractBinaryDigest(bundleAttestPath)
-	if err != nil {
-		result.Errors = append(result.Errors, fmt.Sprintf("could not extract binary digest from bundle attestation: %v", err))
-		result.setTrust(TrustAttested, "could not extract binary digest from bundle attestation")
-		return result, nil
-	}
-
-	binaryBuilder, err := VerifyBinaryAttestation(ctx, binaryAttestPath, identityPattern, binaryDigest)
-	if err != nil {
-		result.Errors = append(result.Errors, fmt.Sprintf("binary attestation verification failed: %v", err))
-		result.setTrust(TrustAttested, "binary attestation verification failed")
-		return result, nil
-	}
-	result.BinaryAttested = true
-	result.IdentityPinned = true
-	result.BinaryBuilder = binaryBuilder
-
-	slog.Debug("binary attestation verified", "builder", binaryBuilder)
 
 	// Full chain verified — check if external data caps trust at attested
 	dataDir, joinErr := deployer.SafeJoin(bundleDir, "data")
@@ -275,6 +250,55 @@ func Verify(ctx context.Context, bundleDir string, opts *VerifyOptions) (*Verify
 
 	result.setTrust(TrustVerified, "full chain verified: checksums, bundle attestation, binary attestation with NVIDIA CI identity")
 	return result, nil
+}
+
+// verifyBinaryStep runs steps 4-5 of Verify: locate and verify the binary
+// attestation, binding it to the binary digest recorded in the (already
+// verified) bundle attestation at bundleAttestPath. Trust semantics (#1550):
+//
+//   - binary attestation file MISSING → TrustAttested (incomplete chain: the
+//     bundle attestation itself verified, nothing claims more);
+//   - binary attestation PRESENT but its digest cannot be extracted or its
+//     verification FAILS → TrustUnknown (a claim exists and could not be
+//     substantiated — a hard failure, not a degraded success).
+//
+// Returns done=true when Verify should return the populated result as-is
+// (verification outcome, nil error); a non-nil error is a hard fault
+// (unsafe path), for which Verify returns no result.
+func verifyBinaryStep(ctx context.Context, bundleDir, bundleAttestPath, identityPattern string, result *VerifyResult) (bool, error) {
+	binaryAttestPath, joinErr := deployer.SafeJoin(bundleDir, attestation.BinaryAttestationFile)
+	if joinErr != nil {
+		return false, errors.Wrap(errors.ErrCodeInternal, "unsafe binary attestation path", joinErr)
+	}
+	if _, statErr := os.Stat(binaryAttestPath); os.IsNotExist(statErr) {
+		// Bundle attested but no binary attestation — chain incomplete
+		result.setTrust(TrustAttested, "bundle attested but binary attestation not found (incomplete chain)")
+		return true, nil
+	}
+
+	// Verify binary attestation with identity pinning. Extract the binary
+	// digest from the bundle attestation's resolvedDependencies rather than
+	// hashing the running binary — the verifying binary may be a different
+	// version than the one that created the bundle.
+	binaryDigest, err := extractBinaryDigest(bundleAttestPath)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("could not extract binary digest from bundle attestation: %v", err))
+		result.setTrust(TrustUnknown, "binary attestation present but binary digest could not be extracted from bundle attestation")
+		return true, nil
+	}
+
+	binaryBuilder, err := VerifyBinaryAttestation(ctx, binaryAttestPath, identityPattern, binaryDigest)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("binary attestation verification failed: %v", err))
+		result.setTrust(TrustUnknown, "binary attestation present but failed verification")
+		return true, nil
+	}
+	result.BinaryAttested = true
+	result.IdentityPinned = true
+	result.BinaryBuilder = binaryBuilder
+
+	slog.Debug("binary attestation verified", "builder", binaryBuilder)
+	return false, nil
 }
 
 // verifyChecksumStep reads and verifies checksums.txt in a single read (TOCTOU-safe).

--- a/pkg/bundler/verifier/verifier_test.go
+++ b/pkg/bundler/verifier/verifier_test.go
@@ -653,3 +653,123 @@ func TestNewUnionTrustedRoot_LoaderErrorPropagates(t *testing.T) {
 		t.Fatalf("expected ErrCodeInvalidRequest, got %v", err)
 	}
 }
+
+// writeFakeBinaryAttestation writes a garbage (unparseable) binary attestation
+// at the standard bundle-relative path. Parsing fails locally in
+// loadSigstoreBundleBytes, before any trusted-root (network) resolution.
+func writeFakeBinaryAttestation(t *testing.T, dir string) {
+	t.Helper()
+	attestPath := filepath.Join(dir, attestation.BinaryAttestationFile)
+	if err := os.MkdirAll(filepath.Dir(attestPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(attestPath, []byte(`{"not":"a-valid-sigstore-bundle"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestVerifyBinaryStep is the #1550 regression suite: a binary attestation
+// that is PRESENT but fails verification (or whose binary digest cannot be
+// extracted from the bundle attestation) must degrade to unknown, not
+// attested. Only a MISSING binary attestation is the softer attested
+// (incomplete chain).
+func TestVerifyBinaryStep(t *testing.T) {
+	const validDigestStatement = `{"predicate":{"buildDefinition":{"resolvedDependencies":[{"uri":"file:///usr/local/bin/aicr","digest":{"sha256":"afa80429badccee47ca11075328a0d337af1786223bdae6e32076d042dc26996"}}]}}}`
+	const noDigestStatement = `{"predicate":{"buildDefinition":{"resolvedDependencies":[]}}}`
+
+	tests := []struct {
+		name            string
+		bundleStatement string
+		binaryPresent   bool
+		wantTrust       TrustLevel
+		wantErrSubstr   string
+	}{
+		{
+			name:            "missing binary attestation degrades to attested",
+			bundleStatement: validDigestStatement,
+			binaryPresent:   false,
+			wantTrust:       TrustAttested,
+		},
+		{
+			name:            "present but invalid binary attestation is unknown",
+			bundleStatement: validDigestStatement,
+			binaryPresent:   true,
+			wantTrust:       TrustUnknown,
+			wantErrSubstr:   "binary attestation verification failed",
+		},
+		{
+			name:            "digest extraction failure with binary attestation present is unknown",
+			bundleStatement: noDigestStatement,
+			binaryPresent:   true,
+			wantTrust:       TrustUnknown,
+			wantErrSubstr:   "could not extract binary digest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bundleAttestPath := writeBundleWithStatement(t, tt.bundleStatement)
+			if tt.binaryPresent {
+				writeFakeBinaryAttestation(t, dir)
+			}
+
+			result := &VerifyResult{ChecksumsPassed: true, BundleAttested: true}
+			done, err := verifyBinaryStep(context.Background(), dir, bundleAttestPath, TrustedRepositoryPattern, result)
+			if err != nil {
+				t.Fatalf("verifyBinaryStep() error: %v", err)
+			}
+			if !done {
+				t.Fatal("verifyBinaryStep() done = false, want true (Verify must return the outcome)")
+			}
+			if result.TrustLevel != tt.wantTrust {
+				t.Errorf("TrustLevel = %s, want %s (reason: %s)", result.TrustLevel, tt.wantTrust, result.TrustReason)
+			}
+			if result.BinaryAttested {
+				t.Error("BinaryAttested = true, want false")
+			}
+			if tt.wantErrSubstr == "" {
+				if len(result.Errors) != 0 {
+					t.Errorf("Errors = %v, want none", result.Errors)
+				}
+				return
+			}
+			found := false
+			for _, e := range result.Errors {
+				if strings.Contains(e, tt.wantErrSubstr) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Errors = %v, want one containing %q", result.Errors, tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+// TestVerifyBinaryStep_FailedVerifyMaxStaysVerified pins the policy
+// interaction: a failed-verify bundle reports unknown while its max
+// achievable stays verified, so --min-trust-level max fails it.
+func TestVerifyBinaryStep_FailedVerifyMaxStaysVerified(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeBinaryAttestation(t, dir)
+	bundleAttestPath := writeBundleWithStatement(t,
+		`{"predicate":{"buildDefinition":{"resolvedDependencies":[{"digest":{"sha256":"afa80429badccee47ca11075328a0d337af1786223bdae6e32076d042dc26996"}}]}}}`)
+
+	result := &VerifyResult{ChecksumsPassed: true, BundleAttested: true}
+	if _, err := verifyBinaryStep(context.Background(), dir, bundleAttestPath, TrustedRepositoryPattern, result); err != nil {
+		t.Fatalf("verifyBinaryStep() error: %v", err)
+	}
+	if result.TrustLevel != TrustUnknown {
+		t.Fatalf("TrustLevel = %s, want unknown", result.TrustLevel)
+	}
+	if got := result.MaxAchievableTrustLevel(); got != TrustVerified {
+		t.Fatalf("MaxAchievableTrustLevel() = %s, want verified", got)
+	}
+	failure, err := result.CheckPolicy(Policy{MinTrustLevel: "max"})
+	if err != nil {
+		t.Fatalf("CheckPolicy() error: %v", err)
+	}
+	if failure == "" {
+		t.Error("CheckPolicy(max) passed; a failed binary attestation must fail --min-trust-level max")
+	}
+}

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -44,7 +44,7 @@ Trust levels:
   verified    Full chain verified: checksums, bundle attestation, binary attestation with NVIDIA CI identity
   attested    Chain verified but binary attestation missing or external data used
   unverified  Checksums valid, no attestation files (--attest was not used)
-  unknown     Missing checksums or attestation files
+  unknown     Missing/invalid checksums, or an attestation present but failing verification
 
 Examples:
 

--- a/pkg/corroborate/classify.go
+++ b/pkg/corroborate/classify.go
@@ -15,13 +15,7 @@
 package corroborate
 
 import (
-	"fmt"
-	"regexp"
-	"regexp/syntax"
-	"strings"
-
-	"github.com/NVIDIA/aicr/pkg/errors"
-	"gopkg.in/yaml.v3"
+	"github.com/NVIDIA/aicr/pkg/evidence/allowlist"
 )
 
 // Class is a corroboration source class. A signer's class is derived from its
@@ -31,284 +25,41 @@ type Class string
 const (
 	// ClassFirstParty is the project's own UAT signer (GH-Actions OIDC pinned
 	// to NVIDIA/aicr).
-	ClassFirstParty Class = "first-party"
+	ClassFirstParty Class = Class(allowlist.ClassFirstParty)
 
 	// ClassCommunity is an allowlisted community signer (and the fallback class
 	// for a verified-but-unallowlisted "reported" signer).
-	ClassCommunity Class = "community"
+	ClassCommunity Class = Class(allowlist.ClassCommunity)
 
 	// ClassPartner is an allowlisted partner signer.
-	ClassPartner Class = "partner"
+	ClassPartner Class = Class(allowlist.ClassPartner)
 )
 
-// maxAllowlistBytes bounds the allowlist file read. The allowlist is a small,
-// hand-curated, PR-reviewed file; anything larger is malformed or hostile.
-const maxAllowlistBytes = 1 << 20 // 1 MiB
-
-// SupportedAllowlistSchemaVersion is the allowlist schema (GP1-owned, Contract
-// 2) this classifier understands. The loader fails closed on any other value:
-// a future GP1 schema bump may carry semantics these classification rules do
-// not enforce, so GP4 must be updated rather than silently classifying under
-// stale assumptions.
-const SupportedAllowlistSchemaVersion = "1.0.0"
-
-// AllowlistEntry pins one verified signer: an exact issuer and an identity that
-// is either an exact string or a tightly-bounded regex (recognized by a leading
-// "^"). Over-broad identities are rejected by Allowlist.Validate.
-type AllowlistEntry struct {
-	Issuer   string `yaml:"issuer" json:"issuer"`
-	Identity string `yaml:"identity" json:"identity"`
-}
-
 // Allowlist is the in-tree, PR-reviewed signer allowlist
-// (recipes/evidence/allowlist.yaml, owned by GP1; this is the consumer-side
-// loader/classifier). The three class sections are disjoint and non-overlapping.
-type Allowlist struct {
-	SchemaVersion string           `yaml:"schemaVersion" json:"schemaVersion"`
-	FirstParty    []AllowlistEntry `yaml:"firstParty" json:"firstParty"`
-	Community     []AllowlistEntry `yaml:"community" json:"community"`
-	Partner       []AllowlistEntry `yaml:"partner" json:"partner"`
-}
+// (recipes/evidence/allowlist.yaml, owned by GP1). GP4 consumes the shared
+// authoritative loader in pkg/evidence/allowlist so producer (GP2) and
+// consumer (GP4) parse the identical identityPattern/source schema (#1505).
+type Allowlist = allowlist.Allowlist
 
-// classEntry pairs an entry with its class for whole-list iteration.
-type classEntry struct {
-	class Class
-	entry AllowlistEntry
-}
-
-// entries returns every entry tagged with its class, in class order
-// (first-party, community, partner) then file order.
-func (a *Allowlist) entries() []classEntry {
-	out := make([]classEntry, 0, len(a.FirstParty)+len(a.Community)+len(a.Partner))
-	for _, e := range a.FirstParty {
-		out = append(out, classEntry{ClassFirstParty, e})
-	}
-	for _, e := range a.Community {
-		out = append(out, classEntry{ClassCommunity, e})
-	}
-	for _, e := range a.Partner {
-		out = append(out, classEntry{ClassPartner, e})
-	}
-	return out
-}
-
-// LoadAllowlist reads and validates the allowlist at path. The read is bounded
-// (maxAllowlistBytes) before parse so an attacker-influenced path cannot OOM
-// the generator.
+// LoadAllowlist reads and validates the allowlist at path via the shared
+// loader. The read is size-bounded before parse, the schema version is
+// gated (1.0.x), and the anti-sybil invariants (anchored entries, disjoint
+// classes, no overlaps) are enforced — a malformed file fails closed.
 func LoadAllowlist(path string) (*Allowlist, error) {
-	data, err := readBoundedFile(path, maxAllowlistBytes)
+	al, err := allowlist.Load(path)
 	if err != nil {
-		return nil, err
+		return nil, err // already coded (ErrCodeNotFound / ErrCodeInvalidRequest)
 	}
-
-	var al Allowlist
-	if err := yaml.Unmarshal(data, &al); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "parse allowlist "+path, err)
-	}
-	// Fail closed on an unsupported schema before any classification: an
-	// unrecognized version may change the trust semantics this loader enforces.
-	if al.SchemaVersion != SupportedAllowlistSchemaVersion {
-		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("allowlist %s schemaVersion %q is unsupported (want %q)",
-				path, al.SchemaVersion, SupportedAllowlistSchemaVersion))
-	}
-	if err := al.Validate(); err != nil {
-		return nil, err
-	}
-	return &al, nil
+	return al, nil
 }
 
-// Validate enforces the anti-sybil invariants on the allowlist so it is not
-// itself an attack surface:
-//
-//   - every entry has a non-empty issuer and identity;
-//   - no identity is over-broad (no unbounded wildcard org/repo segment);
-//   - the classes are disjoint and no two entries overlap (one verified
-//     identity matches at most one entry).
-func (a *Allowlist) Validate() error {
-	all := a.entries()
-
-	// Per-entry shape + over-broad lint.
-	for _, ce := range all {
-		if strings.TrimSpace(ce.entry.Issuer) == "" {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("allowlist %s entry has empty issuer", ce.class))
-		}
-		if strings.TrimSpace(ce.entry.Identity) == "" {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("allowlist %s entry has empty identity", ce.class))
-		}
-		if reason, broad := overBroadIdentity(ce.entry.Identity); broad {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("allowlist %s entry identity %q is over-broad: %s",
-					ce.class, ce.entry.Identity, reason))
-		}
-		if _, err := compileIdentity(ce.entry.Identity); err != nil {
-			return err
-		}
+// classifySigner adapts the shared allowlist Classify to GP4 semantics: a
+// verified signer matching no entry is admitted as a zero-weight reported
+// dot — class community, allowlisted false.
+func classifySigner(a *Allowlist, issuer, identity string) (Class, bool) {
+	class, _, ok := a.Classify(issuer, identity)
+	if !ok {
+		return ClassCommunity, false
 	}
-
-	// Disjoint + non-overlapping across the whole list.
-	for i := range all {
-		for j := i + 1; j < len(all); j++ {
-			if overlaps(all[i].entry, all[j].entry) {
-				return errors.New(errors.ErrCodeInvalidRequest,
-					fmt.Sprintf("allowlist entries overlap: %s %q and %s %q match a common identity",
-						all[i].class, all[i].entry.Identity, all[j].class, all[j].entry.Identity))
-			}
-		}
-	}
-	return nil
-}
-
-// Classify resolves a verified (issuer, identity) to its class and whether it
-// counts toward corroboration. A signer matching no entry is admitted as a
-// zero-weight reported dot: class community, allowlisted false.
-func (a *Allowlist) Classify(issuer, identity string) (Class, bool) {
-	for _, ce := range a.entries() {
-		if ce.entry.Issuer != issuer {
-			continue
-		}
-		m, err := compileIdentity(ce.entry.Identity)
-		if err != nil {
-			continue // a malformed entry can never grant weight
-		}
-		if m(identity) {
-			return ce.class, true
-		}
-	}
-	return ClassCommunity, false
-}
-
-// identityMatcher reports whether a verified identity matches an allowlist
-// entry's identity pattern.
-type identityMatcher func(identity string) bool
-
-// compileIdentity turns an entry identity into a matcher. A leading "^" marks a
-// regex (compiled anchored at both ends); anything else is an exact-string
-// match.
-func compileIdentity(pattern string) (identityMatcher, error) {
-	if !strings.HasPrefix(pattern, "^") {
-		want := pattern
-		return func(identity string) bool { return identity == want }, nil
-	}
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "compile allowlist identity "+pattern, err)
-	}
-	return func(identity string) bool {
-		loc := re.FindStringIndex(identity)
-		// Require a full-string match: the regex is anchored with ^ and should
-		// also anchor the end, but enforce full coverage defensively.
-		return loc != nil && loc[0] == 0 && loc[1] == len(identity)
-	}, nil
-}
-
-// overBroadIdentity reports whether an identity pattern is over-broad. Exact
-// (non-regex) identities are inherently specific. A regex is over-broad when it
-// contains UNBOUNDED repetition (*, +, or {n,}) anywhere in its AST — that is
-// what lets a single entry match many distinct orgs/repos and manufacture a
-// CONFIRMED (e.g. "^https://github.com/.+/.+/..." or "^.../[^/]+/attest$" or
-// "^.../\\w+$"). Bounded quantifiers ({n,m}, ?) and fixed alternations
-// ("(aws|gcp)") cannot span an arbitrary segment, so they are allowed.
-//
-// Walking the parsed AST catches every unbounded construct (\w+, [^/]+, .{2,},
-// nested groups, a wildcard alternation branch), which a substring scan for a
-// fixed set of tokens cannot.
-func overBroadIdentity(pattern string) (reason string, broad bool) {
-	if !strings.HasPrefix(pattern, "^") {
-		return "", false // exact identities are inherently specific
-	}
-	re, err := syntax.Parse(pattern, syntax.Perl)
-	if err != nil {
-		// A malformed regex is rejected separately by compileIdentity; it is
-		// not "over-broad", so let that path produce the precise compile error.
-		return "", false
-	}
-	if q := unboundedRepetition(re); q != "" {
-		return "contains unbounded repetition " + q + " that can span an org/repo segment", true
-	}
-	return "", false
-}
-
-// unboundedRepetition returns a token for the first unbounded repetition in the
-// regex AST, or "" if none. Unbounded means *, +, or {n,} (open-ended) —
-// repetitions that can match an arbitrary number of characters and therefore an
-// arbitrary org/repo segment.
-func unboundedRepetition(re *syntax.Regexp) string {
-	// if/else rather than a switch on syntax.Op: bounded quantifiers ({n,m}, ?),
-	// literals, char classes, anchors, captures, concats, and alternations are
-	// not themselves unbounded, so they simply fall through to the recursion.
-	switch {
-	case re.Op == syntax.OpStar:
-		return "*"
-	case re.Op == syntax.OpPlus:
-		return "+"
-	case re.Op == syntax.OpRepeat && re.Max == -1: // {n,} has no upper bound
-		return "{n,}"
-	}
-	for _, sub := range re.Sub {
-		if q := unboundedRepetition(sub); q != "" {
-			return q
-		}
-	}
-	return ""
-}
-
-// overlaps reports whether two allowlist entries could both match one verified
-// identity. Different issuers never overlap (issuer is an exact match). For a
-// shared issuer it cross-applies each entry's matcher to the other's
-// representative identity, which catches exact duplicates, an exact identity
-// also covered by a foreign regex, and alternation-equivalent regexes.
-//
-// Sound regex-intersection emptiness is undecidable in general, so this is a
-// best-effort SECONDARY guard. The load-bearing anti-sybil controls are the
-// over-broad lint (overBroadIdentity, which forbids the unbounded repetition a
-// truly broad pattern would need) and the anchored full-string match in
-// compileIdentity; this check primarily stops the same identity being listed in
-// two classes.
-func overlaps(x, y AllowlistEntry) bool {
-	if x.Issuer != y.Issuer {
-		return false
-	}
-	mx, errX := compileIdentity(x.Identity)
-	my, errY := compileIdentity(y.Identity)
-	if errX != nil || errY != nil {
-		// Malformed patterns are rejected elsewhere; conservatively report no
-		// overlap so the precise compile error surfaces instead.
-		return false
-	}
-	return mx(representativeIdentity(y.Identity)) || my(representativeIdentity(x.Identity))
-}
-
-// representativeIdentity returns a concrete identity string that pattern
-// matches, so two patterns can be cross-tested for overlap. For an exact
-// identity it is the identity itself; for a regex it strips the anchors,
-// unescapes "\.", and resolves a leading alternation to its first option —
-// enough to expose duplicate or nested tightly-bounded patterns.
-func representativeIdentity(pattern string) string {
-	if !strings.HasPrefix(pattern, "^") {
-		return pattern
-	}
-	s := strings.TrimSuffix(strings.TrimPrefix(pattern, "^"), "$")
-	s = strings.ReplaceAll(s, `\.`, ".")
-	// Resolve "(a|b|c)" alternations to their first option.
-	for {
-		open := strings.IndexByte(s, '(')
-		if open < 0 {
-			break
-		}
-		closeIdx := strings.IndexByte(s[open:], ')')
-		if closeIdx < 0 {
-			break
-		}
-		closeIdx += open
-		group := s[open+1 : closeIdx]
-		first := group
-		if bar := strings.IndexByte(group, '|'); bar >= 0 {
-			first = group[:bar]
-		}
-		s = s[:open] + first + s[closeIdx+1:]
-	}
-	return s
+	return Class(class), true
 }

--- a/pkg/corroborate/classify_test.go
+++ b/pkg/corroborate/classify_test.go
@@ -31,7 +31,7 @@ func loadExampleAllowlist(t *testing.T) *Allowlist {
 	return al
 }
 
-func TestClassify(t *testing.T) {
+func TestClassifySigner(t *testing.T) {
 	al := loadExampleAllowlist(t)
 	tests := []struct {
 		name      string
@@ -41,25 +41,25 @@ func TestClassify(t *testing.T) {
 		wantAllow bool
 	}{
 		{
-			name:      "first-party from issuer pin (regex match)",
+			name:      "first-party from identityPattern (aws)",
 			issuer:    ghIssuer,
 			identity:  "https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main",
 			wantClass: ClassFirstParty, wantAllow: true,
 		},
 		{
-			name:      "first-party gcp variant (alternation match)",
+			name:      "first-party gcp variant on a non-main branch ref",
 			issuer:    ghIssuer,
-			identity:  "https://github.com/NVIDIA/aicr/.github/workflows/uat-gcp.yaml@refs/heads/main",
+			identity:  "https://github.com/NVIDIA/aicr/.github/workflows/uat-gcp.yaml@refs/heads/uat-fix",
 			wantClass: ClassFirstParty, wantAllow: true,
 		},
 		{
-			name:      "community from allowlist (exact match)",
+			name:      "community from source slug",
 			issuer:    ghIssuer,
 			identity:  "https://github.com/acme-gpu/aicr-attest/.github/workflows/attest.yaml@refs/heads/main",
 			wantClass: ClassCommunity, wantAllow: true,
 		},
 		{
-			name:      "partner from allowlist",
+			name:      "partner from source slug",
 			issuer:    "https://oidc.coreweave-lab.example",
 			identity:  "https://oidc.coreweave-lab.example/attest",
 			wantClass: ClassPartner, wantAllow: true,
@@ -77,7 +77,7 @@ func TestClassify(t *testing.T) {
 			wantClass: ClassCommunity, wantAllow: false,
 		},
 		{
-			name:      "first-party regex does not match a sibling repo",
+			name:      "first-party pattern does not match a sibling repo",
 			issuer:    ghIssuer,
 			identity:  "https://github.com/NVIDIA/other-repo/.github/workflows/uat-aws.yaml@refs/heads/main",
 			wantClass: ClassCommunity, wantAllow: false,
@@ -85,162 +85,84 @@ func TestClassify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotClass, gotAllow := al.Classify(tt.issuer, tt.identity)
+			gotClass, gotAllow := classifySigner(al, tt.issuer, tt.identity)
 			if gotClass != tt.wantClass || gotAllow != tt.wantAllow {
-				t.Errorf("Classify(%q,%q) = (%q,%v), want (%q,%v)",
+				t.Errorf("classifySigner(%q,%q) = (%q,%v), want (%q,%v)",
 					tt.issuer, tt.identity, gotClass, gotAllow, tt.wantClass, tt.wantAllow)
 			}
 		})
 	}
 }
 
-func TestAllowlistValidate(t *testing.T) {
-	tests := []struct {
-		name    string
-		al      Allowlist
-		wantErr bool
-	}{
-		{
-			name: "valid disjoint allowlist",
-			al: Allowlist{
-				FirstParty: []AllowlistEntry{{Issuer: ghIssuer, Identity: `^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/main$`}},
-				Community:  []AllowlistEntry{{Issuer: ghIssuer, Identity: "https://github.com/acme/attest"}},
-			},
-		},
-		{
-			name: "over-broad wildcard org/repo is rejected",
-			al: Allowlist{
-				Community: []AllowlistEntry{{Issuer: ghIssuer, Identity: `^https://github\.com/.+/.+/\.github/workflows/attest\.yaml@refs/heads/main$`}},
-			},
-			wantErr: true,
-		},
-		{
-			name: "over-broad .* is rejected",
-			al: Allowlist{
-				Community: []AllowlistEntry{{Issuer: ghIssuer, Identity: `^https://github\.com/acme/.*$`}},
-			},
-			wantErr: true,
-		},
-		{
-			name: "over-broad segment class is rejected",
-			al: Allowlist{
-				Partner: []AllowlistEntry{{Issuer: ghIssuer, Identity: `^https://github\.com/[^/]+/attest$`}},
-			},
-			wantErr: true,
-		},
-		{
-			name:    "empty issuer is rejected",
-			al:      Allowlist{Community: []AllowlistEntry{{Identity: "https://github.com/acme/attest"}}},
-			wantErr: true,
-		},
-		{
-			name:    "empty identity is rejected",
-			al:      Allowlist{Community: []AllowlistEntry{{Issuer: ghIssuer}}},
-			wantErr: true,
-		},
-		{
-			name: "uncompilable regex is rejected",
-			al: Allowlist{
-				Community: []AllowlistEntry{{Issuer: ghIssuer, Identity: "^https://github.com/acme/(attest"}},
-			},
-			wantErr: true,
-		},
-		{
-			name: "duplicate exact identity across classes overlaps",
-			al: Allowlist{
-				Community: []AllowlistEntry{{Issuer: ghIssuer, Identity: "https://github.com/acme/attest"}},
-				Partner:   []AllowlistEntry{{Issuer: ghIssuer, Identity: "https://github.com/acme/attest"}},
-			},
-			wantErr: true,
-		},
-		{
-			name: "exact identity also covered by a foreign regex overlaps",
-			al: Allowlist{
-				FirstParty: []AllowlistEntry{{Issuer: ghIssuer, Identity: `^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-aws\.yaml@refs/heads/main$`}},
-				Community:  []AllowlistEntry{{Issuer: ghIssuer, Identity: "https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main"}},
-			},
-			wantErr: true,
-		},
-		{
-			name: "same identity, different issuers do not overlap",
-			al: Allowlist{
-				Community: []AllowlistEntry{{Issuer: ghIssuer, Identity: "https://example.test/attest"}},
-				Partner:   []AllowlistEntry{{Issuer: "https://other.example", Identity: "https://example.test/attest"}},
-			},
-		},
+// TestLoadAllowlist_CanonicalFile is the #1505 acceptance check: GP4's loader
+// must parse the real GP1 allowlist (identityPattern/source schema).
+func TestLoadAllowlist_CanonicalFile(t *testing.T) {
+	al, err := LoadAllowlist(filepath.Join("..", "..", "recipes", "evidence", "allowlist.yaml"))
+	if err != nil {
+		t.Fatalf("LoadAllowlist(recipes/evidence/allowlist.yaml): %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.al.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() err = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+	class, ok := classifySigner(al, ghIssuer,
+		"https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main")
+	if class != ClassFirstParty || !ok {
+		t.Errorf("canonical allowlist classified UAT signer as (%q,%v), want (first-party,true)", class, ok)
 	}
 }
 
 func TestLoadAllowlist(t *testing.T) {
+	writeAllowlist := func(t *testing.T, body string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "allowlist.yaml")
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "valid canonical schema",
+			body: "schemaVersion: \"1.0.0\"\nfirstParty:\n  - issuer: " + ghIssuer +
+				"\n    identityPattern: '^https://github\\.com/NVIDIA/aicr/\\.github/workflows/uat-aws\\.yaml@refs/heads/.+$'\n",
+		},
+		{
+			name:    "malformed yaml fails closed",
+			body:    "firstParty: [::: not yaml",
+			wantErr: true,
+		},
+		{
+			name: "legacy cleartext identity field is rejected",
+			body: "schemaVersion: \"1.0.0\"\ncommunity:\n  - issuer: " + ghIssuer +
+				"\n    identity: https://github.com/acme/attest\n",
+			wantErr: true,
+		},
+		{
+			name: "unsupported schemaVersion is rejected at load",
+			body: "schemaVersion: \"9.9.9\"\ncommunity:\n  - issuer: " + ghIssuer +
+				"\n    source: f1f1cf33e7d868f95ea0f5b7542e6662\n",
+			wantErr: true,
+		},
+		{
+			name: "over-broad identityPattern (wildcard left of @) is rejected",
+			body: "schemaVersion: \"1.0.0\"\nfirstParty:\n  - issuer: " + ghIssuer +
+				"\n    identityPattern: '^https://github\\.com/.+/x\\.yaml@refs/heads/main$'\n",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadAllowlist(writeAllowlist(t, tt.body))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadAllowlist() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
 	t.Run("missing file", func(t *testing.T) {
 		if _, err := LoadAllowlist(filepath.Join("testdata", "nope.yaml")); err == nil {
 			t.Fatal("expected error for missing file")
 		}
 	})
-	t.Run("malformed yaml", func(t *testing.T) {
-		dir := t.TempDir()
-		p := filepath.Join(dir, "bad.yaml")
-		if err := os.WriteFile(p, []byte("firstParty: [::: not yaml"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := LoadAllowlist(p); err == nil {
-			t.Fatal("expected parse error")
-		}
-	})
-	t.Run("unsupported schemaVersion is rejected at load", func(t *testing.T) {
-		dir := t.TempDir()
-		p := filepath.Join(dir, "future.yaml")
-		body := "schemaVersion: \"9.9.9\"\ncommunity:\n  - issuer: " + ghIssuer + "\n    identity: https://github.com/acme/attest\n"
-		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := LoadAllowlist(p); err == nil {
-			t.Fatal("expected unsupported-schemaVersion rejection at load")
-		}
-	})
-	t.Run("over-broad file is rejected at load", func(t *testing.T) {
-		dir := t.TempDir()
-		p := filepath.Join(dir, "broad.yaml")
-		body := "schemaVersion: \"1.0.0\"\ncommunity:\n  - issuer: " + ghIssuer + "\n    identity: '^https://github\\.com/.+/.+/x$'\n"
-		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := LoadAllowlist(p); err == nil {
-			t.Fatal("expected over-broad rejection at load")
-		}
-	})
-}
-
-func TestOverBroadIdentity(t *testing.T) {
-	tests := []struct {
-		pattern string
-		broad   bool
-	}{
-		{"https://github.com/acme/attest", false},                                                           // exact
-		{`^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/main$`, false}, // bounded regex
-		{`^https://github\.com/acme/repo\.yaml{0,3}$`, false},                                               // bounded {n,m}
-		{`^https://github\.com/acme/repos?$`, false},                                                        // ? is bounded
-		{`^https://github\.com/.+/.+/x$`, true},
-		{`^https://github\.com/acme/.*$`, true},
-		{`^https://github\.com/[^/]+/x$`, true},     // char-class +
-		{`^https://github\.com/[^/]*/x$`, true},     // char-class *
-		{`^https://github\.com/\w+/x$`, true},       // perl-class + (missed by a substring scan)
-		{`^https://github\.com/a{2,}/x$`, true},     // open-ended {n,}
-		{`^https://github\.com/(acme|.+)/x$`, true}, // wildcard alternation branch (nested)
-	}
-	for _, tt := range tests {
-		t.Run(tt.pattern, func(t *testing.T) {
-			if _, got := overBroadIdentity(tt.pattern); got != tt.broad {
-				t.Errorf("overBroadIdentity(%q) = %v, want %v", tt.pattern, got, tt.broad)
-			}
-		})
-	}
 }

--- a/pkg/corroborate/generate.go
+++ b/pkg/corroborate/generate.go
@@ -263,8 +263,9 @@ func loadRun(metaPath string, allowlist *Allowlist) (*signerRun, error) {
 		return nil, err
 	}
 	// Schema gate, fail-closed on an incompatible major — symmetric with
-	// LoadAllowlist (classify.go), which rejects an unsupported allowlist
-	// schemaVersion because a future schema may change the trust semantics. A
+	// LoadAllowlist (the shared pkg/evidence/allowlist loader), which rejects an
+	// unsupported allowlist schemaVersion because a future schema may change the
+	// trust semantics. A
 	// meta/v2 that repurposes a field (e.g. signer/allowlisted) must not be parsed
 	// under v1 assumptions, so a different major is skipped (errSkipRun) rather
 	// than aborting the whole dashboard. An empty version is tolerated by design
@@ -283,7 +284,7 @@ func loadRun(metaPath string, allowlist *Allowlist) (*signerRun, error) {
 	class := Class(meta.Signer.Class)
 	allowlisted := meta.Signer.Allowlisted
 	if allowlist != nil {
-		derived, ok := allowlist.Classify(meta.Signer.Issuer, meta.Signer.Identity)
+		derived, ok := classifySigner(allowlist, meta.Signer.Issuer, meta.Signer.Identity)
 		if (derived != class || ok != allowlisted) && meta.Signer.Class != "" {
 			slog.Warn("meta.json signer class disagrees with allowlist; using allowlist",
 				"signer", meta.Signer.Identity, "metaClass", meta.Signer.Class,

--- a/pkg/corroborate/generate_test.go
+++ b/pkg/corroborate/generate_test.go
@@ -548,7 +548,7 @@ func TestGenerateErrors(t *testing.T) {
 	t.Run("over-broad allowlist rejected", func(t *testing.T) {
 		dir := t.TempDir()
 		p := filepath.Join(dir, "broad.yaml")
-		body := "schemaVersion: \"1.0.0\"\ncommunity:\n  - issuer: " + ghIssuer + "\n    identity: '^https://github\\.com/.+/.+/x$'\n"
+		body := "schemaVersion: \"1.0.0\"\nfirstParty:\n  - issuer: " + ghIssuer + "\n    identityPattern: '^https://github\\.com/.+/x\\.yaml@refs/heads/main$'\n"
 		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/corroborate/meta.go
+++ b/pkg/corroborate/meta.go
@@ -68,10 +68,10 @@ type RunMetaSigner struct {
 	Allowlisted bool   `json:"allowlisted"`
 }
 
-// readBoundedFile opens path and reads up to maxBytes, rejecting larger files
-// instead of allocating them (os.ReadFile would OOM on an attacker-influenced
-// path such as a /proc symlink or a network mount). Shared by the meta/CTRF
-// readers and the allowlist loader.
+// readBoundedFile opens path and reads up to maxRunFileBytes, rejecting
+// larger files instead of allocating them (os.ReadFile would OOM on an
+// attacker-influenced path such as a /proc symlink or a network mount).
+// Shared by the meta/CTRF readers.
 //
 // It refuses to follow symlinks and to read non-regular files (FIFOs, devices,
 // sockets): a hostile input tree could otherwise point a meta.json at /proc or
@@ -81,7 +81,7 @@ type RunMetaSigner struct {
 // the regular-file check then validates the opened descriptor itself, not the
 // path. It preserves the open error classification (not-found vs symlink vs
 // permission/other) so callers can tell a missing run apart from an I/O failure.
-func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
+func readBoundedFile(path string) ([]byte, error) {
 	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0) //nolint:gosec // O_NOFOLLOW rejects symlinks atomically; descriptor validated below; operator-supplied input tree / allowlist
 	if err != nil {
 		switch {
@@ -104,11 +104,11 @@ func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, path+" is not a regular file")
 	}
 
-	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	data, err := io.ReadAll(io.LimitReader(f, int64(maxRunFileBytes)+1))
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "read "+path, err)
 	}
-	if int64(len(data)) > maxBytes {
+	if int64(len(data)) > maxRunFileBytes {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, path+" exceeds size limit")
 	}
 	return data, nil
@@ -116,7 +116,7 @@ func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
 
 // readRunMeta parses a meta.json file.
 func readRunMeta(path string) (*RunMeta, error) {
-	data, err := readBoundedFile(path, maxRunFileBytes)
+	data, err := readBoundedFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func readRunMeta(path string) (*RunMeta, error) {
 
 // readCTRF parses a ctrf/<phase>.json file.
 func readCTRF(path string) (*ctrf.Report, error) {
-	data, err := readBoundedFile(path, maxRunFileBytes)
+	data, err := readBoundedFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corroborate/meta_test.go
+++ b/pkg/corroborate/meta_test.go
@@ -85,7 +85,7 @@ func TestReadBoundedFileSizeLimit(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readBoundedFile(big, maxRunFileBytes); err == nil {
+	if _, err := readBoundedFile(big); err == nil {
 		t.Fatal("expected size-limit rejection")
 	}
 }
@@ -101,14 +101,14 @@ func TestReadBoundedFileRejectsSymlinkAndNonRegular(t *testing.T) {
 		if err := os.Symlink(target, link); err != nil {
 			t.Skipf("symlinks unsupported on this platform: %v", err)
 		}
-		if _, err := readBoundedFile(link, maxRunFileBytes); err == nil {
+		if _, err := readBoundedFile(link); err == nil {
 			t.Fatal("expected symlink rejection")
 		}
 	})
 	t.Run("non-regular file is rejected", func(t *testing.T) {
 		// A directory is non-regular; readBoundedFile must reject it rather than
 		// attempting to read it.
-		if _, err := readBoundedFile(t.TempDir(), maxRunFileBytes); err == nil {
+		if _, err := readBoundedFile(t.TempDir()); err == nil {
 			t.Fatal("expected non-regular-file rejection")
 		}
 	})

--- a/pkg/corroborate/testdata/allowlist.yaml
+++ b/pkg/corroborate/testdata/allowlist.yaml
@@ -1,21 +1,28 @@
 ---
-# Contract 2 fixture — recipes/evidence/allowlist.yaml
-# Entries pin a fully-anchored issuer+identity pair. identity is an exact string
-# or a tightly-bounded regex with NO wildcard org/repo. Classes are disjoint and
-# no two entries overlap. A CI lint (GP1) rejects violations.
+# Test fixture mirroring the canonical recipes/evidence/allowlist.yaml schema
+# (GP1-owned, parsed by the shared pkg/evidence/allowlist loader).
+# First-party CI signers pin an anchored identityPattern (wildcard only in
+# the ref, right of the OIDC subject's '@'); community/partner entries are
+# keyed by the one-way source slug — first 32 hex of
+# sha256(issuer + "\n" + identity) — never a cleartext identity.
 schemaVersion: "1.0.0"
 
 firstParty:
-  - issuer: https://token.actions.githubusercontent.com
-    # exact org/repo; only the ref varies, bounded to this repo's workflows
-    identity: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/main$'
+  - label: aicr-uat-aws
+    issuer: https://token.actions.githubusercontent.com
+    identityPattern: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-aws\.yaml@refs/heads/.+$'
+  - label: aicr-uat-gcp
+    issuer: https://token.actions.githubusercontent.com
+    identityPattern: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-gcp\.yaml@refs/heads/.+$'
 
 community:
-  - issuer: https://token.actions.githubusercontent.com
-    identity: https://github.com/acme-gpu/aicr-attest/.github/workflows/attest.yaml@refs/heads/main
-  - issuer: https://gitlab.com
-    identity: https://gitlab.com/hydra-ml/evidence
+  # slug of https://github.com/acme-gpu/aicr-attest/.github/workflows/attest.yaml@refs/heads/main
+  - label: acme-gpu
+    issuer: https://token.actions.githubusercontent.com
+    source: f1f1cf33e7d868f95ea0f5b7542e6662
 
 partner:
-  - issuer: https://oidc.coreweave-lab.example
-    identity: https://oidc.coreweave-lab.example/attest
+  # slug of https://oidc.coreweave-lab.example/attest
+  - label: coreweave-lab
+    issuer: https://oidc.coreweave-lab.example
+    source: dbdbbe0e022faf8e9820537fa63164eb

--- a/pkg/evidence/project/classify.go
+++ b/pkg/evidence/project/classify.go
@@ -15,14 +15,9 @@
 package project
 
 import (
-	"fmt"
 	"regexp"
-	"regexp/syntax"
-	"strings"
 
-	"github.com/NVIDIA/aicr/pkg/defaults"
-	"github.com/NVIDIA/aicr/pkg/errors"
-	"gopkg.in/yaml.v3"
+	"github.com/NVIDIA/aicr/pkg/evidence/allowlist"
 )
 
 // Class is the trust classification recorded for a verified signer. It
@@ -30,23 +25,24 @@ import (
 // sources count toward consensus; everything else is reported but
 // contributes zero weight.
 //
-// The schema and matching semantics here intentionally mirror the
-// consumer-side loader in pkg/corroborate so the producer and the GP4
-// generator read the identical recipes/evidence/allowlist.yaml (owned by
-// GP1) and classify a verified signer identically.
+// Classification delegates to the shared authoritative loader in
+// pkg/evidence/allowlist so the producer (GP2) and the GP4 consumer
+// (pkg/corroborate) read the identical recipes/evidence/allowlist.yaml
+// (owned by GP1, identityPattern/source schema) and classify a verified
+// signer identically (#1505).
 type Class string
 
 const (
 	// ClassFirstParty marks evidence produced by AICR's own UAT pipeline.
-	ClassFirstParty Class = "first-party"
+	ClassFirstParty Class = Class(allowlist.ClassFirstParty)
 
 	// ClassCommunity marks evidence from an allowlisted community signer,
 	// and is also the fail-closed fallback for a verified-but-unallowlisted
 	// signer (reported, but never counted).
-	ClassCommunity Class = "community"
+	ClassCommunity Class = Class(allowlist.ClassCommunity)
 
 	// ClassPartner marks evidence from an allowlisted partner signer.
-	ClassPartner Class = "partner"
+	ClassPartner Class = Class(allowlist.ClassPartner)
 )
 
 // firstPartyIssuer is the GitHub Actions OIDC token issuer used by the
@@ -59,262 +55,49 @@ const firstPartyIssuer = "https://token.actions.githubusercontent.com"
 // (^…$) so neither a look-alike host nor an arbitrary other path/ref under
 // NVIDIA/aicr (e.g. a fork-PR workflow or a non-UAT workflow) can satisfy
 // it. Mirrors FIRST_PARTY_IDENTITY in evidence-ingest.yaml and the
-// documented firstParty allowlist entry that replaces this heuristic once
-// recipes/evidence/allowlist.yaml ships. Used only when no allowlist file
-// is present.
+// firstParty entries in recipes/evidence/allowlist.yaml. Used only when no
+// allowlist file is loaded (nil *Allowlist).
 var firstPartyIdentity = regexp.MustCompile(
 	`^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/.+$`)
 
-// AllowlistEntry pins one verified signer: an exact issuer and an
-// identity that is either an exact string or a tightly-bounded regex
-// (recognized by a leading "^"). Over-broad identities are rejected by
-// Allowlist.Validate.
-type AllowlistEntry struct {
-	Issuer   string `yaml:"issuer" json:"issuer"`
-	Identity string `yaml:"identity" json:"identity"`
-}
-
-// Allowlist is the in-tree, PR-reviewed signer allowlist
-// (recipes/evidence/allowlist.yaml, owned by GP1). The three class
-// sections are disjoint and non-overlapping. A nil *Allowlist is valid
-// and applies only the interim first-party heuristic plus the community
-// fail-closed default.
+// Allowlist wraps the shared GP1 allowlist loader (pkg/evidence/allowlist)
+// for the GP2 producer. A nil *Allowlist is valid and applies only the
+// interim first-party heuristic plus the community fail-closed default.
 type Allowlist struct {
-	SchemaVersion string           `yaml:"schemaVersion" json:"schemaVersion"`
-	FirstParty    []AllowlistEntry `yaml:"firstParty" json:"firstParty"`
-	Community     []AllowlistEntry `yaml:"community" json:"community"`
-	Partner       []AllowlistEntry `yaml:"partner" json:"partner"`
+	shared *allowlist.Allowlist
 }
 
-// classEntry pairs an entry with its class for whole-list iteration.
-type classEntry struct {
-	class Class
-	entry AllowlistEntry
-}
-
-// entries returns every entry tagged with its class, in class order
-// (first-party, community, partner) then file order.
-func (a *Allowlist) entries() []classEntry {
-	if a == nil {
-		return nil
-	}
-	out := make([]classEntry, 0, len(a.FirstParty)+len(a.Community)+len(a.Partner))
-	for _, e := range a.FirstParty {
-		out = append(out, classEntry{ClassFirstParty, e})
-	}
-	for _, e := range a.Community {
-		out = append(out, classEntry{ClassCommunity, e})
-	}
-	for _, e := range a.Partner {
-		out = append(out, classEntry{ClassPartner, e})
-	}
-	return out
-}
-
-// LoadAllowlist reads, parses, and validates the allowlist at path. The
-// read is size-bounded before parse so an attacker-influenced path
-// cannot OOM the process. Returns ErrCodeInvalidRequest on a bad file.
+// LoadAllowlist reads, parses, and validates the allowlist at path via the
+// shared loader: size-bounded read, schema-version gate (1.0.x), anchored
+// entries, disjoint classes, no overlaps. A malformed file fails closed
+// with ErrCodeInvalidRequest (ErrCodeNotFound when missing).
 func LoadAllowlist(path string) (*Allowlist, error) {
-	data, err := readBoundedFile(path, "allowlist "+path, defaults.HTTPResponseBodyLimit)
+	al, err := allowlist.Load(path)
 	if err != nil {
-		return nil, err
+		return nil, err // already coded by the shared loader
 	}
-
-	var al Allowlist
-	if err := yaml.Unmarshal(data, &al); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "parse allowlist "+path, err)
-	}
-	if err := al.Validate(); err != nil {
-		return nil, err
-	}
-	return &al, nil
-}
-
-// Validate enforces the anti-sybil invariants so the allowlist is not
-// itself an attack surface: every entry has a non-empty issuer and
-// identity; no identity is over-broad (no unbounded wildcard segment);
-// and the classes are disjoint (one verified identity matches at most
-// one entry). The producer re-checks these (defense in depth) even
-// though GP1 lints the file in its own repo CI.
-func (a *Allowlist) Validate() error {
-	all := a.entries()
-	for _, ce := range all {
-		if strings.TrimSpace(ce.entry.Issuer) == "" {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("allowlist %s entry has empty issuer", ce.class))
-		}
-		if strings.TrimSpace(ce.entry.Identity) == "" {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("allowlist %s entry has empty identity", ce.class))
-		}
-		if reason, unsafe := unsafeIdentityConstruct(ce.entry.Identity); unsafe {
-			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("allowlist %s entry identity %q is unsafe: %s",
-					ce.class, ce.entry.Identity, reason))
-		}
-		if _, err := compileIdentity(ce.entry.Identity); err != nil {
-			return err
-		}
-	}
-	for i := range all {
-		for j := i + 1; j < len(all); j++ {
-			if overlaps(all[i].entry, all[j].entry) {
-				return errors.New(errors.ErrCodeInvalidRequest,
-					fmt.Sprintf("allowlist entries overlap: %s %q and %s %q match a common identity",
-						all[i].class, all[i].entry.Identity, all[j].class, all[j].entry.Identity))
-			}
-		}
-	}
-	return nil
+	return &Allowlist{shared: al}, nil
 }
 
 // Classify resolves a verified (issuer, identity) to its class and
 // whether it counts toward corroboration. Resolution order:
 //
-//  1. The first matching allowlist entry wins (allowlisted=true).
-//  2. When no allowlist is loaded (nil receiver, the interim state
-//     before GP1 ships recipes/evidence/allowlist.yaml), the built-in
-//     first-party heuristic admits AICR's own UAT identity so it is not
-//     mislabeled community. Once the allowlist file exists this branch
-//     is never reached — classification then matches the GP4 consumer
-//     exactly.
-//  3. Otherwise community, not allowlisted — the fail-closed default.
+//  1. With an allowlist loaded, the shared classifier decides: a matching
+//     entry wins (allowlisted=true); an unmatched signer is community, not
+//     allowlisted — the fail-closed default (reported, never counted).
+//  2. When no allowlist is loaded (nil receiver), the built-in first-party
+//     heuristic admits AICR's own UAT identity so it is not mislabeled
+//     community; everything else falls through to community, not
+//     allowlisted.
 func (a *Allowlist) Classify(issuer, identity string) (Class, bool) {
-	for _, ce := range a.entries() {
-		if ce.entry.Issuer != issuer {
-			continue
+	if a != nil && a.shared != nil {
+		if class, _, ok := a.shared.Classify(issuer, identity); ok {
+			return Class(class), true
 		}
-		m, err := compileIdentity(ce.entry.Identity)
-		if err != nil {
-			continue // a malformed entry can never grant weight
-		}
-		if m(identity) {
-			return ce.class, true
-		}
+		return ClassCommunity, false
 	}
-	if a == nil && issuer == firstPartyIssuer && firstPartyIdentity.MatchString(identity) {
+	if issuer == firstPartyIssuer && firstPartyIdentity.MatchString(identity) {
 		return ClassFirstParty, true
 	}
 	return ClassCommunity, false
-}
-
-// identityMatcher reports whether a verified identity matches an entry's
-// identity pattern.
-type identityMatcher func(identity string) bool
-
-// compileIdentity turns an entry identity into a matcher. A leading "^"
-// marks a regex (full-string match); anything else is an exact-string
-// match.
-func compileIdentity(pattern string) (identityMatcher, error) {
-	if !strings.HasPrefix(pattern, "^") {
-		want := pattern
-		return func(identity string) bool { return identity == want }, nil
-	}
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "compile allowlist identity "+pattern, err)
-	}
-	return func(identity string) bool {
-		loc := re.FindStringIndex(identity)
-		return loc != nil && loc[0] == 0 && loc[1] == len(identity)
-	}, nil
-}
-
-// unsafeIdentityConstruct reports whether a regex identity pattern uses a
-// construct that makes it either over-broad or impossible to overlap-check
-// soundly. An exact (non-regex) identity is always safe. For a regex, only
-// literals, concatenation, capture groups, alternation, and the ^/$ anchors
-// are permitted. That keeps every accepted pattern finitely enumerable down
-// its first alternation branch — the precondition for the single-sample
-// cross-test in overlaps() (via representativeIdentity) to be exact rather
-// than a heuristic that can miss intersecting entries. Any repetition
-// (*, +, ?, {n,m}), character class, or '.' is rejected: repetition can
-// span an org/repo segment and manufacture a confirmed source, while a
-// character class or '.' lets two distinct entries intersect on an input
-// that representativeIdentity never samples.
-func unsafeIdentityConstruct(pattern string) (reason string, unsafe bool) {
-	if !strings.HasPrefix(pattern, "^") {
-		return "", false
-	}
-	re, err := syntax.Parse(pattern, syntax.Perl)
-	if err != nil {
-		return "", false // a malformed regex is rejected by compileIdentity
-	}
-	return walkIdentityAST(re)
-}
-
-// walkIdentityAST returns a human-readable reason for the first unsafe node
-// in a parsed identity regex, or ("", false) when every node is supported.
-func walkIdentityAST(re *syntax.Regexp) (reason string, unsafe bool) {
-	switch re.Op {
-	case syntax.OpStar:
-		return "contains unbounded repetition '*' that can span an org/repo segment", true
-	case syntax.OpPlus:
-		return "contains unbounded repetition '+' that can span an org/repo segment", true
-	case syntax.OpRepeat:
-		return "contains repetition '{n,m}' that can span an org/repo segment", true
-	case syntax.OpQuest:
-		return "contains optional '?' which the overlap check cannot sample", true
-	case syntax.OpCharClass, syntax.OpAnyChar, syntax.OpAnyCharNotNL:
-		return "contains a character class or '.' which the overlap check cannot sample", true
-	case syntax.OpNoMatch, syntax.OpWordBoundary, syntax.OpNoWordBoundary:
-		return "contains an unsupported regex construct", true
-	case syntax.OpEmptyMatch, syntax.OpLiteral, syntax.OpConcat,
-		syntax.OpAlternate, syntax.OpCapture,
-		syntax.OpBeginText, syntax.OpEndText,
-		syntax.OpBeginLine, syntax.OpEndLine:
-		for _, sub := range re.Sub {
-			if r, u := walkIdentityAST(sub); u {
-				return r, u
-			}
-		}
-		return "", false
-	default:
-		return "contains an unsupported regex construct", true
-	}
-}
-
-// overlaps reports whether two entries could both match one verified
-// identity. Different issuers never overlap. For a shared issuer it
-// cross-applies each entry's matcher to the other's representative
-// identity — catching exact duplicates, an exact identity also covered
-// by a foreign regex, and alternation-equivalent regexes.
-func overlaps(x, y AllowlistEntry) bool {
-	if x.Issuer != y.Issuer {
-		return false
-	}
-	mx, errX := compileIdentity(x.Identity)
-	my, errY := compileIdentity(y.Identity)
-	if errX != nil || errY != nil {
-		return false
-	}
-	return mx(representativeIdentity(y.Identity)) || my(representativeIdentity(x.Identity))
-}
-
-// representativeIdentity returns a concrete identity string that pattern
-// matches, so two patterns can be cross-tested for overlap.
-func representativeIdentity(pattern string) string {
-	if !strings.HasPrefix(pattern, "^") {
-		return pattern
-	}
-	s := strings.TrimSuffix(strings.TrimPrefix(pattern, "^"), "$")
-	s = strings.ReplaceAll(s, `\.`, ".")
-	for {
-		open := strings.IndexByte(s, '(')
-		if open < 0 {
-			break
-		}
-		closeIdx := strings.IndexByte(s[open:], ')')
-		if closeIdx < 0 {
-			break
-		}
-		closeIdx += open
-		group := s[open+1 : closeIdx]
-		first := group
-		if bar := strings.IndexByte(group, '|'); bar >= 0 {
-			first = group[:bar]
-		}
-		s = s[:open] + first + s[closeIdx+1:]
-	}
-	return s
 }

--- a/pkg/evidence/project/classify_test.go
+++ b/pkg/evidence/project/classify_test.go
@@ -15,9 +15,12 @@
 package project
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
 )
 
 func writeFile(t *testing.T, dir, name, content string) string {
@@ -29,24 +32,51 @@ func writeFile(t *testing.T, dir, name, content string) string {
 	return p
 }
 
-const ghaIssuer = "https://token.actions.githubusercontent.com"
+const (
+	ghaIssuer       = "https://token.actions.githubusercontent.com"
+	communityIssuer = "https://github.com/login/oauth"
+	partnerIssuer   = "https://oidc.coreweave-lab.example"
 
-// sampleAllowlist mirrors the GP1 recipes/evidence/allowlist.yaml schema.
-const sampleAllowlist = `schemaVersion: "1.0.0"
+	communityIdentity = "contributor@example.com"
+	partnerIdentity   = "https://oidc.coreweave-lab.example/attest"
+)
+
+// sampleAllowlist renders a fixture in the canonical GP1
+// recipes/evidence/allowlist.yaml schema: first-party CI pinned by an
+// anchored identityPattern, community/partner keyed by the one-way source
+// slug of the signer's (issuer, identity).
+func sampleAllowlist(t *testing.T) string {
+	t.Helper()
+	communitySlug, err := attestation.SourceSlug(communityIssuer, communityIdentity)
+	if err != nil {
+		t.Fatalf("SourceSlug(community): %v", err)
+	}
+	partnerSlug, err := attestation.SourceSlug(partnerIssuer, partnerIdentity)
+	if err != nil {
+		t.Fatalf("SourceSlug(partner): %v", err)
+	}
+	return fmt.Sprintf(`schemaVersion: "1.0.0"
 firstParty:
-  - issuer: https://token.actions.githubusercontent.com
-    identity: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/main$'
+  - label: aicr-uat-aws
+    issuer: %s
+    identityPattern: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-aws\.yaml@refs/heads/.+$'
+  - label: aicr-uat-gcp
+    issuer: %s
+    identityPattern: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-gcp\.yaml@refs/heads/.+$'
 community:
-  - issuer: https://token.actions.githubusercontent.com
-    identity: https://github.com/acme-gpu/aicr-attest/.github/workflows/attest.yaml@refs/heads/main
+  - label: acme-contributor
+    issuer: %s
+    source: %s
 partner:
-  - issuer: https://oidc.coreweave-lab.example
-    identity: https://oidc.coreweave-lab.example/attest
-`
+  - label: coreweave-lab
+    issuer: %s
+    source: %s
+`, ghaIssuer, ghaIssuer, communityIssuer, communitySlug, partnerIssuer, partnerSlug)
+}
 
 func TestLoadAllowlistAndClassify(t *testing.T) {
 	dir := t.TempDir()
-	al, err := LoadAllowlist(writeFile(t, dir, "allowlist.yaml", sampleAllowlist))
+	al, err := LoadAllowlist(writeFile(t, dir, "allowlist.yaml", sampleAllowlist(t)))
 	if err != nil {
 		t.Fatalf("LoadAllowlist: %v", err)
 	}
@@ -59,37 +89,37 @@ func TestLoadAllowlistAndClassify(t *testing.T) {
 		wantAllowed bool
 	}{
 		{
-			name:        "first-party regex (aws ref)",
+			name:        "first-party identityPattern (aws ref)",
 			issuer:      ghaIssuer,
 			identity:    "https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main",
 			wantClass:   ClassFirstParty,
 			wantAllowed: true,
 		},
 		{
-			name:        "first-party regex (gcp ref)",
+			name:        "first-party identityPattern (gcp, non-main ref)",
 			issuer:      ghaIssuer,
-			identity:    "https://github.com/NVIDIA/aicr/.github/workflows/uat-gcp.yaml@refs/heads/main",
+			identity:    "https://github.com/NVIDIA/aicr/.github/workflows/uat-gcp.yaml@refs/heads/uat-fix",
 			wantClass:   ClassFirstParty,
 			wantAllowed: true,
 		},
 		{
-			name:        "exact community match",
-			issuer:      ghaIssuer,
-			identity:    "https://github.com/acme-gpu/aicr-attest/.github/workflows/attest.yaml@refs/heads/main",
+			name:        "community source-slug match",
+			issuer:      communityIssuer,
+			identity:    communityIdentity,
 			wantClass:   ClassCommunity,
 			wantAllowed: true,
 		},
 		{
-			name:        "partner on its own issuer",
-			issuer:      "https://oidc.coreweave-lab.example",
-			identity:    "https://oidc.coreweave-lab.example/attest",
+			name:        "partner source-slug match on its own issuer",
+			issuer:      partnerIssuer,
+			identity:    partnerIdentity,
 			wantClass:   ClassPartner,
 			wantAllowed: true,
 		},
 		{
-			name:        "right repo, wrong ref → not first-party",
+			name:        "sibling repo → not first-party",
 			issuer:      ghaIssuer,
-			identity:    "https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/dev",
+			identity:    "https://github.com/NVIDIA/other-repo/.github/workflows/uat-aws.yaml@refs/heads/main",
 			wantClass:   ClassCommunity,
 			wantAllowed: false,
 		},
@@ -103,7 +133,7 @@ func TestLoadAllowlistAndClassify(t *testing.T) {
 		{
 			name:        "right identity, wrong issuer",
 			issuer:      "https://evil.example",
-			identity:    "https://oidc.coreweave-lab.example/attest",
+			identity:    partnerIdentity,
 			wantClass:   ClassCommunity,
 			wantAllowed: false,
 		},
@@ -118,8 +148,22 @@ func TestLoadAllowlistAndClassify(t *testing.T) {
 	}
 }
 
-// TestClassify_NilAllowlist covers the interim state before GP1 ships the
-// allowlist file: the built-in first-party heuristic admits AICR's own
+// TestLoadAllowlist_CanonicalFile is the #1505 acceptance check: the GP2
+// producer must parse the real GP1 allowlist (identityPattern/source schema).
+func TestLoadAllowlist_CanonicalFile(t *testing.T) {
+	al, err := LoadAllowlist(filepath.Join("..", "..", "..", "recipes", "evidence", "allowlist.yaml"))
+	if err != nil {
+		t.Fatalf("LoadAllowlist(recipes/evidence/allowlist.yaml): %v", err)
+	}
+	class, ok := al.Classify(ghaIssuer,
+		"https://github.com/NVIDIA/aicr/.github/workflows/uat-gcp.yaml@refs/heads/main")
+	if class != ClassFirstParty || !ok {
+		t.Errorf("canonical allowlist classified UAT signer as (%q,%v), want (first-party,true)", class, ok)
+	}
+}
+
+// TestClassify_NilAllowlist covers the interim state before an allowlist
+// file is passed: the built-in first-party heuristic admits AICR's own
 // UAT identity, everything else fails closed to community.
 func TestClassify_NilAllowlist(t *testing.T) {
 	var al *Allowlist // nil
@@ -133,7 +177,7 @@ func TestClassify_NilAllowlist(t *testing.T) {
 		{"first-party heuristic", ghaIssuer, "https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main", ClassFirstParty, true},
 		{"foreign repo is community", ghaIssuer, "https://github.com/evil/aicr/.github/workflows/x.yaml@refs/heads/main", ClassCommunity, false},
 		{"look-alike host not first-party", ghaIssuer, "https://github.com.evil.example/NVIDIA/aicr/x.yaml", ClassCommunity, false},
-		{"community email", "https://github.com/login/oauth", "yuanchen97@gmail.com", ClassCommunity, false},
+		{"community email", communityIssuer, "yuanchen97@gmail.com", ClassCommunity, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -151,13 +195,13 @@ func TestLoadAllowlist_Errors(t *testing.T) {
 		name    string
 		content string
 	}{
-		{"empty issuer", "firstParty:\n  - issuer: \"\"\n    identity: x\n"},
-		{"empty identity", "community:\n  - issuer: a\n    identity: \"\"\n"},
-		{"over-broad unbounded regex", "partner:\n  - issuer: a\n    identity: '^https://github\\.com/.+/attest$'\n"},
-		{"unsampleable char class", "partner:\n  - issuer: a\n    identity: '^https://github\\.com/acme[0-9]/attest$'\n"},
-		{"unsampleable optional", "partner:\n  - issuer: a\n    identity: '^https://github\\.com/acmes?/attest$'\n"},
-		{"bad regexp", "partner:\n  - issuer: a\n    identity: \"^(\"\n"},
-		{"overlapping classes", "firstParty:\n  - issuer: a\n    identity: x\ncommunity:\n  - issuer: a\n    identity: x\n"},
+		{"empty issuer", "schemaVersion: \"1.0.0\"\nfirstParty:\n  - identityPattern: '^x@y$'\n"},
+		{"legacy cleartext identity field", "schemaVersion: \"1.0.0\"\ncommunity:\n  - issuer: a\n    identity: x\n"},
+		{"unsupported schemaVersion", "schemaVersion: \"9.9.9\"\npartner: []\n"},
+		{"over-broad wildcard left of @", "schemaVersion: \"1.0.0\"\nfirstParty:\n  - issuer: a\n    identityPattern: '^https://github\\.com/.+/attest\\.yaml@refs/heads/main$'\n"},
+		{"unanchored pattern", "schemaVersion: \"1.0.0\"\nfirstParty:\n  - issuer: a\n    identityPattern: 'x@y'\n"},
+		{"malformed source slug", "schemaVersion: \"1.0.0\"\ncommunity:\n  - issuer: a\n    source: NOT-A-SLUG\n"},
+		{"duplicate source slug across classes", "schemaVersion: \"1.0.0\"\ncommunity:\n  - issuer: a\n    source: f1f1cf33e7d868f95ea0f5b7542e6662\npartner:\n  - issuer: a\n    source: f1f1cf33e7d868f95ea0f5b7542e6662\n"},
 		{"not yaml", "::: not yaml :::\n\t- x\n"},
 	}
 	for _, tt := range tests {
@@ -174,18 +218,19 @@ func TestLoadAllowlist_Errors(t *testing.T) {
 	}
 }
 
-// TestAllowlist_BoundedAndAnchored guards the anti-sybil matcher: a
-// tightly-bounded regex must full-string match, not substring match.
+// TestAllowlist_AnchoredFullMatch guards the anti-sybil matcher: an anchored
+// identityPattern must full-string match — a probe with extra characters
+// inside the literal segment must not match.
 func TestAllowlist_AnchoredFullMatch(t *testing.T) {
 	dir := t.TempDir()
-	al, err := LoadAllowlist(writeFile(t, dir, "al.yaml", sampleAllowlist))
+	al, err := LoadAllowlist(writeFile(t, dir, "al.yaml", sampleAllowlist(t)))
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A trailing suffix beyond the anchored pattern must NOT match.
+	// Extra path bytes between the workflow file and the '@' must NOT match.
 	class, allowed := al.Classify(ghaIssuer,
-		"https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main/extra")
+		"https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml.evil@refs/heads/main")
 	if allowed || class != ClassCommunity {
-		t.Errorf("suffix beyond anchored regex matched: (%s, %v)", class, allowed)
+		t.Errorf("probe beyond anchored pattern matched: (%s, %v)", class, allowed)
 	}
 }


### PR DESCRIPTION
## Summary

`aicr verify` now fails closed: a binary attestation that is present but fails verification yields trust level `unknown` instead of degrading to `attested`. Also retires the two stale hand-rolled allowlist loaders (GP2/GP4) in favor of the shared `pkg/evidence/allowlist` schema so the real `recipes/evidence/allowlist.yaml` parses everywhere.

## Motivation / Context

A tampered or invalid binary attestation was treated the same as a legitimately missing one (`attested`), hiding an active verification failure (P1 security correctness). Separately, the GP2 producer and GP4 consumer loaders still expected the outdated `issuer`+`identity` schema, so neither could parse the canonical `identityPattern`/`source` allowlist — forcing the dashboard publish workflow to drop `-allowlist`.

Fixes: #1550
Fixes: #1505

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/corroborate`, `pkg/evidence/project`, `pkg/cli` help text, `.github/workflows/evidence-dashboard-publish.yaml`

## Implementation Notes

- Verifier: missing binary attestation still reports `attested` (incomplete chain — nothing claims more). Present-but-unverifiable (digest extraction failure or `VerifyBinaryAttestation` error) now reports `unknown` — a claim exists and could not be substantiated. `MaxAchievableTrustLevel` is unchanged (computed from contents), so `--min-trust-level max` correctly fails such bundles; a regression test pins this interaction. Steps 4–5 were extracted into `verifyBinaryStep` for network-free testability.
- Allowlist: `corroborate.Allowlist` is now a type alias to `allowlist.Allowlist` with `LoadAllowlist` delegating to the shared loader; `project.Allowlist` is a thin wrapper (not an alias) to preserve the documented nil-receiver first-party heuristic used when `-allowlist` is absent. Unlisted signers still classify as (`community`, allowlisted=false). Testdata rewritten to the canonical schema; both packages gained a test loading the real `recipes/evidence/allowlist.yaml`.
- `-allowlist recipes/evidence/allowlist.yaml` re-enabled on both corroborate invocations in the publish workflow (defense in depth over the class baked into `meta.json` at ingest).
- Docs: trust-level tables in `docs/user/artifact-verification.md` and `docs/user/cli-reference.md` updated (failed verify → `unknown`); `docs/contributor/evidence-ingest.md` classification section now documents the real schema; `evidence-dashboard-publish.md` deferral note replaced.

## Testing

```bash
make qualify
```

`make qualify` passed locally (unit tests with `-race`, golangci-lint + yamllint, e2e incl. chainsaw 23/23, grype scan clean, license headers). Acceptance from #1505 verified: `corroborate -allowlist recipes/evidence/allowlist.yaml` loads and classifies the canonical file. New tests: `TestVerifyBinaryStep` (missing→attested, invalid→unknown, no-digest→unknown), `TestVerifyBinaryStep_FailedVerifyMaxStaysVerified`, rewritten `classify_test.go` in both packages (precedence, unlisted→reported, fail-closed on malformed/legacy-schema files).

Coverage (pkg/corroborate + pkg/evidence/project + pkg/bundler/verifier combined): 85.1% → 85.3% (+0.2%).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Bundles with a valid or absent binary attestation are unaffected. Bundles whose binary attestation fails verification now report `unknown`, so policies pinned to `--min-trust-level attested` will (correctly) start rejecting them.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
