### PR TITLE
fix(recipe): reject enabled Helm refs lacking a deployable, versioned chart primary

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -248,6 +248,7 @@ slog.Error("operation failed", "error", err, "component", "gpu-collector")
   helm:
     defaultRepository: https://charts.example.com
     defaultChart: example/my-operator
+    defaultVersion: v1.0.0  # required: an unpinned Helm chart fails recipe resolution
   nodeScheduling:
     system:
       nodeSelectorPaths: [operator.nodeSelector]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,7 @@ slog.Error("operation failed", "error", err, "component", "gpu-collector")
   helm:
     defaultRepository: https://charts.example.com
     defaultChart: example/my-operator
+    defaultVersion: v1.0.0  # required: an unpinned Helm chart fails recipe resolution
   nodeScheduling:
     system:
       nodeSelectorPaths: [operator.nodeSelector]

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -1490,8 +1490,15 @@ components:
                   Deployment type; send the canonical value `Helm` or
                   `Kustomize` (the normative contract). A Helm ref must not carry
                   `tag`/`path`; a Kustomize ref requires `path` (and, when it
-                  sets `tag`, a `source`). Incoherent combinations are rejected
-                  with 400. For back-compatibility the server back-fills a
+                  sets `tag`, a `source`). An enabled Helm ref must reference a
+                  deployable primary: either an external chart (a `source`
+                  repository plus an effective `version`; the chart name falls
+                  back to the component name when `chart` is unset, but a
+                  `chart` without a `source` is rejected) or local primary
+                  `manifestFiles` (a manifest-only component; `preManifestFiles`
+                  alone do not qualify). Helm `chart` and `source` values must
+                  not carry surrounding whitespace. Incoherent combinations are
+                  rejected with 400. For back-compatibility the server back-fills a
                   missing type on an enabled ref from the registry when the
                   component is known (a missing type on an unknown component is
                   rejected with 400), and accepts other casings (e.g. `helm`)
@@ -1499,19 +1506,61 @@ components:
                   values above.
               version:
                 type: string
-                description: Chart version (Helm)
+                description: >-
+                  Chart version (Helm). Required for an enabled Helm ref that
+                  references an external chart: an empty, whitespace-only, or
+                  bare `v` value is rejected with 400, as is a value carrying
+                  surrounding whitespace (deployers consume the version
+                  verbatim). Flux and Argo CD strip
+                  a leading `v` for non-OCI outputs (Helm resolves the empty
+                  remainder as "latest"), non-vendored Helm/Helmfile and OCI
+                  outputs preserve it, and vendored wrappers substitute a
+                  fabricated default — a bare `v` is rejected uniformly to
+                  avoid output-dependent chart identities. Not required for
+                  manifest-only Helm components, but when set there the same
+                  whitespace and bare-`v` rules apply (the value lands in the
+                  rendered chart's `helm.sh/chart` label).
               tag:
                 type: string
                 description: Git tag/ref (Kustomize); only meaningful with a source
               source:
                 type: string
-                description: Chart repository URL (Helm) or OCI/Git source reference (Kustomize)
+                description: >-
+                  Chart repository URL (Helm) or OCI/Git source reference
+                  (Kustomize). For Helm refs, values with surrounding
+                  whitespace are rejected with 400 — deployers consume the
+                  field verbatim. (Kustomize sources are not whitespace-
+                  validated today.)
               chart:
                 type: string
-                description: Helm chart name
+                description: >-
+                  Helm chart name; falls back to the component name when unset
+                  on a source-backed ref. Values with surrounding whitespace
+                  are rejected with 400. A chart without a source is rejected
+                  (nothing to pull from).
               path:
                 type: string
                 description: Path within the source to the kustomization (Kustomize)
+              manifestFiles:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Manifest files bundled with a Helm component (paths relative
+                  to the data directory). Without a chart/source they form the
+                  manifest-only primary and exempt the ref from the `version`
+                  requirement; with an external chart they apply AFTER the
+                  primary release. Rejected with 400 on Kustomize refs (a
+                  Kustomize ref wraps a single primary source).
+              preManifestFiles:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Manifest files applied BEFORE the component's primary release
+                  (paths relative to the data directory). Auxiliary only:
+                  pre-manifests alone do not make a ref deployable or exempt it
+                  from the `version` requirement.
               patches:
                 type: array
                 items:

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -158,6 +158,24 @@ implicit `kustomization.yaml` pickup.
 Reference the component from an overlay's `componentRefs:` to include it in
 recipes that match the overlay's criteria.
 
+**Helm components must resolve with an effective chart version.** Declare
+`helm.defaultVersion` in the registry entry, or pin `version:` on every
+`componentRef` that references the component. A Helm `componentRef` that
+resolves without one is rejected at recipe resolution (`INVALID_REQUEST`)
+rather than passed through — several deployers would otherwise emit the empty
+version verbatim and Helm would silently install "latest" at deploy time.
+Whitespace-only versions and a bare `v` count as absent — Flux and Argo CD
+strip a leading `v` for non-OCI outputs (Helm resolves the empty remainder as
+"latest"), non-vendored Helm/Helmfile and OCI outputs preserve it, and
+vendored wrappers substitute a fabricated default; a bare `v` is rejected
+uniformly to avoid output-dependent chart identities. Also,
+`chart`, `source`, and `version` values carrying surrounding whitespace are
+rejected outright, since deployers consume those fields verbatim. Manifest-only Helm components are exempt: a ref
+whose chart and source are both empty and that ships at least one primary
+`manifestFiles` entry has no chart version to pin. `preManifestFiles` alone
+do not qualify — pre-manifests are auxiliary to a primary release, so a ref
+with only pre-manifests is rejected as having no deployable primary.
+
 ## Precedence rules
 
 | Resource | Behavior |

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -443,6 +443,15 @@ These are the recipe **components** in [`recipes/registry.yaml`](https://github.
 > `dependencyRefs`. The filter prunes those edges safely (a filtered-out
 > dependency is assumed satisfied externally) and rejects unknown or disabled
 > component names with HTTP 400.
+>
+> Enabled Helm refs must reference a deployable primary: an external chart
+> (a `source` repository plus an effective `version` — empty, whitespace-only,
+> or a bare `v` is rejected; the chart name falls back to the component name
+> when `chart` is unset, but a `chart` without a `source` is rejected) or
+> local primary `manifestFiles`. `chart`, `source`, and `version` values
+> carrying surrounding whitespace are rejected — deployers consume them
+> verbatim.
+> Incoherent refs are rejected with HTTP 400 naming the component.
 
 ```shell
 # Basic: pipe recipe to bundle

--- a/pkg/bundler/deployer/argocd/argocd.go
+++ b/pkg/bundler/deployer/argocd/argocd.go
@@ -676,10 +676,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 func (g *Generator) toLocalformatComponents(refs []recipe.ComponentRef) []localformat.Component {
 	out := make([]localformat.Component, 0, len(refs))
 	for _, ref := range refs {
-		chart := ref.Chart
-		if chart == "" {
-			chart = ref.Name
-		}
+		chart := ref.EffectiveChart()
 		values := g.ComponentValues[ref.Name]
 		if values == nil {
 			values = make(map[string]any)
@@ -725,10 +722,7 @@ func findComponentRef(refs []recipe.ComponentRef, parent string) *recipe.Compone
 // Argo CD's Git-only $values multi-source ref. Errors from value marshaling
 // surface as ErrCodeInternal.
 func buildApplicationData(comp recipe.ComponentRef, f localformat.Folder, syncWave int, repoURL, targetRevision string, values map[string]any, inline bool) (ApplicationData, error) {
-	chart := comp.Chart
-	if chart == "" {
-		chart = comp.Name
-	}
+	chart := comp.EffectiveChart()
 	data := ApplicationData{
 		Name:           f.Name,
 		Namespace:      comp.Namespace,

--- a/pkg/bundler/deployer/flux/flux.go
+++ b/pkg/bundler/deployer/flux/flux.go
@@ -710,8 +710,10 @@ func buildComponentSummaries(sortedRefs []recipe.ComponentRef, preManifests, man
 		})
 
 		// Mixed components (Helm chart + manifests) produce a post HelmRelease
-		// that depends on the primary.
-		isMixed := ref.Chart != "" && ref.Source != "" && len(manifests[ref.Name]) > 0
+		// that depends on the primary. Chart-or-source matches the generation
+		// predicate (and terminalReleaseNameFor): a source-only ref with
+		// manifests emits a post release the README must list.
+		isMixed := (ref.Chart != "" || ref.Source != "") && len(manifests[ref.Name]) > 0
 		if isMixed {
 			summaries = append(summaries, ComponentSummary{
 				Name:         ref.Name + "-post",

--- a/pkg/bundler/deployer/flux/flux_test.go
+++ b/pkg/bundler/deployer/flux/flux_test.go
@@ -2627,3 +2627,51 @@ func TestGenerate_CustomOCISourceName(t *testing.T) {
 		t.Error("ArtifactGenerator should NOT contain default 'aicr-bundle'")
 	}
 }
+
+// TestGenerate_SourceOnlyRefChartFallsBackToName pins the chart-name
+// fallback: a source-only ref (no explicit chart — a long-standing deployable
+// shape whose chart name the localformat deployer derives from the component
+// name) must emit a HelmRelease whose chart is the component name, not an
+// empty string Flux cannot reconcile.
+func TestGenerate_SourceOnlyRefChartFallsBackToName(t *testing.T) {
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{
+		{
+			Name:      "gpu-operator",
+			Namespace: "gpu-operator",
+			Version:   "v25.3.3",
+			Type:      recipe.ComponentTypeHelm,
+			Source:    "https://helm.ngc.nvidia.com/nvidia",
+		},
+	}
+	recipeResult.DeploymentOrder = []string{"gpu-operator"}
+
+	g := &Generator{
+		RecipeResult: recipeResult,
+		Version:      "v0.9.0",
+		// Post-manifests make this a source-only MIXED component: the
+		// generator emits a <name>-post release, and the README summary must
+		// list it (its isMixed predicate keys on chart-or-source, matching
+		// terminalReleaseNameFor).
+		ComponentManifests: map[string]map[string][]byte{
+			"gpu-operator": {"extra.yaml": []byte("kind: ConfigMap\nmetadata:\n  name: extra\n")},
+		},
+	}
+	if _, err := g.Generate(ctx, outputDir); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	hr := readFile(t, filepath.Join(outputDir, "gpu-operator", "helmrelease.yaml"))
+	if !strings.Contains(hr, "chart: gpu-operator") {
+		t.Errorf("HelmRelease should fall back to the component name for the chart, got:\n%s", hr)
+	}
+
+	readme := readFile(t, filepath.Join(outputDir, "README.md"))
+	if !strings.Contains(readme, "gpu-operator-post") {
+		t.Errorf("README should list the gpu-operator-post release for a source-only mixed component, got:\n%s", readme)
+	}
+}

--- a/pkg/bundler/deployer/flux/helm.go
+++ b/pkg/bundler/deployer/flux/helm.go
@@ -166,11 +166,16 @@ func (g *Generator) generateHelmComponent(ref recipe.ComponentRef, compDir strin
 		version = deployer.NormalizeVersion(version)
 	}
 
+	// Parity with localformat's renderInputFor: the chart name falls back
+	// to the component name so a source-only ref (a long-standing deployable
+	// shape) does not emit a HelmRelease with an empty chart reference.
+	chart := ref.EffectiveChart()
+
 	data := HelmReleaseData{
 		Name:            ref.Name,
 		Namespace:       g.resolveNamespace(),
 		TargetNamespace: ref.Namespace,
-		Chart:           ref.Chart,
+		Chart:           chart,
 		Version:         version,
 		SourceKind:      "HelmRepository",
 		SourceName:      sName,
@@ -327,10 +332,7 @@ func (g *Generator) generateVendoredHelmComponent(ctx context.Context, ref recip
 	puller localformat.ChartPuller,
 	output *deployer.Output) (bool, localformat.VendorRecord, []string, error) {
 
-	chartName := ref.Chart
-	if chartName == "" {
-		chartName = ref.Name
-	}
+	chartName := ref.EffectiveChart()
 
 	// Build localformat.Component for the puller.
 	lfc := localformat.Component{

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -268,10 +268,7 @@ func (g *Generator) buildComponentDataList() ([]ComponentData, error) {
 				fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", ref.Name))
 		}
 
-		chartName := ref.Chart
-		if chartName == "" {
-			chartName = ref.Name
-		}
+		chartName := ref.EffectiveChart()
 
 		components = append(components, ComponentData{
 			Name:       ref.Name,

--- a/pkg/bundler/deployer/helmfile/helmfile.go
+++ b/pkg/bundler/deployer/helmfile/helmfile.go
@@ -336,10 +336,7 @@ func toLocalformatComponents(
 	out := make([]localformat.Component, 0, len(refs))
 	ns := make(map[string]string, len(refs))
 	for _, ref := range refs {
-		chartName := ref.Chart
-		if chartName == "" {
-			chartName = ref.Name
-		}
+		chartName := ref.EffectiveChart()
 		out = append(out, localformat.Component{
 			Name:         ref.Name,
 			Namespace:    ref.Namespace,

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -827,12 +827,21 @@ func facadeResultFromInternal(r *recipe.RecipeResult, name string) *RecipeResult
 		internal:     r,
 	}
 	for _, c := range r.ComponentRefs {
+		// Project the chart the component actually deploys: a source-only
+		// Helm ref falls back to the component name (the deployers'
+		// EffectiveChart rule), so SDK consumers never see an empty chart
+		// for a deployable external chart. Manifest-only Helm refs and
+		// Kustomize refs stay chartless.
+		chart := c.Chart
+		if c.HasExternalChart() {
+			chart = c.EffectiveChart()
+		}
 		out.Components = append(out.Components, ComponentRef{
 			Name:      c.Name,
 			Kind:      string(c.Type),
 			Version:   c.Version,
 			Source:    c.Source,
-			Chart:     c.Chart,
+			Chart:     chart,
 			Namespace: c.Namespace,
 		})
 	}

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -829,7 +829,7 @@ func TestAdoptRecipe_DeepCopiesForClientIsolation(t *testing.T) {
 		APIVersion: recipe.RecipeAPIVersion,
 		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 		ComponentRefs: []recipe.ComponentRef{
-			{Name: "c1", Type: recipe.ComponentTypeHelm},
+			{Name: "c1", Type: recipe.ComponentTypeHelm, Source: "https://charts.example.com", Chart: "c1", Version: "1.0.0"},
 		},
 	}
 	if input.DataProvider() != nil {
@@ -1094,7 +1094,7 @@ func TestAdoptRecipe_RejectsIncoherentRef(t *testing.T) {
 	// Coherent, lowercase type (OpenAPI wire form) -> accepted AND canonicalized
 	// so downstream deployers see the canonical constant.
 	res, err := client.adoptRecipe(t.Context(), base([]recipe.ComponentRef{
-		{Name: "gpu-operator", Type: recipe.ComponentType("helm"), Version: "v1"},
+		{Name: "gpu-operator", Type: recipe.ComponentType("helm"), Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1"},
 	}))
 	if err != nil {
 		t.Fatalf("adoptRecipe rejected a coherent lowercase-typed ref: %v", err)
@@ -1107,7 +1107,7 @@ func TestAdoptRecipe_RejectsIncoherentRef(t *testing.T) {
 	// deployers derive the type from fields) must be back-filled from the
 	// registry, not rejected.
 	res2, err := client.adoptRecipe(t.Context(), base([]recipe.ComponentRef{
-		{Name: "gpu-operator", Version: "v1"},
+		{Name: "gpu-operator", Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1"},
 	}))
 	if err != nil {
 		t.Fatalf("adoptRecipe rejected a type-less registry ref instead of back-filling: %v", err)
@@ -1213,5 +1213,140 @@ func TestClient_CloseDrainsInflightAdopt(t *testing.T) {
 	case <-closeDone:
 	case <-time.After(10 * time.Second):
 		t.Fatal("Close did not complete within 10s after adopt drained")
+	}
+}
+
+// TestAdoptRecipe_RejectsVersionlessHelmRef pins the #1615 invariant at the
+// CLIENT boundary (not just recipe.PrepareAndValidate, which adoptRecipe
+// delegates to): an externally-supplied RecipeResult whose enabled Helm ref
+// references a chart source without a version must be rejected by
+// adoptRecipe with ErrCodeInvalidRequest naming the component.
+func TestAdoptRecipe_RejectsVersionlessHelmRef(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(WithRecipeSource(EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	input := &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeAPIVersion,
+		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:   "versionless-helm",
+				Type:   recipe.ComponentTypeHelm,
+				Source: "https://charts.example.com",
+				Chart:  "versionless-helm",
+			},
+		},
+	}
+	_, err = client.adoptRecipe(t.Context(), input)
+	if err == nil {
+		t.Fatal("adoptRecipe accepted an enabled Helm ref without a chart version")
+	}
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error code = %v, want %v", err, aicrerrors.ErrCodeInvalidRequest)
+	}
+	for _, want := range []string{"versionless-helm", "chart version"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+
+	// The exported facade must reject with the identical shape.
+	_, err = client.AdoptRecipe(t.Context(), input)
+	if err == nil {
+		t.Fatal("AdoptRecipe accepted an enabled Helm ref without a chart version")
+	}
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("AdoptRecipe error code = %v, want %v", err, aicrerrors.ErrCodeInvalidRequest)
+	}
+	for _, want := range []string{"versionless-helm", "chart version"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("AdoptRecipe error %q does not contain %q", err.Error(), want)
+		}
+	}
+
+	// Whitespace-only versions are equally rejected at this boundary (Helm
+	// trims the argument and installs latest).
+	wsInput := &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeAPIVersion,
+		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "versionless-helm",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "https://charts.example.com",
+				Chart:   "versionless-helm",
+				Version: "   ",
+			},
+		},
+	}
+	if _, err := client.adoptRecipe(t.Context(), wsInput); err == nil ||
+		!stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+
+		t.Errorf("adoptRecipe(whitespace version) error = %v, want %v", err, aicrerrors.ErrCodeInvalidRequest)
+	}
+}
+
+// TestFacadeResultFromInternal_ChartProjection pins the facade's chart
+// projection against the deployers' EffectiveChart rule (and the facade
+// ComponentRef.Chart contract in types.go): a source-only Helm ref exposes
+// the component-name fallback the deployers actually install, while
+// manifest-only Helm refs and Kustomize refs stay chartless.
+func TestFacadeResultFromInternal_ChartProjection(t *testing.T) {
+	t.Parallel()
+
+	internal := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "explicit-chart",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "https://charts.example.com",
+				Chart:   "the-chart",
+				Version: "1.0.0",
+			},
+			{
+				Name:    "source-only",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "https://charts.example.com",
+				Version: "1.0.0",
+			},
+			{
+				Name:          "manifest-only",
+				Type:          recipe.ComponentTypeHelm,
+				ManifestFiles: []string{"components/manifest-only/manifests/a.yaml"},
+			},
+			{
+				Name: "kustomize-comp",
+				Type: recipe.ComponentTypeKustomize,
+				Path: "deploy",
+			},
+		},
+	}
+
+	out := facadeResultFromInternal(internal, "test")
+	if len(out.Components) != len(internal.ComponentRefs) {
+		t.Fatalf("components = %d, want %d", len(out.Components), len(internal.ComponentRefs))
+	}
+	wantCharts := map[string]string{
+		"explicit-chart": "the-chart",
+		"source-only":    "source-only", // EffectiveChart fallback, not ""
+		"manifest-only":  "",
+		"kustomize-comp": "",
+	}
+	for _, comp := range out.Components {
+		want, ok := wantCharts[comp.Name]
+		if !ok {
+			t.Errorf("unexpected component %q", comp.Name)
+			continue
+		}
+		if comp.Chart != want {
+			t.Errorf("component %q Chart = %q, want %q", comp.Name, comp.Chart, want)
+		}
 	}
 }

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -661,6 +661,7 @@ spec:
       type: Helm
       source: https://example.com/facade-test
       chart: facade-marker-` + marker + `
+      version: "1.0.0"
 `
 	}
 

--- a/pkg/evidence/attestation/bom.go
+++ b/pkg/evidence/attestation/bom.go
@@ -86,12 +86,21 @@ func BuildAutoBOM(rec *recipe.RecipeResult, snap *snapshotter.Snapshot, cat *cat
 		if c.Type == recipe.ComponentTypeKustomize {
 			pin = c.Tag
 		}
+		// Record the chart the component actually deploys: a source-only
+		// Helm ref falls back to the component name (EffectiveChart, the
+		// deployers' rule), so the digest-bound evidence identifies the
+		// deployed chart instead of omitting aicr:helm:chart. Manifest-only
+		// Helm refs and Kustomize refs stay chartless.
+		chart := c.Chart
+		if c.HasExternalChart() {
+			chart = c.EffectiveChart()
+		}
 		results = append(results, bom.ComponentResult{
 			Name:        c.Name,
 			DisplayName: c.Name,
 			Type:        string(c.Type),
 			Repository:  c.Source,
-			Chart:       c.Chart,
+			Chart:       chart,
 			Version:     pin,
 			Namespace:   c.Namespace,
 			Pinned:      pin != "",

--- a/pkg/evidence/attestation/bom_test.go
+++ b/pkg/evidence/attestation/bom_test.go
@@ -336,3 +336,65 @@ func TestBuildAutoBOM_IncludesRecipeAndValidatorComponents(t *testing.T) {
 		t.Errorf("disabled component must not appear in auto BOM")
 	}
 }
+
+// TestBuildAutoBOM_SourceOnlyRefRecordsEffectiveChart pins the auto-BOM chart
+// projection: a source-only Helm ref deploys the component-name chart (the
+// deployers' EffectiveChart fallback), so the digest-bound evidence must
+// carry aicr:helm:chart for it rather than omitting the property. A
+// manifest-only Helm ref deploys no external chart and stays chartless.
+func TestBuildAutoBOM_SourceOnlyRefRecordsEffectiveChart(t *testing.T) {
+	rec := &recipe.RecipeResult{
+		Criteria: &recipe.Criteria{
+			Service:     recipe.CriteriaServiceEKS,
+			Accelerator: recipe.CriteriaAcceleratorH100,
+		},
+		ComponentRefs: []recipe.ComponentRef{
+			{Name: "source-only", Type: recipe.ComponentTypeHelm, Source: "https://charts.example.com", Version: "1.0.0"},
+			{Name: "manifest-only", Type: recipe.ComponentTypeHelm, ManifestFiles: []string{"components/manifest-only/manifests/a.yaml"}},
+		},
+	}
+
+	body, err := BuildAutoBOM(rec, nil, nil, "v0.1.0")
+	if err != nil {
+		t.Fatalf("BuildAutoBOM: %v", err)
+	}
+
+	doc := &cdx.BOM{}
+	if err := json.Unmarshal(body, doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc.Components == nil {
+		t.Fatal("BOM has no components")
+	}
+
+	chartProp := func(c cdx.Component) (string, bool) {
+		if c.Properties == nil {
+			return "", false
+		}
+		for _, p := range *c.Properties {
+			if p.Name == "aicr:helm:chart" {
+				return p.Value, true
+			}
+		}
+		return "", false
+	}
+
+	var sawSourceOnly, sawManifestOnly bool
+	for _, c := range *doc.Components {
+		switch c.Name {
+		case "source-only":
+			sawSourceOnly = true
+			if got, ok := chartProp(c); !ok || got != "source-only" {
+				t.Errorf("source-only aicr:helm:chart = (%q, %v), want the component-name fallback", got, ok)
+			}
+		case "manifest-only":
+			sawManifestOnly = true
+			if got, ok := chartProp(c); ok {
+				t.Errorf("manifest-only aicr:helm:chart = %q, want absent (no external chart deploys)", got)
+			}
+		}
+	}
+	if !sawSourceOnly || !sawManifestOnly {
+		t.Fatalf("components missing from auto BOM: source-only=%v manifest-only=%v", sawSourceOnly, sawManifestOnly)
+	}
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -263,7 +263,7 @@ func computeCombo(entry recipe.CatalogEntry, result *recipe.RecipeResult, err er
 // Manifest-only "Helm" components (typed Helm but carrying local manifestFiles
 // with no external chart/source — e.g. nodewright-customizations) are also
 // skipped: there is no external chart version to pin, so grading them against
-// the pin requirement is a false positive. See isManifestOnlyHelm.
+// the pin requirement is a false positive. See recipe.ComponentRef.IsManifestOnlyHelm.
 //
 // A recipe with no enabled Helm components (e.g. pure-Kustomize) scores a
 // vacuous pass with an explanatory detail, since Kustomize defaultTag pinning
@@ -287,12 +287,27 @@ func classifyChartPinned(result *recipe.RecipeResult) (state, detail string) {
 		// Manifest-only "Helm" components (e.g. nodewright-customizations) are
 		// typed Helm but ship local manifestFiles with no external chart, so
 		// they have no chart version to pin. Skip them — exactly like disabled
-		// components — rather than flag a non-existent pin as unpinned.
-		if isManifestOnlyHelm(ref) {
+		// components — rather than flag a non-existent pin as unpinned. But a
+		// version they DO set still ships raw into the rendered chart's
+		// .Chart.Version / helm.sh/chart label, so a MALFORMED one (bare "v",
+		// padded) is graded before the exemption applies — matching the
+		// coherence check, which rejects those shapes outright (the classifier
+		// grades directly-constructed results as defense-in-depth).
+		if ref.IsManifestOnlyHelm() {
+			if ref.Version != "" && !isEffectiveRawVersion(ref.Version) {
+				helmCount++
+				unpinned = append(unpinned, ref.Name)
+			}
 			continue
 		}
 		helmCount++
-		if ref.Version == "" {
+		// Shared rule with the coherence check (recipe.IsEffectiveChartVersion):
+		// whitespace-only and bare-"v" versions do not pin what deploys. A
+		// PADDED version is equally unpinned — the deployers consume the
+		// field raw (a broken semver in Flux, an invalid helm.sh/chart
+		// label for manifest-rendered charts), so the trimmed value that
+		// grades here is not the value that ships.
+		if !isEffectiveRawVersion(ref.Version) {
 			unpinned = append(unpinned, ref.Name)
 		}
 	}
@@ -305,6 +320,15 @@ func classifyChartPinned(result *recipe.RecipeResult) (state, detail string) {
 		return StatusPass, "no enabled Helm components; chart-version pinning not applicable (Kustomize tag pinning is out of scope)"
 	}
 	return StatusPass, ""
+}
+
+// isEffectiveRawVersion reports whether version pins what actually deploys:
+// effective after the deployers' normalization (recipe.IsEffectiveChartVersion)
+// AND free of surrounding whitespace — the deployers consume the field raw, so
+// a padded value that grades clean when trimmed is not the value that ships.
+func isEffectiveRawVersion(version string) bool {
+	return recipe.IsEffectiveChartVersion(version) &&
+		version == strings.TrimSpace(version)
 }
 
 // classifyConstraintsWellformed grades the constraints_wellformed dimension
@@ -366,18 +390,6 @@ func classifyConstraintsWellformed(result *recipe.RecipeResult) (state, detail s
 	}
 
 	return StatusPass, ""
-}
-
-// isManifestOnlyHelm reports whether a Helm-typed ComponentRef is a
-// manifest-only component: it references no external chart (empty Chart and
-// Source) but ships local manifest files. Such a component has no chart
-// version to pin, so chart_pinned must not grade it. This mirrors the
-// manifest-only detection in the bundler's deployers (ref.Chart == "" &&
-// ref.Source == "" with manifests present), keeping the health signal aligned
-// with what is actually bundled and deployed.
-func isManifestOnlyHelm(ref recipe.ComponentRef) bool {
-	return ref.Chart == "" && ref.Source == "" &&
-		(len(ref.ManifestFiles) > 0 || len(ref.PreManifestFiles) > 0)
 }
 
 // computeCoverage builds the declared_coverage descriptor from the resolved

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -178,6 +178,104 @@ func TestClassifyChartPinned(t *testing.T) {
 			result(manifestOnly("nodewright-customizations")),
 			StatusPass, "not applicable",
 		},
+		{
+			// Whitespace-only trims to empty in Helm — counted as unpinned.
+			"whitespace-only version fails",
+			result(helm("ws", "   ")),
+			StatusFail, "ws",
+		},
+		{
+			// A PADDED version is unpinned: deployers consume the field raw,
+			// so the trimmed value graded here is not the value that ships.
+			"padded version fails",
+			result(helm("padded", " 1.0.0 ")),
+			StatusFail, "padded",
+		},
+		{
+			// A literal "v" normalizes to empty in the Flux generator
+			// (deployer.NormalizeVersion) — counted as unpinned.
+			"literal v version fails",
+			result(helm("v-only", "v")),
+			StatusFail, "v-only",
+		},
+		{
+			// A bare "v" counts as unpinned on OCI sources too: vendored
+			// wrappers normalize it to a fabricated default, so the pin is
+			// not what deploys.
+			"oci bare v tag fails",
+			result(recipe.ComponentRef{
+				Name: "oci-comp", Type: recipe.ComponentTypeHelm,
+				Source: "oci://registry.example.com/charts", Version: "v",
+			}),
+			StatusFail, "oci-comp",
+		},
+		{
+			// v-prefixed full versions are pinned on any source.
+			"oci v-prefixed version passes",
+			result(recipe.ComponentRef{
+				Name: "oci-comp", Type: recipe.ComponentTypeHelm,
+				Source: "oci://registry.example.com/charts", Version: "v1.2.3",
+			}),
+			StatusPass, "",
+		},
+		{
+			// Pre-manifests are auxiliary to a primary release: a pre-only ref
+			// does NOT qualify for the manifest-only exemption (it cannot be
+			// built by the resolver since #1615, but the classifier grades
+			// directly-constructed results as defense-in-depth).
+			"pre-manifest-only helm counted as unpinned",
+			result(recipe.ComponentRef{
+				Name: "pre-only", Type: recipe.ComponentTypeHelm,
+				PreManifestFiles: []string{"components/pre-only/manifests/ns.yaml"},
+			}),
+			StatusFail, "pre-only",
+		},
+		{
+			// Primary manifests qualify even when pre-manifests ride along.
+			"manifest-only with pre-manifests keeps exemption",
+			result(recipe.ComponentRef{
+				Name: "nodewright-customizations", Type: recipe.ComponentTypeHelm,
+				ManifestFiles:    []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+				PreManifestFiles: []string{"components/nodewright-customizations/manifests/ns.yaml"},
+			}),
+			StatusPass, "not applicable",
+		},
+		{
+			// The exemption covers the ABSENT version, not a malformed one:
+			// a version the ref does set ships raw into the rendered chart's
+			// .Chart.Version / helm.sh/chart label, so a padded value is
+			// graded before the manifest-only skip (coherence rejects the
+			// shape; the classifier is defense-in-depth).
+			"manifest-only with padded version fails",
+			result(recipe.ComponentRef{
+				Name: "nodewright-customizations", Type: recipe.ComponentTypeHelm,
+				Version:       " 1.0.0 ",
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}),
+			StatusFail, "nodewright-customizations",
+		},
+		{
+			// A bare "v" on a manifest-only ref is fabricated into "0.1.0"
+			// by NormalizeVersionWithDefault — malformed, not exempt.
+			"manifest-only with bare v version fails",
+			result(recipe.ComponentRef{
+				Name: "nodewright-customizations", Type: recipe.ComponentTypeHelm,
+				Version:       "v",
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}),
+			StatusFail, "nodewright-customizations",
+		},
+		{
+			// A WELL-FORMED set version keeps the exemption: there is no
+			// external chart to pin, and the value ships cleanly.
+			"manifest-only with valid version keeps exemption",
+			result(recipe.ComponentRef{
+				Name: "nodewright-customizations", Type: recipe.ComponentTypeHelm,
+				Version:       "1.0.0",
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}),
+			StatusPass, "not applicable",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -542,8 +640,12 @@ components:
 // TestComputeChartPinnedFailThroughBuilder drives a chart_pinned fail through
 // the real builder: a leaf with a Helm component whose registry entry declares
 // no default chart version, so the resolved ComponentRef carries an empty
-// Version. The recipe resolves cleanly (resolves=pass) but chart_pinned must
-// fail, dragging the rolled-up status to fail.
+// Version. Since #1615, resolution itself fails closed on such a ref
+// (ValidateCoherence rejects a chart-referencing Helm ref without a version),
+// so the combo fails at resolves — the unpinned chart can never reach a
+// deployer. The chart_pinned dimension no longer sees this case through the
+// builder; it remains as defense-in-depth for directly-constructed
+// RecipeResults (covered by TestClassifyChartPinned).
 func TestComputeChartPinnedFailThroughBuilder(t *testing.T) {
 	provider := newInMemoryProvider(map[string][]byte{
 		"overlays/base.yaml": []byte(`kind: RecipeMetadata
@@ -588,21 +690,33 @@ components:
 	if combo == nil {
 		t.Fatalf("unpinned-leaf was not enumerated; combos = %+v", report.Combos)
 	}
-	if got := combo.Structure.Dimensions[DimResolves]; got != StatusPass {
-		t.Errorf("resolves = %q, want %q (recipe should resolve cleanly)", got, StatusPass)
-	}
-	if got := combo.Structure.Dimensions[DimChartPinned]; got != StatusFail {
-		t.Errorf("chart_pinned = %q, want %q (unpinned Helm chart)", got, StatusFail)
+	if got := combo.Structure.Dimensions[DimResolves]; got != StatusFail {
+		t.Errorf("resolves = %q, want %q (an unpinned chart-referencing Helm ref must fail resolution, #1615)",
+			got, StatusFail)
 	}
 	if combo.Structure.Status != StatusFail {
 		t.Errorf("status = %q, want %q", combo.Structure.Status, StatusFail)
 	}
-	if d := combo.Structure.Detail[DimChartPinned]; !strings.Contains(d, "unpinned-helm") {
-		t.Errorf("detail = %q, want it to name the unpinned component", d)
+	d := combo.Structure.Detail[DimResolves]
+	if !strings.Contains(d, "unpinned-helm") || !strings.Contains(d, "chart version") {
+		t.Errorf("detail = %q, want it to name the unpinned component and the missing chart version", d)
 	}
-	// The recipe resolved, so the descriptor must be populated (non-nil).
-	if combo.Structure.Coverage == nil {
-		t.Error("Coverage = nil, want non-nil on a resolved recipe")
+	// No RecipeResult survives a failed resolve, so the descriptor is omitted
+	// and no graded dimension beyond resolves is emitted — chart_pinned must
+	// be absent, not a misleading pass/fail.
+	if combo.Structure.Coverage != nil {
+		t.Errorf("Coverage = %+v, want nil on a failed resolve", *combo.Structure.Coverage)
+	}
+	if got, present := combo.Structure.Dimensions[DimChartPinned]; present {
+		t.Errorf("chart_pinned = %q, want absent on a failed resolve", got)
+	}
+	if got, present := combo.Structure.Dimensions[DimConstraintsWellformed]; present {
+		t.Errorf("constraints_wellformed = %q, want absent on a failed resolve", got)
+	}
+	for _, dim := range []string{DimChartPinned, DimConstraintsWellformed} {
+		if d, present := combo.Structure.Detail[dim]; present {
+			t.Errorf("Detail[%s] = %q, want absent on a failed resolve", dim, d)
+		}
 	}
 }
 

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -131,8 +131,12 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 
 			var allImages []string
 
-			// Helm components: render chart and extract images.
-			if compRef.Type == recipe.ComponentTypeHelm {
+			// Helm components with an external chart: render it and extract
+			// images. Manifest-only refs (neither chart nor source) have no
+			// chart to render — their images come from the manifest scan
+			// below, so invoking Helm with a fabricated chart name would only
+			// produce a spurious warning.
+			if compRef.Type == recipe.ComponentTypeHelm && compRef.HasExternalChart() {
 				values, valErr := rec.GetValuesForComponentWithContext(gctx, compRef.Name)
 				if valErr != nil {
 					slog.Warn("failed to load values for component",
@@ -148,9 +152,12 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 					}
 					applyValueOverrides(values, keyOverrides)
 
+					// Source-only refs omit the chart name; EffectiveChart
+					// applies the same component-name fallback the deployers
+					// use, so the mirror inventory matches what deploys.
 					rendered, renderErr := l.helmRenderer.Render(gctx, helm.ChartInput{
 						Name:        compRef.Name,
-						Chart:       compRef.Chart,
+						Chart:       compRef.EffectiveChart(),
 						Repository:  compRef.Source,
 						Version:     compRef.Version,
 						Namespace:   compRef.Namespace,
@@ -200,13 +207,16 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 			slices.Sort(allImages)
 			ci.Images = slices.Compact(allImages)
 
-			// Build ChartRef for Helm components.
+			// Build ChartRef for Helm components. A source-only ref has an
+			// external chart whose name falls back to the component name
+			// (matching the deployers); a ref with neither chart nor source
+			// is manifest-only and has no chart to mirror.
 			var chartRef *ChartRef
-			if compRef.Type == recipe.ComponentTypeHelm && compRef.Chart != "" {
+			if compRef.Type == recipe.ComponentTypeHelm && compRef.HasExternalChart() {
 				chartRef = &ChartRef{
 					Name:       compRef.Name,
 					Repository: compRef.Source,
-					Chart:      compRef.Chart,
+					Chart:      compRef.EffectiveChart(),
 					Version:    compRef.Version,
 					Namespace:  compRef.Namespace,
 				}

--- a/pkg/mirror/discover_test.go
+++ b/pkg/mirror/discover_test.go
@@ -91,6 +91,42 @@ spec:
 			wantComps:  1,
 		},
 		{
+			// A source-only ref (no explicit chart) is a deployable shape
+			// whose chart name falls back to the component name in the
+			// deployers; the mirror inventory must apply the same fallback
+			// rather than silently omitting the chart and its images.
+			name: "source-only helm ref falls back to component name",
+			rec: &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:    "gpu-operator",
+						Type:    recipe.ComponentTypeHelm,
+						Source:  "https://helm.ngc.nvidia.com/nvidia",
+						Version: "v25.3.0",
+					},
+				},
+			},
+			helmRenderer: &helmtest.MockRenderer{
+				Rendered: map[string][]byte{
+					"gpu-operator": []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: gpu-operator
+        image: nvcr.io/nvidia/gpu-operator:v25.3.0
+`),
+				},
+			},
+			wantImages: 1,
+			wantCharts: 1,
+			wantComps:  1,
+		},
+		{
 			name: "helm render failure produces warning",
 			rec: &recipe.RecipeResult{
 				ComponentRefs: []recipe.ComponentRef{
@@ -474,5 +510,50 @@ func TestDiscover_NilDataProviderFallsBackToEmbedded(t *testing.T) {
 		if c.Component == "network-operator" && len(c.Warnings) > 0 {
 			t.Errorf("unexpected warnings reading embedded manifest: %v", c.Warnings)
 		}
+	}
+}
+
+// TestDiscover_SourceOnlyFallbackShape pins the source-only fallback
+// precisely: the renderer must receive the component name as the chart, the
+// resulting ChartRef must carry the fallback name, and a manifest-only ref
+// must not invoke the renderer at all (its images come from the manifest
+// scan; a fabricated chart render would only produce a spurious warning).
+func TestDiscover_SourceOnlyFallbackShape(t *testing.T) {
+	renderer := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{"gpu-operator": []byte("kind: ConfigMap\n")},
+	}
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "gpu-operator",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "https://helm.ngc.nvidia.com/nvidia",
+				Version: "v25.3.0",
+			},
+			{
+				Name:          "nodewright-customizations",
+				Type:          recipe.ComponentTypeHelm,
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			},
+		},
+	}
+
+	lister := NewLister(WithHelmRenderer(renderer))
+	list, err := lister.Discover(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	if len(renderer.Inputs) != 1 {
+		t.Fatalf("renderer calls = %d, want 1 (manifest-only refs must not render)", len(renderer.Inputs))
+	}
+	if got := renderer.Inputs[0].Chart; got != "gpu-operator" {
+		t.Errorf("renderer ChartInput.Chart = %q, want fallback to component name %q", got, "gpu-operator")
+	}
+	if len(list.Charts) != 1 {
+		t.Fatalf("charts = %d, want 1 (source-only mirrored, manifest-only chartless)", len(list.Charts))
+	}
+	if got := list.Charts[0].Chart; got != "gpu-operator" {
+		t.Errorf("ChartRef.Chart = %q, want fallback %q", got, "gpu-operator")
 	}
 }

--- a/pkg/recipe/componentref_coherence_test.go
+++ b/pkg/recipe/componentref_coherence_test.go
@@ -36,12 +36,12 @@ func TestComponentRefCoherenceProblem(t *testing.T) {
 		},
 		{
 			name:    "helm carries kustomize tag",
-			ref:     ComponentRef{Name: "a", Type: ComponentTypeHelm, Version: "v1", Tag: "v2"},
+			ref:     ComponentRef{Name: "a", Type: ComponentTypeHelm, Source: "https://charts", Chart: "a", Version: "v1", Tag: "v2"},
 			wantBad: true,
 		},
 		{
 			name:    "helm carries kustomize path",
-			ref:     ComponentRef{Name: "a", Type: ComponentTypeHelm, Version: "v1", Path: "deploy"},
+			ref:     ComponentRef{Name: "a", Type: ComponentTypeHelm, Source: "https://charts", Chart: "a", Version: "v1", Path: "deploy"},
 			wantBad: true,
 		},
 		{
@@ -86,7 +86,7 @@ func TestComponentRefCoherenceProblem(t *testing.T) {
 			// recipes / older clients); the canonical form is Helm. It must be
 			// accepted case-insensitively, not rejected as an unsupported type.
 			name: "lowercase helm is accepted",
-			ref:  ComponentRef{Name: "a", Type: ComponentType("helm"), Version: "v1"},
+			ref:  ComponentRef{Name: "a", Type: ComponentType("helm"), Source: "https://charts", Chart: "a", Version: "v1"},
 		},
 		{
 			name: "lowercase kustomize is accepted",
@@ -96,14 +96,14 @@ func TestComponentRefCoherenceProblem(t *testing.T) {
 			// Case-insensitivity does not weaken the rules: a lowercase Helm ref
 			// still may not carry Kustomize fields.
 			name:    "lowercase helm still rejects tag",
-			ref:     ComponentRef{Name: "a", Type: ComponentType("helm"), Version: "v1", Tag: "v2"},
+			ref:     ComponentRef{Name: "a", Type: ComponentType("helm"), Source: "https://charts", Chart: "a", Version: "v1", Tag: "v2"},
 			wantBad: true,
 		},
 		{
 			// Patches are carried through resolution but applied by no deployer;
 			// a ref that declares them is rejected rather than silently dropped.
 			name:    "helm with patches rejected",
-			ref:     ComponentRef{Name: "a", Type: ComponentTypeHelm, Version: "v1", Patches: []string{"p.yaml"}},
+			ref:     ComponentRef{Name: "a", Type: ComponentTypeHelm, Source: "https://charts", Chart: "a", Version: "v1", Patches: []string{"p.yaml"}},
 			wantBad: true,
 		},
 		{
@@ -125,7 +125,7 @@ func TestComponentRefCoherenceProblem(t *testing.T) {
 func TestRecipeResultValidateCoherence(t *testing.T) {
 	// Coherent set → no error.
 	ok := &RecipeResult{ComponentRefs: []ComponentRef{
-		{Name: "h", Type: ComponentTypeHelm, Version: "v1"},
+		{Name: "h", Type: ComponentTypeHelm, Source: "https://charts", Chart: "h", Version: "v1"},
 		{Name: "k", Type: ComponentTypeKustomize, Path: "deploy"},
 	}}
 	if err := ok.ValidateCoherence(); err != nil {
@@ -134,7 +134,7 @@ func TestRecipeResultValidateCoherence(t *testing.T) {
 
 	// Two incoherent refs → single ErrCodeInvalidRequest naming both.
 	bad := &RecipeResult{ComponentRefs: []ComponentRef{
-		{Name: "h", Type: ComponentTypeHelm, Tag: "v2"},
+		{Name: "h", Type: ComponentTypeHelm, Source: "https://charts", Chart: "h", Version: "v1", Tag: "v2"},
 		{Name: "k", Type: ComponentTypeKustomize, Source: "git://x", Tag: "v1"}, // no path
 	}}
 	err := bad.ValidateCoherence()
@@ -184,7 +184,7 @@ func TestPrepareAndValidate_PropagatesRegistryError(t *testing.T) {
 	// non-retryable "unsupported type" rejection.
 	r := &RecipeResult{
 		provider:      failingRegistryProvider{},
-		ComponentRefs: []ComponentRef{{Name: "gpu-operator", Version: "v1"}}, // type-less
+		ComponentRefs: []ComponentRef{{Name: "gpu-operator", Source: "https://charts", Chart: "gpu-operator", Version: "v1"}}, // type-less
 	}
 	err := r.PrepareAndValidate()
 	if err == nil {
@@ -202,7 +202,7 @@ func TestPrepareAndValidate_PropagatesRegistryError(t *testing.T) {
 	// provider does not cause an error.
 	ok := &RecipeResult{
 		provider:      failingRegistryProvider{},
-		ComponentRefs: []ComponentRef{{Name: "gpu-operator", Type: ComponentTypeHelm, Version: "v1"}},
+		ComponentRefs: []ComponentRef{{Name: "gpu-operator", Type: ComponentTypeHelm, Source: "https://charts", Chart: "gpu-operator", Version: "v1"}},
 	}
 	if err := ok.PrepareAndValidate(); err != nil {
 		t.Errorf("no back-fill needed, but got error (registry should not be read): %v", err)
@@ -214,7 +214,7 @@ func TestPrepareAndValidate_PropagatesRegistryError(t *testing.T) {
 	disabledStub := &RecipeResult{
 		provider: failingRegistryProvider{},
 		ComponentRefs: []ComponentRef{
-			{Name: "enabled-helm", Type: ComponentTypeHelm, Version: "v1"},
+			{Name: "enabled-helm", Type: ComponentTypeHelm, Source: "https://charts", Chart: "enabled-helm", Version: "v1"},
 			{Name: "legacy-stub", Overrides: map[string]any{"enabled": false}}, // type-less + disabled
 		},
 	}
@@ -232,8 +232,8 @@ func TestPrepareAndValidate_BackfillLoopSkipsDisabled(t *testing.T) {
 	r := &RecipeResult{
 		provider: dp,
 		ComponentRefs: []ComponentRef{
-			{Name: "gpu-operator", Version: "v1"},                                   // enabled + type-less -> back-filled
-			{Name: "network-operator", Overrides: map[string]any{"enabled": false}}, // disabled + type-less registry component -> loop must skip
+			{Name: "gpu-operator", Source: "https://charts", Chart: "gpu-operator", Version: "v1"}, // enabled + type-less -> back-filled
+			{Name: "network-operator", Overrides: map[string]any{"enabled": false}},                // disabled + type-less registry component -> loop must skip
 		},
 	}
 	if err := r.PrepareAndValidate(); err != nil {
@@ -279,7 +279,8 @@ func TestPrepareAndValidate_RejectsReservedDeployerName(t *testing.T) {
 		{
 			name: "non-reserved names pass",
 			refs: []ComponentRef{
-				{Name: "gpu-operator", Type: ComponentTypeHelm, Version: "v1"},
+				{Name: "gpu-operator", Type: ComponentTypeHelm, Version: "v1",
+					Source: "https://charts", Chart: "gpu-operator"},
 			},
 			wantErr: false,
 		},

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -238,7 +238,10 @@ func (ref *ComponentRef) ApplyRegistryDefaults(config *ComponentConfig) {
 //     conversely, is rejected outright by the Helm-only Flux generator — see
 //     #1588.);
 //   - a Kustomize ref needs a Path to build from;
-//   - a Tag is only meaningful with a Source (git repo / OCI ref); and
+//   - a Tag is only meaningful with a Source (git repo / OCI ref);
+//   - a Helm ref that is not manifest-only must pin a chart version — an
+//     empty version reaches Helm as "latest" through the helmfile/flux/argocd
+//     deployers (see #1615); and
 //   - no deployer applies ComponentRef.Patches, so a ref that declares patch
 //     files is rejected rather than silently producing an unpatched bundle
 //     (see #1588).
@@ -268,6 +271,86 @@ func (ref *ComponentRef) coherenceProblem() string {
 				"or convert it into a coherent Kustomize ref (which needs a path, and a source if it sets a tag)",
 				ref.Name, ref.Tag, ref.Path)
 		}
+		// Chart/source values carrying ANY surrounding whitespace (including
+		// whitespace-only values) are rejected outright rather than trimmed:
+		// the deployers consume these fields RAW — flux's manifest-only
+		// detection and OCI classification, localformat's classifier, the
+		// HelmRepository URL — so a padded value would validate as one shape
+		// here and deploy as another (or as a broken URL) there.
+		if ref.Chart != strings.TrimSpace(ref.Chart) {
+			return fmt.Sprintf("Helm component %q has a chart name with surrounding "+
+				"whitespace (%q); set the exact chart name or omit the field (see #1615)",
+				ref.Name, ref.Chart)
+		}
+		if ref.Source != strings.TrimSpace(ref.Source) {
+			return fmt.Sprintf("Helm component %q has a source with surrounding "+
+				"whitespace (%q); set the exact repository or omit the field (see #1615)",
+				ref.Name, ref.Source)
+		}
+		// Any SET version must be well-formed, whatever the primary shape:
+		// a padded value is rejected for the same reason as padded
+		// chart/source values — the deployers consume the field RAW.
+		// NormalizeVersion only strips a "v" prefix, so " 1.0.0" lands
+		// verbatim in a Flux HelmRelease (a broken semver range) and in
+		// helm --version arguments; and even a MANIFEST-ONLY ref propagates
+		// its version into the rendered chart's .Chart.Version
+		// (localformat's renderInputFor → helm.sh/chart labels), so a
+		// padded value ships an invalid label value. Whitespace-only
+		// versions are padded values too and are caught here.
+		if ref.Version != strings.TrimSpace(ref.Version) {
+			return fmt.Sprintf("Helm component %q has a chart version with surrounding "+
+				"whitespace (%q); set the exact chart version (see #1615)",
+				ref.Name, ref.Version)
+		}
+		// A bare "v" is rejected for every output kind and shape (see
+		// IsEffectiveChartVersion, the shared rule): Flux/Argo CD normalize
+		// it to empty for non-OCI outputs (unpinned/latest), vendored
+		// wrappers and manifest-only rendering substitute a fabricated
+		// default (NormalizeVersionWithDefault), and Helm/Helmfile/
+		// non-vendored-OCI preserve it — one recipe, output-dependent chart
+		// identities. Longer values keep their leading "v" ("v1.0.0" is
+		// fine everywhere). An UNSET version is judged per shape below.
+		if ref.Version != "" && !IsEffectiveChartVersion(ref.Version) {
+			return fmt.Sprintf("Helm component %q has chart version %q, which Flux/Argo CD "+
+				"normalize to empty for non-OCI outputs and vendored wrappers replace with a "+
+				"fabricated default; set a full chart version (see #1615)", ref.Name, ref.Version)
+		}
+		// A Helm ref needs a deployable primary: an external chart (a source
+		// repository; the chart name falls back to the component name in the
+		// deployers when unset) or local primary manifest files. A chart name
+		// WITHOUT a source is not deployable — Flux skips HelmRepository
+		// creation for an empty source and localformat's chart pull rejects a
+		// missing repository. Pre-manifests are auxiliary to a primary
+		// release and qualify nothing on their own. The raw comparisons below
+		// match the deployers'; whitespace-only values were rejected above.
+		hasChart := ref.Chart != ""
+		hasSource := ref.Source != ""
+		switch {
+		case hasSource:
+			// External chart: it must pin an EFFECTIVE version. The
+			// localformat deployer hard-fails on an empty one, but
+			// helmfile/flux/argocd emit it verbatim and Helm resolves
+			// "latest" at install time — a silent stale-default failure
+			// (#1615). Unreachable for embedded-registry resolution
+			// (bom-pinning-check pins every Helm chart), but an external
+			// --data registry can omit defaultVersion, and loaded/adopted
+			// RecipeResults never run ApplyRegistryDefaults at all.
+			// Well-formedness (padding, bare "v") was checked above; here
+			// only PRESENCE remains.
+			if ref.Version == "" {
+				return fmt.Sprintf("Helm component %q has no chart version; set version: on the "+
+					"componentRef — criteria-resolved recipes may inherit it from helm.defaultVersion "+
+					"in the component registry (see #1615)", ref.Name)
+			}
+		case hasChart:
+			return fmt.Sprintf("Helm component %q has a chart name (%q) but no source repository; "+
+				"the deployers have no repository to pull from — set source:, or remove the chart "+
+				"for a manifest-only component (see #1615)", ref.Name, ref.Chart)
+		case len(ref.ManifestFiles) == 0:
+			return fmt.Sprintf("Helm component %q has no deployable primary (no source, no chart, "+
+				"and no primary manifestFiles; preManifestFiles alone are auxiliary to a primary "+
+				"release) — add a chart source or primary manifest files (see #1615)", ref.Name)
+		}
 	case strings.EqualFold(string(ref.Type), string(ComponentTypeKustomize)):
 		if !hasPath {
 			return fmt.Sprintf("component %q is Kustomize but has no path; a path is required to build from", ref.Name)
@@ -294,6 +377,66 @@ func (ref *ComponentRef) coherenceProblem() string {
 			ref.Name, ref.Type, ComponentTypeHelm, ComponentTypeKustomize)
 	}
 	return ""
+}
+
+// IsManifestOnlyHelm reports whether a Helm-typed ref ships only local
+// primary manifest files with no external chart — e.g.
+// nodewright-customizations, whose registry entry declares an empty
+// helm.defaultRepository and no defaultVersion. Such refs are typed Helm (the
+// ComponentConfig.GetType default) but have no chart version to pin: the
+// deployers render their manifests into a local chart directory instead of
+// pulling an upstream chart.
+//
+// PreManifestFiles do NOT qualify: pre-manifests are auxiliary resources
+// injected ahead of a primary release (every real pre-manifest-carrying ref
+// resolves with a chart from the registry), so a ref whose only content is
+// pre-manifests has no deployable primary — it is a husk, not a manifest-only
+// component. Both the coherence check and pkg/health's chart_pinned dimension
+// key off this predicate.
+func (ref *ComponentRef) IsManifestOnlyHelm() bool {
+	// Raw comparisons match the deployers' manifest-only detection (flux) and
+	// classifier (localformat); whitespace-only chart/source values are
+	// rejected by the coherence check, so they never reach consumers. The
+	// Type guard keeps the exported name honest: a Kustomize ref with
+	// manifests and blank chart/source is not a manifest-only HELM ref.
+	return strings.EqualFold(string(ref.Type), string(ComponentTypeHelm)) &&
+		ref.Chart == "" && ref.Source == "" && len(ref.ManifestFiles) > 0
+}
+
+// HasExternalChart reports whether a Helm-typed ref references an external
+// chart: a source repository, optionally with an explicit chart name. Non-Helm
+// refs and refs whose only chart signal is a chart name (nothing to pull
+// from — coherence rejects that shape) do not qualify.
+func (ref *ComponentRef) HasExternalChart() bool {
+	return strings.EqualFold(string(ref.Type), string(ComponentTypeHelm)) && ref.Source != ""
+}
+
+// EffectiveChart returns the chart name a Helm-typed ref deploys: the
+// explicit Chart, falling back to the component name when unset (a
+// source-only ref). Every ComponentRef consumer derives the chart through
+// this method — the flux, argocd, helmfile, and helm deployers, pkg/mirror,
+// and the facade/query/BOM projections. (localformat keeps an equivalent
+// fallback on its own Component type, which is constructed from
+// EffectiveChart-derived inputs but also serves direct callers.)
+func (ref *ComponentRef) EffectiveChart() string {
+	if ref.Chart != "" {
+		return ref.Chart
+	}
+	return ref.Name
+}
+
+// IsEffectiveChartVersion reports whether version still pins an actual chart
+// version once the deployers' normalization is applied: non-empty after
+// trimming, and not a bare "v". Flux and Argo CD strip the leading "v" for
+// non-OCI outputs (deployer.NormalizeVersion) and treat the empty remainder
+// as unpinned; Helm/Helmfile and non-vendored OCI outputs preserve the value;
+// vendored wrappers substitute a fabricated default
+// (deployer.NormalizeVersionWithDefault). A bare "v" is rejected uniformly so
+// one recipe cannot carry output-dependent chart identities. The coherence
+// check and pkg/health's chart_pinned dimension share this rule.
+func IsEffectiveChartVersion(version string) bool {
+	v := strings.TrimSpace(version)
+	return v != "" && strings.TrimPrefix(v, "v") != ""
 }
 
 // canonicalizeComponentTypes normalizes each ref's case-insensitively-matched

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -1350,10 +1350,11 @@ func TestMixinConstraintFailureExcludesOnlyAffectedCandidateChain(t *testing.T) 
 	independentLeaf.Spec.Mixins = []string{"monitoring-gate"}
 	independentLeaf.Spec.ComponentRefs = []ComponentRef{
 		{
-			Name:   "dcgm-exporter",
-			Type:   ComponentTypeHelm,
-			Source: "https://example.com/charts",
-			Chart:  "dcgm-exporter",
+			Name:    "dcgm-exporter",
+			Type:    ComponentTypeHelm,
+			Source:  "https://example.com/charts",
+			Chart:   "dcgm-exporter",
+			Version: "1.0.0",
 		},
 	}
 
@@ -1399,10 +1400,11 @@ func TestMixinConstraintFailureExcludesOnlyAffectedCandidateChain(t *testing.T) 
 					},
 					ComponentRefs: []ComponentRef{
 						{
-							Name:   "nvidia-dcgm-exporter",
-							Type:   ComponentTypeHelm,
-							Source: "https://example.com/charts",
-							Chart:  "nvidia-dcgm-exporter",
+							Name:    "nvidia-dcgm-exporter",
+							Type:    ComponentTypeHelm,
+							Source:  "https://example.com/charts",
+							Chart:   "nvidia-dcgm-exporter",
+							Version: "1.0.0",
 						},
 					},
 				},
@@ -1504,10 +1506,11 @@ func TestMixinConstraintFailurePreservesSharedAncestorsForSurvivingLeaf(t *testi
 	}
 	sharedTraining.Spec.ComponentRefs = []ComponentRef{
 		{
-			Name:   "shared-component",
-			Type:   ComponentTypeHelm,
-			Source: "https://example.com/charts",
-			Chart:  "shared-component",
+			Name:    "shared-component",
+			Type:    ComponentTypeHelm,
+			Source:  "https://example.com/charts",
+			Chart:   "shared-component",
+			Version: "1.0.0",
 		},
 	}
 
@@ -1564,10 +1567,11 @@ func TestMixinConstraintFailurePreservesSharedAncestorsForSurvivingLeaf(t *testi
 				}{
 					Constraints: []Constraint{{Name: "Monitoring.enabled", Value: "true"}},
 					ComponentRefs: []ComponentRef{{
-						Name:   "surviving-component",
-						Type:   ComponentTypeHelm,
-						Source: "https://example.com/charts",
-						Chart:  "surviving-component",
+						Name:    "surviving-component",
+						Type:    ComponentTypeHelm,
+						Source:  "https://example.com/charts",
+						Chart:   "surviving-component",
+						Version: "1.0.0",
 					}},
 				},
 			},

--- a/pkg/recipe/query.go
+++ b/pkg/recipe/query.go
@@ -100,7 +100,17 @@ func HydrateResultWithContext(ctx context.Context, result *RecipeResult) (map[st
 		if ref.Namespace != "" {
 			comp["namespace"] = ref.Namespace
 		}
-		if ref.Chart != "" {
+		// Expose the chart the component actually deploys: a source-only
+		// Helm ref falls back to the component name (EffectiveChart, the
+		// deployers' rule), so components.<name>.chart resolves for every
+		// deployable external chart. Manifest-only Helm refs and Kustomize
+		// refs stay chartless; a raw Chart on a non-external ref (rejected
+		// by coherence, but query also serves directly-constructed results)
+		// is surfaced as-is rather than hidden.
+		switch {
+		case ref.HasExternalChart():
+			comp["chart"] = ref.EffectiveChart()
+		case ref.Chart != "":
 			comp["chart"] = ref.Chart
 		}
 		if ref.Version != "" {

--- a/pkg/recipe/query_test.go
+++ b/pkg/recipe/query_test.go
@@ -250,6 +250,53 @@ func TestHydrateResult(t *testing.T) {
 		}
 	})
 
+	t.Run("source-only helm ref exposes the effective chart", func(t *testing.T) {
+		// A source-only ref deploys the component-name chart (the deployers'
+		// EffectiveChart fallback); the hydrated projection must expose it so
+		// a components.<name>.chart selector resolves instead of NOT_FOUND.
+		// Manifest-only Helm refs have no chart and must stay chartless.
+		result := &RecipeResult{
+			Kind:       "RecipeResult",
+			APIVersion: "aicr.run/v1alpha2",
+			ComponentRefs: []ComponentRef{
+				{
+					Name:    "source-only",
+					Type:    ComponentTypeHelm,
+					Source:  "https://example.com/charts",
+					Version: "v1.0.0",
+				},
+				{
+					Name:          "manifest-only",
+					Type:          ComponentTypeHelm,
+					ManifestFiles: []string{"components/manifest-only/manifests/a.yaml"},
+				},
+			},
+		}
+
+		hydrated, err := HydrateResult(result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		components, ok := hydrated["components"].(map[string]any)
+		if !ok {
+			t.Fatal("components is not a map")
+		}
+		srcOnly, ok := components["source-only"].(map[string]any)
+		if !ok {
+			t.Fatal("source-only is not a map")
+		}
+		if srcOnly["chart"] != "source-only" {
+			t.Errorf("source-only chart = %v, want the component-name fallback", srcOnly["chart"])
+		}
+		manifestOnly, ok := components["manifest-only"].(map[string]any)
+		if !ok {
+			t.Fatal("manifest-only is not a map")
+		}
+		if _, exists := manifestOnly["chart"]; exists {
+			t.Errorf("manifest-only chart = %v, want absent (no chart deploys)", manifestOnly["chart"])
+		}
+	})
+
 	t.Run("excluded overlays include reasons", func(t *testing.T) {
 		result := &RecipeResult{
 			Kind:            "RecipeResult",

--- a/pkg/recipe/version_required_test.go
+++ b/pkg/recipe/version_required_test.go
@@ -1,0 +1,533 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// These tests pin the #1615 invariant: an ENABLED Helm componentRef that is
+// not manifest-only must carry a chart version, enforced at ValidateCoherence
+// — the shared boundary all three RecipeResult entry paths converge on:
+//
+//   - criteria resolution (finalizeRecipeResult, exercised via an external
+//     registry whose Helm component omits defaultVersion; the embedded
+//     registry is guarded separately by bom-pinning-check),
+//   - file load (LoadFromFileWithProvider -> PrepareAndValidate), and
+//   - adoption (client adoptRecipe -> PrepareAndValidate, exercised here at
+//     the PrepareAndValidate boundary the client calls).
+//
+// Without the check, helmfile/flux/argocd emit the empty version verbatim and
+// Helm resolves "latest" at install time — a silent stale-default failure.
+
+// wantEmptyVersionError asserts the #1615 rejection shape: an
+// ErrCodeInvalidRequest that names the component and the missing version.
+func wantEmptyVersionError(t *testing.T, err error, component string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error for Helm component %q without a chart version, got nil", component)
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error code = %v, want %v", err, errors.ErrCodeInvalidRequest)
+	}
+	for _, want := range []string{component, "chart version"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+// TestResolveRejectsEmptyHelmVersion_ExternalRegistry drives the criteria-
+// resolution path against an external-style registry whose Helm component
+// declares a repository and chart but no defaultVersion, and whose
+// componentRef pins nothing: the resolved ref would reach the deployers with
+// Version == "", so resolution must fail closed.
+func TestResolveRejectsEmptyHelmVersion_ExternalRegistry(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+
+	provider := newInMemoryProvider("external-unpinned", map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/unpinned-leaf.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: unpinned-leaf
+spec:
+  criteria:
+    service: eks
+  componentRefs:
+    - name: unpinned-helm
+`),
+		"registry.yaml": []byte(`apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components:
+  - name: unpinned-helm
+    displayName: Unpinned Helm Component
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/unpinned-helm
+`),
+	})
+
+	ctx := context.Background()
+	// Loading/building also populates the component- and criteria-registry
+	// caches keyed by provider; evict all three so no package-global state
+	// leaks past this test.
+	t.Cleanup(func() {
+		EvictCachedStore(provider)
+		EvictCachedRegistry(provider)
+		EvictCachedCriteriaRegistry(provider)
+	})
+	store, err := LoadMetadataStoreFor(ctx, provider)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor: %v", err)
+	}
+	overlay, ok := store.GetRecipeByName("unpinned-leaf")
+	if !ok {
+		t.Fatal("unpinned-leaf overlay not found in store")
+	}
+
+	_, err = store.BuildRecipeResult(ctx, overlay.Spec.Criteria)
+	wantEmptyVersionError(t, err, "unpinned-helm")
+
+	// The same registry with an overlay-level version pin resolves cleanly:
+	// the invariant demands a version, not a registry default specifically.
+	provider2 := newInMemoryProvider("external-pinned", map[string][]byte{
+		"overlays/base.yaml": provider.files["overlays/base.yaml"],
+		"registry.yaml":      provider.files["registry.yaml"],
+		"overlays/pinned-leaf.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: pinned-leaf
+spec:
+  criteria:
+    service: eks
+  componentRefs:
+    - name: unpinned-helm
+      version: "1.2.3"
+`),
+	})
+	t.Cleanup(func() {
+		EvictCachedStore(provider2)
+		EvictCachedRegistry(provider2)
+		EvictCachedCriteriaRegistry(provider2)
+	})
+	store2, err := LoadMetadataStoreFor(ctx, provider2)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor(pinned): %v", err)
+	}
+	pinned, ok := store2.GetRecipeByName("pinned-leaf")
+	if !ok {
+		t.Fatal("pinned-leaf overlay not found in store")
+	}
+	result, err := store2.BuildRecipeResult(ctx, pinned.Spec.Criteria)
+	if err != nil {
+		t.Fatalf("BuildRecipeResult(pinned): %v", err)
+	}
+	if ref := result.GetComponentRef("unpinned-helm"); ref == nil || ref.Version != "1.2.3" {
+		t.Errorf("pinned ref = %+v, want version 1.2.3", ref)
+	}
+
+	// A whitespace-only defaultVersion is treated as populated by
+	// ApplyRegistryDefaults but trims to empty in Helm — it must be rejected
+	// the same as an omitted one.
+	provider3 := newInMemoryProvider("external-whitespace", map[string][]byte{
+		"overlays/base.yaml":          provider.files["overlays/base.yaml"],
+		"overlays/unpinned-leaf.yaml": provider.files["overlays/unpinned-leaf.yaml"],
+		"registry.yaml": []byte(`apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components:
+  - name: unpinned-helm
+    displayName: Unpinned Helm Component
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/unpinned-helm
+      defaultVersion: "   "
+`),
+	})
+	t.Cleanup(func() {
+		EvictCachedStore(provider3)
+		EvictCachedRegistry(provider3)
+		EvictCachedCriteriaRegistry(provider3)
+	})
+	store3, err := LoadMetadataStoreFor(ctx, provider3)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor(whitespace): %v", err)
+	}
+	wsLeaf, ok := store3.GetRecipeByName("unpinned-leaf")
+	if !ok {
+		t.Fatal("unpinned-leaf overlay not found in whitespace store")
+	}
+	_, err = store3.BuildRecipeResult(ctx, wsLeaf.Spec.Criteria)
+	wantEmptyVersionError(t, err, "unpinned-helm")
+}
+
+// TestLoadRejectsEmptyHelmVersion drives the file-load path: a hand-authored
+// hydrated RecipeResult with an enabled chart-referencing Helm ref and no
+// version bypasses ApplyRegistryDefaults entirely, so PrepareAndValidate (via
+// LoadFromFileWithProvider) must reject it.
+func TestLoadRejectsEmptyHelmVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recipe.yaml")
+	content := `kind: RecipeResult
+apiVersion: aicr.run/v1alpha2
+criteria:
+  service: eks
+componentRefs:
+  - name: hand-authored-helm
+    type: Helm
+    source: https://charts.example.com
+    chart: hand-authored-helm
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := LoadFromFileWithProvider(t.Context(), path, "", "test", nil)
+	wantEmptyVersionError(t, err, "hand-authored-helm")
+
+	// Whitespace-only is empty: Helm trims the argument and installs latest.
+	wsPath := filepath.Join(dir, "recipe-ws.yaml")
+	wsContent := content + "    version: \"   \"\n"
+	if writeErr := os.WriteFile(wsPath, []byte(wsContent), 0o600); writeErr != nil {
+		t.Fatalf("WriteFile: %v", writeErr)
+	}
+	_, err = LoadFromFileWithProvider(t.Context(), wsPath, "", "test", nil)
+	wantEmptyVersionError(t, err, "hand-authored-helm")
+}
+
+// TestPrepareAndValidateRejectsEmptyHelmVersion pins the adopt boundary:
+// client adoptRecipe funnels externally-supplied RecipeResults through
+// PrepareAndValidate, which must reject an enabled chart-referencing Helm ref
+// without a version — and must keep accepting the shapes that legitimately
+// carry none.
+func TestPrepareAndValidateRejectsEmptyHelmVersion(t *testing.T) {
+	chartRef := func(version string) ComponentRef {
+		return ComponentRef{
+			Name:    "adopted-helm",
+			Type:    ComponentTypeHelm,
+			Source:  "https://charts.example.com",
+			Chart:   "adopted-helm",
+			Version: version,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		refs    []ComponentRef
+		wantErr bool
+		wantMsg string // substring the error must contain ("" = the version message)
+	}{
+		{name: "chart ref without version rejected", refs: []ComponentRef{chartRef("")}, wantErr: true},
+		{
+			// Whitespace-only is empty: Helm trims the argument and installs
+			// latest, the exact silent failure the invariant targets.
+			name: "chart ref with whitespace-only version rejected", refs: []ComponentRef{chartRef("   ")},
+			wantErr: true,
+		},
+		{
+			// A PADDED version diverges between the trimmed validator view
+			// and the deployers' raw view: NormalizeVersion only strips a
+			// "v" prefix, so " 1.0.0" lands verbatim in a Flux HelmRelease
+			// (a broken semver range) and in helm --version arguments.
+			name: "chart ref with padded version rejected", refs: []ComponentRef{chartRef(" 1.0.0")},
+			wantErr: true, wantMsg: "surrounding whitespace",
+		},
+		{
+			name: "chart ref with trailing-space version rejected", refs: []ComponentRef{chartRef("1.0.0 ")},
+			wantErr: true, wantMsg: "surrounding whitespace",
+		},
+		{name: "chart ref with version accepted", refs: []ComponentRef{chartRef("1.0.0")}, wantErr: false},
+		{name: "chart ref with v-prefixed version accepted", refs: []ComponentRef{chartRef("v1.0.0")}, wantErr: false},
+		{
+			// The Flux generator strips a leading "v" and omits an empty
+			// remainder — a literal "v" is effectively no version at all.
+			name: "chart ref with literal v version rejected", refs: []ComponentRef{chartRef("v")},
+			wantErr: true, wantMsg: "normalize",
+		},
+		{
+			// A chart name with no source is undeployable: Flux skips
+			// HelmRepository creation for an empty source, and localformat's
+			// chart pull rejects a missing repository.
+			name: "chart without source rejected",
+			refs: []ComponentRef{{
+				Name: "chart-only", Type: ComponentTypeHelm, Chart: "chart-only", Version: "1.0.0",
+			}},
+			wantErr: true, wantMsg: "no source repository",
+		},
+		{
+			// A source with no chart name is a long-standing deployable
+			// shape: the deployers fall back to the component name for the
+			// chart (localformat renderInputFor; the flux generator gained
+			// the same fallback).
+			name: "source without chart accepted",
+			refs: []ComponentRef{{
+				Name: "source-only", Type: ComponentTypeHelm,
+				Source: "https://charts.example.com", Version: "1.0.0",
+			}},
+			wantErr: false,
+		},
+		{
+			// A bare "v" is rejected for OCI sources too: the tag pulls
+			// literally, but vendored wrappers normalize it to a fabricated
+			// "0.1.0" — one recipe, two conflicting chart identities.
+			name: "oci source with bare v tag rejected",
+			refs: []ComponentRef{{
+				Name: "oci-comp", Type: ComponentTypeHelm, Chart: "oci-comp",
+				Source: "oci://registry.example.com/charts", Version: "v",
+			}},
+			wantErr: true, wantMsg: "normalize",
+		},
+		{
+			// v-prefixed full versions stay valid on OCI sources.
+			name: "oci source with v-prefixed version accepted",
+			refs: []ComponentRef{{
+				Name: "oci-comp", Type: ComponentTypeHelm, Chart: "oci-comp",
+				Source: "oci://registry.example.com/charts", Version: "v1.2.3",
+			}},
+			wantErr: false,
+		},
+		{
+			// Whitespace-only chart/source are rejected outright: the
+			// deployers compare these fields raw, so a whitespace value would
+			// validate as manifest-only here but deploy as a broken external
+			// chart there.
+			name: "whitespace-only chart rejected",
+			refs: []ComponentRef{{
+				Name: "ws-chart", Type: ComponentTypeHelm, Chart: "   ",
+				ManifestFiles: []string{"components/ws-chart/manifests/a.yaml"},
+			}},
+			wantErr: true, wantMsg: "surrounding whitespace",
+		},
+		{
+			name: "whitespace-only source rejected",
+			refs: []ComponentRef{{
+				Name: "ws-source", Type: ComponentTypeHelm, Source: "  ", Version: "1.0.0",
+			}},
+			wantErr: true, wantMsg: "surrounding whitespace",
+		},
+		{
+			// A PADDED (not merely whitespace-only) source diverges between
+			// the trimmed validator view and the deployers' raw view — e.g.
+			// " oci://…" would be graded OCI here but non-OCI by flux.
+			name: "padded oci source rejected",
+			refs: []ComponentRef{{
+				Name: "padded-oci", Type: ComponentTypeHelm,
+				Source: " oci://registry.example.com/charts", Version: "v",
+			}},
+			wantErr: true, wantMsg: "surrounding whitespace",
+		},
+		{
+			// A husk (no chart, no source, no manifests) references nothing
+			// deployable, version or not; fail closed.
+			name: "empty husk rejected", refs: []ComponentRef{{Name: "husk", Type: ComponentTypeHelm}},
+			wantErr: true, wantMsg: "no deployable primary",
+		},
+		{
+			name:    "versioned husk rejected",
+			refs:    []ComponentRef{{Name: "husk", Type: ComponentTypeHelm, Version: "1.0.0"}},
+			wantErr: true, wantMsg: "no deployable primary",
+		},
+		{
+			// Manifest-only Helm refs (e.g. nodewright-customizations) have no
+			// chart version to require.
+			name: "manifest-only helm accepted",
+			refs: []ComponentRef{{
+				Name: "nodewright-customizations", Type: ComponentTypeHelm,
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}},
+			wantErr: false,
+		},
+		{
+			// Manifest-only refs may set a version (it lands in the rendered
+			// chart's .Chart.Version / helm.sh/chart label).
+			name: "manifest-only helm with version accepted",
+			refs: []ComponentRef{{
+				Name: "nodewright-customizations", Type: ComponentTypeHelm, Version: "1.0.0",
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}},
+			wantErr: false,
+		},
+		{
+			// A PADDED version is rejected on manifest-only refs too:
+			// localformat's renderInputFor propagates it raw into
+			// .Chart.Version, and the manifests bake it into the
+			// helm.sh/chart label — an invalid label value.
+			name: "manifest-only helm with padded version rejected",
+			refs: []ComponentRef{{
+				Name: "nodewright-customizations", Type: ComponentTypeHelm, Version: " 1.0.0 ",
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}},
+			wantErr: true, wantMsg: "surrounding whitespace",
+		},
+		{
+			// A bare "v" on a manifest-only ref is fabricated into "0.1.0"
+			// by NormalizeVersionWithDefault — reject the degenerate value
+			// rather than ship a version nobody set.
+			name: "manifest-only helm with bare v version rejected",
+			refs: []ComponentRef{{
+				Name: "nodewright-customizations", Type: ComponentTypeHelm, Version: "v",
+				ManifestFiles: []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+			}},
+			wantErr: true, wantMsg: "normalize",
+		},
+		{
+			// Pre-manifests are auxiliary to a primary release; a ref whose
+			// only content is pre-manifests has no deployable primary and
+			// must NOT ride the manifest-only exemption.
+			name: "pre-manifest-only helm without version rejected",
+			refs: []ComponentRef{{
+				Name: "quota-only", Type: ComponentTypeHelm,
+				PreManifestFiles: []string{"components/quota-only/manifests/quota.yaml"},
+			}},
+			wantErr: true, wantMsg: "no deployable primary",
+		},
+		{
+			// Supplying a version does not make a pre-only ref deployable:
+			// localformat would classify it as an upstream release with no
+			// chart to pull.
+			name: "pre-manifest-only helm with version rejected",
+			refs: []ComponentRef{{
+				Name: "quota-only", Type: ComponentTypeHelm, Version: "1.0.0",
+				PreManifestFiles: []string{"components/quota-only/manifests/quota.yaml"},
+			}},
+			wantErr: true, wantMsg: "no deployable primary",
+		},
+		{
+			// A primary-manifest ref that also carries pre-manifests keeps
+			// the exemption — the primary content is what qualifies it.
+			name: "manifest-only with pre-manifests accepted",
+			refs: []ComponentRef{{
+				Name: "nodewright-customizations", Type: ComponentTypeHelm,
+				ManifestFiles:    []string{"components/nodewright-customizations/manifests/tuning.yaml"},
+				PreManifestFiles: []string{"components/nodewright-customizations/manifests/ns.yaml"},
+			}},
+			wantErr: false,
+		},
+		{
+			// Disabled refs are excluded from the bundle; their shape never
+			// reaches a deployer.
+			name: "disabled chart ref without version accepted",
+			refs: []ComponentRef{{
+				Name: "off", Type: ComponentTypeHelm, Chart: "off",
+				Overrides: map[string]any{"enabled": false},
+			}},
+			wantErr: false,
+		},
+		{
+			// Lowercase type is backward-compatible input and must not dodge
+			// the version requirement.
+			name: "lowercase helm chart ref without version rejected",
+			refs: []ComponentRef{{
+				Name: "adopted-helm", Type: ComponentType("helm"),
+				Source: "https://charts.example.com", Chart: "adopted-helm",
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RecipeResult{ComponentRefs: tt.refs}
+			err := r.PrepareAndValidate()
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("PrepareAndValidate() error = %v, want nil", err)
+				}
+				return
+			}
+			if tt.wantMsg != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantMsg) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantMsg)
+				}
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("error code = %v, want %v", err, errors.ErrCodeInvalidRequest)
+				}
+				return
+			}
+			wantEmptyVersionError(t, err, tt.refs[0].Name)
+		})
+	}
+}
+
+// TestIsManifestOnlyHelm pins the predicate directly — in particular the
+// Helm-type guard, whose only production caller (pkg/health) pre-filters by
+// type, so this is the coverage that keeps the exported name honest.
+func TestIsManifestOnlyHelm(t *testing.T) {
+	manifests := []string{"components/x/manifests/a.yaml"}
+	tests := []struct {
+		name string
+		ref  ComponentRef
+		want bool
+	}{
+		{"canonical helm manifest-only", ComponentRef{Type: ComponentTypeHelm, ManifestFiles: manifests}, true},
+		{"lowercase helm manifest-only", ComponentRef{Type: ComponentType("helm"), ManifestFiles: manifests}, true},
+		{"kustomize with manifests is not manifest-only helm", ComponentRef{Type: ComponentTypeKustomize, ManifestFiles: manifests}, false},
+		{"unknown type with manifests is not manifest-only helm", ComponentRef{Type: ComponentType("flux"), ManifestFiles: manifests}, false},
+		{"empty type with manifests is not manifest-only helm", ComponentRef{ManifestFiles: manifests}, false},
+		{"helm with chart is not manifest-only", ComponentRef{Type: ComponentTypeHelm, Chart: "c", ManifestFiles: manifests}, false},
+		{"helm with source is not manifest-only", ComponentRef{Type: ComponentTypeHelm, Source: "https://r", ManifestFiles: manifests}, false},
+		{"helm without manifests is not manifest-only", ComponentRef{Type: ComponentTypeHelm}, false},
+		{"helm with only pre-manifests is not manifest-only", ComponentRef{Type: ComponentTypeHelm, PreManifestFiles: manifests}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ref.IsManifestOnlyHelm(); got != tt.want {
+				t.Errorf("IsManifestOnlyHelm() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComponentRefChartHelpers pins the exported chart-shape helpers directly:
+// HasExternalChart requires a Helm type AND a source (a chart name alone
+// references nothing pullable), and EffectiveChart falls back to the
+// component name exactly when Chart is unset.
+func TestComponentRefChartHelpers(t *testing.T) {
+	tests := []struct {
+		name          string
+		ref           ComponentRef
+		wantExternal  bool
+		wantEffective string
+	}{
+		{"source and chart", ComponentRef{Name: "n", Type: ComponentTypeHelm, Source: "https://r", Chart: "c"}, true, "c"},
+		{"source only falls back", ComponentRef{Name: "n", Type: ComponentTypeHelm, Source: "https://r"}, true, "n"},
+		{"lowercase helm source only", ComponentRef{Name: "n", Type: ComponentType("helm"), Source: "https://r"}, true, "n"},
+		{"chart only does not qualify", ComponentRef{Name: "n", Type: ComponentTypeHelm, Chart: "c"}, false, "c"},
+		{"neither does not qualify", ComponentRef{Name: "n", Type: ComponentTypeHelm}, false, "n"},
+		{"kustomize with source does not qualify", ComponentRef{Name: "n", Type: ComponentTypeKustomize, Source: "git://x"}, false, "n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ref.HasExternalChart(); got != tt.wantExternal {
+				t.Errorf("HasExternalChart() = %v, want %v", got, tt.wantExternal)
+			}
+			if got := tt.ref.EffectiveChart(); got != tt.wantEffective {
+				t.Errorf("EffectiveChart() = %q, want %q", got, tt.wantEffective)
+			}
+		})
+	}
+}

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -809,7 +809,11 @@ metadata:
   version: dev
 componentRefs:
   - name: gpu-operator
-    enabled: true
+    type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
+    namespace: gpu-operator
 validation:
   deployment:
     checks:
@@ -862,7 +866,11 @@ metadata:
   version: dev
 componentRefs:
   - name: gpu-operator
-    enabled: true
+    type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
+    namespace: gpu-operator
 validation:
   deployment:
     checks:
@@ -916,9 +924,15 @@ componentRefs:
   # carries no expectedResources so it is inert for these checks.
   - name: gpu-operator
     type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
     namespace: gpu-operator
   - name: nonexistent-component
     type: Helm
+    source: https://charts.example.com
+    chart: nonexistent-component
+    version: v1.0.0
     namespace: gpu-operator
     expectedResources:
       - kind: Deployment
@@ -986,6 +1000,26 @@ RECIPE
     fi
 
     if [ "$helm_install_ok" = true ]; then
+      # Derive the installed chart version so the recipes below describe what
+      # is actually deployed (the install is unpinned; a fabricated pin would
+      # lie). Coherence requires SOME version on a chart-referencing ref.
+      # Fail closed: the pipeline is guarded against set -e/pipefail so a
+      # helm/jq failure reaches the fail branch (and the nginx cleanup below)
+      # instead of killing the run, and only an exact nginx-<version> result
+      # is accepted — an empty or null answer must not become a fabricated pin.
+      local nginx_chart nginx_chart_ver=""
+      nginx_chart=$(helm list -n "$nginx_ns" -o json 2>/dev/null \
+        | jq -r --arg r "$nginx_release" '[.[] | select(.name == $r) | .chart][0] // empty' \
+        2>/dev/null) || nginx_chart=""
+      case "$nginx_chart" in
+        nginx-?*) nginx_chart_ver="${nginx_chart#nginx-}" ;;
+      esac
+
+      if [ -z "$nginx_chart_ver" ]; then
+        fail "validate/expected-resources-manual-pass" "could not determine installed nginx chart version (helm list chart: '${nginx_chart}')"
+        fail "validate/expected-resources-manual-merge" "could not determine installed nginx chart version (helm list chart: '${nginx_chart}')"
+      else
+
       # Test: Manual expectedResources pointing to real Deployment (should pass)
       msg "--- Test: Manual expectedResources matching deployed workload ---"
       local recipe_manual="${validate_dir}/recipe-manual-pass.yaml"
@@ -1000,11 +1034,15 @@ componentRefs:
   # carries no expectedResources so it is inert for these checks.
   - name: gpu-operator
     type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
     namespace: gpu-operator
   - name: ${nginx_release}
     type: Helm
     source: https://charts.bitnami.com/bitnami
     chart: nginx
+    version: "${nginx_chart_ver}"
     namespace: ${nginx_ns}
     expectedResources:
       - kind: Deployment
@@ -1054,11 +1092,15 @@ componentRefs:
   # carries no expectedResources so it is inert for these checks.
   - name: gpu-operator
     type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
     namespace: gpu-operator
   - name: ${nginx_release}
     type: Helm
     source: https://charts.bitnami.com/bitnami
     chart: nginx
+    version: "${nginx_chart_ver}"
     namespace: ${nginx_ns}
     expectedResources:
       - kind: Deployment
@@ -1095,6 +1137,7 @@ RECIPE
         fi
       else
         fail "validate/expected-resources-manual-merge" "expected-resources not found in output"
+      fi
       fi
     else
       skip "validate/expected-resources-manual-pass" "helm install failed"
@@ -1134,6 +1177,9 @@ metadata:
 componentRefs:
   - name: gpu-operator
     type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
     namespace: gpu-operator
 validation:
   deployment:
@@ -1187,6 +1233,9 @@ metadata:
 componentRefs:
   - name: gpu-operator
     type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
     namespace: gpu-operator
     expectedResources:
       - kind: Deployment
@@ -1271,7 +1320,11 @@ metadata:
   version: dev
 componentRefs:
   - name: gpu-operator
-    enabled: true
+    type: Helm
+    source: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    version: v24.6.0
+    namespace: gpu-operator
 validation:
   deployment:
     checks:

--- a/tools/bom/main.go
+++ b/tools/bom/main.go
@@ -32,12 +32,14 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/NVIDIA/aicr/pkg/bom"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/helm"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 const (
@@ -113,7 +115,15 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 	if strict {
 		var hardErrs []string
 		for _, r := range results {
-			if r.Type == kindHelm && r.Version == "" {
+			// Shared rule with recipe resolution (IsEffectiveChartVersion):
+			// a whitespace-only or bare-"v" defaultVersion would pass an
+			// empty-string check here but fail ValidateCoherence at resolve
+			// time — the gate must be at least as strict as the resolver it
+			// guards. Padded values are equally rejected (deployers consume
+			// the version verbatim).
+			if r.Type == kindHelm &&
+				(!recipe.IsEffectiveChartVersion(r.Version) || r.Version != strings.TrimSpace(r.Version)) {
+
 				hardErrs = append(hardErrs, fmt.Sprintf("%s: chart version is not pinned", r.Name))
 			}
 			for _, w := range r.Warnings {
@@ -203,7 +213,7 @@ func renderHelmComponent(ctx context.Context, repoRoot string, c component, r he
 	}
 	out, err := r.Render(ctx, helm.ChartInput{
 		Name:       c.Name,
-		Chart:      c.Helm.DefaultChart,
+		Chart:      c.effectiveChart(),
 		Repository: c.Helm.DefaultRepository,
 		Version:    c.Helm.DefaultVersion,
 		Namespace:  c.Helm.DefaultNamespace,
@@ -231,7 +241,7 @@ func surveyComponent(ctx context.Context, repoRoot string, c component, r helm.R
 		DisplayName: c.DisplayName,
 		Type:        c.kind(),
 		Repository:  repository,
-		Chart:       c.Helm.DefaultChart,
+		Chart:       c.effectiveChart(),
 		Version:     version,
 		Namespace:   c.Helm.DefaultNamespace,
 		Pinned:      version != "",

--- a/tools/bom/main_test.go
+++ b/tools/bom/main_test.go
@@ -655,3 +655,93 @@ func TestRunMixedComponents(t *testing.T) {
 		t.Fatalf("run() error = %v", err)
 	}
 }
+
+// TestRunStrictDegenerateVersions pins the strict gate against the shared
+// resolution rule (recipe.IsEffectiveChartVersion plus the padded-value
+// rejection): a defaultVersion that is whitespace-only, a bare "v", or
+// padded would pass an empty-string check here but fail ValidateCoherence
+// at recipe resolution — the CI gate must be at least as strict as the
+// resolver it guards.
+func TestRunStrictDegenerateVersions(t *testing.T) {
+	registryFor := func(version string) string {
+		return `apiVersion: v1
+kind: ComponentRegistry
+components:
+  - name: gpu-operator
+    displayName: GPU Operator
+    helm:
+      defaultRepository: "oci://ghcr.io/nvidia"
+      defaultChart: gpu-operator
+      defaultVersion: "` + version + `"
+      defaultNamespace: gpu-operator
+`
+	}
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{"whitespace-only version fails strict", "   ", true},
+		{"bare v version fails strict", "v", true},
+		{"padded version fails strict", " 1.0.0", true},
+		{"trailing-space version fails strict", "1.0.0 ", true},
+		{"pinned version passes strict", "v25.3.0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeTestRegistry(t, registryFor(tt.version))
+			outDir := t.TempDir()
+			mock := &helmtest.MockRenderer{
+				Rendered: map[string][]byte{"gpu-operator": []byte(renderedYAML)},
+			}
+			err := run(root, outDir, "test-v1", mock, false, true, true, true)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestSurveyComponentSourceOnlyChartFallback pins the registry-level chart
+// fallback: a Helm entry with a defaultRepository but no defaultChart deploys
+// the component-name chart (recipe.ComponentRef.EffectiveChart), so the BOM
+// must render that chart and record it — not pass an empty chart to the
+// renderer ("no helm chart configured" in strict mode) and omit the metadata.
+func TestSurveyComponentSourceOnlyChartFallback(t *testing.T) {
+	root := writeTestRegistry(t, testRegistryHelm)
+	mock := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{
+			"gpu-operator": []byte(renderedYAML),
+		},
+	}
+
+	c := component{
+		Name:        "gpu-operator",
+		DisplayName: "GPU Operator",
+		Helm: helmCfg{
+			DefaultRepository: "oci://ghcr.io/nvidia",
+			DefaultVersion:    "25.3.0",
+			DefaultNamespace:  "gpu-operator",
+		},
+	}
+
+	res := surveyComponent(context.Background(), root, c, mock, false)
+	if len(res.Warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", res.Warnings)
+	}
+	if res.Chart != "gpu-operator" {
+		t.Errorf("Chart = %q, want the component-name fallback %q", res.Chart, "gpu-operator")
+	}
+	if len(mock.Inputs) != 1 {
+		t.Fatalf("renderer calls = %d, want 1", len(mock.Inputs))
+	}
+	if got := mock.Inputs[0].Chart; got != "gpu-operator" {
+		t.Errorf("renderer ChartInput.Chart = %q, want fallback %q", got, "gpu-operator")
+	}
+
+	// A manifest-only entry (no repository, no chart) stays chartless.
+	manifestOnly := component{Name: "nodewright-customizations", DisplayName: "nodewright"}
+	if got := manifestOnly.effectiveChart(); got != "" {
+		t.Errorf("manifest-only effectiveChart() = %q, want empty", got)
+	}
+}

--- a/tools/bom/registry.go
+++ b/tools/bom/registry.go
@@ -58,6 +58,23 @@ func (c component) kind() string {
 	}
 }
 
+// effectiveChart returns the chart a Helm registry entry deploys: the
+// explicit defaultChart, falling back to the component name when unset on a
+// source-backed (defaultRepository) entry. This mirrors
+// recipe.ComponentRef.EffectiveChart, which the resolver and deployers apply
+// to the resolved ref — the BOM must render and record the same chart.
+// Entries with neither repository nor chart (manifest-only / Kustomize)
+// return "".
+func (c component) effectiveChart() string {
+	if c.Helm.DefaultChart != "" {
+		return c.Helm.DefaultChart
+	}
+	if c.Helm.DefaultRepository != "" {
+		return c.Name
+	}
+	return ""
+}
+
 func loadRegistry(path string) (*registry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/tools/component-test/README.md
+++ b/tools/component-test/README.md
@@ -44,6 +44,26 @@ Or set `testTier` in `registry.yaml`:
   helm: ...
 ```
 
+**Dependencies are not deployed.** The harness bundles and deploys exactly one
+component; `dependencyRefs` declared on the component's overlay/mixin refs are
+NOT installed — for chart-backed and manifest-only components alike. If the
+component hard-depends on another component (e.g. `nodewright-customizations`
+applies a Skyhook CR whose CRD ships with `nodewright-operator`;
+`kubeflow-trainer` needs `cert-manager` webhooks), install the dependency
+first with `KEEP_CLUSTER=true` so the EXIT-trap cleanup does not immediately
+uninstall it — for example
+`make component-test COMPONENT=nodewright-operator KEEP_CLUSTER=true` — or
+expect the deploy step to fail on the bare test cluster. The deploy script
+prints a warning listing undeployed dependencies: for manifest-only
+components these come from the exact overlay ref the recipe was synthesized
+from; for chart-backed components (whose synthesized recipe is registry
+defaults, tied to no variant) the warning lists the union across recipe
+variants, so some entries may be variant-only (e.g. a GB200 leaf's DRA
+driver) and not needed by the default configuration. Platform-specific
+dependencies (e.g. the `*-ocp*`/OLM chains, whose `OperatorGroup` and
+`Subscription` manifests need OLM CRDs) cannot be pre-installed with this
+Kind-based harness — test those against a matching cluster.
+
 ## Make Targets
 
 ```bash

--- a/tools/component-test/deploy-component.sh
+++ b/tools/component-test/deploy-component.sh
@@ -151,6 +151,84 @@ if [[ -z "$values_file" ]]; then
     fi
 fi
 
+# Manifest-only Helm components (registry declares helm: with no repository and
+# no chart, e.g. nodewright-customizations) deploy local manifestFiles instead
+# of an external chart. Recipe coherence rejects a Helm ref with no source, no
+# chart, AND no primary manifestFiles ("no deployable primary", #1615), so
+# gather the manifest list from the first overlay/mixin that declares it.
+manifest_files=""
+manifest_overrides=""
+manifest_deps=""
+if [[ "$chart_type" == "Helm" && -z "$chart_source" && -z "$chart_name" ]]; then
+    checked_base=false
+    for overlay in "${REPO_ROOT}"/recipes/overlays/base.yaml \
+        "${REPO_ROOT}"/recipes/overlays/*.yaml \
+        "${REPO_ROOT}"/recipes/mixins/*.yaml; do
+        [[ -f "$overlay" ]] || continue
+        # base.yaml appears in both the explicit path and the glob; skip the duplicate
+        if [[ "$(basename "$overlay")" == "base.yaml" ]]; then
+            if [[ "$checked_base" == "true" ]]; then continue; fi
+            checked_base=true
+        fi
+        candidate=$(yq eval ".spec.componentRefs[] | select(.name == \"${COMPONENT}\") | .manifestFiles[]" "$overlay" 2>/dev/null)
+        if [[ -n "$candidate" ]]; then
+            manifest_files="$candidate"
+            # Carry the SAME ref's overrides: manifest-only components render
+            # their manifests against them (e.g. nodewright-customizations
+            # selects its Skyhook tuning by overrides.service/accelerator/
+            # intent — without them the rendered Skyhook has an empty
+            # accelerator). Strip `enabled`: the harness always deploys the
+            # component it is testing, even where the source overlay gates it.
+            manifest_overrides=$(yq eval ".spec.componentRefs[] | select(.name == \"${COMPONENT}\") | .overrides // {} | del(.enabled) | select(length > 0)" "$overlay" 2>/dev/null)
+            # The synthesized config IS this overlay ref, so only ITS
+            # dependencyRefs apply to what actually deploys here.
+            manifest_deps=$(yq eval ".spec.componentRefs[] | select(.name == \"${COMPONENT}\") | (.dependencyRefs // [])[]" "$overlay" 2>/dev/null)
+            break
+        fi
+    done
+    if [[ -z "$manifest_files" ]]; then
+        log_error "Component '$COMPONENT' is a manifest-only Helm component (no chart repository in the registry),"
+        log_error "but no overlay or mixin declares manifestFiles for it — the synthesized recipe would have no"
+        log_error "deployable primary and be rejected at bundle generation (see #1615)"
+        exit 1
+    fi
+fi
+
+# This harness deploys exactly ONE component; dependencyRefs declared on the
+# component's overlay/mixin refs are NOT installed — for chart-backed and
+# manifest-only components alike. Some dependencies are hard requirements
+# (e.g. nodewright-customizations applies a Skyhook CR whose CRD ships with
+# nodewright-operator; kubeflow-trainer needs cert-manager webhooks), so a
+# bare test cluster fails at deploy time. Warn loudly rather than fail: the
+# dependency may legitimately be pre-installed from a prior run.
+#
+# Scope the warning to the configuration actually synthesized:
+#   - manifest-only: only the matched overlay ref's deps apply (another
+#     leaf's variant-only deps — e.g. a GB200 leaf's DRA driver — do not);
+#   - chart-backed: the recipe is registry defaults, tied to no variant, so
+#     report the UNION of deps across variants, labeled as variant-declared.
+component_deps=""
+dep_context=""
+if [[ -n "$manifest_files" ]]; then
+    component_deps="${manifest_deps:-}"
+    dep_context="declared by the overlay ref this recipe was synthesized from"
+else
+    component_deps=$(for overlay in "${REPO_ROOT}"/recipes/overlays/*.yaml "${REPO_ROOT}"/recipes/mixins/*.yaml; do
+        [[ -f "$overlay" ]] || continue
+        yq eval ".spec.componentRefs[] | select(.name == \"${COMPONENT}\") | (.dependencyRefs // [])[]" "$overlay" 2>/dev/null
+    done | grep -v '^$' | sort -u) || component_deps=""
+    dep_context="declared by one or more recipe variants; the registry-default configuration synthesized here may not require all of them"
+fi
+if [[ -n "$component_deps" ]]; then
+    log_warning "Component '$COMPONENT' has dependencies this single-component harness does NOT deploy (${dep_context}):"
+    while IFS= read -r dep; do
+        [[ -n "$dep" ]] && log_warning "  - ${dep}"
+    done <<< "$component_deps"
+    log_warning "Deployment may fail if required ones are absent (e.g. missing CRDs or webhooks). Kind-compatible"
+    log_warning "dependencies can be pre-installed via: make component-test COMPONENT=<dep> KEEP_CLUSTER=true —"
+    log_warning "platform-specific ones (e.g. *-ocp*/OLM components) need a matching cluster, not this Kind harness."
+fi
+
 # Build a minimal resolved recipe (RecipeResult format, which aicr bundle expects)
 cat > "${WORK_DIR}/recipe.yaml" <<EOF
 kind: RecipeResult
@@ -161,8 +239,11 @@ componentRefs:
   - name: ${COMPONENT}
     namespace: ${HELM_NAMESPACE}
     type: ${chart_type}
-    source: ${chart_source}
 EOF
+
+if [[ -n "$chart_source" ]]; then
+    echo "    source: ${chart_source}" >> "${WORK_DIR}/recipe.yaml"
+fi
 
 if [[ -n "$chart_name" ]]; then
     echo "    chart: ${chart_name}" >> "${WORK_DIR}/recipe.yaml"
@@ -170,6 +251,19 @@ fi
 
 if [[ -n "$chart_version" ]]; then
     echo "    version: ${chart_version}" >> "${WORK_DIR}/recipe.yaml"
+fi
+
+if [[ -n "$manifest_files" ]]; then
+    echo "    manifestFiles:" >> "${WORK_DIR}/recipe.yaml"
+    while IFS= read -r mf; do
+        [[ -n "$mf" ]] && echo "      - ${mf}" >> "${WORK_DIR}/recipe.yaml"
+    done <<< "$manifest_files"
+fi
+
+if [[ -n "$manifest_overrides" ]]; then
+    echo "    overrides:" >> "${WORK_DIR}/recipe.yaml"
+    # Re-indent the yq-extracted overrides map under the componentRef.
+    sed 's/^/      /' <<< "$manifest_overrides" >> "${WORK_DIR}/recipe.yaml"
 fi
 
 if [[ -n "$values_file" ]]; then


### PR DESCRIPTION
## Summary

Reject enabled Helm componentRefs that reach validation without a chart version, at `ValidateCoherence` — the shared boundary all three RecipeResult entry paths converge on. Manifest-only Helm refs (e.g. `nodewright-customizations`) and disabled refs are exempt; Kustomize refs are explicitly out of scope.

## Motivation / Context

An enabled Helm ref could reach the deployers with `Version == ""`: the localformat deployer hard-fails, but helmfile/flux/argocd emit the empty version verbatim and Helm resolves "latest" at install time — a silent stale-default failure. Reachable through three paths, not one: criteria resolution against an external `--data` registry whose Helm component omits `defaultVersion` (the embedded registry is separately guarded by `bom-pinning-check`), file load (`LoadFromFileWithProvider`), and adoption (client `adoptRecipe`) — the latter two never run `ApplyRegistryDefaults` at all.

Fixes: #1615
Related: #1611

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/health` (chart_pinned interaction)

## Implementation Notes

- **The invariant is scoped to chart-referencing refs, not all Helm-typed refs.** `ComponentConfig.GetType()` defaults to Helm, so manifest-only components (empty `helm.defaultRepository`, local manifest files only — `nodewright-customizations` ships in most recipes this way) are legitimately Helm-typed with no version. The check exempts them via a new exported `ComponentRef.IsManifestOnlyHelm()` — the same predicate `pkg/health`'s `chart_pinned` dimension already used privately; health now consumes the shared method — with deliberate grading changes: whitespace-only and bare-`v` versions count as unpinned, and pre-manifests-only refs no longer ride the exemption. An "empty husk" ref (no chart, no source, no manifests, no version) is rejected — it references nothing deployable.
- **Deployable-primary rules (per Codex review, refined against deployer reality):** an enabled Helm ref must reference either an external chart — a `source` repository plus an *effective* version — or local primary `manifestFiles`. The chart name is optional with a source: localformat has always fallen back to the component name (`renderInputFor`), and the Flux generator now gains the same fallback (previously it emitted an empty `chart:` Flux cannot reconcile) — so source-only refs, a long-standing deployable shape used by shipping fixtures, keep working. A `chart` without a `source` is rejected (nothing to pull from anywhere). Chart/source values carrying ANY surrounding whitespace (including whitespace-only values) are rejected outright rather than trimmed — the deployers consume these fields raw (Flux manifest-only detection and OCI classification, localformat's classifier, the HelmRepository URL), so a padded value would validate as one shape and deploy as another. An effective version excludes empty, whitespace-only, and a bare `v`: Flux and Argo CD strip the leading `v` for non-OCI outputs and omit the empty remainder (unpinned/latest), non-vendored Helm/Helmfile and OCI outputs preserve it, and vendored wrappers substitute a fabricated `0.1.0` via `NormalizeVersionWithDefault` — so a bare `v` would give one recipe output-dependent chart identities and is rejected uniformly. `v`-prefixed full versions (`v1.2.3`) stay valid everywhere. Pre-manifests alone qualify nothing. `classifyChartPinned` applies the same effective-version rules.
- **Placement in `coherenceProblem()`** means every path is covered with one check: resolution (`finalizeRecipeResult` → `ValidateCoherence`), load and adopt (`PrepareAndValidate` → `ValidateCoherence`). The error is `ErrCodeInvalidRequest`, names the component, and points at both fixes (`version:` on the componentRef; `helm.defaultVersion` for criteria-resolved recipes).
- **`pkg/health` interaction (decided per #1615):** `TestComputeChartPinnedFailThroughBuilder` inverted — an unpinned chart-referencing Helm ref now fails the `resolves` dimension instead of resolving cleanly and failing `chart_pinned`. The `chart_pinned` dimension is retained as defense-in-depth for directly-constructed RecipeResults (its own logic keeps full coverage via `TestClassifyChartPinned`).
- **Empty-version audit (per #1615):** the gpu-operator DRA-annotation warn-and-skip in `pkg/bundler` and its tolerance test are retained as defense-in-depth behind `DefaultBundler.Make`'s own `PrepareAndValidate` backstop; localformat's `validateForPull` hard-fail retained; `flux buildComponentSummaries`' `version → tag` fallback is README display only (unchanged); `pkg/client`'s empty-version sentinel is a tool version, not a chart version (unrelated).
- The OpenAPI contract (`api/aicr/v1/server.yaml`) documents the requirement in the componentRefs `type`/`version` descriptions AND gains `manifestFiles`/`preManifestFiles` properties so generated clients can express the manifest-only carve-out; `docs/user/api-reference.md` carries the same caveat.
- `IsManifestOnlyHelm` guards on the Helm type, so the exported name stays honest for non-Helm refs.
- The adopt path is tested at the client boundary (`adoptRecipe` and the exported `AdoptRecipe`), not just at `PrepareAndValidate`.
- `pkg/mirror` applies the same chart-name fallback for source-only refs, so `aicr mirror list` includes their chart and images in the air-gap inventory instead of silently omitting them.
- Two Flux generator alignments shipped with the invariant: the chart name falls back to the component name (localformat parity — previously a source-only ref emitted an empty `chart:` Flux cannot reconcile), and the README summary's mixed-component predicate now matches generation (chart-or-source), so a source-only ref with post-manifests lists its `<name>-post` release.
- Eight generated E2E recipes in `tests/e2e/run.sh` (the Kind-backed suite GitHub CI runs) carried skeletal or versionless Helm refs that the new invariant rejects at load; they are now valid hydrated refs. Verified by extracting every heredoc-generated recipe and loading each through `recipe.LoadFromFileWithProvider` — the exact path that failed in CI (all 8 pass; two nginx fixtures with chart+source but no version were caught beyond the five CI surfaced).
- Several unit-test fixtures carried versionless or chart-only refs incidental to what they test (two mixin-exclusion tests in `pkg/recipe`, the adopt deep-copy and cross-source isolation tests in `pkg/client/v1`); they now pin `1.0.0`.

- **Review-round additions (cross-review, applied at `7643ce4d` and `e85cf1b2`):**
  - Public projections now expose the effective chart: the `pkg/client/v1` facade and `pkg/recipe` query hydration project `EffectiveChart()` for source-backed refs (previously an SDK consumer saw an empty `chart` and `components.<name>.chart` returned not-found for a ref that deploys fine), and `BuildAutoBOM` records it so digest-bound evidence names the chart actually deployed.
  - The version whitespace rule is now uniform with chart/source: a padded `version` (e.g. `" 1.0.0"`) is rejected — validation previously judged the trimmed value while deployers consume it raw (`NormalizeVersion` only strips a `v` prefix), so a padded value would land verbatim in a Flux HelmRelease.
  - `argocd`, `helmfile`, and `helm` deployers now call `ComponentRef.EffectiveChart()` instead of inline `chart == "" → name` copies (behavior-neutral consolidation; localformat keeps an equivalent fallback on its own `Component` type).
  - The `tools/bom` strict pinning gate uses `recipe.IsEffectiveChartVersion` plus the padded-value rejection, so a whitespace-only, bare-`v`, or padded `defaultVersion` fails CI instead of passing the gate and failing at recipe resolution.
  - `tools/component-test/deploy-component.sh` now emits `manifestFiles` (gathered from the first overlay/mixin declaring them) when synthesizing a recipe for a manifest-only component, so `make component-deploy`/`component-test` still work under the invariant; with no manifests found it fails fast with an actionable message.
  - The `AGENTS.md`/`.claude/CLAUDE.md` declarative Helm-component example gains `defaultVersion` (following it verbatim in an external registry would otherwise fail resolution).

## Testing

```bash
make qualify
```

- `make qualify` passes end-to-end at the review-round head (test + lint + `tools/e2e` [23/23] + scan; note: `tools/e2e` is CLI-only — the Kind-backed `tests/e2e/run.sh` this PR also fixes runs in GitHub CI's `tests / E2E` job).
- New tests (`pkg/recipe/version_required_test.go`) pin all three entry paths: external-registry fixture without `defaultVersion` (plus the positive case where an overlay `version:` pin satisfies the invariant against the same registry), loaded hydrated recipe without `version:`, and the `PrepareAndValidate` boundary the client adopt path calls — each fails `ErrCodeInvalidRequest` naming the component. Negative-space cases: manifest-only (with and without pre-manifests), pre-manifest-only (versioned and unversioned, both rejected), empty and versioned husks (rejected), whitespace-only versions on all three paths (rejected), disabled and lowercase-typed refs. The external-registry test evicts all three provider-keyed caches.
- Coverage: `pkg/recipe` 87.3% → 87.5% (+0.2%); `pkg/bundler/deployer/flux` 84.5% → 84.7% (+0.2%); `pkg/client/v1` 74.0% → 74.2% (+0.2%); `pkg/mirror` 71.4% (flat); `pkg/health` 100% → 100%. Project-wide floor: 78.6% vs the 75% threshold.
- Review-round tests: facade/query/BOM chart-projection tests, padded-version rejection cases in `TestPrepareAndValidateRejectsEmptyHelmVersion`, and table-driven `TestRunStrictDegenerateVersions` for the `tools/bom` gate.
- Second review round: version well-formedness (padding, bare `v`) now applies to every Helm ref shape, not just source-backed — a manifest-only ref's version lands in the rendered chart's `.Chart.Version` / `helm.sh/chart` label (manifest-only version cases added; `classifyChartPinned` grades padded versions as unpinned). `tools/bom` renders/records the component-name chart fallback for source-only registry entries (`TestSurveyComponentSourceOnlyChartFallback`). The component-test harness carries the matched overlay ref's `overrides` for manifest-only components (verified by rendering the nodewright bundle: `accelerator: h100` present) and the last inline chart fallback (`argocd buildApplicationData`) now uses `EffectiveChart()`.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Unreachable for embedded-catalog users (every Helm chart is pinned by `bom-pinning-check`). External-registry users whose Helm components omit `defaultVersion` — previously silently installing "latest" — now get an actionable `INVALID_REQUEST` telling them where to pin; `docs/integrator/data-extension.md` documents the requirement.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)


