### PR TITLE
fix(recipes): raise ebs-csi node sidecar memory limits for p5 nodes

### DIFF
--- a/recipes/components/aws-ebs-csi-driver/values.yaml
+++ b/recipes/components/aws-ebs-csi-driver/values.yaml
@@ -54,6 +54,34 @@ node:
     rollingUpdate:
       maxUnavailable: "10%"
 
+# Sidecar memory limits. The chart defaults (32Mi) are too tight for the node
+# DaemonSet's livenessProbe / node-driver-registrar containers on high-core
+# instances (e.g. p5.48xlarge, 192 vCPU). The Go binary's resident set alone is
+# ~24Mi (file-rss); adding per-P runtime overhead (Go sizes runtime structures
+# by GOMAXPROCS, which defaults to the host core count) pushes the working set
+# to ~31.7Mi during cold start under bringup load, cgroup-OOM-killing
+# livenessProbe (observed: CONSTRAINT_MEMCG, RSS 31.7Mi vs 32Mi). Killing the
+# livenessProbe removes the /healthz endpoint the ebs-plugin livenessProbe
+# depends on, so kubelet restarts ebs-plugin -> CrashLoopBackOff -> the
+# aws-ebs-csi-driver health check trips -> expected-resources (deployment
+# validation) fails. 128Mi gives headroom above the observed peak and is
+# independent of instance core count.
+sidecars:
+  nodeDriverRegistrar:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 128Mi
+  livenessProbe:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 128Mi
+
 storageClasses: []
 
 # Provision a cluster-default StorageClass (ebs-csi-default-sc: gp3,


### PR DESCRIPTION
## Summary

Raise the `aws-ebs-csi-driver` node DaemonSet sidecar memory limits (`livenessProbe`, `nodeDriverRegistrar`) from the chart-default 32Mi to 128Mi, so they don't OOM on high-core GPU instances (p5.48xlarge, 192 vCPU).

## Motivation / Context

On p5.48xlarge UAT clusters, `expected-resources` (deployment-phase validation) intermittently-to-consistently fails on the `aws-ebs-csi-driver` health check:

```
[chainsaw] aws-ebs-csi-driver: health check failed:
Pod kube-system/ebs-csi-node-... matches forbidden shape
(phase=Running, waiting=CrashLoopBackOff, ...)
```

Root cause (from node dmesg during bringup):

```
livenessprobe invoked oom-killer ... constraint=CONSTRAINT_MEMCG
Memory cgroup out of memory: Killed process (livenessprobe)
total-vm:1368464kB, anon-rss:7680kB, file-rss:24032kB   → RSS ≈ 31.7 MB vs 32 MiB limit
```

The chart's 32Mi limit on the node sidecars is too tight on high-core nodes. The Go binary's resident set alone is ~24 MiB (`file-rss`); per-P runtime overhead (Go sizes runtime structures by `GOMAXPROCS`, which defaults to the host core count — 192 on p5) pushes the working set to ~31.7 MiB during cold start under bringup load, cgroup-OOM-killing the `livenessProbe` container. That removes the `/healthz` endpoint the `ebs-plugin` livenessProbe depends on → kubelet restarts `ebs-plugin` → CrashLoopBackOff → the `aws-ebs-csi-driver` health check trips → `expected-resources` fails → UAT fails on p5. The smaller `m7i.xlarge` system nodes never hit this (fewer cores → smaller runtime footprint), which is why it is p5-specific.

Fix: give both node sidecars headroom above the observed ~31.7 MiB peak (128Mi), independent of instance core count.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — component values (`recipes/components/aws-ebs-csi-driver/values.yaml`)

## Implementation Notes

- Adds a `sidecars:` block setting `nodeDriverRegistrar` and `livenessProbe` limits to 128Mi (requests unchanged at 40Mi). These sidecar keys apply to both node and controller instances in the chart.
- `GOMAXPROCS` pinning was considered but deliberately not used as the fix: forensics show it is a minor contributor (~5 MiB of the working set), and raising the limit is the deterministic, core-count-independent fix. It can be added later as defense-in-depth if desired.
- No image, chart version, or pin changes — the BOM is unaffected.

## Testing

```bash
# values-only change (no Go); validated by:
yq '.sidecars' recipes/components/aws-ebs-csi-driver/values.yaml   # parses, limits applied
```

- Diagnosed on a live p5 UAT cluster: confirmed the cgroup-OOM chain end-to-end via node dmesg, per-container exit codes (`livenessprobe` exit 137/OOMKilled at 32Mi; `ebs-plugin` exit 2 from liveness kill), and the failing `aws-ebs-csi-driver` chainsaw assert.
- **Honest caveat on validation:** the OOM only manifests under real bringup load (cold cache + 192-core CPU/memory contention). It could not be reproduced on the same node 3h post-bringup once quiesced, so this fix is justified deductively (a cgroup-OOM at a measured 31.7 MiB peak is eliminated by a 128 MiB limit) rather than by a live A/B. Full validation will come from the next p5 UAT bringup with this change in place.
- No Go changes, so the mandatory Go lint gate does not apply; CI (`make qualify`) covers recipe/render checks.

## Risk Assessment

- [x] **Low** — Isolated change (a single component's sidecar memory limits), trivially revertible, cannot regress smaller nodes (they used far less than 32Mi already).

**Rollout notes:** Takes effect on the next deploy/UAT bringup. Backwards compatible; no migration.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A (no Go changes)
- [ ] Linter passes (`make lint`) — N/A (values-only)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (component values)
- [x] I updated docs if user-facing behavior changed — N/A (internal deploy tuning)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
