### PR TITLE
feat(bom): render divergent recipe version pins as BOM variants

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -368,23 +368,27 @@ jobs:
         with:
           go-version: ${{ steps.versions.outputs.go }}
           cache: false
-      - name: Verify committed BOM versions match the registry
+      - name: Verify committed BOM versions and variants match the recipes
         env:
           GOFLAGS: -mod=vendor
-        # `go test -run <name>` exits 0 with "no tests to run" if the test is
+        # `go test -run <name>` exits 0 with "no tests to run" if a test is
         # renamed or removed, which would let this gate silently no-op. Assert
-        # the named test actually executed by requiring its PASS line.
+        # each named test actually executed by requiring its PASS line — a
+        # docs-only PR must not be able to forge either the Components table
+        # or the Version variants table.
         run: |
           set -uo pipefail
-          out=$(go test ./tools/bom/... -run '^TestCommittedBOMVersionsMatchRegistry$' -v -count=1 2>&1) && rc=0 || rc=$?
+          out=$(go test ./tools/bom/... -run '^(TestCommittedBOMVersionsMatchRegistry|TestCommittedBOMVariantsMatchRecipePins)$' -v -count=1 2>&1) && rc=0 || rc=$?
           echo "$out"
           if [ "$rc" -ne 0 ]; then
             exit "$rc"
           fi
-          if ! grep -q '^--- PASS: TestCommittedBOMVersionsMatchRegistry' <<<"$out"; then
-            echo "::error::TestCommittedBOMVersionsMatchRegistry did not execute (renamed or removed?); the BOM freshness gate would silently pass. Update this job to run the freshness check."
-            exit 1
-          fi
+          for t in TestCommittedBOMVersionsMatchRegistry TestCommittedBOMVariantsMatchRecipePins; do
+            if ! grep -q "^--- PASS: $t" <<<"$out"; then
+              echo "::error::$t did not execute (renamed or removed?); the BOM freshness gate would silently pass. Update this job to run the freshness check."
+              exit 1
+            fi
+          done
 
   bom-freshness-skip:
     needs: [check-paths]

--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -493,9 +493,19 @@ unpinned row cannot slip through. Because a docs-only PR that edits the committe
 BOM skips the full `tests` job, the `bom-freshness` job in
 `.github/workflows/merge-gate.yaml` runs this same test whenever
 `docs/user/container-images.md` or `recipes/registry.yaml` change, so
-the gate holds for docs-only edits too. It does **not** catch *upstream
-image drift* — a chart bumping an image inside its own templates without
-a pin change on our side. Full `make bom-check` verifies that too by
+the gate holds for docs-only edits too.
+
+`TestCommittedBOMVariantsMatchRecipePins` (same file, same jobs) gates
+the doc's **Version variants** table the same way: it derives every
+explicit base/overlay/mixin Helm pin that differs from its registry
+default and compares bidirectionally — a new divergent pin without a
+variant row fails, and a stale row without a backing pin fails. Variant
+discovery reads only the recipe data (the pins are the source facts);
+it has no dependency on the version-pin guard's exemption policy, which
+decides whether a divergence is *allowed*, not what deploys.
+
+Neither gate catches *upstream image drift* — a chart bumping an image
+inside its own templates without a pin change on our side. Full `make bom-check` verifies that too by
 re-rendering, but it is **opt-in only** — not wired into `make qualify`,
 `make lint`, or the PR gate. So you still must run `make bom-docs` after
 a values change.

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -20,10 +20,12 @@ A machine-readable **CycloneDX 1.6 JSON** companion to this page is produced by 
 ## Summary
 
 - Components: **33**
-- Unique images: **82**
+- Unique images: **86**
 - Distinct registries: **11**
 
 Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev`, `docker.io`, `gcr.io`, `ghcr.io`, `gke.gcr.io`, `nvcr.io`, `public.ecr.aws`, `quay.io`, `registry.k8s.io`, `us-docker.pkg.dev`
+
+_Rendering fidelity:_ `catalog-parity: charts are rendered with the shared recipes/components/<name>/values.yaml; per-recipe overlay overrides are not applied`
 
 ## Components
 
@@ -62,6 +64,15 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | slinky-slurm | helm | slurm | 1.2.0 | 5 |
 | slinky-slurm-operator | helm | slurm-operator | 1.2.0 | 2 |
 | slinky-slurm-operator-crds | helm | slurm-operator-crds | 1.2.0 | 0 |
+
+## Version variants
+
+These versions are explicitly pinned by the listed sources and differ
+from the component's registry default above.
+
+| Component | Variant Version | Declared By | Images |
+|-----------|-----------------|-------------|--------|
+| kube-prometheus-stack | 83.7.0 | aks | 8 |
 
 ## Images by component
 
@@ -254,6 +265,17 @@ _No images extracted._
 ### slinky-slurm-operator-crds
 
 _No images extracted._
+
+### kube-prometheus-stack@83.7.0 (variant)
+
+- `docker.io/grafana/grafana:12.4.3`
+- `ghcr.io/jkroepke/kube-webhook-certgen:1.8.1`
+- `quay.io/kiwigrid/k8s-sidecar:2.6.0`
+- `quay.io/prometheus-operator/prometheus-operator:v0.90.1`
+- `quay.io/prometheus/alertmanager:v0.32.0`
+- `quay.io/prometheus/node-exporter:v1.11.1`
+- `quay.io/prometheus/prometheus:v3.11.2`
+- `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0`
 
 <!-- END AICR-BOM -->
 

--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -15,6 +15,7 @@
 package bom
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,6 +23,8 @@ import (
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/google/uuid"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 const (
@@ -76,6 +79,13 @@ type Metadata struct {
 	// auto-generated middle of docs/user/container-images.md, where the
 	// title and surrounding prose are hand-edited).
 	NoTitle bool
+
+	// RenderFidelity, when non-empty, is stated in the Markdown header and
+	// attached to the CycloneDX metadata as an aicr:render:fidelity
+	// property. Producers set it to describe HOW image sets were obtained
+	// (tools/bom sets RenderFidelityCatalogParity); producers with a
+	// different story leave it empty rather than stamp a false claim.
+	RenderFidelity string
 }
 
 // ComponentResult is the per-component image survey input to BuildBOM.
@@ -101,8 +111,20 @@ type ComponentResult struct {
 //	  └─ each ComponentResult as an `application` (bom-ref: "<name>/<comp>")
 //	       └─ each unique image as a `container` (bom-ref: "img:<ref>")
 //
-// Image entries are de-duplicated across components.
+// Image entries are de-duplicated across components. For a BOM that also
+// carries per-source version variants — with fail-closed bom-ref uniqueness —
+// use BuildBOMWithVariants; this legacy entry point is preserved unchanged
+// for existing importers.
 func BuildBOM(meta Metadata, results []ComponentResult) *cdx.BOM {
+	doc, _ := buildBOMDoc(meta, results, nil, false) // unchecked mode cannot error
+	return doc
+}
+
+// buildBOMDoc is the shared builder behind BuildBOM (checked=false: legacy
+// semantics, duplicate component refs are emitted as-is and no variants) and
+// BuildBOMWithVariants (checked=true: every bom-ref claims through a global
+// identity set and collisions fail closed).
+func buildBOMDoc(meta Metadata, results []ComponentResult, variants []VariantResult, checked bool) (*cdx.BOM, error) {
 	if meta.Name == "" {
 		meta.Name = defaultRootName
 	}
@@ -135,6 +157,11 @@ func BuildBOM(meta Metadata, results []ComponentResult) *cdx.BOM {
 			},
 		},
 	}
+	if meta.RenderFidelity != "" {
+		bom.Metadata.Properties = &[]cdx.Property{
+			{Name: "aicr:render:fidelity", Value: meta.RenderFidelity},
+		}
+	}
 
 	// Copy before sorting so callers (e.g., pkg/bundler when it consumes
 	// this) don't observe their input slice reordered.
@@ -143,55 +170,21 @@ func BuildBOM(meta Metadata, results []ComponentResult) *cdx.BOM {
 		return sorted[i].Name < sorted[j].Name
 	})
 
+	claims := newRefClaims(meta.Name, checked)
 	var (
 		comps []cdx.Component
 		deps  []cdx.Dependency
-		seen  = map[string]struct{}{}
 	)
-	rootChildren := make([]string, 0, len(sorted))
+	rootChildren := make([]string, 0, len(sorted)+len(variants))
 
 	for _, r := range sorted {
 		compRef := meta.Name + "/" + r.Name
+		if err := claims.claimRef(compRef); err != nil {
+			return nil, err
+		}
 		rootChildren = append(rootChildren, compRef)
 
-		// Name the deployment properties by effective component type so a
-		// Kustomize component's Git source and tag are not mislabeled as a Helm
-		// repository/version (the CycloneDX doc already declares
-		// aicr:component:type). Helm and manifest components keep the
-		// aicr:helm:* names. Chart is Helm-only and omitted for Kustomize.
-		kustomize := strings.EqualFold(r.Type, TypeKustomize)
-		props := []cdx.Property{
-			{Name: "aicr:component:type", Value: r.Type},
-		}
-		if r.Repository != "" {
-			name := "aicr:helm:repository"
-			if kustomize {
-				name = "aicr:kustomize:source"
-			}
-			props = append(props, cdx.Property{Name: name, Value: r.Repository})
-		}
-		if r.Chart != "" && !kustomize {
-			props = append(props, cdx.Property{Name: "aicr:helm:chart", Value: r.Chart})
-		}
-		if r.Version != "" {
-			name := "aicr:helm:version"
-			if kustomize {
-				name = "aicr:kustomize:tag"
-			}
-			props = append(props, cdx.Property{Name: name, Value: r.Version})
-		}
-		if r.Namespace != "" {
-			name := "aicr:helm:namespace"
-			if kustomize {
-				name = "aicr:kustomize:namespace"
-			}
-			props = append(props, cdx.Property{Name: name, Value: r.Namespace})
-		}
-		props = append(props, cdx.Property{Name: "aicr:version:pinned", Value: strconv.FormatBool(r.Pinned)})
-		for _, w := range r.Warnings {
-			props = append(props, cdx.Property{Name: "aicr:render:warning", Value: w})
-		}
-
+		props := componentProperties(r)
 		comps = append(comps, cdx.Component{
 			BOMRef:      compRef,
 			Type:        cdx.ComponentTypeApplication,
@@ -200,34 +193,33 @@ func BuildBOM(meta Metadata, results []ComponentResult) *cdx.BOM {
 			Version:     r.Version,
 			Properties:  &props,
 		})
-
-		var imgRefs []string
-		for _, img := range r.Images {
-			ref := ParseImageRef(img)
-			imgRef := "img:" + img
-			if _, ok := seen[imgRef]; !ok {
-				seen[imgRef] = struct{}{}
-				comps = append(comps, cdx.Component{
-					BOMRef:     imgRef,
-					Type:       cdx.ComponentTypeContainer,
-					Name:       ref.Registry + "/" + ref.Repository,
-					Version:    versionOrTag(ref),
-					PackageURL: ref.PURL(),
-					Properties: &[]cdx.Property{
-						{Name: "aicr:image:registry", Value: ref.Registry},
-						{Name: "aicr:image:repository", Value: ref.Repository},
-						{Name: "aicr:image:tag", Value: ref.Tag},
-						{Name: "aicr:image:digest", Value: ref.Digest},
-					},
-				})
-			}
-			imgRefs = append(imgRefs, imgRef)
+		var err error
+		comps, deps, err = appendImageEntries(claims, comps, deps, compRef, r.Images)
+		if err != nil {
+			return nil, err
 		}
-		if len(imgRefs) > 0 {
-			deps = append(deps, cdx.Dependency{
-				Ref:          compRef,
-				Dependencies: refList(imgRefs),
-			})
+	}
+
+	// Variants (checked mode only): version-qualified refs so default
+	// entries stay untouched, sorted by (name, version) for determinism.
+	sortedVariants := append([]VariantResult(nil), variants...)
+	sort.Slice(sortedVariants, func(i, j int) bool {
+		if sortedVariants[i].Name != sortedVariants[j].Name {
+			return sortedVariants[i].Name < sortedVariants[j].Name
+		}
+		return sortedVariants[i].Version < sortedVariants[j].Version
+	})
+	for _, v := range sortedVariants {
+		compRef := meta.Name + "/" + v.Name + "@" + v.Version
+		if err := claims.claimRef(compRef); err != nil {
+			return nil, err
+		}
+		rootChildren = append(rootChildren, compRef)
+		comps = append(comps, variantComponent(compRef, v))
+		var err error
+		comps, deps, err = appendImageEntries(claims, comps, deps, compRef, v.Images)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -237,7 +229,143 @@ func BuildBOM(meta Metadata, results []ComponentResult) *cdx.BOM {
 
 	bom.Components = &comps
 	bom.Dependencies = &deps
-	return bom
+	return bom, nil
+}
+
+// refClaims tracks bom-ref identity across a document build. refs is the
+// global identity set used in checked mode: root, components, variants, and
+// images all pass through it (CycloneDX requires unique bom-refs). The value
+// records whether the ref is an image — images legitimately repeat across
+// components (a repeat is a dedup, not a collision), any other reuse fails
+// closed. Unchecked (legacy) mode keeps the historical behavior: no claims,
+// image-level dedup only via seen.
+type refClaims struct {
+	checked bool
+	seen    map[string]struct{}
+	refs    map[string]bool
+}
+
+func newRefClaims(rootRef string, checked bool) *refClaims {
+	return &refClaims{
+		checked: checked,
+		seen:    map[string]struct{}{},
+		refs:    map[string]bool{rootRef: false},
+	}
+}
+
+// claimRef claims a component/variant identity; a duplicate fails closed in
+// checked mode.
+func (c *refClaims) claimRef(ref string) error {
+	if !c.checked {
+		return nil
+	}
+	if _, dup := c.refs[ref]; dup {
+		return errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+			"duplicate bom-ref %q: component and variant identities must be unique "+
+				"(CycloneDX requires unique bom-refs and the dependency graph would be ambiguous)", ref))
+	}
+	c.refs[ref] = false
+	return nil
+}
+
+// claimImage claims an image ref, reporting whether it is fresh (needs an
+// entry). A repeat of another image is a cross-component dedup; colliding
+// with a non-image identity fails closed in checked mode.
+func (c *refClaims) claimImage(ref string) (bool, error) {
+	if _, dup := c.seen[ref]; dup {
+		return false, nil
+	}
+	if c.checked {
+		if isImage, exists := c.refs[ref]; exists && !isImage {
+			return false, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+				"duplicate bom-ref %q: an image reference collides with a component identity", ref))
+		}
+		c.refs[ref] = true
+	}
+	c.seen[ref] = struct{}{}
+	return true, nil
+}
+
+// appendImageEntries claims each image under compRef, appends container
+// entries for fresh images, and records the compRef→images dependency edge.
+func appendImageEntries(claims *refClaims, comps []cdx.Component, deps []cdx.Dependency, compRef string, images []string) ([]cdx.Component, []cdx.Dependency, error) {
+	imgRefs := make([]string, 0, len(images))
+	for _, img := range images {
+		fresh, err := claims.claimImage("img:" + img)
+		if err != nil {
+			return nil, nil, err
+		}
+		if fresh {
+			comps = append(comps, imageComponent(img))
+		}
+		imgRefs = append(imgRefs, "img:"+img)
+	}
+	if len(imgRefs) > 0 {
+		deps = append(deps, cdx.Dependency{
+			Ref:          compRef,
+			Dependencies: refList(imgRefs),
+		})
+	}
+	return comps, deps, nil
+}
+
+// componentProperties names the deployment properties by effective component
+// type so a Kustomize component's Git source and tag are not mislabeled as a
+// Helm repository/version (the CycloneDX doc already declares
+// aicr:component:type). Helm and manifest components keep the aicr:helm:*
+// names. Chart is Helm-only and omitted for Kustomize.
+func componentProperties(r ComponentResult) []cdx.Property {
+	kustomize := strings.EqualFold(r.Type, TypeKustomize)
+	props := []cdx.Property{
+		{Name: "aicr:component:type", Value: r.Type},
+	}
+	if r.Repository != "" {
+		name := "aicr:helm:repository"
+		if kustomize {
+			name = "aicr:kustomize:source"
+		}
+		props = append(props, cdx.Property{Name: name, Value: r.Repository})
+	}
+	if r.Chart != "" && !kustomize {
+		props = append(props, cdx.Property{Name: "aicr:helm:chart", Value: r.Chart})
+	}
+	if r.Version != "" {
+		name := "aicr:helm:version"
+		if kustomize {
+			name = "aicr:kustomize:tag"
+		}
+		props = append(props, cdx.Property{Name: name, Value: r.Version})
+	}
+	if r.Namespace != "" {
+		name := "aicr:helm:namespace"
+		if kustomize {
+			name = "aicr:kustomize:namespace"
+		}
+		props = append(props, cdx.Property{Name: name, Value: r.Namespace})
+	}
+	props = append(props, cdx.Property{Name: "aicr:version:pinned", Value: strconv.FormatBool(r.Pinned)})
+	for _, w := range r.Warnings {
+		props = append(props, cdx.Property{Name: "aicr:render:warning", Value: w})
+	}
+	return props
+}
+
+// imageComponent renders one image reference as a CycloneDX container entry.
+func imageComponent(img string) cdx.Component {
+	ref := ParseImageRef(img)
+	return cdx.Component{
+		BOMRef:     "img:" + img,
+		Type:       cdx.ComponentTypeContainer,
+		Name:       ref.Registry + "/" + ref.Repository,
+		Version:    versionOrTag(ref),
+		PackageURL: ref.PURL(),
+		Properties: &[]cdx.Property{
+			{Name: "aicr:image:registry", Value: ref.Registry},
+			{Name: "aicr:image:repository", Value: ref.Repository},
+			{Name: "aicr:image:tag", Value: ref.Tag},
+			{Name: "aicr:image:digest", Value: ref.Digest},
+		},
+	}
 }
 
 // bomSerialNumber picks a SerialNumber for the BOM based on Metadata. The

--- a/pkg/bom/markdown.go
+++ b/pkg/bom/markdown.go
@@ -46,12 +46,27 @@ func (s *stickyWriter) Write(p []byte) (int, error) {
 // WriteMarkdown emits a human-readable summary of a component-level BOM
 // suitable for embedding in docs.
 func WriteMarkdown(w io.Writer, meta Metadata, results []ComponentResult) error {
+	return writeMarkdownDoc(w, meta, results, nil)
+}
+
+// writeMarkdownDoc is the shared writer behind WriteMarkdown (nil variants:
+// legacy output, byte-identical) and WriteMarkdownWithVariants.
+func writeMarkdownDoc(w io.Writer, meta Metadata, results []ComponentResult, variants []VariantResult) error {
 	// Copy before sorting so callers don't observe their input reordered.
 	sorted := append([]ComponentResult(nil), results...)
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i].Name < sorted[j].Name
 	})
 	results = sorted
+
+	sortedVariants := append([]VariantResult(nil), variants...)
+	sort.Slice(sortedVariants, func(i, j int) bool {
+		if sortedVariants[i].Name != sortedVariants[j].Name {
+			return sortedVariants[i].Name < sortedVariants[j].Name
+		}
+		return sortedVariants[i].Version < sortedVariants[j].Version
+	})
+	variants = sortedVariants
 
 	var (
 		totalImages     int
@@ -60,6 +75,15 @@ func WriteMarkdown(w io.Writer, meta Metadata, results []ComponentResult) error 
 	)
 	for _, r := range results {
 		for _, img := range r.Images {
+			if _, dup := uniqueImages[img]; !dup {
+				uniqueImages[img] = struct{}{}
+				totalImages++
+				totalRegistries[ParseImageRef(img).Registry] = struct{}{}
+			}
+		}
+	}
+	for _, v := range variants {
+		for _, img := range v.Images {
 			if _, dup := uniqueImages[img]; !dup {
 				uniqueImages[img] = struct{}{}
 				totalImages++
@@ -97,6 +121,15 @@ func WriteMarkdown(w io.Writer, meta Metadata, results []ComponentResult) error 
 	sort.Strings(regs)
 	fmt.Fprintf(sw, "Registries: %s\n\n", strings.Join(quoteAll(regs), ", "))
 
+	// State the rendering fidelity when the producer supplies one (the
+	// CycloneDX metadata carries the same note for JSON consumers). The
+	// value goes in a code span so a literal placeholder like <name> renders
+	// as text instead of being swallowed as raw HTML. Legacy callers never
+	// set the field, so their output is unchanged.
+	if meta.RenderFidelity != "" {
+		fmt.Fprintf(sw, "_Rendering fidelity:_ `%s`\n\n", meta.RenderFidelity)
+	}
+
 	fmt.Fprintf(sw, "## Components\n\n")
 	fmt.Fprintln(sw, "| Component | Type | Chart | Pinned Version | Images |")
 	fmt.Fprintln(sw, "|-----------|------|-------|----------------|--------|")
@@ -113,26 +146,54 @@ func WriteMarkdown(w io.Writer, meta Metadata, results []ComponentResult) error 
 			r.Name, r.Type, chart, ver, len(r.Images))
 	}
 
+	// Version variants: a separate table (with distinct column headers) so
+	// the one-row-per-registry-component Components table — and its
+	// freshness gate — remains intact. Omitted entirely when no divergent
+	// pins exist.
+	if len(variants) > 0 {
+		fmt.Fprintf(sw, "\n## Version variants\n\n")
+		fmt.Fprintln(sw, "These versions are explicitly pinned by the listed sources and differ")
+		fmt.Fprintln(sw, "from the component's registry default above.")
+		fmt.Fprintln(sw)
+		fmt.Fprintln(sw, "| Component | Variant Version | Declared By | Images |")
+		fmt.Fprintln(sw, "|-----------|-----------------|-------------|--------|")
+		for _, v := range variants {
+			srcs := append([]string(nil), v.Sources...)
+			sort.Strings(srcs)
+			fmt.Fprintf(sw, "| %s | %s | %s | %d |\n",
+				v.Name, v.Version, strings.Join(srcs, ", "), len(v.Images))
+		}
+	}
+
 	fmt.Fprintf(sw, "\n## Images by component\n\n")
 	for _, r := range results {
-		fmt.Fprintf(sw, "### %s\n\n", r.Name)
-		for _, warn := range r.Warnings {
-			fmt.Fprintf(sw, "> Warning: %s\n\n", warn)
-		}
-		if len(r.Images) == 0 {
-			fmt.Fprintln(sw, "_No images extracted._")
-		} else {
-			for _, img := range r.Images {
-				fmt.Fprintf(sw, "- `%s`\n", img)
-			}
-		}
-		fmt.Fprintln(sw)
+		writeImageSection(sw, r.Name, r.Warnings, r.Images)
+	}
+	for _, v := range variants {
+		writeImageSection(sw, v.Name+"@"+v.Version+" (variant)", v.Warnings, v.Images)
 	}
 
 	if sw.err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to write markdown BOM", sw.err)
 	}
 	return nil
+}
+
+// writeImageSection renders one "### <heading>" block with its warnings and
+// image list; shared by default components and version variants.
+func writeImageSection(sw *stickyWriter, heading string, warnings, images []string) {
+	fmt.Fprintf(sw, "### %s\n\n", heading)
+	for _, warn := range warnings {
+		fmt.Fprintf(sw, "> Warning: %s\n\n", warn)
+	}
+	if len(images) == 0 {
+		fmt.Fprintln(sw, "_No images extracted._")
+	} else {
+		for _, img := range images {
+			fmt.Fprintf(sw, "- `%s`\n", img)
+		}
+	}
+	fmt.Fprintln(sw)
 }
 
 func titleFor(m Metadata) string {

--- a/pkg/bom/variants.go
+++ b/pkg/bom/variants.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bom
+
+import (
+	"io"
+	"sort"
+	"strings"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+)
+
+// RenderFidelityCatalogParity documents the uniform rendering limitation of
+// every entry in the catalog BOM (tools/bom) — default and variant alike:
+// charts are templated with the shared per-component values file only. It is
+// caller-supplied via Metadata.RenderFidelity because other BOM producers
+// have a different fidelity story and must not carry a false claim. See
+// issue #1611.
+const RenderFidelityCatalogParity = "catalog-parity: charts are rendered with the shared " +
+	"recipes/components/<name>/values.yaml; per-recipe overlay overrides are not applied"
+
+// VariantResult is a per-source version variant of a registry component: an
+// explicit base/overlay/mixin Helm componentRef.version pin that differs from
+// the component's registry defaultVersion. Variants are derived from recipe
+// data (the declared pins themselves), aggregated by (Name, Version), and
+// rendered at catalog parity with the REGISTRY chart coordinates. See issue
+// #1611 — coordinate or type divergence and effective-inheritance resolution
+// are explicit non-goals of the variants model.
+type VariantResult struct {
+	Name       string   // component identifier, e.g., "kube-prometheus-stack"
+	Version    string   // the divergent pinned chart version
+	Sources    []string // sorted base/overlay/mixin metadata.names declaring the pin
+	Repository string   // chart repository URL (registry coordinates)
+	Chart      string   // chart name (registry coordinates)
+	Namespace  string   // default namespace
+	Images     []string // sorted, deduplicated image references at this version
+	Warnings   []string // non-fatal issues to attach as properties
+}
+
+// BuildBOMWithVariants is the variant-aware companion to BuildBOM: default
+// component entries are byte-identical to BuildBOM's, variant entries carry
+// version-qualified bom-refs ("<meta.Name>/<comp>@<ver>") with sorted
+// aicr:variant:sources, and — unlike the legacy entry point — every bom-ref
+// claims through a global identity set, so duplicates fail closed with
+// ErrCodeInvalidRequest instead of producing an ambiguous dependency graph.
+func BuildBOMWithVariants(meta Metadata, results []ComponentResult, variants []VariantResult) (*cdx.BOM, error) {
+	return buildBOMDoc(meta, results, variants, true)
+}
+
+// WriteMarkdownWithVariants is the variant-aware companion to WriteMarkdown:
+// variants render as a separate "Version variants" table (distinct column
+// headers, so the Components table and its freshness gate stay intact) plus
+// per-variant image sections; the section is omitted entirely when no
+// variants exist. The legacy WriteMarkdown output is unchanged.
+func WriteMarkdownWithVariants(w io.Writer, meta Metadata, results []ComponentResult, variants []VariantResult) error {
+	return writeMarkdownDoc(w, meta, results, variants)
+}
+
+// variantComponent renders one VariantResult as a CycloneDX application
+// entry with its version-qualified bom-ref and variant properties.
+func variantComponent(compRef string, v VariantResult) cdx.Component {
+	srcs := append([]string(nil), v.Sources...)
+	sort.Strings(srcs)
+	props := []cdx.Property{
+		{Name: "aicr:component:type", Value: TypeHelm},
+		{Name: "aicr:variant:of", Value: v.Name},
+		{Name: "aicr:variant:sources", Value: strings.Join(srcs, ",")},
+	}
+	if v.Repository != "" {
+		props = append(props, cdx.Property{Name: "aicr:helm:repository", Value: v.Repository})
+	}
+	if v.Chart != "" {
+		props = append(props, cdx.Property{Name: "aicr:helm:chart", Value: v.Chart})
+	}
+	props = append(props, cdx.Property{Name: "aicr:helm:version", Value: v.Version})
+	if v.Namespace != "" {
+		props = append(props, cdx.Property{Name: "aicr:helm:namespace", Value: v.Namespace})
+	}
+	props = append(props, cdx.Property{Name: "aicr:version:pinned", Value: "true"})
+	for _, w := range v.Warnings {
+		props = append(props, cdx.Property{Name: "aicr:render:warning", Value: w})
+	}
+	return cdx.Component{
+		BOMRef:     compRef,
+		Type:       cdx.ComponentTypeApplication,
+		Name:       v.Name,
+		Version:    v.Version,
+		Properties: &props,
+	}
+}

--- a/pkg/bom/variants_test.go
+++ b/pkg/bom/variants_test.go
@@ -22,6 +22,19 @@ import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 )
 
+// encodeBOM serializes a CycloneDX BOM to canonical JSON for byte-stable
+// regression comparisons.
+func encodeBOM(t *testing.T, doc *cdx.BOM) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := cdx.NewBOMEncoder(&buf, cdx.BOMFileFormatJSON)
+	enc.SetPretty(true)
+	if err := enc.Encode(doc); err != nil {
+		t.Fatalf("encode BOM: %v", err)
+	}
+	return buf.String()
+}
+
 func sampleVariants() []VariantResult {
 	return []VariantResult{
 		{
@@ -241,6 +254,17 @@ func TestLegacyEntryPointsUnchanged(t *testing.T) {
 	}
 	if legacy.String() != modern.String() {
 		t.Error("WriteMarkdown and WriteMarkdownWithVariants(nil) diverged")
+	}
+
+	// The CycloneDX surface must match too: the legacy BuildBOM and the
+	// variant-aware BuildBOMWithVariants(nil) must serialize byte-identically,
+	// locking component/dependency ordering and image dedup for importers.
+	modernBOM, err := BuildBOMWithVariants(meta, results, nil)
+	if err != nil {
+		t.Fatalf("BuildBOMWithVariants: %v", err)
+	}
+	if encodeBOM(t, BuildBOM(meta, results)) != encodeBOM(t, modernBOM) {
+		t.Error("BuildBOM and BuildBOMWithVariants(nil) serialized differently")
 	}
 
 	// Legacy BuildBOM tolerates duplicate component names exactly as before.

--- a/pkg/bom/variants_test.go
+++ b/pkg/bom/variants_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bom
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+)
+
+func sampleVariants() []VariantResult {
+	return []VariantResult{
+		{
+			Name:       "kube-prometheus-stack",
+			Version:    "83.7.0",
+			Sources:    []string{"platform-x", "aks"}, // deliberately unsorted input
+			Repository: "https://prometheus-community.github.io/helm-charts",
+			Chart:      "prometheus-community/kube-prometheus-stack",
+			Namespace:  "monitoring",
+			Images:     []string{"quay.io/prometheus/prometheus:v2.83.0"},
+		},
+	}
+}
+
+// TestBuildBOMWithVariants pins the variant contract: default component
+// bom-refs are identical to the legacy builder's, variant entries get
+// version-qualified refs with sorted aicr:variant:sources, variant images
+// join the dependency graph, and the caller-supplied fidelity note lands in
+// the CycloneDX metadata.
+func TestBuildBOMWithVariants(t *testing.T) {
+	results := []ComponentResult{{
+		Name: "kube-prometheus-stack", Type: TypeHelm, Version: "84.4.0",
+		Images: []string{"quay.io/prometheus/prometheus:v3.0.0"},
+	}}
+	doc, err := BuildBOMWithVariants(Metadata{
+		Name: "aicr", Version: "v1", RenderFidelity: RenderFidelityCatalogParity,
+	}, results, sampleVariants())
+	if err != nil {
+		t.Fatalf("BuildBOMWithVariants: %v", err)
+	}
+
+	var defaultRef, variantRef *cdx.Component
+	for i := range *doc.Components {
+		c := &(*doc.Components)[i]
+		switch c.BOMRef {
+		case "aicr/kube-prometheus-stack":
+			defaultRef = c
+		case "aicr/kube-prometheus-stack@83.7.0":
+			variantRef = c
+		}
+	}
+	if defaultRef == nil {
+		t.Fatal("default component bom-ref changed or missing — variants must not alter default identities")
+	}
+	if variantRef == nil {
+		t.Fatal("variant entry aicr/kube-prometheus-stack@83.7.0 missing")
+	}
+	if variantRef.Version != "83.7.0" {
+		t.Errorf("variant version = %q, want 83.7.0", variantRef.Version)
+	}
+	var sources string
+	for _, p := range *variantRef.Properties {
+		if p.Name == "aicr:variant:sources" {
+			sources = p.Value
+		}
+	}
+	if sources != "aks,platform-x" {
+		t.Errorf("aicr:variant:sources = %q, want sorted \"aks,platform-x\"", sources)
+	}
+
+	var rootDeps, variantDeps []string
+	for _, d := range *doc.Dependencies {
+		if d.Dependencies == nil {
+			continue
+		}
+		switch d.Ref {
+		case "aicr":
+			rootDeps = *d.Dependencies
+		case "aicr/kube-prometheus-stack@83.7.0":
+			variantDeps = *d.Dependencies
+		}
+	}
+	found := map[string]bool{}
+	for _, r := range rootDeps {
+		found[r] = true
+	}
+	if !found["aicr/kube-prometheus-stack"] || !found["aicr/kube-prometheus-stack@83.7.0"] {
+		t.Errorf("root dependencies = %v, want both default and variant refs", rootDeps)
+	}
+	if len(variantDeps) != 1 || variantDeps[0] != "img:quay.io/prometheus/prometheus:v2.83.0" {
+		t.Errorf("variant deps = %v, want the variant's rendered image", variantDeps)
+	}
+
+	var fidelity string
+	if doc.Metadata.Properties != nil {
+		for _, p := range *doc.Metadata.Properties {
+			if p.Name == "aicr:render:fidelity" {
+				fidelity = p.Value
+			}
+		}
+	}
+	if fidelity != RenderFidelityCatalogParity {
+		t.Errorf("aicr:render:fidelity = %q, want the caller-supplied catalog-parity note", fidelity)
+	}
+}
+
+// TestBuildBOMWithVariants_DuplicateRefsFailClosed pins the checked mode's
+// fail-closed contract, which the legacy BuildBOM deliberately does not have.
+func TestBuildBOMWithVariants_DuplicateRefsFailClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []ComponentResult
+		variants []VariantResult
+	}{
+		{
+			"duplicate components",
+			[]ComponentResult{{Name: "a", Type: TypeHelm}, {Name: "a", Type: TypeHelm}},
+			nil,
+		},
+		{
+			"duplicate variants",
+			nil,
+			[]VariantResult{
+				{Name: "a", Version: "1.0.0"},
+				{Name: "a", Version: "1.0.0"},
+			},
+		},
+		{
+			// meta.Name "img:nvcr.io" + component "gpu:v1" produces the
+			// application ref "img:nvcr.io/gpu:v1", colliding with the
+			// container entry for image "nvcr.io/gpu:v1".
+			"image ref colliding with a component identity",
+			[]ComponentResult{
+				{Name: "gpu:v1", Type: TypeHelm, Version: "1.0.0"},
+				{Name: "other", Type: TypeHelm, Version: "1.0.0", Images: []string{"nvcr.io/gpu:v1"}},
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := Metadata{Name: "aicr"}
+			if tt.name == "image ref colliding with a component identity" {
+				meta.Name = "img:nvcr.io"
+			}
+			_, err := BuildBOMWithVariants(meta, tt.results, tt.variants)
+			if err == nil {
+				t.Fatal("BuildBOMWithVariants accepted duplicate bom-refs")
+			}
+			if !strings.Contains(err.Error(), "duplicate bom-ref") {
+				t.Errorf("error = %v, want a duplicate bom-ref rejection", err)
+			}
+		})
+	}
+
+	// Cross-component image reuse stays a dedup, not a collision.
+	doc, err := BuildBOMWithVariants(Metadata{Name: "aicr"}, []ComponentResult{
+		{Name: "a", Type: TypeHelm, Version: "1.0.0", Images: []string{"nvcr.io/shared:v1"}},
+		{Name: "b", Type: TypeHelm, Version: "1.0.0", Images: []string{"nvcr.io/shared:v1"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildBOMWithVariants rejected a legitimate cross-component image dedup: %v", err)
+	}
+	count := 0
+	for _, c := range *doc.Components {
+		if c.BOMRef == "img:nvcr.io/shared:v1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("shared image entries = %d, want exactly 1", count)
+	}
+}
+
+// TestWriteMarkdownWithVariants pins the Markdown projection: a separate
+// Version-variants table with distinct headers, per-variant image sections,
+// the caller-supplied fidelity note in a code span, and full omission when
+// no variants exist.
+func TestWriteMarkdownWithVariants(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteMarkdownWithVariants(&buf, Metadata{
+		Name: "aicr", Deterministic: true, RenderFidelity: RenderFidelityCatalogParity,
+	}, sampleResults(), sampleVariants())
+	if err != nil {
+		t.Fatalf("WriteMarkdownWithVariants: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"## Version variants",
+		"| Component | Variant Version | Declared By | Images |",
+		"| kube-prometheus-stack | 83.7.0 | aks, platform-x | 1 |",
+		"### kube-prometheus-stack@83.7.0 (variant)",
+		"- `quay.io/prometheus/prometheus:v2.83.0`",
+		"_Rendering fidelity:_",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown missing %q:\n%s", want, out)
+		}
+	}
+
+	var noVar bytes.Buffer
+	if err := WriteMarkdownWithVariants(&noVar, Metadata{Name: "aicr", Deterministic: true}, sampleResults(), nil); err != nil {
+		t.Fatalf("WriteMarkdownWithVariants(no variants): %v", err)
+	}
+	if strings.Contains(noVar.String(), "## Version variants") {
+		t.Error("variants section should be omitted entirely when no divergent pins exist")
+	}
+	if strings.Contains(noVar.String(), "_Rendering fidelity:") {
+		t.Error("fidelity note should be absent without a caller-supplied value")
+	}
+}
+
+// TestLegacyEntryPointsUnchanged pins the compatibility contract: the legacy
+// BuildBOM/WriteMarkdown surfaces are byte-equivalent to the variant-aware
+// entry points called with no variants and no fidelity — external importers
+// see no behavioral change.
+func TestLegacyEntryPointsUnchanged(t *testing.T) {
+	meta := Metadata{Name: "aicr", Version: "v1", Deterministic: true}
+	results := sampleResults()
+
+	var legacy, modern bytes.Buffer
+	if err := WriteMarkdown(&legacy, meta, results); err != nil {
+		t.Fatalf("WriteMarkdown: %v", err)
+	}
+	if err := WriteMarkdownWithVariants(&modern, meta, results, nil); err != nil {
+		t.Fatalf("WriteMarkdownWithVariants: %v", err)
+	}
+	if legacy.String() != modern.String() {
+		t.Error("WriteMarkdown and WriteMarkdownWithVariants(nil) diverged")
+	}
+
+	// Legacy BuildBOM tolerates duplicate component names exactly as before.
+	doc := BuildBOM(meta, []ComponentResult{
+		{Name: "a", Type: TypeHelm}, {Name: "a", Type: TypeHelm},
+	})
+	count := 0
+	for _, c := range *doc.Components {
+		if c.BOMRef == "aicr/a" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("legacy BuildBOM emitted %d entries for the duplicate, want the historical 2", count)
+	}
+}

--- a/tools/bom/freshness_parse_test.go
+++ b/tools/bom/freshness_parse_test.go
@@ -180,6 +180,21 @@ func TestParseBOMVariantsTable(t *testing.T) {
 			true, 0, true,
 		},
 		{
+			// A header followed by a blank line and prose (instead of the
+			// delimiter row) must fail closed, not silently reset table
+			// state and count as a present-but-empty table.
+			"header followed by blank line and prose",
+			"## Version variants\n\n| Component | Variant Version | Declared By | Images |\n\nno delimiter here\n",
+			true, 0, true,
+		},
+		{
+			// A header that is the last line of the section (loop ends while
+			// still awaiting the delimiter row) must also fail closed.
+			"header is the last line",
+			"## Version variants\n\n| Component | Variant Version | Declared By | Images |\n",
+			true, 0, true,
+		},
+		{
 			// The header must be the generator's exact four columns: a hand
 			// edit that drops Images is an unrecognized table, and the
 			// heading-without-table mismatch fails the gate loudly.

--- a/tools/bom/freshness_parse_test.go
+++ b/tools/bom/freshness_parse_test.go
@@ -197,6 +197,13 @@ func TestParseBOMVariantsTable(t *testing.T) {
 			goodTable + "| kps2 | 82.0.0 | aks | 8 | extra |\n",
 			true, 0, true,
 		},
+		{
+			// An all-blank data row must be rejected, not silently skipped:
+			// a mangled doc row like `| | | | |` is malformed table state.
+			"all-blank data row",
+			goodTable + "| | | | |\n",
+			true, 0, true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/bom/freshness_parse_test.go
+++ b/tools/bom/freshness_parse_test.go
@@ -130,3 +130,86 @@ func TestParseBOMVersionTable(t *testing.T) {
 		})
 	}
 }
+
+// TestParseBOMVariantsTable pins the parser's shape guarantees directly:
+// presence anchored on the heading, tables outside the section ignored,
+// heading/table mismatch and malformed or duplicate rows rejected.
+func TestParseBOMVariantsTable(t *testing.T) {
+	const goodTable = `## Version variants
+
+| Component | Variant Version | Declared By | Images |
+|-----------|-----------------|-------------|--------|
+| kps | 83.7.0 | aks | 8 |
+`
+	tests := []struct {
+		name        string
+		section     string
+		wantPresent bool
+		wantRows    int
+		wantErr     bool
+	}{
+		{"absent entirely", "## Components\n\n| Component | Pinned Version |\n|--|--|\n| a | 1 |\n", false, 0, false},
+		{"well-formed", goodTable, true, 1, false},
+		{
+			// A matching table under a DIFFERENT section must not count as
+			// the variants table: no heading, no table, cleanly absent.
+			"table outside the section ignored",
+			"## Other\n\n| Component | Variant Version | Declared By | Images |\n|--|--|--|--|\n| kps | 83.7.0 | aks | 8 |\n",
+			false, 0, false,
+		},
+		{
+			"heading without its table",
+			"## Version variants\n\nno table here\n",
+			true, 0, true,
+		},
+		{
+			"duplicate row",
+			goodTable + "| kps | 83.7.0 | aks | 8 |\n",
+			true, 0, true,
+		},
+		{
+			"malformed row",
+			"## Version variants\n\n| Component | Variant Version | Declared By | Images |\n|--|--|--|--|\n| kps | | aks | 8 |\n",
+			true, 0, true,
+		},
+		{
+			// Without the |---| delimiter GFM renders no table at all; the
+			// gate must reject rather than silently parse the pseudo-rows.
+			"missing delimiter row",
+			"## Version variants\n\n| Component | Variant Version | Declared By | Images |\n| kps | 83.7.0 | aks | 8 |\n",
+			true, 0, true,
+		},
+		{
+			// The header must be the generator's exact four columns: a hand
+			// edit that drops Images is an unrecognized table, and the
+			// heading-without-table mismatch fails the gate loudly.
+			"header missing the Images column",
+			"## Version variants\n\n| Component | Variant Version | Declared By |\n|--|--|--|\n| kps | 83.7.0 | aks |\n",
+			true, 0, true,
+		},
+		{
+			"header with a renamed column",
+			"## Version variants\n\n| Component | Variant Version | Declared By | Pictures |\n|--|--|--|--|\n| kps | 83.7.0 | aks | 8 |\n",
+			true, 0, true,
+		},
+		{
+			"row wider than the header",
+			goodTable + "| kps2 | 82.0.0 | aks | 8 | extra |\n",
+			true, 0, true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, present, err := parseBOMVariantsTable(tt.section)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if present != tt.wantPresent {
+				t.Errorf("present = %v, want %v", present, tt.wantPresent)
+			}
+			if err == nil && len(rows) != tt.wantRows {
+				t.Errorf("rows = %d, want %d", len(rows), tt.wantRows)
+			}
+		})
+	}
+}

--- a/tools/bom/freshness_test.go
+++ b/tools/bom/freshness_test.go
@@ -432,6 +432,14 @@ func parseBOMVariantsTable(section string) (map[variantKey]string, bool, error) 
 			underHeading = false
 		}
 		if !strings.HasPrefix(trimmed, "|") {
+			// A matched header MUST be immediately followed by its delimiter
+			// row; a blank line, prose, or a new heading here means the
+			// delimiter is missing, so fail closed rather than silently
+			// resetting state and counting the table as present-but-empty.
+			if expectSeparator {
+				return nil, headings > 0, fmt.Errorf("Version variants table header is not followed by " +
+					"a valid Markdown delimiter row — run `make bom-docs`")
+			}
 			// ANY non-table line (blank, prose, or a new heading) ends the
 			// current table: rows may not resume after an interruption, and
 			// a table state must never survive into a different section.
@@ -494,6 +502,12 @@ func parseBOMVariantsTable(section string) (map[variantKey]string, bool, error) 
 	// a table without its heading, or duplicated sections are all stale or
 	// hand-mangled doc state.
 	present := headings > 0
+	// The header may be the last line of the section, so the loop can end
+	// while still awaiting the delimiter row: fail closed here too.
+	if expectSeparator {
+		return nil, present, fmt.Errorf("Version variants table header is not followed by a valid " +
+			"Markdown delimiter row — run `make bom-docs`")
+	}
 	if headings > 1 || tables > 1 {
 		return nil, present, fmt.Errorf("expected at most one Version variants section, found %d headings "+
 			"and %d tables — run `make bom-docs`", headings, tables)

--- a/tools/bom/freshness_test.go
+++ b/tools/bom/freshness_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -259,6 +260,23 @@ func parseBOMVersionTable(section string) (map[string]string, error) {
 	return out, nil
 }
 
+// isDelimiterRow reports whether cells form a valid GFM delimiter row for a
+// table with want columns: exactly want cells, each matching `:?-+:?`.
+func isDelimiterRow(cells []string, want int) bool {
+	if len(cells) != want {
+		return false
+	}
+	for _, c := range cells {
+		c = strings.TrimSpace(c)
+		c = strings.TrimPrefix(c, ":")
+		c = strings.TrimSuffix(c, ":")
+		if c == "" || strings.Trim(c, "-") != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // splitMarkdownRow splits a "| a | b | c |" row into its trimmed inner cells,
 // dropping the empty leading/trailing segments the outer pipes produce.
 func splitMarkdownRow(row string) []string {
@@ -275,4 +293,217 @@ func splitMarkdownRow(row string) []string {
 		cells = cells[:len(cells)-1]
 	}
 	return cells
+}
+
+// TestCommittedBOMVariantsMatchRecipePins asserts that the committed doc's
+// "Version variants" table is an exact projection of the variants derived
+// from recipe data: every explicit base/overlay/mixin Helm pin that differs
+// from its registry default (issue #1611). The check is bidirectional and
+// exact, mirroring TestCommittedBOMVersionsMatchRegistry:
+//   - every derived variant must have a row (a new divergent pin that skipped
+//     `make bom-docs` fails);
+//   - every row must correspond to a derived variant (a re-aligned or removed
+//     pin that left a stale row fails);
+//   - the Declared By column must list exactly the sorted declaring sources;
+//   - when nothing diverges, the table must be absent entirely.
+//
+// Variant discovery reads the registry and recipe sources from the repo root
+// and deliberately has no dependency on the version-pin guard's exemption
+// policy: the pins are the source facts; the guard decides whether a
+// divergence is ALLOWED, not what is deployed.
+func TestCommittedBOMVariantsMatchRecipePins(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+
+	reg, err := loadRegistry(filepath.Join(repoRoot, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), repoRoot)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+	derived, err := deriveVariants(reg, sources)
+	if err != nil {
+		t.Fatalf("deriveVariants: %v", err)
+	}
+
+	docPath := filepath.Join(repoRoot, "docs", "user", "container-images.md")
+	data, err := os.ReadFile(docPath) //nolint:gosec // fixed in-repo doc path
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	section, err := extractGeneratedSection(string(data))
+	if err != nil {
+		t.Fatalf("locate generated BOM section in %s: %v", docPath, err)
+	}
+
+	docVariants, tablePresent, err := parseBOMVariantsTable(section)
+	if err != nil {
+		t.Fatalf("parse Version variants table in %s: %v", docPath, err)
+	}
+
+	if len(derived) == 0 {
+		// The generator omits the table entirely when nothing diverges, so a
+		// PRESENT table — even an empty one — is stale doc state, not merely
+		// zero rows.
+		if tablePresent {
+			t.Fatalf("no divergent pins derived from recipes, but the doc still has a Version "+
+				"variants table (%d rows).\n"+
+				"  Run `make bom-docs` and commit the regenerated doc. See #1611.", len(docVariants))
+		}
+		t.Log("no divergent pins and no variants table — vacuously consistent")
+		return
+	}
+	if !tablePresent {
+		t.Fatalf("%d variants derived from recipe pins, but the doc has no Version variants table.\n"+
+			"  Run `make bom-docs` and commit the regenerated doc. See #1611.", len(derived))
+	}
+
+	derivedByKey := make(map[variantKey][]string, len(derived))
+	for _, v := range derived {
+		derivedByKey[variantKey{name: v.Name, version: v.Version}] = v.Sources
+	}
+
+	for k, wantSources := range derivedByKey {
+		gotSources, ok := docVariants[k]
+		if !ok {
+			t.Errorf("derived variant %s@%s (pinned by %s) has no row in the Version variants table of "+
+				"docs/user/container-images.md.\n"+
+				"  Run `make bom-docs` and commit the regenerated doc. See #1611.",
+				k.name, k.version, strings.Join(wantSources, ", "))
+			continue
+		}
+		if want := strings.Join(wantSources, ", "); gotSources != want {
+			t.Errorf("variant %s@%s Declared By = %q, want %q.\n"+
+				"  Run `make bom-docs` and commit the regenerated doc. See #1611.",
+				k.name, k.version, gotSources, want)
+		}
+	}
+	for k := range docVariants {
+		if _, ok := derivedByKey[k]; !ok {
+			t.Errorf("stale variant row %s@%s: it appears in docs/user/container-images.md but no "+
+				"base/overlay/mixin pin diverges from the registry default at that version.\n"+
+				"  Run `make bom-docs` and commit the regenerated doc. See #1611.", k.name, k.version)
+		}
+	}
+	t.Logf("verified %d variant rows against %d derived variants", len(docVariants), len(derived))
+}
+
+// parseBOMVariantsTable extracts (component, variant version) -> declared-by
+// from the "Version variants" table, plus whether the table was present at
+// all (the generator omits it entirely when nothing diverges, so absence and
+// emptiness are distinct facts). The header must match the generator's exact
+// four columns — a hand edit that drops or renames a column (e.g. Images)
+// must fail the gate loudly (via the heading/table mismatch below), not
+// parse a narrower table; the headers also differ from the Components table
+// ("Variant Version" vs "Pinned Version") so the two parsers cannot conflate
+// tables. Malformed rows are errors, not skips — a silently dropped row
+// would weaken the bidirectional guarantee.
+func parseBOMVariantsTable(section string) (map[variantKey]string, bool, error) {
+	// The exact header pkg/bom's writeMarkdownDoc emits, lowercased.
+	wantHeader := []string{"component", "variant version", "declared by", "images"}
+	const (
+		nameCol = 0
+		verCol  = 1
+		srcCol  = 2
+	)
+
+	const sectionHeading = "## version variants"
+
+	out := map[variantKey]string{}
+	headerCols := 0
+	inTable := false
+	expectSeparator := false
+	// underHeading tracks whether the scanner is inside the "## Version
+	// variants" SECTION (between its heading and the next "## " heading):
+	// a matching table elsewhere in the doc must not count, and a variants
+	// heading whose own table is missing must fail the heading/table match.
+	underHeading := false
+	headings, tables := 0, 0
+
+	for _, line := range strings.Split(section, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.EqualFold(trimmed, sectionHeading) {
+			headings++
+			underHeading = true
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") {
+			underHeading = false
+		}
+		if !strings.HasPrefix(trimmed, "|") {
+			// ANY non-table line (blank, prose, or a new heading) ends the
+			// current table: rows may not resume after an interruption, and
+			// a table state must never survive into a different section.
+			inTable = false
+			expectSeparator = false
+			continue
+		}
+
+		cells := splitMarkdownRow(trimmed)
+		if !inTable {
+			if !underHeading {
+				continue
+			}
+			match := len(cells) == len(wantHeader)
+			for i := 0; match && i < len(cells); i++ {
+				match = strings.ToLower(strings.TrimSpace(cells[i])) == wantHeader[i]
+			}
+			if match {
+				headerCols = len(cells)
+				inTable = true
+				expectSeparator = true
+				tables++
+			}
+			continue
+		}
+
+		// GFM requires the delimiter row for a table to exist at all, with
+		// one `---` cell per header column; a header followed by data rows,
+		// a bare "||||", or a one-cell delimiter renders as plain text (or a
+		// different table), so the gate must reject rather than parse it.
+		if expectSeparator {
+			if !isDelimiterRow(cells, headerCols) {
+				return nil, headings > 0, fmt.Errorf("Version variants table header is not followed by "+
+					"a valid Markdown delimiter row (got %q) — run `make bom-docs`", trimmed)
+			}
+			expectSeparator = false
+			continue
+		}
+		if strings.Trim(trimmed, "|-: ") == "" {
+			continue
+		}
+		if len(cells) != headerCols {
+			return nil, headings > 0, fmt.Errorf("malformed Version variants row %q: %d cells, want the "+
+				"header's %d — run `make bom-docs`", trimmed, len(cells), headerCols)
+		}
+		name := strings.TrimSpace(cells[nameCol])
+		ver := strings.TrimSpace(cells[verCol])
+		src := strings.TrimSpace(cells[srcCol])
+		if name == "" || ver == "" {
+			return nil, headings > 0, fmt.Errorf("malformed Version variants row %q: empty component or "+
+				"version cell — run `make bom-docs`", trimmed)
+		}
+		k := variantKey{name: name, version: ver}
+		if _, dup := out[k]; dup {
+			return nil, headings > 0, fmt.Errorf("duplicate row for variant %s@%s in the Version variants "+
+				"table — run `make bom-docs`", name, ver)
+		}
+		out[k] = src
+	}
+
+	// Presence is anchored on the "## Version variants" HEADING, not merely a
+	// well-formed table header: a heading whose table is missing/malformed,
+	// a table without its heading, or duplicated sections are all stale or
+	// hand-mangled doc state.
+	present := headings > 0
+	if headings > 1 || tables > 1 {
+		return nil, present, fmt.Errorf("expected at most one Version variants section, found %d headings "+
+			"and %d tables — run `make bom-docs`", headings, tables)
+	}
+	if headings != tables {
+		return nil, present, fmt.Errorf("Version variants heading/table mismatch (%d headings, %d tables) — "+
+			"run `make bom-docs`", headings, tables)
+	}
+	return out, present, nil
 }

--- a/tools/bom/freshness_test.go
+++ b/tools/bom/freshness_test.go
@@ -470,9 +470,6 @@ func parseBOMVariantsTable(section string) (map[variantKey]string, bool, error) 
 			expectSeparator = false
 			continue
 		}
-		if strings.Trim(trimmed, "|-: ") == "" {
-			continue
-		}
 		if len(cells) != headerCols {
 			return nil, headings > 0, fmt.Errorf("malformed Version variants row %q: %d cells, want the "+
 				"header's %d — run `make bom-docs`", trimmed, len(cells), headerCols)

--- a/tools/bom/main.go
+++ b/tools/bom/main.go
@@ -112,6 +112,25 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 		results = append(results, surveyComponent(ctx, repoRoot, c, renderer, skipHelm))
 	}
 
+	// Version variants: explicit base/overlay/mixin Helm pins that differ
+	// from the registry default, derived from the recipe data itself and
+	// rendered at catalog parity (issue #1611).
+	sources, err := loadRecipeSources(ctx, repoRoot)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "load recipe sources")
+	}
+	byName := make(map[string]component, len(reg.Components))
+	for _, c := range reg.Components {
+		byName[c.Name] = c
+	}
+	variants, err := deriveVariants(reg, sources)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "derive variants")
+	}
+	for i, v := range variants {
+		variants[i] = surveyVariant(ctx, repoRoot, v, byName[v.Name], renderer, skipHelm)
+	}
+
 	if strict {
 		var hardErrs []string
 		for _, r := range results {
@@ -130,6 +149,11 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 				hardErrs = append(hardErrs, r.Name+": "+w)
 			}
 		}
+		for _, v := range variants {
+			for _, w := range v.Warnings {
+				hardErrs = append(hardErrs, v.Name+"@"+v.Version+": "+w)
+			}
+		}
 		if len(hardErrs) > 0 {
 			sort.Strings(hardErrs)
 			for _, e := range hardErrs {
@@ -140,13 +164,17 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 		}
 	}
 
-	doc := bom.BuildBOM(bom.Metadata{
-		Name:        "aicr",
-		Version:     aicrVersion,
-		Description: "NVIDIA AI Cluster Runtime",
-		ToolName:    "aicr-bom",
-		ToolVersion: aicrVersion,
-	}, results)
+	doc, err := bom.BuildBOMWithVariants(bom.Metadata{
+		Name:           "aicr",
+		Version:        aicrVersion,
+		Description:    "NVIDIA AI Cluster Runtime",
+		ToolName:       "aicr-bom",
+		ToolVersion:    aicrVersion,
+		RenderFidelity: bom.RenderFidelityCatalogParity,
+	}, results, variants)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "build cyclonedx bom")
+	}
 
 	jsonPath := filepath.Join(outDir, "bom.cdx.json")
 	jf, err := os.Create(jsonPath) //nolint:gosec // outDir is operator-supplied
@@ -169,13 +197,14 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "create "+mdPath, err)
 	}
-	mdErr := bom.WriteMarkdown(mf, bom.Metadata{
-		Name:          "aicr",
-		Version:       aicrVersion,
-		Description:   "NVIDIA AI Cluster Runtime",
-		Deterministic: deterministic,
-		NoTitle:       noTitle,
-	}, results)
+	mdErr := bom.WriteMarkdownWithVariants(mf, bom.Metadata{
+		Name:           "aicr",
+		Version:        aicrVersion,
+		Description:    "NVIDIA AI Cluster Runtime",
+		Deterministic:  deterministic,
+		NoTitle:        noTitle,
+		RenderFidelity: bom.RenderFidelityCatalogParity,
+	}, results, variants)
 	closeErr = mf.Close()
 	if mdErr != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "render markdown", mdErr)
@@ -188,8 +217,11 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 	for _, r := range results {
 		totalImages += len(r.Images)
 	}
-	fmt.Printf("bom: wrote %s and %s (%d components, %d image refs)\n",
-		jsonPath, mdPath, len(results), totalImages)
+	for _, v := range variants {
+		totalImages += len(v.Images)
+	}
+	fmt.Printf("bom: wrote %s and %s (%d components, %d variants, %d image refs)\n",
+		jsonPath, mdPath, len(results), len(variants), totalImages)
 	return nil
 }
 

--- a/tools/bom/main_test.go
+++ b/tools/bom/main_test.go
@@ -30,8 +30,12 @@ func writeTestRegistry(t *testing.T, content string) string {
 	t.Helper()
 	root := t.TempDir()
 	dir := filepath.Join(root, "recipes")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir recipes: %v", err)
+	// overlays/ and mixins/ always exist in a real repo root; variant
+	// discovery fails closed when either is missing.
+	for _, sub := range []string{"overlays", "mixins"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir recipes/%s: %v", sub, err)
+		}
 	}
 	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write registry.yaml: %v", err)

--- a/tools/bom/variants.go
+++ b/tools/bom/variants.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/bom"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/helm"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// Variant discovery is DECLARATION-level, per the revised #1611: it inspects
+// the explicit Helm componentRef.version pins declared by the base, overlays,
+// and mixins and compares each against the component's registry
+// defaultVersion. Explicit NON-GOALS of this model (document them, do not
+// approximate them):
+//   - effective-recipe resolution (inheritance chains, mixin composition,
+//     criteria matching) — that is the recipe resolver's job;
+//   - source/chart coordinate divergence — variants render at REGISTRY
+//     coordinates by definition (catalog parity);
+//   - componentRef type analysis beyond "is this declared pin a Helm pin"
+//     (explicitly non-Helm-typed refs are skipped).
+//
+// The registry and these sources are read from the same -repo-root, so
+// variant data can never mix checkouts.
+
+// recipeSource is one loaded base/overlay/mixin: the declaring name and its
+// componentRefs, parsed into the CANONICAL pkg/recipe types so this tool's
+// view of a pin cannot drift from the resolver's.
+type recipeSource struct {
+	Name string
+	Refs []recipe.ComponentRef
+}
+
+// sourceDirs maps each recipe directory to its kind discipline.
+var sourceDirs = []struct {
+	dir  string
+	kind string
+}{
+	{dir: "overlays", kind: recipe.RecipeMetadataKind},
+	{dir: "mixins", kind: recipe.RecipeMixinKind},
+}
+
+// parseRecipeSource decodes one overlay/mixin file with the canonical
+// metadata store's exact semantics; ok is false when the store would skip
+// the file. Mixins decode strictly (KnownFields, hard kind check) — a typo'd
+// field fails closed just as it does at recipe load. Overlays decode
+// leniently (plain Unmarshal; empty kind is legacy RecipeMetadata; any other
+// kind, e.g. a stray ValidatorCatalog, is skipped): a field the resolver
+// would ignore is equally invisible here, so the projection matches what
+// actually deploys.
+func parseRecipeSource(rel, wantKind string, data []byte) (src recipeSource, ok bool, err error) {
+	if wantKind == recipe.RecipeMixinKind {
+		var mixin recipe.RecipeMixin
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(&mixin); err != nil {
+			return recipeSource{}, false, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"parse "+rel+" (unknown fields are not allowed)", err)
+		}
+		if mixin.Kind != recipe.RecipeMixinKind {
+			return recipeSource{}, false, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+				"mixin file %s has wrong kind %q, expected %q", rel, mixin.Kind, recipe.RecipeMixinKind))
+		}
+		return recipeSource{Name: mixin.Metadata.Name, Refs: mixin.Spec.ComponentRefs}, true, nil
+	}
+	var metadata recipe.RecipeMetadata
+	if err := yaml.Unmarshal(data, &metadata); err != nil {
+		return recipeSource{}, false, errors.Wrap(errors.ErrCodeInvalidRequest, "parse "+rel, err)
+	}
+	if metadata.Kind != "" && metadata.Kind != recipe.RecipeMetadataKind {
+		return recipeSource{}, false, nil
+	}
+	return recipeSource{Name: metadata.Metadata.Name, Refs: metadata.Spec.ComponentRefs}, true, nil
+}
+
+// loadRecipeSources reads every overlay and mixin YAML under repoRoot's
+// recipes/ tree with the canonical loader's semantics: the walk is RECURSIVE
+// (subdirectories under overlays/ are documented and supported, so a nested
+// divergent pin must not be silently omitted). A file that fails to read or
+// parse is an error — silently skipping a source could hide a divergent pin
+// — and duplicate source identities fail closed, since declaration-level
+// scanning cannot know which duplicate "wins" during resolution. Reads are
+// size-bounded, honor ctx between steps, and are confined to the recipes
+// root via os.Root, so a checked-in symlink cannot smuggle another
+// checkout's overlay in.
+func loadRecipeSources(ctx context.Context, repoRoot string) ([]recipeSource, error) {
+	root, err := os.OpenRoot(filepath.Join(repoRoot, "recipes"))
+	if err != nil {
+		if stderrors.Is(err, fs.ErrNotExist) {
+			return nil, errors.Wrap(errors.ErrCodeNotFound, "recipes root not found", err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeInternal, "open recipes root", err)
+	}
+	defer root.Close()
+
+	var sources []recipeSource
+	seenNames := map[string]string{}
+	for _, sd := range sourceDirs {
+		files, err := walkYAML(ctx, root, sd.dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, rel := range files {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, errors.Wrap(errors.ErrCodeTimeout, "loading recipe sources canceled", ctxErr)
+			}
+			data, err := readBoundedFile(root, rel)
+			if err != nil {
+				return nil, err
+			}
+			src, ok, err := parseRecipeSource(rel, sd.kind, data)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue // foreign kind under overlays/: skipped, never mined
+			}
+			if src.Name == "" {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("recipe source %s has no metadata.name", rel))
+			}
+			if prev, dup := seenNames[src.Name]; dup {
+				return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+					"duplicate recipe source name %q (%s and %s); declaration-level variant "+
+						"discovery cannot attribute pins to an ambiguous identity",
+					src.Name, prev, rel))
+			}
+			seenNames[src.Name] = rel
+			sources = append(sources, src)
+		}
+	}
+	return sources, nil
+}
+
+// walkYAML recursively collects every regular .yaml file under dir inside
+// root, sorted. The walk is fail-closed — any I/O error aborts rather than
+// yielding a silently incomplete source set — and checks ctx per entry so a
+// timed-out caller stops the traversal.
+func walkYAML(ctx context.Context, root *os.Root, dir string) ([]string, error) {
+	var files []string
+	err := fs.WalkDir(root.FS(), dir, func(path string, d fs.DirEntry, werr error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() || filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+		// Symlinks are collected, not skipped: root.Open resolves them under
+		// os.Root confinement, so an in-tree link is read like the canonical
+		// loader would read it and an escaping link fails closed instead of
+		// silently dropping a source.
+		if !d.Type().IsRegular() && d.Type()&fs.ModeSymlink == 0 {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		switch {
+		case stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded):
+			return nil, errors.Wrap(errors.ErrCodeTimeout, "listing recipes/"+dir+" timed out", err)
+		case stderrors.Is(err, fs.ErrNotExist):
+			return nil, errors.Wrap(errors.ErrCodeNotFound, "recipes/"+dir+" not found", err)
+		default:
+			return nil, errors.Wrap(errors.ErrCodeInternal, "walk recipes/"+dir, err)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// readBoundedFile reads rel inside root with a size bound (the standard
+// defense against reading an unexpectedly huge file whole). root.OpenFile
+// confines symlink resolution to the recipes tree: an escaping symlink is
+// invalid operator input, not an internal fault. The open is O_NONBLOCK so a
+// FIFO target cannot block it (opening a FIFO for read otherwise waits for a
+// writer; O_NONBLOCK is a no-op for regular-file reads), and the regular-file
+// requirement is checked by fstat on the OPENED handle — validating the
+// descriptor we actually read leaves no stat-to-open window in which the
+// target could be swapped for a blocking file.
+func readBoundedFile(root *os.Root, rel string) ([]byte, error) {
+	mapErr := func(op string, err error) error {
+		switch {
+		case stderrors.Is(err, fs.ErrNotExist):
+			return errors.Wrap(errors.ErrCodeNotFound, "recipe source "+rel+" not found", err)
+		case strings.Contains(err.Error(), "escapes from parent"):
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				"recipe source "+rel+" escapes the recipes root (symlinks must stay inside the checkout)", err)
+		default:
+			return errors.Wrap(errors.ErrCodeInternal, op+" "+rel, err)
+		}
+	}
+	fh, err := root.OpenFile(rel, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, mapErr("open", err)
+	}
+	defer fh.Close() // read-only handle
+	info, err := fh.Stat()
+	if err != nil {
+		return nil, mapErr("stat", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+			"recipe source %s resolves to a non-regular file (%s); sources must be regular files",
+			rel, info.Mode().Type()))
+	}
+	data, err := io.ReadAll(io.LimitReader(fh, defaults.MaxExternalDataFileBytes+1))
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "read "+rel, err)
+	}
+	if int64(len(data)) > defaults.MaxExternalDataFileBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+			"recipe source %s exceeds %d bytes", rel, defaults.MaxExternalDataFileBytes))
+	}
+	return data, nil
+}
+
+// variantKey aggregates divergent pins by (component, version): multiple
+// sources pinning the same divergent version become one variant.
+type variantKey struct {
+	name    string
+	version string
+}
+
+// deriveVariants compares every explicit Helm componentRef.version pin
+// declared by the base, overlays, and mixins against the component's
+// registry defaultVersion. A differing pin yields a variant aggregated by
+// (component, version) with the sorted declaring source names; default-equal
+// pins yield nothing. The recipe pins are the source facts — the derivation
+// deliberately has no dependency on the version-pin guard's exemption policy
+// (which decides whether a divergence is ALLOWED, not what is deployed). See
+// issue #1611 and the non-goals at the top of this file.
+func deriveVariants(reg *registry, sources []recipeSource) ([]bom.VariantResult, error) {
+	byName := make(map[string]component, len(reg.Components))
+	for _, c := range reg.Components {
+		byName[c.Name] = c
+	}
+
+	agg := map[variantKey]map[string]struct{}{}
+	for _, src := range sources {
+		for _, ref := range src.Refs {
+			pin := ref.Version
+			if pin == "" {
+				continue
+			}
+			// The pin is a source fact — never normalize it. A padded value
+			// is rejected explicitly: the doc could not faithfully represent
+			// a distinct explicit value it silently trimmed.
+			if pin != strings.TrimSpace(pin) {
+				return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+					"source %s pins component %s to version %q with surrounding whitespace; "+
+						"fix the pin", src.Name, ref.Name, pin))
+			}
+			// An explicitly non-Helm-typed ref is not a Helm chart pin;
+			// type analysis beyond this is a documented non-goal. A
+			// type-less ref inherits the registry component's type, checked
+			// below via c.kind().
+			if ref.Type != "" && !strings.EqualFold(string(ref.Type), "helm") {
+				continue
+			}
+			c, ok := byName[ref.Name]
+			if !ok {
+				// Not a registry component; the BOM does not render it from
+				// a registry default, so there is no default to diverge from.
+				continue
+			}
+			if c.kind() != kindHelm {
+				continue
+			}
+			// An explicit pin with NO registry default is still the version
+			// the source deploys: render it as a variant (the default row
+			// shows the unpinned sentinel) rather than dropping it from the
+			// inventory. Unreachable for the embedded registry
+			// (bom-pinning-check), but -repo-root data is arbitrary.
+			if pin == c.Helm.DefaultVersion {
+				continue
+			}
+			k := variantKey{name: ref.Name, version: pin}
+			if agg[k] == nil {
+				agg[k] = map[string]struct{}{}
+			}
+			agg[k][src.Name] = struct{}{}
+		}
+	}
+
+	variants := make([]bom.VariantResult, 0, len(agg))
+	for k, srcSet := range agg {
+		srcs := make([]string, 0, len(srcSet))
+		for s := range srcSet {
+			srcs = append(srcs, s)
+		}
+		sort.Strings(srcs)
+		c := byName[k.name]
+		variants = append(variants, bom.VariantResult{
+			Name:       k.name,
+			Version:    k.version,
+			Sources:    srcs,
+			Repository: c.Helm.DefaultRepository,
+			Chart:      c.Helm.DefaultChart,
+			Namespace:  c.Helm.DefaultNamespace,
+		})
+	}
+	sort.Slice(variants, func(i, j int) bool {
+		if variants[i].Name != variants[j].Name {
+			return variants[i].Name < variants[j].Name
+		}
+		return variants[i].Version < variants[j].Version
+	})
+	return variants, nil
+}
+
+// surveyVariant surveys the variant through the SAME path as default entries
+// (surveyComponent: chart render plus the embedded manifests walk), with the
+// component's default version swapped for the variant version — catalog
+// parity, not deployment fidelity. Variant image sets are rendered, never
+// copied from the default entry: the two versions may ship different images,
+// and a mixed Helm+manifest component contributes its manifest images too.
+func surveyVariant(ctx context.Context, repoRoot string, v bom.VariantResult, base component, r helm.Renderer, skipHelm bool) bom.VariantResult {
+	variantComponent := base
+	variantComponent.Helm.DefaultVersion = v.Version
+	res := surveyComponent(ctx, repoRoot, variantComponent, r, skipHelm)
+	v.Images = res.Images
+	v.Warnings = append(v.Warnings, res.Warnings...)
+	return v
+}

--- a/tools/bom/variants.go
+++ b/tools/bom/variants.go
@@ -60,6 +60,17 @@ type recipeSource struct {
 }
 
 // sourceDirs maps each recipe directory to its kind discipline.
+//
+// Scope note: this loader intentionally scans only overlays/ and mixins/,
+// whereas the canonical metadata store (pkg/recipe/metadata_store.go) walks
+// the entire recipes/ tree and treats any .yaml outside checks/, components/,
+// and mixins/ (minus data-v1.yaml/registry.yaml) as RecipeMetadata. By
+// convention every recipe overlay lives under overlays/, so the two scopes
+// agree today. A RecipeMetadata file parked elsewhere (e.g. directly under
+// recipes/) would be resolvable by the store but invisible to variant
+// discovery — a silent gap in the "projection matches what deploys" claim. If
+// the recipes/ layout ever grows metadata outside overlays/, this list must be
+// widened to match the store's scan so no divergent pin is dropped.
 var sourceDirs = []struct {
 	dir  string
 	kind string

--- a/tools/bom/variants_test.go
+++ b/tools/bom/variants_test.go
@@ -1,0 +1,565 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/bom"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/helm/helmtest"
+)
+
+// writeRecipeTree lays out a minimal repo root with the shared variant-test
+// registry and the given recipe sources.
+func writeRecipeTree(t *testing.T, sources map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, dir := range []string{"overlays", "mixins"} {
+		if err := os.MkdirAll(filepath.Join(root, "recipes", dir), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "recipes", "registry.yaml"), []byte(variantTestRegistry), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	for rel, content := range sources {
+		if err := os.WriteFile(filepath.Join(root, "recipes", rel), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+const variantTestRegistry = `apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components:
+  - name: kube-prometheus-stack
+    displayName: Kube Prometheus Stack
+    helm:
+      defaultRepository: https://prometheus-community.github.io/helm-charts
+      defaultChart: prometheus-community/kube-prometheus-stack
+      defaultVersion: 84.4.0
+      defaultNamespace: monitoring
+  - name: gpu-operator
+    displayName: GPU Operator
+    helm:
+      defaultRepository: https://helm.ngc.nvidia.com/nvidia
+      defaultChart: nvidia/gpu-operator
+      defaultVersion: v25.3.0
+  - name: my-kustomize
+    displayName: My Kustomize
+    kustomize:
+      defaultSource: https://github.com/example/app
+      defaultTag: v1.0.0
+`
+
+func TestDeriveVariants(t *testing.T) {
+	root := writeRecipeTree(t, map[string]string{
+		// Two sources pin the SAME divergent version -> one aggregated variant.
+		"overlays/aks.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: aks
+spec:
+  componentRefs:
+    - name: kube-prometheus-stack
+      version: "83.7.0"
+`,
+		"mixins/platform-x.yaml": `kind: RecipeMixin
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: platform-x
+spec:
+  componentRefs:
+    - name: kube-prometheus-stack
+      version: "83.7.0"
+`,
+		// Default-equal pin -> no variant.
+		"overlays/base.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: base
+spec:
+  componentRefs:
+    - name: gpu-operator
+      version: v25.3.0
+`,
+		// Non-registry component and a Kustomize tag-only ref -> no variant.
+		"overlays/extra.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: extra
+spec:
+  componentRefs:
+    - name: not-in-registry
+      version: "9.9.9"
+    - name: my-kustomize
+      version: "2.0.0"
+`,
+	})
+
+	reg, err := loadRegistry(filepath.Join(root, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+
+	variants, err := deriveVariants(reg, sources)
+	if err != nil {
+		t.Fatalf("deriveVariants: %v", err)
+	}
+	if len(variants) != 1 {
+		t.Fatalf("variants = %+v, want exactly one (the aggregated kube-prometheus-stack divergence)", variants)
+	}
+	v := variants[0]
+	if v.Name != "kube-prometheus-stack" || v.Version != "83.7.0" {
+		t.Errorf("variant = %s@%s, want kube-prometheus-stack@83.7.0", v.Name, v.Version)
+	}
+	if want := []string{"aks", "platform-x"}; !reflect.DeepEqual(v.Sources, want) {
+		t.Errorf("sources = %v, want %v (aggregated and sorted)", v.Sources, want)
+	}
+	if v.Repository == "" || v.Chart == "" {
+		t.Errorf("variant should inherit chart coordinates from the registry, got repo=%q chart=%q",
+			v.Repository, v.Chart)
+	}
+}
+
+func TestDeriveVariantsMultipleVersionsSameComponent(t *testing.T) {
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/a.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: a
+spec:
+  componentRefs:
+    - name: kube-prometheus-stack
+      version: "83.7.0"
+`,
+		"overlays/b.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: b
+spec:
+  componentRefs:
+    - name: kube-prometheus-stack
+      version: "82.0.0"
+`,
+	})
+
+	reg, err := loadRegistry(filepath.Join(root, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+
+	variants, err := deriveVariants(reg, sources)
+	if err != nil {
+		t.Fatalf("deriveVariants: %v", err)
+	}
+	if len(variants) != 2 {
+		t.Fatalf("variants = %+v, want two (distinct versions are distinct variants)", variants)
+	}
+	// Deterministic ordering by (name, version).
+	if variants[0].Version != "82.0.0" || variants[1].Version != "83.7.0" {
+		t.Errorf("variant order = %s, %s; want 82.0.0 then 83.7.0",
+			variants[0].Version, variants[1].Version)
+	}
+}
+
+func TestLoadRecipeSourcesRejectsMalformed(t *testing.T) {
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/broken.yaml": "not: [valid: yaml: {{",
+	})
+	if _, err := loadRecipeSources(context.Background(), root); err == nil {
+		t.Fatal("loadRecipeSources accepted a malformed source; a skipped source could hide a divergent pin")
+	}
+
+	root2 := writeRecipeTree(t, map[string]string{
+		"overlays/anon.yaml": "kind: RecipeMetadata\nspec:\n  componentRefs: []\n",
+	})
+	if _, err := loadRecipeSources(context.Background(), root2); err == nil {
+		t.Fatal("loadRecipeSources accepted a source without metadata.name")
+	}
+}
+
+func TestSurveyVariantRendersAtVariantVersion(t *testing.T) {
+	root := writeRecipeTree(t, nil)
+	mock := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{
+			"kube-prometheus-stack": []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kps
+spec:
+  template:
+    spec:
+      containers:
+      - name: prometheus
+        image: quay.io/prometheus/prometheus:v2.83.0
+`),
+		},
+	}
+
+	base := component{
+		Name: "kube-prometheus-stack",
+		Helm: helmCfg{
+			DefaultRepository: "https://prometheus-community.github.io/helm-charts",
+			DefaultChart:      "prometheus-community/kube-prometheus-stack",
+			DefaultVersion:    "84.4.0",
+		},
+	}
+	v := bom.VariantResult{Name: "kube-prometheus-stack", Version: "83.7.0", Sources: []string{"aks"}}
+
+	got := surveyVariant(context.Background(), root, v, base, mock, false)
+	if len(got.Images) != 1 || got.Images[0] != "quay.io/prometheus/prometheus:v2.83.0" {
+		t.Errorf("images = %v, want the rendered image", got.Images)
+	}
+	if len(mock.Inputs) != 1 {
+		t.Fatalf("renderer calls = %d, want 1", len(mock.Inputs))
+	}
+	if mock.Inputs[0].Version != "83.7.0" {
+		t.Errorf("rendered at version %q, want the VARIANT version 83.7.0 — variant image sets must be "+
+			"rendered, not copied from the default entry", mock.Inputs[0].Version)
+	}
+
+	// skipHelm leaves the variant unrendered (no images, no renderer call).
+	mock2 := &helmtest.MockRenderer{}
+	got2 := surveyVariant(context.Background(), root, v, base, mock2, true)
+	if len(got2.Images) != 0 || len(mock2.Inputs) != 0 {
+		t.Errorf("skipHelm variant should not render, got images=%v calls=%d", got2.Images, len(mock2.Inputs))
+	}
+}
+
+func TestLoadRecipeSourcesSkipsForeignKindLikeCanonicalLoader(t *testing.T) {
+	// The canonical metadata store SKIPS non-RecipeMetadata files under the
+	// overlay walk (e.g. a stray ValidatorCatalog); the BOM loader matches —
+	// the file is not an error, and crucially it is never mined for pins.
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/stray.yaml": "kind: ComponentRegistry\nmetadata:\n  name: stray\nspec:\n  componentRefs:\n    - name: kube-prometheus-stack\n      version: \"83.7.0\"\n",
+	})
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources rejected a foreign-kind file the canonical loader skips: %v", err)
+	}
+	if len(sources) != 0 {
+		t.Fatalf("sources = %+v; a skipped foreign-kind file must contribute no pins", sources)
+	}
+}
+
+func TestLoadRecipeSourcesAcceptsLegacyEmptyKindOverlay(t *testing.T) {
+	// The canonical store treats an overlay without a kind as legacy
+	// RecipeMetadata; the BOM loader must not reject what the store loads.
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/legacy.yaml": "apiVersion: aicr.run/v1alpha2\nmetadata:\n  name: legacy\nspec:\n  componentRefs:\n    - name: kube-prometheus-stack\n      version: \"83.7.0\"\n",
+	})
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources rejected a legacy empty-kind overlay: %v", err)
+	}
+	if len(sources) != 1 || sources[0].Name != "legacy" {
+		t.Fatalf("sources = %+v, want the legacy overlay loaded", sources)
+	}
+}
+
+func TestLoadRecipeSourcesDiscoversNestedOverlays(t *testing.T) {
+	// Subdirectories under overlays/ are documented and supported
+	// (docs/integrator/data-extension.md); a nested divergent pin must not
+	// be silently omitted from the projection.
+	root := writeRecipeTree(t, nil)
+	nested := filepath.Join(root, "recipes", "overlays", "team-a")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	overlay := "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: team-a-leaf\nspec:\n  componentRefs:\n    - name: kube-prometheus-stack\n      version: \"83.7.0\"\n"
+	if err := os.WriteFile(filepath.Join(nested, "leaf.yaml"), []byte(overlay), 0o600); err != nil {
+		t.Fatalf("write nested overlay: %v", err)
+	}
+
+	reg, err := loadRegistry(filepath.Join(root, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+	variants, err := deriveVariants(reg, sources)
+	if err != nil {
+		t.Fatalf("deriveVariants: %v", err)
+	}
+	if len(variants) != 1 || variants[0].Sources[0] != "team-a-leaf" {
+		t.Fatalf("variants = %+v, want the nested overlay's divergent pin discovered", variants)
+	}
+}
+
+func TestDeriveVariantsRejectsPaddedPin(t *testing.T) {
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/padded.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: padded
+spec:
+  componentRefs:
+    - name: kube-prometheus-stack
+      version: " 83.7.0"
+`,
+	})
+	reg, err := loadRegistry(filepath.Join(root, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+	if _, err := deriveVariants(reg, sources); err == nil {
+		t.Fatal("deriveVariants accepted a padded pin; the source fact must be preserved or rejected, never normalized")
+	}
+}
+
+func TestDeriveVariantsSkipsExplicitNonHelmType(t *testing.T) {
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/typed.yaml": `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: typed
+spec:
+  componentRefs:
+    - name: kube-prometheus-stack
+      type: Kustomize
+      version: "83.7.0"
+`,
+	})
+	reg, err := loadRegistry(filepath.Join(root, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+	variants, err := deriveVariants(reg, sources)
+	if err != nil {
+		t.Fatalf("deriveVariants: %v", err)
+	}
+	if len(variants) != 0 {
+		t.Fatalf("variants = %+v; an explicitly non-Helm-typed ref is not a Helm chart pin", variants)
+	}
+}
+
+func TestSurveyVariantIncludesManifestImages(t *testing.T) {
+	root := writeRecipeTree(t, nil)
+	manifestsDir := filepath.Join(root, "recipes", "components", "kube-prometheus-stack", "manifests")
+	if err := os.MkdirAll(manifestsDir, 0o755); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	manifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: extra
+spec:
+  containers:
+  - name: extra
+    image: nvcr.io/nvidia/extra:v1.0.0
+`
+	if err := os.WriteFile(filepath.Join(manifestsDir, "extra.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	base := component{
+		Name: "kube-prometheus-stack",
+		Helm: helmCfg{
+			DefaultRepository: "https://prometheus-community.github.io/helm-charts",
+			DefaultChart:      "prometheus-community/kube-prometheus-stack",
+			DefaultVersion:    "84.4.0",
+		},
+	}
+	v := bom.VariantResult{Name: "kube-prometheus-stack", Version: "83.7.0", Sources: []string{"aks"}}
+
+	// With -skip-helm the variant must still pick up manifest images, exactly
+	// like the default survey path.
+	got := surveyVariant(context.Background(), root, v, base, &helmtest.MockRenderer{}, true)
+	if len(got.Images) != 1 || got.Images[0] != "nvcr.io/nvidia/extra:v1.0.0" {
+		t.Errorf("skip-helm variant images = %v, want the embedded manifest image", got.Images)
+	}
+}
+
+func TestLoadRecipeSourcesKindPerDirectory(t *testing.T) {
+	// Canonical parity: a RecipeMixin under overlays/ is skipped (foreign
+	// kind in the overlay walk, contributes no pins); a RecipeMetadata under
+	// mixins/ is a hard error (the store rejects wrong-kind mixin files).
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/misplaced.yaml": "kind: RecipeMixin\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: misplaced\nspec:\n  componentRefs:\n    - name: kube-prometheus-stack\n      version: \"83.7.0\"\n",
+	})
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("misplaced mixin under overlays should be skipped, got error: %v", err)
+	}
+	if len(sources) != 0 {
+		t.Fatalf("sources = %+v; a skipped misplaced mixin must contribute no pins", sources)
+	}
+
+	root2 := writeRecipeTree(t, map[string]string{
+		"mixins/misplaced.yaml": "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: misplaced\nspec:\n  componentRefs: []\n",
+	})
+	if _, err := loadRecipeSources(context.Background(), root2); err == nil {
+		t.Fatal("loadRecipeSources accepted a RecipeMetadata under mixins/ (the canonical store hard-errors)")
+	}
+}
+
+func TestDeriveVariantsRendersPinWithEmptyRegistryDefault(t *testing.T) {
+	// An external -repo-root registry may omit defaultVersion. The explicit
+	// pin is still the version the source deploys: it must surface as a
+	// variant, not vanish from the inventory.
+	root := t.TempDir()
+	for _, dir := range []string{"overlays", "mixins"} {
+		if err := os.MkdirAll(filepath.Join(root, "recipes", dir), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	registry := `apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components:
+  - name: unpinned-helm
+    displayName: Unpinned Helm
+    helm:
+      defaultRepository: https://charts.example.com
+      defaultChart: example/unpinned-helm
+`
+	if err := os.WriteFile(filepath.Join(root, "recipes", "registry.yaml"), []byte(registry), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	overlay := `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: pinned-leaf
+spec:
+  componentRefs:
+    - name: unpinned-helm
+      version: "1.2.3"
+`
+	if err := os.WriteFile(filepath.Join(root, "recipes", "overlays", "pinned-leaf.yaml"), []byte(overlay), 0o600); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	reg, err := loadRegistry(filepath.Join(root, "recipes", "registry.yaml"))
+	if err != nil {
+		t.Fatalf("loadRegistry: %v", err)
+	}
+	sources, err := loadRecipeSources(context.Background(), root)
+	if err != nil {
+		t.Fatalf("loadRecipeSources: %v", err)
+	}
+	variants, err := deriveVariants(reg, sources)
+	if err != nil {
+		t.Fatalf("deriveVariants: %v", err)
+	}
+	if len(variants) != 1 || variants[0].Version != "1.2.3" {
+		t.Fatalf("variants = %+v, want the explicit pin rendered as a variant", variants)
+	}
+}
+
+func TestLoadRecipeSourcesRejectsEscapingSymlink(t *testing.T) {
+	// A checked-in symlink that escapes the recipes root could smuggle
+	// another checkout's overlay in — exactly the checkout skew the
+	// same-repo-root design prevents. os.Root confines resolution.
+	root := writeRecipeTree(t, nil)
+	outside := filepath.Join(t.TempDir(), "outside.yaml")
+	if err := os.WriteFile(outside, []byte("kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: outside\nspec:\n  componentRefs: []\n"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "recipes", "overlays", "escape.yaml")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	_, err := loadRecipeSources(context.Background(), root)
+	if err == nil {
+		t.Fatal("loadRecipeSources followed a symlink escaping the recipes root")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error code = %v, want %v (an escaping symlink is invalid operator input)",
+			err, errors.ErrCodeInvalidRequest)
+	}
+	if !strings.Contains(err.Error(), "escapes the recipes root") {
+		t.Errorf("error %q does not explain the confinement violation", err.Error())
+	}
+}
+
+func TestLoadRecipeSourcesPreCanceledContext(t *testing.T) {
+	root := writeRecipeTree(t, map[string]string{
+		"overlays/base.yaml": "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: base\nspec:\n  componentRefs: []\n",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := loadRecipeSources(ctx, root); err == nil {
+		t.Fatal("loadRecipeSources succeeded with a pre-canceled context")
+	}
+}
+
+func TestLoadRecipeSourcesRejectsDuplicateNames(t *testing.T) {
+	// Two recursively discovered sources with one identity: declaration-level
+	// scanning cannot know which duplicate "wins" during resolution, so the
+	// ambiguity fails closed (stricter than the canonical store's map-order
+	// behavior for overlays, deliberately).
+	root := writeRecipeTree(t, nil)
+	nested := filepath.Join(root, "recipes", "overlays", "team-a")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	overlay := "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: dup\nspec:\n  componentRefs: []\n"
+	if err := os.WriteFile(filepath.Join(root, "recipes", "overlays", "dup.yaml"), []byte(overlay), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "dup.yaml"), []byte(overlay), 0o600); err != nil {
+		t.Fatalf("write nested: %v", err)
+	}
+	if _, err := loadRecipeSources(context.Background(), root); err == nil {
+		t.Fatal("loadRecipeSources accepted duplicate source identities")
+	}
+}
+
+func TestLoadRecipeSourcesRejectsMixinUnknownField(t *testing.T) {
+	// Canonical parity: the metadata store decodes mixins with
+	// KnownFields(true), so a typo'd field (which could hide a divergent
+	// pin) fails at recipe load — and must fail here identically, not
+	// silently parse to an empty source.
+	root := writeRecipeTree(t, map[string]string{
+		"mixins/typo.yaml": `kind: RecipeMixin
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: typo
+spec:
+  componentRef:
+    - name: kube-prometheus-stack
+      version: "83.7.0"
+`,
+	})
+	if _, err := loadRecipeSources(context.Background(), root); err == nil {
+		t.Fatal("loadRecipeSources accepted a mixin with an unknown field (canonical store rejects via KnownFields)")
+	}
+}

--- a/tools/bom/variants_unix_test.go
+++ b/tools/bom/variants_unix_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func TestLoadRecipeSourcesRejectsSymlinkToNonRegularFile(t *testing.T) {
+	// Opening a FIFO for read blocks until a writer appears, so a symlinked
+	// FIFO must fail closed instead of hanging BOM generation: sources are
+	// opened O_NONBLOCK and the regular-file requirement is checked by fstat
+	// on the opened descriptor, so any non-regular resolved target is
+	// rejected with no stat-to-open race window.
+	root := writeRecipeTree(t, nil)
+	// The FIFO lives INSIDE the recipes root (non-.yaml, so the walk never
+	// collects the FIFO itself): resolution stays confined and the escape
+	// rejection cannot be what saves us — only the non-regular check can.
+	fifo := filepath.Join(root, "recipes", "overlays", "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	if err := os.Symlink("fifo", filepath.Join(root, "recipes", "overlays", "hang.yaml")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := loadRecipeSources(context.Background(), root)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("loadRecipeSources read a symlinked FIFO as a recipe source")
+		}
+		if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+			t.Errorf("error code = %v, want %v", err, errors.ErrCodeInvalidRequest)
+		}
+		if !strings.Contains(err.Error(), "non-regular") {
+			t.Errorf("error %q does not name the non-regular target", err.Error())
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("loadRecipeSources hung on a symlinked FIFO (blocked open)")
+	}
+}


### PR DESCRIPTION
## Summary

The container BOM (`docs/user/container-images.md` and the CycloneDX output of `tools/bom`) now lists **version variants**: every Helm chart version explicitly pinned by a base/overlay/mixin that differs from the component's registry default, with the images that version actually ships.

## Motivation / Context

A recipe source that pins a component to a non-default chart version deploys images the BOM never mentioned — the doc only rendered each component at its registry `defaultVersion`. Issue #1611 (revised) scopes the fix to **declaration-level** discovery: derive variants directly from the explicit `componentRefs[].version` pins versus the registry defaults, with no shared exemption file and no effective-recipe resolution. Today that surfaces one variant: `kube-prometheus-stack@83.7.0`, pinned by `aks`.

Fixes: #1611
Related: #1615, #1616

**Non-goals** (documented in `tools/bom/variants.go`, per the revised #1611):

- Effective-recipe resolution (inheritance chains, mixin composition, criteria matching) — that is the recipe resolver's job.
- Source/chart coordinate divergence analysis — variants render at **registry coordinates** by definition (catalog parity).
- ComponentRef type analysis beyond "is this declared pin a Helm pin" — explicitly non-Helm-typed refs are skipped.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/bom`, `tools/bom`, `.github/workflows/merge-gate.yaml`

## Implementation Notes

**Discovery (`tools/bom/variants.go`):**

- `loadRecipeSources` reads every overlay/mixin YAML under the same `-repo-root` recursively (nested overlay subdirectories are documented and supported), parsing into the **canonical `pkg/recipe` types** with the metadata store's exact semantics: mixins decode strictly (`KnownFields(true)`, hard `RecipeMixin` kind check — a typo'd field fails closed just as it does at recipe load); overlays decode leniently exactly as the store does (empty kind is legacy `RecipeMetadata`, any other kind is skipped and never mined for pins — a field the resolver would ignore is equally invisible here, so the projection matches what deploys).
- Fail-closed on ambiguity: malformed YAML, a missing `metadata.name`, duplicate source names, and whitespace-padded version pins are errors, never silent skips — a silently dropped source could hide a divergent pin.
- Reads are confined to the recipes root via `os.Root` (an escaping symlink is rejected, not followed) and size-bounded; sources are opened `O_NONBLOCK` and validated regular via `fstat` on the opened handle, so a non-regular target (e.g. a symlinked FIFO, whose open would otherwise block until a writer appears) fails closed with no stat-to-open race window; the walk checks `ctx` per entry.
- `deriveVariants` compares each explicit Helm pin against the registry `defaultVersion` and aggregates divergences by `(component, version)` with the sorted declaring source names. An explicit pin over an empty registry default still renders as a variant (external `-repo-root` registries may omit `defaultVersion`). The version-pin guard's `versionPinExemptions` plays no role: it is validation policy (whether a divergence is *allowed*), not deployment fact.
- Variants render through the **same** `surveyComponent` path as default entries, at the variant version — so variant image sets are rendered, never copied, and mixed Helm+manifest components contribute their manifest images too.

**Rendering (`pkg/bom`):**

- Additive entry points `BuildBOMWithVariants` / `WriteMarkdownWithVariants`; the legacy `BuildBOM` / `WriteMarkdown` surfaces are **byte-identical to main** (pinned by `TestLegacyEntryPointsUnchanged`), so external importers see no behavioral change. `pkg/evidence/attestation` is untouched.
- Variant CycloneDX entries get version-qualified bom-refs (`<meta.Name>/<comp>@<ver>`) with `aicr:variant:of` and sorted `aicr:variant:sources` properties; variant images join the dependency graph. The checked builder fails closed on any duplicate bom-ref instead of emitting an ambiguous graph.
- Markdown gains a `## Version variants` table (distinct headers, so the Components table and its existing freshness gate are unaffected) and per-variant image sections; the section is omitted entirely when no variants exist. A caller-supplied rendering-fidelity note (`Metadata.RenderFidelity`) documents the catalog-parity limitation: charts are rendered with the shared `recipes/components/<name>/values.yaml`, per-recipe overlay overrides are not applied.

**Freshness gate:**

- `TestCommittedBOMVariantsMatchRecipePins` gates the committed variants table bidirectionally: a new divergent pin without a variant row fails, and a stale row without a backing pin fails. The table parser is strict (heading-anchored, delimiter-validated, malformed rows are errors) so a mangled doc cannot pass vacuously.
- The `bom-freshness` merge-gate job runs both freshness tests and positively asserts a PASS line for each, so a rename or skip cannot silently drop either gate.

## Testing

```bash
make qualify           # full gate, passing at the pushed SHA
go test -race ./pkg/bom/... ./tools/bom/...
make bom-docs          # regenerated docs/user/container-images.md (committed)
```

- Coverage vs `origin/main`: `pkg/bom` 95.5% → 95.8% (+0.3%), `tools/bom` 79.5% → 81.8% (+2.3%).
- Legacy compatibility is pinned by test: `WriteMarkdown` ≡ `WriteMarkdownWithVariants(nil)` byte-for-byte; legacy `BuildBOM` keeps its historical duplicate tolerance. All pre-existing `pkg/bom` and `tools/bom` tests pass unchanged.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Additive only. The legacy `pkg/bom` Go API and its output are byte-identical; `tools/bom` output changes are confined to the new variants table, the fidelity note, and variant entries in the CycloneDX document. Reverting restores the previous BOM shape with no migration.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
