### PR TITLE
fix(ci): point aws-h100 UAT reservation at cr-0e16ad417f9a5bf69

### DIFF
--- a/infra/uat/reservations.yaml
+++ b/infra/uat/reservations.yaml
@@ -71,7 +71,7 @@
 reservations:
   - name: aws-h100
     cloud: aws
-    reservation-id: cr-0cbe491320188dfa6
+    reservation-id: cr-0e16ad417f9a5bf69
     accelerator: h100
     gpu-count: 8
     cluster-config-path: tests/uat/aws/cluster-config.yaml


### PR DESCRIPTION
## Summary

Point the `aws-h100` UAT reservation lease at `cr-0e16ad417f9a5bf69` instead of `cr-0cbe491320188dfa6`.

## Motivation / Context

The previous AWS reservation (`cr-0cbe491320188dfa6`) is shared with non-UAT DGXC dev clusters that consume nearly all of its p5.48xlarge slots (recently 9/10 occupied), so UAT batch runs are left without reserved GPU capacity. Two of those occupied slots were held by an orphaned, already-deleted cluster's node pool squatting on the reservation. Switching the `aws-h100` lease to `cr-0e16ad417f9a5bf69` — a dedicated reservation with free capacity — lets UAT runs acquire GPUs reliably.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `infra/uat/reservations.yaml` (UAT reservation registry / day-night broker)

## Implementation Notes

Single-field change to the reservation registry — the `name: aws-h100` lease key is unchanged, so the GitHub Actions concurrency group (`uat-aws-h100`) and all downstream broker behavior are unaffected. Only the underlying capacity-reservation ID the actuator targets changes. The reservation ID is an identifier, not a secret (see the header comment in `reservations.yaml`).

## Testing

```bash
# Config-only change (one identifier in a data file); no code paths altered.
# Validated by confirming cr-0e16ad417f9a5bf69 is an active, targeted p5.48xlarge
# reservation in the same AZ (us-east-1e) with free capacity.
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Takes effect on the next UAT run that reads the registry. Trivially reversible by restoring the prior reservation ID. Note `cr-0e16ad417f9a5bf69` is a smaller reservation; if UAT needs more concurrent GPU nodes than it provides, the reservation may need resizing or a follow-up split.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
