### PR TITLE
feat(supply-chain): default keyless and KMS signing to Rekor v2

### DIFF
--- a/.github/actions/cli-e2e/action.yml
+++ b/.github/actions/cli-e2e/action.yml
@@ -34,10 +34,21 @@ inputs:
   helmfile_sha256:
     description: 'Helmfile SHA256 checksum for linux/amd64 (from .settings.yaml)'
     required: true
+  cosign_version:
+    description: 'Cosign version (from .settings.yaml via load-versions; must be >= v3.1.0 so DSSE attestations are logged to Rekor v2 as hashedrekord/PAE)'
+    required: true
 
 runs:
   using: 'composite'
   steps:
+    # `required: true` on composite-action inputs is not enforced at runtime, so
+    # a caller that omits cosign_version would silently get the cosign-installer
+    # default (which lags the v3.1.0 floor DSSE-on-v2 needs). Fail closed. See #1650.
+    - name: Require cosign_version
+      shell: bash
+      env:
+        COSIGN_VERSION: ${{ inputs.cosign_version }}
+      run: '[ -n "$COSIGN_VERSION" ] || { echo "cosign_version input is required (>= v3.1.0 for Rekor v2)" >&2; exit 1; }'
     - name: Setup Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
       with:
@@ -46,6 +57,11 @@ runs:
 
     - name: Install Cosign
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4.0.0
+      with:
+        # Pin from .settings.yaml (>= v3.1.0) so cosign logs DSSE attestations to
+        # Rekor v2 as hashedrekord/PAE. The installer default (v3.0.2) writes the
+        # legacy dsse entry type, which sigstore-go cannot verify. See #1650.
+        cosign-release: '${{ inputs.cosign_version }}'
 
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0

--- a/.github/actions/generate-slsa-predicate/action.yml
+++ b/.github/actions/generate-slsa-predicate/action.yml
@@ -52,3 +52,30 @@ runs:
         }
         EOF
         echo "SLSA_PREDICATE=${PREDICATE}" >> "$GITHUB_ENV"
+
+        # AICR signs release attestations to Rekor v2 (NVIDIA/aicr#1650). Fetch
+        # the TUF-distributed v2 SigningConfig (Rekor v2 endpoint + timestamp
+        # authority) so the goreleaser cosign + sign-catalog hooks can point
+        # --signing-config at it. Co-located with SLSA_PREDICATE so the invariant
+        # "signing enabled (SLSA_PREDICATE set) => signing config present" holds
+        # for every signing workflow, not just the release. go run compiles aicr
+        # from source (the built binaries do not exist yet). Requires Go, which
+        # every caller sets up before this action.
+        SC="${RUNNER_TEMP}/aicr-signing-config.json"
+        # Retry the TUF fetch (3 attempts, 5s/10s backoff) to absorb transient
+        # Sigstore TUF CDN blips, mirroring the goreleaser cosign hook — this is a
+        # hard prerequisite for the whole signing flow, which fails closed if the
+        # config is missing. The `-s` check treats an exit-0-but-empty-file result
+        # as a failure so a truncated write is retried, not silently exported.
+        for n in 1 2 3; do
+          GOFLAGS=-mod=vendor go run ./cmd/aicr trust update --emit-signing-config "${SC}" && [ -s "${SC}" ] && break
+          if [ "$n" -lt 3 ]; then
+            echo "trust update attempt $n failed; retrying" >&2
+            sleep $((n * 5))
+          else
+            echo "trust update failed after 3 attempts" >&2
+            exit 1
+          fi
+        done
+        echo "AICR_SIGNING_CONFIG=${SC}" >> "$GITHUB_ENV"
+        echo "Rekor v2 signing config written to ${SC}"

--- a/.github/actions/go-build-release/action.yml
+++ b/.github/actions/go-build-release/action.yml
@@ -75,6 +75,10 @@ runs:
       with:
         registry: ${{ inputs.registry }}
 
+    # Note: the Rekor v2 signing config (AICR_SIGNING_CONFIG) is fetched and
+    # exported by the generate-slsa-predicate action, co-located with
+    # SLSA_PREDICATE, so it is present here without a separate step. See #1650.
+
     - name: Build and Release
       id: release
       shell: bash

--- a/.github/actions/install-aicr-release/action.yml
+++ b/.github/actions/install-aicr-release/action.yml
@@ -27,15 +27,32 @@ inputs:
   aicr-version:
     description: 'Released aicr version tag to install (e.g. v1.2.3).'
     required: true
+  cosign_version:
+    description: 'Cosign version (from .settings.yaml via load-versions; must be >= v3.1.0 to verify release provenance logged to Rekor v2 as hashedrekord/PAE).'
+    required: true
 
 runs:
   using: composite
   steps:
+    # GitHub does not enforce `required: true` on composite-action inputs at
+    # runtime, so a caller that omits cosign_version would pass '' to
+    # cosign-release and silently get the installer default (which lags the
+    # v3.1.0 floor). Fail closed instead. See #1650.
+    - name: Require cosign_version
+      shell: bash
+      env:
+        COSIGN_VERSION: ${{ inputs.cosign_version }}
+      run: '[ -n "$COSIGN_VERSION" ] || { echo "cosign_version input is required (>= v3.1.0 for Rekor v2)" >&2; exit 1; }'
     # verify-blob-attestation needs no OIDC token (verification, not signing);
     # it fetches only the Sigstore trusted root, so the caller's contents:read
     # ceiling suffices. Pinned to the same SHA the release/build workflows use.
     - name: Install Cosign
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      with:
+        # Pin from .settings.yaml (>= v3.1.0). The release binary provenance is
+        # logged to Rekor v2 as hashedrekord/PAE; keep the verifier in lockstep
+        # with the signer rather than the installer default (v3.0.6). See #1650.
+        cosign-release: '${{ inputs.cosign_version }}'
     - name: Download, verify, and install released aicr
       shell: bash
       env:

--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -64,6 +64,9 @@ outputs:
   grype:
     description: 'Grype version'
     value: ${{ steps.versions.outputs.grype }}
+  cosign:
+    description: 'Cosign version (must be >= v3.1.0 so DSSE attestations are logged to Rekor v2 as hashedrekord/PAE, not the legacy dsse entry type)'
+    value: ${{ steps.versions.outputs.cosign }}
   yamllint:
     description: 'yamllint version'
     value: ${{ steps.versions.outputs.yamllint }}
@@ -168,6 +171,7 @@ runs:
 
         # Security tools
         echo "grype=$(yq eval '.security_tools.grype' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "cosign=$(yq eval '.security_tools.cosign' .settings.yaml)" >> $GITHUB_OUTPUT
 
         # Testing tools
         echo "kubectl=$(yq eval '.testing_tools.kubectl' .settings.yaml)" >> $GITHUB_OUTPUT
@@ -222,6 +226,7 @@ runs:
         echo "  addlicense: ${{ steps.versions.outputs.addlicense }}"
         echo "  go_licenses: ${{ steps.versions.outputs.go_licenses }}"
         echo "  grype: ${{ steps.versions.outputs.grype }}"
+        echo "  cosign: ${{ steps.versions.outputs.cosign }}"
         echo "  kubectl: ${{ steps.versions.outputs.kubectl }}"
         echo "  kubelogin: ${{ steps.versions.outputs.kubelogin }}"
         echo "  kind: ${{ steps.versions.outputs.kind }}"

--- a/.github/workflows/build-attested.yaml
+++ b/.github/workflows/build-attested.yaml
@@ -60,6 +60,11 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin from .settings.yaml (>= v3.1.0) so cosign logs DSSE attestations
+          # to Rekor v2 as hashedrekord/PAE. The installer default (v3.0.6) writes
+          # the legacy dsse entry type, which sigstore-go cannot verify. See #1650.
+          cosign-release: ${{ steps.versions.outputs.cosign }}
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3

--- a/.github/workflows/kms-ministack-e2e.yaml
+++ b/.github/workflows/kms-ministack-e2e.yaml
@@ -130,6 +130,11 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin from .settings.yaml (>= v3.1.0) so cosign logs DSSE attestations
+          # to Rekor v2 as hashedrekord/PAE. The installer default (v3.0.6) writes
+          # the legacy dsse entry type, which sigstore-go cannot verify. See #1650.
+          cosign-release: ${{ steps.versions.outputs.cosign }}
 
       - name: Generate SLSA predicate
         uses: ./.github/actions/generate-slsa-predicate

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -114,6 +114,11 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin from .settings.yaml (>= v3.1.0) so cosign logs DSSE attestations
+          # to Rekor v2 as hashedrekord/PAE. The installer default (v3.0.6) writes
+          # the legacy dsse entry type, which sigstore-go cannot verify. See #1650.
+          cosign-release: ${{ steps.versions.outputs.cosign }}
 
       - name: Generate SLSA predicate
         uses: ./.github/actions/generate-slsa-predicate

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -118,6 +118,7 @@ jobs:
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           helmfile_version: ${{ steps.versions.outputs.helmfile }}
           helmfile_sha256: ${{ steps.versions.outputs.helmfile_sha256_linux_amd64 }}
+          cosign_version: ${{ steps.versions.outputs.cosign }}
 
   e2e:
     name: E2E

--- a/.github/workflows/sigstore-scaffolding-e2e.yaml
+++ b/.github/workflows/sigstore-scaffolding-e2e.yaml
@@ -115,6 +115,11 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin from .settings.yaml (>= v3.1.0) so cosign logs DSSE attestations
+          # to Rekor v2 as hashedrekord/PAE. The installer default (v3.0.6) writes
+          # the legacy dsse entry type, which sigstore-go cannot verify. See #1650.
+          cosign-release: ${{ steps.versions.outputs.cosign }}
 
       # run.sh drives the stack: kind + helm install scaffold + port-forward +
       # TLS proxy + chainsaw, so it needs chainsaw, kind, kubectl, helm, and yq.

--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -221,6 +221,7 @@ jobs:
         uses: ./.github/actions/install-aicr-release
         with:
           aicr-version: ${{ inputs.aicr_version }}
+          cosign_version: ${{ steps.versions.outputs.cosign }}
 
       - name: Authenticate to GHCR
         uses: ./.github/actions/ghcr-login

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -236,6 +236,7 @@ jobs:
         uses: ./.github/actions/install-aicr-release
         with:
           aicr-version: ${{ inputs.aicr_version }}
+          cosign_version: ${{ steps.versions.outputs.cosign }}
 
       - name: Authenticate to GHCR
         uses: ./.github/actions/ghcr-login

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -217,6 +217,7 @@ jobs:
         uses: ./.github/actions/install-aicr-release
         with:
           aicr-version: ${{ inputs.aicr_version }}
+          cosign_version: ${{ steps.versions.outputs.cosign }}
 
       - name: Authenticate to GHCR
         uses: ./.github/actions/ghcr-login

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,8 +35,13 @@ builds:
       -X github.com/NVIDIA/aicr/pkg/cli.date={{.Date}}
     hooks:
       post:
-        ## cosign v1 attestation with slsa provenance v1.
+        ## cosign attestation (Rekor v2) with slsa provenance v1.
         ## NOTE: below aicrd currently attests via github attestation
+        ##
+        ## Signs to Rekor v2 via the SigningConfig fetched from TUF into
+        ## $AICR_SIGNING_CONFIG by the go-build-release action (see #1650).
+        ## Rekor v2 emits no inline signed timestamp, so the config also
+        ## carries a timestamp authority the bundle uses for trusted time.
         ##
         ## Wrap cosign in a 3-attempt bash retry loop with 5s/10s backoffs
         ## (no sleep after the final failed attempt — that would just
@@ -50,10 +55,12 @@ builds:
         ## See issue #1249.
         - cmd: >-
             bash -c '[ -z "${SLSA_PREDICATE:-}" ] && exit 0;
+            [ -z "${AICR_SIGNING_CONFIG:-}" ] && { echo "AICR_SIGNING_CONFIG unset while signing; refusing to fall back to Rekor v1" >&2; exit 1; };
             for n in 1 2 3; do
             cosign attest-blob
             --predicate "${SLSA_PREDICATE}"
             --type https://slsa.dev/provenance/v1
+            --signing-config "${AICR_SIGNING_CONFIG}"
             --bundle "$(dirname "{{ .Path }}")/aicr-attestation.sigstore.json"
             --yes "{{ .Path }}" && exit 0;
             echo "cosign attest-blob attempt $n failed; retrying" >&2;
@@ -74,7 +81,9 @@ builds:
         - cmd: >-
             bash -c 'if [ "{{ .Os }}/{{ .Arch }}" != "linux/amd64" ]; then exit 0; fi;
             if [ -z "${SLSA_PREDICATE:-}" ]; then exit 0; fi;
+            if [ -z "${AICR_SIGNING_CONFIG:-}" ]; then echo "AICR_SIGNING_CONFIG unset while signing; refusing to fall back to Rekor v1" >&2; exit 1; fi;
             "{{ .Path }}" recipe sign-catalog
+            --signing-config "${AICR_SIGNING_CONFIG}"
             --output "$(dirname "{{ .Path }}")/recipe-catalog.sigstore.json"'
           output: true
     goos:

--- a/docs/contributor/rekor-v2-signing.md
+++ b/docs/contributor/rekor-v2-signing.md
@@ -1,0 +1,189 @@
+# Rekor v2 Signing
+
+AICR signs its keyless attestations to **Rekor v2** by default. This page
+explains what Rekor v2 is, why AICR moved to it, and how the signing path is
+wired, so contributors can reason about the transparency-log behavior and its
+verification and monitoring consequences.
+
+## What Rekor v2 is
+
+Rekor is Sigstore's signature transparency log: the append-only, publicly
+auditable record that every keyless signature is entered into, so that a
+signature cannot be produced and then hidden. Rekor v2 is a redesign of that log
+with a few properties that matter here:
+
+- **Tile-based.** The log is served as immutable, content-addressed tiles (the
+  C2SP tlog-tiles layout, backed by Trillian-Tessera) rather than a live
+  database queried entry-by-entry. Tiles are static files, cheap to host on a
+  CDN and cheap to read in bulk.
+- **Yearly shards.** Each year gets a fresh log shard at
+  `log<year>-<rev>.rekor.sigstore.dev` (for example `log2025-1`). A shard is
+  bounded in size, and old shards are frozen and archived as static tiles. This
+  is the core of v2's "cheaper to run" thesis, and it keeps consistency proofs
+  and monitoring bounded.
+- **Integrated witnessing.** v2 folds witnessing into the log, strengthening the
+  append-only guarantee.
+- **No inline timestamp.** A v2 entry does not carry a signed entry timestamp
+  (the "SET" that v1 provided). A bundle needs trusted time from a separate
+  RFC3161 **timestamp authority (TSA)** instead. This is why AICR attaches a TSA
+  when signing to v2 and fails closed if a v2 target has no TSA.
+- **No search index.** v2 removed v1's `/api/v1/index/retrieve` search. Finding
+  entries is delegated to clients reading tiles.
+
+For the migration status and Sigstore's own guidance, see the
+[Rekor v2 GA post](https://blog.sigstore.dev/rekor-v2-ga/) and the
+[Rekor evolution post](https://blog.sigstore.dev/rekor-evolution/).
+
+## Why AICR moved to Rekor v2
+
+The motivating driver is **release-identity monitoring**. AICR wants to watch the
+public-good log for any entry made under its release-signing identity that a
+release did not produce, since such an entry signals OIDC or key compromise. On
+Rekor v1 that is not feasible: v1 has no way to query the index by certificate
+SAN, and AICR's release identity is keyless (an ephemeral Fulcio certificate, no
+email, no fixed public key), so the only way to find AICR's entries is a linear
+walk of the entire public-good firehose. Measured, that scan runs roughly 50x
+slower than the log grows, so it can never keep up in a bounded job. The analysis
+and the pivot are tracked in [#1623](https://github.com/NVIDIA/aicr/issues/1623).
+
+Rekor v2 makes monitoring feasible: tiles are read in bulk (256-entry bundles),
+so a scan runs about two orders of magnitude faster than the v1 per-entry fetch,
+and a single worker keeps up with the ecosystem's write rate. A yearly shard is
+also small and bounded rather than billions of entries. Signing to v2 is the
+prerequisite for that monitoring, tracked in
+[#1650](https://github.com/NVIDIA/aicr/issues/1650), under the closed
+supply-chain epic [#1149](https://github.com/NVIDIA/aicr/issues/1149).
+
+Beyond monitoring, v2 is Sigstore's forward direction (cheaper to operate,
+stronger append-only guarantees), and AICR is pre-1.0, so adopting it early is a
+deliberate, low-cost choice.
+
+Note that the public-good Sigstore default still points other clients at Rekor
+v1 for now, so AICR opts into v2 explicitly by consuming the v2 signing config
+(below) rather than waiting for the ecosystem default to flip.
+
+## How AICR signs to v2
+
+### Signing config from TUF, not hardcoded
+
+Signing endpoints (which Fulcio, which Rekor, which TSA) come from a Sigstore
+**SigningConfig**. Sigstore distributes a v2 SigningConfig as a TUF target
+(`signing_config_rekor_v2.v0.2.json`) that lists the current v2 shard and a TSA,
+each with a validity window. AICR fetches that target through the TUF client
+(`pkg/trust`), so shard rotation is handled by Sigstore and nothing is
+hardcoded. `aicr trust update` refreshes both the trusted root (verification
+material) and this signing config (sign-side endpoints); signing also resolves
+the config from the local cache and falls back to a bounded network fetch on a
+cold cache, so a signer works without a prior explicit update.
+
+Selection of the active Rekor and TSA from the config uses sigstore-go's
+`root.SelectServices`, which prefers the highest supported API version and never
+mixes versions. Because the v2 config lists both a v2 and a v1 Rekor, this
+selects v2; the v1 entry is only a fallback for clients that support v1 only.
+
+### The default is set at the CLI layer
+
+Rekor v2 is the default for keyless signing, but the default is computed in the
+CLI commands, not in the library's zero-value options. This keeps library,
+server, and test callers of `attestation.ResolveOptions` on their existing v1
+behavior, so the flip is contained to the signing commands and does not
+surprise embedders. All three keyless signing paths default to v2 consistently:
+
+- `aicr bundle --attest`
+- `aicr recipe sign-catalog`
+- evidence signing (`aicr validate --emit-attestation --push`,
+  `aicr evidence publish`, `aicr evidence sign`)
+
+The single `attestation.SignOptionsFromResolve` mapper carries the signing-target
+fields (Fulcio, Rekor, signing config) from `ResolveOptions` into `SignOptions`
+for every path, so a new field cannot be dropped by one caller and silently sign
+to the wrong log.
+
+### Opting out to Rekor v1 or a custom config
+
+Signing target selection has this precedence: a `--signing-config` file, then the
+TUF v2 config (default), then a Rekor v1 URL.
+
+- `--rekor-url <url>` signs to **Rekor v1** at that URL, for a private instance
+  or the public-good v1 URL. Existing users who set `--rekor-url` or
+  `spec.bundle.rekorURL` are therefore unaffected by the default flip.
+- `--signing-config <file>` signs with a custom SigningConfig JSON, for an edited
+  config or a private v2 instance.
+- KMS signing (`--signing-key`) follows the same rules: it signs to Rekor v2 by
+  default and honors the same `--rekor-url` / `--signing-config` opt-outs. The
+  `KMSAttester` builds its transparency policy through the same
+  `transparencyForOptions` path as keyless signing, so both stay in lockstep. A
+  KMS v2 entry carries public-key verification material (no Fulcio certificate).
+
+`--rekor-url` and `--signing-config` are mutually exclusive, so an operator's
+private Rekor is never silently overridden by the v2 default.
+
+### Fail-closed rules
+
+- A v2 selection with no timestamp authority is rejected: a v2 bundle carries no
+  inline timestamp, so it would have no trusted time and could not be verified.
+- In the release pipeline, if signing is enabled (`SLSA_PREDICATE` set) but the
+  signing config path is unset, the goreleaser hooks error rather than let cosign
+  silently fall back to Rekor v1.
+
+### Release wiring
+
+At release time the `generate-slsa-predicate` action runs
+`aicr trust update --emit-signing-config` to materialize the v2 SigningConfig to
+a file and exports its path as `AICR_SIGNING_CONFIG` (co-located with
+`SLSA_PREDICATE` so every signing workflow inherits it). The goreleaser hooks pass
+that file to both `cosign attest-blob --signing-config` (the binary attestation)
+and `aicr recipe sign-catalog --signing-config` (the recipe catalog), so both
+land in the same v2 log. `cosign` cannot fetch the TUF-distributed v2 config
+itself (`cosign signing-config create` only builds one from hardcoded URLs), so
+`aicr` supplies it.
+
+**The signer must be Cosign >= v3.1.0** (pinned in `.settings.yaml` and passed to
+`cosign-installer` via `cosign-release` in every signing workflow). Only v3.1.0+
+logs a DSSE attestation to Rekor v2 as a `hashedrekord` entry over the envelope's
+pre-auth encoding (PAE); older Cosign writes the legacy `dsse` entry type, which
+no released sigstore-go can verify. The `bundle-headless-oidc-ci` chainsaw guard
+only catches a regression on the `bundle --attest` path, so keep the pin in step
+with the installer default (which lags well behind v3.1.0). See #1650.
+
+## Verification
+
+The consumer verification commands do not change. A bundle self-describes which
+log it is in (the entry, its inclusion proof, and the checkpoint origin are all
+embedded), and the public-good trusted root already carries the v2 log's key and
+a TSA, so `aicr verify` and `cosign verify-blob-attestation` verify a v2 bundle
+with the same flags as a v1 one.
+
+`aicr verify` needs only the `aicr` binary and handles v1 and v2 transparently
+(it embeds a v2-capable sigstore-go). The **Cosign v3.0.1+** floor applies only to
+the `cosign verify-blob-attestation` path: older Cosign cannot parse a v2 tiles
+inclusion proof or its RFC3161 timestamp. Releases published before the v2
+cutover remain in Rekor v1 and verify with any recent Cosign.
+
+## Operational notes
+
+- **Shard rotation** is Sigstore's responsibility: when a new yearly shard is
+  deployed, Sigstore updates the TUF signing-config target, and AICR picks it up
+  on the next `trust update` or on-demand fetch. Do not hardcode a shard URL.
+- **Stale-cache downgrade window.** `root.SelectServices` applies each service's
+  validity window at sign time. If a cached signing config's v2 shard ages past
+  its `validFor.end` before the cache refreshes, selection falls back to the
+  still-valid v1 entry — a silent Rekor v1 downgrade. The window is bounded: the
+  TUF client refreshes the cache when its timestamp metadata expires, so the
+  worst case is that expiry interval, and a v1 selection under the v2 default is
+  logged as a warning (see `NewSigningConfigPolicyFromTUF`). Run `aicr trust
+  update` to refresh eagerly; the `bundle-headless-oidc-ci` shard assertion
+  guards the CI path but not individual end users.
+- **A private or local Rekor v2 test stack** would need both a `rekor-tiles`
+  server and a `timestamp-authority`, driven via `--signing-config`. The existing
+  private-Sigstore chainsaw test exercises the Rekor v1 path via `--rekor-url` and
+  is unaffected.
+- **`AICR_SIGNING_CONFIG` binds as `--signing-config` process-wide.** Because
+  `generate-slsa-predicate` exports it into the job environment, any later
+  `aicr … --rekor-url …` in the same job auto-picks it up as `--signing-config`
+  and fails closed with the mutual-exclusivity error (the two select different
+  logs). A caller combining a private `--rekor-url` with an inherited config env
+  must `unset AICR_SIGNING_CONFIG` first — as the private-Sigstore chainsaw test
+  does. The error message names both env vars so the collision is diagnosable.
+- The `bundle-headless-oidc-ci` chainsaw test asserts that a default signature
+  lands in a v2 shard, guarding against a silent revert to v1.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -108,6 +108,8 @@ navigation:
         path: contributor/skills.md
       - page: Maintaining AICR
         path: contributor/maintaining.md
+      - page: Rekor v2 Signing
+        path: contributor/rekor-v2-signing.md
       - page: Publishing Recipe Evidence
         path: contributor/evidence-publishing.md
       - page: UAT Day/Night Cycle

--- a/docs/integrator/supply-chain-verification.md
+++ b/docs/integrator/supply-chain-verification.md
@@ -16,6 +16,18 @@ the [GitHub CLI](https://cli.github.com/) (`gh`), `crane` (recommended; `docker 
 `jq`, and — for in-cluster enforcement — `kubectl`. Binary and bundle
 verification (`aicr verify`) need only the `aicr` binary.
 
+**Cosign version.** AICR release signatures (the binary attestation and the
+signed recipe catalog) are recorded in **Rekor v2** as of the v2 cutover (see the
+release notes for the exact version). Verifying those bundles **with Cosign**
+requires **Cosign v3.0.1+**: older Cosign cannot parse a Rekor v2
+inclusion proof or its RFC3161 timestamp. `aicr verify` needs only the `aicr`
+binary and verifies both v1 and v2 transparently, so the Cosign floor does not
+apply to it. Releases published before the cutover are in Rekor v1 and verify
+with any recent Cosign. The verification *commands* are identical either way: a
+bundle self-describes which log it is in, so nothing in your workflow changes
+beyond the Cosign version. For why AICR signs to Rekor v2 and how the signing
+path works, see [Rekor v2 Signing](../contributor/rekor-v2-signing.md).
+
 Export the following variables once; the rest of this guide reuses them.
 Tags are mutable and can be repointed to a different image, so resolve the
 tag to an immutable `@sha256:` digest and verify against the digest.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1261,8 +1261,9 @@ aicr bundle [flags]
 | `--identity-token` | | string | Pre-fetched OIDC identity token for `--attest` keyless signing. Skips ambient/browser/device-code flows. Prefer `COSIGN_IDENTITY_TOKEN` on shared hosts — flag values are visible in `ps` and `/proc/<pid>/cmdline`. |
 | `--oidc-device-flow` | | bool | Use the OAuth 2.0 device authorization grant for `--attest` instead of opening a browser callback. Useful on headless hosts that can still reach Sigstore (`--identity-token` and CI ambient OIDC are alternatives). Also reads `AICR_OIDC_DEVICE_FLOW`. |
 | `--fulcio-url` | | string | Override the Fulcio CA URL for `--attest` keyless signing, pointing at a private Sigstore instance. Must be an absolute `https://` URL with no embedded credentials. Defaults to the public-good Fulcio when omitted. Also reads `AICR_FULCIO_URL`. |
-| `--rekor-url` | | string | Override the Rekor transparency-log URL for `--attest` keyless signing, pointing at a private Sigstore instance. Must be an absolute `https://` URL with no embedded credentials. Defaults to the public-good Rekor when omitted. Also reads `AICR_REKOR_URL`. The two URLs are independent — a private Fulcio can pair with the public Rekor or vice versa. |
-| `--signing-key` | | string | Sign the `--attest` bundle with a KMS-backed key instead of keyless OIDC, for CI/CD environments without OIDC (Jenkins, internal pipelines). Takes a cloud KMS URI; supported schemes are `awskms://`, `gcpkms://`, and `azurekms://`. Mutually exclusive with `--identity-token`, `--oidc-device-flow`, and `--fulcio-url` (the keyless-only flags); passing both is a validation error. `--rekor-url` may still be combined to log to a private Rekor. See [KMS-Backed Signing](#kms-backed-signing). |
+| `--rekor-url` | | string | Sign the `--attest` bundle to **Rekor v1** at this URL instead of the **Rekor v2 default** (a private Sigstore instance, or the public-good v1 URL). Must be an absolute `https://` URL with no embedded credentials. Also reads `AICR_REKOR_URL`. Independent of `--fulcio-url`. Mutually exclusive with `--signing-config`. |
+| `--signing-config` | | string | Sign the `--attest` bundle with a custom Sigstore signing config JSON instead of the default Rekor v2 config (advanced — e.g. an edited config or a private v2 instance). Also reads `AICR_SIGNING_CONFIG`. Mutually exclusive with `--rekor-url`. |
+| `--signing-key` | | string | Sign the `--attest` bundle with a KMS-backed key instead of keyless OIDC, for CI/CD environments without OIDC (Jenkins, internal pipelines). Takes a cloud KMS URI; supported schemes are `awskms://`, `gcpkms://`, and `azurekms://`. Like keyless signing, KMS signs to Rekor v2 by default; opt out with `--rekor-url` (v1) or `--signing-config` (custom). Mutually exclusive with `--identity-token`, `--oidc-device-flow`, and `--fulcio-url` (the keyless-only flags); passing both is a validation error. See [KMS-Backed Signing](#kms-backed-signing). |
 | `--yes` | `--assume-yes` | bool | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. See [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures). |
 
 #### Bundle Config File Mode
@@ -2171,9 +2172,9 @@ When `--attest` is passed, the bundle command performs five steps:
 4. **Signs the bundle** — Creates a SLSA Build Provenance v1 in-toto statement binding the creator's identity to the files listed in `checksums.txt` (recipe.yaml is currently excluded, #1549) and the binary that produced it.
 5. **Writes attestation files** — `attestation/bundle-attestation.sigstore.json` and `attestation/aicr-attestation.sigstore.json` are added to the bundle output.
 
-Attestation is opt-in; bundles are unsigned by default. By default, signing uses Sigstore keyless signing (Fulcio CA + Rekor transparency log). For CI/CD environments without OIDC, pass `--signing-key` to sign with a cloud KMS key instead; see [KMS-Backed Signing](#kms-backed-signing) below. For verification, see [`aicr verify`](#aicr-verify).
+Attestation is opt-in; bundles are unsigned by default. By default, signing uses Sigstore keyless signing (Fulcio CA + Rekor transparency log) and records the entry in **Rekor v2** (the signing config is fetched from Sigstore's TUF repository, so shard rotation is handled automatically; a cold cache is fetched on demand). Verifying such bundles with `aicr verify` needs only the `aicr` binary; verifying them with `cosign verify-blob-attestation` needs Cosign v3.0.1+. For CI/CD environments without OIDC, pass `--signing-key` to sign with a cloud KMS key instead; see [KMS-Backed Signing](#kms-backed-signing) below. For verification, see [`aicr verify`](#aicr-verify).
 
-**Private Sigstore infrastructure:** organizations running their own Fulcio CA or Rekor log can redirect signing with `--fulcio-url` and `--rekor-url` (both must be absolute `https://` URLs with no embedded credentials). The two are independent, so a private Fulcio can pair with the public Rekor or vice versa. Public Sigstore remains the default when the flags are omitted.
+**Rekor v1 / private Sigstore:** pass `--rekor-url` to sign to Rekor **v1** at a specific URL — a private instance, or the public-good v1 URL — instead of the v2 default. Organizations running their own Fulcio CA can also redirect with `--fulcio-url` (both must be absolute `https://` URLs with no embedded credentials); the two are independent. For a fully custom v2 setup, `--signing-config` takes a Sigstore signing config JSON (mutually exclusive with `--rekor-url`).
 
 > **Verification:** these flags redirect **signing** only. Verify the resulting bundles with `aicr verify --trust-root <trusted_root.json>`, supplying the `trusted_root.json` your self-hosted Fulcio/Rekor emits. That root is unioned with AICR's built-in public-good root, so privately-signed and NVIDIA-signed bundles both verify; see the [`aicr verify`](#aicr-verify) `--trust-root` flag.
 
@@ -2276,9 +2277,10 @@ aicr bundle --recipe recipe.yaml --attest \
 `--signing-key` together with any of them is a validation error, since they
 select incompatible signing modes (KMS key versus Fulcio-issued certificate).
 
-`--rekor-url` is **not** mutually exclusive: KMS-signed bundles upload to the
-public-good Rekor transparency log by default, mirroring keyless signing. Pass
-`--rekor-url` to log to a private Rekor instead.
+Like keyless signing, KMS signs to **Rekor v2** by default. Opt out with
+`--rekor-url` to log to a Rekor v1 instance (private or public-good), or
+`--signing-config` to use a custom signing config; the two opt-outs are mutually
+exclusive with each other but both compose with `--signing-key`.
 
 The resulting bundle uses the same Sigstore bundle format as keyless signing,
 but its verification material is the signing key's public key rather than a
@@ -2839,14 +2841,20 @@ See [`demos/evidence.md`](https://github.com/NVIDIA/aicr/blob/main/demos/evidenc
 
 ### aicr trust update
 
-Fetch the latest Sigstore trusted root from the TUF CDN and update the local cache at `~/.sigstore/root/`. This is needed when Sigstore rotates signing keys (a few times per year).
+Fetch the latest Sigstore trusted root **and Rekor v2 signing config** from the TUF CDN and update the local cache at `~/.sigstore/root/`. This is needed when Sigstore rotates signing keys (a few times per year). The trusted root is verification material (which signatures are valid); the signing config is sign-side (which Rekor/timestamp endpoints signing writes to — AICR signs to Rekor v2 by default).
 
 **Synopsis:**
 ```shell
-aicr trust update
+aicr trust update [--emit-signing-config <path>]
 ```
 
-**No flags.** This command contacts `tuf-repo-cdn.sigstore.dev`, verifies the update chain against the embedded TUF root, and writes the result to `~/.sigstore/root/`.
+This command contacts `tuf-repo-cdn.sigstore.dev`, verifies the update chain against the embedded TUF root, and writes the result to `~/.sigstore/root/`.
+
+**Flags:**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--emit-signing-config` | string | Also write the fetched Rekor v2 signing config to this file path, for tools that take a signing-config path (e.g. `cosign attest-blob --signing-config`). |
 
 **When to run:**
 - After initial installation (the install script runs this automatically)
@@ -2856,6 +2864,7 @@ aicr trust update
 **Example:**
 ```shell
 aicr trust update
+aicr trust update --emit-signing-config signing-config.json
 ```
 
 ---

--- a/pkg/bundler/attestation/keyless.go
+++ b/pkg/bundler/attestation/keyless.go
@@ -25,10 +25,12 @@ import (
 // KeylessAttester signs bundle content using Sigstore keyless OIDC signing
 // (Fulcio for certificates, Rekor for transparency logging).
 type KeylessAttester struct {
-	oidcToken string
-	fulcioURL string
-	rekorURL  string
-	identity  string
+	oidcToken           string
+	fulcioURL           string
+	rekorURL            string
+	signingConfigPath   string
+	useTUFSigningConfig bool
+	identity            string
 }
 
 // NewKeylessAttester returns a new KeylessAttester targeting the given Fulcio
@@ -36,7 +38,14 @@ type KeylessAttester struct {
 // public-good default, so callers that do not run private infrastructure pass
 // "" for both. Non-empty values point signing at a private Sigstore instance
 // (issue #408).
-func NewKeylessAttester(oidcToken, fulcioURL, rekorURL string) *KeylessAttester {
+//
+// signingConfigPath, when non-empty, is the path to a Sigstore SigningConfig
+// (e.g. the TUF-distributed signing_config_rekor_v2 target) that drives
+// transparency-log and timestamp-authority selection; it takes precedence over
+// useTUFSigningConfig and rekorURL. useTUFSigningConfig selects the Rekor v2
+// signing config from the local TUF cache instead. Both are how signing targets
+// Rekor v2 (issue #1650).
+func NewKeylessAttester(oidcToken, fulcioURL, rekorURL, signingConfigPath string, useTUFSigningConfig bool) *KeylessAttester {
 	if fulcioURL == "" {
 		fulcioURL = defaults.SigstoreFulcioURL
 	}
@@ -44,9 +53,11 @@ func NewKeylessAttester(oidcToken, fulcioURL, rekorURL string) *KeylessAttester 
 		rekorURL = defaults.SigstoreRekorURL
 	}
 	return &KeylessAttester{
-		oidcToken: oidcToken,
-		fulcioURL: fulcioURL,
-		rekorURL:  rekorURL,
+		oidcToken:           oidcToken,
+		fulcioURL:           fulcioURL,
+		rekorURL:            rekorURL,
+		signingConfigPath:   signingConfigPath,
+		useTUFSigningConfig: useTUFSigningConfig,
 	}
 }
 
@@ -66,11 +77,12 @@ func (k *KeylessAttester) Attest(ctx context.Context, subject AttestSubject) ([]
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to build attestation statement", err)
 	}
 
-	res, err := SignStatement(ctx, statementJSON, SignOptions{
-		OIDCToken: k.oidcToken,
-		FulcioURL: k.fulcioURL,
-		RekorURL:  k.rekorURL,
-	})
+	res, err := SignStatement(ctx, statementJSON, SignOptionsFromResolve(k.oidcToken, ResolveOptions{
+		FulcioURL:           k.fulcioURL,
+		RekorURL:            k.rekorURL,
+		SigningConfigPath:   k.signingConfigPath,
+		UseTUFSigningConfig: k.useTUFSigningConfig,
+	}))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bundler/attestation/keyless_test.go
+++ b/pkg/bundler/attestation/keyless_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestNewKeylessAttester(t *testing.T) {
-	attester := NewKeylessAttester("test-oidc-token", "", "")
+	attester := NewKeylessAttester("test-oidc-token", "", "", "", false)
 
 	if attester == nil {
 		t.Fatal("NewKeylessAttester() returned nil")
@@ -62,7 +62,7 @@ func TestNewKeylessAttester_SigstoreURLs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := NewKeylessAttester("test-oidc-token", tt.fulcio, tt.rekor)
+			a := NewKeylessAttester("test-oidc-token", tt.fulcio, tt.rekor, "", false)
 			if a.fulcioURL != tt.wantFulcio {
 				t.Errorf("fulcioURL = %q, want %q", a.fulcioURL, tt.wantFulcio)
 			}
@@ -74,7 +74,7 @@ func TestNewKeylessAttester_SigstoreURLs(t *testing.T) {
 }
 
 func TestKeylessAttester_Identity(t *testing.T) {
-	attester := NewKeylessAttester("test-oidc-token", "", "")
+	attester := NewKeylessAttester("test-oidc-token", "", "", "", false)
 
 	// Identity is not known until after Attest() succeeds (Fulcio returns it).
 	// Before signing, identity should be empty.
@@ -84,7 +84,7 @@ func TestKeylessAttester_Identity(t *testing.T) {
 }
 
 func TestKeylessAttester_HasRekorEntry(t *testing.T) {
-	attester := NewKeylessAttester("test-oidc-token", "", "")
+	attester := NewKeylessAttester("test-oidc-token", "", "", "", false)
 
 	if !attester.HasRekorEntry() {
 		t.Error("HasRekorEntry() = false, want true (keyless always uses Rekor)")

--- a/pkg/bundler/attestation/kms.go
+++ b/pkg/bundler/attestation/kms.go
@@ -30,16 +30,32 @@ var _ Attester = (*KMSAttester)(nil)
 type KMSAttester struct {
 	keyURI   string
 	identity SigningIdentity
-	tlog     TransparencyPolicy
+
+	// target carries the transparency-target fields (RekorURL, SigningConfigPath,
+	// UseTUFSigningConfig; OIDC/Fulcio fields are unused for KMS). It is built by
+	// the shared SignOptionsFromResolve mapper — the same single mapping the
+	// keyless and evidence paths use — so a new signing-target field cannot be
+	// silently dropped on the KMS path (guarded by TestSignOptionsFromResolve).
+	target SignOptions
+
+	// tlog, when non-nil, overrides the transparency policy that Attest would
+	// otherwise compute from target. Used to inject a no-tlog policy for offline
+	// testing, and reserved for a future --tlog-upload=false opt-out (#409).
+	tlog TransparencyPolicy
 }
 
-// NewKMSAttester returns a KMSAttester for keyURI. Empty rekorURL falls back to
-// the Sigstore public-good Rekor default.
-func NewKMSAttester(keyURI, rekorURL string) *KMSAttester {
+// NewKMSAttester returns a KMSAttester for keyURI. Like keyless signing, KMS
+// signs to Rekor v2 by default (via the TUF-distributed signing config, which
+// also supplies the timestamp authority v2 requires) unless target opts out to a
+// Rekor v1 URL or a custom signing config. target is produced by
+// SignOptionsFromResolve so the KMS path shares the keyless path's signing-target
+// mapping. The transparency-log entry carries public-key verification material
+// (no Fulcio certificate). See #1650.
+func NewKMSAttester(keyURI string, target SignOptions) *KMSAttester {
 	return &KMSAttester{
 		keyURI:   keyURI,
 		identity: NewKMSIdentity(keyURI),
-		tlog:     NewRekorPolicy(rekorURL),
+		target:   target,
 	}
 }
 
@@ -55,7 +71,15 @@ func (k *KMSAttester) Attest(ctx context.Context, subject AttestSubject) ([]byte
 		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to build attestation statement")
 	}
 
-	res, err := SignStatementWith(ctx, statementJSON, k.identity, k.tlog)
+	tlog := k.tlog
+	if tlog == nil {
+		tlog, err = transparencyForOptions(ctx, k.target)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	res, err := SignStatementWith(ctx, statementJSON, k.identity, tlog)
 	if err != nil {
 		return nil, err
 	}
@@ -69,10 +93,11 @@ func (k *KMSAttester) Attest(ctx context.Context, subject AttestSubject) ([]byte
 // Identity returns the KMS key URI used for signing.
 func (k *KMSAttester) Identity() string { return k.keyURI }
 
-// HasRekorEntry reports whether produced attestations include a Rekor entry,
-// derived from the configured transparency policy. KMS signing uses Rekor by
-// default; this returns false only when paired with the no-tlog policy (the
-// offline/air-gapped path, #409).
+// HasRekorEntry reports whether produced attestations include a Rekor entry.
+// KMS signing records one by default (Rekor v2, or v1 via --rekor-url); it is
+// false only when an explicit no-tlog policy override is set (the offline path,
+// #409). A nil override (the production default) computes a real Rekor policy at
+// Attest time, so this correctly reports true.
 func (k *KMSAttester) HasRekorEntry() bool {
 	_, noTLog := k.tlog.(noTLogPolicy)
 	return !noTLog

--- a/pkg/bundler/attestation/kms_test.go
+++ b/pkg/bundler/attestation/kms_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestKMSAttesterContract(t *testing.T) {
 	var _ Attester = (*KMSAttester)(nil)
-	a := NewKMSAttester("gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k", "")
+	a := NewKMSAttester("gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k", SignOptions{UseTUFSigningConfig: true})
 	if !a.HasRekorEntry() {
 		t.Error("default KMS attester uploads to Rekor")
 	}

--- a/pkg/bundler/attestation/resolver.go
+++ b/pkg/bundler/attestation/resolver.go
@@ -55,6 +55,19 @@ type ResolveOptions struct {
 	FulcioURL string
 	RekorURL  string
 
+	// SigningConfigPath points keyless signing at a Sigstore SigningConfig JSON
+	// file (e.g. the TUF-distributed signing_config_rekor_v2 target) instead of a
+	// single Rekor URL. It takes precedence over UseTUFSigningConfig and RekorURL
+	// and is how release signing targets Rekor v2. Honored by both keyless and
+	// KMS signing. See issue #1650.
+	SigningConfigPath string
+
+	// UseTUFSigningConfig points signing at the Rekor v2 signing config in the
+	// local TUF cache (populated by "aicr trust update"). Preferred, rotation-safe
+	// way to target Rekor v2. Honored by both keyless and KMS signing. See issue
+	// #1650.
+	UseTUFSigningConfig bool
+
 	// SigningKey selects KMS-backed (key-based) signing instead of keyless OIDC.
 	// When non-empty it is a cosign-style KMS URI (awskms:// | gcpkms:// |
 	// azurekms://) and takes precedence over all OIDC source fields, which are
@@ -154,13 +167,13 @@ func ResolveAttester(ctx context.Context, opts ResolveOptions) (Attester, error)
 		return NewNoOpAttester(), nil
 	}
 	if opts.SigningKey != "" {
-		return NewKMSAttester(opts.SigningKey, opts.RekorURL), nil
+		return NewKMSAttester(opts.SigningKey, SignOptionsFromResolve("", opts)), nil
 	}
 	token, err := ResolveOIDCToken(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
-	return NewKeylessAttester(token, opts.FulcioURL, opts.RekorURL), nil
+	return NewKeylessAttester(token, opts.FulcioURL, opts.RekorURL, opts.SigningConfigPath, opts.UseTUFSigningConfig), nil
 }
 
 // ResolveAttesterLazy is the deferred-token variant of ResolveAttester.
@@ -176,13 +189,13 @@ func ResolveAttester(ctx context.Context, opts ResolveOptions) (Attester, error)
 // ResolveAttester exactly so callers can swap entry points without
 // changing the test surface.
 //
-//nolint:unparam // error return mirrors ResolveAttester so callers can swap entry points; reserved for future construction-time validation.
+//nolint:unparam // error return mirrors ResolveAttester so callers can swap entry points; the token-resolution error is deferred to Attest.
 func ResolveAttesterLazy(_ context.Context, opts ResolveOptions) (Attester, error) {
 	if !opts.Attest {
 		return NewNoOpAttester(), nil
 	}
 	if opts.SigningKey != "" {
-		return NewKMSAttester(opts.SigningKey, opts.RekorURL), nil
+		return NewKMSAttester(opts.SigningKey, SignOptionsFromResolve("", opts)), nil
 	}
 	return NewLazyKeylessAttester(opts), nil
 }
@@ -222,7 +235,7 @@ func (l *LazyKeylessAttester) Attest(ctx context.Context, subject AttestSubject)
 			l.mu.Unlock()
 			return nil, err
 		}
-		l.inner = NewKeylessAttester(token, l.opts.FulcioURL, l.opts.RekorURL)
+		l.inner = NewKeylessAttester(token, l.opts.FulcioURL, l.opts.RekorURL, l.opts.SigningConfigPath, l.opts.UseTUFSigningConfig)
 	}
 	inner := l.inner
 	l.mu.Unlock()

--- a/pkg/bundler/attestation/signing.go
+++ b/pkg/bundler/attestation/signing.go
@@ -43,8 +43,39 @@ type SignOptions struct {
 	FulcioURL string
 
 	// RekorURL is the Rekor transparency log URL. Empty falls back to
-	// defaults.SigstoreRekorURL.
+	// defaults.SigstoreRekorURL. Ignored when SigningConfigPath or
+	// UseTUFSigningConfig is set (both take precedence).
 	RekorURL string
+
+	// SigningConfigPath, when non-empty, is the path to a Sigstore SigningConfig
+	// JSON file (e.g. the TUF-distributed signing_config_rekor_v2 target written
+	// to disk). It takes precedence over UseTUFSigningConfig and RekorURL and
+	// drives transparency-log and timestamp-authority selection via
+	// root.SelectServices — this is how AICR targets Rekor v2. See #1650.
+	SigningConfigPath string
+
+	// UseTUFSigningConfig selects the Rekor v2 signing config from the local TUF
+	// cache (populated by "aicr trust update"). It is the preferred, rotation-safe
+	// way to target Rekor v2 — the endpoint set is Sigstore-maintained and nothing
+	// is hardcoded. Ignored when SigningConfigPath is set. See #1650.
+	UseTUFSigningConfig bool
+}
+
+// SignOptionsFromResolve maps a resolved OIDC token plus the signing-target
+// fields of a ResolveOptions into SignOptions. It is the single source of that
+// mapping, shared by the keyless attester and the evidence signing paths so a
+// new signing field (e.g. SigningConfigPath / UseTUFSigningConfig) cannot be
+// silently dropped by one caller — the drift that would otherwise leave a path
+// signing to the wrong Rekor. OIDC source selection is already resolved into
+// token, so only the transparency-target fields are copied.
+func SignOptionsFromResolve(token string, o ResolveOptions) SignOptions {
+	return SignOptions{
+		OIDCToken:           token,
+		FulcioURL:           o.FulcioURL,
+		RekorURL:            o.RekorURL,
+		SigningConfigPath:   o.SigningConfigPath,
+		UseTUFSigningConfig: o.UseTUFSigningConfig,
+	}
 }
 
 // SignedAttestation is the result of SignStatement: a Sigstore bundle
@@ -101,8 +132,41 @@ func SignStatement(ctx context.Context, statementJSON []byte, opts SignOptions) 
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "OIDC token is required for keyless signing")
 	}
 	id := NewKeylessIdentity(opts.OIDCToken, opts.FulcioURL)
-	tlog := NewRekorPolicy(opts.RekorURL)
+	tlog, err := transparencyForOptions(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
 	return SignStatementWith(ctx, statementJSON, id, tlog)
+}
+
+// transparencyForOptions selects the transparency policy from SignOptions,
+// in precedence order: an explicit SigningConfig file, then the TUF-distributed
+// Rekor v2 signing config, then the single Rekor v1 URL policy. The first two
+// are SigningConfig-driven (Rekor v2 + timestamp authority). ctx bounds the TUF
+// fetch the v2 path may perform on a cold cache.
+func transparencyForOptions(ctx context.Context, opts SignOptions) (TransparencyPolicy, error) {
+	switch {
+	case opts.SigningConfigPath != "":
+		return NewSigningConfigPolicyFromPath(opts.SigningConfigPath)
+	case opts.UseTUFSigningConfig:
+		// Bound the Rekor v2 signing-config resolution (cache read plus a
+		// possible network TUF fetch on a cold cache) so an unbounded caller
+		// context cannot hang here, before SignStatementWith applies its own
+		// sign deadline. Shared by keyless SignStatement and KMSAttester.Attest.
+		//
+		// Budget note: when the caller ctx already carries a sign deadline (the
+		// evidence path passes EvidenceBundleSignTimeout), a cold-cache fetch here
+		// draws from that same budget before SignStatementWith's retry loop, so a
+		// first-ever cold sign has less than the full retry budget (see
+		// TestSigstoreRetryBudgetInvariant). It fails closed, and release CI
+		// pre-warms the cache via `aicr trust update`, so the retry loop keeps its
+		// budget in practice; only cold ad-hoc signing is affected.
+		tufCtx, cancel := context.WithTimeout(ctx, defaults.SigstoreSignTimeout)
+		defer cancel()
+		return NewSigningConfigPolicyFromTUF(tufCtx)
+	default:
+		return NewRekorPolicy(opts.RekorURL), nil
+	}
 }
 
 // SignStatementWith DSSE-wraps an in-toto Statement and signs it using the
@@ -145,6 +209,7 @@ func SignStatementWith(ctx context.Context, statementJSON []byte, id SigningIden
 			CertificateProvider:        certProvider,
 			CertificateProviderOptions: certOpts,
 			TransparencyLogs:           tlog.Logs(),
+			TimestampAuthorities:       tlog.TimestampAuthorities(),
 			Context:                    attemptCtx,
 		})
 	})

--- a/pkg/bundler/attestation/signing_targeting_test.go
+++ b/pkg/bundler/attestation/signing_targeting_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"testing"
+)
+
+// TestTransparencyForOptions covers the policy-selection precedence in
+// SignOptions: an explicit SigningConfig file, then the TUF-cached v2 config,
+// then the single Rekor URL (v1). The TUF branch is exercised via its own
+// error surface (it needs a warmed cache) rather than a live selection here.
+func TestTransparencyForOptions(t *testing.T) {
+	// want encodes the expected policy per case:
+	//   "signingConfig" — a signingConfigPolicy (explicit file).
+	//   "notRekor"      — the TUF branch, which may succeed or error offline but
+	//                     must never fall through to a Rekor v1 policy.
+	//   "rekor"         — a rekorPolicy; wantURL "" asserts a non-empty
+	//                     public-good default, otherwise an exact URL match.
+	// ignoreErr tolerates the TUF branch's cold-cache/offline error.
+	tests := []struct {
+		name      string
+		opts      SignOptions
+		want      string
+		wantURL   string
+		ignoreErr bool
+		network   bool // drives a live TUF fetch; skipped in -short
+	}{
+		{
+			name: "signing config file yields a signing-config policy",
+			opts: SignOptions{SigningConfigPath: "testdata/signing_config_v2.json"},
+			want: "signingConfig",
+		},
+		{
+			name: "signing config file takes precedence over rekor URL",
+			opts: SignOptions{SigningConfigPath: "testdata/signing_config_v2.json", RekorURL: "https://rekor.example.com"},
+			want: "signingConfig",
+		},
+		{
+			// Drives a real trust.ResolveSigningConfig (network) on a cold cache.
+			// Offline this is best-effort: on fetch failure p is nil, which still
+			// satisfies "not a rekorPolicy"; the deterministic file cases above
+			// carry the load-bearing precedence assertions. Skipped in -short.
+			name:      "TUF v2 config takes precedence over rekor URL",
+			opts:      SignOptions{UseTUFSigningConfig: true, RekorURL: "https://rekor.example.com"},
+			want:      "notRekor",
+			ignoreErr: true,
+			network:   true,
+		},
+		{
+			name: "default is Rekor v1 public-good",
+			opts: SignOptions{},
+			want: "rekor",
+		},
+		{
+			name:    "explicit rekor URL yields a v1 policy at that URL",
+			opts:    SignOptions{RekorURL: "https://rekor.internal.example.com"},
+			want:    "rekor",
+			wantURL: "https://rekor.internal.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.network && testing.Short() {
+				t.Skip("skipping live TUF fetch in short mode")
+			}
+			p, err := transparencyForOptions(context.Background(), tt.opts)
+			if err != nil && !tt.ignoreErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			switch tt.want {
+			case "signingConfig":
+				if _, ok := p.(signingConfigPolicy); !ok {
+					t.Errorf("got %T, want signingConfigPolicy", p)
+				}
+			case "notRekor":
+				if _, ok := p.(rekorPolicy); ok {
+					t.Error("got rekorPolicy; UseTUFSigningConfig must take precedence over RekorURL")
+				}
+			case "rekor":
+				rp, ok := p.(rekorPolicy)
+				if !ok {
+					t.Fatalf("got %T, want rekorPolicy", p)
+				}
+				if tt.wantURL == "" {
+					if rp.url == "" {
+						t.Error("default rekorPolicy should fall back to the public-good URL, got empty")
+					}
+				} else if rp.url != tt.wantURL {
+					t.Errorf("rekor URL = %q, want %q", rp.url, tt.wantURL)
+				}
+			}
+		})
+	}
+}
+
+// TestSignOptionsFromResolve guards the single ResolveOptions->SignOptions
+// mapping shared by the keyless attester and the evidence signing paths: every
+// signing-target field must copy through. A dropped field here is how a signing
+// path silently reverts to the wrong Rekor (the evidence-signs-v1 bug this
+// helper was introduced to prevent). See #1650.
+func TestSignOptionsFromResolve(t *testing.T) {
+	ro := ResolveOptions{
+		FulcioURL:           "https://fulcio.example.com",
+		RekorURL:            "https://rekor.example.com",
+		SigningConfigPath:   "sc.json",
+		UseTUFSigningConfig: true,
+	}
+	so := SignOptionsFromResolve("the-token", ro)
+
+	if so.OIDCToken != "the-token" {
+		t.Errorf("OIDCToken = %q, want the-token", so.OIDCToken)
+	}
+	if so.FulcioURL != ro.FulcioURL {
+		t.Errorf("FulcioURL = %q, want %q", so.FulcioURL, ro.FulcioURL)
+	}
+	if so.RekorURL != ro.RekorURL {
+		t.Errorf("RekorURL = %q, want %q", so.RekorURL, ro.RekorURL)
+	}
+	if so.SigningConfigPath != ro.SigningConfigPath {
+		t.Errorf("SigningConfigPath = %q, want %q", so.SigningConfigPath, ro.SigningConfigPath)
+	}
+	if so.UseTUFSigningConfig != ro.UseTUFSigningConfig {
+		t.Errorf("UseTUFSigningConfig = %v, want %v", so.UseTUFSigningConfig, ro.UseTUFSigningConfig)
+	}
+}
+
+// TestResolveAttester_KMS verifies KMS signing resolves to a KMSAttester across
+// the v2 default and both opt-outs — KMS signs to Rekor v2 by default, and a
+// signing config (file or TUF) is valid with KMS (no longer rejected). Covers
+// both resolver entry points.
+func TestResolveAttester_KMS(t *testing.T) {
+	cases := []struct {
+		name string
+		opts ResolveOptions
+	}{
+		{"KMS default (v2)", ResolveOptions{Attest: true, SigningKey: "awskms://alias/k", UseTUFSigningConfig: true}},
+		{"KMS + signing config file", ResolveOptions{Attest: true, SigningKey: "awskms://alias/k", SigningConfigPath: "x.json"}},
+		{"KMS + Rekor v1 URL", ResolveOptions{Attest: true, SigningKey: "awskms://alias/k", RekorURL: "https://rekor.example.com"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := ResolveAttester(context.Background(), tc.opts)
+			if err != nil {
+				t.Fatalf("ResolveAttester: unexpected error: %v", err)
+			}
+			ka, ok := a.(*KMSAttester)
+			if !ok {
+				t.Fatalf("ResolveAttester: got %T, want *KMSAttester", a)
+			}
+			// The KMS path must carry the same signing target the mapper produces,
+			// so a new field added to SignOptionsFromResolve reaches Rekor selection
+			// on the KMS path too (the drift the mapper exists to prevent).
+			want := SignOptionsFromResolve("", tc.opts)
+			if ka.target != want {
+				t.Errorf("KMS target = %+v, want %+v", ka.target, want)
+			}
+			la, err := ResolveAttesterLazy(context.Background(), tc.opts)
+			if err != nil {
+				t.Fatalf("ResolveAttesterLazy: unexpected error: %v", err)
+			}
+			if _, ok := la.(*KMSAttester); !ok {
+				t.Errorf("ResolveAttesterLazy: got %T, want *KMSAttester", la)
+			}
+		})
+	}
+}

--- a/pkg/bundler/attestation/signingconfig.go
+++ b/pkg/bundler/attestation/signingconfig.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/sign"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/trust"
+)
+
+// signingConfigPolicy writes transparency-log entries and RFC3161 timestamps
+// chosen from a Sigstore SigningConfig, exactly as cosign does. Services are
+// picked with root.SelectServices, which prefers the highest supported API
+// version, never mixes versions, and honors the config's selector and
+// per-service validity windows.
+//
+// This is how AICR targets Rekor v2: the public-good v2 signing config
+// (signing_config_rekor_v2, distributed via TUF) lists both a v2 and a v1 rekor
+// service, and SelectServices picks v2 because it is the highest version — the
+// v1 entry is only a fallback for clients that support v1 only. Because a Rekor
+// v2 entry carries no inline signed timestamp, the config's timestamp authority
+// is attached so the bundle still has trusted time; a v2 selection with no TSA
+// fails closed rather than emit bundles that cannot be verified for time. See
+// #1650.
+type signingConfigPolicy struct {
+	logs []sign.Transparency
+	tsas []*sign.TimestampAuthority
+}
+
+// NewSigningConfigPolicyFromPath loads a Sigstore SigningConfig JSON file (e.g.
+// the TUF-distributed signing_config_rekor_v2 target written to disk) and
+// returns a TransparencyPolicy that signs to the services it selects for the
+// current time.
+func NewSigningConfigPolicyFromPath(path string) (TransparencyPolicy, error) {
+	// Bound the read instead of sigstore-go's bare os.ReadFile: the path is a
+	// user-supplied CLI/env argument, so cap it before the bytes hit memory to
+	// keep an attacker-influenced path (a /proc symlink, an NFS/FUSE mount) from
+	// OOMing the process, mirroring loadPEMPublicKey / the trusted-root loader.
+	f, err := os.Open(path) //nolint:gosec // path is an operator-supplied signer input, bounded below
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to open signing config", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(f, defaults.MaxSigningConfigBytes+1))
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to read signing config", err)
+	}
+	if int64(len(data)) > defaults.MaxSigningConfigBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "signing config file exceeds size limit")
+	}
+
+	sc, err := root.NewSigningConfigFromJSON(data)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to load signing config", err)
+	}
+	// A user-supplied config file may legitimately be v1, so a v1 selection here
+	// is not a downgrade — no warning.
+	return newSigningConfigPolicy(sc, time.Now(), false)
+}
+
+// NewSigningConfigPolicyFromTUF returns a TransparencyPolicy built from the
+// Rekor v2 signing config distributed via TUF — AICR's default signing target.
+// The endpoint set is Sigstore-maintained and rotation-safe (shard URLs carry
+// validity windows), so nothing is hardcoded and no config file is passed
+// around. It prefers the local cache and falls back to a bounded network fetch
+// when cold, so signing works without a prior explicit "aicr trust update".
+//
+// warnOnV1Downgrade is set because this is the v2-intended path: if a stale
+// cache selects a v1 service (its v2 shard aged past its validity window before
+// the cache refreshed), the caller should see that the entry silently landed in
+// Rekor v1 rather than v2.
+func NewSigningConfigPolicyFromTUF(ctx context.Context) (TransparencyPolicy, error) {
+	sc, err := trust.ResolveSigningConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return newSigningConfigPolicy(sc, time.Now(), true)
+}
+
+// newSigningConfigPolicy builds the policy from an already-parsed SigningConfig
+// at the given time. Split from the public loaders so tests can pin the
+// selection time against fixed service validity windows. When warnOnV1Downgrade
+// is true (the TUF v2-default path), a v1 selection is logged as a downgrade so
+// a stale-cache fall-back to Rekor v1 is visible rather than silent.
+func newSigningConfigPolicy(sc *root.SigningConfig, now time.Time, warnOnV1Downgrade bool) (TransparencyPolicy, error) {
+	if sc == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "signing config is nil")
+	}
+
+	rekorSvcs, tsaSvcs, err := selectSigningServices(sc, now)
+	if err != nil {
+		return nil, err
+	}
+
+	logs := make([]sign.Transparency, 0, len(rekorSvcs))
+	usesV2 := false
+	for _, svc := range rekorSvcs {
+		logs = append(logs, sign.NewRekor(&sign.RekorOptions{
+			BaseURL: svc.URL,
+			Version: svc.MajorAPIVersion,
+		}))
+		if svc.MajorAPIVersion >= 2 {
+			usesV2 = true
+		}
+	}
+
+	// A cached TUF config whose v2 shard has aged past its validity window still
+	// carries a valid v1 entry, so SelectServices quietly picks v1 — the silent
+	// downgrade this signing path otherwise fails closed against. Surface it so
+	// the operator knows to run `aicr trust update`.
+	if warnOnV1Downgrade && !usesV2 && len(rekorSvcs) > 0 {
+		slog.Warn("Rekor v2 signing requested but the signing config selected a Rekor v1 service; "+
+			"the cached TUF config may be stale (its v2 shard is past its validity window) — run 'aicr trust update' to refresh",
+			"selectedRekorURL", rekorSvcs[0].URL,
+			"selectedRekorAPIVersion", rekorSvcs[0].MajorAPIVersion)
+	}
+
+	tsas := make([]*sign.TimestampAuthority, 0, len(tsaSvcs))
+	for _, svc := range tsaSvcs {
+		tsas = append(tsas, sign.NewTimestampAuthority(&sign.TimestampAuthorityOptions{URL: svc.URL}))
+	}
+
+	// A Rekor v2 entry has no inline signed timestamp, so a v2 target without a
+	// timestamp authority would produce bundles with no trusted time — fail
+	// closed instead of shipping unverifiable attestations.
+	if usesV2 && len(tsas) == 0 {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"signing config selects Rekor v2 but has no timestamp authority; bundles would lack trusted time")
+	}
+
+	return signingConfigPolicy{logs: logs, tsas: tsas}, nil
+}
+
+// selectSigningServices resolves the rekor and timestamp-authority services to
+// sign to from a SigningConfig at now, applying each section's selector,
+// validity windows, and the supported API versions. A config with no timestamp
+// authorities returns an empty tsa slice (valid for Rekor v1); the v2-requires-
+// TSA rule is enforced by the caller.
+func selectSigningServices(sc *root.SigningConfig, now time.Time) (rekor, tsa []root.Service, err error) {
+	rekor, err = root.SelectServices(sc.RekorLogURLs(), sc.RekorLogURLsConfig(), sign.RekorAPIVersions, now)
+	if err != nil {
+		return nil, nil, errors.Wrap(errors.ErrCodeInvalidRequest, "no usable rekor service in signing config", err)
+	}
+
+	if len(sc.TimestampAuthorityURLs()) == 0 {
+		return rekor, nil, nil
+	}
+	// TSA selection is best-effort. A config may list timestamp authorities that
+	// are all outside their validity window, which is harmless for a Rekor v1
+	// selection: v1 carries its own signed entry timestamp and uses no TSA.
+	// Whether a TSA is *required* is version-dependent and enforced by the caller
+	// (newSigningConfigPolicy fails closed when a v2 log has no TSA), so a
+	// no-selectable-TSA result here is an empty set, not an error.
+	tsa, err = root.SelectServices(sc.TimestampAuthorityURLs(), sc.TimestampAuthorityURLsConfig(), sign.TimestampAuthorityAPIVersions, now)
+	if err != nil {
+		return rekor, nil, nil
+	}
+	return rekor, tsa, nil
+}
+
+func (p signingConfigPolicy) Logs() []sign.Transparency { return p.logs }
+
+func (p signingConfigPolicy) TimestampAuthorities() []*sign.TimestampAuthority { return p.tsas }

--- a/pkg/bundler/attestation/signingconfig_test.go
+++ b/pkg/bundler/attestation/signingconfig_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
+)
+
+// afterV2 is inside the v2 rekor validity window (validFor.start 2026-01-01) in
+// testdata/signing_config_v2.json; beforeV2 is after v1 + TSA start but before
+// v2, so the highest-version-wins selection falls back to v1.
+var (
+	afterV2  = time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+	beforeV2 = time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC)
+)
+
+func loadSigningConfig(t *testing.T, name string) *root.SigningConfig {
+	t.Helper()
+	sc, err := root.NewSigningConfigFromPath("testdata/" + name)
+	if err != nil {
+		t.Fatalf("load %s: %v", name, err)
+	}
+	return sc
+}
+
+func TestSelectSigningServices(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       string
+		now          time.Time
+		wantRekorURL string
+		wantRekorAPI uint32
+		wantTSAURL   string // "" means expect no TSA
+		wantErr      bool
+	}{
+		{
+			// The v2 config lists both v2 and v1 with selector ANY; at current
+			// time SelectServices prefers the highest API version, so it picks v2.
+			name:         "v2 config selects v2 at current time",
+			config:       "signing_config_v2.json",
+			now:          afterV2,
+			wantRekorURL: "https://log2025-1.rekor.sigstore.dev",
+			wantRekorAPI: 2,
+			wantTSAURL:   "https://timestamp.sigstore.dev/api/v1/timestamp",
+		},
+		{
+			// Before the v2 validity window, the same config falls back to v1.
+			name:         "v2 config falls back to v1 before v2 window",
+			config:       "signing_config_v2.json",
+			now:          beforeV2,
+			wantRekorURL: "https://rekor.sigstore.dev",
+			wantRekorAPI: 1,
+			wantTSAURL:   "https://timestamp.sigstore.dev/api/v1/timestamp",
+		},
+		{
+			name:         "v1 config selects v1",
+			config:       "signing_config_v1.json",
+			now:          afterV2,
+			wantRekorURL: "https://rekor.sigstore.dev",
+			wantRekorAPI: 1,
+			wantTSAURL:   "https://timestamp.sigstore.dev/api/v1/timestamp",
+		},
+		{
+			name:         "v2-only no TSA selects v2 with empty TSA set",
+			config:       "signing_config_v2_no_tsa.json",
+			now:          afterV2,
+			wantRekorURL: "https://log2025-1.rekor.sigstore.dev",
+			wantRekorAPI: 2,
+			wantTSAURL:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := loadSigningConfig(t, tt.config)
+			rekor, tsa, err := selectSigningServices(sc, tt.now)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(rekor) != 1 {
+				t.Fatalf("want 1 rekor service, got %d", len(rekor))
+			}
+			if rekor[0].URL != tt.wantRekorURL {
+				t.Errorf("rekor URL = %q, want %q", rekor[0].URL, tt.wantRekorURL)
+			}
+			if rekor[0].MajorAPIVersion != tt.wantRekorAPI {
+				t.Errorf("rekor API = %d, want %d", rekor[0].MajorAPIVersion, tt.wantRekorAPI)
+			}
+			if tt.wantTSAURL == "" {
+				if len(tsa) != 0 {
+					t.Errorf("want no TSA, got %d", len(tsa))
+				}
+				return
+			}
+			if len(tsa) != 1 {
+				t.Fatalf("want 1 TSA, got %d", len(tsa))
+			}
+			if tsa[0].URL != tt.wantTSAURL {
+				t.Errorf("TSA URL = %q, want %q", tsa[0].URL, tt.wantTSAURL)
+			}
+		})
+	}
+}
+
+// TestSelectSigningServices_V1WithUnusableTSA verifies that a TSA which is
+// outside its validity window does not fail a Rekor v1 selection: v1 carries its
+// own signed entry timestamp and uses no TSA, so an unusable TSA is dropped, not
+// fatal. The v2-requires-TSA rule stays with the caller.
+func TestSelectSigningServices_V1WithUnusableTSA(t *testing.T) {
+	sc := loadSigningConfig(t, "signing_config_v1.json")
+	// v1 rekor is valid from 2021-01-12; the TSA only from 2025-07-04.
+	beforeTSA := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	rekor, tsa, err := selectSigningServices(sc, beforeTSA)
+	if err != nil {
+		t.Fatalf("selectSigningServices should not fail on an unusable TSA for v1: %v", err)
+	}
+	if len(rekor) != 1 || rekor[0].MajorAPIVersion != 1 {
+		t.Errorf("want a single v1 rekor service, got %+v", rekor)
+	}
+	if len(tsa) != 0 {
+		t.Errorf("want no TSA selected, got %d", len(tsa))
+	}
+	// The policy builds successfully too — v1 needs no TSA. Exercise the
+	// warn-on-v1-downgrade branch (TUF path): a v1 selection must still build a
+	// working policy, the warning is a visibility side effect only.
+	if _, err := newSigningConfigPolicy(sc, beforeTSA, true); err != nil {
+		t.Errorf("newSigningConfigPolicy for v1 without a usable TSA: %v", err)
+	}
+}
+
+func TestNewSigningConfigPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		now      time.Time
+		wantLogs int
+		wantTSAs int
+		wantErr  bool
+	}{
+		{
+			name:     "v2 config yields one log and one TSA",
+			config:   "signing_config_v2.json",
+			now:      afterV2,
+			wantLogs: 1,
+			wantTSAs: 1,
+		},
+		{
+			name:     "v1 config yields one log and one TSA",
+			config:   "signing_config_v1.json",
+			now:      afterV2,
+			wantLogs: 1,
+			wantTSAs: 1,
+		},
+		{
+			// A v2 selection with no timestamp authority must fail closed:
+			// v2 has no inline timestamp, so the bundle would lack trusted time.
+			name:    "v2 without TSA fails closed",
+			config:  "signing_config_v2_no_tsa.json",
+			now:     afterV2,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := loadSigningConfig(t, tt.config)
+			policy, err := newSigningConfigPolicy(sc, tt.now, false)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got := len(policy.Logs()); got != tt.wantLogs {
+				t.Errorf("Logs() = %d, want %d", got, tt.wantLogs)
+			}
+			if got := len(policy.TimestampAuthorities()); got != tt.wantTSAs {
+				t.Errorf("TimestampAuthorities() = %d, want %d", got, tt.wantTSAs)
+			}
+		})
+	}
+}
+
+func TestNewSigningConfigPolicyNil(t *testing.T) {
+	if _, err := newSigningConfigPolicy(nil, afterV2, false); err == nil {
+		t.Fatal("want error for nil signing config, got nil")
+	}
+}
+
+func TestNewSigningConfigPolicyFromPath(t *testing.T) {
+	// The public loader uses time.Now(); the v2 window opened 2026-01-01, so at
+	// test-run time it selects v2 + TSA and succeeds.
+	policy, err := NewSigningConfigPolicyFromPath("testdata/signing_config_v2.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(policy.Logs()) != 1 || len(policy.TimestampAuthorities()) != 1 {
+		t.Errorf("want 1 log + 1 TSA, got %d + %d", len(policy.Logs()), len(policy.TimestampAuthorities()))
+	}
+
+	if _, err := NewSigningConfigPolicyFromPath("testdata/does_not_exist.json"); err == nil {
+		t.Error("want error for missing file, got nil")
+	}
+}

--- a/pkg/bundler/attestation/testdata/signing_config_v1.json
+++ b/pkg/bundler/attestation/testdata/signing_config_v1.json
@@ -1,0 +1,49 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstore.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://rekor.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2021-01-12T11:53:27.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "tsaUrls": [
+    {
+      "url": "https://timestamp.sigstore.dev/api/v1/timestamp",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-07-04T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}

--- a/pkg/bundler/attestation/testdata/signing_config_v2.json
+++ b/pkg/bundler/attestation/testdata/signing_config_v2.json
@@ -1,0 +1,57 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstore.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://log2025-1.rekor.sigstore.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2026-01-01T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://rekor.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2021-01-12T11:53:27.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "tsaUrls": [
+    {
+      "url": "https://timestamp.sigstore.dev/api/v1/timestamp",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-07-04T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}

--- a/pkg/bundler/attestation/testdata/signing_config_v2_no_tsa.json
+++ b/pkg/bundler/attestation/testdata/signing_config_v2_no_tsa.json
@@ -1,0 +1,40 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstore.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://log2025-1.rekor.sigstore.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2026-01-01T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "tsaUrls": [],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}

--- a/pkg/bundler/attestation/transparency.go
+++ b/pkg/bundler/attestation/transparency.go
@@ -20,13 +20,20 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 )
 
-// TransparencyPolicy decides which transparency logs (if any) a signing
-// operation writes to. It is the second of the two composable axes of
-// SignStatementWith; pair it with a SigningIdentity.
+// TransparencyPolicy decides which transparency logs and timestamp authorities
+// (if any) a signing operation writes to. It is the second of the two composable
+// axes of SignStatementWith; pair it with a SigningIdentity.
 type TransparencyPolicy interface {
 	// Logs returns the sigstore-go transparency-log clients to attach, or
 	// nil for offline signing (no Rekor entry).
 	Logs() []sign.Transparency
+
+	// TimestampAuthorities returns the RFC3161 timestamp-authority clients to
+	// attach, or nil. A Rekor v1 entry carries its own inline signed entry
+	// timestamp, so v1 policies return nil; Rekor v2 returns no inline
+	// timestamp, so a SigningConfig-driven v2 policy attaches a TSA here to give
+	// the bundle trusted time.
+	TimestampAuthorities() []*sign.TimestampAuthority
 }
 
 // rekorPolicy writes one Rekor transparency-log entry. Empty URL falls back
@@ -46,6 +53,10 @@ func (p rekorPolicy) Logs() []sign.Transparency {
 	return []sign.Transparency{sign.NewRekor(&sign.RekorOptions{BaseURL: p.url})}
 }
 
+// TimestampAuthorities returns nil: a Rekor v1 entry carries its own signed
+// entry timestamp, so no separate RFC3161 timestamp authority is required.
+func (rekorPolicy) TimestampAuthorities() []*sign.TimestampAuthority { return nil }
+
 // noTLogPolicy attaches no transparency log (offline / air-gapped signing,
 // issue #409).
 type noTLogPolicy struct{}
@@ -55,3 +66,6 @@ type noTLogPolicy struct{}
 func NewNoTLogPolicy() TransparencyPolicy { return noTLogPolicy{} }
 
 func (noTLogPolicy) Logs() []sign.Transparency { return nil }
+
+// TimestampAuthorities returns nil: offline signing attaches no timestamp.
+func (noTLogPolicy) TimestampAuthorities() []*sign.TimestampAuthority { return nil }

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -105,6 +105,18 @@ type bundleCmdOptions struct {
 	fulcioURL string
 	rekorURL  string
 
+	// useTUFSigningConfig signs to Rekor v2 using the TUF-distributed signing
+	// config — the default for both keyless and KMS signing. Computed as the
+	// absence of a v1/custom opt-out (rekorURL, signingConfigPath), not a user
+	// flag; signingKey is deliberately not an opt-out, so KMS also defaults to v2.
+	// See #1650.
+	useTUFSigningConfig bool
+
+	// signingConfigPath signs with a custom Sigstore signing config file instead
+	// of the default Rekor v2 config (advanced escape hatch, e.g. an edited
+	// config or a private v2 instance). See #1650.
+	signingConfigPath string
+
 	// OCI output reference (nil if outputting to local directory)
 	ociRef        *oci.Reference
 	plainHTTP     bool
@@ -156,9 +168,19 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		assumeYes:                 cmd.Bool(flagAssumeYes),
 		fulcioURL:                 stringFlagOrConfig(cmd, flagFulcioURL, resolved.FulcioURL),
 		rekorURL:                  stringFlagOrConfig(cmd, flagRekorURL, resolved.RekorURL),
+		signingConfigPath:         cmd.String(flagSigningConfig),
 		insecureTLS:               boolFlagOrConfig(cmd, flagInsecureTLS, resolved.InsecureTLS),
 		plainHTTP:                 boolFlagOrConfig(cmd, flagPlainHTTP, resolved.PlainHTTP),
 		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", resolved.ImageRefs),
+	}
+
+	// Rekor v2 is the default for both keyless and KMS --attest signing: the
+	// TUF-distributed v2 signing config is used unless the caller opts out to a
+	// Rekor v1 URL or supplies a custom signing config file. Shared with
+	// recipe sign-catalog so the derivation and the exclusivity rule stay in sync.
+	opts.useTUFSigningConfig, err = signingTargetFromFlags(opts.rekorURL, opts.signingConfigPath)
+	if err != nil {
+		return nil, err
 	}
 
 	if opts.recipeFilePath == "" {
@@ -398,10 +420,31 @@ func validateSigningKeyExclusivity(cmd *cli.Command, opts *bundleCmdOptions) err
 // values (non-empty endpoints that are not absolute https:// URLs). The
 // HTTPS check is shared with the config layer via config.ValidateHTTPSURL.
 func validateSigstoreEndpoints(opts *bundleCmdOptions) error {
+	// The --rekor-url / --signing-config exclusivity is enforced up-front by
+	// signingTargetFromFlags (in parseBundleCmdOptions), so only URL shape is
+	// checked here.
 	if err := config.ValidateHTTPSURL("fulcio URL", opts.fulcioURL); err != nil {
 		return err
 	}
 	return config.ValidateHTTPSURL("rekor URL", opts.rekorURL)
+}
+
+// signingTargetFromFlags derives the transparency-signing target shared by the
+// signing commands (bundle --attest, recipe sign-catalog): with neither opt-out
+// set, signing uses the TUF-distributed Rekor v2 default (useTUF == true);
+// --rekor-url selects a Rekor v1 URL and --signing-config a custom config file,
+// and the two are mutually exclusive. Either value can also arrive from a
+// non-flag source (AICR_REKOR_URL / AICR_SIGNING_CONFIG env, or
+// spec.bundle.rekorURL in --config), so the message names those sources rather
+// than citing a flag the caller may never have typed. Centralized so a future
+// policy change lands in one place instead of drifting across per-command copies.
+func signingTargetFromFlags(rekorURL, signingConfigPath string) (useTUF bool, err error) {
+	if rekorURL != "" && signingConfigPath != "" {
+		return false, errors.New(errors.ErrCodeInvalidRequest,
+			"--"+flagRekorURL+" and --"+flagSigningConfig+
+				" (or their env vars AICR_REKOR_URL / AICR_SIGNING_CONFIG, or spec.bundle.rekorURL in --config) are mutually exclusive")
+	}
+	return rekorURL == "" && signingConfigPath == "", nil
 }
 
 // resolveOutputTarget returns the parsed *oci.Reference for --output,
@@ -715,7 +758,7 @@ Package with explicit tag (overrides CLI version):
 			},
 			&cli.StringFlag{
 				Name:     flagSigningKey,
-				Usage:    "Sign --attest bundles with a KMS-backed key (awskms:// | gcpkms:// | azurekms://) instead of keyless OIDC, for CI/CD without OIDC. Mutually exclusive with --identity-token, --oidc-device-flow, --fulcio-url. Combine with --rekor-url to log to a private Rekor. Verify the resulting bundle with `aicr verify --key <uri>`.",
+				Usage:    "Sign --attest bundles with a KMS-backed key (awskms:// | gcpkms:// | azurekms://) instead of keyless OIDC, for CI/CD without OIDC. Mutually exclusive with --identity-token, --oidc-device-flow, --fulcio-url. Like keyless, KMS signs to Rekor v2 by default; opt out with --rekor-url (v1) or --signing-config (custom). Verify the resulting bundle with `aicr verify --key <uri>`.",
 				Category: catDeployment,
 			},
 			&cli.BoolFlag{
@@ -732,8 +775,14 @@ Package with explicit tag (overrides CLI version):
 			},
 			&cli.StringFlag{
 				Name:     flagRekorURL,
-				Usage:    "Override the Rekor transparency-log URL for --attest keyless signing (e.g. a private Sigstore instance). Must be an absolute https:// URL with no embedded credentials. Defaults to the public-good Rekor. Also reads AICR_REKOR_URL.",
+				Usage:    "Sign --attest bundles to Rekor v1 at this URL instead of the Rekor v2 default (e.g. a private Sigstore instance, or the public-good v1 URL). Must be an absolute https:// URL with no embedded credentials. Also reads AICR_REKOR_URL.",
 				Sources:  cli.EnvVars("AICR_REKOR_URL"),
+				Category: catDeployment,
+			},
+			&cli.StringFlag{
+				Name:     flagSigningConfig,
+				Usage:    "Sign --attest bundles with a custom Sigstore signing config JSON instead of the default Rekor v2 config (advanced). Also reads AICR_SIGNING_CONFIG.",
+				Sources:  cli.EnvVars("AICR_SIGNING_CONFIG"),
 				Category: catDeployment,
 			},
 			assumeYesFlag(catDeployment),
@@ -945,14 +994,16 @@ func selectAttester(ctx context.Context, opts *bundleCmdOptions) (attestation.At
 // disclosure gate so both reason about the identical token-source precedence.
 func bundleOIDCResolveOptions(opts *bundleCmdOptions) attestation.ResolveOptions {
 	return attestation.ResolveOptions{
-		Attest:        opts.attest,
-		IdentityToken: opts.identityToken,
-		SigningKey:    opts.signingKey,
-		AmbientURL:    os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
-		AmbientToken:  os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
-		DeviceFlow:    opts.oidcDeviceFlow,
-		FulcioURL:     opts.fulcioURL,
-		RekorURL:      opts.rekorURL,
+		Attest:              opts.attest,
+		IdentityToken:       opts.identityToken,
+		SigningKey:          opts.signingKey,
+		AmbientURL:          os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
+		AmbientToken:        os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+		DeviceFlow:          opts.oidcDeviceFlow,
+		FulcioURL:           opts.fulcioURL,
+		RekorURL:            opts.rekorURL,
+		SigningConfigPath:   opts.signingConfigPath,
+		UseTUFSigningConfig: opts.useTUFSigningConfig,
 		// Prompts (verification URL + user code) go to stderr so they don't
 		// pollute stdout when callers redirect bundle output.
 		PromptWriter: os.Stderr,

--- a/pkg/cli/bundle_rekor_v2_test.go
+++ b/pkg/cli/bundle_rekor_v2_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestParseBundleCmdOptions_RekorV2Default covers the Rekor v2 default and its
+// opt-outs for `bundle --attest` keyless signing: with no signing flags the
+// command signs to Rekor v2 (useTUFSigningConfig), and --rekor-url,
+// --signing-config, or --signing-key each opt out. See #1650.
+func TestParseBundleCmdOptions_RekorV2Default(t *testing.T) {
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	scPath := filepath.Join(tmp, "sc.json")
+	base := []string{"--recipe", recipePath, "--output", filepath.Join(tmp, "out")}
+	with := func(extra ...string) []string { return append(append([]string{}, base...), extra...) }
+
+	t.Run("no signing flags default to Rekor v2", func(t *testing.T) {
+		opts := captureBundleOpts(t, base)
+		if !opts.useTUFSigningConfig {
+			t.Error("useTUFSigningConfig = false, want true (v2 default) with no signing flags")
+		}
+		if opts.rekorURL != "" || opts.signingConfigPath != "" {
+			t.Errorf("want empty rekorURL/signingConfigPath, got %q/%q", opts.rekorURL, opts.signingConfigPath)
+		}
+	})
+
+	t.Run("--rekor-url opts out to Rekor v1", func(t *testing.T) {
+		const u = "https://rekor.internal.example.com"
+		opts := captureBundleOpts(t, with("--rekor-url", u))
+		if opts.useTUFSigningConfig {
+			t.Error("useTUFSigningConfig = true, want false when --rekor-url is set")
+		}
+		if opts.rekorURL != u {
+			t.Errorf("rekorURL = %q, want %q", opts.rekorURL, u)
+		}
+	})
+
+	t.Run("--signing-config opts out of the v2 default", func(t *testing.T) {
+		opts := captureBundleOpts(t, with("--signing-config", scPath))
+		if opts.useTUFSigningConfig {
+			t.Error("useTUFSigningConfig = true, want false when --signing-config is set")
+		}
+		if opts.signingConfigPath != scPath {
+			t.Errorf("signingConfigPath = %q, want %q", opts.signingConfigPath, scPath)
+		}
+	})
+
+	t.Run("--signing-key (KMS) still defaults to Rekor v2", func(t *testing.T) {
+		opts := captureBundleOpts(t, with("--signing-key", "awskms://alias/k"))
+		if !opts.useTUFSigningConfig {
+			t.Error("useTUFSigningConfig = false, want true (KMS defaults to v2 like keyless)")
+		}
+	})
+
+	t.Run("--signing-key with --signing-config is allowed (KMS custom v2)", func(t *testing.T) {
+		opts := captureBundleOpts(t, with("--signing-key", "awskms://alias/k", "--signing-config", scPath))
+		if opts.useTUFSigningConfig {
+			t.Error("useTUFSigningConfig = true, want false when --signing-config is set")
+		}
+		if opts.signingConfigPath != scPath {
+			t.Errorf("signingConfigPath = %q, want %q", opts.signingConfigPath, scPath)
+		}
+	})
+
+	// The parsed bundleCmdOptions are only correct if they propagate into the
+	// ResolveOptions actually handed to the attester. Assert that final mapping.
+	t.Run("options propagate into ResolveOptions", func(t *testing.T) {
+		ro := bundleOIDCResolveOptions(captureBundleOpts(t, base))
+		if !ro.UseTUFSigningConfig {
+			t.Error("ResolveOptions.UseTUFSigningConfig = false, want true (v2 default)")
+		}
+
+		ro = bundleOIDCResolveOptions(captureBundleOpts(t, with("--rekor-url", "https://rekor.example.com")))
+		if ro.UseTUFSigningConfig || ro.RekorURL != "https://rekor.example.com" {
+			t.Errorf("with --rekor-url: UseTUFSigningConfig=%v RekorURL=%q", ro.UseTUFSigningConfig, ro.RekorURL)
+		}
+
+		ro = bundleOIDCResolveOptions(captureBundleOpts(t, with("--signing-config", scPath)))
+		if ro.UseTUFSigningConfig || ro.SigningConfigPath != scPath {
+			t.Errorf("with --signing-config: UseTUFSigningConfig=%v SigningConfigPath=%q", ro.UseTUFSigningConfig, ro.SigningConfigPath)
+		}
+	})
+
+	t.Run("--rekor-url and --signing-config are mutually exclusive", func(t *testing.T) {
+		_, err := tryCaptureBundleOpts(t, with("--rekor-url", "https://rekor.example.com", "--signing-config", scPath))
+		if err == nil {
+			t.Fatal("want error for --rekor-url + --signing-config, got nil")
+		}
+		if !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("error should mention mutual exclusivity, got: %v", err)
+		}
+	})
+}

--- a/pkg/cli/bundle_test.go
+++ b/pkg/cli/bundle_test.go
@@ -513,10 +513,11 @@ func runExclusivityCheck(t *testing.T, args []string) error {
 	cmd := bundleCmd()
 	cmd.Action = func(_ context.Context, c *cli.Command) error {
 		opts := &bundleCmdOptions{
-			signingKey:     c.String(flagSigningKey),
-			identityToken:  c.String(flagIdentityToken),
-			oidcDeviceFlow: c.Bool(flagOIDCDeviceFlow),
-			fulcioURL:      c.String(flagFulcioURL),
+			signingKey:        c.String(flagSigningKey),
+			identityToken:     c.String(flagIdentityToken),
+			oidcDeviceFlow:    c.Bool(flagOIDCDeviceFlow),
+			fulcioURL:         c.String(flagFulcioURL),
+			signingConfigPath: c.String(flagSigningConfig),
 		}
 		return validateSigningKeyExclusivity(c, opts)
 	}
@@ -564,6 +565,13 @@ func TestValidateSigningKeyExclusivity(t *testing.T) {
 			name:    "signing-key with fulcio-url is rejected",
 			args:    []string{"--signing-key", key, "--fulcio-url", "https://fulcio.example.com"},
 			wantErr: true,
+		},
+		{
+			// KMS signs to Rekor v2 by default and accepts a custom signing
+			// config, so --signing-key + --signing-config is valid (#1650).
+			name:    "signing-key with signing-config is allowed",
+			args:    []string{"--signing-key", key, "--signing-config", "sc.json"},
+			wantErr: false,
 		},
 		{
 			// --rekor-url is orthogonal to keyless-vs-KMS: KMS signing uploads

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -46,14 +46,16 @@ const criteriaAny = "any"
 // (goconst flags a string repeated ≥3 times across the package) and the
 // flag wiring stays consistent across the commands that sign+push.
 const (
-	flagIdentityToken  = "identity-token"
-	flagOIDCDeviceFlow = "oidc-device-flow"
-	flagFulcioURL      = "fulcio-url"
-	flagRekorURL       = "rekor-url"
-	flagSigningKey     = "signing-key"
-	flagInsecureTLS    = "insecure-tls"
-	flagPlainHTTP      = "plain-http"
-	flagPush           = "push"
+	flagIdentityToken     = "identity-token"
+	flagOIDCDeviceFlow    = "oidc-device-flow"
+	flagFulcioURL         = "fulcio-url"
+	flagRekorURL          = "rekor-url"
+	flagSigningConfig     = "signing-config"
+	flagEmitSigningConfig = "emit-signing-config"
+	flagSigningKey        = "signing-key"
+	flagInsecureTLS       = "insecure-tls"
+	flagPlainHTTP         = "plain-http"
+	flagPush              = "push"
 	// flagNoSign pushes an unsigned evidence bundle and writes a pointer whose
 	// attestation has a nil Signer (the unsigned state — distinct from a
 	// signed-without-Rekor pointer, which has a Signer with a nil

--- a/pkg/cli/recipe_sign_catalog.go
+++ b/pkg/cli/recipe_sign_catalog.go
@@ -64,8 +64,13 @@ Keyless OIDC signing uses the same precedence chain as 'aicr bundle --attest':
 			},
 			&cli.StringFlag{
 				Name:    flagRekorURL,
-				Usage:   "Override the Rekor transparency-log URL (defaults to public-good).",
+				Usage:   "Sign to Rekor v1 at this URL instead of the Rekor v2 default (e.g. a private v1 instance, or the public-good v1 URL).",
 				Sources: cli.EnvVars("AICR_REKOR_URL"),
+			},
+			&cli.StringFlag{
+				Name:    flagSigningConfig,
+				Usage:   "Path to a Sigstore signing config JSON to sign with, instead of the default Rekor v2 config (advanced).",
+				Sources: cli.EnvVars("AICR_SIGNING_CONFIG"),
 			},
 		},
 		Action: runRecipeSignCatalogCmd,
@@ -75,15 +80,26 @@ Keyless OIDC signing uses the same precedence chain as 'aicr bundle --attest':
 func runRecipeSignCatalogCmd(ctx context.Context, cmd *cli.Command) error {
 	output := cmd.String("output")
 
+	rekorURL := cmd.String(flagRekorURL)
+	signingConfig := cmd.String(flagSigningConfig)
+	// Shared with bundle --attest: derive the Rekor v2 default and enforce the
+	// --rekor-url / --signing-config exclusivity in one place.
+	useV2, err := signingTargetFromFlags(rekorURL, signingConfig)
+	if err != nil {
+		return err
+	}
+
 	attester, err := attestation.ResolveAttesterLazy(ctx, attestation.ResolveOptions{
-		Attest:        true,
-		IdentityToken: cmd.String(flagIdentityToken),
-		AmbientURL:    os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
-		AmbientToken:  os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
-		DeviceFlow:    cmd.Bool(flagOIDCDeviceFlow),
-		FulcioURL:     cmd.String(flagFulcioURL),
-		RekorURL:      cmd.String(flagRekorURL),
-		PromptWriter:  os.Stderr,
+		Attest:              true,
+		IdentityToken:       cmd.String(flagIdentityToken),
+		AmbientURL:          os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
+		AmbientToken:        os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+		DeviceFlow:          cmd.Bool(flagOIDCDeviceFlow),
+		FulcioURL:           cmd.String(flagFulcioURL),
+		RekorURL:            rekorURL,
+		SigningConfigPath:   signingConfig,
+		UseTUFSigningConfig: useV2,
+		PromptWriter:        os.Stderr,
 	})
 	if err != nil {
 		return errors.PropagateOrWrap(err, errors.ErrCodeUnauthorized, "could not resolve OIDC attester")

--- a/pkg/cli/trust.go
+++ b/pkg/cli/trust.go
@@ -17,7 +17,9 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/trust"
 	"github.com/urfave/cli/v3"
 )
@@ -37,16 +39,27 @@ func trustUpdateCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "update",
 		Usage: "Fetch the latest Sigstore trusted root via TUF.",
-		Description: `Fetches the latest Sigstore trusted root from the TUF CDN and
-updates the local cache. This is needed when Sigstore rotates
-their signing keys (a few times per year).
+		Description: `Fetches the latest Sigstore trusted root and Rekor v2 signing
+config from the TUF CDN and updates the local cache. This is needed
+when Sigstore rotates their signing keys (a few times per year).
 
 The trusted root enables offline verification of bundle attestations
-without contacting Sigstore infrastructure.
+without contacting Sigstore infrastructure. The signing config drives
+which Rekor/timestamp endpoints signing writes to (e.g. Rekor v2).
+
+Use --emit-signing-config to also write the signing config to a file
+for tools that take a signing-config path (e.g. cosign attest-blob).
 
 Example:
   aicr trust update
+  aicr trust update --emit-signing-config signing-config.json
 `,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  flagEmitSigningConfig,
+				Usage: "Write the fetched Rekor v2 signing config to this file path.",
+			},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			material, err := trust.Update(ctx)
 			if err != nil {
@@ -60,6 +73,33 @@ Example:
 			fmt.Fprintf(w, "  ✓ Trusted root updated\n")
 			fmt.Fprintf(w, "  CAs: %d certificate authorities\n", len(material.FulcioCertificateAuthorities()))
 			fmt.Fprintf(w, "  Logs: %d transparency logs\n", len(material.RekorLogs()))
+
+			// Report the Rekor v2 signing config warmed into the cache by Update.
+			// Best-effort: the trusted root (verification) is the primary result,
+			// so a missing/failed signing config is surfaced as a note, not an
+			// error — signers that need it get a clear error at sign time.
+			if sc, scErr := trust.GetSigningConfig(); scErr != nil {
+				fmt.Fprintf(w, "  Signing config: unavailable (%v)\n", scErr)
+			} else {
+				fmt.Fprintf(w, "  ✓ Signing config updated\n")
+				for _, s := range sc.RekorLogURLs() {
+					fmt.Fprintf(w, "  Rekor: %s (v%d)\n", s.URL, s.MajorAPIVersion)
+				}
+			}
+
+			// Optionally materialize the signing config to a file for tools that
+			// take a signing-config path (cosign). Writes the raw TUF-verified
+			// bytes so the file is byte-identical to what Sigstore distributes.
+			if out := cmd.String(flagEmitSigningConfig); out != "" {
+				scJSON, err := trust.SigningConfigJSON()
+				if err != nil {
+					return err
+				}
+				if err := os.WriteFile(out, scJSON, 0o600); err != nil {
+					return errors.Wrap(errors.ErrCodeInternal, "failed to write signing config file", err)
+				}
+				fmt.Fprintf(w, "  ✓ Signing config written to %s\n", out)
+			}
 
 			return nil
 		},

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -85,15 +85,22 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 // oidcResolveOptionsFromFlags builds the keyless-signing OIDC resolution
 // options from the shared --identity-token / --oidc-device-flow flag pair
 // plus the GitHub Actions ambient-OIDC env vars. Shared by every command
-// that signs an evidence bundle (`validate --push`, `evidence publish`) so
-// the source-precedence wiring stays in one place.
+// that signs an evidence bundle (`validate --push`, `evidence publish`,
+// `evidence sign`) so the source-precedence wiring stays in one place.
+//
+// Evidence signing targets Rekor v2 (UseTUFSigningConfig), matching bundle and
+// catalog signing so all AICR keyless signatures land in the same log. Evidence
+// commands expose no Rekor-v1 override today, so this is unconditional; add the
+// bundle command's --rekor-url / --signing-config opt-outs here if a private
+// evidence-signing use case appears. See #1650.
 func oidcResolveOptionsFromFlags(cmd *cli.Command) bundleattest.ResolveOptions {
 	return bundleattest.ResolveOptions{
-		IdentityToken: cmd.String(flagIdentityToken),
-		AmbientURL:    os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
-		AmbientToken:  os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
-		DeviceFlow:    cmd.Bool(flagOIDCDeviceFlow),
-		PromptWriter:  os.Stderr,
+		IdentityToken:       cmd.String(flagIdentityToken),
+		AmbientURL:          os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
+		AmbientToken:        os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+		DeviceFlow:          cmd.Bool(flagOIDCDeviceFlow),
+		UseTUFSigningConfig: true,
+		PromptWriter:        os.Stderr,
 	}
 }
 

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -777,6 +777,13 @@ const (
 	// OOM the process the way os.ReadFile would.
 	MaxTrustedRootBytes int64 = 1 * 1024 * 1024 // 1 MiB
 
+	// MaxSigningConfigBytes caps the size of a user-supplied Sigstore
+	// signing_config.json passed to `aicr bundle --signing-config` (#1650). A
+	// real signing config is a few KB; 1 MiB is generous headroom while bounding
+	// an attacker-influenced path (a /proc symlink, an NFS mount) so it cannot
+	// OOM the process the way sigstore-go's bare os.ReadFile would.
+	MaxSigningConfigBytes int64 = 1 * 1024 * 1024 // 1 MiB
+
 	// MaxExternalDataFileBytes caps the size of recipe/registry data files
 	// read from the external data directory by LayeredDataProvider. This is
 	// the single source of truth for the external-data size limit:

--- a/pkg/defaults/timeouts_test.go
+++ b/pkg/defaults/timeouts_test.go
@@ -108,6 +108,12 @@ func TestJobEnvelopeMarginInvariant(t *testing.T) {
 // sum of backoffs between attempts, and that total must not exceed
 // SigstoreSignTimeout — otherwise the inner retry loop would race the
 // outer deadline. See issue #1249.
+//
+// Caveat: the Rekor v2 signing path (attestation.transparencyForOptions) may
+// prepend a cold-cache TUF signing-config fetch that draws from the same caller
+// budget before this retry loop runs, so a first-ever cold sign has less than
+// the full budget asserted here. It fails closed and release CI pre-warms the
+// cache via `aicr trust update`; see the budget note in transparencyForOptions.
 func TestSigstoreRetryBudgetInvariant(t *testing.T) {
 	if SigstoreRetryBudget <= 0 {
 		t.Fatalf("SigstoreRetryBudget must be > 0; got %d", SigstoreRetryBudget)

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -344,16 +344,13 @@ func signAndPush(ctx context.Context, bundle *Bundle, opts signPushOptions) (emi
 
 	signCtx, signCancel := context.WithTimeout(ctx, defaults.EvidenceBundleSignTimeout)
 	defer signCancel()
-	// Honor any configured private Sigstore endpoints rather than forcing
-	// public Sigstore. Empty values fall back to the public-good defaults
-	// inside SignStatement. (The validate-emit path does not yet expose
-	// --fulcio-url/--rekor-url, so these are empty today; this keeps the
-	// signer from overriding a configured endpoint once it does.)
-	signRes, err := bundleattest.SignStatement(signCtx, artifactStmt, bundleattest.SignOptions{
-		OIDCToken: token,
-		FulcioURL: opts.OIDCResolve.FulcioURL,
-		RekorURL:  opts.OIDCResolve.RekorURL,
-	})
+	// Map the full resolved signing target (Fulcio/Rekor endpoints plus the
+	// Rekor v2 signing-config selection) through the shared helper so evidence
+	// signing stays in lockstep with bundle/catalog signing — evidence defaults
+	// to Rekor v2 via ResolveOptions.UseTUFSigningConfig. Empty endpoint values
+	// fall back to the public-good defaults inside SignStatement.
+	signRes, err := bundleattest.SignStatement(signCtx, artifactStmt,
+		bundleattest.SignOptionsFromResolve(token, opts.OIDCResolve))
 	if err != nil {
 		return emitOutcome{}, err
 	}

--- a/pkg/evidence/attestation/sign.go
+++ b/pkg/evidence/attestation/sign.go
@@ -111,11 +111,11 @@ func SignExisting(ctx context.Context, opts SignExistingOptions) error {
 
 	signCtx, signCancel := context.WithTimeout(ctx, defaults.EvidenceBundleSignTimeout)
 	defer signCancel()
-	signRes, err := bundleattest.SignStatement(signCtx, artifactStmt, bundleattest.SignOptions{
-		OIDCToken: token,
-		FulcioURL: opts.OIDCResolve.FulcioURL,
-		RekorURL:  opts.OIDCResolve.RekorURL,
-	})
+	// Shared mapper keeps evidence signing in lockstep with bundle/catalog: the
+	// Rekor v2 signing-config selection (ResolveOptions.UseTUFSigningConfig) is
+	// carried through, not just the Fulcio/Rekor endpoints.
+	signRes, err := bundleattest.SignStatement(signCtx, artifactStmt,
+		bundleattest.SignOptionsFromResolve(token, opts.OIDCResolve))
 	if err != nil {
 		return err
 	}

--- a/pkg/trust/trust.go
+++ b/pkg/trust/trust.go
@@ -104,6 +104,135 @@ func GetTrustedMaterial() (root.TrustedMaterial, error) {
 	return trustedMaterialFromClient(client)
 }
 
+// signingConfigTarget is the TUF target name for the Sigstore signing config
+// that routes signing to Rekor v2. AICR signs to Rekor v2 by default, so this is
+// the config the signer resolves unless the caller opts out to a Rekor v1 URL.
+// Sigstore distributes it alongside the default (v1) signing config; the
+// public-good default still points *other* clients at Rekor v1, so we consume
+// this v2 target explicitly. When Sigstore makes v2 the ecosystem default this
+// can move to the default "signing_config.v0.2.json" target. See NVIDIA/aicr#1650.
+const signingConfigTarget = "signing_config_rekor_v2.v0.2.json"
+
+// GetSigningConfig returns the Sigstore signing config that targets Rekor v2,
+// read from the local TUF cache (ForceCache, no network). The cache is populated
+// by Update ("aicr trust update"). It is the sign-side counterpart to
+// GetTrustedMaterial: the trusted root answers "is this signature valid?", the
+// signing config answers "which Rekor/TSA endpoints do I sign to?". Both are
+// resolved offline and refreshed only on explicit update.
+func GetSigningConfig() (*root.SigningConfig, error) {
+	client, err := newCacheTUFClient()
+	if err != nil {
+		return nil, err
+	}
+	return signingConfigFromClient(client)
+}
+
+// newCacheTUFClient builds a ForceCache (offline) TUF client. Shared by the
+// signing-config cache readers so the construction and its error classification
+// stay in one place.
+func newCacheTUFClient() (*tuf.Client, error) {
+	client, err := tuf.New(tuf.DefaultOptions().WithForceCache())
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to initialize TUF client", err)
+	}
+	return client, nil
+}
+
+// ResolveSigningConfig returns the Rekor v2 signing config, preferring the local
+// TUF cache (offline) and falling back to a bounded network TUF fetch when the
+// cache is cold. Because AICR signs to Rekor v2 by default, signers must succeed
+// without a prior explicit "aicr trust update"; signing is already an online
+// operation, so a one-time fetch of the endpoint config is acceptable and it
+// also warms the cache for next time. Bounded by defaults.TUFUpdateTimeout.
+func ResolveSigningConfig(ctx context.Context) (*root.SigningConfig, error) {
+	if sc, err := GetSigningConfig(); err == nil {
+		return sc, nil
+	}
+	// Cold cache: fetch from the TUF CDN. Mirrors Update's bounded-goroutine
+	// pattern because the underlying tuf.New / Refresh calls do not take context.
+	ctx, cancel := context.WithTimeout(ctx, defaults.TUFUpdateTimeout)
+	defer cancel()
+
+	slog.Info("signing config not cached; fetching via TUF...")
+
+	type result struct {
+		sc  *root.SigningConfig
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		client, err := tuf.New(tuf.DefaultOptions())
+		if err != nil {
+			ch <- result{err: errors.Wrap(errors.ErrCodeInternal, "failed to initialize TUF client for signing config fetch", err)}
+			return
+		}
+		if refreshErr := client.Refresh(); refreshErr != nil {
+			code := classifyTUFError(refreshErr)
+			ch <- result{err: errors.Wrap(code, "TUF refresh failed while fetching signing config", refreshErr)}
+			return
+		}
+		sc, err := signingConfigFromClient(client)
+		ch <- result{sc: sc, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "signing config fetch timed out", ctx.Err())
+	case r := <-ch:
+		return r.sc, r.err
+	}
+}
+
+// SigningConfigJSON returns the raw, TUF-verified bytes of the Rekor v2 signing
+// config from the local cache (ForceCache, no network). Use this to materialize
+// the config to a file for tools that take a signing-config path (e.g. `cosign
+// attest-blob --signing-config`); GetSigningConfig returns the parsed form for
+// in-process signing. The cache is populated by Update.
+func SigningConfigJSON() ([]byte, error) {
+	client, err := newCacheTUFClient()
+	if err != nil {
+		return nil, err
+	}
+	return signingConfigTargetBytes(client)
+}
+
+// signingConfigTargetBytes fetches the raw signing-config target from a TUF
+// client (cache read on ForceCache, download-and-cache on a network client) and
+// classifies the error consistently. Shared by SigningConfigJSON (raw bytes) and
+// signingConfigFromClient (parsed).
+func signingConfigTargetBytes(client *tuf.Client) ([]byte, error) {
+	scJSON, err := client.GetTarget(signingConfigTarget)
+	if err != nil {
+		code := classifyTUFError(err)
+		msg := "failed to get signing config from TUF"
+		switch code { //nolint:exhaustive // only the three codes classifyTUFError can return are interesting
+		case errors.ErrCodeUnavailable:
+			msg = "failed to get signing config from TUF (transport error)"
+		case errors.ErrCodeUnauthorized:
+			msg = "failed to get signing config from TUF (signature or verification error)"
+		}
+		return nil, errors.Wrap(code, msg, err)
+	}
+	return scJSON, nil
+}
+
+// signingConfigFromClient loads and parses the signing config target from a TUF
+// client.
+func signingConfigFromClient(client *tuf.Client) (*root.SigningConfig, error) {
+	scJSON, err := signingConfigTargetBytes(client)
+	if err != nil {
+		return nil, err
+	}
+
+	sc, err := root.NewSigningConfigFromJSON(scJSON)
+	if err != nil {
+		// Bytes came from the verified TUF target / cache, not user input — a
+		// parse failure means the cache is corrupt or the payload changed shape.
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse signing config", err)
+	}
+	return sc, nil
+}
+
 // Update fetches the latest Sigstore trusted root via TUF CDN
 // and updates the local cache. Bounded by defaults.TUFUpdateTimeout
 // (longer than a single-request HTTPClientTimeout because TUF refreshes
@@ -160,6 +289,18 @@ func Update(ctx context.Context) (root.TrustedMaterial, error) {
 		}
 
 		material, err := trustedMaterialFromClient(client)
+		if err == nil {
+			// Warm the Rekor v2 signing config target into the same TUF cache so
+			// signers can read it offline via GetSigningConfig. Best-effort: this
+			// is additive to trust update's primary job (the trusted root), so a
+			// fetch failure (e.g. a target-name change) warns rather than fails
+			// the whole update — a signer that needs it gets a clear error from
+			// GetSigningConfig at sign time.
+			if _, scErr := signingConfigFromClient(client); scErr != nil {
+				slog.Warn("signing config not refreshed during trust update",
+					"error", scErr, "target", signingConfigTarget)
+			}
+		}
 		ch <- updateResult{material: material, err: err}
 	}()
 

--- a/pkg/trust/trust_test.go
+++ b/pkg/trust/trust_test.go
@@ -96,6 +96,43 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	}
 }
 
+// TestResolveSigningConfig contacts the public Sigstore TUF CDN to resolve the
+// Rekor v2 signing config (cache-first, network fallback). Integration test
+// (network); skipped in short mode like TestUpdate_Success. It must offer a
+// Rekor v2 log and a timestamp authority — a v2 bundle carries no inline Rekor
+// SET, so a TSA is required for trusted time. See NVIDIA/aicr#1650.
+func TestResolveSigningConfig(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	sc, err := ResolveSigningConfig(ctx)
+	if err != nil {
+		t.Fatalf("ResolveSigningConfig() error: %v", err)
+	}
+	if sc == nil {
+		t.Fatal("ResolveSigningConfig() returned nil")
+	}
+
+	hasV2 := false
+	for _, s := range sc.RekorLogURLs() {
+		if s.MajorAPIVersion >= 2 {
+			hasV2 = true
+		}
+	}
+	if !hasV2 {
+		t.Error("expected a Rekor v2 log URL in the resolved signing config")
+	}
+	if len(sc.TimestampAuthorityURLs()) == 0 {
+		t.Error("expected a timestamp authority in the resolved signing config")
+	}
+}
+
 func TestLoadTrustedMaterialFromFile(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		tm, err := LoadTrustedMaterialFromFile("testdata/trusted_root.json")

--- a/tests/chainsaw/signing/bundle-attestation-private-sigstore/chainsaw-test.yaml
+++ b/tests/chainsaw/signing/bundle-attestation-private-sigstore/chainsaw-test.yaml
@@ -93,6 +93,13 @@ spec:
               REKOR_URL="${REKOR_URL:?Set REKOR_URL to the local Rekor endpoint (https://)}"
               OIDC_TOKEN="${OIDC_TOKEN:?Set OIDC_TOKEN to a valid OIDC token for the local issuer}"
               WORK="/tmp/chainsaw-bundle-attestation-private-sigstore"
+              # This suite signs the bundle attestation against the PRIVATE stack
+              # via --rekor-url. The CI job also exports AICR_SIGNING_CONFIG (the
+              # public-good Rekor v2 signing config, used to attest the binary),
+              # which the bundle command would otherwise pick up as --signing-config
+              # and reject as mutually exclusive with --rekor-url. Drop it so the
+              # explicit private-stack flags are the only signing target. See #1650.
+              unset AICR_SIGNING_CONFIG
               # --certificate-identity-regexp pins the *binary* attestation identity
               # (verified against public Sigstore). The CI binary is attested by this
               # e2e/build-attested workflow, not on-tag, so the bundler must be told

--- a/tests/chainsaw/signing/bundle-headless-oidc-ci/chainsaw-test.yaml
+++ b/tests/chainsaw/signing/bundle-headless-oidc-ci/chainsaw-test.yaml
@@ -83,6 +83,17 @@ spec:
               test -s "${WORK}/b-flag/attestation/bundle-attestation.sigstore.json"
               test -s "${WORK}/b-flag/attestation/aicr-attestation.sigstore.json"
               test -s "${WORK}/b-flag/checksums.txt"
+
+              # The freshly signed bundle attestation must land in a Rekor v2
+              # shard (log<YEAR>-<rev>.rekor.sigstore.dev), not v1
+              # (rekor.sigstore.dev). Guards against the signing default silently
+              # reverting to Rekor v1. The regex is rotation-safe across yearly
+              # shards; validated against log2025-1.rekor.sigstore.dev. If a
+              # future shard adopts a non-numeric revision suffix, widen it here.
+              # See NVIDIA/aicr#1650.
+              ORIGIN="$(jq -r '.verificationMaterial.tlogEntries[0].inclusionProof.checkpoint.envelope' \
+                "${WORK}/b-flag/attestation/bundle-attestation.sigstore.json" | head -1)"
+              echo "${ORIGIN}" | grep -qE '^log[0-9]{4}-[0-9]+\.rekor\.sigstore\.dev'
             check:
               ($error == null): true
 
@@ -112,6 +123,13 @@ spec:
 
               test -s "${WORK}/b-env/attestation/bundle-attestation.sigstore.json"
               test -s "${WORK}/b-env/attestation/aicr-attestation.sigstore.json"
+
+              # Same v2-shard guard as the b-flag step: the env-sourced token path
+              # is the same default signing code path, so assert it also lands in a
+              # Rekor v2 shard (log<YEAR>-<rev>.rekor.sigstore.dev), not v1.
+              ORIGIN="$(jq -r '.verificationMaterial.tlogEntries[0].inclusionProof.checkpoint.envelope' \
+                "${WORK}/b-env/attestation/bundle-attestation.sigstore.json" | head -1)"
+              echo "${ORIGIN}" | grep -qE '^log[0-9]{4}-[0-9]+\.rekor\.sigstore\.dev'
             check:
               ($error == null): true
 


### PR DESCRIPTION
## Summary

AICR attestations now record their transparency-log entry in **Rekor v2** by default instead of Rekor v1, for both keyless OIDC and KMS-backed signing, with opt-outs to v1 and a `cosign v3` verification floor.

## Motivation / Context

Rekor v2 is Sigstore's tile-based transparency log. It matters here because it makes **release-identity monitoring feasible**: monitoring AICR's release signer on the Rekor v1 firehose is ~50x too slow to keep up (there is no index query for a keyless SAN identity), whereas v2's bulk tile reads make a single-worker scan keep up. This PR is the signing half of that move; the monitoring half rides on it.

The public-good Sigstore default still points other clients at Rekor v1, so AICR opts into v2 explicitly by consuming the Sigstore-maintained v2 signing config from TUF. Pre-1.0, adopting it early is a deliberate, low-cost choice.

Fixes: N/A
Related: #1650, #1149

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/trust`, `pkg/evidence`, `.goreleaser.yaml`, `.github/actions`

## Implementation Notes

- **v2 signing config from TUF, not hardcoded.** `pkg/trust` fetches Sigstore's `signing_config_rekor_v2` target; `aicr trust update` refreshes it alongside the trusted root, signing resolves it from cache with a bounded network fallback on a cold cache, and shard rotation is handled by Sigstore. Selection uses sigstore-go's `root.SelectServices` (prefers highest API version, so v2 wins), matching cosign.
- **Default computed at the CLI layer.** Library, server, and test callers of `ResolveOptions` keep their v1 zero-value behavior; only the signing commands flip. All signing paths (bundle, catalog, evidence, KMS) go through one `transparencyForOptions` policy selection and one `SignOptionsFromResolve` mapper, so a signing field cannot be dropped by one caller.
- **Fail-closed rules.** A v2 selection with no timestamp authority is rejected (v2 has no inline SET, so the bundle would lack trusted time); the release hooks error if signing is enabled but the config path is unset (no silent fall-back to v1).
- **Opt-outs preserve v1.** `--rekor-url` (private/public v1) and `--signing-config` (custom) are mutually exclusive; existing users on `--rekor-url` / `spec.bundle.rekorURL` are unaffected. KMS follows the same rules.
- **Release wiring.** The `go-build-release` action runs `aicr trust update --emit-signing-config` (cosign cannot fetch the TUF v2 config itself) and feeds `cosign attest-blob --signing-config` + `aicr recipe sign-catalog --signing-config`.

## Testing

```bash
make qualify
```

Full `make qualify` passes: `make test` (`-race`, 0 failures), coverage **77.8%** (floor 75%), lint, tuning-check, e2e (CLI chainsaw, 23/23), scan (no vulnerabilities). Proven end-to-end: a default keyless sign lands in `log2025-1.rekor.sigstore.dev` (v2) with an RFC3161 TSA timestamp and verifies through sigstore-go v1.2.2 (AICR's pinned version). A code review (superpowers:code-reviewer) caught and fixed a bug where evidence signing still went to v1; a drift-guard test now covers the shared mapper. `bundle-headless-oidc-ci` asserts the default lands in a v2 shard.

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

**Rollout notes:** Verifying v2 bundles requires **Cosign v3.0.1+**; the verify *commands* are unchanged (a bundle self-describes its log), and releases published before the cutover remain in Rekor v1 and verify with any recent Cosign. `aicr verify` handles both. KMS+v2 is exercised by the `kms-ministack` e2e workflow but was not run locally (no KMS key). A private/local v2 e2e stack (`rekor-tiles` + `timestamp-authority`) is deferred and tracked on #1650.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
