### PR TITLE
fix(uat): tolerate skyhook runtime-required taint in AWS snapshot

### DIFF
--- a/tests/uat/aws/tests/h100-inference-config.yaml
+++ b/tests/uat/aws/tests/h100-inference-config.yaml
@@ -49,6 +49,11 @@ spec:
         - dedicated=worker-workload:NoSchedule
         - dedicated=worker-workload:NoExecute
         - nvidia.com/gpu=present:NoSchedule
+        # The GPU pool carries skyhook.nvidia.com=runtime-required:NoSchedule
+        # (cluster-config.yaml) until NodeWright finishes tuning + reboot. The
+        # snapshot runs pre-deployment, so this taint is still present and the
+        # agent — pinned to the GPU pool above — must tolerate it to schedule.
+        - skyhook.nvidia.com=runtime-required:NoSchedule
 
   recipe:
     criteria:

--- a/tests/uat/aws/tests/h100-training-config.yaml
+++ b/tests/uat/aws/tests/h100-training-config.yaml
@@ -49,6 +49,11 @@ spec:
         - dedicated=worker-workload:NoSchedule
         - dedicated=worker-workload:NoExecute
         - nvidia.com/gpu=present:NoSchedule
+        # The GPU pool carries skyhook.nvidia.com=runtime-required:NoSchedule
+        # (cluster-config.yaml) until NodeWright finishes tuning + reboot. The
+        # snapshot runs pre-deployment, so this taint is still present and the
+        # agent — pinned to the GPU pool above — must tolerate it to schedule.
+        - skyhook.nvidia.com=runtime-required:NoSchedule
 
   recipe:
     criteria:


### PR DESCRIPTION
## Summary

Add the `skyhook.nvidia.com=runtime-required:NoSchedule` toleration to the AWS UAT snapshot agent (training + inference configs) so the pre-deployment `prep` snapshot can schedule onto the freshly-tainted GPU pool.

## Motivation / Context

#1614 added `skyhook.nvidia.com=runtime-required:NoSchedule` to the AWS UAT GPU pool in `tests/uat/aws/cluster-config.yaml`. Skyhook applies it at cluster creation and it is removed only after NodeWright finishes tuning + reboot.

The `prep` phase runs `aicr snapshot` **before** deployment, so the taint is still present. The snapshot agent is pinned to the GPU pool (`nodeSelector: nodeGroup=gpu-worker`) with an **explicit** tolerations list, which overrides the tolerate-all default in `pkg/snapshotter/agent.go`. That list omitted the skyhook taint, so the agent pod stayed `Pending`, never became Ready, and the snapshot failed. #1614 updated the cluster-config but not the snapshot-agent configs.

Fixes: N/A
Related: #1614

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Other: AWS UAT configs (`tests/uat/aws`)

## Implementation Notes

Only `spec.snapshot.agent.tolerations` is changed — that is the sole path that runs pre-deployment while the taint is present. `validate.agent` and the bundle `acceleratedNodeTolerations` target the same GPU pool but run post-deployment, after NodeWright has removed the taint, so they are intentionally left untouched.

## Testing

```bash
yamllint tests/uat/aws/tests/h100-training-config.yaml tests/uat/aws/tests/h100-inference-config.yaml   # clean
```

Toleration string `skyhook.nvidia.com=runtime-required:NoSchedule` matches the `key=value:effect` grammar parsed by `snapshotter.ParseTolerations`. End-to-end validation is the next AWS UAT nightly run.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Confined to two AWS UAT test configs; no product code or user-facing behavior changes. N/A for migration.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed (N/A — internal UAT config)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
