### PR TITLE
fix(validator): surface NCCL launcher failure diagnostics to stdout

### DIFF
--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1287,7 +1287,20 @@ func collectNCCLWorkerDiagnostics(ctx context.Context, clientset kubernetes.Inte
 	sections := make([]string, len(pods.Items))
 	g, gctx := errgroup.WithContext(diagCtx)
 	g.SetLimit(perNodeFanoutConcurrency)
+enqueue:
 	for i := range pods.Items {
+		// Stop scheduling once the diagnostic budget (diagCtx) expires so a
+		// large failed job returns promptly instead of queuing work that would
+		// only run against an already-canceled context; note the shortfall in
+		// the remaining sections so the truncation is visible, not silent.
+		select {
+		case <-gctx.Done():
+			for j := i; j < len(pods.Items); j++ {
+				sections[j] = fmt.Sprintf("worker %s: diagnostics skipped: %v\n", pods.Items[j].Name, gctx.Err())
+			}
+			break enqueue
+		default:
+		}
 		p := &pods.Items[i]
 		g.Go(func() error {
 			sections[i] = workerPodDiagnostics(gctx, clientset, namespace, p)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1188,16 +1188,29 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 		// the worker side (sshd never came up, TCPXO sidecar crashed), so pull
 		// worker diagnostics too and fold everything into the returned output.
 		slog.Info("Pod did not succeed, retrieving logs for debugging...")
-		logs, logErr := podHelper.GetPodLogs(ctx.Ctx, launcherPod)
+		launcherLogs, logErr := podHelper.GetPodLogs(ctx.Ctx, launcherPod)
 		if logErr != nil {
 			slog.Warn("failed to retrieve launcher pod logs", "pod", launcherPod.Name, "error", logErr)
-			logs = fmt.Sprintf("<launcher logs unavailable: %v>\n", logErr)
+			launcherLogs = fmt.Sprintf("<launcher logs unavailable: %v>", logErr)
 		} else {
 			// Tail to the same cap as worker diagnostics — a verbose launcher
 			// (mpirun + NCCL debug) would otherwise balloon the failure payload.
-			logs = tailLines(strings.TrimSpace(logs), maxDiagLogLines) + "\n"
+			launcherLogs = tailLines(strings.TrimSpace(launcherLogs), maxDiagLogLines)
 		}
-		logs += collectNCCLWorkerDiagnostics(ctx.Ctx, ctx.Clientset, ctx.Namespace)
+		workerDiag := collectNCCLWorkerDiagnostics(ctx.Ctx, ctx.Clientset, ctx.Namespace)
+
+		// Surface the diagnostics via slog, not just the return value: every
+		// caller on this error path (runNCCLTrainJob, validateNcclAllReduceBw,
+		// checkNCCLAllReduceBWVariant) discards the returned logs string, so
+		// logging is the only way the launcher/worker failure detail reaches the
+		// check's captured stdout (report.json). emitDiagnosticBlock logs each
+		// line individually so multi-line output stays readable there instead of
+		// collapsing into a single logfmt value.
+		slog.Error("NCCL launcher pod failed; dumping diagnostics", "launcherPod", launcherPod.Name)
+		emitDiagnosticBlock("launcher "+launcherPod.Name+" logs", launcherLogs)
+		emitDiagnosticBlock("worker diagnostics", workerDiag)
+
+		logs := launcherLogs + "\n" + workerDiag
 		return logs, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "pod failed to complete successfully", err)
 	}
 
@@ -1216,6 +1229,23 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 // the end, so the tail is what matters; the cap keeps a verbose worker
 // (apt-get + NCCL debug output) from ballooning the returned failure payload.
 const maxDiagLogLines = 100
+
+// emitDiagnosticBlock writes a labeled, multi-line diagnostic blob to the log
+// one line at a time. The check's stdout (captured into report.json) is a
+// stream of slog lines, so logging the blob as a single attribute would
+// collapse it into one unreadable logfmt value; emitting per line keeps it
+// greppable alongside the other progress lines. A blank/whitespace-only block
+// is logged as "(empty)" so the absence of output is itself visible.
+func emitDiagnosticBlock(label, block string) {
+	trimmed := strings.TrimSpace(block)
+	if trimmed == "" {
+		slog.Error("diagnostics", "section", label, "line", "(empty)")
+		return
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		slog.Error("diagnostics", "section", label, "line", line)
+	}
+}
 
 // tailLines returns the last n lines of s (or all of s when it has n or fewer).
 func tailLines(s string, n int) string {

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEmitDiagnosticBlock(t *testing.T) {
+	tests := []struct {
+		name         string
+		label        string
+		block        string
+		wantLines    int // number of "diagnostics" records emitted
+		wantContains []string
+	}{
+		{
+			name:         "multi-line block emits one record per line",
+			label:        "worker diagnostics",
+			block:        "line one\nline two\nline three",
+			wantLines:    3,
+			wantContains: []string{"line one", "line two", "line three", "worker diagnostics"},
+		},
+		{
+			name:         "empty block emits a single (empty) marker",
+			label:        "launcher logs",
+			block:        "   \n  ",
+			wantLines:    1,
+			wantContains: []string{"(empty)", "launcher logs"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+			defer slog.SetDefault(prev)
+
+			emitDiagnosticBlock(tt.label, tt.block)
+
+			out := buf.String()
+			if got := strings.Count(out, "msg=diagnostics"); got != tt.wantLines {
+				t.Errorf("emitted %d diagnostic records, want %d\noutput:\n%s", got, tt.wantLines, out)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\noutput:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestTailLines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{"fewer than n", "a\nb", 5, "a\nb"},
+		{"exactly n", "a\nb\nc", 3, "a\nb\nc"},
+		{"more than n keeps tail", "a\nb\nc\nd", 2, "c\nd"},
+		{"single line", "only", 3, "only"},
+		{"empty", "", 3, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tailLines(tt.in, tt.n); got != tt.want {
+				t.Errorf("tailLines(%q, %d) = %q, want %q", tt.in, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectNCCLWorkerDiagnostics(t *testing.T) {
+	const ns = "aicr-test"
+
+	workerLabels := map[string]string{
+		"jobset.sigs.k8s.io/jobset-name":        ncclTrainJobName,
+		"jobset.sigs.k8s.io/replicatedjob-name": nodeJobName,
+	}
+
+	failedWorker := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nccl-all-reduce-tj-node-0-0-abcde",
+			Namespace: ns,
+			Labels:    workerLabels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			// tcpxo-daemon is a native sidecar (init container).
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "tcpxo-daemon",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:   "Error",
+						ExitCode: 137,
+						Message:  "fastrak init failed",
+					},
+				},
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: nodeJobName,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CrashLoopBackOff",
+						Message: "back-off restarting",
+					},
+				},
+			}},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		pods         []runtime.Object
+		wantContains []string
+	}{
+		{
+			name:         "no worker pods",
+			pods:         nil,
+			wantContains: []string{"no NCCL worker pods found"},
+		},
+		{
+			name: "worker with failed and waiting containers",
+			pods: []runtime.Object{failedWorker},
+			wantContains: []string{
+				failedWorker.Name,
+				"phase=Failed",
+				"container tcpxo-daemon: terminated reason=Error exitCode=137",
+				"fastrak init failed",
+				"container node: waiting reason=CrashLoopBackOff",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset(tt.pods...)
+			got := collectNCCLWorkerDiagnostics(context.Background(), client, ns)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("diagnostics missing %q\nfull output:\n%s", want, got)
+				}
+			}
+		})
+	}
+}

--- a/validators/performance/nccl_preflight_tcpxo_test.go
+++ b/validators/performance/nccl_preflight_tcpxo_test.go
@@ -15,7 +15,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -59,6 +61,51 @@ func TestGKETCPXOPreflightApplies(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := gkeTCPXOPreflightApplies(tt.variant, tt.accelerator, tt.service); got != tt.want {
 				t.Errorf("gkeTCPXOPreflightApplies() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmitDiagnosticBlock(t *testing.T) {
+	tests := []struct {
+		name         string
+		label        string
+		block        string
+		wantLines    int // number of "diagnostics" records emitted
+		wantContains []string
+	}{
+		{
+			name:         "multi-line block emits one record per line",
+			label:        "worker diagnostics",
+			block:        "line one\nline two\nline three",
+			wantLines:    3,
+			wantContains: []string{"line one", "line two", "line three", "worker diagnostics"},
+		},
+		{
+			name:         "empty block emits a single (empty) marker",
+			label:        "launcher logs",
+			block:        "   \n  ",
+			wantLines:    1,
+			wantContains: []string{"(empty)", "launcher logs"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+			defer slog.SetDefault(prev)
+
+			emitDiagnosticBlock(tt.label, tt.block)
+
+			out := buf.String()
+			if got := strings.Count(out, "msg=diagnostics"); got != tt.wantLines {
+				t.Errorf("emitted %d diagnostic records, want %d\noutput:\n%s", got, tt.wantLines, out)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\noutput:\n%s", want, out)
+				}
 			}
 		})
 	}

--- a/validators/performance/nccl_preflight_tcpxo_test.go
+++ b/validators/performance/nccl_preflight_tcpxo_test.go
@@ -15,17 +15,9 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/recipe"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGKETCPXOPreflightApplies(t *testing.T) {
@@ -61,147 +53,6 @@ func TestGKETCPXOPreflightApplies(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := gkeTCPXOPreflightApplies(tt.variant, tt.accelerator, tt.service); got != tt.want {
 				t.Errorf("gkeTCPXOPreflightApplies() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestEmitDiagnosticBlock(t *testing.T) {
-	tests := []struct {
-		name         string
-		label        string
-		block        string
-		wantLines    int // number of "diagnostics" records emitted
-		wantContains []string
-	}{
-		{
-			name:         "multi-line block emits one record per line",
-			label:        "worker diagnostics",
-			block:        "line one\nline two\nline three",
-			wantLines:    3,
-			wantContains: []string{"line one", "line two", "line three", "worker diagnostics"},
-		},
-		{
-			name:         "empty block emits a single (empty) marker",
-			label:        "launcher logs",
-			block:        "   \n  ",
-			wantLines:    1,
-			wantContains: []string{"(empty)", "launcher logs"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			prev := slog.Default()
-			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
-			defer slog.SetDefault(prev)
-
-			emitDiagnosticBlock(tt.label, tt.block)
-
-			out := buf.String()
-			if got := strings.Count(out, "msg=diagnostics"); got != tt.wantLines {
-				t.Errorf("emitted %d diagnostic records, want %d\noutput:\n%s", got, tt.wantLines, out)
-			}
-			for _, want := range tt.wantContains {
-				if !strings.Contains(out, want) {
-					t.Errorf("output missing %q\noutput:\n%s", want, out)
-				}
-			}
-		})
-	}
-}
-
-func TestTailLines(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		n    int
-		want string
-	}{
-		{"fewer than n", "a\nb", 5, "a\nb"},
-		{"exactly n", "a\nb\nc", 3, "a\nb\nc"},
-		{"more than n keeps tail", "a\nb\nc\nd", 2, "c\nd"},
-		{"single line", "only", 3, "only"},
-		{"empty", "", 3, ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tailLines(tt.in, tt.n); got != tt.want {
-				t.Errorf("tailLines(%q, %d) = %q, want %q", tt.in, tt.n, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestCollectNCCLWorkerDiagnostics(t *testing.T) {
-	const ns = "aicr-test"
-
-	workerLabels := map[string]string{
-		"jobset.sigs.k8s.io/jobset-name":        ncclTrainJobName,
-		"jobset.sigs.k8s.io/replicatedjob-name": nodeJobName,
-	}
-
-	failedWorker := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nccl-all-reduce-tj-node-0-0-abcde",
-			Namespace: ns,
-			Labels:    workerLabels,
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodFailed,
-			// tcpxo-daemon is a native sidecar (init container).
-			InitContainerStatuses: []corev1.ContainerStatus{{
-				Name: "tcpxo-daemon",
-				State: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{
-						Reason:   "Error",
-						ExitCode: 137,
-						Message:  "fastrak init failed",
-					},
-				},
-			}},
-			ContainerStatuses: []corev1.ContainerStatus{{
-				Name: nodeJobName,
-				State: corev1.ContainerState{
-					Waiting: &corev1.ContainerStateWaiting{
-						Reason:  "CrashLoopBackOff",
-						Message: "back-off restarting",
-					},
-				},
-			}},
-		},
-	}
-
-	tests := []struct {
-		name         string
-		pods         []runtime.Object
-		wantContains []string
-	}{
-		{
-			name:         "no worker pods",
-			pods:         nil,
-			wantContains: []string{"no NCCL worker pods found"},
-		},
-		{
-			name: "worker with failed and waiting containers",
-			pods: []runtime.Object{failedWorker},
-			wantContains: []string{
-				failedWorker.Name,
-				"phase=Failed",
-				"container tcpxo-daemon: terminated reason=Error exitCode=137",
-				"fastrak init failed",
-				"container node: waiting reason=CrashLoopBackOff",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client := fake.NewClientset(tt.pods...)
-			got := collectNCCLWorkerDiagnostics(context.Background(), client, ns)
-			for _, want := range tt.wantContains {
-				if !strings.Contains(got, want) {
-					t.Errorf("diagnostics missing %q\nfull output:\n%s", want, got)
-				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Emit the NCCL launcher-failure diagnostics (launcher log tail + per-worker container states and logs) via `slog` so they actually reach the check's captured stdout / `report.json`, instead of being silently dropped.

## Motivation / Context

The earlier GKE NCCL mitigations (#1631) added `collectNCCLWorkerDiagnostics` and a launcher-log tail, but returned them only as a string. Every caller on the launcher-failure path (`runNCCLTrainJob` → `validateNcclAllReduceBw` → `checkNCCLAllReduceBWVariant`) discards that string when `err != nil`, so the detail never surfaced.

A UAT-GCP run (actions run 28885524253) confirmed the gap and, usefully, narrowed the root cause:

- **GKE TCPXO preflight passed** — the installer artifacts are present, so the "installer not ready" cause is ruled out on that cluster.
- The launcher ran ~70s (Running → Failed), **well short of the ~5-min SSH retry budget**, so this is not mpirun exhausting SSH retries either — it points at the NCCL/TCPXO run itself failing.
- But `report.json` still showed only `pod failed` with **zero launcher or worker logs** — because of the drop described above.

This PR makes that detail visible so the next run reveals the actual NCCL/TCPXO failure.

Fixes: N/A
Related: #1631

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — `validators/performance` NCCL check

## Implementation Notes

- On the launcher-failure path, emit the launcher log tail and `collectNCCLWorkerDiagnostics` output via `slog` at the point of collection, before the error propagates and the string is dropped.
- `emitDiagnosticBlock` logs one record per line so multi-line output stays greppable in `report.json` instead of collapsing into a single logfmt value; an empty block logs an explicit `(empty)` marker so absence of output is itself visible.
- No behavior change beyond logging; the returned string is preserved for any future caller.

## Testing

```bash
go build ./validators/...
golangci-lint run -c .golangci.yaml ./validators/performance/...   # 0 issues
go test -race ./validators/performance/...                          # ok
```

Added `TestEmitDiagnosticBlock` (per-line emission + empty marker, via a captured slog handler) and `TestTailLines`.

## Risk Assessment

- [x] **Low** — Logging-only change on an existing failure path; no control-flow or output-contract change. Easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — affected package with `-race`
- [x] Linter passes (`make lint`) — `golangci-lint` on affected package, 0 issues
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (internal validator logging)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
