### PR TITLE
feat(uat): gate AWS GPU pool with skyhook runtime-required taint

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -105,10 +105,12 @@ jobs:
       # DC2 selects the AICRConfig by intent; both intents drive the same
       # cluster-config (GPU pool from the reservation, system/CPU pools dynamic).
       TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-${{ inputs.intent }}-config.yaml
-      # v0.4.23 — required for the .eks-nested cluster-config schema; the
-      # prior pin (v0.2.6) read .compute.nodeGroups.* directly and failed
+      # v0.4.27 — required for node-group taints in the cluster-config schema
+      # (GPU pool carries skyhook.nvidia.com=runtime-required:NoSchedule until
+      # NodeWrite finishes tuning + reboot). Earlier v0.4.x pins predate taint
+      # support; v0.2.6 read .compute.nodeGroups.* directly and failed
       # Terraform parse with "object with 1 attribute eks".
-      EKS_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:57fd2bf77055f8e0090bd7b8e099e7f11fd874f0b5764057439d11f1cd32a8b1"
+      EKS_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:8bc33d14e6e5659d242aa2cdbcd69fca389cfcdb9e94f7a7a1b82fd33176befa"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
       # Pin validator-image resolution for MAIN cells to this run's freshly

--- a/tests/uat/aws/cluster-config.yaml
+++ b/tests/uat/aws/cluster-config.yaml
@@ -104,3 +104,7 @@ compute:
           labels:
             nodeGroup: gpu-worker
             dedicated: user-workload
+          taints:
+            - key: skyhook.nvidia.com
+              value: runtime-required
+              effect: NoSchedule


### PR DESCRIPTION
## Summary

Gate the AWS UAT GPU node group with the `skyhook.nvidia.com=runtime-required:NoSchedule` taint and bump the EKS provisioner image to v0.4.27 (adds node-group taint support to the cluster-config schema).

## Motivation / Context

UAT readiness flakes on a race between the NodeWrite tuning reboot and the deployment of all other components. Applying the runtime-required taint at cluster-infra provisioning keeps every other component from landing on GPU nodes until NodeWrite finishes optimization and removes the taint before the node reboot — eliminating the race.

Per the Skyhook team, the runtime-required taint key is still `skyhook.nvidia.com` today; the API surface (CRD, taints/labels/annotations) is planned to migrate to NodeWright. We'll migrate this config when that lands in AICR.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT workflow + cluster config (`.github/workflows/uat-aws.yaml`, `tests/uat/aws/cluster-config.yaml`)

## Implementation Notes

- The new `EKS_IMAGE` digest resolves to `ghcr.io/mchmarny/cluster/eks:v0.4.27`; earlier v0.4.x pins predate taint support in the cluster-config schema.
- NodeWrite (via Skyhook) removes the taint itself once tuning + reboot complete — no teardown-side change is needed.
- Fixed a doubled `@sha256:sha256:` prefix in the initial digest edit (invalid image reference) and refreshed the stale `v0.4.23` pin comment.

## Testing

```bash
yamllint -c .yamllint.yaml tests/uat/aws/cluster-config.yaml .github/workflows/uat-aws.yaml
```

YAML-only change; verified the pinned digest exists in ghcr and is tagged `v0.4.27`. No Go code changed, so no coverage delta. Will validate end-to-end on the next UAT run.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Affects only the AWS UAT harness. If NodeWrite fails to remove the taint, GPU-scheduled UAT components will stay Pending — that is a real readiness failure surfaced explicitly rather than a race. Revert restores the prior image pin and untainted pool.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
