### PR TITLE
fix(uat): drop gVNIC network from GKE GPU pool (TCPXO RxDM 7/8)

### DIFF
--- a/tests/uat/gcp/cluster-config.yaml
+++ b/tests/uat/gcp/cluster-config.yaml
@@ -51,7 +51,12 @@ network:
       count: 8
       mtu: 8244
       cidrBase: "192.168.0.0/16"
-      gvnicCidr: "192.168.128.0/20"
+      # No gvnicCidr: an extra gVNIC additional network on an a3-megagpu-8g GPU
+      # pool has no free PCI slot, so it takes a GPU-NIC slot (0000:06:00.0) and
+      # displaces gpu-nic-7 onto a virtio slot. RxDM then detects only 7/8 GPU
+      # NICs in the PCI tree, exits 1, and never binds its UDS, so NCCL fails
+      # with "connect() 111: Connection refused" on NET/FasTrak. Nothing here
+      # consumes the gVNIC network. See docs/integrator/gke-tcpxo-networking.md.
     firewallRules:
       # Allows all intra-VPC TCP/UDP/ICMP from 10.0.0.0/8, which covers node
       # subnets and the GKE pod secondary ranges. NATS (4222) is already


### PR DESCRIPTION
## Summary

Remove `gvnicCidr` from the UAT GKE `cluster-config.yaml` so the a3-megagpu-8g GPU node pool is provisioned with only the 8 GPU NIC networks (`gpu-nic-0`…`gpu-nic-7`) and GPUDirect-TCPXO RxDM can initialize.

## Motivation / Context

`nccl-all-reduce-bw` has been failing on UAT-GCP (GKE H100). Live debugging on cluster `aicr-28964466473` traced it to the GPU node pool carrying an extra gVNIC additional network:

- `gvnicCidr` sets `gvnic_net_enabled=true` in the mchmarny/cluster GKE actuator, which attaches a gVNIC additional network to any pool with a `guestAccelerator`.
- `a3-megagpu-8g` has exactly 1 control NIC + 8 GPU RDMA NIC PCI slots and no spare, so the gVNIC takes a GPU-NIC slot (`0000:06:00.0`) and displaces `gpu-nic-7` onto a virtio slot (`0000:00:0d.0`) that cannot do dmabuf RDMA.
- RxDM (`fastrak_gpumem_manager`) then logs `Number of GPUs detected in the PCI tree 7 is not equal to the actual number of GPUs reported by CUDA 8`, exits 1, and never binds `rxdm_uds_nic_mapping`.
- Every NCCL rank fails with `connect() error: 111: Connection refused` on `NET/FasTrak`, and the launcher mpirun tears the run down (`ORTE was unable to reliably start one or more daemons`).

Confirmed live via a `tcpxo-daemon` sidecar log capture. This corrects the config to match the prerequisite already documented in `docs/integrator/gke-tcpxo-networking.md` ("the GPU node pool must NOT include a gVNIC additional network"), which the runtime template and demo manifest also warn about. Nothing in the repo consumes the gVNIC network; the unrelated `nodeConfig.gvnic: true` NIC-driver toggle is untouched.

Fixes: N/A
Related: #381

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: UAT test infra (`tests/uat/gcp/cluster-config.yaml`)

## Implementation Notes

Single-line removal (replaced with an explanatory comment). Takes effect on the next UAT provision, which recreates the GPU node pool without the gVNIC network so all 8 GPU NICs land on `eth1`–`eth8`.

## Testing

YAML-only change to UAT cluster provisioning input; no Go code touched. Root cause reproduced and the absence of the gVNIC network validated against the live cluster's node NIC map and the RxDM sidecar log. Full confirmation is the next UAT-GCP run provisioning a clean GPU pool.

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert

**Rollout notes:** Requires GPU node pool reprovision (changing `additional_node_network_configs` forces node recreation) — handled by the normal UAT provision step.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed (already documented; config now matches)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
