### PR TITLE
feat(evidence): mode-aware CNCF dra-support and secure-access collection

### DIFF
--- a/demos/cuj2-demo.md
+++ b/demos/cuj2-demo.md
@@ -291,9 +291,11 @@ http://127.0.0.1:9090/chat.html
 
     Feature                  Description
     ──────────────────────── ─────────────────────────────────────────────
-    dra-support              DRA support test (full-GPU DRA ResourceClaim; #1629)
+    dra-support              DRA support test (mode-aware: full-GPU claim under DRA
+                             policy, slice-evidence N/A path under device-plugin)
     gang-scheduling          Gang scheduling co-scheduling test
-    secure-access            Secure accelerator access (DRA ResourceClaim isolation)
+    secure-access            Secure accelerator access (device-plugin or DRA
+                             ResourceClaim isolation, policy/mode-selected)
     accelerator-metrics      Accelerator & AI service metrics
     inference-gateway        Inference API gateway conditions
     robust-operator          Robust AI operator + webhook test

--- a/docs/conformance/cncf/index.md
+++ b/docs/conformance/cncf/index.md
@@ -103,7 +103,7 @@ names are `dra`, `gang`, `secure`, `accelerator-metrics`, `service-metrics`,
 | **Speed** | ~3 minutes | ~5-10 minutes |
 | **Deploys workloads** | Yes (GPU allocation via DRA or device plugin, gang, HPA, secure access) | Yes (all + GPU stress test) |
 | **Output** | Pass/fail + diagnostic artifacts | Detailed behavioral evidence (command outputs, logs, metrics) |
-| **GPU allocation test** | secure-accelerator-access deploys a test pod via DRA or the device plugin (capability-driven) and verifies GPU access + isolation; dra-support's full-GPU DRA behavioral subtest is recorded N/A on ComputeDomain-only clusters | DRA-only evidence script + nvidia-smi output capture (mode-aware collection tracked in [#1629](https://github.com/NVIDIA/aicr/issues/1629)) |
+| **GPU allocation test** | secure-accelerator-access deploys a test pod via DRA or the device plugin (capability-driven) and verifies GPU access + isolation; dra-support's full-GPU DRA behavioral subtest is recorded N/A on ComputeDomain-only clusters | Mode-aware evidence script (recipe policy selects the mode, standalone runs detect capability): behavioral full-GPU ResourceClaim test under DRA, device-plugin two-container isolation test + ResourceSlice evidence otherwise; nvidia-smi output capture |
 | **Gang scheduling test** | Deploys PodGroup, verifies co-scheduling | Same + worker logs |
 | **HPA autoscaling** | Metrics API + scale-up validation | CUDA GPU stress test + scale-up |
 | **Metrics** | Custom metrics API data-path verification | DCGM exporter + Prometheus queries |

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -627,9 +627,18 @@ Run validation without failing on check errors (informational mode):
 			}
 
 			// Short-circuit: --cncf-submission bypasses normal validation and runs
-			// the behavioral evidence collector directly.
+			// the behavioral evidence collector directly. When recipe context is
+			// available (--recipe or config input), the recipe's GPU allocation
+			// policy is resolved and threaded into the collector so the
+			// dra-support and secure-access sections are mode-aware (#1629);
+			// standalone runs pass no policy and keep capability-driven
+			// detection (#1327 contract).
 			if cncfSubmission {
-				return runCNCFSubmission(ctx, evidenceDir, features, cmd.String("kubeconfig"))
+				policy, policyErr := resolveCNCFAllocationPolicy(ctx, cmd, cfg, resolved)
+				if policyErr != nil {
+					return policyErr
+				}
+				return runCNCFSubmission(ctx, evidenceDir, features, cmd.String("kubeconfig"), policy)
 			}
 
 			phases, err := validator.ParsePhaseSelection(stringSliceFlagOrConfig(cmd, "phase", resolved.Phases))
@@ -773,9 +782,38 @@ Run validation without failing on check errors (informational mode):
 	}
 }
 
+// resolveCNCFAllocationPolicy resolves the recipe-configured GPU allocation
+// policy for --cncf-submission runs. Without recipe context (no --recipe flag
+// and no config recipe input) it returns "" — a standalone run keeps the
+// evidence script's capability-driven detection, mirroring the #1327 contract
+// ("only recipe-less standalone runs select automatically"). With recipe
+// context, load/resolution errors fail closed: an invalid allocation
+// configuration must not silently collect evidence for the wrong mechanism.
+func resolveCNCFAllocationPolicy(ctx context.Context, cmd *cli.Command, cfg *config.AICRConfig, resolved *config.ValidateResolved) (string, error) {
+	recipeFilePath := stringFlagOrConfig(cmd, "recipe", resolved.RecipePath)
+	if recipeFilePath == "" {
+		return "", nil
+	}
+
+	client, err := recipeClientFromCmd(cmd, cfg)
+	if err != nil {
+		return "", errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to initialize data provider")
+	}
+	defer func() { _ = client.Close() }()
+
+	slog.Info("loading recipe to resolve the GPU allocation policy for CNCF evidence collection", "uri", recipeFilePath)
+	rec, err := client.LoadRecipe(ctx, recipeFilePath, cmd.String("kubeconfig"))
+	if err != nil {
+		return "", err
+	}
+	return v1.ResolveGPUAllocationPolicy(ctx, rec.Resolved())
+}
+
 // runCNCFSubmission handles --cncf-submission: validates feature names and
-// runs the behavioral evidence collector against the live cluster.
-func runCNCFSubmission(ctx context.Context, evidenceDir string, features []string, kubeconfig string) error {
+// runs the behavioral evidence collector against the live cluster. policy is
+// the recipe-resolved GPU allocation policy ("" for standalone runs — see
+// resolveCNCFAllocationPolicy).
+func runCNCFSubmission(ctx context.Context, evidenceDir string, features []string, kubeconfig, policy string) error {
 	// Validate feature names.
 	for _, f := range features {
 		if !cncf.IsValidFeature(f) {
@@ -790,11 +828,15 @@ func runCNCFSubmission(ctx context.Context, evidenceDir string, features []strin
 	defer cancel()
 
 	slog.Info("starting CNCF submission evidence collection",
-		"evidenceDir", evidenceDir, "features", features)
+		"evidenceDir", evidenceDir, "features", features, "gpuAllocationPolicy", policy)
 
-	collector := cncf.NewCollector(evidenceDir,
+	opts := []cncf.CollectorOption{
 		cncf.WithFeatures(features),
 		cncf.WithKubeconfig(kubeconfig),
-	)
+	}
+	if policy != "" {
+		opts = append(opts, cncf.WithAllocationPolicy(policy))
+	}
+	collector := cncf.NewCollector(evidenceDir, opts...)
 	return collector.Run(ctx)
 }

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -22,7 +23,81 @@ import (
 	"testing"
 
 	"github.com/urfave/cli/v3"
+
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 )
+
+// TestResolveCNCFAllocationPolicy exercises the #1629 policy threading for
+// --cncf-submission runs: no recipe context resolves to an empty policy
+// (standalone runs keep the evidence script's capability detection), a
+// recipe-backed run resolves the policy from the hydrated recipe, and a
+// broken recipe path fails closed instead of silently collecting without a
+// policy. The validate Action is overridden so only the resolution flow runs
+// — never the collector (which would contact a live cluster).
+func TestResolveCNCFAllocationPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		recipeYAML string // written to a temp recipe file when non-empty
+		recipePath string // used verbatim when non-empty (overrides recipeYAML)
+		wantPolicy string
+		wantErr    bool
+	}{
+		{
+			name:       "no recipe context resolves empty policy",
+			wantPolicy: "",
+		},
+		{
+			name: "recipe context resolves the hydrated policy",
+			// Auto-hydrates from the embedded catalog; stock recipes default
+			// to device-plugin allocation since the #1327/#1671 flip.
+			recipeYAML: "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: test\nspec:\n  criteria:\n    service: eks\n    accelerator: h100\n    intent: training\n    os: ubuntu\n",
+			wantPolicy: v1.GPUAllocationPolicyDevicePluginExtendedResource,
+		},
+		{
+			name:       "unreadable recipe fails closed",
+			recipePath: filepath.Join(t.TempDir(), "does-not-exist.yaml"),
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{"validate", "--no-cluster"}
+			recipePath := tt.recipePath
+			if tt.recipeYAML != "" {
+				recipePath = filepath.Join(t.TempDir(), "recipe.yaml")
+				if err := os.WriteFile(recipePath, []byte(tt.recipeYAML), 0o600); err != nil {
+					t.Fatalf("failed to write test recipe file: %v", err)
+				}
+			}
+			if recipePath != "" {
+				args = append(args, "--recipe", recipePath)
+			}
+
+			var gotPolicy string
+			cmd := validateCmd()
+			cmd.Action = func(ctx context.Context, c *cli.Command) error {
+				cfg, err := loadCmdConfig(ctx, c)
+				if err != nil {
+					return err
+				}
+				resolved, err := cfg.Validation().Resolve()
+				if err != nil {
+					return err
+				}
+				gotPolicy, err = resolveCNCFAllocationPolicy(ctx, c, cfg, resolved)
+				return err
+			}
+			err := cmd.Run(t.Context(), args)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && gotPolicy != tt.wantPolicy {
+				t.Errorf("policy = %q, want %q", gotPolicy, tt.wantPolicy)
+			}
+		})
+	}
+}
 
 func TestValidateCmd_CommandStructure(t *testing.T) {
 	cmd := validateCmd()

--- a/pkg/evidence/cncf/claim_shape_test.go
+++ b/pkg/evidence/cncf/claim_shape_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cncf
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// runEmitClaim writes the embedded evidence script to a temp file and invokes
+// its hidden `emit-claim` subcommand — added exactly for this test so the
+// SHIPPED emitter function is exercised (not a copy) without contacting a
+// cluster. Returns the emitted YAML and the command error.
+func runEmitClaim(t *testing.T, version string) ([]byte, error) {
+	t.Helper()
+
+	scriptPath := filepath.Join(t.TempDir(), "collect-evidence.sh")
+	if err := os.WriteFile(scriptPath, collectScript, 0o700); err != nil { //nolint:gosec // test script needs execute permission
+		t.Fatalf("failed to write embedded script: %v", err)
+	}
+	//nolint:gosec // fixed binary name; args are test-table constants
+	return exec.Command("bash", scriptPath, "emit-claim",
+		version, "test-claim", "test-ns", "gpu.nvidia.com").Output()
+}
+
+// nestedMap walks a decoded YAML document through map keys, failing the test
+// when an intermediate value is missing or not a map.
+func nestedMap(t *testing.T, obj map[string]any, path ...string) map[string]any {
+	t.Helper()
+	current := obj
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			t.Fatalf("path %v: key %q missing or not a map (got %T)", path, key, current[key])
+		}
+		current = next
+	}
+	return current
+}
+
+// TestEmitResourceClaimShapes asserts the evidence script emits the
+// version-correct ResourceClaim schema for every resource.k8s.io API version
+// the collector supports, matching the vendored Kubernetes types
+// (vendor/k8s.io/api/resource/{v1,v1beta2,v1beta1}/types.go):
+//
+//   - v1 and v1beta2 wrap the request in `exactly`
+//     (spec.devices.requests[0].exactly.deviceClassName) and must NOT carry a
+//     bare deviceClassName on the request;
+//   - v1beta1 has no `exactly` wrapper — deviceClassName sits directly on the
+//     request.
+func TestEmitResourceClaimShapes(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping script emitter test")
+	}
+
+	tests := []struct {
+		name        string
+		version     string
+		wantExactly bool
+	}{
+		{"v1 uses exactly wrapper", "v1", true},
+		{"v1beta2 uses exactly wrapper", "v1beta2", true},
+		{"v1beta1 uses bare deviceClassName", "v1beta1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runEmitClaim(t, tt.version)
+			if err != nil {
+				t.Fatalf("emit-claim %s failed: %v (output: %s)", tt.version, err, out)
+			}
+
+			var claim map[string]any
+			if err := yaml.Unmarshal(out, &claim); err != nil {
+				t.Fatalf("emitted YAML does not parse: %v\n%s", err, out)
+			}
+
+			wantAPIVersion := "resource.k8s.io/" + tt.version
+			if got := claim["apiVersion"]; got != wantAPIVersion {
+				t.Errorf("apiVersion = %v, want %s", got, wantAPIVersion)
+			}
+			if got := claim["kind"]; got != "ResourceClaim" {
+				t.Errorf("kind = %v, want ResourceClaim", got)
+			}
+			metadata := nestedMap(t, claim, "metadata")
+			if got := metadata["name"]; got != "test-claim" {
+				t.Errorf("metadata.name = %v, want test-claim", got)
+			}
+			if got := metadata["namespace"]; got != "test-ns" {
+				t.Errorf("metadata.namespace = %v, want test-ns", got)
+			}
+
+			devices := nestedMap(t, claim, "spec", "devices")
+			requests, ok := devices["requests"].([]any)
+			if !ok || len(requests) != 1 {
+				t.Fatalf("spec.devices.requests = %v, want exactly one request", devices["requests"])
+			}
+			request, ok := requests[0].(map[string]any)
+			if !ok {
+				t.Fatalf("spec.devices.requests[0] is %T, want map", requests[0])
+			}
+			if got := request["name"]; got != "gpu" {
+				t.Errorf("request name = %v, want gpu", got)
+			}
+
+			// carrier is where deviceClassName/allocationMode/count must live:
+			// the `exactly` wrapper for v1/v1beta2, the request itself for
+			// v1beta1.
+			carrier := request
+			if tt.wantExactly {
+				if _, bare := request["deviceClassName"]; bare {
+					t.Errorf("%s request carries a bare deviceClassName — must be nested under exactly", tt.version)
+				}
+				exactly, ok := request["exactly"].(map[string]any)
+				if !ok {
+					t.Fatalf("%s request missing the exactly wrapper (got %T)", tt.version, request["exactly"])
+				}
+				carrier = exactly
+			} else {
+				if _, wrapped := request["exactly"]; wrapped {
+					t.Errorf("%s request carries an exactly wrapper — v1beta1 has no such field", tt.version)
+				}
+			}
+			if got := carrier["deviceClassName"]; got != "gpu.nvidia.com" {
+				t.Errorf("deviceClassName = %v, want gpu.nvidia.com", got)
+			}
+			if got := carrier["allocationMode"]; got != "ExactCount" {
+				t.Errorf("allocationMode = %v, want ExactCount", got)
+			}
+			if got := carrier["count"]; got != 1 {
+				t.Errorf("count = %v (%T), want 1", got, got)
+			}
+		})
+	}
+}
+
+// TestEmitResourceClaimRejectsUnknownVersion asserts the emitter fails closed
+// on an unsupported resource.k8s.io version instead of guessing a shape.
+func TestEmitResourceClaimRejectsUnknownVersion(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping script emitter test")
+	}
+
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"unknown version", "v2"},
+		{"empty version", ""},
+		{"retired alpha version", "v1alpha3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runEmitClaim(t, tt.version)
+			if err == nil {
+				t.Errorf("emit-claim %q succeeded, want failure (output: %s)", tt.version, out)
+			}
+		})
+	}
+}

--- a/pkg/evidence/cncf/collector.go
+++ b/pkg/evidence/cncf/collector.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -124,9 +125,9 @@ func ScriptSection(feature string) string {
 
 // FeatureDescriptions maps feature names to human-readable descriptions.
 var FeatureDescriptions = map[string]string{
-	featureDRASupport:         "DRA support test (submission collector deploys a gpu.nvidia.com ResourceClaim pod — requires full-GPU DRA; mode-aware collection: #1629)",
+	featureDRASupport:         "DRA support test (mode-aware: behavioral full-GPU ResourceClaim allocation under the DRA policy; ResourceSlice/API evidence with an N/A behavioral note under device-plugin)",
 	featureGangScheduling:     "Gang scheduling co-scheduling test",
-	featureSecureAccess:       "Secure accelerator access verification (submission collector exercises DRA ResourceClaim isolation — requires full-GPU DRA; device-plugin-mode collection: #1629)",
+	featureSecureAccess:       "Secure accelerator access verification (device-plugin two-container isolation or DRA ResourceClaim isolation, policy/mode-selected)",
 	featureAcceleratorMetrics: "Accelerator metrics (DCGM exporter)",
 	featureAIServiceMetrics:   "AI service metrics (Prometheus ServiceMonitor discovery)",
 	featureInferenceGateway:   "Inference API gateway conditions",
@@ -146,11 +147,12 @@ type sectionRunner func(ctx context.Context, scriptPath, scriptDir, section stri
 // Collector orchestrates behavioral evidence collection by invoking the
 // embedded collect-evidence.sh script against a live Kubernetes cluster.
 type Collector struct {
-	outputDir  string
-	features   []string
-	noCleanup  bool
-	noCluster  bool
-	kubeconfig string
+	outputDir        string
+	features         []string
+	noCleanup        bool
+	noCluster        bool
+	kubeconfig       string
+	allocationPolicy string
 
 	// runSectionFn is overridable in tests. Defaults to c.runSection.
 	runSectionFn sectionRunner
@@ -189,6 +191,19 @@ func WithNoCleanup(noCleanup bool) CollectorOption {
 func WithKubeconfig(kubeconfig string) CollectorOption {
 	return func(c *Collector) {
 		c.kubeconfig = kubeconfig
+	}
+}
+
+// WithAllocationPolicy threads the recipe-resolved GPU allocation policy
+// (#1327 contract: configuration selects the allocation policy) into the
+// evidence script as the AICR_GPU_ALLOCATION_POLICY environment variable, so
+// the dra-support and secure-access sections exercise the configured
+// mechanism (#1629). An empty policy means no recipe context (standalone
+// run): the variable is not set and the script falls back to capability
+// detection.
+func WithAllocationPolicy(policy string) CollectorOption {
+	return func(c *Collector) {
+		c.allocationPolicy = policy
 	}
 }
 
@@ -352,15 +367,27 @@ func (c *Collector) runSection(ctx context.Context, scriptPath, scriptDir, secti
 
 	cmd := exec.CommandContext(subCtx, "bash", scriptPath, section)
 	cmd.Dir = scriptDir
-	cmd.Env = append(os.Environ(),
+	// Strip any ambient AICR_GPU_ALLOCATION_POLICY: the script must see the
+	// policy the collector resolved (appended below when set) or nothing at
+	// all (standalone runs use capability detection). Inheriting a stray
+	// value from the parent shell/CI would silently override detection and
+	// collect evidence for the wrong mode.
+	env := slices.DeleteFunc(os.Environ(), func(kv string) bool {
+		return strings.HasPrefix(kv, "AICR_GPU_ALLOCATION_POLICY=")
+	})
+	env = append(env,
 		"EVIDENCE_DIR="+c.outputDir,
 		"SCRIPT_DIR="+scriptDir,
 	)
+	cmd.Env = env
 	if c.noCleanup {
 		cmd.Env = append(cmd.Env, "NO_CLEANUP=true")
 	}
 	if c.kubeconfig != "" {
 		cmd.Env = append(cmd.Env, "KUBECONFIG="+c.kubeconfig)
+	}
+	if c.allocationPolicy != "" {
+		cmd.Env = append(cmd.Env, "AICR_GPU_ALLOCATION_POLICY="+c.allocationPolicy)
 	}
 
 	stdout := newBoundedBuffer(defaults.EvidenceMaxOutputBytes)

--- a/pkg/evidence/cncf/collector_test.go
+++ b/pkg/evidence/cncf/collector_test.go
@@ -17,12 +17,79 @@ package cncf
 import (
 	"context"
 	stderrors "errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
+
+// TestRunSectionThreadsAllocationPolicyEnv verifies the #1629 threading
+// contract at the subprocess boundary: WithAllocationPolicy must surface as
+// the AICR_GPU_ALLOCATION_POLICY environment variable inside the invoked
+// script, and a Collector without a policy must leave the variable unset
+// (standalone runs keep capability-driven detection).
+func TestRunSectionThreadsAllocationPolicyEnv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping subprocess env test")
+	}
+
+	tests := []struct {
+		name   string
+		policy string
+		// ambient, when set, is exported into the test process environment
+		// before the run — the collector must not let it leak through.
+		ambient string
+		// script exits 0 only when the env var matches expectations.
+		script string
+	}{
+		{
+			name:   "policy threaded into script env",
+			policy: "dra-resource-claim",
+			script: `[ "${AICR_GPU_ALLOCATION_POLICY:-}" = "dra-resource-claim" ]`,
+		},
+		{
+			name:   "no policy leaves env unset",
+			policy: "",
+			script: `[ -z "${AICR_GPU_ALLOCATION_POLICY:-}" ]`,
+		},
+		{
+			name:    "ambient env var stripped for standalone runs",
+			policy:  "",
+			ambient: "dra-resource-claim",
+			script:  `[ -z "${AICR_GPU_ALLOCATION_POLICY:-}" ]`,
+		},
+		{
+			name:    "resolved policy overrides ambient env var",
+			policy:  "device-plugin-extended-resource",
+			ambient: "dra-resource-claim",
+			script:  `[ "${AICR_GPU_ALLOCATION_POLICY:-}" = "device-plugin-extended-resource" ]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ambient != "" {
+				t.Setenv("AICR_GPU_ALLOCATION_POLICY", tt.ambient)
+			}
+			dir := t.TempDir()
+			scriptPath := filepath.Join(dir, "probe.sh")
+			if err := os.WriteFile(scriptPath, []byte("#!/usr/bin/env bash\n"+tt.script+"\n"), 0o700); err != nil { //nolint:gosec // test script needs execute permission
+				t.Fatalf("failed to write probe script: %v", err)
+			}
+
+			opts := []CollectorOption{}
+			if tt.policy != "" {
+				opts = append(opts, WithAllocationPolicy(tt.policy))
+			}
+			c := NewCollector(filepath.Join(dir, "out"), opts...)
+			if err := c.runSection(context.Background(), scriptPath, dir, "dra"); err != nil {
+				t.Errorf("runSection() = %v, want nil (env expectation in probe script not met)", err)
+			}
+		})
+	}
+}
 
 func TestResolveFeature(t *testing.T) {
 	tests := []struct {
@@ -130,6 +197,7 @@ func TestNewCollector(t *testing.T) {
 			WithFeatures([]string{"dra", "gang"}),
 			WithNoCleanup(true),
 			WithKubeconfig("/path/to/kubeconfig"),
+			WithAllocationPolicy("device-plugin-extended-resource"),
 		)
 		if len(c.features) != 2 {
 			t.Errorf("features length = %d, want 2", len(c.features))
@@ -140,12 +208,22 @@ func TestNewCollector(t *testing.T) {
 		if c.kubeconfig != "/path/to/kubeconfig" {
 			t.Errorf("kubeconfig = %q, want %q", c.kubeconfig, "/path/to/kubeconfig")
 		}
+		if c.allocationPolicy != "device-plugin-extended-resource" {
+			t.Errorf("allocationPolicy = %q, want %q", c.allocationPolicy, "device-plugin-extended-resource")
+		}
 	})
 
 	t.Run("empty kubeconfig not set", func(t *testing.T) {
 		c := NewCollector("/tmp/out", WithKubeconfig(""))
 		if c.kubeconfig != "" {
 			t.Errorf("kubeconfig = %q, want empty", c.kubeconfig)
+		}
+	})
+
+	t.Run("default allocation policy empty", func(t *testing.T) {
+		c := NewCollector("/tmp/out")
+		if c.allocationPolicy != "" {
+			t.Errorf("allocationPolicy = %q, want empty (standalone runs pass no policy)", c.allocationPolicy)
 		}
 	})
 }

--- a/pkg/evidence/cncf/scripts/collect-evidence.sh
+++ b/pkg/evidence/cncf/scripts/collect-evidence.sh
@@ -245,7 +245,7 @@ spec:
 EOF
             ;;
         *)
-            log_error "emit_resourceclaim_yaml: unsupported resource.k8s.io version: ${version:-<empty>}"
+            log_error "emit_resourceclaim_yaml: unsupported resource.k8s.io version: ${version:-<empty>}" >&2
             return 1
             ;;
     esac
@@ -970,8 +970,8 @@ MANIFEST
     fi
     rm -f "${test_manifest}"
 
-    log_info "Waiting for isolation test pod (up to 60s)..."
-    pod_phase=$(wait_for_pod "secure-access-test" "isolation-test" 60)
+    log_info "Waiting for isolation test pod (up to ${POD_TIMEOUT}s)..."
+    pod_phase=$(wait_for_pod "secure-access-test" "isolation-test" "${POD_TIMEOUT}")
     log_info "Pod phase: ${pod_phase}"
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
@@ -1058,6 +1058,10 @@ metadata:
   namespace: secure-access-test
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault
   tolerations:
     - operator: Exists
   containers:
@@ -1080,6 +1084,8 @@ spec:
             echo "FAIL: expected exactly 1 GPU, saw ${count}"
             exit 1
           fi
+      securityContext:
+        allowPrivilegeEscalation: false
       resources:
         limits:
           nvidia.com/gpu: 1
@@ -1102,6 +1108,8 @@ spec:
             exit 1
           fi
           echo "PASS: nvidia-smi absent or fails without GPU allocation"
+      securityContext:
+        allowPrivilegeEscalation: false
 MANIFEST
 
     if ! capture "Apply isolation test manifest" kubectl apply -f "${dp_manifest}"; then

--- a/pkg/evidence/cncf/scripts/collect-evidence.sh
+++ b/pkg/evidence/cncf/scripts/collect-evidence.sh
@@ -60,13 +60,19 @@ capture() {
     # Strip any remaining absolute paths to manifests (e.g., temp dirs from aicr evidence)
     cmd_display=$(echo "${cmd_display}" | sed 's|[^ ]*/manifests/|manifests/|g')
     echo "\$ ${cmd_display}" >> "${EVIDENCE_FILE}"
+    local rc=0
     if output=$("$@" 2>&1); then
         echo "${output}" >> "${EVIDENCE_FILE}"
     else
+        rc=$?
         echo "${output}" >> "${EVIDENCE_FILE}"
-        echo "(exit code: $?)" >> "${EVIDENCE_FILE}"
+        echo "(exit code: ${rc})" >> "${EVIDENCE_FILE}"
     fi
     echo '```' >> "${EVIDENCE_FILE}"
+    # Propagate the command's status so callers whose step must succeed
+    # (e.g. applying the test workload) can fail closed. Callers that only
+    # record diagnostics ignore the return value, as before.
+    return "${rc}"
 }
 
 # Wait for a pod to reach a terminal phase (Succeeded or Failed).
@@ -155,6 +161,313 @@ cleanup_ns() {
     kubectl delete namespace "$ns" --ignore-not-found --timeout=60s &>/dev/null || true
 }
 
+# ensure_fresh_namespace deletes any prior run's namespace and VERIFIES it is
+# gone before the caller deploys a new workload. Without the verification, a
+# stuck/terminating namespace makes the subsequent apply fail while a stale
+# previously-successful pod survives — wait_for_pod would then observe the OLD
+# pod's phase and produce a false PASS. Returns nonzero (callers record FAIL)
+# when the namespace still exists after ~90s.
+ensure_fresh_namespace() {
+    local ns="$1" elapsed=0
+    cleanup_ns "$ns" pre
+    while kubectl get namespace "$ns" &>/dev/null; do
+        if [ "$elapsed" -ge 90 ]; then
+            log_error "namespace ${ns} still present after ${elapsed}s — cannot guarantee a fresh workload"
+            return 1
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+    return 0
+}
+
+# --- GPU allocation mode helpers (#1629) ---
+
+# detect_resource_api_version prints the newest SERVED resource.k8s.io API
+# version — preference order v1, v1beta2, v1beta1, mirroring
+# validators/internal/allocmode.APIVersionPreference — or nothing when the
+# group is not served or the discovery query fails. Callers that need the DRA
+# API treat an empty result as "API not served" and record FAIL (fail closed).
+detect_resource_api_version() {
+    local served v
+    served=$(kubectl api-versions 2>/dev/null) || return 0
+    for v in v1 v1beta2 v1beta1; do
+        if echo "${served}" | grep -qx "resource.k8s.io/${v}"; then
+            echo "${v}"
+            return 0
+        fi
+    done
+}
+
+# emit_resourceclaim_yaml prints a single-GPU ResourceClaim manifest at the
+# given served resource.k8s.io API version. Schema shapes verified against the
+# vendored types (vendor/k8s.io/api/resource/*/types.go):
+#   v1, v1beta2: spec.devices.requests[0].exactly.deviceClassName
+#                (DeviceRequest.Exactly -> ExactDeviceRequest)
+#   v1beta1:     spec.devices.requests[0].deviceClassName — no `exactly`
+#                wrapper (DeviceRequest carries the fields directly)
+# Any other version is an error (fail closed).
+# Usage: emit_resourceclaim_yaml <version> <name> <namespace> <deviceclass>
+emit_resourceclaim_yaml() {
+    local version="$1" name="$2" namespace="$3" deviceclass="$4"
+    case "${version}" in
+        v1|v1beta2)
+            cat <<EOF
+apiVersion: resource.k8s.io/${version}
+kind: ResourceClaim
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: ${deviceclass}
+          allocationMode: ExactCount
+          count: 1
+EOF
+            ;;
+        v1beta1)
+            cat <<EOF
+apiVersion: resource.k8s.io/v1beta1
+kind: ResourceClaim
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  devices:
+    requests:
+      - name: gpu
+        deviceClassName: ${deviceclass}
+        allocationMode: ExactCount
+        count: 1
+EOF
+            ;;
+        *)
+            log_error "emit_resourceclaim_yaml: unsupported resource.k8s.io version: ${version:-<empty>}"
+            return 1
+            ;;
+    esac
+}
+
+# count_resourceslices_for_driver prints the number of ResourceSlices
+# published by the given DRA driver, or "error" (and returns 1) when the
+# query or parse fails — callers must fail closed on "error", never treat it
+# as zero.
+count_resourceslices_for_driver() {
+    local driver="$1" out
+    if ! out=$(kubectl get resourceslices -o json 2>/dev/null | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+print(sum(1 for s in data.get("items", [])
+          if s.get("spec", {}).get("driver") == sys.argv[1]))
+' "${driver}" 2>/dev/null) || [ -z "${out}" ]; then
+        echo "error"
+        return 1
+    fi
+    echo "${out}"
+}
+
+# resolve_alloc_mode resolves which GPU allocation mode the dra-support and
+# secure-access sections must exercise, mirroring the Go validators' #1327
+# contract: configuration selects the allocation policy (the recipe-resolved
+# AICR_GPU_ALLOCATION_POLICY env var, threaded by `aicr validate
+# --cncf-submission` when recipe context is available); only recipe-less
+# standalone runs fall back to capability detection. An unknown or
+# unverifiable policy — including the reserved dra-extended-resource — fails
+# closed with NO fallback to detection, mirroring allocmode.Verify.
+#
+# Result is cached in globals (resolved once per script invocation):
+#   ALLOC_MODE         "dra" | "device-plugin" (empty on failure)
+#   ALLOC_MODE_SOURCE  provenance of the decision (policy vs detection)
+#   ALLOC_MODE_DETAIL  detection basis / evidence lines (detection path only)
+#   ALLOC_MODE_ERROR   fail-closed reason when resolution failed (returns 1)
+resolve_alloc_mode() {
+    if [ -n "${ALLOC_MODE_RESOLVED:-}" ]; then
+        [ -n "${ALLOC_MODE_ERROR}" ] && return 1
+        return 0
+    fi
+    ALLOC_MODE_RESOLVED=1
+    ALLOC_MODE=""
+    ALLOC_MODE_SOURCE=""
+    ALLOC_MODE_DETAIL=""
+    ALLOC_MODE_ERROR=""
+
+    local policy="${AICR_GPU_ALLOCATION_POLICY:-}"
+    case "${policy}" in
+        device-plugin-extended-resource)
+            ALLOC_MODE="device-plugin"
+            ALLOC_MODE_SOURCE="recipe-configured GPU allocation policy \"${policy}\""
+            return 0
+            ;;
+        dra-resource-claim)
+            ALLOC_MODE="dra"
+            ALLOC_MODE_SOURCE="recipe-configured GPU allocation policy \"${policy}\""
+            return 0
+            ;;
+        ""|unspecified)
+            # No configured policy — standalone run, capability detection below.
+            ;;
+        *)
+            ALLOC_MODE_ERROR="unknown/unverifiable GPU allocation policy \"${policy}\" — mirrors allocmode.Verify fail-closed semantics, issue #1327"
+            return 1
+            ;;
+    esac
+
+    # Capability detection (standalone runs), mirroring
+    # validators/internal/allocmode.Detect as far as bash reasonably can:
+    #   DRA usable:           gpu.nvidia.com DeviceClass exists AND >=1
+    #                         node-local (spec.nodeName) gpu.nvidia.com
+    #                         ResourceSlice advertises >=1 device on a Ready,
+    #                         schedulable node.
+    #   Device-plugin usable: a Ready, schedulable node has allocatable
+    #                         nvidia.com/gpu > 0.
+    # Every query failure is fail-closed: the mechanism is treated as NOT
+    # usable and the failure is recorded — never silently skipped.
+    ALLOC_MODE_SOURCE="capability detection (no recipe-configured GPU allocation policy)"
+
+    local api_version dra_detail plugin_detail
+    local dra_usable="false" plugin_usable="false"
+    api_version=$(detect_resource_api_version)
+
+    if [ -z "${api_version}" ]; then
+        dra_detail="DRA not usable: no served resource.k8s.io API version (or discovery query failed — treated as not usable, fail closed)"
+    elif ! kubectl get deviceclass gpu.nvidia.com &>/dev/null; then
+        dra_detail="DRA not usable: DeviceClass gpu.nvidia.com not found (or query failed — treated as not usable, fail closed)"
+    else
+        local nodes_json_file slices_json_file
+        nodes_json_file=$(mktemp "${TMPDIR:-/tmp}/aicr-evidence-XXXXXX")
+        slices_json_file=$(mktemp "${TMPDIR:-/tmp}/aicr-evidence-XXXXXX")
+        if kubectl get nodes -o json > "${nodes_json_file}" 2>/dev/null \
+            && kubectl get resourceslices -o json > "${slices_json_file}" 2>/dev/null \
+            && dra_detail=$(python3 - "${nodes_json_file}" "${slices_json_file}" <<'PYEOF'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    nodes = json.load(f)
+with open(sys.argv[2]) as f:
+    slices = json.load(f)
+
+eligible = set()
+for n in nodes.get("items", []):
+    if n.get("spec", {}).get("unschedulable"):
+        continue
+    conditions = n.get("status", {}).get("conditions", []) or []
+    if any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+        eligible.add(n["metadata"]["name"])
+
+counts = {}
+for s in slices.get("items", []):
+    spec = s.get("spec", {})
+    if spec.get("driver") != "gpu.nvidia.com":
+        continue
+    node = spec.get("nodeName", "")
+    devices = spec.get("devices", []) or []
+    if node in eligible and len(devices) > 0:
+        counts[node] = counts.get(node, 0) + len(devices)
+
+if counts:
+    fmt = ",".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    print("DRA usable: DeviceClass gpu.nvidia.com exists and node-local "
+          f"gpu.nvidia.com ResourceSlice device(s) on Ready, schedulable node(s) [{fmt}]")
+else:
+    print("DRA not usable: DeviceClass gpu.nvidia.com exists but no gpu.nvidia.com "
+          "ResourceSlice advertises a device (via spec.nodeName) on a Ready, schedulable node")
+PYEOF
+        ); then
+            case "${dra_detail}" in
+                "DRA usable:"*) dra_usable="true" ;;
+            esac
+        else
+            dra_detail="DRA not usable: node/ResourceSlice query or parse failed — treated as not usable, fail closed"
+        fi
+        rm -f "${nodes_json_file}" "${slices_json_file}"
+    fi
+
+    if plugin_detail=$(kubectl get nodes -o json 2>/dev/null | python3 -c '
+import json
+import sys
+
+nodes = json.load(sys.stdin)
+usable = []
+for n in nodes.get("items", []):
+    if n.get("spec", {}).get("unschedulable"):
+        continue
+    conditions = n.get("status", {}).get("conditions", []) or []
+    if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+        continue
+    alloc = n.get("status", {}).get("allocatable", {}).get("nvidia.com/gpu", "0")
+    try:
+        count = int(alloc)
+    except ValueError:
+        count = 0
+    if count > 0:
+        usable.append("{}={}".format(n["metadata"]["name"], count))
+
+if usable:
+    print("device plugin usable: Ready, schedulable node(s) with allocatable "
+          "nvidia.com/gpu [{}]".format(",".join(sorted(usable))))
+else:
+    print("device plugin not usable: no Ready, schedulable node advertises "
+          "allocatable nvidia.com/gpu")
+' 2>/dev/null); then
+        case "${plugin_detail}" in
+            "device plugin usable:"*) plugin_usable="true" ;;
+        esac
+    else
+        plugin_detail="device plugin not usable: node query or parse failed — treated as not usable, fail closed"
+    fi
+
+    ALLOC_MODE_DETAIL="${dra_detail}
+${plugin_detail}
+note: this detection checks DeviceClass existence, node-local ResourceSlice publication, and scalar allocatable only — full pool-generation/completeness, device-taint, and topology validation is performed by the Go validators (validators/internal/allocmode), not this script"
+
+    # Preference order must match validators/conformance/secure_access_check.go
+    # capability dispatch: DRA when usable, else device plugin, else FAIL.
+    if [ "${dra_usable}" = "true" ]; then
+        ALLOC_MODE="dra"
+    elif [ "${plugin_usable}" = "true" ]; then
+        ALLOC_MODE="device-plugin"
+    else
+        ALLOC_MODE_ERROR="no usable whole-GPU allocation mechanism detected: ${dra_detail}; ${plugin_detail}"
+        return 1
+    fi
+    return 0
+}
+
+# write_alloc_mode_evidence appends the resolved GPU allocation mode (or the
+# fail-closed resolution error) to the current EVIDENCE_FILE. Returns
+# resolve_alloc_mode's status so callers can bail out after recording FAIL.
+write_alloc_mode_evidence() {
+    local ok=true
+    resolve_alloc_mode || ok=false
+
+    cat >> "${EVIDENCE_FILE}" <<EOF
+## GPU Allocation Mode
+
+**Configured policy (AICR_GPU_ALLOCATION_POLICY):** \`${AICR_GPU_ALLOCATION_POLICY:-<unset>}\`
+**Mode source:** ${ALLOC_MODE_SOURCE:-n/a}
+EOF
+    if [ "${ok}" = "true" ]; then
+        echo "**Resolved mode:** \`${ALLOC_MODE}\`" >> "${EVIDENCE_FILE}"
+    fi
+    if [ -n "${ALLOC_MODE_DETAIL}" ]; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Detection basis:**" >> "${EVIDENCE_FILE}"
+        echo '```' >> "${EVIDENCE_FILE}"
+        echo "${ALLOC_MODE_DETAIL}" >> "${EVIDENCE_FILE}"
+        echo '```' >> "${EVIDENCE_FILE}"
+    fi
+    if [ "${ok}" != "true" ]; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — ${ALLOC_MODE_ERROR}" >> "${EVIDENCE_FILE}"
+        return 1
+    fi
+    return 0
+}
+
 # Detect cluster info once and cache in global variables.
 # Sets: CLUSTER_DESC, CLUSTER_K8S_VERSION, CLUSTER_PLATFORM, CLUSTER_OS_IMAGE,
 #        CLUSTER_PROVIDER_ID, CLUSTER_INSTANCE_TYPE, CLUSTER_ACCELERATOR
@@ -204,6 +517,13 @@ EOF
 }
 
 # --- Section 1: DRA Support ---
+# Mode-aware (#1629), mirroring validators/conformance/dra_support_check.go:
+# always records the served resource.k8s.io version and per-driver
+# ResourceSlice inventory; the behavioral full-GPU ResourceClaim test runs
+# only under the DRA allocation mode. Under the device-plugin mode whole GPUs
+# are device-plugin-allocated, so the behavioral claim test is recorded as
+# not applicable and the section passes on API + NVIDIA slice evidence
+# (compute-domain.nvidia.com slices count as valid NVIDIA DRA publication).
 collect_dra() {
     EVIDENCE_FILE="${EVIDENCE_DIR}/dra-support.md"
     log_info "Collecting DRA Support evidence → ${EVIDENCE_FILE}"
@@ -211,12 +531,31 @@ collect_dra() {
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 Demonstrates that the cluster supports DRA (resource.k8s.io API group), has a working
-DRA driver, advertises GPU devices via ResourceSlices, and can allocate GPUs to pods
-through ResourceClaims.
+DRA driver, and advertises NVIDIA devices via ResourceSlices. Under the DRA GPU
+allocation mode a behavioral test additionally allocates a GPU to a pod through a
+ResourceClaim; under the device-plugin mode whole GPUs are device-plugin-allocated
+and the behavioral ResourceClaim test is not applicable.
+
+EOF
+    if ! write_alloc_mode_evidence; then
+        log_error "GPU allocation mode resolution failed: ${ALLOC_MODE_ERROR}"
+        return
+    fi
+
+    local api_version
+    api_version=$(detect_resource_api_version)
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
 
 ## DRA API Enabled
 EOF
     capture "DRA API resources" kubectl api-resources --api-group=resource.k8s.io
+    echo "" >> "${EVIDENCE_FILE}"
+    if [ -n "${api_version}" ]; then
+        echo "**Served resource.k8s.io version (newest):** \`resource.k8s.io/${api_version}\`" >> "${EVIDENCE_FILE}"
+    else
+        echo "**Served resource.k8s.io version (newest):** none — the resource.k8s.io API group is not served" >> "${EVIDENCE_FILE}"
+    fi
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
@@ -236,24 +575,89 @@ EOF
 EOF
     capture "ResourceSlices" kubectl get resourceslices
 
+    # Per-driver inventory: gpu.nvidia.com (full-GPU DRA) and
+    # compute-domain.nvidia.com (IMEX channels — the supported NVIDIA DRA
+    # configuration under the device-plugin default, #1620/#1327). "error"
+    # means the query failed and is treated as no evidence (fail closed).
+    local gpu_slices cd_slices
+    gpu_slices=$(count_resourceslices_for_driver gpu.nvidia.com) || true
+    cd_slices=$(count_resourceslices_for_driver compute-domain.nvidia.com) || true
+    cat >> "${EVIDENCE_FILE}" <<EOF
+
+**ResourceSlice inventory by NVIDIA driver**
+\`\`\`
+gpu.nvidia.com:            ${gpu_slices} slice(s)
+compute-domain.nvidia.com: ${cd_slices} slice(s)
+\`\`\`
+EOF
+
+    if [ "${ALLOC_MODE}" = "device-plugin" ]; then
+        collect_dra_device_plugin_verdict "${api_version}" "${gpu_slices}" "${cd_slices}"
+        return
+    fi
+
+    # Fail closed on a failed inventory query in DRA mode too: the slice
+    # inventory is part of the submission evidence, and a behavioral PASS
+    # must not ship alongside an "error" inventory row.
+    if [ "${gpu_slices}" = "error" ] || [ "${cd_slices}" = "error" ]; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — ResourceSlice inventory query failed (fail closed); rerun with a reachable API server." >> "${EVIDENCE_FILE}"
+        log_error "ResourceSlice inventory query failed in DRA mode"
+        return
+    fi
+
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
 ## GPU Allocation Test
 
 Deploy a test pod that requests 1 GPU via ResourceClaim and verifies device access.
-
-**Test manifest:** `pkg/evidence/cncf/scripts/manifests/dra-gpu-test.yaml`
+The ResourceClaim is generated at the newest served resource.k8s.io API version;
+the namespace and pod come from `pkg/evidence/cncf/scripts/manifests/dra-gpu-test.yaml`.
 EOF
+
+    if [ -z "${api_version}" ]; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — DRA allocation mode selected but no served resource.k8s.io API version was discovered; the ResourceClaim test cannot run." >> "${EVIDENCE_FILE}"
+        log_error "DRA mode with no served resource.k8s.io API version"
+        return
+    fi
+
+    # Compose the test manifest: drop the embedded ResourceClaim document from
+    # dra-gpu-test.yaml and substitute the version-correct claim.
+    local test_manifest
+    test_manifest=$(mktemp "${TMPDIR:-/tmp}/aicr-evidence-XXXXXX")
+    awk 'BEGIN{RS="---\n"; ORS="---\n"} $0 !~ /kind: ResourceClaim/' \
+        "${SCRIPT_DIR}/manifests/dra-gpu-test.yaml" > "${test_manifest}"
+    if ! emit_resourceclaim_yaml "${api_version}" gpu-claim dra-test gpu.nvidia.com >> "${test_manifest}"; then
+        rm -f "${test_manifest}"
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — could not generate a ResourceClaim for served version ${api_version}." >> "${EVIDENCE_FILE}"
+        return
+    fi
+
     echo '```yaml' >> "${EVIDENCE_FILE}"
-    cat "${SCRIPT_DIR}/manifests/dra-gpu-test.yaml" >> "${EVIDENCE_FILE}"
+    cat "${test_manifest}" >> "${EVIDENCE_FILE}"
     echo '```' >> "${EVIDENCE_FILE}"
 
-    # Clean up any previous run
-    cleanup_ns dra-test pre
+    # Clean up any previous run and verify it is actually gone — a stale
+    # Succeeded pod from a prior run must not satisfy wait_for_pod.
+    if ! ensure_fresh_namespace dra-test; then
+        rm -f "${test_manifest}"
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — previous dra-test namespace could not be removed; cannot guarantee a fresh workload." >> "${EVIDENCE_FILE}"
+        return
+    fi
 
-    # Deploy test
+    # Deploy test (fail closed when the apply itself fails)
     log_info "Deploying DRA GPU test..."
-    capture "Apply test manifest" kubectl apply -f "${SCRIPT_DIR}/manifests/dra-gpu-test.yaml"
+    if ! capture "Apply test manifest" kubectl apply -f "${test_manifest}"; then
+        rm -f "${test_manifest}"
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — applying the DRA test manifest failed." >> "${EVIDENCE_FILE}"
+        cleanup_ns dra-test
+        return
+    fi
+    rm -f "${test_manifest}"
 
     # Wait for pod completion
     log_info "Waiting for DRA test pod (up to ${POD_TIMEOUT}s)..."
@@ -281,6 +685,49 @@ EOF
     capture "Delete test namespace" cleanup_ns dra-test
 
     log_info "DRA evidence collection complete."
+}
+
+# collect_dra_device_plugin_verdict renders the device-plugin-mode verdict for
+# the dra-support section: no claim pod is deployed (whole GPUs are
+# device-plugin-allocated); PASS requires a served resource.k8s.io version AND
+# at least one ResourceSlice from an NVIDIA driver (gpu.nvidia.com or
+# compute-domain.nvidia.com — the latter is the supported publication under
+# the device-plugin default). A failed slice query ("error") fails closed.
+collect_dra_device_plugin_verdict() {
+    local api_version="$1" gpu_slices="$2" cd_slices="$3"
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
+## GPU Allocation Test
+
+**Behavioral full-GPU allocation: Not applicable** — device-plugin allocation
+policy; whole GPUs are device-plugin-allocated (`nvidia.com/gpu` extended
+resource), so no full-GPU ResourceClaim test pod is deployed. DRA support is
+evidenced by the served resource.k8s.io API and NVIDIA driver ResourceSlice
+publication above.
+
+> **Note:** this section validates a subset under the device-plugin mode —
+> API served + NVIDIA ResourceSlice publication. Full pool-generation and
+> device-taint validation of the slices is performed by the Go validators
+> (`aicr validate --phase conformance`, dra-support check), not this script.
+EOF
+
+    echo "" >> "${EVIDENCE_FILE}"
+    if [ -z "${api_version}" ]; then
+        echo "**Result: FAIL** — the resource.k8s.io API group is not served (requires K8s 1.32+)." >> "${EVIDENCE_FILE}"
+        return
+    fi
+    if [ "${gpu_slices}" = "error" ] || [ "${cd_slices}" = "error" ]; then
+        echo "**Result: FAIL** — ResourceSlice inventory query failed (gpu.nvidia.com: ${gpu_slices}, compute-domain.nvidia.com: ${cd_slices}) — fail closed." >> "${EVIDENCE_FILE}"
+        return
+    fi
+    if [ "$((gpu_slices + cd_slices))" -ge 1 ]; then
+        echo "**Result: PASS** — resource.k8s.io/${api_version} is served and NVIDIA DRA driver(s) publish ResourceSlices (gpu.nvidia.com: ${gpu_slices}, compute-domain.nvidia.com: ${cd_slices}). Behavioral full-GPU claim test not applicable under the device-plugin allocation policy." >> "${EVIDENCE_FILE}"
+    else
+        echo "**Result: FAIL** — resource.k8s.io/${api_version} is served but no NVIDIA DRA driver publishes any ResourceSlice (gpu.nvidia.com: 0, compute-domain.nvidia.com: 0)." >> "${EVIDENCE_FILE}"
+    fi
+
+    log_info "DRA evidence collection complete (device-plugin mode)."
 }
 
 # --- Section 2: Gang Scheduling ---
@@ -356,15 +803,31 @@ EOF
 }
 
 # --- Section 3: Secure Accelerator Access ---
+# Mode-aware (#1629), mirroring validators/conformance/secure_access_check.go:
+# under the DRA mode the isolation test allocates a GPU through a
+# ResourceClaim (generated at the served resource.k8s.io version); under the
+# device-plugin mode it ports the two-container pattern from
+# kubernetes-sigs/ai-conformance#75 — an authorized container with
+# `nvidia.com/gpu: 1` limits must see exactly one GPU, and an unauthorized
+# sibling container with no GPU request must see none.
 collect_secure() {
     EVIDENCE_FILE="${EVIDENCE_DIR}/secure-accelerator-access.md"
     log_info "Collecting Secure Accelerator Access evidence → ${EVIDENCE_FILE}"
     write_section_header "Secure Accelerator Access"
 
     cat >> "${EVIDENCE_FILE}" <<'EOF'
-Demonstrates that GPU access is mediated through Kubernetes APIs (DRA ResourceClaims
-and GPU Operator), not via direct host device mounts. This ensures proper isolation,
-access control, and auditability of accelerator usage.
+Demonstrates that GPU access is mediated through Kubernetes allocation APIs
+(DRA ResourceClaims or device plugin resource limits, per the cluster's GPU
+allocation mode), not via direct host device mounts. This ensures proper
+isolation, access control, and auditability of accelerator usage.
+
+EOF
+    if ! write_alloc_mode_evidence; then
+        log_error "GPU allocation mode resolution failed: ${ALLOC_MODE_ERROR}"
+        return
+    fi
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
 
 ## GPU Operator Health
 
@@ -384,11 +847,22 @@ EOF
 EOF
     capture "GPU operator DaemonSets" kubectl get ds -n gpu-operator
 
+    if [ "${ALLOC_MODE}" = "device-plugin" ]; then
+        collect_secure_device_plugin
+    else
+        collect_secure_dra
+    fi
+}
+
+# collect_secure_dra exercises the DRA isolation test: a pod granted one GPU
+# through a gpu.nvidia.com ResourceClaim generated at the newest served
+# resource.k8s.io API version.
+collect_secure_dra() {
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
 ## DRA-Mediated GPU Access
 
-GPU access is provided through DRA ResourceClaims (`resource.k8s.io/v1`), not through
+GPU access is provided through DRA ResourceClaims (`resource.k8s.io`), not through
 direct `hostPath` volume mounts to `/dev/nvidia*`. The DRA driver advertises individual
 GPU devices via ResourceSlices, and pods request access through ResourceClaims.
 
@@ -406,35 +880,42 @@ EOF
 
 ## Device Isolation Verification
 
-Deploy a test pod requesting 1 GPU via ResourceClaim and verify:
+Deploy a test pod requesting 1 GPU via ResourceClaim (generated at the newest
+served resource.k8s.io API version) and verify:
 1. No `hostPath` volumes to `/dev/nvidia*`
 2. Pod spec uses `resourceClaims` (DRA), not `resources.limits` (device plugin)
 3. Only the allocated GPU device is visible inside the container
 EOF
 
-    # Clean up any previous run
-    cleanup_ns secure-access-test pre
+    local api_version
+    api_version=$(detect_resource_api_version)
+    if [ -z "${api_version}" ]; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — DRA allocation mode selected but no served resource.k8s.io API version was discovered; the ResourceClaim isolation test cannot run." >> "${EVIDENCE_FILE}"
+        log_error "DRA mode with no served resource.k8s.io API version"
+        return
+    fi
 
-    # Deploy DRA test for isolation verification
-    cat <<'MANIFEST' | kubectl apply -f -
+    # Clean up any previous run
+    if ! ensure_fresh_namespace secure-access-test; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — previous secure-access-test namespace could not be removed; cannot guarantee a fresh workload." >> "${EVIDENCE_FILE}"
+        return
+    fi
+
+    # Compose the isolation test manifest with the version-correct claim.
+    local test_manifest
+    test_manifest=$(mktemp "${TMPDIR:-/tmp}/aicr-evidence-XXXXXX")
+    {
+        cat <<'MANIFEST'
 apiVersion: v1
 kind: Namespace
 metadata:
   name: secure-access-test
 ---
-apiVersion: resource.k8s.io/v1
-kind: ResourceClaim
-metadata:
-  name: isolated-gpu
-  namespace: secure-access-test
-spec:
-  devices:
-    requests:
-      - name: gpu
-        exactly:
-          deviceClassName: gpu.nvidia.com
-          allocationMode: ExactCount
-          count: 1
+MANIFEST
+        emit_resourceclaim_yaml "${api_version}" isolated-gpu secure-access-test gpu.nvidia.com
+        cat <<'MANIFEST'
 ---
 apiVersion: v1
 kind: Pod
@@ -458,17 +939,36 @@ spec:
           echo "=== Visible NVIDIA devices ==="
           ls -la /dev/nvidia* 2>/dev/null || echo "No /dev/nvidia* devices"
           echo ""
-          echo "=== nvidia-smi output ==="
-          nvidia-smi -L
+          echo "=== nvidia-smi output (claim requests exactly 1 GPU) ==="
+          if ! nvidia-smi -L; then
+            echo "FAIL: nvidia-smi cannot enumerate GPUs - no usable GPU granted"
+            exit 1
+          fi
+          count=$(nvidia-smi -L | wc -l)
           echo ""
           echo "=== GPU count ==="
           nvidia-smi --query-gpu=index,name,uuid --format=csv,noheader
-          echo ""
+          echo "visible GPU count: ${count}"
+          if [ "${count}" != "1" ]; then
+            echo "FAIL: expected exactly 1 GPU visible via the ResourceClaim, saw ${count}"
+            exit 1
+          fi
+          echo "PASS: exactly one GPU visible"
           echo "Secure accelerator access test completed"
       resources:
         claims:
           - name: gpu
 MANIFEST
+    } > "${test_manifest}"
+
+    if ! capture "Apply isolation test manifest" kubectl apply -f "${test_manifest}"; then
+        rm -f "${test_manifest}"
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — applying the isolation test manifest failed." >> "${EVIDENCE_FILE}"
+        cleanup_ns secure-access-test
+        return
+    fi
+    rm -f "${test_manifest}"
 
     log_info "Waiting for isolation test pod (up to 60s)..."
     pod_phase=$(wait_for_pod "secure-access-test" "isolation-test" 60)
@@ -493,7 +993,7 @@ EOF
     # Verdict
     echo "" >> "${EVIDENCE_FILE}"
     if [ "${pod_phase}" = "Succeeded" ]; then
-        echo "**Result: PASS** — GPU access mediated through DRA ResourceClaim. No direct host device mounts. Only allocated GPU visible in container." >> "${EVIDENCE_FILE}"
+        echo "**Result: PASS** — GPU access mediated through DRA ResourceClaim (resource.k8s.io/${api_version}). No direct host device mounts. Only allocated GPU visible in container." >> "${EVIDENCE_FILE}"
     else
         echo "**Result: FAIL** — Pod phase: ${pod_phase}" >> "${EVIDENCE_FILE}"
     fi
@@ -505,6 +1005,157 @@ EOF
     capture "Delete test namespace" cleanup_ns secure-access-test
 
     log_info "Secure accelerator access evidence collection complete."
+}
+
+# collect_secure_device_plugin exercises the device-plugin isolation pattern
+# ported from kubernetes-sigs/ai-conformance#75 (mirrored by
+# validators/conformance/secure_access_check.go): one pod with two containers —
+# an authorized container requesting `nvidia.com/gpu: 1` that must see EXACTLY
+# one GPU via nvidia-smi (positive probe), and an unauthorized sibling
+# container with no GPU request that must see no /dev/nvidia* device nodes and
+# no working nvidia-smi (negative probes). The pod reaches phase Succeeded only
+# when every container exits 0, so PASS requires all probes to pass; any probe
+# or query failure fails closed.
+collect_secure_device_plugin() {
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
+## Device-Plugin-Mediated GPU Access
+
+GPU access is provided through the device plugin (`nvidia.com/gpu` extended
+resource in `resources.limits`), not through direct `hostPath` volume mounts to
+`/dev/nvidia*`. The kubelet grants each container exactly the devices the
+device plugin allocated to it.
+
+## Device Isolation Verification
+
+Deploy a test pod with two containers and verify container-level isolation
+(kubernetes-sigs/ai-conformance#75 pattern):
+1. Authorized container (`nvidia.com/gpu: 1` limit): `nvidia-smi` sees EXACTLY one GPU
+2. Unauthorized sibling container (no GPU request): no `/dev/nvidia*` device nodes,
+   and `nvidia-smi` is absent or fails
+3. No `hostPath` volumes to `/dev/nvidia*`
+EOF
+
+    # Clean up any previous run and verify it is actually gone.
+    if ! ensure_fresh_namespace secure-access-test; then
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — previous secure-access-test namespace could not be removed; cannot guarantee a fresh workload." >> "${EVIDENCE_FILE}"
+        return
+    fi
+
+    local dp_manifest
+    dp_manifest=$(mktemp "${TMPDIR:-/tmp}/aicr-evidence-XXXXXX")
+    cat <<'MANIFEST' > "${dp_manifest}"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secure-access-test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: isolation-test
+  namespace: secure-access-test
+spec:
+  restartPolicy: Never
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: authorized
+      image: nvidia/cuda:12.9.0-base-ubuntu24.04
+      command:
+        - bash
+        - -c
+        - |
+          echo "=== nvidia-smi -L (authorized container, nvidia.com/gpu: 1) ==="
+          if ! nvidia-smi -L; then
+            echo "FAIL: nvidia-smi cannot enumerate GPUs - no usable GPU granted"
+            exit 1
+          fi
+          count=$(nvidia-smi -L | wc -l)
+          echo "visible GPU count: ${count}"
+          if [ "${count}" = "1" ]; then
+            echo "PASS: exactly one GPU visible"
+          else
+            echo "FAIL: expected exactly 1 GPU, saw ${count}"
+            exit 1
+          fi
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+    - name: unauthorized
+      image: nvidia/cuda:12.9.0-base-ubuntu24.04
+      command:
+        - bash
+        - -c
+        - |
+          echo "=== /dev/nvidia* (unauthorized sibling, no GPU request) ==="
+          if ls /dev/nvidia* 2>/dev/null; then
+            echo "FAIL: GPU device nodes visible without GPU allocation"
+            exit 1
+          fi
+          echo "PASS: no /dev/nvidia* device nodes visible"
+          echo ""
+          echo "=== nvidia-smi (must be absent or fail) ==="
+          if nvidia-smi -L 2>/dev/null; then
+            echo "FAIL: nvidia-smi enumerated GPUs without GPU allocation"
+            exit 1
+          fi
+          echo "PASS: nvidia-smi absent or fails without GPU allocation"
+MANIFEST
+
+    if ! capture "Apply isolation test manifest" kubectl apply -f "${dp_manifest}"; then
+        rm -f "${dp_manifest}"
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — applying the isolation test manifest failed." >> "${EVIDENCE_FILE}"
+        cleanup_ns secure-access-test
+        return
+    fi
+    rm -f "${dp_manifest}"
+
+    log_info "Waiting for device-plugin isolation test pod (up to ${POD_TIMEOUT}s)..."
+    pod_phase=$(wait_for_pod "secure-access-test" "isolation-test" "${POD_TIMEOUT}")
+    log_info "Pod phase: ${pod_phase}"
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
+### Pod Spec (device plugin limits, no hostPath volumes)
+EOF
+    capture "Container GPU limits" kubectl get pod isolation-test -n secure-access-test \
+        -o jsonpath='{range .spec.containers[*]}{.name}{": nvidia.com/gpu="}{.resources.limits.nvidia\.com/gpu}{"\n"}{end}'
+    capture "Pod volumes (no hostPath)" kubectl get pod isolation-test -n secure-access-test -o jsonpath='{.spec.volumes}'
+    capture "Container exit codes" kubectl get pod isolation-test -n secure-access-test \
+        -o jsonpath='{range .status.containerStatuses[*]}{.name}{": exitCode="}{.state.terminated.exitCode}{"\n"}{end}'
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
+### Authorized Container (positive probe: exactly one GPU)
+EOF
+    capture "Authorized container logs" kubectl logs isolation-test -c authorized -n secure-access-test
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
+### Unauthorized Sibling Container (negative probes: no GPU visible)
+EOF
+    capture "Unauthorized container logs" kubectl logs isolation-test -c unauthorized -n secure-access-test
+
+    # Verdict: phase Succeeded requires every container to exit 0, i.e. the
+    # positive probe AND both negative probes passed. Anything else — probe
+    # failure, scheduling failure, timeout, query failure — is FAIL.
+    echo "" >> "${EVIDENCE_FILE}"
+    if [ "${pod_phase}" = "Succeeded" ]; then
+        echo "**Result: PASS** — GPU access mediated through device plugin \`nvidia.com/gpu\` limits: the authorized container saw exactly one GPU and the unauthorized sibling container saw none. No direct host device mounts." >> "${EVIDENCE_FILE}"
+    else
+        echo "**Result: FAIL** — Pod phase: ${pod_phase} (PASS requires the authorized container to see exactly one GPU AND the unauthorized sibling to see none)." >> "${EVIDENCE_FILE}"
+    fi
+
+    cat >> "${EVIDENCE_FILE}" <<'EOF'
+
+## Cleanup
+EOF
+    capture "Delete test namespace" cleanup_ns secure-access-test
+
+    log_info "Secure accelerator access evidence collection complete (device-plugin mode)."
 }
 
 # --- Section 4a: Accelerator Metrics (DCGM Exporter) ---
@@ -2296,5 +2947,14 @@ main() {
     echo "  Total: $((passed + failed + skipped)) | Passed: ${passed} | Failed: ${failed} | Skipped: ${skipped}"
     echo ""
 }
+
+# Hidden subcommand for unit tests (pkg/evidence/cncf/claim_shape_test.go):
+# print the version-correct ResourceClaim YAML and exit without contacting a
+# cluster. Not part of the documented section interface.
+# Usage: collect-evidence.sh emit-claim <version> [name] [namespace] [deviceclass]
+if [ "${SECTION}" = "emit-claim" ]; then
+    emit_resourceclaim_yaml "${2:-}" "${3:-gpu-claim}" "${4:-dra-test}" "${5:-gpu.nvidia.com}"
+    exit $?
+fi
 
 main


### PR DESCRIPTION
## Summary

Makes CNCF submission evidence collection (`aicr validate --cncf-submission`) mode-aware: the `dra-support` and `secure-access` sections now follow the recipe-configured GPU allocation policy (threaded via `AICR_GPU_ALLOCATION_POLICY`, fail-closed on unknown values) or, on standalone runs, a fail-closed capability detection mirroring `allocmode.Detect` — instead of hardcoding full-GPU DRA at `resource.k8s.io/v1`.

## Motivation / Context

The Go validators became policy/mode-aware in the #1327 train, but `collect-evidence.sh` still hardcoded a full-GPU `gpu.nvidia.com` ResourceClaim in both paths. After the device-plugin default flip (#1671), those sections fail structurally on every stock cluster while the CLI reports success. This PR brings the submission script to parity with the validator semantics (`dra_support_check.go`, `secure_access_check.go`).

Fixes: #1629
Related: #1327, #1671, #1692 (failure propagation — deliberately out of scope here), kubernetes-sigs/ai-conformance#75 (device-plugin secure-access shape)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: CNCF evidence collector (`pkg/evidence/cncf`)

## Implementation Notes

- **Policy threading**: `--cncf-submission` resolves the recipe's policy via `ResolveGPUAllocationPolicy` and passes it to the collector (`WithAllocationPolicy` → `AICR_GPU_ALLOCATION_POLICY`). Recipe load/resolution errors fail closed before any evidence is collected. No recipe → standalone detection.
- **Fail-closed policy consumption**: the script maps `device-plugin-extended-resource` / `dra-resource-claim` directly; unknown or reserved values (e.g. `dra-extended-resource`) FAIL rather than silently falling back — mirrors `allocmode.Verify`.
- **Standalone detection** mirrors `allocmode.Detect` as far as bash reasonably can (DeviceClass + node-local `gpu.nvidia.com` slice devices on Ready, schedulable nodes; allocatable `nvidia.com/gpu` for device plugin), with the validator's preference order (DRA when usable, else device plugin, else FAIL). Every query failure is fail-closed and recorded; the evidence notes that pool-generation/taint validation remains Go-side.
- **`dra-support`**: always records the served `resource.k8s.io` version and per-driver ResourceSlice inventory (compute-domain slices count as valid NVIDIA publication — the #1620 forward constraint). Behavioral claim pod only under DRA mode, with a version-correct claim (`v1`/`v1beta2` `exactly` wrapper; `v1beta1` bare `deviceClassName`) from served-version discovery. Under device-plugin mode the behavioral subtest is recorded Not applicable, verdict from API + slice evidence — matching `dra_support_check.go`.
- **`secure-access`**: new device-plugin isolation path (authorized container with `nvidia.com/gpu: 1` must see exactly one GPU via `nvidia-smi`; unauthorized sibling must have no `/dev/nvidia*` and no working `nvidia-smi`), ported from the ai-conformance PR #75 shape; DRA path kept, version-corrected.
- **Claim-shape test**: a hidden `emit-claim` script subcommand lets a Go test exercise the embedded emitter for all three API versions (asserted against vendored types) plus the fail-closed unknown-version branch.
- Failure propagation (`Result: FAIL` → nonzero exit) is intentionally out of scope — it needs first-class SKIP semantics first; tracked in #1692.

## Testing

```bash
make qualify   # full gate — PASS (isolated golangci-lint cache)
```

- Coverage: `pkg/evidence/cncf` 77.9% → 86.3% (+8.4%); `pkg/cli` 69.0% → 69.1%.
- New tests: claim shapes ×3 versions + fail-closed unknown version; `WithAllocationPolicy` env threading (subprocess); `resolveCNCFAllocationPolicy` table test. `bash -n` clean; shellcheck delta vs baseline: one style note.

**Live matrix** (EKS GB200 `yljtrxpmzu`, stock post-flip cluster, chart `0.4.1`, 2026-07-09):

| Cell | Setup | Result |
|---|---|---|
| Policy-threaded (device-plugin) | binary from this branch, stock training recipe | `gpuAllocationPolicy=device-plugin-extended-resource` logged; `dra-support` **PASS** (behavioral N/A note, compute-domain slice evidence); `secure-access` **PASS** via the new device-plugin isolation test (authorized saw exactly 1 GPU, sibling saw none) |
| Standalone detection (device-plugin) | direct script run, no recipe | detection resolved `device-plugin` with fail-closed provenance ("DeviceClass gpu.nvidia.com not found"); both sections **PASS** |
| Standalone detection (DRA) | full-GPU DRA advertisement temporarily re-enabled (dual state) | detection preferred `dra` (validator ordering); behavioral claim pod **PASS** via version-discovered `resource.k8s.io/v1` claim; DRA isolation **PASS** |

| Full policy-threaded collection at final head `3175208b` (2026-07-10) | binary from the final head, stock recipe, deployment values verified == main's stock hydrated tuple | 4/4 **PASS** (`dra-support` N/A-path, `secure-access` device-plugin isolation, `gang-scheduling`, `accelerator-metrics`) — exercises the fresh-namespace and status-checked-apply fixes live |

| 8-feature run, **generated inference recipe** (`eks/gb200/inference/dynamo/ubuntu`, 2026-07-10) | recipe generated by the head binary; stock vllm-agg DGD deployed for the Dynamo-dependent sections | **8/8 PASS** — the 4 core cells plus `ai-service-metrics` (Dynamo PodMonitor discovery), `inference-gateway`, `robust-operator`, `pod-autoscaling` (HPA on `gpu_utilization`); `cluster-autoscaling` excluded (scales the shared cluster's nodegroups). First pass surfaced two prerequisite-shaped issues, both resolved by deploying the DGD: `robust-operator` needs a live DynamoGraphDeployment, and `ai-service-metrics` exceeded the per-section timeout while self-deploying one (its evidence file read PASS while the section timed out — exactly the FAIL/exit-status inconsistency #1692 will formalize) |

Cluster restored to the stock post-flip state afterward (compute-domain-only slices, slinky workload 2/2 with IMEX claims re-allocated).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No behavior change for `aicr validate` outside `--cncf-submission`. DRA-mode clusters keep the previous evidence behavior (version-corrected); device-plugin clusters go from structurally-failing evidence to correct mode-aware evidence. Section FAIL still exits 0 (pre-existing; #1692).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)


