### PR TITLE
fix(kwok): deadline-derived sync-gate budgets + 18m tier timeout

### DIFF
--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -77,9 +77,11 @@ inputs:
       KWOK_SYNC_DEADLINE_EPOCH (deadline = step start + this budget - 240s
       diagnostics margin) so the chainsaw sync gates always finish - and
       print their catch-block diagnostics - before GitHub kills the job.
-      Keep in sync with the calling job's timeout-minutes.
-    required: false
-    default: '18'
+      Required with no default: every caller must wire its own
+      timeout-minutes here, so a job that changes its timeout cannot
+      silently drift from a stale default (a missing value fails the
+      integer validation below loudly).
+    required: true
 
 runs:
   using: 'composite'

--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -71,10 +71,42 @@ inputs:
     description: 'Number of days to retain debug artifacts'
     required: false
     default: '7'
+  job_timeout_minutes:
+    description: >-
+      The calling job's timeout-minutes. Used to derive
+      KWOK_SYNC_DEADLINE_EPOCH (deadline = step start + this budget - 240s
+      diagnostics margin) so the chainsaw sync gates always finish - and
+      print their catch-block diagnostics - before GitHub kills the job.
+      Keep in sync with the calling job's timeout-minutes.
+    required: false
+    default: '18'
 
 runs:
   using: 'composite'
   steps:
+    - name: Derive sync-gate deadline
+      shell: bash
+      env:
+        JOB_TIMEOUT_MINUTES: ${{ inputs.job_timeout_minutes }}
+      run: |
+        # Anchor the sync-gate deadline as early as possible in the job:
+        # only checkout + load-versions run before this step, so the
+        # unaccounted job-start drift stays inside the 240s margin's 60s
+        # allowance (the other 180s is reserved for post-gate work:
+        # chainsaw catch diagnostics, verify_pods, debug-artifact upload).
+        # Anchoring later (at the test step, after setup-go + tool installs
+        # + make build) lets the deadline land past GitHub's job kill and
+        # silently re-creates the CANCELLED-without-diagnostics failure
+        # this mechanism exists to prevent.
+        # See kwok/scripts/lib/sync-budget.sh for the consuming side.
+        if ! [[ "${JOB_TIMEOUT_MINUTES}" =~ ^[0-9]+$ ]]; then
+          echo "::error::job_timeout_minutes must be an integer, got '${JOB_TIMEOUT_MINUTES}'"
+          exit 1
+        fi
+        KWOK_SYNC_DEADLINE_EPOCH=$(( $(date +%s) + JOB_TIMEOUT_MINUTES * 60 - 240 ))
+        echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH}" >> "$GITHUB_ENV"
+        echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH} (job_timeout_minutes=${JOB_TIMEOUT_MINUTES}, margin=240s)"
+
     - name: Set up Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
       with:

--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -75,12 +75,14 @@ inputs:
     description: >-
       The calling job's timeout-minutes. Used to derive
       KWOK_SYNC_DEADLINE_EPOCH (deadline = step start + this budget - 240s
-      diagnostics margin) so the chainsaw sync gates always finish - and
-      print their catch-block diagnostics - before GitHub kills the job.
-      Required with no default: every caller must wire its own
-      timeout-minutes here, so a job that changes its timeout cannot
-      silently drift from a stale default (a missing value fails the
-      integer validation below loudly).
+      diagnostics margin) so each chainsaw sync gate's budget stays within
+      that margin, letting the gate finish - and print its catch-block
+      diagnostics - before GitHub kills the job in the expected
+      single-gate-dominates case (this bounds each gate operation, not the
+      job's overall wall time). Required with no default: every caller
+      must wire its own timeout-minutes here, so a job that changes its
+      timeout cannot silently drift from a stale default (a missing value
+      fails the integer validation below loudly).
     required: true
 
 runs:
@@ -101,13 +103,13 @@ runs:
         # silently re-creates the CANCELLED-without-diagnostics failure
         # this mechanism exists to prevent.
         # See kwok/scripts/lib/sync-budget.sh for the consuming side.
-        if ! [[ "${JOB_TIMEOUT_MINUTES}" =~ ^[0-9]+$ ]]; then
-          echo "::error::job_timeout_minutes must be an integer, got '${JOB_TIMEOUT_MINUTES}'"
+        if ! [[ "${JOB_TIMEOUT_MINUTES}" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::job_timeout_minutes must be a positive integer, no leading zeros, got '${JOB_TIMEOUT_MINUTES}'"
           exit 1
         fi
-        KWOK_SYNC_DEADLINE_EPOCH=$(( $(date +%s) + JOB_TIMEOUT_MINUTES * 60 - 240 ))
+        KWOK_SYNC_DEADLINE_EPOCH=$(( $(date +%s) + 10#${JOB_TIMEOUT_MINUTES} * 60 - 240 ))
         echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH}" >> "$GITHUB_ENV"
-        echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH} (job_timeout_minutes=${JOB_TIMEOUT_MINUTES}, margin=240s)"
+        echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH} (job_timeout_minutes=${JOB_TIMEOUT_MINUTES}, margin=240s, job kill in ~$(( 10#${JOB_TIMEOUT_MINUTES} * 60 ))s)"
 
     - name: Set up Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0

--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -107,6 +107,14 @@ runs:
           echo "::error::job_timeout_minutes must be a positive integer, no leading zeros, got '${JOB_TIMEOUT_MINUTES}'"
           exit 1
         fi
+        # 120 must equal SYNC_BUDGET_FLOOR_SECONDS in kwok/scripts/lib/sync-budget.sh
+        # (hand-synced literal, guarded by sync-budget_test.sh — same contract as the
+        # 240s margin). A budget under the floor would compute an already-unusable
+        # deadline that only fails later, inside the job, after setup burned CI minutes.
+        if (( 10#${JOB_TIMEOUT_MINUTES} * 60 - 240 < 120 )); then
+          echo "::error::job_timeout_minutes=${JOB_TIMEOUT_MINUTES} leaves no usable sync budget after the 240s diagnostics margin (need >= 6)"
+          exit 1
+        fi
         KWOK_SYNC_DEADLINE_EPOCH=$(( $(date +%s) + 10#${JOB_TIMEOUT_MINUTES} * 60 - 240 ))
         echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH}" >> "$GITHUB_ENV"
         echo "KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH} (job_timeout_minutes=${JOB_TIMEOUT_MINUTES}, margin=240s, job kill in ~$(( 10#${JOB_TIMEOUT_MINUTES} * 60 ))s)"

--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -323,6 +323,7 @@ jobs:
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           kind_node_image: ${{ steps.versions.outputs.kind_node_image }}
+          # keep == this job's timeout-minutes (asserted by sync-budget_test.sh)
           job_timeout_minutes: '18'
 
   # ── Tier 2: diff-aware accelerator tests (PR only, conditional) ──
@@ -364,6 +365,7 @@ jobs:
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           kind_node_image: ${{ steps.versions.outputs.kind_node_image }}
+          # keep == this job's timeout-minutes (asserted by sync-budget_test.sh)
           job_timeout_minutes: '18'
 
   # ── Tier 3: full matrix (push to main + nightly schedule) ──

--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -92,6 +92,9 @@ jobs:
           # Full checkout needed for diff-aware Tier 2 discovery
           fetch-depth: 0
 
+      - name: Script unit tests (kwok/scripts/lib)
+        run: bash kwok/scripts/lib/sync-budget_test.sh
+
       - name: Classify recipes into tiers
         id: classify
         shell: bash
@@ -288,7 +291,7 @@ jobs:
       needs.discover.outputs.tier1 != '[]' &&
       needs.discover.outputs.tier1 != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:
@@ -320,6 +323,7 @@ jobs:
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           kind_node_image: ${{ steps.versions.outputs.kind_node_image }}
+          job_timeout_minutes: '18'
 
   # ── Tier 2: diff-aware accelerator tests (PR only, conditional) ──
   test-tier2:
@@ -330,7 +334,7 @@ jobs:
       needs.discover.outputs.tier2 != '[]' &&
       needs.discover.outputs.tier2 != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:
@@ -360,6 +364,7 @@ jobs:
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           kind_node_image: ${{ steps.versions.outputs.kind_node_image }}
+          job_timeout_minutes: '18'
 
   # ── Tier 3: full matrix (push to main + nightly schedule) ──
   # The recipe × deployer cross-product exceeds GitHub's 256-config matrix cap,

--- a/.github/workflows/kwok-tier3-shard.yaml
+++ b/.github/workflows/kwok-tier3-shard.yaml
@@ -35,7 +35,7 @@ jobs:
   test:
     name: 'Tier 3: ${{ matrix.pair.recipe }} (${{ matrix.pair.deployer }})'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:
@@ -66,3 +66,4 @@ jobs:
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           kind_node_image: ${{ steps.versions.outputs.kind_node_image }}
+          job_timeout_minutes: '18'

--- a/.github/workflows/kwok-tier3-shard.yaml
+++ b/.github/workflows/kwok-tier3-shard.yaml
@@ -66,4 +66,5 @@ jobs:
           chainsaw_version: ${{ steps.versions.outputs.chainsaw }}
           chainsaw_sha256: ${{ steps.versions.outputs.chainsaw_sha256_linux_amd64 }}
           kind_node_image: ${{ steps.versions.outputs.kind_node_image }}
+          # keep == this job's timeout-minutes (asserted by sync-budget_test.sh)
           job_timeout_minutes: '18'

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -387,8 +387,10 @@ sits within ~60 s of job start — from its `job_timeout_minutes` input
 must equal that caller's `timeout-minutes`; currently `18` for the
 KWOK jobs) minus a 240 s margin reserved for chainsaw catch-block
 diagnostics, pod verification, and debug-artifact upload. The input
-must be a positive integer with no leading zeros; the step fails fast
-otherwise. Local runs leave it unset and keep the fixed defaults above.
+must be a positive integer with no leading zeros, and must leave at
+least 120 s of usable budget after the 240 s margin (i.e. `>= 6`); the
+step fails fast otherwise. Local runs leave it unset and keep the
+fixed defaults above.
 
 The Git-source lanes (`flux-git`, `argocd-git`) additionally honor
 `KWOK_GITEA_HOST_PORT` (default `3300`), `KWOK_GITEA_USER` (default

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -383,11 +383,12 @@ independent.
 In CI, the `kwok-test` action derives `KWOK_SYNC_DEADLINE_EPOCH` in its
 first step — before toolchain setup and the `aicr` build, so the anchor
 sits within ~60 s of job start — from its `job_timeout_minutes` input
-(default `18`, kept in sync with the calling job's `timeout-minutes`)
-minus a 240 s margin reserved for chainsaw catch-block diagnostics,
-pod verification, and debug-artifact upload. The input must be an
-integer; the step fails fast otherwise. Local runs leave it unset and
-keep the fixed defaults above.
+(required, no default — every caller must wire its own value, which
+must equal that caller's `timeout-minutes`; currently `18` for the
+KWOK jobs) minus a 240 s margin reserved for chainsaw catch-block
+diagnostics, pod verification, and debug-artifact upload. The input
+must be a positive integer with no leading zeros; the step fails fast
+otherwise. Local runs leave it unset and keep the fixed defaults above.
 
 The Git-source lanes (`flux-git`, `argocd-git`) additionally honor
 `KWOK_GITEA_HOST_PORT` (default `3300`), `KWOK_GITEA_USER` (default

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -368,7 +368,7 @@ scheduling-shape failures.
 
 ### Tuning the Sync Deadline
 
-Four environment variables shape how long the GitOps lanes wait
+Five environment variables shape how long the GitOps lanes wait
 before declaring a sync timeout. Argo CD and Flux pairs are
 independent.
 
@@ -378,6 +378,16 @@ independent.
 | `KWOK_ARGOCD_ROOT_GRACE` | `30` s | Grace period for the root Application before deadline counting starts |
 | `KWOK_FLUX_SYNC_TIMEOUT` | `500` s | Deadline for source fetch (OCIRepository or GitRepository) + Kustomization apply + HelmReleases `Ready=True` + ArtifactGenerators Ready |
 | `KWOK_FLUX_ROOT_GRACE` | `30` s | Grace period for the outer Kustomization before deadline counting starts |
+| `KWOK_SYNC_DEADLINE_EPOCH` | unset | Absolute epoch deadline for sync-gate work (CI only). When set, each gate budget becomes min(default, deadline − now); below a 120 s floor the gate fails fast with exit 50 so chainsaw's catch-block diagnostics always print before GitHub's job timeout |
+
+In CI, the `kwok-test` action derives `KWOK_SYNC_DEADLINE_EPOCH` in its
+first step — before toolchain setup and the `aicr` build, so the anchor
+sits within ~60 s of job start — from its `job_timeout_minutes` input
+(default `18`, kept in sync with the calling job's `timeout-minutes`)
+minus a 240 s margin reserved for chainsaw catch-block diagnostics,
+pod verification, and debug-artifact upload. The input must be an
+integer; the step fails fast otherwise. Local runs leave it unset and
+keep the fixed defaults above.
 
 The Git-source lanes (`flux-git`, `argocd-git`) additionally honor
 `KWOK_GITEA_HOST_PORT` (default `3300`), `KWOK_GITEA_USER` (default

--- a/kwok/scripts/lib/sync-budget.sh
+++ b/kwok/scripts/lib/sync-budget.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Deadline-derived sync-gate budgets for the KWOK deployer-matrix CI lane.
+#
+# Sourced by validate-scheduling.sh. CI (.github/actions/kwok-test) exports
+# KWOK_SYNC_DEADLINE_EPOCH — the absolute epoch after which the job has no
+# time left for sync-gate work (job timeout minus a diagnostics margin).
+# Each chainsaw sync gate derives its budget as min(<gate default>,
+# deadline − now) so chainsaw always times out — and prints its catch-block
+# diagnostics — BEFORE GitHub's job timeout kills the runner with a silent
+# CANCELLED and zero error report.
+#
+# Source guard: constants and functions only, no side effects at source
+# time (same contract as lib/cleanup.sh).
+
+# Below this floor a shrunken budget cannot produce a meaningful gate run;
+# callers fail fast with an explicit error instead — which is itself the
+# diagnosis a silent CANCELLED would have destroyed.
+readonly SYNC_BUDGET_FLOOR_SECONDS=120
+
+# compute_sync_budget <default_seconds> [<now_epoch>]
+#
+# Prints the effective sync-gate budget (seconds) to stdout:
+#   - KWOK_SYNC_DEADLINE_EPOCH unset/empty: <default_seconds> unchanged
+#     (local runs keep today's fixed budgets).
+#   - Set: min(<default_seconds>, KWOK_SYNC_DEADLINE_EPOCH − now).
+# Returns 1 (printing nothing) when the derived budget is below
+# SYNC_BUDGET_FLOOR_SECONDS — callers must fail fast (exit code 50).
+# <now_epoch> is injectable for tests; defaults to $(date +%s).
+compute_sync_budget() {
+    local default_seconds="$1"
+    local now="${2:-$(date +%s)}"
+    if [[ -z "${KWOK_SYNC_DEADLINE_EPOCH:-}" ]]; then
+        echo "${default_seconds}"
+        return 0
+    fi
+    local remaining=$(( KWOK_SYNC_DEADLINE_EPOCH - now ))
+    local budget="${default_seconds}"
+    if (( remaining < budget )); then
+        budget="${remaining}"
+    fi
+    if (( budget < SYNC_BUDGET_FLOOR_SECONDS )); then
+        return 1
+    fi
+    echo "${budget}"
+}

--- a/kwok/scripts/lib/sync-budget.sh
+++ b/kwok/scripts/lib/sync-budget.sh
@@ -14,9 +14,10 @@
 # KWOK_SYNC_DEADLINE_EPOCH — the absolute epoch after which the job has no
 # time left for sync-gate work (job timeout minus a diagnostics margin).
 # Each chainsaw sync gate derives its budget as min(<gate default>,
-# deadline − now) so chainsaw always times out — and prints its catch-block
-# diagnostics — BEFORE GitHub's job timeout kills the runner with a silent
-# CANCELLED and zero error report.
+# deadline − now), bounding that gate's assert/error operation so it
+# finishes — and prints its catch-block diagnostics — before GitHub's
+# job timeout kills the runner in the expected single-gate-dominates
+# case (this bounds each gate operation, not the job's whole wall time).
 #
 # Source guard: constants and functions only, no side effects at source
 # time (same contract as lib/cleanup.sh).

--- a/kwok/scripts/lib/sync-budget_test.sh
+++ b/kwok/scripts/lib/sync-budget_test.sh
@@ -58,8 +58,48 @@ export KWOK_SYNC_DEADLINE_EPOCH=999000
 out=$(compute_sync_budget 500 1000000); rc=$?
 check "deadline-past-fails" 1 "" "${rc}" "${out}"
 
+# 7. Literal-sync guard: job_timeout_minutes must equal the SAME job's
+# timeout-minutes in every caller workflow. This is a hand-synced literal
+# (the composite action cannot read the calling job's own timeout-minutes);
+# drift silently re-creates the CANCELLED-without-diagnostics failure this
+# whole mechanism exists to prevent. Resolve workflows SCRIPT_DIR-relative
+# so this always tests THIS checkout, never a deployed copy.
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# job_timeout_sync <workflow_file> -> one "<job>:jtm=<X>,tm=<Y>" line per
+# job that sets job_timeout_minutes, where <X> is that value and <Y> is
+# the nearest preceding job-level (4-space-indented) timeout-minutes
+# ("unset" if none was seen for the current job).
+job_timeout_sync() {
+    local file="$1" job="" job_timeout=""
+    while IFS= read -r line; do
+        if [[ "${line}" =~ ^\ \ ([A-Za-z0-9_-]+):[[:space:]]*$ ]]; then
+            job="${BASH_REMATCH[1]}"
+            job_timeout=""
+            continue
+        fi
+        if [[ "${line}" =~ ^\ \ \ \ timeout-minutes:\ *([0-9]+)[[:space:]]*$ ]]; then
+            job_timeout="${BASH_REMATCH[1]}"
+            continue
+        fi
+        if [[ "${line}" =~ job_timeout_minutes:\ *\'?([0-9]+)\'? ]]; then
+            echo "${job}:jtm=${BASH_REMATCH[1]},tm=${job_timeout:-unset}"
+        fi
+    done < "${file}"
+}
+
+kwok_recipes_out=$(job_timeout_sync "${REPO_ROOT}/.github/workflows/kwok-recipes.yaml")
+check "kwok-recipes-tier1-job-timeout-in-sync" 0 "test-tier1:jtm=18,tm=18" \
+    0 "$(echo "${kwok_recipes_out}" | grep '^test-tier1:')"
+check "kwok-recipes-tier2-job-timeout-in-sync" 0 "test-tier2:jtm=18,tm=18" \
+    0 "$(echo "${kwok_recipes_out}" | grep '^test-tier2:')"
+
+tier3_shard_out=$(job_timeout_sync "${REPO_ROOT}/.github/workflows/kwok-tier3-shard.yaml")
+check "kwok-tier3-shard-job-timeout-in-sync" 0 "test:jtm=18,tm=18" \
+    0 "$(echo "${tier3_shard_out}" | grep '^test:')"
+
 if (( fails > 0 )); then
     echo "${fails} test(s) failed"
     exit 1
 fi
-echo "All 6 tests passed"
+echo "All 9 tests passed"

--- a/kwok/scripts/lib/sync-budget_test.sh
+++ b/kwok/scripts/lib/sync-budget_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unit harness for lib/sync-budget.sh (deadline-derived sync-gate budgets).
+# Run directly: bash kwok/scripts/lib/sync-budget_test.sh
+# Wired into CI by the kwok-recipes discover job.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve the subject SCRIPT_DIR-relative — never a deployed copy.
+# shellcheck source=sync-budget.sh
+source "${SCRIPT_DIR}/sync-budget.sh"
+
+fails=0
+check() { # <name> <want_rc> <want_stdout> <got_rc> <got_stdout>
+    local name="$1" want_rc="$2" want_out="$3" got_rc="$4" got_out="$5"
+    if [[ "${got_rc}" == "${want_rc}" && "${got_out}" == "${want_out}" ]]; then
+        echo "PASS: ${name}"
+    else
+        echo "FAIL: ${name} (want rc=${want_rc} out='${want_out}'; got rc=${got_rc} out='${got_out}')"
+        fails=$((fails + 1))
+    fi
+}
+
+# 1. Env unset -> default passthrough (local runs keep fixed budgets).
+unset KWOK_SYNC_DEADLINE_EPOCH
+out=$(compute_sync_budget 500 1000000); rc=$?
+check "env-unset-returns-default" 0 "500" "${rc}" "${out}"
+
+# 2. Ample remaining (10000s) -> default wins the min().
+export KWOK_SYNC_DEADLINE_EPOCH=1010000
+out=$(compute_sync_budget 500 1000000); rc=$?
+check "ample-remaining-returns-default" 0 "500" "${rc}" "${out}"
+
+# 3. Tight remaining (300s < 500s default) -> budget shrinks to remaining.
+export KWOK_SYNC_DEADLINE_EPOCH=1000300
+out=$(compute_sync_budget 500 1000000); rc=$?
+check "tight-remaining-shrinks-budget" 0 "300" "${rc}" "${out}"
+
+# 4. Remaining exactly at the 120s floor -> still runs (boundary).
+export KWOK_SYNC_DEADLINE_EPOCH=1000120
+out=$(compute_sync_budget 500 1000000); rc=$?
+check "floor-boundary-runs" 0 "120" "${rc}" "${out}"
+
+# 5. Remaining below floor (119s) -> rc 1, no output (caller fails fast).
+export KWOK_SYNC_DEADLINE_EPOCH=1000119
+out=$(compute_sync_budget 500 1000000); rc=$?
+check "below-floor-fails" 1 "" "${rc}" "${out}"
+
+# 6. Deadline already in the past -> rc 1, no output.
+export KWOK_SYNC_DEADLINE_EPOCH=999000
+out=$(compute_sync_budget 500 1000000); rc=$?
+check "deadline-past-fails" 1 "" "${rc}" "${out}"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All 6 tests passed"

--- a/kwok/scripts/lib/sync-budget_test.sh
+++ b/kwok/scripts/lib/sync-budget_test.sh
@@ -98,8 +98,50 @@ tier3_shard_out=$(job_timeout_sync "${REPO_ROOT}/.github/workflows/kwok-tier3-sh
 check "kwok-tier3-shard-job-timeout-in-sync" 0 "test:jtm=18,tm=18" \
     0 "$(echo "${tier3_shard_out}" | grep '^test:')"
 
+# 10-11. Margin-floor guard in the "Derive sync-gate deadline" step
+# (action.yml): job_timeout_minutes must leave >= SYNC_BUDGET_FLOOR_SECONDS
+# of usable budget after the 240s diagnostics margin, or the step must fail
+# fast before toolchain setup + make build burn CI minutes. Extracted
+# straight from action.yml (not reimplemented here) so this always exercises
+# THIS checkout's actual CI logic, never a stale copy.
+ACTION_YML="${REPO_ROOT}/.github/actions/kwok-test/action.yml"
+
+# extract_derive_step <file> -> the dedented run: block of the "Derive
+# sync-gate deadline" step.
+extract_derive_step() {
+    local file="$1"
+    awk '
+        /^    - name: Derive sync-gate deadline$/ { in_step=1; next }
+        in_step && /^      run: \|$/ { in_run=1; next }
+        in_run && /^    - name:/ { exit }
+        in_run { sub(/^        /, ""); print }
+    ' "${file}"
+}
+
+# run_derive_step <job_timeout_minutes> -> sets got_rc, got_env_file
+# (caller-owned temp file, removed by caller). -eo pipefail mirrors the
+# composite step's actual shell (`shell: bash` -> bash -eo pipefail) so a
+# future set -e interaction cannot diverge between CI and this harness.
+run_derive_step() {
+    local jtm="$1"
+    got_env_file=$(mktemp)
+    JOB_TIMEOUT_MINUTES="${jtm}" GITHUB_ENV="${got_env_file}" \
+        bash -eo pipefail -c "$(extract_derive_step "${ACTION_YML}")" > /dev/null 2>&1
+    got_rc=$?
+}
+
+run_derive_step 5
+check "derive-step-below-floor-fails" 1 "" "${got_rc}" ""
+rm -f "${got_env_file}"
+
+run_derive_step 6
+env_has_deadline="no"
+grep -q '^KWOK_SYNC_DEADLINE_EPOCH=' "${got_env_file}" && env_has_deadline="yes"
+check "derive-step-at-floor-boundary-succeeds" 0 "yes" "${got_rc}" "${env_has_deadline}"
+rm -f "${got_env_file}"
+
 if (( fails > 0 )); then
     echo "${fails} test(s) failed"
     exit 1
 fi
-echo "All 9 tests passed"
+echo "All 11 tests passed"

--- a/kwok/scripts/validate-scheduling.sh
+++ b/kwok/scripts/validate-scheduling.sh
@@ -80,6 +80,19 @@
 #                            Kustomization after the grace window indicates
 #                            kubectl apply silently produced no resource
 #                            (RBAC denial, CRD missing). Default: 30.
+#   KWOK_SYNC_DEADLINE_EPOCH Absolute unix-epoch deadline for sync-gate work.
+#                            Set by CI (.github/actions/kwok-test) in the
+#                            action's FIRST step — before toolchain setup
+#                            and the aicr build — from the job's
+#                            timeout-minutes minus a 240s diagnostics
+#                            margin, so pre-action drift stays within the
+#                            margin's 60s allowance. When set, each
+#                            sync-gate budget becomes min(default, deadline
+#                            − now); below a 120s floor the gate fails
+#                            fast with exit 50 instead of letting the job
+#                            timeout destroy chainsaw's catch-block
+#                            diagnostics. Unset locally: fixed defaults
+#                            apply.
 #   KWOK_GITEA_HOST_PORT     (flux-git / argocd-git) Host port the in-cluster
 #                            Gitea is reachable on from the runner for
 #                            `git push`. MUST match install-infra.sh /
@@ -123,6 +136,7 @@ REPO_ROOT="$(cd "${KWOK_DIR}/.." && pwd)"
 # run-all-recipes.sh so the system-ns allowlist lives in one place.
 # shellcheck source=lib/cleanup.sh
 source "${SCRIPT_DIR}/lib/cleanup.sh"
+source "${SCRIPT_DIR}/lib/sync-budget.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -1553,9 +1567,14 @@ wait_for_argocd_sync() {
             test_dir="${REPO_ROOT}/tests/chainsaw/kwok/argocd-sync"
             ;;
     esac
-    local sync_timeout="${KWOK_ARGOCD_SYNC_TIMEOUT:-480}s"
+    local budget_seconds
+    if ! budget_seconds=$(compute_sync_budget "${KWOK_ARGOCD_SYNC_TIMEOUT:-480}"); then
+        log_error "Argo CD sync gate: <${SYNC_BUDGET_FLOOR_SECONDS}s left before the job deadline (KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH:-unset}) — setup consumed the budget"
+        return "$EXIT_ARGOCD_SYNC_TIMEOUT"
+    fi
+    local sync_timeout="${budget_seconds}s"
 
-    log_info "Argo CD sync gate (chainsaw): rootApp=${ARGOCD_ROOT_APP} timeout=${sync_timeout}"
+    log_info "Argo CD sync gate (chainsaw): rootApp=${ARGOCD_ROOT_APP} timeout=${sync_timeout} (default ${KWOK_ARGOCD_SYNC_TIMEOUT:-480}s; deadline-derived when KWOK_SYNC_DEADLINE_EPOCH is set)"
 
     # --assert-timeout overrides spec.timeouts.assert per CLI invocation,
     # letting the bash driver vary the deadline by env var without forking
@@ -1638,8 +1657,13 @@ wait_for_flux_sync() {
             ;;
     esac
 
-    local sync_timeout="${KWOK_FLUX_SYNC_TIMEOUT:-500}s"
-    log_info "Flux sync timeout: ${sync_timeout}"
+    local budget_seconds
+    if ! budget_seconds=$(compute_sync_budget "${KWOK_FLUX_SYNC_TIMEOUT:-500}"); then
+        log_error "Flux sync gate: <${SYNC_BUDGET_FLOOR_SECONDS}s left before the job deadline (KWOK_SYNC_DEADLINE_EPOCH=${KWOK_SYNC_DEADLINE_EPOCH:-unset}) — setup consumed the budget"
+        return "$EXIT_ARGOCD_SYNC_TIMEOUT"
+    fi
+    local sync_timeout="${budget_seconds}s"
+    log_info "Flux sync timeout: ${sync_timeout} (default ${KWOK_FLUX_SYNC_TIMEOUT:-500}s; deadline-derived when KWOK_SYNC_DEADLINE_EPOCH is set)"
 
     # See the argocd shim's comment for the --set vs --values choice;
     # --values requires YAML, --set takes inline key=value pairs.


### PR DESCRIPTION
## Summary

Makes chainsaw sync-gate diagnostics structurally guaranteed in the KWOK CI lane: gate budgets derive from the remaining job time (new `KWOK_SYNC_DEADLINE_EPOCH` contract) with a fail-fast floor, and tier job timeouts move 15m → 18m so the full budget actually fits.

## Motivation / Context

KWOK tier jobs (`timeout-minutes: 15`) raced the chainsaw sync gates' fixed budgets (flux 500s, argocd 480s): GitHub killed the job ~1 minute before chainsaw would time out and print its `catch:` diagnostics, so failures surfaced as CANCELLED with zero error report (job 86181256207 on PR #1686 shows the shape). The budget was over-committed even on the good path: ~300s setup + 500s gate + ~180s post-gate diagnostics/verify/artifact-upload ≈ 980s > 900s. Sibling PR #1707 fixes the Docker Hub throttling that made setup slow enough to hit this consistently; this PR guarantees that whenever anything slow happens again, the lane reports instead of silently dying.

Fixes: N/A
Related: #1707, #1686 (diagnosis context)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling
- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`)
- [x] Other: KWOK CI lane (`kwok/scripts/`, `.github/actions/kwok-test`, `.github/workflows/kwok-recipes.yaml`, `.github/workflows/kwok-tier3-shard.yaml`)

## Implementation Notes

- `kwok/scripts/lib/sync-budget.sh`: `compute_sync_budget` returns `min(gate default, deadline − now)`; below a 120s floor the gate fails fast with the existing GitOps sync-deadline exit code (50) and an explicit "setup consumed the budget" error — itself the diagnosis a silent CANCELLED used to destroy. Env unset (local runs) ⇒ behavior unchanged.
- Both gates (argocd + flux) consume it; existing `KWOK_ARGOCD_SYNC_TIMEOUT`/`KWOK_FLUX_SYNC_TIMEOUT` overrides still work; the derived budget is logged on every run so the margin is tunable from evidence.
- The kwok-test action derives the deadline in its **first step** — before toolchain setup and the aicr build — so unaccounted job-start drift stays within the 240s margin's 60s allowance (180s is reserved for post-gate diagnostics/artifacts). The `job_timeout_minutes` input is required (no default), integer-guarded (positive, no leading zeros), and passed explicitly by all three call sites — a sync-budget_test.sh case asserts each caller's value matches its job's `timeout-minutes`.
- 18m tier budget: 1080s fits ~300s setup + 500s gate + 180s margin with ~100s slack. Passing runs are unaffected; only failing runs use the extra time.
- The sync-budget unit harness runs as a step in the `discover` job, so a regression fails the lane before any cluster spins up.
- Chainsaw test files untouched (flux-sync/flux-git-sync byte-identical sibling contract preserved).

## Testing

```bash
bash kwok/scripts/lib/sync-budget_test.sh                        # 6/6 pass
shellcheck -x -P SCRIPTDIR kwok/scripts/validate-scheduling.sh \
  kwok/scripts/lib/sync-budget.sh kwok/scripts/lib/sync-budget_test.sh  # rc=0
actionlint .github/workflows/kwok-recipes.yaml \
  .github/workflows/kwok-tier3-shard.yaml       # zero new findings vs base
make kwok-e2e RECIPE=aks-inference               # rc=0
make qualify                                     # rc=0
```

Live behavioral verification on a local kind cluster:
- Ample deadline, full flux-oci lane: **rc=0**, gate logs `Flux sync timeout: 500s (default 500s; deadline-derived when KWOK_SYNC_DEADLINE_EPOCH is set)`.
- Nearly-consumed deadline: gate prints `[ERROR] Flux sync gate: <120s left before the job deadline (…) — setup consumed the budget` and exits 50 — the failure now reports instead of CANCELLED-with-nothing.

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

**Rollout notes:** CI-only behavior; local runs are unaffected (env unset ⇒ fixed defaults). Revert restores the fixed budgets and 15m timeouts. If the 240s margin proves mistuned, the derived budget is logged on every run for evidence-based adjustment.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

