### PR TITLE
chore(recipes): bump nvidia-dra-driver-gpu to 0.4.1 GA

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -55,7 +55,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | nfd-ocp-olm | manifest | — | — | 0 |
 | nodewright-customizations | manifest | — | — | 5 |
 | nodewright-operator | helm | nodewright | v0.17.1 | 3 |
-| nvidia-dra-driver-gpu | helm | dra-driver-nvidia-gpu | 0.4.1-rc.1 | 1 |
+| nvidia-dra-driver-gpu | helm | dra-driver-nvidia-gpu | 0.4.1 | 1 |
 | nvsentinel | helm | nvsentinel | v1.9.0 | 6 |
 | prometheus-adapter | helm | prometheus-community/prometheus-adapter | 5.3.0 | 1 |
 | prometheus-operator-crds | helm | prometheus-community/prometheus-operator-crds | 28.0.1 | 0 |
@@ -219,7 +219,7 @@ _No images extracted._
 
 ### nvidia-dra-driver-gpu
 
-- `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1-rc.1`
+- `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1`
 
 ### nvsentinel
 
@@ -355,9 +355,9 @@ Component: nvidia-dra-driver-gpu (1 images)
 Presence-only check: does NOT verify publisher trust/identity.
 Y = artifact attached, - = artifact absent, ? = could not probe.
 
-  Image                                                                Sig  SBOM  Prov  Notes
-  -------------------------------------------------------------------  ---  ----  ----  -----
-  registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1-rc.1  Y    -     -
+  Image                                                           Sig  SBOM  Prov  Notes
+  --------------------------------------------------------------  ---  ----  ----  -----
+  registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1  Y    -     -
 
 Summary: 1/1 signed · 0/1 SBOM · 0/1 provenance
 ```

--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -113,7 +113,7 @@ componentRefs:
     chart: dra-driver-nvidia-gpu
     type: Helm
     source: oci://registry.k8s.io/dra-driver-nvidia/charts
-    version: 0.4.1-rc.1
+    version: 0.4.1
     valuesFile: components/nvidia-dra-driver-gpu/values.yaml
     overrides:
       controller:

--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -129,7 +129,7 @@ componentRefs:
     chart: dra-driver-nvidia-gpu
     type: Helm
     source: oci://registry.k8s.io/dra-driver-nvidia/charts
-    version: 0.4.1-rc.1
+    version: 0.4.1
     valuesFile: components/nvidia-dra-driver-gpu/values.yaml
     dependencyRefs:
       - gpu-operator

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -96,10 +96,7 @@ spec:
     - name: nvidia-dra-driver-gpu
       type: Helm
       source: oci://registry.k8s.io/dra-driver-nvidia/charts
-      # TEMPORARY: pinned to 0.4.1-rc.1 to fix the duplicate pod-template label
-      # key 0.4.0 emits (invalid YAML breaking Argo CD/Flux/strict consumers).
-      # Bump to 0.4.1 GA once released (week of 2026-06-29). See registry.yaml.
-      version: "0.4.1-rc.1"
+      version: "0.4.1"
       valuesFile: components/nvidia-dra-driver-gpu/values.yaml
       dependencyRefs:
         - gpu-operator

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -286,12 +286,7 @@ components:
     helm:
       defaultRepository: oci://registry.k8s.io/dra-driver-nvidia/charts
       defaultChart: dra-driver-nvidia-gpu
-      # TEMPORARY: pinned to 0.4.1-rc.1 to pick up the fix for the duplicate
-      # pod-template label key that 0.4.0 emits with our values (invalid YAML
-      # that breaks strict consumers — Argo CD/Flux/kustomize/yq). Bump to the
-      # 0.4.1 GA release once it lands (scheduled week of 2026-06-29).
-      # See https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1184
-      defaultVersion: "0.4.1-rc.1"
+      defaultVersion: "0.4.1"
       defaultNamespace: nvidia-dra-driver
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary

Bump `nvidia-dra-driver-gpu` from the temporary `0.4.1-rc.1` pin to the `0.4.1` GA release, and remove the TEMPORARY pin comments in `recipes/registry.yaml` and `recipes/overlays/base.yaml`.

## Motivation / Context

#1341 pinned the chart to `0.4.1-rc.1` as a stopgap for the duplicate pod-template label key that `0.4.0` emitted with our values (invalid YAML that broke Argo CD/Flux/strict consumers — kubernetes-sigs/dra-driver-nvidia-gpu#1184, our #1289). The pin comment committed us to moving to the GA release once it landed. `v0.4.1` GA was published upstream on 2026-06-30 (non-prerelease; includes the #1184 fix, which closed 2026-06-11 ahead of rc.1).

Fixes: N/A
Related: #1289, #1341

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Version pins updated in `recipes/registry.yaml` (`defaultVersion`) and `recipes/overlays/base.yaml` (`version`); both TEMPORARY comment blocks removed since the GA bump they promised is now done.
- Example recipes (`examples/recipes/aks-training.yaml`, `examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml`) updated to match.
- `docs/user/container-images.md` regenerated via `make bom-docs`; only the DRA chart version and image tag changed (`v0.4.1-rc.1` → `v0.4.1`, still 1 image). The hand-written `tools/s3c` example output in the prose section referenced the rc tag and was updated in step (column alignment preserved).
- Verified the chart exists upstream before bumping: `helm show chart oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu --version 0.4.1` resolves (digest `sha256:7a00373f…`).

## Testing

```bash
make qualify   # full gate: test (-race) + lint + e2e + scan
make bom-docs  # BOM regen — committed output matches fresh regen
```

No Go code changed; no test asserts a DRA chart version (UAT/chainsaw `assert-recipe.yaml` files match on component name only).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** rc.1 → GA of the same patch release; the strict-YAML fix was already in rc.1. Revert = restore the previous pin.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
