### PR TITLE
feat(validator): AKS H100 NCCL all-reduce performance validation

### DIFF
--- a/docs/integrator/aks-gpu-setup.md
+++ b/docs/integrator/aks-gpu-setup.md
@@ -173,11 +173,23 @@ time. See
 `Standard_ND96isr_H100_v5` is the 8-GPU ND H100 v5 SKU. The AKS Dynamo
 inference throughput gate (`inference-throughput`) is a fixed absolute
 **full-node** floor calibrated on an 8-GPU H100 node, so this SKU is the
-supported happy path for that gate. Smaller NCads H100 SKUs
-(`Standard_NC80adis_H100_v5` = 2 GPUs, `Standard_NC40ads_H100_v5` = 1 GPU) run
-fine for deployment but will false-fail the throughput floor; gate on
-`inference-ttft-p99` only on those until the per-GPU normalization in
+supported happy path for that gate. The same applies to the AKS H100 training
+NCCL gate (`nccl-all-reduce-bw >= 150`): its floor is calibrated on full
+ND96isr nodes using the Network Operator's RDMA shared device pool
+(`rdma/hca_shared_devices_a`) over the SKU's multi-HCA InfiniBand fabric.
+Smaller NCads H100 SKUs (`Standard_NC80adis_H100_v5` = 2 GPUs,
+`Standard_NC40ads_H100_v5` = 1 GPU) run fine for deployment but will
+false-fail both full-node floors — they lack the GPU count and IB fabric the
+calibrations assume; gate on `inference-ttft-p99` only on those until the
+per-GPU normalization in
 [#1254](https://github.com/NVIDIA/aicr/issues/1254) lands.
+
+The NCCL gate's benchmark pods pull the `nccl-tests` image from
+`public.ecr.aws` (AWS's public registry) — a cross-cloud pull when running on
+Azure. Private or egress-restricted AKS clusters must allow registry egress to
+`public.ecr.aws` or mirror the image into an Azure-reachable registry (e.g.
+ACR) before running the performance phase; otherwise the benchmark workers
+fail at image pull and the check fails without measuring anything.
 
 ### Alternative: Use the AKS Driver-Only Profile
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -47,7 +47,7 @@ ones) that match the target fabric:
 
 | Check | Transport | When it's selected |
 |---|---|---|
-| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | H100/H200 on EKS, H100 on GKE, and B200/GB200 on self-managed clusters (`service=any`). Preserves the pre-variant behavior. |
+| `nccl-all-reduce-bw` | Auto-detect (whatever NCCL picks) | H100/H200 on EKS, H100 on GKE, H100 on AKS (ND-series InfiniBand — NCCL's built-in IB/verbs transport over the `rdma/hca_shared_devices_a` shared device pool), and B200/GB200 on self-managed clusters (`service=any`). Preserves the pre-variant behavior. |
 | `nccl-all-reduce-bw-net` | NET (EFA on EKS by default; ConnectX RoCE via `AICR_NCCL_FABRIC=roce`) | GB200 + EKS. Asserts EFA actually carried traffic — catches silent fallback to Socket when the NVIDIA driver is missing `NVreg_GrdmaPciTopoCheckOverride=1`. |
 | `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS, and GB200 + OKE. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA (EKS) or Socket (OKE) when the IMEX domain is misconfigured. |
 

--- a/examples/recipes/aks-training.yaml
+++ b/examples/recipes/aks-training.yaml
@@ -168,6 +168,14 @@ validation:
       - expected-resources
       - gpu-operator-version
       - check-nvidia-smi
+  performance:
+    checks:
+      - nccl-all-reduce-bw
+    constraints:
+      # Provisional floor pending calibration on an ND96isr_H100_v5 testbed —
+      # see recipes/overlays/h100-aks-training.yaml.
+      - name: nccl-all-reduce-bw
+        value: '>= 150'
   conformance:
     checks:
       - platform-health

--- a/recipes/overlays/a100-aks-training.yaml
+++ b/recipes/overlays/a100-aks-training.yaml
@@ -63,12 +63,13 @@ spec:
   # here.
   #
   # Performance gating is intentionally omitted until an empirical A100-on-Azure
-  # NCCL baseline is established. AKS has no validator NCCL runtime template or
-  # scheduling path (it is not in the support table), so even the H100 AKS
-  # training overlay leaves the performance phase undeclared rather than gate on
-  # an unmeasured floor (see issue #1337). A100 on Azure is likewise unmeasured
-  # and would need its own fabric-aware baseline (#1256), so carrying any floor
-  # here would only false-fail healthy runs.
+  # NCCL baseline is established. The validator's AKS NCCL runtime path covers
+  # H100 only (supportedNCCLCombinations in
+  # validators/performance/nccl_all_reduce_bw_constraint.go; h100-aks-training
+  # declares nccl-all-reduce-bw with a floor calibrated on ND96isr_H100_v5).
+  # A100 on Azure is unmeasured and needs its own fabric-aware baseline (#1256)
+  # plus an aks/a100 support-table entry (#1337), so carrying any floor here
+  # would only false-fail healthy runs.
   validation:
     conformance:
       checks:

--- a/recipes/overlays/h100-aks-training.yaml
+++ b/recipes/overlays/h100-aks-training.yaml
@@ -66,13 +66,23 @@ spec:
       constraints:
         - name: Deployment.gpu-operator.version
           value: ">= v24.6.0"
-    # No performance phase: the nccl-all-reduce-bw check is intentionally not
-    # declared here. The validator has no AKS NCCL runtime template or
-    # scheduling path (AKS is not in the support table), so a declared check
-    # would silently skip and report the phase as passed without measuring
-    # anything — false assurance. Wire it (testbed-validated AKS runtime
-    # template + scheduling path + support-table entry + real threshold) once
-    # an H100 AKS testbed is characterized. See issue #1337.
+    performance:
+      checks:
+        - nccl-all-reduce-bw
+      # PROVISIONAL floor, set at half the calibrated EKS H100 value (>= 300,
+      # p5.48xlarge: 8x H100 SXM, 32x EFA). Live baseline: 157.24 GB/s busbw
+      # measured UNTUNED (16 GiB all-reduce, NCCL built-in IB/verbs with
+      # NCCL_NET_PLUGIN=none over the network-operator shared HCA pool) on
+      # aicr-test1, 2x Standard_ND96isr_H100_v5 (8x H100 SXM, 8x 400Gb NDR
+      # InfiniBand per node), 2026-07-09. There is substantial tuning headroom
+      # — 8x 400Gb NDR line rate is ~400 GB/s — so recalibrate this floor
+      # upward once the IB path is tuned rather than treating 157 as the
+      # fabric's ceiling. See issue #1337; the general fabric-class-aware
+      # floor work is tracked in
+      # https://github.com/NVIDIA/aicr/issues/1256.
+      constraints:
+        - name: nccl-all-reduce-bw
+          value: ">= 150"
     conformance:
       checks:
         - platform-health

--- a/validators/performance/nccl_aks_utils.go
+++ b/validators/performance/nccl_aks_utils.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// aksRdmaSharedResource is the extended resource published by the network
+// operator's rdma-shared-device-plugin on AICR AKS clusters (selector
+// vendors=15b3 drivers=mlx5_core). The resource name hca_shared_devices_a is
+// pinned by recipes/components/network-operator/manifests/
+// nic-cluster-policy-aks.yaml for workload compatibility — keep the two in
+// sync. It is a *shared* device pool: a pod that requests one unit is granted
+// access to every InfiniBand HCA on the node (/dev/infiniband/*), so NCCL
+// workers request exactly 1 regardless of the HCA count.
+const aksRdmaSharedResource = "rdma/hca_shared_devices_a"
+
+// discoverAKSRdmaCount reads the allocatable rdma-shared-device-plugin
+// resource count from a GPU node. 0 is valid (network-operator RDMA shared
+// device plugin not installed) — NCCL falls back to TCP over the pod network,
+// mirroring the EKS zero-EFA behavior. On ND-series InfiniBand SKUs
+// (e.g. Standard_ND96isr_H100_v5) the plugin advertises a large shared pool
+// (allocatable "1k" = 1000).
+func discoverAKSRdmaCount(node v1.Node) int {
+	rdmaQuantity := node.Status.Allocatable[v1.ResourceName(aksRdmaSharedResource)]
+	return int(rdmaQuantity.Value())
+}
+
+// applyAKSTemplateData populates the AKS-specific runtime template variables:
+// the ${RDMA_RESOURCE_LIMITS}/${RDMA_RESOURCE_REQUESTS} worker resource lines
+// discovered from the first target node, with the same TCP fallback the EKS
+// zero-EFA path uses (reduced max message size) when the RDMA shared device
+// plugin is absent.
+func applyAKSTemplateData(config *gpuConfiguration, templateData map[string]string) {
+	warnIfHeterogeneousNodes(config.Nodes)
+	rdmaCount := discoverAKSRdmaCount(config.Nodes[0])
+	// Indentation matches the resource block position in runtime.yaml.
+	const rdmaIndent = "                      "
+	templateData["RDMA_RESOURCE_LIMITS"] = buildAKSRdmaResourceLine(rdmaCount, rdmaIndent)
+	templateData["RDMA_RESOURCE_REQUESTS"] = buildAKSRdmaResourceLine(rdmaCount, rdmaIndent)
+	if rdmaCount == 0 {
+		templateData["MAX_MESSAGE_SIZE"] = maxMessageSizeTCP
+		slog.Warn("No shared RDMA devices found — NCCL will use TCP (reduced bandwidth)",
+			"resource", aksRdmaSharedResource, "maxMessageSize", maxMessageSizeTCP)
+	} else {
+		slog.Info("Discovered AKS shared RDMA device pool", "resource", aksRdmaSharedResource, "allocatable", rdmaCount)
+	}
+}
+
+// buildAKSRdmaResourceLine returns the YAML line requesting one unit of the
+// shared RDMA resource at the correct indentation, or an empty string when
+// the node advertises none (TCP fallback — the placeholder line is dropped
+// from the rendered runtime). Requesting "1" (not the pool size) is the
+// rdma-shared-device-plugin contract: any positive request mounts every
+// shared IB device into the container.
+func buildAKSRdmaResourceLine(rdmaCount int, indent string) string {
+	if rdmaCount == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s%s: \"1\"", indent, aksRdmaSharedResource)
+}

--- a/validators/performance/nccl_aks_utils_test.go
+++ b/validators/performance/nccl_aks_utils_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDiscoverAKSRdmaCount(t *testing.T) {
+	tests := []struct {
+		name string
+		node v1.Node
+		want int
+	}{
+		{
+			// Standard_ND96isr_H100_v5 with the network-operator
+			// rdma-shared-device-plugin: allocatable is advertised as "1k"
+			// (the shared pool size), which resource.Quantity parses as 1000.
+			name: "ND96isr_H100_v5 with shared RDMA pool",
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "Standard_ND96isr_H100_v5",
+					},
+				},
+				Status: v1.NodeStatus{
+					Allocatable: v1.ResourceList{
+						v1.ResourceName("nvidia.com/gpu"):      resource.MustParse("8"),
+						v1.ResourceName(aksRdmaSharedResource): resource.MustParse("1k"),
+					},
+				},
+			},
+			want: 1000,
+		},
+		{
+			name: "no RDMA shared device plugin (falls back to TCP)",
+			node: v1.Node{
+				Status: v1.NodeStatus{
+					Allocatable: v1.ResourceList{
+						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "no allocatable at all",
+			node: v1.Node{},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := discoverAKSRdmaCount(tt.node); got != tt.want {
+				t.Errorf("discoverAKSRdmaCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyAKSTemplateData(t *testing.T) {
+	const rdmaLine = `                      rdma/hca_shared_devices_a: "1"`
+	tests := []struct {
+		name           string
+		allocatable    v1.ResourceList
+		wantLine       string
+		wantMaxMsgSize string
+	}{
+		{
+			name: "shared RDMA pool present keeps IB message size",
+			allocatable: v1.ResourceList{
+				v1.ResourceName("nvidia.com/gpu"):      resource.MustParse("8"),
+				v1.ResourceName(aksRdmaSharedResource): resource.MustParse("1k"),
+			},
+			wantLine:       rdmaLine,
+			wantMaxMsgSize: maxMessageSize,
+		},
+		{
+			name: "no RDMA pool falls back to TCP with reduced message size",
+			allocatable: v1.ResourceList{
+				v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+			},
+			wantLine:       "",
+			wantMaxMsgSize: maxMessageSizeTCP,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &gpuConfiguration{
+				WorkerCount:     2,
+				GPUCountPerNode: 8,
+				TotalGPUCount:   16,
+				Nodes: []v1.Node{
+					{Status: v1.NodeStatus{Allocatable: tt.allocatable}},
+					{Status: v1.NodeStatus{Allocatable: tt.allocatable}},
+				},
+			}
+			templateData := map[string]string{"MAX_MESSAGE_SIZE": maxMessageSize}
+			applyAKSTemplateData(config, templateData)
+			if got := templateData["RDMA_RESOURCE_LIMITS"]; got != tt.wantLine {
+				t.Errorf("RDMA_RESOURCE_LIMITS = %q, want %q", got, tt.wantLine)
+			}
+			if got := templateData["RDMA_RESOURCE_REQUESTS"]; got != tt.wantLine {
+				t.Errorf("RDMA_RESOURCE_REQUESTS = %q, want %q", got, tt.wantLine)
+			}
+			if got := templateData["MAX_MESSAGE_SIZE"]; got != tt.wantMaxMsgSize {
+				t.Errorf("MAX_MESSAGE_SIZE = %q, want %q", got, tt.wantMaxMsgSize)
+			}
+		})
+	}
+}
+
+func TestBuildAKSRdmaResourceLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		rdmaCount int
+		indent    string
+		want      string
+	}{
+		{
+			// A worker always requests exactly 1 unit, never the pool size:
+			// the rdma-shared-device-plugin grants access to every shared IB
+			// device per unit requested.
+			name:      "shared pool of 1000 requests a single unit",
+			rdmaCount: 1000,
+			indent:    "                      ",
+			want:      `                      rdma/hca_shared_devices_a: "1"`,
+		},
+		{
+			name:      "single device still requests one unit",
+			rdmaCount: 1,
+			indent:    "                      ",
+			want:      `                      rdma/hca_shared_devices_a: "1"`,
+		},
+		{
+			name:      "no RDMA — empty string",
+			rdmaCount: 0,
+			indent:    "                      ",
+			want:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAKSRdmaResourceLine(tt.rdmaCount, tt.indent)
+			if got != tt.want {
+				t.Errorf("buildAKSRdmaResourceLine(%d) = %q, want %q", tt.rdmaCount, got, tt.want)
+			}
+		})
+	}
+}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -215,6 +215,11 @@ var supportedNCCLCombinations = map[ncclVariant]map[recipe.CriteriaServiceType][
 		// runtime template and the same calibrated >= 300 GB/s floor.
 		recipe.CriteriaServiceEKS: {recipe.CriteriaAcceleratorH100, recipe.CriteriaAcceleratorH200},
 		recipe.CriteriaServiceGKE: {recipe.CriteriaAcceleratorH100},
+		// AKS ND-series H100 (e.g. Standard_ND96isr_H100_v5): 8x H100 SXM
+		// intra-node NVLink, 8x 400Gb NDR InfiniBand inter-node via the
+		// network-operator rdma-shared-device-plugin. NCCL uses its built-in
+		// IB/verbs transport (see testdata/h100/aks/runtime.yaml).
+		recipe.CriteriaServiceAKS: {recipe.CriteriaAcceleratorH100},
 		recipe.CriteriaServiceAny: {recipe.CriteriaAcceleratorB200, recipe.CriteriaAcceleratorGB200},
 	},
 	variantNET: {
@@ -711,6 +716,16 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 		}
 	}
 
+	// For AKS, discover the rdma-shared-device-plugin resource on the target
+	// GPU nodes. ND-series InfiniBand SKUs expose the node's IB HCAs through a
+	// shared pool (rdma/hca_shared_devices_a); a worker requests one unit to
+	// have every /dev/infiniband device mounted. A count of 0 is valid —
+	// NCCL falls back to TCP over the pod network (slower but functional),
+	// mirroring the EKS zero-EFA behavior above.
+	if service == recipe.CriteriaServiceAKS {
+		applyAKSTemplateData(config, templateData)
+	}
+
 	// Build effective worker scheduling: user override takes precedence over platform default.
 	defaultNodeSelector, defaultTolerations, err := platformWorkerScheduling(service, instanceType, config.Nodes)
 	if err != nil {
@@ -1065,7 +1080,7 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 // platformWorkerScheduling returns the default nodeSelector and tolerations
 // for NCCL worker pods on the given service. instanceType is only used for EKS;
 // nodes (the accelerator-narrowed target set from resolveTargetGPUNodes) is
-// used for GKE (the gke-accelerator label) and OKE (the shared
+// used for GKE (the gke-accelerator label) and OKE/AKS (the shared
 // nvidia.com/gpu.product label).
 func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType string, nodes []v1.Node) (map[string]string, []v1.Toleration, error) {
 	switch service {
@@ -1091,7 +1106,7 @@ func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType s
 			{Operator: v1.TolerationOpExists},
 			{Key: "nvidia.com/gpu", Operator: v1.TolerationOpEqual, Value: "present", Effect: v1.TaintEffectNoSchedule},
 		}, nil
-	case recipe.CriteriaServiceOKE:
+	case recipe.CriteriaServiceOKE, recipe.CriteriaServiceAKS:
 		// OKE bare-metal GB200 pools are commonly tainted and may coexist
 		// with other GPU shapes under one control plane. Tolerate the pool
 		// taint (mirroring EKS/GKE) and pin workers to the same cohort the
@@ -1100,12 +1115,19 @@ func platformWorkerScheduling(service recipe.CriteriaServiceType, instanceType s
 		// on. On non-GFD installs no shared product label exists, so emit no
 		// selector — matching the counting path's unfiltered fallback so the
 		// two stay aligned.
+		//
+		// AKS shares this shape: GPU pools carry the nvidia.com/gpu=present:
+		// NoSchedule taint and AICR recipes deploy the GPU Operator with GFD,
+		// so gpu.product (e.g. NVIDIA-H100-80GB-HBM3) is the discriminating
+		// label. The AKS-native kubernetes.azure.com/accelerator label is not
+		// used because its value is just "nvidia" — it cannot pin the H100
+		// cohort narrowByAccelerator sized the job against.
 		var nodeSelector map[string]string
 		if product := commonGPUProduct(nodes); product != "" {
 			nodeSelector = map[string]string{gpuProductLabel: product}
 		}
 		return nodeSelector, []v1.Toleration{{Operator: v1.TolerationOpExists}}, nil
-	case recipe.CriteriaServiceAny, recipe.CriteriaServiceAKS, recipe.CriteriaServiceOCP, recipe.CriteriaServiceKind, recipe.CriteriaServiceLKE, recipe.CriteriaServiceBCM, recipe.CriteriaServiceMetal3:
+	case recipe.CriteriaServiceAny, recipe.CriteriaServiceOCP, recipe.CriteriaServiceKind, recipe.CriteriaServiceLKE, recipe.CriteriaServiceBCM, recipe.CriteriaServiceMetal3:
 		return nil, nil, nil
 	default:
 		return nil, nil, nil

--- a/validators/performance/nccl_test.go
+++ b/validators/performance/nccl_test.go
@@ -495,6 +495,37 @@ func TestPlatformWorkerScheduling(t *testing.T) {
 			t.Errorf("OKE non-GFD tolerations = %v, want tolerate-all", tols)
 		}
 	})
+	t.Run("AKS pins to shared gpu.product and tolerates taints", func(t *testing.T) {
+		nodes := []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-H100-80GB-HBM3"}}},
+			{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{gpuProductLabel: "NVIDIA-H100-80GB-HBM3"}}},
+		}
+		ns, tols, err := platformWorkerScheduling(recipe.CriteriaServiceAKS, "", nodes)
+		if err != nil {
+			t.Fatalf("platformWorkerScheduling() error = %v", err)
+		}
+		if ns[gpuProductLabel] != "NVIDIA-H100-80GB-HBM3" {
+			t.Errorf("AKS nodeSelector = %v, want %s=NVIDIA-H100-80GB-HBM3", ns, gpuProductLabel)
+		}
+		if len(tols) != 1 || tols[0].Operator != corev1.TolerationOpExists {
+			t.Errorf("AKS tolerations = %v, want tolerate-all", tols)
+		}
+	})
+	t.Run("AKS on non-GFD cluster omits selector but still tolerates taints", func(t *testing.T) {
+		nodes := []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}},
+		}
+		ns, tols, err := platformWorkerScheduling(recipe.CriteriaServiceAKS, "", nodes)
+		if err != nil {
+			t.Fatalf("platformWorkerScheduling() error = %v", err)
+		}
+		if ns != nil {
+			t.Errorf("AKS non-GFD nodeSelector = %v, want nil", ns)
+		}
+		if len(tols) != 1 || tols[0].Operator != corev1.TolerationOpExists {
+			t.Errorf("AKS non-GFD tolerations = %v, want tolerate-all", tols)
+		}
+	})
 	t.Run("unknown service returns nil", func(t *testing.T) {
 		ns, tols, err := platformWorkerScheduling("unknown", "", nil)
 		if err != nil {
@@ -952,6 +983,12 @@ func TestSupportedNCCLCombinations_Variants(t *testing.T) {
 	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceAny]; len(accels) != 2 {
 		t.Errorf("variantDefault Any count = %d, want 2 (B200, GB200)", len(accels))
 	}
+	// AKS ND-series H100 runs the default variant over NCCL's built-in
+	// IB/verbs transport (testdata/h100/aks/runtime.yaml).
+	wantAKS := []recipe.CriteriaAcceleratorType{recipe.CriteriaAcceleratorH100}
+	if accels := supportedNCCLCombinations[variantDefault][recipe.CriteriaServiceAKS]; !reflect.DeepEqual(accels, wantAKS) {
+		t.Errorf("variantDefault AKS = %v, want %v", accels, wantAKS)
+	}
 }
 
 func TestSupportedNCCLCombinationsHaveRuntimeTemplates(t *testing.T) {
@@ -961,16 +998,18 @@ func TestSupportedNCCLCombinationsHaveRuntimeTemplates(t *testing.T) {
 	// against real NCCL logs during validation.
 	const efaIndent = "                      "
 	data := map[string]string{
-		"NAMESPACE":             "aicr-validation",
-		"WORKER_COUNT":          "2",
-		"GPU_COUNT_PER_NODE":    "8",
-		"GPU_COUNT":             "16",
-		"TEST_TYPE":             testType,
-		"MIN_MESSAGE_SIZE":      minMessageSize,
-		"MAX_MESSAGE_SIZE":      maxMessageSize,
-		"EFA_RESOURCE_LIMITS":   buildEFAResourceLine(1, efaIndent),
-		"EFA_RESOURCE_REQUESTS": buildEFAResourceLine(1, efaIndent),
-		"ROCE_DEVICE_COUNT":     "8",
+		"NAMESPACE":              "aicr-validation",
+		"WORKER_COUNT":           "2",
+		"GPU_COUNT_PER_NODE":     "8",
+		"GPU_COUNT":              "16",
+		"TEST_TYPE":              testType,
+		"MIN_MESSAGE_SIZE":       minMessageSize,
+		"MAX_MESSAGE_SIZE":       maxMessageSize,
+		"EFA_RESOURCE_LIMITS":    buildEFAResourceLine(1, efaIndent),
+		"EFA_RESOURCE_REQUESTS":  buildEFAResourceLine(1, efaIndent),
+		"RDMA_RESOURCE_LIMITS":   buildAKSRdmaResourceLine(1000, efaIndent),
+		"RDMA_RESOURCE_REQUESTS": buildAKSRdmaResourceLine(1000, efaIndent),
+		"ROCE_DEVICE_COUNT":      "8",
 		"GKE_NETWORK_INTERFACES": buildGKENetworkInterfacesAnnotation([]string{
 			"gpu-nic-0",
 			"gpu-nic-1",

--- a/validators/performance/testdata/h100/aks/runtime.yaml
+++ b/validators/performance/testdata/h100/aks/runtime.yaml
@@ -1,0 +1,221 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NCCL All-Reduce TrainingRuntime — AKS ND-series H100 InfiniBand fabric.
+#
+# Derived from the EKS H100 template (testdata/h100/eks/runtime.yaml) with the
+# transport swapped from EFA/Libfabric to NCCL's built-in IB/verbs:
+#   - Fabric: 8x 400Gb NDR InfiniBand HCAs per node (mlx5), exposed to pods by
+#     the network-operator rdma-shared-device-plugin. Workers request one unit
+#     of ${RDMA_RESOURCE_*} (rdma/hca_shared_devices_a — a shared pool, one
+#     unit mounts every /dev/infiniband device).
+#   - Transport: NCCL_NET_PLUGIN=none bypasses the aws-ofi-nccl (EFA/Libfabric)
+#     plugin bundled in this image so NCCL's built-in IB transport binds the
+#     mlx5 HCAs directly; no FI_* / EFA env. NCCL_IB_HCA is deliberately not
+#     pinned — NCCL auto-detects the HCAs and skips ports without active link.
+#   - IPC_LOCK stays: NCCL's IB transport registers pinned (memlocked) buffers
+#     via ibverbs, same requirement the EFA path has.
+# Everything else (image, MPI bootstrap, SSH wiring, resource shape) is kept
+# in lockstep with the EKS template. The image ships sshd, nccl-tests, and
+# rdma-core (EFA itself is an ibverbs device), so it runs IB unmodified.
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: nccl-all-reduce-runtime
+  namespace: ${NAMESPACE}
+  labels:
+    trainer.kubeflow.org/framework: mpi
+spec:
+  mlPolicy:
+    mpi:
+      mpiImplementation: OpenMPI
+      numProcPerNode: ${GPU_COUNT_PER_NODE}
+      runLauncherAsNode: false
+      # Mount the SSH secret to /tmp/mpi-keys (not /root/.ssh) so that init containers
+      # can copy the private key to /root/.ssh with chmod 600. Kubernetes secret volumes
+      # default to 0644, and SSH refuses to use a private key with permissions > 0600.
+      sshAuthMountPath: /tmp/mpi-keys
+  template:
+    spec:
+      network:
+        # Required: JobSet sets spec.subdomain on pods and creates the headless service
+        # that makes pod FQDNs (e.g. nccl-all-reduce-tj-node-0-0.nccl-all-reduce-tj) resolvable.
+        enableDNSHostnames: true
+        # Required: publish DNS records for pods not yet Ready so mpirun can resolve
+        # workers before they finish initialization.
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - name: launcher
+        replicas: 1
+        template:
+          spec:
+            template:
+              spec:
+                tolerations:
+                - operator: Exists
+                initContainers:
+                # Fix SSH key permissions: the MPI plugin mounts the secret at /tmp/mpi-keys
+                # with default 0644 permissions. SSH refuses to use id_rsa with > 0600.
+                # This init container copies the key to a writable emptyDir (/root/.ssh)
+                # with correct permissions before mpirun starts.
+                - name: fix-ssh-perms
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/id_rsa /root/.ssh/id_rsa
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys
+                  volumeMounts:
+                  # mpi-ssh-auth is injected by the MPI plugin into the pod volumes list
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                # Container must be named "node" — the MPI plugin only processes containers
+                # with this name (constants.Node) to inject: SSH auth mount, hostfile mount,
+                # and OpenMPI env vars (OMPI_MCA_orte_default_hostfile, OMPI_MCA_plm_rsh_args,
+                # OMPI_MCA_orte_default_slots, OMPI_MCA_orte_keep_fqdn_hostnames).
+                - name: node
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  env:
+                  # Unlike the EKS template, /opt/amazon/ofi-nccl/... is omitted:
+                  # with NCCL_NET_PLUGIN=none the aws-ofi-nccl plugin must not be
+                  # discoverable, so NCCL's built-in IB transport is used.
+                  # mpirun propagates this path to workers via -x LD_LIBRARY_PATH below.
+                  - name: LD_LIBRARY_PATH
+                    value: "/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/usr/local/nvidia/lib"
+                  - name: PATH
+                    value: "$PATH:/usr/bin"
+                  command:
+                  - /opt/amazon/openmpi/bin/mpirun
+                  - -np
+                  - "${GPU_COUNT}"
+                  - --allow-run-as-root
+                  - -bind-to
+                  - none
+                  - --mca
+                  - plm_rsh_agent
+                  - ssh
+                  # Override plm_rsh_args to suppress host-key checking (known_hosts is empty
+                  # on fresh pods) and include retry count so mpirun waits for worker sshd.
+                  - --mca
+                  - plm_rsh_args
+                  - -o StrictHostKeyChecking=no -o ConnectionAttempts=10
+                  - -x
+                  - LD_LIBRARY_PATH
+                  - -x
+                  - PATH
+                  - -x
+                  - NCCL_DEBUG=WARN
+                  # Use NCCL's built-in IB/verbs transport over the ND-series
+                  # InfiniBand HCAs; disable the bundled aws-ofi-nccl (EFA) plugin.
+                  - -x
+                  - NCCL_NET_PLUGIN=none
+                  - -x
+                  - NCCL_IB_DISABLE=0
+                  - -x
+                  - NCCL_SOCKET_IFNAME=eth0
+                  - -x
+                  - NCCL_IGNORE_DISABLED_P2P=1
+                  - /opt/nccl-tests/build/${TEST_TYPE}
+                  - -b
+                  - ${MIN_MESSAGE_SIZE}
+                  - -e
+                  - ${MAX_MESSAGE_SIZE}
+                  - -f
+                  - "2"
+                  - -g
+                  - "1"
+                  resources:
+                    limits:
+                      cpu: "2"
+                      memory: 128Mi
+                  volumeMounts:
+                  # ssh-config emptyDir holds the chmod-fixed keys from the init container.
+                  # The plugin will also mount mpi-ssh-auth at /tmp/mpi-keys on this container.
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+      # This replicatedJob must be named "node" — the MPI plugin identifies the training
+      # workers by constants.Node ("node") to override replicas from TrainJob.spec.trainer.numNodes
+      # and to mount SSH auth credentials so the launcher can SSH in.
+      - name: node
+        template:
+          spec:
+            template:
+              spec:
+                initContainers:
+                # Fix authorized_keys permissions so sshd accepts incoming connections.
+                # The MPI plugin mounts the secret at /tmp/mpi-keys with 0644; sshd
+                # with StrictModes requires authorized_keys to not be group/world writable,
+                # and requires the .ssh directory to be 0700.
+                - name: fix-ssh-perms
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    mkdir -p /root/.ssh
+                    cp /tmp/mpi-keys/authorized_keys /root/.ssh/authorized_keys
+                    chmod 700 /root/.ssh
+                    chmod 600 /root/.ssh/authorized_keys
+                  volumeMounts:
+                  - name: mpi-ssh-auth
+                    mountPath: /tmp/mpi-keys
+                    readOnly: true
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                containers:
+                # Container must be named "node" for the MPI plugin to mount SSH auth volume.
+                - name: node
+                  image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
+                  # Run sshd in foreground so the launcher can SSH in and run the NCCL test.
+                  command: ["/usr/sbin/sshd", "-De"]
+                  resources:
+                    limits:
+                      nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
+${RDMA_RESOURCE_LIMITS}
+                    requests:
+                      nvidia.com/gpu: ${GPU_COUNT_PER_NODE}
+${RDMA_RESOURCE_REQUESTS}
+                  securityContext:
+                    capabilities:
+                      # NCCL's IB transport registers pinned (memlocked) GPU/host
+                      # buffers via ibverbs — IPC_LOCK lifts RLIMIT_MEMLOCK.
+                      add: ["IPC_LOCK"]
+                  volumeMounts:
+                  # ssh-config holds the chmod-fixed authorized_keys from the init container.
+                  # The plugin will also mount mpi-ssh-auth at /tmp/mpi-keys on this container.
+                  - name: ssh-config
+                    mountPath: /root/.ssh
+                  - name: dshm
+                    mountPath: /dev/shm
+                volumes:
+                - name: ssh-config
+                  emptyDir: {}
+                - name: dshm
+                  emptyDir:
+                    medium: Memory
+      successPolicy:
+        operator: All
+        targetReplicatedJobs:
+        - launcher


### PR DESCRIPTION
## Summary

Adds AKS (Azure) support to the `nccl-all-reduce-bw` performance validator — service=aks + accelerator=h100 now runs the NCCL all-reduce bandwidth benchmark over the ND-series InfiniBand fabric — and declares the performance phase in the `h100-aks-training` overlay with a provisional busbw floor.

## Motivation / Context

`recipes/overlays/h100-aks-training.yaml` carried an intentional-skip comment: the performance phase was deliberately not declared because the validator had no AKS NCCL runtime template, scheduling path, or support-table entry — a declared check would have silently skipped and reported the phase as passed without measuring anything. This PR wires the full path (runtime template + RDMA discovery + worker scheduling + support-table entry + recipe constraint) and replaces that comment with a real performance block, verified end-to-end on a live AKS H100 cluster.

Fixes: N/A
Related: #1337, #1256

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `validators/performance` (validator pod binary + testdata), `recipes/overlays`

## Implementation Notes

- **Support table**: `aks -> [h100]` added to `supportedNCCLCombinations[variantDefault]` only. EKS H100 exists only in the default variant, so no `-net`/`-nvls` entries (those are GB200-specific).
- **Transport (`testdata/h100/aks/runtime.yaml`)**: derived from the EKS H100 TrainingRuntime, same `public.ecr.aws/hpc-cloud/nccl-tests` image (ships sshd, nccl-tests, rdma-core). `NCCL_NET_PLUGIN=none` bypasses the bundled aws-ofi-nccl (EFA/Libfabric) plugin so NCCL's built-in IB/verbs transport binds the mlx5 HCAs directly; all `FI_*`/EFA env dropped; `IPC_LOCK` retained (ibverbs pinned-buffer registration). `NCCL_IB_HCA` is deliberately not pinned — NCCL auto-detects HCAs and skips inactive ports.
- **RDMA resource (`nccl_aks_utils.go`)**: workers request one unit of `rdma/hca_shared_devices_a`, the shared pool published by the network-operator rdma-shared-device-plugin (resource name pinned by `recipes/components/network-operator/manifests/nic-cluster-policy-aks.yaml`). Shared-pool semantics: one unit mounts every `/dev/infiniband` device, so the request is always `"1"` regardless of HCA count. Zero allocatable devices falls back to TCP with the reduced 4G message cap, mirroring the EKS zero-EFA behavior.
- **Worker scheduling**: AKS joins the OKE branch of `platformWorkerScheduling` — pin workers to the common GFD `nvidia.com/gpu.product` label (the same label `narrowByAccelerator` sized the cohort against) and tolerate the pool taint (`nvidia.com/gpu=present:NoSchedule`). The AKS-native `kubernetes.azure.com/accelerator` label was rejected: its value is just `nvidia` (verified live), so it cannot pin the H100 cohort on a mixed-accelerator cluster.
- **Provisional floor + live baseline**: the overlay declares `nccl-all-reduce-bw >= 150` — half the calibrated EKS H100 floor (300). Live baseline: 157.24 GB/s busbw measured untuned on 2x Standard_ND96isr_H100_v5 (8x H100 SXM, 8x 400Gb NDR IB per node). 8x NDR line rate is ~400 GB/s, so the floor should be recalibrated upward after IB tuning; the comment in the overlay records this.
- **Known limitation (worth a follow-up issue)**: building the validator images with `docker build` from a macOS checkout is broken repo-wide — git tracks both `vendor/github.com/NVIDIA` and `vendor/github.com/nvidia`, which collide on case-insensitive filesystems, so the docker build context only ever contains one of them and the in-container `go build` fails on the `k8s-launch-kit` imports. CI/Linux is unaffected; local `go build` works (case-insensitive lookup). Workaround: build from a `git archive` tar context.

## Testing

```bash
make qualify
```

- Full `make qualify` (test-coverage + lint + tuning-check + e2e + scan + license-check) passes, exit 0.
- `make test-coverage`: 78.7% total (threshold 75%) — passes.
- Coverage delta `validators/performance`: 50.1% -> 50.3% (+0.2% vs origin/main baseline via worktree method). No new exported functions (all new helpers are unexported and covered: `discoverAKSRdmaCount` 100%, `buildAKSRdmaResourceLine` 100%, `applyAKSTemplateData` covered by `TestApplyAKSTemplateData`).
- `golangci-lint run -c .golangci.yaml ./validators/performance/...` — 0 issues.
- New table-driven tests mirror the EKS tests (`nccl_aks_utils_test.go`), plus AKS subtests in `TestPlatformWorkerScheduling`, an AKS assertion in the support-table test, and the template wiring-guard now parses `testdata/h100/aks/runtime.yaml`.
- Recipe hydration verified: `aicr recipe --service aks --accelerator h100 --intent training --os ubuntu` emits the performance block with the `>= 150` constraint.
- **Live verification (aicr-test1, AKS westus)**: deployed `h100-aks-ubuntu-training-kubeflow`, ran the performance phase with a dev validator image (`ghcr.io/yuanchen8911/aicr-validators/performance:aks-nccl-dev`, linux/amd64). `nccl-all-reduce-bw` was selected and **passed**: 157.24 GB/s busbw at 16 GiB all-reduce across 2x ND96isr_H100_v5 over IB (mlx5), against the >= 150 floor (10% tolerance). The real image ships via CI on merge; the dev image was only used to test pre-merge.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Additive: a new (service, accelerator) tuple in the validator support table and a new performance block in the AKS overlay. Existing services/recipes are untouched; AKS clusters without the RDMA shared device plugin degrade to the TCP fallback rather than failing. Revert = drop the overlay block and the AKS table entry.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
