### PR TITLE
fix(recipes): pin toolkit containerd config source to file on AKS

### DIFF
--- a/recipes/components/gpu-operator/values-aks-training.yaml
+++ b/recipes/components/gpu-operator/values-aks-training.yaml
@@ -40,3 +40,17 @@ validator:
     env:
       - name: WITH_WORKLOAD
         value: "false"
+
+# AKS Ubuntu 24.04 GPU nodes run containerd 2.x (2.3 on current node
+# images) with a version=2 root config at /etc/containerd/config.toml. The container-toolkit's default
+# config source ("command" = `containerd config dump`) returns the
+# MIGRATED effective config (version=4), so the generated
+# /etc/containerd/conf.d/99-nvidia.toml declares a higher version than
+# the root file and containerd refuses to start ("drop-in config
+# version 4 higher than root config version 2"), taking the node
+# NotReady. Reading the on-disk file instead emits a matching
+# version=2 drop-in. See issue #1688.
+toolkit:
+  env:
+    - name: RUNTIME_CONFIG_SOURCE
+      value: file

--- a/recipes/components/gpu-operator/values-aks.yaml
+++ b/recipes/components/gpu-operator/values-aks.yaml
@@ -68,3 +68,17 @@ driver:
 #   serviceMonitor:
 #     additionalLabels:
 #       release: kube-prometheus  # Must match kube-prometheus-stack Helm release name
+
+# AKS Ubuntu 24.04 GPU nodes run containerd 2.x (2.3 on current node
+# images) with a version=2 root config at /etc/containerd/config.toml. The container-toolkit's default
+# config source ("command" = `containerd config dump`) returns the
+# MIGRATED effective config (version=4), so the generated
+# /etc/containerd/conf.d/99-nvidia.toml declares a higher version than
+# the root file and containerd refuses to start ("drop-in config
+# version 4 higher than root config version 2"), taking the node
+# NotReady. Reading the on-disk file instead emits a matching
+# version=2 drop-in. See issue #1688.
+toolkit:
+  env:
+    - name: RUNTIME_CONFIG_SOURCE
+      value: file


### PR DESCRIPTION
## Summary

Sets `RUNTIME_CONFIG_SOURCE=file` on the gpu-operator container-toolkit in both AKS values variants, so the toolkit's containerd drop-in matches the on-disk root config version instead of the migrated (`containerd config dump`) version that kills containerd on AKS Ubuntu 24.04.

## Motivation / Context

nvidia-container-toolkit v1.19.1 (shipped by gpu-operator v26.3.2) defaults its containerd config source to `["command", "file"]`; the `command` loader returns the migrated effective config — `version = 4` on containerd 2.2 — while AKS's on-disk `/etc/containerd/config.toml` declares `version = 2`. The generated `/etc/containerd/conf.d/99-nvidia.toml` then carries a higher version than the root config, containerd fails to start (`drop-in config version 4 higher than root config version 2`), and every GPU node goes NotReady with kubelet down. Toolkit refs (v1.19.1): default `ConfigSources` in `cmd/nvidia-ctk-installer/container/runtime/runtime.go` (env `RUNTIME_CONFIG_SOURCE`), version derived from the source loader in `pkg/config/engine/containerd/containerd.go`.

Fixes: #1688

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`recipes/` components, overlays, values)

## Implementation Notes

- The env is added to **both** `values-aks.yaml` and `values-aks-training.yaml` because `aks-training.yaml` *replaces* (does not chain) the componentRef's `valuesFile`.
- Scoped to AKS, where the mismatch is reproduced and the fix verified; other services' node images have not exhibited the mismatch (nightly UAT green on EKS/GKE with the same gpu-operator pin).
- `make bom-docs` run: no change (env-only values edit).

## Testing

```bash
make qualify   # PASS
```

- Hydration verified for both AKS recipe shapes: `aicr query --service aks --accelerator h100 --intent {training,inference} --os ubuntu --selector components.gpu-operator.values.toolkit` returns the env in both.
- Live verification on AKS `aicr-test1` (K8s 1.35.5, Ubuntu 24.04, containerd 2.2), which reproduced #1688 with both GPU nodes NotReady: with `RUNTIME_CONFIG_SOURCE=file` applied via ClusterPolicy, the toolkit regenerates the drop-in as `version = 2`, containerd stays up, the full gpu-operator stack converges (validators Completed), and `nvidia.com/gpu: 8` is allocatable on both nodes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Affects newly generated AKS bundles only. Clusters already broken by the v4 drop-in additionally need the stale `/etc/containerd/conf.d/99-nvidia.toml` removed and containerd/kubelet restarted before the corrected toolkit pod can run (documented in #1688).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)