### PR TITLE
fix(ci): target aws-h100 UAT nodes at cr-0e16ad417f9a5bf69

### DIFF
--- a/tests/uat/aws/cluster-config.yaml
+++ b/tests/uat/aws/cluster-config.yaml
@@ -100,7 +100,7 @@ compute:
             desired: 2
             reservation:
               preference: capacity-reservations-only
-              target: cr-0cbe491320188dfa6
+              target: cr-0e16ad417f9a5bf69
           labels:
             nodeGroup: gpu-worker
             dedicated: user-workload


### PR DESCRIPTION
## Summary

Update the `aws-h100` UAT gpu-worker `reservation.target` in `tests/uat/aws/cluster-config.yaml` to `cr-0e16ad417f9a5bf69`, matching the reservation-id already merged into `infra/uat/reservations.yaml`.

## Motivation / Context

The reservation-registry swap (previous PR) changed the `aws-h100` reservation-id in `infra/uat/reservations.yaml`, but the actuator places GPU nodes using the `reservation.target` embedded in the cluster-config — and `reservations.yaml`'s header comment requires the two to match verbatim. Without this follow-up the registry points at the new reservation while nodes still launch into the old one (`cr-0cbe491320188dfa6`), so the swap is a no-op at provisioning time.

`cr-0e16ad417f9a5bf69` holds 2 p5.48xlarge slots, which satisfies the `desired: 2` gpu-worker capacity and the post-lease capacity assertion in `uat-aws.yaml`.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `tests/uat/aws/cluster-config.yaml` (UAT AWS cluster config consumed by the actuator)

## Implementation Notes

Single-field change (`reservation.target`). Pairs with the already-merged registry change so the `aws-h100` reservation-id and the cluster-config target are consistent. The reservation ID is an identifier, not a secret (see the header comment in `infra/uat/reservations.yaml`).

## Testing

```bash
# Config-only change (one identifier in a data file); no code paths altered.
# Verified cr-0e16ad417f9a5bf69 is an active, targeted p5.48xlarge reservation
# in us-east-1e with 2 free slots (matches desired: 2).
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Takes effect on the next UAT run. Reversible by restoring the prior target. If UAT later needs more than 2 concurrent GPU nodes, the reservation will need resizing.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
