### PR TITLE
chore(deps): consolidate GitHub Actions updates

### DIFF
--- a/.github/workflows/fern-docs-ci.yaml
+++ b/.github/workflows/fern-docs-ci.yaml
@@ -51,7 +51,7 @@ jobs:
         run: fern check
 
       - name: Check links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --offline --no-progress 'docs/**/*.md'
           fail: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.1.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629  # v10.4.0
         with:
           # Issue settings
           stale-issue-message: |


### PR DESCRIPTION
## Summary

Consolidates the two open Dependabot GitHub Actions updates into one change: `lycheeverse/lychee-action` 2.8.0 → 2.9.0 and `actions/stale` 10.3.0 → 10.4.0.

## Motivation / Context

Reviewing and merging these independent action updates together avoids repeated rebases and CI runs while preserving the immutable SHA pins from the original Dependabot PRs.

Fixes: N/A
Related: #1700, #1701

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/api`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions workflows

## Implementation Notes

- Preserves the exact immutable action SHAs from #1700 and #1701.
- Verifies both SHAs resolve to the proposed upstream release tags and signed upstream commits.
- Keeps the existing action inputs unchanged; the two updates touch separate workflows.
- Corrects the stale `actions/stale` inline version annotation to `v10.4.0`.
- Requires no BOM regeneration or Go coverage delta because no recipe, chart, component, or Go files change.

## Testing

```bash
actionlint .github/workflows/fern-docs-ci.yaml .github/workflows/stale.yaml
yamllint -c .yamllint.yaml .github/workflows/fern-docs-ci.yaml .github/workflows/stale.yaml
unset GITLAB_TOKEN
make qualify
```

- `make qualify`: passed
- Race-enabled unit tests: passed
- Coverage: 78.1% (75% required)
- golangci-lint: 0 issues
- Chainsaw E2E: 23 passed, 0 failed, 0 skipped
- Vulnerability and license gates: passed
- The targeted `actionlint` command exits successfully with one pre-existing SC2046 warning on an untouched Fern install line.

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration is required. Revert the single commit to restore both previous action pins.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
  - Not applicable: this dependency-only update adds no functionality; existing workflow and qualification gates cover the changed pins.
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
