### PR TITLE
fix(bundler): emit disableValidation on CRD-dependent -post wrappers

### DIFF
--- a/docs/contributor/component.md
+++ b/docs/contributor/component.md
@@ -85,7 +85,7 @@ operator:
 - `healthCheck.assertFile:` — chainsaw conformance assertions ([validator.md](validator.md))
 - `storageClassPaths:` — where `--storage-class` is injected
 - `podScheduling.workload.workloadSelectorPaths` — for workload-pod placement
-- `gkeCriticalPriority`, `hasSelfRefCRDs` — narrow service-specific quirks (see godoc on `ComponentConfig` for when these apply)
+- `gkeCriticalPriority`, `hasSelfRefCRDs`, `manifestsUseChartCRDs` — narrow service-specific quirks (see godoc on `ComponentConfig` for when these apply)
 
 **4. Run `make bom-docs`** and commit the regenerated
 `docs/user/container-images.md` in the same PR. CLAUDE.md treats this
@@ -137,7 +137,7 @@ One-liner per field:
 | `storageClassPaths` | Where `--storage-class` is written |
 | `validations` | Bundle-time component check list ([validator.md](validator.md#component-validations-bundle-time)) |
 | `healthCheck.assertFile` | Chainsaw assert YAML path (relative to data dir) |
-| `gkeCriticalPriority`, `hasSelfRefCRDs` | Narrow service-specific flags (see godoc) |
+| `gkeCriticalPriority`, `hasSelfRefCRDs`, `manifestsUseChartCRDs` | Narrow service-specific flags (see godoc) |
 
 ## `nodeScheduling.system` vs `accelerated`
 

--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -100,6 +100,7 @@ components:
 | `healthCheck.assertFile` | string | **yes** | Chainsaw assert YAML (relative to data dir) consumed by `aicr validate --phase deployment` (runtime — #1220) and by `make check-health` locally. Content is restricted to the read-only `assert` / `error` operation allowlist. Enforced at PR time by `pkg/recipe.TestComponentRegistry_RequiresHealthCheck` (every component must declare a path) and `validators/chainsaw.TestValidateTestReadOnly_RegistryContent` (every declared path must pass the allowlist) — see #1223. |
 | `gkeCriticalPriority` | bool | no | Synthesize ResourceQuota on GKE so `system-*-critical` pods admit |
 | `hasSelfRefCRDs` | bool | no | Tells helmfile to emit `disableValidation: true` (chart ships CRD + CR in same release) |
+| `manifestsUseChartCRDs` | bool | no | Tells helmfile to emit `disableValidation: true` on the release carrying the attached manifests — the injected `-post` wrapper, or the collapsed vendored folder under `--vendor-charts` (manifests create CRs of CRDs the chart installs) |
 
 `HelmConfig`: `defaultRepository`, `defaultChart`, `defaultVersion`,
 `defaultNamespace`. `KustomizeConfig`: `defaultSource`, `defaultPath`,

--- a/pkg/bundler/deployer/helmfile/helmfile.go
+++ b/pkg/bundler/deployer/helmfile/helmfile.go
@@ -417,12 +417,14 @@ func writeTopHelmfile(outputDir string, subPaths []string) (string, int64, error
 
 // componentFlags captures the registry-derived behavioral flags that
 // affect how a component's release is rendered in the generated
-// helmfile. Today only HasSelfRefCRDs is consumed (it drives
-// disableValidation: true per release); the struct exists as a
-// gathering point so future per-release knobs can be added without
-// changing call signatures.
+// helmfile. HasSelfRefCRDs drives disableValidation: true on the
+// primary release; ManifestsUseChartCRDs drives it on the injected
+// -post wrapper release. The struct exists as a gathering point so
+// future per-release knobs can be added without changing call
+// signatures.
 type componentFlags struct {
-	HasSelfRefCRDs bool
+	HasSelfRefCRDs        bool
+	ManifestsUseChartCRDs bool
 }
 
 // componentFlagsByName returns a per-component map of registry flags
@@ -446,7 +448,8 @@ func componentFlagsByName(refs []recipe.ComponentRef, provider recipe.DataProvid
 			continue
 		}
 		out[ref.Name] = componentFlags{
-			HasSelfRefCRDs: cfg.HasSelfRefCRDs,
+			HasSelfRefCRDs:        cfg.HasSelfRefCRDs,
+			ManifestsUseChartCRDs: cfg.ManifestsUseChartCRDs,
 		}
 	}
 	return out, nil

--- a/pkg/bundler/deployer/helmfile/helmfile_test.go
+++ b/pkg/bundler/deployer/helmfile/helmfile_test.go
@@ -542,6 +542,122 @@ func TestBuildHelmfile_DisableValidationPrimaryOnly(t *testing.T) {
 	}
 }
 
+// TestBuildHelmfile_DisableValidationPostManifests asserts that the
+// registry flag ManifestsUseChartCRDs emits `disableValidation: true`
+// on the release whose folder carries the post-phase manifests
+// (Folder.CarriesPostManifests) — not the primary, not the -pre
+// wrapper. The manifests instantiate CRs whose CRDs the parent chart
+// installs at apply time; because the folder shares the parent's DAG
+// level, helm-diff runs its REST-mapper check before the parent has
+// applied, so on a fresh cluster the check can never pass
+// (network-operator's NicClusterPolicy on AKS is the canonical case).
+// The primary keeps validation: its own chart renders no CRs of
+// unregistered CRDs, and #929's typo-check argument still holds for
+// -pre wrappers, whose manifests apply before the chart and therefore
+// cannot depend on its CRDs.
+func TestBuildHelmfile_DisableValidationPostManifests(t *testing.T) {
+	folders := []localformat.Folder{
+		{Index: 1, Dir: "001-network-operator-pre", Kind: localformat.KindLocalHelm,
+			Name: "network-operator-pre", Parent: "network-operator"},
+		{Index: 2, Dir: "002-network-operator", Kind: localformat.KindUpstreamHelm,
+			Name: "network-operator", Parent: "network-operator",
+			Upstream: &localformat.Upstream{Chart: "network-operator", Repo: "https://helm.ngc.nvidia.com/nvidia", Version: "26.1.1"}},
+		{Index: 3, Dir: "003-network-operator-post", Kind: localformat.KindLocalHelm,
+			Name: "network-operator-post", Parent: "network-operator",
+			CarriesPostManifests: true},
+	}
+	ns := map[string]string{"network-operator": "nvidia-network-operator"}
+	flags := map[string]componentFlags{"network-operator": {ManifestsUseChartCRDs: true}}
+	doc, err := buildHelmfile(folders, ns, nil, flags)
+	if err != nil {
+		t.Fatalf("buildHelmfile() error = %v", err)
+	}
+	if len(doc.Releases) != 3 {
+		t.Fatalf("expected 3 releases (pre + primary + post), got %d", len(doc.Releases))
+	}
+	if doc.Releases[0].DisableValidation {
+		t.Error("release[0] (network-operator-pre) DisableValidation = true, want false — " +
+			"-pre manifests apply before the chart and cannot depend on its CRDs")
+	}
+	if doc.Releases[1].DisableValidation {
+		t.Error("release[1] (network-operator) DisableValidation = true, want false — " +
+			"the primary chart has no self-referencing CRDs; only the post-manifest folder needs the bypass")
+	}
+	if !doc.Releases[2].DisableValidation {
+		t.Error("release[2] (network-operator-post) DisableValidation = false, want true — " +
+			"the wrapper's CRs reference CRDs the parent installs after the wrapper's diff runs")
+	}
+}
+
+// TestBuildHelmfile_DisableValidationVendoredMixed pins the vendored
+// layout: under --vendor-charts a mixed component collapses into ONE
+// folder (Name == Parent, no -post split) whose templates/ embed the
+// post-phase manifests as post-install hooks, so a release-name-suffix
+// check would silently skip the bypass there. The marker travels with
+// the manifests instead: the collapsed folder gets disableValidation
+// when the flag is set, and a vendored pure-Helm sibling (no post
+// manifests, no marker) keeps the mapper check.
+func TestBuildHelmfile_DisableValidationVendoredMixed(t *testing.T) {
+	folders := []localformat.Folder{
+		{Index: 1, Dir: "001-network-operator", Kind: localformat.KindLocalHelm,
+			Name: "network-operator", Parent: "network-operator",
+			CarriesPostManifests: true},
+		{Index: 2, Dir: "002-nfd", Kind: localformat.KindLocalHelm,
+			Name: "nfd", Parent: "nfd"},
+	}
+	ns := map[string]string{"network-operator": "nvidia-network-operator", "nfd": "node-feature-discovery"}
+	flags := map[string]componentFlags{"network-operator": {ManifestsUseChartCRDs: true}}
+	doc, err := buildHelmfile(folders, ns, nil, flags)
+	if err != nil {
+		t.Fatalf("buildHelmfile() error = %v", err)
+	}
+	if len(doc.Releases) != 2 {
+		t.Fatalf("expected 2 releases, got %d", len(doc.Releases))
+	}
+	if !doc.Releases[0].DisableValidation {
+		t.Error("release[0] (vendored mixed network-operator) DisableValidation = false, want true — " +
+			"the collapsed vendored folder carries the CRD-dependent post manifests as hook templates")
+	}
+	if doc.Releases[1].DisableValidation {
+		t.Error("release[1] (vendored pure-Helm nfd) DisableValidation = true, want false — " +
+			"no post manifests, the mapper check must stay on")
+	}
+}
+
+// TestBuildHelmfile_DisableValidationBothFlags pins the kubeflow-trainer
+// shape: hasSelfRefCRDs covers the primary (its templates create CRs of
+// CRDs in its own crds/, #914) while manifestsUseChartCRDs covers the
+// injected -post wrapper (platform-kubeflow attaches a
+// ClusterTrainingRuntime CR as manifestFiles). Both releases need the
+// helm-diff bypass; each flag stays scoped to its own release.
+func TestBuildHelmfile_DisableValidationBothFlags(t *testing.T) {
+	folders := []localformat.Folder{
+		{Index: 1, Dir: "001-kubeflow-trainer", Kind: localformat.KindUpstreamHelm,
+			Name: "kubeflow-trainer", Parent: "kubeflow-trainer",
+			Upstream: &localformat.Upstream{Chart: "trainer", Repo: "oci://ghcr.io/kubeflow/charts", Version: "v2.1.0"}},
+		{Index: 2, Dir: "002-kubeflow-trainer-post", Kind: localformat.KindLocalHelm,
+			Name: "kubeflow-trainer-post", Parent: "kubeflow-trainer",
+			CarriesPostManifests: true},
+	}
+	ns := map[string]string{"kubeflow-trainer": "kubeflow-system"}
+	flags := map[string]componentFlags{"kubeflow-trainer": {HasSelfRefCRDs: true, ManifestsUseChartCRDs: true}}
+	doc, err := buildHelmfile(folders, ns, nil, flags)
+	if err != nil {
+		t.Fatalf("buildHelmfile() error = %v", err)
+	}
+	if len(doc.Releases) != 2 {
+		t.Fatalf("expected 2 releases (primary + post), got %d", len(doc.Releases))
+	}
+	if !doc.Releases[0].DisableValidation {
+		t.Error("release[0] (kubeflow-trainer) DisableValidation = false, want true — " +
+			"hasSelfRefCRDs covers the primary's own CR templates (#914)")
+	}
+	if !doc.Releases[1].DisableValidation {
+		t.Error("release[1] (kubeflow-trainer-post) DisableValidation = false, want true — " +
+			"manifestsUseChartCRDs covers the wrapper's ClusterTrainingRuntime manifest")
+	}
+}
+
 // TestGenerate_NamespaceOwningPreManifest is the integration counterpart:
 // a pre-manifest containing a Namespace resource flows end-to-end through
 // localformat.Write → buildHelmfile and surfaces as `createNamespace: false`

--- a/pkg/bundler/deployer/helmfile/releases.go
+++ b/pkg/bundler/deployer/helmfile/releases.go
@@ -95,15 +95,15 @@ type Release struct {
 	// (true) applies otherwise. Pointer so a deliberate false survives
 	// YAML marshaling and a nil value omits the field entirely.
 	CreateNamespace *bool `yaml:"createNamespace,omitempty"`
-	// DisableValidation is emitted when the chart self-references its
-	// own CRDs at diff time (registry flag HasSelfRefCRDs). helm-diff
-	// will skip the live-cluster REST-mapper check for this release,
-	// letting render succeed when a template creates a CR whose CRD
-	// is shipped under `crds/` in the same chart and not yet present
-	// in the cluster. Scoped to the primary release only — injected
-	// -pre / -post wrapper folders carry raw manifests, not the
-	// self-ref chart, so they keep the safety check. Issues #914,
-	// #929.
+	// DisableValidation tells helm-diff to skip the live-cluster
+	// REST-mapper check for this release, letting render succeed when
+	// a manifest creates a CR whose CRD is not yet present in the
+	// cluster. Emitted in two registry-driven cases: on the primary
+	// release when the chart self-references its own CRDs
+	// (HasSelfRefCRDs), and on the injected -post wrapper when its
+	// manifests instantiate CRs of CRDs the parent chart installs
+	// (ManifestsUseChartCRDs). All other wrappers keep the safety
+	// check. Issues #914, #929.
 	DisableValidation bool `yaml:"disableValidation,omitempty"`
 }
 
@@ -220,6 +220,24 @@ func buildHelmfile(folders []localformat.Folder, namespaceByComponent map[string
 		// the wrapper's manifests — a typo in a resource Kind would
 		// render at diff time and fail at apply. See issue #929.
 		if f.Name == f.Parent && flags[f.Parent].HasSelfRefCRDs {
+			rel.DisableValidation = true
+		}
+		// ManifestsUseChartCRDs is the post-manifest counterpart: the
+		// component's attached manifests instantiate CRs whose CRDs the
+		// component's own chart installs. The manifest-bearing folder
+		// shares the parent's DAG level, and helmfile diffs every
+		// release in a level before applying any — the `needs:` edge
+		// orders apply, not diff — so on a fresh cluster its mapper
+		// check can never pass (network-operator's NicClusterPolicy on
+		// AKS; kubeflow-trainer's ClusterTrainingRuntime). Keyed off
+		// Folder.CarriesPostManifests, which both the injected -post
+		// wrapper and the collapsed vendored mixed folder set — a
+		// release-name suffix check would silently miss the vendored
+		// layout, where Name == Parent. Primaries without post
+		// manifests and -pre wrappers (whose manifests apply before
+		// the chart and cannot depend on its CRDs) keep the mapper
+		// sanity check per issue #929.
+		if f.CarriesPostManifests && flags[f.Parent].ManifestsUseChartCRDs {
 			rel.DisableValidation = true
 		}
 

--- a/pkg/bundler/deployer/localformat/folder.go
+++ b/pkg/bundler/deployer/localformat/folder.go
@@ -67,4 +67,14 @@ type Folder struct {
 	// --create-namespace because that namespace lacks the release's
 	// ownership annotations.
 	CreateNamespace bool
+	// CarriesPostManifests is true when this folder's chart contains the
+	// component's post-phase raw manifests: the injected "<name>-post"
+	// wrapper for non-vendored mixed components, or the single vendored
+	// wrapper whose templates/ embed the manifests as post-install hooks
+	// (VendorCharts collapses mixed components into one folder). Deployers
+	// key manifest-specific per-release behavior off this marker (e.g.
+	// helmfile's disableValidation for ManifestsUseChartCRDs components)
+	// instead of re-deriving the folder shape from release-name suffixes,
+	// which the vendored layout does not carry.
+	CarriesPostManifests bool
 }

--- a/pkg/bundler/deployer/localformat/vendor_folder.go
+++ b/pkg/bundler/deployer/localformat/vendor_folder.go
@@ -190,6 +190,11 @@ func writeVendoredHelmFolder(
 		// render; the chart-owns-Namespace detection does not apply
 		// here. Default to true to match the upstream-helm path.
 		CreateNamespace: true,
+		// Mixed components collapse into this single folder under
+		// VendorCharts, so the post-phase manifests live in its
+		// templates/ as post-install hooks (see writeMixedManifests
+		// above) — the marker travels with them.
+		CarriesPostManifests: len(manifests) > 0,
 	}, rec, nil
 }
 

--- a/pkg/bundler/deployer/localformat/vendor_write_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_write_test.go
@@ -83,6 +83,9 @@ func TestWrite_VendorCharts_PureHelm(t *testing.T) {
 	if !strings.HasPrefix(want, "001-") {
 		t.Errorf("dir prefix = %q, want 001-", want)
 	}
+	if folders[0].CarriesPostManifests {
+		t.Error("folders[0].CarriesPostManifests = true, want false — pure-Helm vendored folder has no post manifests")
+	}
 
 	// Wrapper Chart.yaml present and references the vendored subchart.
 	chartYAML, err := os.ReadFile(filepath.Join(outDir, folders[0].Dir, "Chart.yaml"))
@@ -154,6 +157,10 @@ func TestWrite_VendorCharts_Mixed(t *testing.T) {
 	}
 	if len(recs) != 1 {
 		t.Fatalf("got %d vendor records, want 1", len(recs))
+	}
+	if !folders[0].CarriesPostManifests {
+		t.Error("folders[0].CarriesPostManifests = false, want true — the collapsed vendored folder " +
+			"embeds the post manifests as hook templates and deployers key the helm-diff bypass off this marker")
 	}
 
 	// Manifest in templates/ has post-install hook annotation.

--- a/pkg/bundler/deployer/localformat/writer.go
+++ b/pkg/bundler/deployer/localformat/writer.go
@@ -192,6 +192,10 @@ func (opts *Options) injectAuxiliaryFolder(idx int, c Component, phase injection
 	if err != nil {
 		return nil, err
 	}
+	// Mark the post wrapper so deployers can key manifest-specific
+	// behavior off the folder shape (see Folder.CarriesPostManifests);
+	// the vendored writer sets the same marker on its collapsed folder.
+	f.CarriesPostManifests = phase == phasePost
 	return &f, nil
 }
 

--- a/pkg/bundler/deployer/localformat/writer_test.go
+++ b/pkg/bundler/deployer/localformat/writer_test.go
@@ -295,6 +295,12 @@ metadata:
 	if folders[1].Name != "gpu-operator-post" {
 		t.Errorf("folders[1].Name = %q, want gpu-operator-post", folders[1].Name)
 	}
+	if folders[0].CarriesPostManifests {
+		t.Error("folders[0].CarriesPostManifests = true, want false — primary carries no post manifests")
+	}
+	if !folders[1].CarriesPostManifests {
+		t.Error("folders[1].CarriesPostManifests = false, want true — deployers key the helm-diff bypass off this marker")
+	}
 
 	// Primary has NO Chart.yaml (upstream-helm)
 	if _, err := os.Stat(filepath.Join(outDir, "001-gpu-operator", "Chart.yaml")); !os.IsNotExist(err) {

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -108,6 +108,27 @@ type ComponentConfig struct {
 	// templates create a ClusterPolicy CR of the ClusterPolicy CRD it
 	// ships in `crds/`. See https://github.com/NVIDIA/aicr/issues/914.
 	HasSelfRefCRDs bool `yaml:"hasSelfRefCRDs,omitempty"`
+
+	// ManifestsUseChartCRDs signals that the component's attached
+	// manifestFiles (wrapped by the bundler into an injected -post
+	// local-helm release) instantiate CRs whose CRDs this component's
+	// own chart installs at apply time. The -post wrapper shares the
+	// parent's DAG level, so the stratified sub-helmfile layout (see
+	// HasSelfRefCRDs above) does not help: helmfile diffs every
+	// release in a level before applying any of them, and the `needs:`
+	// edge orders apply, not diff — on a fresh cluster the wrapper's
+	// helm-diff REST-mapper check can therefore never pass. This flag
+	// instructs the helmfile deployer to emit `disableValidation: true`
+	// on the release whose folder carries the post-phase manifests —
+	// the injected -post wrapper, or the collapsed single folder under
+	// --vendor-charts (mixed components do not split there). Releases
+	// without post manifests and -pre wrappers keep the mapper check;
+	// see issue #929. Canonical examples: network-operator (the AKS
+	// overlay attaches a NicClusterPolicy CR whose CRD the chart
+	// installs) and kubeflow-trainer (platform-kubeflow attaches a
+	// ClusterTrainingRuntime CR of the CRD shipped in the chart's
+	// crds/).
+	ManifestsUseChartCRDs bool `yaml:"manifestsUseChartCRDs,omitempty"`
 }
 
 // HealthCheckConfig defines custom health check settings for a component.

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -125,6 +125,17 @@ components:
     displayName: network-operator
     valueOverrideKeys:
       - networkoperator
+    # Overlays attach NicClusterPolicy CRs (mellanox.com API group) as
+    # manifestFiles — e.g. aks.yaml's nic-cluster-policy-aks.yaml —
+    # which the bundler wraps into the injected network-operator-post
+    # release. Those CRDs are installed by this chart at apply time,
+    # but the wrapper shares the parent's sub-helmfile level and
+    # helm-diff runs before anything in the level applies, so on a
+    # fresh cluster the wrapper's REST-mapper check can never pass
+    # ("no matches for kind NicClusterPolicy"). This flag emits
+    # disableValidation: true on the -post wrapper release only.
+    # See issues #914 and #929 for the pattern.
+    manifestsUseChartCRDs: true
     healthCheck:
       assertFile: checks/network-operator/health-check.yaml
     helm:
@@ -574,6 +585,15 @@ components:
     # on this release tells helm-diff to skip the live-mapper check.
     # See https://github.com/NVIDIA/aicr/issues/914.
     hasSelfRefCRDs: true
+    # recipes/mixins/platform-kubeflow.yaml additionally attaches
+    # torch-distributed-cluster-training-runtime.yaml (a
+    # ClusterTrainingRuntime CR of the CRD this chart ships) as
+    # manifestFiles, which the bundler wraps into the injected
+    # kubeflow-trainer-post release (or the chart's own vendored
+    # wrapper under --vendor-charts). hasSelfRefCRDs above covers only
+    # the primary release (#929); this flag extends the helm-diff
+    # bypass to the manifest-bearing folder. See #1666.
+    manifestsUseChartCRDs: true
     healthCheck:
       assertFile: checks/kubeflow-trainer/health-check.yaml
     helm:


### PR DESCRIPTION
## Summary

Helmfile bundles now emit `disableValidation: true` on an injected `-post` wrapper release when its manifests instantiate CRs of CRDs the parent chart installs, via a new registry flag `manifestsUseChartCRDs` (set on `network-operator`). Fixes fresh-cluster `helmfile apply` failing with `no matches for kind "NicClusterPolicy" in version "mellanox.com/v1alpha1"`.

## Motivation / Context

The AKS overlay attaches `nic-cluster-policy-aks.yaml` (a `NicClusterPolicy` CR) as `manifestFiles` on `network-operator`; the bundler wraps it into the injected `network-operator-post` release. That wrapper shares the parent's sub-helmfile level, and helmfile diffs every release in a level before applying any — the `needs:` edge orders apply, not diff — so on a fresh cluster helm-diff's REST-mapper check runs before the parent has installed the CRDs and can never pass. The existing `disableValidation` mitigation (#914) is deliberately scoped to primary releases (#929), which didn't account for wrapper manifests depending on parent-shipped CRDs.

Fixes: #1666
Related: #914, #929

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New registry flag `manifestsUseChartCRDs` mirrors `hasSelfRefCRDs` (#914) and is plumbed through the same `componentFlags` path; emission is scoped to `f.Name == f.Parent+"-post"` so primary releases and `-pre` wrappers (whose manifests apply before the chart and cannot depend on its CRDs) keep helm-diff's mapper typo-check per #929.
- `make bom-docs` run: no change (comment/flag-only registry edit).

## Testing

```bash
make qualify   # PASS
```

- New `TestBuildHelmfile_DisableValidationPostManifests` pins pre/primary/post emission (written first, red on the missing field).
- Coverage: `pkg/bundler/deployer/helmfile` 85.6% → 86.9% (+1.3%).
- Live verification on a fresh AKS cluster (`aicr-test1`, K8s 1.35.5) that reproduced #1666: with the flag emitted, the previously-fatal `network-operator-post` diff passes, `helmfile apply` completes (exit 0), and the `NicClusterPolicy` CR is created; regenerating the bundle from the same recipe with the patched binary emits `disableValidation: true` on `network-operator-post` automatically.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Only affects newly generated helmfile bundles for recipes whose components carry the new flag (today: `network-operator` with attached manifests, i.e. AKS). Existing bundles are unchanged; regenerate to pick up the fix.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)