### PR TITLE
fix(validator): raise GKE NCCL launcher debug to INFO for root-causing

### DIFF
--- a/validators/performance/testdata/h100/gke/runtime.yaml
+++ b/validators/performance/testdata/h100/gke/runtime.yaml
@@ -123,8 +123,17 @@ spec:
                   # set explicitly for compatibility with non-privileged environments.
                   - -x
                   - LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64
+                  # INFO (was WARN) so a failed run surfaces the exact NCCL/FastRak
+                  # init path — with WARN we only saw the shim's config-checker
+                  # warnings, not the fatal abort. Scoped to INIT,NET,ENV,GRAPH to
+                  # keep the volume manageable within the launcher log tail while
+                  # covering the FastRak/TCPXO transport bring-up where the failure
+                  # occurs. Rank stdout streams back through mpirun to the launcher,
+                  # so this lands in the captured launcher diagnostics.
                   - -x
-                  - NCCL_DEBUG=WARN
+                  - NCCL_DEBUG=INFO
+                  - -x
+                  - NCCL_DEBUG_SUBSYS=INIT,NET,ENV,GRAPH
                   - -x
                   - NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
                   - -x


### PR DESCRIPTION
## Summary

Raise the GKE NCCL launcher's `NCCL_DEBUG` from `WARN` to `INFO` (scoped to `INIT,NET,ENV,GRAPH`) so a failed a3-megagpu-8g run surfaces the exact FastRak/NCCL init error, not just the TCPXO shim's config-checker warnings.

## Motivation / Context

With the launcher diagnostics now reaching `report.json` (#1640), a UAT-GCP run showed the GKE NCCL launcher fails after NCCL/FastRak init begins — `orted` loses both worker SSH sessions ("ORTE was unable to reliably start one or more daemons"), preceded by repeated TCPXO shim warnings (`NCCL/NET (shim) mismatch recommended: NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices (expected unset)` etc.). But `NCCL_DEBUG=WARN` masked the fatal init error itself. INFO (subsystem-scoped to keep volume within the launcher log tail) will show the exact abort on the next run. Rank output streams back through mpirun to the launcher, so it lands in the captured launcher diagnostics.

This is a diagnostic step toward the suspected root cause — a TCPXO rxdm-daemon (`tcpgpudmarxd-dev:v1.0.20`) / NCCL-plugin (`nccl-plugin-gpudirecttcpx-dev:v1.0.15`) version mismatch — which will be reconciled in a follow-up once INFO confirms it.

Fixes: N/A
Related: #1631, #1640

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — `validators/performance` GKE NCCL runtime template

## Implementation Notes

- Only the GKE H100 TrainingRuntime launcher args change: `NCCL_DEBUG=WARN` → `INFO` plus `NCCL_DEBUG_SUBSYS=INIT,NET,ENV,GRAPH`. No control-flow or Go changes.

## Testing

```bash
go test ./validators/performance/...   # ok
# GKE runtime template re-validated as a well-formed TrainingRuntime
```

Real validation is the next UAT-GCP run, which will carry the detailed NCCL init trace in `report.json`.

## Risk Assessment

- [x] **Low** — Logging verbosity only, scoped to the GKE NCCL check's launcher. Trivially revertible once the root cause is fixed.

**Rollout notes:** Intended to be dialed back to `WARN` (or removed) once the underlying TCPXO failure is resolved.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — package tests pass
- [x] Linter passes (`make lint`) — no Go changes; YAML re-validated
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A (diagnostic env change)
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
