### PR TITLE
chore(recipes): move version-pin exemptions to a declarative file

### DIFF
--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -518,8 +518,10 @@ registry default. A version bump must update the registry default (the
 BOM reads it) **and** every pin that sets it, or CI fails. If an
 overlay must legitimately run a different chart version (e.g. a
 platform validated against an older chart), add an entry to
-`versionPinExemptions` with a justification — a declared divergence is
-not a silent one. Do **not** exempt a component whose only consumer
+`recipes/version-pin-exemptions.yaml` with a justification — a declared
+divergence is not a silent one. The file is loaded and validated by
+`internal/versionpins`, the shared source consumed by the guard test
+today and by `tools/bom` once #1611 lands. Do **not** exempt a component whose only consumer
 diverges; that reinstates the exact fiction the guard prevents.
 
 ## Common Pitfalls

--- a/internal/versionpins/versionpins.go
+++ b/internal/versionpins/versionpins.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package versionpins loads the repository's declarative version-pin
+// exemption table (recipes/version-pin-exemptions.yaml): componentRefs whose
+// overlay/mixin version pin is INTENTIONALLY different from the component's
+// registry defaultVersion/defaultTag.
+//
+// The file is repository-only policy data — deliberately NOT embedded into
+// the aicr binary (see recipes/data.go) and not part of the runtime recipe
+// data model, which is why this package lives under internal/ rather than
+// pkg/: it is dev/CI tooling, not public Go API. It is consumed from a
+// repository checkout by the version-pin guard test
+// (pkg/recipe/version_pin_guard_test.go) and, once #1611 wires it, by the
+// BOM generator (tools/bom) — which must read this policy and
+// recipes/registry.yaml from the same checkout (tools/bom -repo-root). The
+// single shared file keeps the guard and the BOM from drifting on which
+// divergences are blessed.
+//
+// Load fails closed: an unreadable, oversized, mis-identified, or
+// semantically invalid file is an error, never an empty exemption list — a
+// malformed policy file must not silently un-bless every divergence (which
+// would fail the guard) or, worse, silently bless none for a consumer that
+// treats absence as "no variants" (tools/bom).
+package versionpins
+
+import (
+	"bytes"
+	"context"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
+)
+
+// FileName is the exemption file's name under the repository's recipes/
+// directory.
+const FileName = "version-pin-exemptions.yaml"
+
+// expectedKind is the document identity Load requires (alongside
+// header.GroupVersion for apiVersion), so an unrelated YAML file passed by
+// mistake cannot masquerade as the exemption table.
+const expectedKind = "VersionPinExemptions"
+
+// Exemption documents a componentRef whose overlay/mixin version pin is
+// INTENTIONALLY different from the component's registry defaultVersion.
+//
+// ExpectedPin/ExpectedDefault bind the exemption to ONE specific divergence:
+// if either the recipe's pin or the registry default later moves, the guard
+// test fails so the divergence is re-reviewed and re-justified rather than a
+// new, unvetted version silently inheriting the old blessing.
+type Exemption struct {
+	// Source is the overlay/mixin metadata.name that declares the pin.
+	Source string `yaml:"source"`
+	// Component is the componentRef name.
+	Component string `yaml:"component"`
+	// ExpectedPin is the exact divergent version/tag this exemption blesses.
+	ExpectedPin string `yaml:"expectedPin"`
+	// ExpectedDefault is the registry default at the time the exemption was
+	// written.
+	ExpectedDefault string `yaml:"expectedDefault"`
+	// Reason records why the divergence is intentional (cite an issue/PR).
+	Reason string `yaml:"reason"`
+}
+
+// document is the on-disk file shape. Exemptions is a pointer so an omitted
+// (or explicit null) key is distinguishable from a declared empty list: a
+// truncated file must fail closed, not read as "no exemptions".
+type document struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Kind       string       `yaml:"kind"`
+	Exemptions *[]Exemption `yaml:"exemptions"`
+}
+
+// Test seams for openRegularBounded's blocking syscalls, so tests can
+// deterministically simulate a hung open(2)/fstat(2) without a pathological
+// filesystem. Production code never reassigns them; tests swap and restore
+// them around a Load call (no test runs Load concurrently with a swap).
+var (
+	osOpen   = os.Open
+	fileStat = (*os.File).Stat
+)
+
+// Load reads and validates the exemption file at path, typically
+// filepath.Join(repoRoot, "recipes", FileName). Open, the regular-file check
+// (fstat on the opened handle — no stat-to-open race), and the read all run
+// inside context-bounded workers under defaults.FileReadTimeout (tightening
+// any caller deadline), so a FIFO blocking in open(2) or a hung network/FUSE
+// mount cannot stall the caller past the deadline. Size is bounded by
+// defaults.MaxVersionPinExemptionsBytes.
+//
+// An explicitly declared empty list (`exemptions: []`) is valid — every pin
+// matches its registry default. Every other defect — missing file, non-regular
+// file, oversize, unknown fields, wrong apiVersion/kind, an omitted or null
+// exemptions key, missing or whitespace-only entry fields, duplicate
+// (source, component) keys, or an entry whose expectedPin equals
+// expectedDefault — is an error.
+func Load(ctx context.Context, path string) ([]Exemption, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaults.FileReadTimeout)
+	defer cancel()
+
+	// Deterministic entry check: an already-expired context must fail here
+	// rather than race the (possibly instant) open/read selects below.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeTimeout,
+			"reading version-pin exemptions file "+path+" timed out", ctxErr)
+	}
+
+	// The helpers classify their own failures as structured errors, so both
+	// propagate as-is (re-wrapping would overwrite their codes).
+	f, err := openRegularBounded(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() // read-only handle; Close error carries no data loss
+
+	data, err := readAllBounded(ctx, f, defaults.MaxVersionPinExemptionsBytes+1, path)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > defaults.MaxVersionPinExemptionsBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+			"version-pin exemptions file %s exceeds %d bytes",
+			path, defaults.MaxVersionPinExemptionsBytes))
+	}
+	return parse(data, path)
+}
+
+// openRegularBounded opens path and verifies it is a regular file, entirely
+// inside a context-bounded worker: a FIFO with no writer blocks in open(2)
+// itself, and a hung network/FUSE mount can block open(2) or the fstat(2)
+// after it — no post-open context check helps with any of those, so every
+// potentially blocking call lives in the worker.
+//
+// Handle lifecycle: delivery over the unbuffered channel is a rendezvous, so
+// the worker always learns whether the caller took the result. On every
+// non-delivery path — open/fstat error, non-regular type, or the caller's
+// deadline firing first — the worker closes the handle itself; there is no
+// drainer goroutine to pin alongside it. If the underlying syscall never
+// returns (a permanently hung mount), exactly one goroutine — this worker —
+// stays pinned until it does; Go cannot cancel a blocked syscall, and
+// unblocking the caller while bounding cleanup is the same trade
+// readAllBounded (and pkg/serializer) makes for reads.
+//
+// Failures are classified here, once, as structured errors: ErrCodeNotFound
+// (fs.ErrNotExist), ErrCodeInvalidRequest (non-regular file), ErrCodeTimeout
+// (deadline), ErrCodeInternal (any other open/stat failure).
+func openRegularBounded(ctx context.Context, path string) (*os.File, error) {
+	type result struct {
+		f   *os.File
+		err error
+	}
+	// Capture the seams before spawning so the worker never reads the
+	// package vars concurrently with a test swapping them.
+	open, stat := osOpen, fileStat
+	ch := make(chan result) // unbuffered: send is a rendezvous with the caller
+	deliver := func(res result) {
+		select {
+		case ch <- res:
+		case <-ctx.Done():
+			// The caller is gone; it will never receive this result.
+			if res.f != nil {
+				_ = res.f.Close()
+			}
+		}
+	}
+	go func() {
+		f, err := open(path)
+		if err != nil {
+			if stderrors.Is(err, fs.ErrNotExist) {
+				deliver(result{err: errors.Wrap(errors.ErrCodeNotFound,
+					"version-pin exemptions file not found at "+path, err)})
+				return
+			}
+			deliver(result{err: errors.Wrap(errors.ErrCodeInternal,
+				"failed to open version-pin exemptions file "+path, err)})
+			return
+		}
+		info, err := stat(f)
+		if err != nil {
+			_ = f.Close()
+			deliver(result{err: errors.Wrap(errors.ErrCodeInternal,
+				"failed to stat version-pin exemptions file "+path, err)})
+			return
+		}
+		if !info.Mode().IsRegular() {
+			_ = f.Close()
+			deliver(result{err: errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+				"version-pin exemptions file %s is not a regular file (mode %s)",
+				path, info.Mode()))})
+			return
+		}
+		deliver(result{f: f})
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, errors.Wrap(errors.ErrCodeTimeout,
+			"opening version-pin exemptions file "+path+" timed out", ctx.Err())
+	case res := <-ch:
+		return res.f, res.err
+	}
+}
+
+// readAllBounded reads up to limit bytes from r, returning early if ctx is
+// canceled or its deadline fires. The read runs in a goroutine so a hung
+// filesystem read (network mount, FUSE) cannot stall the caller past the
+// deadline: the caller is unblocked and the goroutine ends when the
+// underlying Read eventually returns (the buffered channel lets its send
+// always succeed; byte data needs no cleanup, so no rendezvous is required).
+// Mirrors pkg/serializer.readAllBounded. Failures are classified here, once:
+// ErrCodeTimeout (deadline), ErrCodeInternal (read failure).
+func readAllBounded(ctx context.Context, r io.Reader, limit int64, path string) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1) // buffered so the goroutine never leaks on send
+	go func() {
+		data, err := io.ReadAll(io.LimitReader(r, limit))
+		ch <- result{data: data, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, errors.Wrap(errors.ErrCodeTimeout,
+			"reading version-pin exemptions file "+path+" timed out", ctx.Err())
+	case res := <-ch:
+		if res.err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal,
+				"failed to read version-pin exemptions file "+path, res.err)
+		}
+		return res.data, nil
+	}
+}
+
+// parse strictly decodes and validates the exemption document, aggregating
+// every problem into one error so the author sees all defects at once.
+func parse(data []byte, path string) ([]Exemption, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var doc document
+	if err := dec.Decode(&doc); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"failed to parse version-pin exemptions file "+path, err)
+	}
+	// A trailing second YAML document would be silently dropped by a single
+	// Decode; reject it so no exemption can hide in an unread document.
+	if err := dec.Decode(new(document)); !stderrors.Is(err, io.EOF) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"version-pin exemptions file "+path+" must contain exactly one YAML document")
+	}
+
+	var problems []string
+	if doc.APIVersion != header.GroupVersion {
+		problems = append(problems, fmt.Sprintf(
+			"apiVersion %q, want %q", doc.APIVersion, header.GroupVersion))
+	}
+	if doc.Kind != expectedKind {
+		problems = append(problems, fmt.Sprintf(
+			"kind %q, want %q", doc.Kind, expectedKind))
+	}
+	if doc.Exemptions == nil {
+		problems = append(problems, "exemptions key is missing or null; declare "+
+			"an explicit empty list ([]) when no divergence is blessed — a "+
+			"truncated file must not read as \"no exemptions\"")
+	}
+
+	var exemptions []Exemption
+	if doc.Exemptions != nil {
+		exemptions = *doc.Exemptions
+	}
+	type key struct{ source, component string }
+	seen := make(map[key]struct{}, len(exemptions))
+	for i, e := range exemptions {
+		entry := fmt.Sprintf("exemptions[%d] (source=%q component=%q)",
+			i, e.Source, e.Component)
+		// Whitespace-only values are as useless as empty ones — reject both.
+		if strings.TrimSpace(e.Source) == "" {
+			problems = append(problems, entry+" has no source")
+		}
+		if strings.TrimSpace(e.Component) == "" {
+			problems = append(problems, entry+" has no component")
+		}
+		if strings.TrimSpace(e.ExpectedPin) == "" || strings.TrimSpace(e.ExpectedDefault) == "" {
+			problems = append(problems, entry+" must set both expectedPin and "+
+				"expectedDefault so drift within the exemption is caught")
+		}
+		if strings.TrimSpace(e.ExpectedPin) != "" && e.ExpectedPin == e.ExpectedDefault {
+			problems = append(problems, fmt.Sprintf(
+				"%s has expectedPin == expectedDefault (%q); an exemption documents "+
+					"a DIVERGENCE — delete it instead", entry, e.ExpectedPin))
+		}
+		if strings.TrimSpace(e.Reason) == "" {
+			problems = append(problems, entry+" has no reason")
+		}
+		k := key{source: e.Source, component: e.Component}
+		if _, dup := seen[k]; dup {
+			problems = append(problems, entry+" duplicates an earlier entry")
+		}
+		seen[k] = struct{}{}
+	}
+
+	if len(problems) > 0 {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"invalid version-pin exemptions file "+path+": "+strings.Join(problems, "; "))
+	}
+	return exemptions, nil
+}

--- a/internal/versionpins/versionpins_test.go
+++ b/internal/versionpins/versionpins_test.go
@@ -1,0 +1,515 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionpins
+
+import (
+	"context"
+	stderrors "errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+const validDoc = `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    expectedDefault: "84.4.0"
+    reason: validated cluster state (#700)
+`
+
+// write puts content in a fresh temp file and returns its path.
+func write(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), FileName)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantErr  bool
+		wantCode errors.ErrorCode
+		wantMsg  []string // substrings the error must contain
+		wantLen  int
+	}{
+		{
+			name:    "valid single entry",
+			content: validDoc,
+			wantLen: 1,
+		},
+		{
+			name: "valid explicit empty list",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions: []
+`,
+			wantLen: 0,
+		},
+		{
+			name: "omitted exemptions key rejected",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"missing or null"},
+		},
+		{
+			name: "null exemptions key rejected",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions: null
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"missing or null"},
+		},
+		{
+			name: "wrong kind",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+exemptions: []
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{`kind "ComponentRegistry"`},
+		},
+		{
+			name: "wrong apiVersion",
+			content: `apiVersion: aicr.run/v1
+kind: VersionPinExemptions
+exemptions: []
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{`apiVersion "aicr.run/v1"`},
+		},
+		{
+			name: "unknown field rejected by strict decode",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    expectedDefault: "84.4.0"
+    reason: ok (#700)
+    justification: typo-for-reason
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"justification"},
+		},
+		{
+			name: "malformed yaml",
+			content: `apiVersion: [unclosed
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "second document rejected",
+			content: validDoc + `---
+apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions: []
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"exactly one YAML document"},
+		},
+		{
+			name: "missing required fields aggregated",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: ""
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    expectedDefault: "84.4.0"
+    reason: ""
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"has no source", "has no reason"},
+		},
+		{
+			name: "whitespace-only reason rejected",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    expectedDefault: "84.4.0"
+    reason: "   "
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"has no reason"},
+		},
+		{
+			name: "missing expectedDefault",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    reason: ok (#700)
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"both expectedPin and expectedDefault"},
+		},
+		{
+			name: "pin equal to default rejected",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "84.4.0"
+    expectedDefault: "84.4.0"
+    reason: ok (#700)
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"expectedPin == expectedDefault"},
+		},
+		{
+			name: "duplicate source/component rejected",
+			content: `apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    expectedDefault: "84.4.0"
+    reason: ok (#700)
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "82.0.0"
+    expectedDefault: "84.4.0"
+    reason: conflicting duplicate (#700)
+`,
+			wantErr:  true,
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantMsg:  []string{"duplicates an earlier entry"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Load(context.Background(), write(t, tt.content))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Load() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+					t.Errorf("error code = %v, want %v", err, tt.wantCode)
+				}
+				for _, want := range tt.wantMsg {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not contain %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("len(exemptions) = %d, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestLoadFieldsRoundTrip(t *testing.T) {
+	got, err := Load(context.Background(), write(t, validDoc))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(exemptions) = %d, want 1", len(got))
+	}
+	want := Exemption{
+		Source:          "aks",
+		Component:       "kube-prometheus-stack",
+		ExpectedPin:     "83.7.0",
+		ExpectedDefault: "84.4.0",
+		Reason:          "validated cluster state (#700)",
+	}
+	if got[0] != want {
+		t.Errorf("exemption = %+v, want %+v", got[0], want)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	_, err := Load(context.Background(), filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err == nil {
+		t.Fatal("Load() succeeded on a missing file; a malformed or absent policy file must fail closed")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("error code = %v, want %v", err, errors.ErrCodeNotFound)
+	}
+}
+
+func TestLoadNonRegularFile(t *testing.T) {
+	// A directory stands in for any non-regular path that opens without
+	// blocking; the fstat inside the bounded worker must reject it.
+	_, err := Load(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("Load() accepted a non-regular file")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error code = %v, want %v", err, errors.ErrCodeInvalidRequest)
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error %q does not mention the file type", err.Error())
+	}
+}
+
+func TestLoadCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Load(ctx, write(t, validDoc))
+	if err == nil {
+		t.Fatal("Load() succeeded with a canceled context")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+		t.Errorf("error code = %v, want %v", err, errors.ErrCodeTimeout)
+	}
+}
+
+func TestLoadOversizeFile(t *testing.T) {
+	// A file over the cap must be rejected before parsing.
+	pad := strings.Repeat("# padding\n", 1+int(defaults.MaxVersionPinExemptionsBytes)/10)
+	_, err := Load(context.Background(), write(t, validDoc+pad))
+	if err == nil {
+		t.Fatal("Load() accepted a file over MaxVersionPinExemptionsBytes")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error code = %v, want %v", err, errors.ErrCodeInvalidRequest)
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error %q does not mention the size cap", err.Error())
+	}
+}
+
+// swapSeams installs test doubles for the blocking-syscall seams and restores
+// them at cleanup. Load reads the seams synchronously before spawning its
+// worker, so swap/restore in the test goroutine cannot race a worker; tests
+// using this must not run in parallel.
+func swapSeams(t *testing.T, open func(string) (*os.File, error), stat func(*os.File) (fs.FileInfo, error)) {
+	t.Helper()
+	origOpen, origStat := osOpen, fileStat
+	if open != nil {
+		osOpen = open
+	}
+	if stat != nil {
+		fileStat = stat
+	}
+	t.Cleanup(func() { osOpen, fileStat = origOpen, origStat })
+}
+
+// awaitClosed polls until fstat on the handle fails with fs.ErrClosed,
+// proving the worker's close-on-late path released it. Any other Stat error
+// is a test failure — it would mask a handle that was never closed.
+func awaitClosed(t *testing.T, f *os.File) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := f.Stat()
+		switch {
+		case stderrors.Is(err, fs.ErrClosed):
+			return // closed by the worker
+		case err != nil:
+			t.Fatalf("unexpected Stat error while awaiting closure: %v", err)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("late handle was never closed by the worker")
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// loadAsync runs Load in a goroutine and returns its result channel, so a
+// test can sequence: await started → cancel → bounded result check. Calling
+// Load synchronously cannot prove the caller was unblocked WHILE the worker
+// was blocked — the deadline could fire before the worker even starts. The
+// channel is closed after the single send so a cleanup join (a second
+// receive) returns immediately when the body already consumed the result.
+func loadAsync(ctx context.Context, path string) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		_, err := Load(ctx, path)
+		done <- err
+		close(done)
+	}()
+	return done
+}
+
+// joinLoad registers a cleanup that cancels the context, fires the
+// (idempotent) release, and waits for the async Load to return. It must be
+// registered AFTER swapSeams so it runs BEFORE the seam restore (LIFO):
+// no fatal exit path can strand a worker blocked on release, and the seams
+// are never restored while a worker might still read them.
+func joinLoad(t *testing.T, cancel context.CancelFunc, release func(), done <-chan error) {
+	t.Helper()
+	t.Cleanup(func() {
+		cancel()
+		release()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Errorf("async Load never returned during cleanup; a worker may be stranded")
+		}
+	})
+}
+
+// TestLoadBlockedOpenDeterministic drives the full blocked-open lifecycle
+// with explicit started/cancel/done/release synchronization: the context is
+// canceled only once the worker is provably inside the blocking open, the
+// caller must unblock with a timeout error while the open is still blocked,
+// and when the open finally completes the worker must close the now-unwanted
+// handle itself. Every fatal exit path releases the worker via joinLoad.
+func TestLoadBlockedOpenDeterministic(t *testing.T) {
+	path := write(t, validDoc)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	doRelease := func() { releaseOnce.Do(func() { close(release) }) }
+	opened := make(chan *os.File, 1)
+	swapSeams(t, func(p string) (*os.File, error) {
+		close(started)
+		<-release
+		f, err := os.Open(p)
+		if err == nil {
+			opened <- f
+		}
+		return f, err
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := loadAsync(ctx, path)
+	joinLoad(t, cancel, doRelease, done)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker never entered open")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+			t.Fatalf("Load() error = %v, want %v while open is blocked", err, errors.ErrCodeTimeout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load did not unblock after cancellation while open was blocked")
+	}
+
+	doRelease()
+	var f *os.File
+	select {
+	case f = <-opened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("open never completed after release")
+	}
+	awaitClosed(t, f)
+}
+
+// TestLoadBlockedStatDeterministic is the fstat analog: the type check runs
+// inside the same bounded worker, so a hung fstat must also unblock the
+// caller, and the handle must be closed once the stat completes.
+func TestLoadBlockedStatDeterministic(t *testing.T) {
+	path := write(t, validDoc)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	doRelease := func() { releaseOnce.Do(func() { close(release) }) }
+	opened := make(chan *os.File, 1)
+	swapSeams(t,
+		func(p string) (*os.File, error) {
+			f, err := os.Open(p)
+			if err == nil {
+				opened <- f
+			}
+			return f, err
+		},
+		func(f *os.File) (fs.FileInfo, error) {
+			close(started)
+			<-release
+			return f.Stat()
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := loadAsync(ctx, path)
+	joinLoad(t, cancel, doRelease, done)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker never entered fstat")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+			t.Fatalf("Load() error = %v, want %v while fstat is blocked", err, errors.ErrCodeTimeout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load did not unblock after cancellation while fstat was blocked")
+	}
+
+	doRelease()
+	var f *os.File
+	select {
+	case f = <-opened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("open never delivered the handle")
+	}
+	awaitClosed(t, f)
+}
+
+// TestLoadCommittedFile validates the repository's real exemption file, so a
+// bad edit to recipes/version-pin-exemptions.yaml fails this package's tests
+// even before the pkg/recipe guard test consumes it.
+func TestLoadCommittedFile(t *testing.T) {
+	got, err := Load(context.Background(), filepath.Join("..", "..", "recipes", FileName))
+	if err != nil {
+		t.Fatalf("Load(committed file): %v", err)
+	}
+	for _, e := range got {
+		t.Logf("committed exemption: %s/%s pin=%s default=%s",
+			e.Source, e.Component, e.ExpectedPin, e.ExpectedDefault)
+	}
+}

--- a/internal/versionpins/versionpins_unix_test.go
+++ b/internal/versionpins/versionpins_unix_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin || linux
+
+package versionpins
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestLoadBlockedOpenTimesOutOnFIFO is the real-syscall complement to the
+// deterministic seam tests: a FIFO with no writer blocks in open(2) itself,
+// so only a context-bounded open can return. The open seam here still calls
+// the real os.Open — the seam only signals entry, so the release below is
+// deterministic rather than racing the worker to the syscall.
+func TestLoadBlockedOpenTimesOutOnFIFO(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), FileName)
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	started := make(chan struct{})
+	swapSeams(t, func(p string) (*os.File, error) {
+		close(started)
+		return os.Open(p) // genuinely blocks until a writer appears
+	}, nil)
+
+	// releaseWriter unpins the worker from open(2) — Go cannot cancel a
+	// blocked syscall. `started` fires before the worker's open, so the
+	// non-blocking write-open (ENXIO until a reader waits) must connect
+	// within the retry window; not connecting is a real failure that would
+	// leave the worker pinned for the life of the test binary. Once the
+	// writer connects, the worker's open returns a FIFO handle, the
+	// in-worker fstat rejects it as non-regular, and the worker closes it.
+	// Idempotent on SUCCESS only: the success path and cleanup both call it,
+	// and a failed attempt leaves `released` false so cleanup can retry.
+	// Body and cleanup run on the test goroutine, so no locking is needed.
+	released := false
+	releaseWriter := func(fail func(format string, args ...any)) {
+		if released {
+			return
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			w, err := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+			if err == nil {
+				// The reader is released the moment the writer connects, so
+				// mark success before the Close check — a Close failure must
+				// not trigger a misleading cleanup retry.
+				released = true
+				// Writable handle: Close may surface a write-side error.
+				if closeErr := w.Close(); closeErr != nil {
+					fail("closing release writer: %v", closeErr)
+				}
+				return
+			}
+			if time.Now().After(deadline) {
+				fail("release writer never connected; worker left pinned in open(2): %v", err)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Explicit cancellation after `started` (rather than a pre-set deadline)
+	// removes the scheduling race where a short deadline could expire before
+	// the worker even enters the seam.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := loadAsync(ctx, fifo)
+	t.Cleanup(func() {
+		cancel()
+		releaseWriter(t.Errorf)
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Errorf("async Load never returned during cleanup; the worker may be stranded")
+		}
+	})
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker never entered open")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Load() succeeded on a writer-less FIFO; the open should have blocked and timed out")
+		}
+		if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+			t.Errorf("error code = %v, want %v", err, errors.ErrCodeTimeout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load did not unblock while open(2) was blocked on the FIFO")
+	}
+
+	releaseWriter(func(format string, args ...any) {
+		t.Helper()
+		t.Fatalf(format, args...)
+	})
+}

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -742,6 +742,14 @@ const (
 	// swaps a file between walk-time validation and the read at
 	// consumption time.
 	MaxExternalDataFileBytes int64 = 10 * 1024 * 1024 // 10 MiB
+
+	// MaxVersionPinExemptionsBytes caps the size of the repository's
+	// version-pin exemption file (recipes/version-pin-exemptions.yaml) read
+	// by internal/versionpins. The file holds a handful of small entries — 1 MiB
+	// is generous headroom while bounding the read (the loader takes an
+	// arbitrary path, e.g. via tools/bom -repo-root) before the bytes are
+	// allocated into memory.
+	MaxVersionPinExemptionsBytes int64 = 1 * 1024 * 1024 // 1 MiB
 )
 
 // Server-wide handler defaults.

--- a/pkg/recipe/version_pin_guard_test.go
+++ b/pkg/recipe/version_pin_guard_test.go
@@ -17,8 +17,11 @@ package recipe
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/NVIDIA/aicr/internal/versionpins"
 )
 
 // TestOverlayVersionPinsMatchRegistry guards the version-management model so
@@ -42,11 +45,16 @@ import (
 //
 // The invariant enforced here: every overlay/mixin componentRefs version/tag
 // MUST equal the component's registry defaultVersion/defaultTag, unless the
-// divergence is explicitly declared in versionPinExemptions with a reason.
-// This makes the registry default the single source of truth: a component
-// bump must update the registry default (which the BOM reads) and every
-// overlay that pins it, or CI fails. Undeclared drift is a hard failure;
-// declared divergences are, by definition, not silent.
+// divergence is explicitly declared in recipes/version-pin-exemptions.yaml
+// with a reason. This makes the registry default the single source of truth:
+// a component bump must update the registry default (which the BOM reads) and
+// every overlay that pins it, or CI fails. Undeclared drift is a hard
+// failure; declared divergences are, by definition, not silent.
+//
+// The exemption table is loaded (and statically validated — required fields,
+// duplicates, pin != default) by internal/versionpins from the shared
+// declarative file, so tools/bom can consume the same policy once #1611
+// wires it into the BOM.
 func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 	ctx := context.Background()
 
@@ -59,31 +67,21 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 		t.Fatalf("loadMetadataStore: %v", err)
 	}
 
+	// The test binary runs with the package directory as cwd, so the
+	// repository's recipes/ tree is two levels up.
+	exemptions, err := versionpins.Load(ctx, filepath.Join("..", "..", "recipes", versionpins.FileName))
+	if err != nil {
+		t.Fatalf("versionpins.Load: %v", err)
+	}
+
 	// Track which exemptions actually fire so a stale entry (e.g. after a pin
-	// is re-aligned) fails the test instead of silently rotting.
-	usedExemption := make(map[pinKey]bool, len(versionPinExemptions))
-	exemptByKey := make(map[pinKey]versionPinExemption, len(versionPinExemptions))
-	for _, e := range versionPinExemptions {
-		k := pinKey{source: e.source, component: e.component}
-		if _, dup := exemptByKey[k]; dup {
-			t.Errorf("duplicate versionPinExemptions entry for source=%q component=%q",
-				e.source, e.component)
-		}
-		if e.reason == "" {
-			t.Errorf("versionPinExemptions entry for source=%q component=%q has no reason",
-				e.source, e.component)
-		}
-		if e.expectedPin == "" || e.expectedDefault == "" {
-			t.Errorf("versionPinExemptions entry for source=%q component=%q must set both "+
-				"expectedPin and expectedDefault so drift within the exemption is caught",
-				e.source, e.component)
-		}
-		if e.expectedPin == e.expectedDefault {
-			t.Errorf("versionPinExemptions entry for source=%q component=%q has expectedPin == "+
-				"expectedDefault (%q); an exemption documents a DIVERGENCE — delete it instead",
-				e.source, e.component, e.expectedPin)
-		}
-		exemptByKey[k] = e
+	// is re-aligned) fails the test instead of silently rotting. Static
+	// validation (duplicates, empty fields, pin == default) already happened
+	// in versionpins.Load.
+	usedExemption := make(map[pinKey]bool, len(exemptions))
+	exemptByKey := make(map[pinKey]versionpins.Exemption, len(exemptions))
+	for _, e := range exemptions {
+		exemptByKey[pinKey{source: e.Source, component: e.Component}] = e
 	}
 
 	checked := 0
@@ -140,16 +138,16 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 				// no longer describes reality — fail so the author re-reviews
 				// (and re-cites) rather than letting a new divergence ride the
 				// old exemption.
-				if pin != e.expectedPin || def != e.expectedDefault {
-					t.Errorf("out-of-date versionPinExemptions entry for %s/%s: exemption "+
+				if pin != e.ExpectedPin || def != e.ExpectedDefault {
+					t.Errorf("out-of-date exemption entry for %s/%s: recipes/%s "+
 						"blesses pin=%q vs default=%q, but the recipe now has %s=%q vs default=%q.\n"+
 						"  Update the exemption's expectedPin/expectedDefault and re-justify the "+
 						"divergence, or re-align the pin. See issue #1424.",
-						source, ref.Name, e.expectedPin, e.expectedDefault, field, pin, def)
+						source, ref.Name, versionpins.FileName, e.ExpectedPin, e.ExpectedDefault, field, pin, def)
 					continue
 				}
 				t.Logf("exempted divergence: %s/%s pins %s=%q vs registry default %q — %s",
-					source, ref.Name, field, pin, def, e.reason)
+					source, ref.Name, field, pin, def, e.Reason)
 				continue
 			}
 
@@ -158,8 +156,8 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 				"  The BOM (docs/user/container-images.md) renders the registry default, so it would\n"+
 				"  advertise %q while this recipe installs %q. Re-align the pin to the registry default\n"+
 				"  (or bump both together). If the divergence is intentional, add an entry to\n"+
-				"  versionPinExemptions in version_pin_guard_test.go with a justification. See issue #1424.",
-				source, ref.Name, field, pin, def, ref.Name, def, pin)
+				"  recipes/%s with a justification. See issue #1424.",
+				source, ref.Name, field, pin, def, ref.Name, def, pin, versionpins.FileName)
 		}
 	}
 
@@ -184,8 +182,8 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 	}
 	sort.Strings(stale)
 	for _, s := range stale {
-		t.Errorf("stale versionPinExemptions entry %q: the pin now matches the registry "+
-			"default (or was removed). Delete the exemption.", s)
+		t.Errorf("stale exemption entry %q in recipes/%s: the pin now matches the registry "+
+			"default (or was removed). Delete the exemption.", s, versionpins.FileName)
 	}
 
 	// Sole-consumer enforcement: an exemption is only safe if the registry
@@ -194,8 +192,8 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 	// recipe installs — the exact fiction the guard exists to prevent, merely
 	// made explicit rather than fixed. Resolve every overlay once and require
 	// each exemption's registry default to appear, enabled, in some result.
-	if len(versionPinExemptions) > 0 {
-		assertExemptionDefaultsInstalled(ctx, t, store, reg)
+	if len(exemptions) > 0 {
+		assertExemptionDefaultsInstalled(ctx, t, store, reg, exemptions)
 	}
 
 	// A registry/overlay refactor that stops surfacing any pinned refs would
@@ -205,7 +203,7 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 			"verify loadMetadataStore and the recipes/overlays/ directory")
 	}
 	t.Logf("verified %d pinned componentRefs against registry defaults (%d declared exemptions)",
-		checked, len(versionPinExemptions))
+		checked, len(exemptions))
 }
 
 // assertExemptionDefaultsInstalled resolves every overlay with criteria and
@@ -214,7 +212,10 @@ func TestOverlayVersionPinsMatchRegistry(t *testing.T) {
 // "do NOT exempt a component whose only consumer diverges" policy: if the
 // diverging overlay were the sole consumer, the registry default — which the
 // BOM advertises — would be installed by zero recipes.
-func assertExemptionDefaultsInstalled(ctx context.Context, t *testing.T, store *MetadataStore, reg *ComponentRegistry) {
+func assertExemptionDefaultsInstalled(
+	ctx context.Context, t *testing.T, store *MetadataStore, reg *ComponentRegistry, exemptions []versionpins.Exemption,
+) {
+
 	t.Helper()
 
 	// Resolve every overlay carrying criteria once; reuse across exemptions.
@@ -234,8 +235,8 @@ func assertExemptionDefaultsInstalled(ctx context.Context, t *testing.T, store *
 			"policy; verify recipes/overlays/")
 	}
 
-	for _, e := range versionPinExemptions {
-		cfg := reg.Get(e.component)
+	for _, e := range exemptions {
+		cfg := reg.Get(e.Component)
 		if cfg == nil {
 			continue // unknown component is reported elsewhere
 		}
@@ -254,7 +255,7 @@ func assertExemptionDefaultsInstalled(ctx context.Context, t *testing.T, store *
 
 		installed := false
 		for _, r := range results {
-			ref := r.GetComponentRef(e.component)
+			ref := r.GetComponentRef(e.Component)
 			if ref == nil || !ref.IsEnabled() {
 				continue
 			}
@@ -289,11 +290,11 @@ func assertExemptionDefaultsInstalled(ctx context.Context, t *testing.T, store *
 			}
 		}
 		if !installed {
-			t.Errorf("unsafe versionPinExemptions entry for %s/%s: the registry default %q is "+
+			t.Errorf("unsafe exemption entry for %s/%s in recipes/%s: the registry default %q is "+
 				"installed by no resolved recipe, so the BOM advertises a version nothing installs.\n"+
 				"  Either re-align the pin (delete the exemption) or move the registry default to a "+
 				"version some recipe actually runs. See issue #1424.",
-				e.source, e.component, def)
+				e.Source, e.Component, versionpins.FileName, def)
 		}
 	}
 }
@@ -303,37 +304,4 @@ func assertExemptionDefaultsInstalled(ctx context.Context, t *testing.T, store *
 type pinKey struct {
 	source    string
 	component string
-}
-
-// versionPinExemption documents a componentRef whose overlay/mixin version pin
-// is INTENTIONALLY different from the component's registry defaultVersion.
-//
-// Add an entry ONLY when an overlay must legitimately run a different chart
-// version than the registry default (e.g. a platform validated against an
-// older chart). Do NOT exempt a component whose only consumer diverges — that
-// leaves the registry default (and therefore the BOM) advertising a version no
-// recipe installs, the precise failure this guard exists to prevent.
-//
-// expectedPin/expectedDefault bind the exemption to ONE specific divergence:
-// if either the recipe's pin or the registry default later moves, the guard
-// fails so the divergence is re-reviewed and re-justified rather than a new,
-// unvetted version silently inheriting the old blessing.
-type versionPinExemption struct {
-	source          string // overlay/mixin metadata.name that declares the pin
-	component       string // componentRef name
-	expectedPin     string // the exact divergent version/tag this exemption blesses
-	expectedDefault string // the registry default at the time the exemption was written
-	reason          string // why the divergence is intentional (cite an issue/PR)
-}
-
-var versionPinExemptions = []versionPinExemption{
-	{
-		source:          "aks",
-		component:       "kube-prometheus-stack",
-		expectedPin:     "83.7.0",
-		expectedDefault: "84.4.0",
-		reason: "AKS is pinned to chart 83.7.0 to match its validated working cluster " +
-			"state (#700); the registry default (84.4.0) tracks the base/EKS/GKE line and " +
-			"is installed by every non-AKS recipe, so the BOM's default is not fictional.",
-	},
 }

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,6 +1,6 @@
 # Recipe Data Directory
 
-Recipe metadata and component configurations for the AICR bundler. Files in this directory are embedded into the CLI binary and API server at compile time.
+Recipe metadata and component configurations for the AICR bundler. Runtime recipe data is embedded into the CLI binary and API server at compile time — the embed patterns in `data.go` explicitly select what ships (overlays, mixins, the registry, the validator catalog, component values/manifests, and checks). Repository-only files sit deliberately outside those patterns and never ship: `version-pin-exemptions.yaml` (dev/CI version-pin policy) and `evidence/` (published recipe-evidence pointers).
 
 ## Quick Reference
 
@@ -16,6 +16,8 @@ Recipe metadata and component configurations for the AICR bundler. Files in this
 ```
 recipes/
 ├── registry.yaml                  # Component registry (Helm & Kustomize configs)
+├── version-pin-exemptions.yaml    # Blessed overlay/mixin version divergences (NOT embedded; dev/CI only)
+├── evidence/                      # Published recipe-evidence pointers (NOT embedded)
 ├── overlays/                      # Recipe overlays (including base.yaml as root)
 ├── mixins/                        # Composable mixin fragments
 │   ├── os-ubuntu.yaml             # Ubuntu OS constraints

--- a/recipes/version-pin-exemptions.yaml
+++ b/recipes/version-pin-exemptions.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Version-pin exemptions: componentRefs whose overlay/mixin version pin is
+# INTENTIONALLY different from the component's registry defaultVersion.
+#
+# This file is repository-only policy data, deliberately NOT embedded into
+# the aicr binary (see recipes/data.go) and not part of the runtime recipe
+# data model. It is loaded and validated by internal/versionpins and
+# consumed from a repository checkout by dev/CI tooling: the version-pin
+# guard test (pkg/recipe/version_pin_guard_test.go) and, once #1611 wires
+# it, the BOM generator (tools/bom) — which must read this policy and
+# recipes/registry.yaml from the same checkout.
+#
+# Add an entry ONLY when an overlay must legitimately run a different chart
+# version than the registry default (e.g. a platform validated against an
+# older chart). Do NOT exempt a component whose only consumer diverges —
+# that leaves the registry default (and therefore the BOM,
+# docs/user/container-images.md) advertising a version no recipe installs,
+# the precise failure the guard exists to prevent.
+#
+# expectedPin/expectedDefault bind an exemption to ONE specific divergence:
+# if either the recipe's pin or the registry default later moves, the guard
+# fails so the divergence is re-reviewed and re-justified rather than a
+# new, unvetted version silently inheriting the old blessing. reason must
+# explain why the divergence is intentional and cite an issue/PR.
+apiVersion: aicr.run/v1alpha2
+kind: VersionPinExemptions
+exemptions:
+  - source: aks
+    component: kube-prometheus-stack
+    expectedPin: "83.7.0"
+    expectedDefault: "84.4.0"
+    reason: >-
+      AKS is pinned to chart 83.7.0 to match its validated working cluster
+      state (#700); the registry default (84.4.0) tracks the base/EKS/GKE
+      line and is installed by every non-AKS recipe, so the BOM's default
+      is not fictional.


### PR DESCRIPTION
## Summary

Move the version-pin exemption table out of `pkg/recipe/version_pin_guard_test.go` into a declarative, schema-validated file — `recipes/version-pin-exemptions.yaml` — loaded by the new `internal/versionpins` package. No intended behavior change: the guard test enforces the same invariant, from the same single entry (aks/kube-prometheus-stack).

## Motivation / Context

Preparation for #1611 (represent exempted per-overlay version variants in the BOM): `tools/bom` cannot import a Go table defined in a `_test.go` file, and the policy must not be duplicated. A declarative file under `recipes/`, read from repo root, also guarantees `tools/bom -repo-root` reads exemption policy and `recipes/registry.yaml` from the same checkout — a compiled-in table could apply one checkout's policy to another checkout's registry.

Fixes: N/A
Related: #1611

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `internal/versionpins` (new), `pkg/defaults` (new file-size cap constant)

## Implementation Notes

- The loader lives under `internal/` (not `pkg/`) because it is repository-only dev/CI tooling, not public Go API; both the guard test and (with #1611) `tools/bom` can import it within the module.
- `recipes/version-pin-exemptions.yaml` is deliberately NOT added to the `recipes/data.go` embed patterns, so it does not ship in the binary and cannot interact with the runtime data providers or external `--data` merging. `recipes/README.md` documents the exception.
- `versionpins.Load(ctx, path)` fails closed on every defect — missing file (`ErrCodeNotFound` only on `fs.ErrNotExist`), non-regular file (fstat on the opened handle inside the bounded worker, so no stat-to-open race), oversize (`defaults.MaxVersionPinExemptionsBytes`), unknown fields (strict decode), wrong `apiVersion`/`kind` (validated against the canonical `header.GroupVersion`), a second YAML document, an omitted-or-null `exemptions` key (a truncated file must not read as "no exemptions"; an explicit `[]` is required), missing or whitespace-only entry fields, duplicate `(source, component)` keys, and `expectedPin == expectedDefault`. Validation problems are aggregated into one `ErrCodeInvalidRequest` error.
- Open, the fstat type check, and the read all run inside context-bounded workers under `defaults.FileReadTimeout` (tightening any caller deadline) — a FIFO blocking in `open(2)` or a hung network/FUSE mount cannot stall the caller past the deadline. Handle delivery is an unbuffered rendezvous, so the worker always knows whether the caller took the handle and closes it itself on every error/late-completion path — no drainer goroutine. If the underlying syscall never returns, exactly one goroutine (the worker) stays pinned until it does; Go cannot cancel a blocked syscall (the same trade `pkg/serializer.readAllBounded` makes). Helpers classify failures as structured `pkg/errors` codes once, and `Load` propagates them without re-wrapping. Deterministic seam tests drive blocked-open and blocked-fstat with explicit synchronization (async Load, await started, cancel, bounded done check, release) and verify the late handle is closed by requiring fs.ErrClosed. Every fatal exit path releases the blocked worker and then joins the async Load via a t.Cleanup registered before the seam restore (release is idempotent on success and retryable on failure), so no failure can strand a worker or restore seams while a Load is still in flight. A darwin/linux-gated test proves the same against a genuine writer-less FIFO, using explicit post-started cancellation (no deadline race) and a deterministic release that fails the test if the worker would be left pinned.
- The static checks previously inlined in the guard test (duplicates, empty fields, pin == default) moved into the loader so every consumer gets them; the guard-only checks (out-of-date expectations, stale entries, sole-consumer enforcement) stay in the test.
- `tools/bom` is intentionally NOT wired to consume the file in this PR — that is #1611's implementation PR. This PR only makes the shared source available.
- `make bom-docs` regen is not required: no registry entry, chart-version pin, or component values changed.

## Testing

```bash
make qualify
```

- `make qualify` passes end-to-end (test-coverage 78.6% vs 75% threshold, lint 0 issues, tuning-check, e2e "All tests passed", scan "No vulnerabilities found", license-check).
- New package `internal/versionpins`: 90.0% statement coverage (new package, no baseline). Table-driven tests cover valid/empty documents, omitted/null exemptions key, strict-decode rejection, identity (kind/apiVersion) mismatch, multi-document rejection, per-field and whitespace-only validation, duplicates, pin==default, missing file, non-regular file, canceled context, oversize file, and the committed repository file itself.
- `TestOverlayVersionPinsMatchRegistry` passes against the file-based table: 38 pinned componentRefs verified, 1 declared exemption fires with identical semantics to the previous Go table.
- Coverage delta on changed packages: `pkg/recipe` 87.3% → 87.3% (test-only edit); `pkg/defaults` 100% → 100% (constant only).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — dev/CI-time policy only; the file is not embedded in the binary and no runtime path reads it.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
