### PR TITLE
fix(validator): harden NCCL preflight helpers (codes, cancel, SA token)

### DIFF
--- a/validators/performance/nccl_preflight.go
+++ b/validators/performance/nccl_preflight.go
@@ -39,13 +39,6 @@ const (
 	shellBin = "/bin/sh"
 )
 
-// probeNoAutomountSAToken is the addressable false used to disable
-// ServiceAccount-token automounting on the per-node probe pods
-// (PodSpec.AutomountServiceAccountToken is a *bool). The probes only read a
-// hostPath mount and never call the Kubernetes API, so mounting an API token
-// onto them — especially alongside a hostPath — is an unnecessary credential.
-var probeNoAutomountSAToken = false
-
 // runPerNodeProbe fans out a boolean readiness probe across the target nodes
 // with bounded concurrency and returns the sorted list of nodes for which the
 // probe reported false (not-ready). A probe error (schedule/image-pull/log

--- a/validators/performance/nccl_preflight.go
+++ b/validators/performance/nccl_preflight.go
@@ -39,6 +39,13 @@ const (
 	shellBin = "/bin/sh"
 )
 
+// probeNoAutomountSAToken is the addressable false used to disable
+// ServiceAccount-token automounting on the per-node probe pods
+// (PodSpec.AutomountServiceAccountToken is a *bool). The probes only read a
+// hostPath mount and never call the Kubernetes API, so mounting an API token
+// onto them — especially alongside a hostPath — is an unnecessary credential.
+var probeNoAutomountSAToken = false
+
 // runPerNodeProbe fans out a boolean readiness probe across the target nodes
 // with bounded concurrency and returns the sorted list of nodes for which the
 // probe reported false (not-ready). A probe error (schedule/image-pull/log
@@ -61,13 +68,23 @@ func runPerNodeProbe(
 	g, gctx := errgroup.WithContext(ctx.Ctx)
 	g.SetLimit(perNodeFanoutConcurrency)
 	for _, n := range nodes {
+		// Stop scheduling once the group context is canceled — a sibling probe's
+		// hard failure or a parent-context deadline — rather than queuing work
+		// that would only run against an already-canceled context. Any nodes not
+		// yet probed are irrelevant: g.Wait below returns the cancellation error,
+		// so the partial missing-list is never consumed.
+		if gctx.Err() != nil {
+			break
+		}
 		nodeName := n.Name
 		g.Go(func() error {
 			ok, err := probe(gctx, ctx.Clientset, ctx.Namespace, nodeName)
 			if err != nil {
-				return aicrErrors.WrapWithContext(aicrErrors.ErrCodeInternal,
-					probeLabel+" preflight probe failed", err,
-					map[string]interface{}{"node": nodeName})
+				// Preserve the probe's structured code (e.g. ErrCodeTimeout from
+				// the phase wait) instead of flattening every failure to Internal;
+				// only genuinely uncoded errors get the fallback classification.
+				return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
+					probeLabel+" preflight probe failed on node "+nodeName)
 			}
 			if !ok {
 				mu.Lock()

--- a/validators/performance/nccl_preflight_nvreg.go
+++ b/validators/performance/nccl_preflight_nvreg.go
@@ -124,8 +124,9 @@ func checkNVregOnNode(ctx context.Context, clientset kubernetes.Interface, names
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:      nodeName,
-			RestartPolicy: corev1.RestartPolicyNever,
+			NodeName:                     nodeName,
+			RestartPolicy:                corev1.RestartPolicyNever,
+			AutomountServiceAccountToken: &probeNoAutomountSAToken,
 			// Tolerate whatever taints the GPU nodes carry. The preflight
 			// is cheap (busybox + grep) so we accept wherever scheduler
 			// places us on the target node.

--- a/validators/performance/nccl_preflight_nvreg.go
+++ b/validators/performance/nccl_preflight_nvreg.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
@@ -124,9 +125,11 @@ func checkNVregOnNode(ctx context.Context, clientset kubernetes.Interface, names
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:                     nodeName,
-			RestartPolicy:                corev1.RestartPolicyNever,
-			AutomountServiceAccountToken: &probeNoAutomountSAToken,
+			NodeName:      nodeName,
+			RestartPolicy: corev1.RestartPolicyNever,
+			// The probe only reads a hostPath and never calls the Kubernetes API,
+			// so don't mount an API token onto it (defense-in-depth with the hostPath).
+			AutomountServiceAccountToken: ptr.To(false),
 			// Tolerate whatever taints the GPU nodes carry. The preflight
 			// is cheap (busybox + grep) so we accept wherever scheduler
 			// places us on the target node.

--- a/validators/performance/nccl_preflight_tcpxo.go
+++ b/validators/performance/nccl_preflight_tcpxo.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
@@ -134,9 +135,11 @@ func checkTCPXOOnNode(ctx context.Context, clientset kubernetes.Interface, names
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:                     nodeName,
-			RestartPolicy:                corev1.RestartPolicyNever,
-			AutomountServiceAccountToken: &probeNoAutomountSAToken,
+			NodeName:      nodeName,
+			RestartPolicy: corev1.RestartPolicyNever,
+			// The probe only reads a hostPath and never calls the Kubernetes API,
+			// so don't mount an API token onto it (defense-in-depth with the hostPath).
+			AutomountServiceAccountToken: ptr.To(false),
 			// Tolerate whatever taints the GPU nodes carry. The probe is cheap
 			// (busybox + test) so we accept wherever scheduler places us on the
 			// target node.

--- a/validators/performance/nccl_preflight_tcpxo.go
+++ b/validators/performance/nccl_preflight_tcpxo.go
@@ -134,8 +134,9 @@ func checkTCPXOOnNode(ctx context.Context, clientset kubernetes.Interface, names
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:      nodeName,
-			RestartPolicy: corev1.RestartPolicyNever,
+			NodeName:                     nodeName,
+			RestartPolicy:                corev1.RestartPolicyNever,
+			AutomountServiceAccountToken: &probeNoAutomountSAToken,
 			// Tolerate whatever taints the GPU nodes carry. The probe is cheap
 			// (busybox + test) so we accept wherever scheduler places us on the
 			// target node.

--- a/validators/performance/nccl_preflight_test.go
+++ b/validators/performance/nccl_preflight_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/validators"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRunPerNodeProbe(t *testing.T) {
+	node := func(name string) corev1.Node {
+		return corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+	newCtx := func() *validators.Context {
+		return &validators.Context{Ctx: context.Background(), Clientset: fake.NewClientset(), Namespace: "ns"}
+	}
+
+	t.Run("collects not-ready nodes sorted", func(t *testing.T) {
+		missing, err := runPerNodeProbe(newCtx(), []corev1.Node{node("z"), node("a"), node("m")}, "Test",
+			func(_ context.Context, _ kubernetes.Interface, _, nodeName string) (bool, error) {
+				return nodeName == "a", nil // only "a" ready; z and m not-ready
+			})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(missing) != 2 || missing[0] != "m" || missing[1] != "z" {
+			t.Errorf("missing = %v, want sorted [m z]", missing)
+		}
+	})
+
+	t.Run("preserves structured probe error code", func(t *testing.T) {
+		// A probe that fails with ErrCodeTimeout must not be flattened to
+		// ErrCodeInternal by the shared fan-out.
+		_, err := runPerNodeProbe(newCtx(), []corev1.Node{node("n1")}, "Test",
+			func(_ context.Context, _ kubernetes.Interface, _, _ string) (bool, error) {
+				return false, aicrErrors.New(aicrErrors.ErrCodeTimeout, "probe timed out")
+			})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
+			t.Errorf("error code not preserved: got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Three small hardening fixes to the shared NCCL preflight helpers introduced in #1631: preserve structured probe error codes, stop scheduling probes after cancellation, and disable ServiceAccount-token automount on the probe pods.

## Motivation / Context

CodeRabbit flagged these on #1631's helper code (surfaced during the #1640 review). They're valid but out of scope for #1640 (diagnostics logging), so they're collected here.

Fixes: N/A
Related: #1631, #1640

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — `validators/performance` NCCL preflights

## Implementation Notes

- **Preserve probe error codes** (`runPerNodeProbe`): it wrapped every probe failure as `ErrCodeInternal`, masking a probe's `ErrCodeTimeout` (from the phase wait). Switched to `PropagateOrWrap` so already-coded `pkg/errors` values pass through and only genuinely uncoded errors get the fallback classification; node context moved into the message. Matches the CLAUDE.md "don't double-wrap errors that already have proper codes" rule.
- **Cancellation**: `runPerNodeProbe` now breaks out of the scheduling loop once the group context is canceled (deadline or a sibling probe's hard failure) rather than queuing goroutines that would only run against a canceled context. `g.Wait()` returns the cancellation error, so the partial not-ready list is never consumed.
- **SA-token automount**: both probe pods (NVreg + TCPXO) set `AutomountServiceAccountToken: false`. They only read a hostPath and never call the Kubernetes API, so mounting an API token — especially alongside a hostPath — is an unnecessary credential.

## Testing

```bash
go build ./validators/...
golangci-lint run -c .golangci.yaml ./validators/performance/...   # 0 issues
go test -race ./validators/performance/...                          # ok
```

Added `TestRunPerNodeProbe` (sorted not-ready collection + error-code preservation).

## Risk Assessment

- [x] **Low** — Isolated to the preflight helper path; changes are a code-preservation fix, an early-exit on an already-failing context, and a security-hardening flag. Easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — affected package with `-race`
- [x] Linter passes (`make lint`) — `golangci-lint` on affected package, 0 issues
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (internal validator behavior)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
