### PR TITLE
evidence(aks): h100 training + inference-dynamo recipe evidence

### DIFF
--- a/recipes/evidence/allowlist.yaml
+++ b/recipes/evidence/allowlist.yaml
@@ -69,6 +69,8 @@ firstParty:
 community:
   - issuer: https://github.com/login/oauth
     source: 7c4c0edc8c765a95a0f3afdb3bbb8e91
+  - issuer: https://token.actions.githubusercontent.com
+    source: 5bf9e82f0e90a11528ac85f4bcb866c8
 
 # Partner: vetted partner organizations. None onboarded yet.
 partner: []

--- a/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-f8d2a0188274d179f37dfe39a257aeaa3fbb97273162586853e0986bfa5d3c05.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-f8d2a0188274d179f37dfe39a257aeaa3fbb97273162586853e0986bfa5d3c05.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-09T23:33:20Z
+    bundle:
+      digest: sha256:f8d2a0188274d179f37dfe39a257aeaa3fbb97273162586853e0986bfa5d3c05
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-inference-dynamo-722cf4ebe659
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 2133437068
+recipe: h100-aks-ubuntu-inference-dynamo
+schemaVersion: 1.0.0

--- a/recipes/evidence/h100-aks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-7e7c4680bab4c44bb68fab53fc85a7f8d8065ca6b796458a2bc7cb4f4a49bfa9.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-7e7c4680bab4c44bb68fab53fc85a7f8d8065ca6b796458a2bc7cb4f4a49bfa9.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-09T23:24:00Z
+    bundle:
+      digest: sha256:7e7c4680bab4c44bb68fab53fc85a7f8d8065ca6b796458a2bc7cb4f4a49bfa9
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-training-kubeflow-6d74969e6b85
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 2133437683
+recipe: h100-aks-ubuntu-training-kubeflow
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds signed recipe-evidence v1 pointers for two AKS H100 recipes, both validated end-to-end on a from-scratch AKS cluster (`aicr-test5`, 2× Standard_ND96isr_H100_v5, K8s 1.35.5, Ubuntu 24.04):

- **h100-aks-ubuntu-training-kubeflow** — deployment + conformance + performance all passed; NCCL all-reduce **157.11 GB/s** (gate ≥150).
- **h100-aks-ubuntu-inference-dynamo** — deployment + conformance + performance all passed; inference-perf **146,705 tok/s**, TTFT p99 **674 ms** (gates ≥50,000 / ≤2,000).

## Motivation / Context

First recipe-evidence for the AKS H100 training and inference-dynamo recipes. Produced via `aicr validate --phase all --emit-attestation`, published unsigned to the fork's public `ghcr.io/yuanchen8911/aicr-evidence`, then signed by the fork-based `evidence-publish.yaml` workflow (GitHub Actions ambient OIDC — firstParty, no personal PII; Rekor log indices 2133437683 et al.).

Related: the AKS NCCL performance validator landed in #1695.

## Type of Change

- [x] Evidence submission (recipe-evidence v1 pointers)

## Components Affected

- [x] Recipe evidence (`recipes/evidence/`)

## Implementation Notes

- Two signed pointers relocated to their canonical per-source paths under `recipes/evidence/<recipe>/<source>/<digest>.yaml`.
- Adds one pseudonymous `community:` allowlist entry (issuer + one-way source slug `5bf9e82f…`, no label/handle) so the fork-CI signer is trusted, matching the existing community entry's pseudonymous form.
- Bundles are content-addressed OCI artifacts in the fork's public registry; the pointers carry only the reference + digest.

## Testing

- `aicr evidence verify` on both pointers: signature-verify, predicate-parse, and manifest-hash-check all pass (bundle valid, exit 0).
- Evidence generated from passing `validate --phase all` runs on aicr-test5 (deployment + conformance + performance green for both recipes).

## Risk Assessment

- [x] **Low** — additive evidence data + one allowlist slug; no code or recipe behavior change.
