### PR TITLE
chore(lint): queue golangci-lint runs instead of failing on the lock

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,14 @@ run:
   timeout: 5m
   tests: true
   modules-download-mode: readonly
+  # Queue behind golangci-lint's machine-wide lock instead of failing with
+  # "parallel golangci-lint is running". With multiple concurrent sessions on
+  # one dev machine (e.g. several AI coding agents linting different
+  # worktrees), the fail-fast default aborts whole `make qualify` runs over a
+  # transient lock. Runs stay strictly serialized — same mutual exclusion,
+  # same cache safety — the second run just waits its turn. Inert in CI,
+  # where each job has an isolated runner.
+  allow-serial-runners: true
 
 # Output configuration
 output:


### PR DESCRIPTION
## Summary

Set `run.allow-serial-runners: true` in `.golangci.yaml` so a golangci-lint invocation that finds the machine-wide lock held **waits its turn** instead of failing with `parallel golangci-lint is running`. This is particularly useful when multiple AI coding sessions (e.g. several Claude Code / Codex sessions) work on different things in separate worktrees on one dev machine — their lint runs (and the `make qualify` gates that wrap them) now queue automatically instead of aborting each other.

## Motivation / Context

golangci-lint acquires a machine-global file lock at startup. With the defaults (`allow-parallel-runners: false`, `allow-serial-runners: false`) a second concurrent invocation **fails fast** rather than waiting, so an unrelated session's lint run aborts an entire `make qualify` with a transient, non-actionable error. `allow-serial-runners` keeps the exact same execution model — strictly one instance at a time, same mutual exclusion, same cache safety — and only changes what the second arrival does while the lock is held: block until it frees, then run.

`allow-parallel-runners` was deliberately **not** chosen: skipping the lock lets concurrent runs race on the shared analysis cache and oversubscribe CPU/memory (each run uses all cores and holds the fully type-checked package graph).

CI is unaffected: each workflow job runs in an isolated runner where the lock never contends, so the setting is inert there.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.golangci.yaml` (lint runner configuration)

## Implementation Notes

One config key plus an explanatory comment; no lint rules, severities, or exclusions change.

## Testing

```bash
yamllint -c .yamllint.yaml .golangci.yaml     # pass
golangci-lint config verify -c .golangci.yaml # pass
golangci-lint run -c .golangci.yaml ./pkg/defaults/...  # 0 issues (config loads and runs)
```

Infra-only change to a lint runner setting — no Go code, recipes, or docs are touched, so tests/e2e/scan cannot regress; full `make qualify` was skipped in favor of the scoped checks above (config lint, config schema verification, and a live lint run proving the config parses and executes).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No migration. Reverting restores fail-fast lock behavior. Lint results are unchanged in both directions.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; scoped checks above
- [x] Linter passes (`make lint`) — config verified and exercised as above
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, configuration-only
- [x] I updated docs if user-facing behavior changed — N/A, no user-facing behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
