### PR TITLE
fix(validator): skip orphan pods in negative health assertions

### DIFF
--- a/validators/chainsaw/inprocess.go
+++ b/validators/chainsaw/inprocess.go
@@ -19,6 +19,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/kyverno/chainsaw/pkg/apis"
@@ -446,6 +447,15 @@ func evaluateError(ctx context.Context, e *v1alpha1.Error, fetcher ResourceFetch
 			return errors.Wrap(errors.ErrCodeInternal,
 				fmt.Sprintf("list-match canceled for %s in %q", kind, namespace), err)
 		}
+		// Skip ghosts (Terminating or NodeLost): a node replaced or lost
+		// mid-run leaves its DaemonSet/workload pod behind for minutes until
+		// pod GC, while a healthy replacement already runs on the live node.
+		// A negative (error) assertion must not fire on such an orphan — that
+		// is the orphan-pod trap documented in the project anti-patterns, and
+		// it turned a healthy ebs-csi-node DaemonSet into a false failure.
+		if isTerminatingOrLost(actual) {
+			continue
+		}
 		errs, checkErr := checks.Check(ctx, apis.DefaultCompilers, actual, nil, &check)
 		if checkErr != nil {
 			return errors.Wrap(errors.ErrCodeInvalidRequest,
@@ -460,10 +470,88 @@ func evaluateError(ctx context.Context, e *v1alpha1.Error, fetcher ResourceFetch
 				}
 			}
 			return errors.New(errors.ErrCodeInternal,
-				fmt.Sprintf("%s %s/%s matches forbidden shape", kind, namespace, itemName))
+				fmt.Sprintf("%s %s/%s matches forbidden shape%s",
+					kind, namespace, itemName, describePodStatus(actual)))
 		}
 	}
 	return nil
+}
+
+// isTerminatingOrLost reports whether a listed resource is a ghost that a
+// negative (error) assertion must skip: a resource with a deletionTimestamp
+// (Terminating, being garbage-collected) or a pod the node controller has
+// marked NodeLost after its node went unreachable. During UAT, a GPU/inference
+// node replaced or lost mid-run leaves such a pod behind for minutes until pod
+// GC removes it, even though a healthy replacement already runs on the live
+// node. Flagging the ghost is the orphan-pod trap: filter it out so the check
+// reflects the state of live nodes only.
+func isTerminatingOrLost(obj map[string]any) bool {
+	if md, ok := obj["metadata"].(map[string]any); ok {
+		if ts, ok := md["deletionTimestamp"].(string); ok && ts != "" {
+			return true
+		}
+	}
+	if st, ok := obj["status"].(map[string]any); ok {
+		if reason, ok := st["reason"].(string); ok && reason == "NodeLost" {
+			return true
+		}
+	}
+	return false
+}
+
+// describePodStatus renders a compact, human-readable summary of a resource's
+// health-relevant status (phase, first container-waiting reason, node) so a
+// "forbidden shape matched" failure is self-diagnosing in the check report
+// instead of an opaque shape reference. Returns "" for resources without these
+// fields (e.g. non-pod kinds), leaving the message unchanged.
+func describePodStatus(obj map[string]any) string {
+	parts := make([]string, 0, 3)
+	if st, ok := obj["status"].(map[string]any); ok {
+		if phase, ok := st["phase"].(string); ok && phase != "" {
+			parts = append(parts, "phase="+phase)
+		}
+		if reason := firstWaitingReason(st); reason != "" {
+			parts = append(parts, "waiting="+reason)
+		}
+	}
+	if spec, ok := obj["spec"].(map[string]any); ok {
+		if node, ok := spec["nodeName"].(string); ok && node != "" {
+			parts = append(parts, "node="+node)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
+}
+
+// firstWaitingReason returns the first container-waiting reason found across a
+// pod's containerStatuses and initContainerStatuses, or "" if none is waiting.
+func firstWaitingReason(status map[string]any) string {
+	for _, key := range []string{"containerStatuses", "initContainerStatuses"} {
+		list, ok := status[key].([]any)
+		if !ok {
+			continue
+		}
+		for _, cs := range list {
+			csm, ok := cs.(map[string]any)
+			if !ok {
+				continue
+			}
+			state, ok := csm["state"].(map[string]any)
+			if !ok {
+				continue
+			}
+			waiting, ok := state["waiting"].(map[string]any)
+			if !ok {
+				continue
+			}
+			if reason, ok := waiting["reason"].(string); ok && reason != "" {
+				return reason
+			}
+		}
+	}
+	return ""
 }
 
 // extractResourceSelector pulls apiVersion / kind / metadata fields

--- a/validators/chainsaw/inprocess_test.go
+++ b/validators/chainsaw/inprocess_test.go
@@ -41,6 +41,11 @@ func newFakeFetcher() *fakeFetcher {
 	}
 }
 
+// addGet mirrors ResourceFetcher.Fetch(apiVersion, ...); only Deployments
+// (apps/v1) are fetched by name in the current corpus, so apiVersion never
+// varies today — keep it for interface parity.
+//
+//nolint:unparam // apiVersion is constant today; retained for Fetch parity.
 func (f *fakeFetcher) addGet(apiVersion, kind, namespace, name string, obj map[string]any) {
 	key := apiVersion + "/" + kind + "/" + namespace + "/" + name
 	f.gets[key] = obj
@@ -143,6 +148,20 @@ func pod(name, phase string, labels map[string]any) map[string]any {
 	}
 }
 
+// terminating marks a pod fixture as being garbage-collected by setting a
+// deletionTimestamp, turning it into an orphan a negative assertion must skip.
+func terminating(p map[string]any) map[string]any {
+	p["metadata"].(map[string]any)["deletionTimestamp"] = "2026-07-07T19:30:00Z"
+	return p
+}
+
+// nodeLost marks a pod fixture as NodeLost — the state the node controller
+// assigns after a pod's node goes unreachable.
+func nodeLost(p map[string]any) map[string]any {
+	p["status"].(map[string]any)["reason"] = "NodeLost"
+	return p
+}
+
 // TestRunChainsawTestInProcess covers the three load-bearing paths of the
 // in-process executor: a healthy fixture passes both steps; a missing
 // resource fails the assert; a forbidden shape (a Pending pod) fires the
@@ -195,6 +214,41 @@ func TestRunChainsawTestInProcess(t *testing.T) {
 				})
 			},
 			wantPassed: true,
+		},
+		{
+			name: "error skips terminating ghost pod",
+			yaml: readinessYAML,
+			setup: func(f *fakeFetcher) {
+				f.addGet("apps/v1", "Deployment", "ns", "foo", healthyDeployment())
+				f.addList("v1", "Pod", "ns", []map[string]any{
+					terminating(pod("ghost", "Pending", nil)),
+				})
+			},
+			wantPassed: true,
+		},
+		{
+			name: "error skips NodeLost ghost pod",
+			yaml: readinessYAML,
+			setup: func(f *fakeFetcher) {
+				f.addGet("apps/v1", "Deployment", "ns", "foo", healthyDeployment())
+				f.addList("v1", "Pod", "ns", []map[string]any{
+					nodeLost(pod("ghost", "Pending", nil)),
+				})
+			},
+			wantPassed: true,
+		},
+		{
+			name: "error still fires on a live pod beside a ghost",
+			yaml: readinessYAML,
+			setup: func(f *fakeFetcher) {
+				f.addGet("apps/v1", "Deployment", "ns", "foo", healthyDeployment())
+				f.addList("v1", "Pod", "ns", []map[string]any{
+					terminating(pod("ghost", "Pending", nil)),
+					pod("live", "Pending", nil),
+				})
+			},
+			wantPassed: false,
+			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -381,6 +435,70 @@ spec:
 			if elapsed >= defaults.AssertRetryInterval {
 				t.Fatalf("terminal eval error was retried (took %s >= AssertRetryInterval %s) — #1252 regression",
 					elapsed, defaults.AssertRetryInterval)
+			}
+		})
+	}
+}
+
+// TestIsTerminatingOrLost covers the orphan-pod filter that keeps a negative
+// assertion from firing on ghosts left behind by node churn (#uat-aws).
+func TestIsTerminatingOrLost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want bool
+	}{
+		{"live running pod", pod("p", "Running", nil), false},
+		{"live pending pod", pod("p", "Pending", nil), false},
+		{"terminating pod", terminating(pod("p", "Pending", nil)), true},
+		{"node-lost pod", nodeLost(pod("p", "Unknown", nil)), true},
+		{"empty deletionTimestamp is not terminating", func() map[string]any {
+			p := pod("p", "Running", nil)
+			p["metadata"].(map[string]any)["deletionTimestamp"] = ""
+			return p
+		}(), false},
+		{"no metadata or status", map[string]any{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTerminatingOrLost(tt.obj); got != tt.want {
+				t.Errorf("isTerminatingOrLost = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDescribePodStatus verifies the diagnostic suffix appended to a
+// "forbidden shape matched" failure so operators can triage from the report.
+func TestDescribePodStatus(t *testing.T) {
+	t.Parallel()
+	waitingPod := map[string]any{
+		"status": map[string]any{
+			"phase": "Running",
+			"containerStatuses": []any{
+				map[string]any{"state": map[string]any{"running": map[string]any{}}},
+				map[string]any{"state": map[string]any{"waiting": map[string]any{"reason": "CrashLoopBackOff"}}},
+			},
+		},
+		"spec": map[string]any{"nodeName": "gpu-node-1"},
+	}
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want string
+	}{
+		{"phase only", pod("p", "Pending", nil), " (phase=Pending)"},
+		{"phase, waiting reason and node", waitingPod, " (phase=Running, waiting=CrashLoopBackOff, node=gpu-node-1)"},
+		{"non-pod resource yields no suffix", healthyDeployment(), ""},
+		{"empty object yields empty suffix", map[string]any{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := describePodStatus(tt.obj); got != tt.want {
+				t.Errorf("describePodStatus = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The in-process chainsaw executor's negative (`error`) health assertions now skip orphaned pods (Terminating or NodeLost) so a ghost pod left behind by node churn no longer fails an otherwise-healthy check.

## Motivation / Context

In an AWS UAT inference run, the `aws-ebs-csi-driver` `expected-resources` check failed with `Pod kube-system/ebs-csi-node-xhpmz matches forbidden shape` — after the same check had passed twice earlier in the run. The failure burned the full 5-minute `assert` timeout, meaning the pod matched a forbidden shape continuously and never recovered.

Root cause: `ebs-csi-node-*` is a DaemonSet (one pod per node). When a GPU/inference node is replaced or lost mid-run (validate stage), its `ebs-csi-node` pod lingers in phase `Unknown`/`Failed` (or with a `deletionTimestamp`) for minutes until pod GC removes it, while a healthy replacement already runs on the live node. The negative list-and-match loop in `evaluateError` had **no filter for orphaned pods**, so it flagged the ghost — the exact orphan-pod trap documented in the project anti-patterns (`pods.Items[0]` after a label-selector List → filter `DeletionTimestamp != nil`).

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`)

## Implementation Notes

- `evaluateError` skips resources with a `metadata.deletionTimestamp` or `status.reason == "NodeLost"` before evaluating the forbidden shape, so negative assertions reflect the state of live nodes only. Positive (`assert`) matching is intentionally unchanged.
- The `forbidden shape matched` message now appends `(phase=…, waiting=…, node=…)` so future failures are self-diagnosing from the check report instead of an opaque shape reference.

## Testing

```bash
make qualify
```

- Full `make qualify` passed (unit tests with `-race`, lint, chainsaw e2e, vulnerability scan).
- Added table cases (terminating ghost skipped, NodeLost ghost skipped, live pod beside a ghost still fails) plus focused `TestIsTerminatingOrLost` / `TestDescribePodStatus`.
- New helpers covered 100% / 100% / 88.2%; `validators/chainsaw` package coverage unchanged-or-up.

## Risk Assessment

- [x] **Low** — Isolated change to the negative-assertion path, well-tested, easy to revert.

**Rollout notes:** N/A — health-check evaluation only; no API or recipe surface changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — internal evaluator behavior)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
