### PR TITLE
feat(uat): Azure AKS UAT — OIDC federation, dispatch, pipeline (1/2)

### DIFF
--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -70,6 +70,9 @@ outputs:
   kubectl:
     description: 'kubectl version'
     value: ${{ steps.versions.outputs.kubectl }}
+  kubelogin:
+    description: 'kubelogin version'
+    value: ${{ steps.versions.outputs.kubelogin }}
   kwok:
     description: 'KWOK version'
     value: ${{ steps.versions.outputs.kwok }}
@@ -168,6 +171,7 @@ runs:
 
         # Testing tools
         echo "kubectl=$(yq eval '.testing_tools.kubectl' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "kubelogin=$(yq eval '.testing_tools.kubelogin' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "kind=$(yq eval '.testing_tools.kind' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "nvkind=$(yq eval '.testing_tools.nvkind' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "ctlptl=$(yq eval '.testing_tools.ctlptl' .settings.yaml)" >> $GITHUB_OUTPUT
@@ -219,6 +223,7 @@ runs:
         echo "  go_licenses: ${{ steps.versions.outputs.go_licenses }}"
         echo "  grype: ${{ steps.versions.outputs.grype }}"
         echo "  kubectl: ${{ steps.versions.outputs.kubectl }}"
+        echo "  kubelogin: ${{ steps.versions.outputs.kubelogin }}"
         echo "  kind: ${{ steps.versions.outputs.kind }}"
         echo "  nvkind: ${{ steps.versions.outputs.nvkind }}"
         echo "  ctlptl: ${{ steps.versions.outputs.ctlptl }}"

--- a/.github/workflows/evidence-ingest.yaml
+++ b/.github/workflows/evidence-ingest.yaml
@@ -74,8 +74,9 @@ env:
   FIRST_PARTY_ISSUER: 'https://token.actions.githubusercontent.com'
   # Identity regexp pinning first-party UAT signatures to the NVIDIA/aicr
   # UAT workflows. Fully anchored so the verifier's signer match is exact
-  # (matches what uat-aws.yaml / uat-gcp.yaml pin in their own verify step).
-  FIRST_PARTY_IDENTITY: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/.+$'
+  # (matches what uat-aws.yaml / uat-gcp.yaml / uat-azure.yaml pin in their
+  # own verify step).
+  FIRST_PARTY_IDENTITY: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp|azure)\.yaml@refs/heads/.+$'
 
 jobs:
   # ---------------------------------------------------------------------

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -1,0 +1,826 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: UAT - Azure
+
+# Reusable per-cloud UAT pipeline — invoked by uat-run.yaml, the shared
+# dispatch surface that owns the per-reservation concurrency lease (#1274,
+# DC1). It is intentionally NOT directly dispatchable or scheduled: the
+# nightly cron lives in uat-nightly-batch.yaml and ad-hoc runs go through
+# uat-run.yaml, so every run on the Azure quota pool serializes on the same
+# lease. The keyless-cosign signing identity (and the EXPECTED_IDENTITY_REGEXP
+# pin below) is uat-azure.yaml@…; kept in lockstep with uat-gcp.yaml /
+# uat-aws.yaml.
+on:
+  workflow_call:
+    inputs:
+      reservation:
+        description: 'Reservation name (lease key) this run targets; used for labeling and the daytime cluster name.'
+        type: string
+        required: true
+      aicr_version:
+        description: 'Released aicr version to install (e.g. v1.2.3); empty = build from source (main tip).'
+        type: string
+        default: ''
+      intent:
+        description: 'Recipe intent — selects the per-intent test config (h100-<intent>-config.yaml).'
+        type: string
+        default: training
+      lifecycle:
+        description: 'nightly (provision→CUJ→teardown) | daytime-up (provision+deploy+HOLD) | daytime-down (tear down the held daytime cluster).'
+        type: string
+        default: nightly
+      cluster_config_path:
+        description: 'Cluster-config the AKS actuator provisions from (from infra/uat/reservations.yaml).'
+        type: string
+        required: true
+      test_config_dir:
+        description: 'Directory holding the AICRConfig test files (from infra/uat/reservations.yaml).'
+        type: string
+        required: true
+      skip_delete:
+        description: 'Skip cluster teardown (manual runs only; the nightly batch always deletes).'
+        type: boolean
+        default: false
+      skip_tests:
+        description: 'Skip UAT test execution (manual runs only; the nightly batch always tests).'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# NOTE: the per-reservation concurrency lease is owned by the caller
+# (uat-run.yaml). A reusable workflow must not declare its own concurrency
+# here, or every reservation would serialize against one group instead of
+# queueing per reservation.
+
+jobs:
+  uat-azure:
+    if: github.repository == 'nvidia/aicr'
+    runs-on: ubuntu-latest
+    # Budget = uncapped non-UAT steps (build, validator image push, AKS
+    # provisioning, evidence upload ~30m) + UAT phase steps (prep 15 + install 60
+    # + validate 40 + the intent-selected CUJ (train 25 OR serve 40) + verify 5
+    # = up to 160) + the always()-run Destroy Cluster teardown (3 retries, ~10m
+    # each = up to ~40m). Only one of train/serve runs per intent, so the budget
+    # counts the larger (serve). The teardown MUST fit in this budget: a job-level
+    # timeout cancels pending always() steps, so an undersized cap would skip
+    # teardown and leak the GPU node. 160 UAT + ~30 setup + ~40 teardown = ~230,
+    # so 270 leaves the teardown ample headroom even on a worst-case phase run.
+    timeout-minutes: 270
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      packages: write
+    outputs:
+      # Digest-pinned OCI ref of the signed evidence bundle, consumed by
+      # the ingest-evidence job below. Empty when no bundle was produced.
+      bundle_ref: ${{ steps.evidence_ref.outputs.ref }}
+    env:
+      # Entra federation identifiers (infra/uat-azure-account terraform
+      # output; the client id is the github-actions-aicr user-assigned
+      # managed identity). Identifiers, NOT secrets — the federated-credential
+      # subject pins (main + test/uat refs of NVIDIA/aicr), not knowledge of
+      # these ids, gate access.
+      AZURE_CLIENT_ID: "047f0427-5dcf-4e7c-97c3-9c71d92c5abb"
+      AZURE_TENANT_ID: "43083d15-7273-40c1-b7db-39efd9ccc17a"
+      AZURE_SUBSCRIPTION_ID: "e88faa01-b4fd-49d3-b934-0ad9f9fca307"
+      # Managed-identity principal (object) id — the assignee for the
+      # run-scoped cluster-admin grant below (terraform output
+      # AZURE_PRINCIPAL_ID). Inlined because the federated az session may
+      # lack the Graph access needed to resolve the client id to a principal.
+      AZURE_PRINCIPAL_ID: "3c061691-eded-40cb-869e-d5fdb2944a62"
+      # Cluster name (AKS actuator derives both the cluster name and its
+      # resource group `<id>-rg` from .deployment.id). The nightly
+      # per-run lifecycle uses a run-scoped name for per-run isolation; the
+      # daytime lifecycles use a STABLE, reservation-tagged name so the evening
+      # teardown (daytime-down) and the nightly pre-batch guard can find the
+      # held cluster. Reservation names are lowercase alnum+hyphen, so the
+      # derived name is a valid AKS cluster name.
+      DEPLOYMENT_ID: >-
+        ${{ (inputs.lifecycle == 'daytime-up' || inputs.lifecycle == 'daytime-down')
+        && format('aicr-day-{0}', inputs.reservation)
+        || format('aicr-{0}', github.run_id) }}
+      CLUSTER_CONFIG: ${{ inputs.cluster_config_path }}
+      # DC2 selects the AICRConfig by intent; both intents drive the same
+      # cluster-config (GPU pool from the reservation, system/CPU pools dynamic).
+      TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-${{ inputs.intent }}-config.yaml
+      AKS_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/aks@sha256:d3831f21c397b0a03a281e7d55e39e6c9535ba7e099c11dba5c9c0c28cb13c4a"
+      VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
+      VALIDATOR_TAG: "uat-${{ github.run_id }}"
+      # Pin validator-image resolution for MAIN cells to this run's freshly
+      # built+pushed validators (the `Build and push validator images` step
+      # tags them `:uat-<run_id>`), mirroring how AICR_IMAGE pins the agent — so
+      # the validators pair with the binary under test rather than a stale
+      # :latest. The main binary is stamped version=main (below), which the
+      # catalog would otherwise leave on the :latest path. Empty for release
+      # cells (aicr_version set): they use the released :<version> validators the
+      # released binary self-resolves, and an empty AICR_VALIDATOR_IMAGE_TAG is
+      # a no-op (the catalog ignores an empty override).
+      AICR_VALIDATOR_IMAGE_TAG: ${{ inputs.aicr_version == '' && format('uat-{0}', github.run_id) || '' }}
+
+    steps:
+      # Checkout
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Fail closed on an unrecognized intent/lifecycle before any provisioning:
+      # workflow_dispatch constrains these to a choice, but workflow_call passes
+      # free strings, so a caller typo must surface as a clear error rather than
+      # a missing-file failure deep in a phase. Also assert the per-intent config
+      # exists so a missing sibling config fails here, not mid-run.
+      - name: Validate inputs
+        env:
+          INTENT: ${{ inputs.intent }}
+          LIFECYCLE: ${{ inputs.lifecycle }}
+          SKIP_TESTS: ${{ inputs.skip_tests }}
+        run: |
+          set -euo pipefail
+          case "${INTENT}" in
+            training|inference) ;;
+            *) echo "::error::unknown intent '${INTENT}' (want training|inference)"; exit 1 ;;
+          esac
+          case "${LIFECYCLE}" in
+            nightly|daytime-up|daytime-down) ;;
+            *) echo "::error::unknown lifecycle '${LIFECYCLE}' (want nightly|daytime-up|daytime-down)"; exit 1 ;;
+          esac
+          # The per-intent config is only consumed by the UAT phase steps, so
+          # only require it when tests will actually run: skip_tests burn-in
+          # runs and daytime-down (teardown-only) must not fail on a missing
+          # test config before provisioning/teardown even starts.
+          if [[ "${SKIP_TESTS}" != "true" && "${LIFECYCLE}" != "daytime-down" && ! -f "${TEST_CONFIG}" ]]; then
+            echo "::error::test config not found: ${TEST_CONFIG}"; exit 1
+          fi
+          echo "intent=${INTENT} lifecycle=${LIFECYCLE} test-config=${TEST_CONFIG} cluster=${DEPLOYMENT_ID}"
+
+      # Versions
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      # Build from source
+      - name: Setup Go
+        # Main cells only: release cells install a prebuilt binary and must not
+        # depend on the source Go toolchain (a broken Go pin shouldn't fail them).
+        if: inputs.aicr_version == '' && inputs.skip_tests != true
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: '${{ steps.versions.outputs.go }}'
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            vendor/modules.txt
+
+      # Main cell (aicr_version empty): build the aicr binary from the
+      # checked-out source (tip). Release cells install the released binary
+      # instead (next step). daytime-down tears down the held cluster only — it
+      # builds nothing and pushes no images.
+      - name: Build aicr binary
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
+        env:
+          GOFLAGS: -mod=vendor
+          # github.sha via env (never inline ${{ }} in a shell run — expression
+          # injection). It is a 40-hex commit, so no real risk, but env is the
+          # repo norm and keeps zizmor/CodeRabbit quiet.
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Stamp the main-cell binary's version metadata via ldflags (mirroring
+          # goreleaser's pkg/cli.{version,commit,date} targets) so the emitted
+          # recipe/evidence report "main" + the commit instead of the un-stamped
+          # "dev"/"unknown" defaults. version="main" is deliberately NOT a
+          # release-shaped string, so it does not trip the catalog's
+          # :latest→:<version> validator-image rewrite; validator resolution is
+          # pinned explicitly below (AICR_VALIDATOR_IMAGE_TAG). Release cells
+          # install a goreleaser-built binary already stamped with its tag, so
+          # this step is main-only.
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          go build \
+            -ldflags "-X github.com/NVIDIA/aicr/pkg/cli.version=main -X github.com/NVIDIA/aicr/pkg/cli.commit=${COMMIT_SHA} -X github.com/NVIDIA/aicr/pkg/cli.date=${BUILD_DATE}" \
+            -o ./aicr ./cmd/aicr
+          # Assert the stamp actually landed — a broken ldflags target path would
+          # otherwise silently leave the binary on the default dev/unknown
+          # metadata (which then propagates to the evidence/TestGrid version).
+          VER_OUT="$(./aicr --version)"
+          echo "${VER_OUT}"
+          if ! printf '%s' "${VER_OUT}" | grep -qF "main (commit: ${COMMIT_SHA}"; then
+            echo "::error::aicr binary not stamped (want 'main (commit: ${COMMIT_SHA}…'); got: ${VER_OUT}" >&2
+            exit 1
+          fi
+
+      # Release cell (aicr_version set): install the RELEASED aicr binary at that
+      # version instead of building. The released binary self-resolves its own
+      # version's images — validators via pkg/validator/catalog (:latest ->
+      # :<version>) and the snapshot-agent via ghcr.io/nvidia/aicr:<version> — so
+      # the validator/agent build+push steps below are skipped for release cells.
+      - name: Install released aicr
+        if: inputs.aicr_version != '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
+        uses: ./.github/actions/install-aicr-release
+        with:
+          aicr-version: ${{ inputs.aicr_version }}
+
+      - name: Authenticate to GHCR
+        uses: ./.github/actions/ghcr-login
+
+      # Main cell only: release cells use the released validator images the
+      # released binary self-resolves to (skipped when aicr_version is set).
+      - name: Build and push validator images
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
+        run: |
+          GO_VERSION="$(cat .go-version)"
+          # CHAINSAW_* args dropped in #1236 — the deployment validator
+          # no longer ships /usr/local/bin/chainsaw; it executes Chainsaw
+          # Test format in-process via validators/chainsaw/inprocess.go.
+          #
+          # aiperf-bench is an ancillary (non-Go) validator image the
+          # performance phase's inference-perf check pulls at runtime, resolved
+          # through the same AICR_VALIDATOR_IMAGE_TAG=uat-<run_id> override as
+          # the Go validators. It MUST be built+pushed here too, or the AIPerf
+          # pod ImagePullBackOffs on a nonexistent uat-<run_id> tag and hangs
+          # until the job timeout (#1636). It uses a different Dockerfile path
+          # and takes no GO_VERSION build-arg. Keep the phase set in sync with
+          # VALIDATOR_PHASES in on-push.yaml / on-tag.yaml.
+          for phase in deployment performance conformance aiperf-bench; do
+            IMAGE="${VALIDATOR_IMAGE_PREFIX}/${phase}:${VALIDATOR_TAG}"
+            case "${phase}" in
+              aiperf-bench)
+                docker build -f validators/performance/aiperf-bench.Dockerfile \
+                  -t "${IMAGE}" .
+                ;;
+              *)
+                docker build -f "validators/${phase}/Dockerfile" \
+                  --build-arg "GO_VERSION=${GO_VERSION}" \
+                  -t "${IMAGE}" .
+                ;;
+            esac
+            docker push "${IMAGE}"
+          done
+
+      # Auth. azure/login exchanges the GitHub OIDC token against the Entra
+      # federated credential and writes the az CLI context to ~/.azure — the
+      # same context the AKS actuator container consumes (mounted in Bringup/
+      # Destroy below). A federated az session cannot self-refresh (the OIDC
+      # token is single-exchange; access tokens last ~60-75 min), so the long
+      # phases below each re-run azure/login — mirroring the AWS pipeline's
+      # per-stage STS refreshes.
+      - name: Authenticate to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      # Azure capacity posture. This reservation row is QUOTA-backed (westus
+      # NDSH100v5 subscription quota — see infra/uat/reservations.yaml), so
+      # like GCP there is NO pre-flight capacity assertion: the AKS actuator
+      # fails at provision time if quota is exhausted. The reservation lease
+      # (uat-run.yaml) already serializes contending runs, so a provision-time
+      # failure means genuinely exhausted quota, not a race. Recorded in
+      # docs/contributor/uat.md; intentionally no capacity step below.
+
+      # Pre-batch guard (#1275, DC2). The nightly lifecycle refuses to provision
+      # into a reservation that still holds an un-torn-down daytime cluster: a
+      # missed evening teardown must surface as a BLOCKED batch, not as silent
+      # contention. Detect by the stable daytime cluster name
+      # (aicr-day-<reservation>); we already hold the reservation lease
+      # (uat-run.yaml) and are authenticated, so this runs before Bringup and
+      # fails fast rather than racing. Only the nightly lifecycle guards —
+      # daytime-up creates that cluster, daytime-down removes it.
+      - name: Pre-batch guard — refuse if a daytime cluster still holds the reservation
+        id: guard
+        if: inputs.lifecycle == 'nightly'
+        env:
+          RESERVATION: ${{ inputs.reservation }}
+        run: |
+          set -euo pipefail
+          DAYTIME_NAME="aicr-day-${RESERVATION}"
+          set +e
+          OUT=$(az aks show --name "${DAYTIME_NAME}" \
+            --resource-group "${DAYTIME_NAME}-rg" 2>&1)
+          RC=$?
+          set -e
+          if [[ ${RC} -eq 0 ]]; then
+            echo "::error::daytime cluster ${DAYTIME_NAME} still holds reservation ${RESERVATION}; refusing to start the nightly batch. Tear it down first (uat-run lifecycle=daytime-down)."
+            exit 1
+          fi
+          # Fail closed on anything that is NOT a definitive "does not exist":
+          # a throttle/auth error must not be read as "clear to proceed". The
+          # actuator derives the RG as <cluster>-rg, so either the cluster or
+          # its whole RG being absent is a definitive negative.
+          if grep -qE 'ResourceNotFound|ResourceGroupNotFound|could not be found' <<<"${OUT}"; then
+            echo "no daytime cluster on reservation ${RESERVATION}; proceeding"
+          else
+            echo "::error::could not determine daytime-cluster state for ${DAYTIME_NAME}: ${OUT}"
+            exit 1
+          fi
+
+      # Deps
+      - name: Install tools
+        id: deps
+        uses: ./.github/actions/setup-build-tools
+        with:
+          install_kubectl: 'true'
+          kubectl_version: '${{ steps.versions.outputs.kubectl }}'
+          install_yq: 'true'
+          yq_version: '${{ steps.versions.outputs.yq }}'
+          install_helm: 'true'
+          helm_version: '${{ steps.versions.outputs.helm }}'
+          install_helmfile: 'true'
+          helmfile_version: '${{ steps.versions.outputs.helmfile }}'
+          helmfile_sha256: '${{ steps.versions.outputs.helmfile_sha256_linux_amd64 }}'
+          # ko builds the snapshot-agent image (main cells only). Release cells
+          # install a prebuilt binary and build no images, so skip ko — a bad ko
+          # pin or download must not fail a release cell before UAT starts.
+          install_ko: ${{ inputs.aicr_version == '' && inputs.skip_tests != true && 'true' || 'false' }}
+          ko_version: ${{ steps.versions.outputs.ko }}
+
+      # The snapshot agent runs in-cluster as its own image, separate from the
+      # locally-built aicr binary that drives the UAT phases. Left at the
+      # default (ghcr.io/nvidia/aicr:latest), it would be the last *released*
+      # build — so any artifact-schema change in the PR under test (e.g. an
+      # apiVersion bump) produces a snapshot the freshly-built binary rejects.
+      # Build the agent from the PR source and point AICR_IMAGE at it so the
+      # snapshot is stamped by the code under test, not a stale release. Single
+      # arch: the GPU worker (ND H100 v5) is amd64. Lives in the
+      # aicr-validators namespace (not the release ghcr.io/nvidia/aicr repo);
+      # cleaned up below.
+      - name: Build and push snapshot-agent image
+        if: inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
+        env:
+          GOFLAGS: -mod=vendor
+          KO_DOCKER_REPO: ghcr.io/nvidia/aicr-validators/agent
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          ko build ./cmd/aicr \
+            --bare \
+            --platform=linux/amd64 \
+            --image-label="org.opencontainers.image.revision=${COMMIT_SHA}" \
+            --tags="${VALIDATOR_TAG}"
+
+      # Config
+      - name: Update Config
+        id: config
+        run: |
+          set -euox pipefail
+          yq -i '.deployment.id = strenv(DEPLOYMENT_ID)' "$CLUSTER_CONFIG"
+          cat "$CLUSTER_CONFIG"
+
+      # Bringup — skipped for daytime-down (teardown-only; nothing to provision).
+      # The actuator reads Azure credentials from the mounted az CLI context
+      # (~/.azure, written by azure/login above); ARM_* env vars are not
+      # needed. The image runs as user `builder`, so the mount target is
+      # /home/builder/.azure (per the actuator README) — a /root/.azure mount
+      # would leave the container credential-less. Actuator Terraform state
+      # lives in the subscription's clst<sub-hex> storage account
+      # (deployment.state: tenancy; bootstrapped once via the actuator's
+      # setup tool — see infra/uat-azure-account/README.md), which is what
+      # lets the always()-teardown below destroy from the same runner after
+      # a fresh login.
+      - name: Bringup Infra
+        id: infra
+        if: inputs.lifecycle != 'daytime-down'
+        run: |
+          set -euox pipefail
+          docker run \
+            -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
+            -e AUTO_APPROVE=true \
+            -v "$HOME/.azure:/home/builder/.azure" \
+            "${AKS_ACTUATOR_IMAGE}" apply
+
+      # Data-plane kubectl access, scoped to THIS run's cluster. The actuator
+      # provisions AKS with Entra RBAC and local accounts disabled, so the
+      # pipeline identity needs a Kubernetes data-plane role. Granting
+      # "Azure Kubernetes Service RBAC Cluster Admin" at the run's resource
+      # group — instead of the shared subscription — keeps a compromised CI
+      # identity away from co-tenant Azure-RBAC clusters (the UAT
+      # subscription is NOT dedicated). The self-assignment is permitted by
+      # the ABAC-scoped RBAC Administrator grant (infra/uat-azure-account
+      # federation.tf), whose condition allows exactly this role definition
+      # alongside the two the actuator assigns; the assignment is removed
+      # with the resource group at teardown.
+      - name: Grant run-scoped cluster admin
+        if: steps.infra.outcome == 'success'
+        run: |
+          set -euo pipefail
+          SCOPE="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${DEPLOYMENT_ID}-rg"
+          set +e
+          OUT=$(az role assignment create \
+            --assignee-object-id "${AZURE_PRINCIPAL_ID}" \
+            --assignee-principal-type ServicePrincipal \
+            --role "Azure Kubernetes Service RBAC Cluster Admin" \
+            --scope "${SCOPE}" 2>&1)
+          RC=$?
+          set -e
+          # Idempotent for daytime re-runs against a held cluster: an
+          # already-present assignment is success, anything else fails.
+          if [[ ${RC} -ne 0 ]] && ! grep -q 'RoleAssignmentExists\|already exists' <<<"${OUT}"; then
+            echo "${OUT}"
+            echo "::error::failed to grant run-scoped cluster admin on ${SCOPE}"
+            exit 1
+          fi
+          echo "cluster-admin granted (run-scoped): ${SCOPE}"
+
+      # Connect. kubelogin ships with `az aks install-cli`; when the cluster
+      # kubeconfig uses Entra RBAC (exec plugin), convert it to azurecli mode
+      # so kubectl reuses the same az session the per-phase re-logins refresh.
+      # Both versions pinned from .settings.yaml — install-cli defaults BOTH
+      # kubectl and kubelogin to latest, which would drift from the repo pins
+      # (and silently overwrite the kubectl installed by setup-build-tools).
+      - name: Install kubelogin
+        if: steps.infra.outcome == 'success'
+        env:
+          KUBECTL_VERSION: ${{ steps.versions.outputs.kubectl }}
+          KUBELOGIN_VERSION: ${{ steps.versions.outputs.kubelogin }}
+        run: |
+          sudo az aks install-cli \
+            --client-version "${KUBECTL_VERSION}" \
+            --kubelogin-version "${KUBELOGIN_VERSION}"
+
+      - name: Connect to Cluster
+        id: client
+        if: steps.infra.outcome == 'success'
+        shell: bash
+        run: |
+          set -euox pipefail
+          echo "Updating kubeconfig..."
+          az aks get-credentials \
+            --name "${DEPLOYMENT_ID}" \
+            --resource-group "${DEPLOYMENT_ID}-rg" \
+            --overwrite-existing
+          if grep -q 'kubelogin' "$HOME/.kube/config"; then
+            kubelogin convert-kubeconfig -l azurecli
+          fi
+          echo "Verifying cluster connection..."
+          # The run-scoped cluster-admin role assignment (previous step) can
+          # take a few minutes to propagate to the AKS data-plane authorizer;
+          # retry before declaring the connection dead.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if kubectl get nodes; then
+              exit 0
+            fi
+            echo "kubectl not authorized yet (attempt ${attempt}/10); retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::cluster connection failed after 10 attempts (role assignment not propagated?)"
+          exit 1
+
+      # UAT phases — each step invokes tests/uat/azure/run so the demo
+      # (demos/cuj1-training.md) and CI stay in lockstep, and per-phase
+      # failures surface as discrete steps in the GitHub Actions UI. Phases
+      # chain on success: prep → install → conformance → train → verify.
+      # The signed evidence bundle is produced by the conformance step; the
+      # subsequent train step exercises the deployed stack so the recorded
+      # evidence reflects a fully successful run.
+      - name: UAT - prep (snapshot + recipe + validate + bundle)
+        id: prep
+        if: steps.client.outcome == 'success' && inputs.skip_tests != true
+        timeout-minutes: 15
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+          # Snapshot agent: main cell = the PR-built image (see "Build and push
+          # snapshot-agent image"); release cell = the released aicr image at that
+          # version. Honored by `aicr snapshot`.
+          AICR_IMAGE: ${{ inputs.aicr_version == '' && format('ghcr.io/nvidia/aicr-validators/agent:{0}', env.VALIDATOR_TAG) || format('ghcr.io/nvidia/aicr:{0}', inputs.aicr_version) }}
+        run: ./tests/uat/azure/run prep "${TEST_CONFIG}"
+
+      # Per-stage credential refresh. A federated az session cannot
+      # self-refresh, and the UAT chain outlives one access token; re-run
+      # azure/login at each long phase boundary so no phase runs on an
+      # expiring token (mirrors the AWS pipeline's STS refreshes). Gated to
+      # the same condition as the step each precedes.
+      - name: Refresh Azure credentials before install
+        if: steps.prep.outcome == 'success'
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: UAT - install (helmfile apply)
+        id: install
+        if: steps.prep.outcome == 'success'
+        # Capped at 60m — the federated az session CANNOT self-refresh
+        # (client-credentials grant, no refresh token), and its access token
+        # lives ~60-75m. kubelogin's azurecli mode pulls tokens from that
+        # session on every kubectl call, so a step longer than one token
+        # lifetime starts failing auth mid-phase with no way to re-mint
+        # (azure/login only runs between steps). Matches the AWS/GCP install
+        # caps. The helmfile apply (HELMFILE_TIMEOUT_SECONDS, 20m) and the
+        # readiness gate budget inside tests/uat/azure/run must together fit
+        # under this cap; widening it for slow cold-GPU bring-up requires the
+        # readiness loop to re-login mid-phase first (az login
+        # --federated-token with a freshly minted ACTIONS_ID_TOKEN — planned
+        # alongside the run script in PR 2/2). Do NOT copy a >60m phase
+        # budget to future clouds without that mid-phase re-auth.
+        timeout-minutes: 60
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+        run: ./tests/uat/azure/run install "${TEST_CONFIG}"
+
+      # Runs ALL validate phases (deployment + conformance + performance), not
+      # just conformance. The deployment phase polls component health checks
+      # until the GPU stack converges — the readiness barrier the helmfile
+      # bundle lacks (the helm deploy.sh `kubectl wait`s instead). Step id stays
+      # `conformance` so the train/verify gating below is unaffected.
+      # daytime-up provisions and deploys the stack, then HOLDS: the CUJ
+      # (conformance/train/verify + evidence) is a nightly-batch concern, so
+      # daytime-up stops after install and leaves the cluster up for handoff.
+      - name: Refresh Azure credentials before validate
+        if: steps.install.outcome == 'success' && inputs.lifecycle != 'daytime-up'
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: UAT - validate (all phases) + emit signed evidence
+        id: conformance
+        if: steps.install.outcome == 'success' && inputs.lifecycle != 'daytime-up'
+        # Larger budget than conformance-only: the deployment phase waits out
+        # cold-start GPU bring-up (driver install/migration). (The performance
+        # phase's NCCL benchmark skips on single-GPU-node clusters like this
+        # one, so it is not the long pole here.)
+        timeout-minutes: 40
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+        run: ./tests/uat/azure/run conformance "${TEST_CONFIG}"
+
+      # The CUJ phase is intent-selected, mirroring the runner's intent-aware
+      # `all`: training runs the Kubeflow TrainJob; inference would run the
+      # served DynamoGraphDeployment (phase_serve, DC3). For training, the
+      # TrainJob fires; for inference the serve step is currently disabled (see
+      # below), so verify/evidence cover the deployed stack either way.
+      - name: Refresh Azure credentials before CUJ
+        if: steps.conformance.outcome == 'success'
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: UAT - train (TrainJob)
+        id: train
+        if: steps.conformance.outcome == 'success' && inputs.intent == 'training'
+        timeout-minutes: 25
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+        run: ./tests/uat/azure/run train "${TEST_CONFIG}"
+
+      # TEMPORARILY DISABLED (step commented out below). The vLLM workload run is
+      # excluded from UAT for now because the Frontend component pulls the full
+      # ~12GB vllm-runtime image on a fresh (non-GPU) node and never finishes
+      # within the 30m readiness budget: the decode worker reuses the GPU node's
+      # cached image (`already present on machine`), but the Frontend lands on a
+      # different node and pulls from scratch, wedging in ContainerCreating until
+      # the phase times out. The inference STACK (dynamo + KAI scheduler + DRA
+      # driver) is still stood up and validated by prep/install/conformance/verify;
+      # only the served-workload run is skipped (the Serve summary row is a static
+      # `disabled`). Re-enable by uncommenting the step once the pull is addressed
+      # (pre-pull/image cache, or pin the Frontend to the GPU node so it reuses
+      # the cached image).
+      #
+      # - name: UAT - serve (DynamoGraphDeployment + endpoint)
+      #   id: serve
+      #   if: steps.conformance.outcome == 'success' && inputs.intent == 'inference'
+      #   # Larger budget than train: a cold pull of the multi-GB vllm-runtime
+      #   # image + model download + engine warmup precedes the first served
+      #   # token (phase_serve's SERVE_READY_TIMEOUT_SECONDS is 30m).
+      #   timeout-minutes: 40
+      #   shell: bash
+      #   env:
+      #     AICR_BIN: ${{ github.workspace }}/aicr
+      #     RUN_ID: ${{ github.run_id }}
+      #   run: ./tests/uat/azure/run serve "${TEST_CONFIG}"
+
+      - name: UAT - verify (evidence verify)
+        id: verify
+        if: steps.conformance.outcome == 'success'
+        timeout-minutes: 5
+        shell: bash
+        env:
+          AICR_BIN: ${{ github.workspace }}/aicr
+          RUN_ID: ${{ github.run_id }}
+          # Pin the expected Sigstore signer to this workflow's OIDC
+          # identity so verify only passes for bundles signed by this
+          # workflow — without these, any Fulcio identity would verify
+          # and the security check becomes a no-op (see warning in
+          # https://github.com/NVIDIA/aicr/actions/runs/26194736809).
+          EXPECTED_ISSUER: https://token.actions.githubusercontent.com
+          EXPECTED_IDENTITY_REGEXP: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-azure\.yaml@refs/heads/.+$'
+        run: ./tests/uat/azure/run verify "${TEST_CONFIG}"
+
+      # Export the digest-pinned bundle ref for the ingest-evidence job.
+      # Reads the pointer the conformance step wrote; emits empty (job
+      # skips) when no bundle/digest is present.
+      - name: Export evidence bundle ref
+        id: evidence_ref
+        if: steps.conformance.outcome == 'success'
+        uses: ./.github/actions/export-evidence-ref
+
+      # Artifacts + summary run BEFORE teardown so a slow or failing
+      # `Destroy Cluster` (which can take 10+ min) does not delay or
+      # consume the job-timeout budget needed to persist evidence.
+      #
+      # The signed evidence bundle itself is pushed to OCI by the
+      # conformance step (ghcr.io/nvidia/aicr-evidence/h100-aks-ubuntu-training-kubeflow:run-${{
+      # github.run_id }}) and is the source of truth; here we attach the
+      # lightweight pointer so a reviewer can locate that bundle directly
+      # from the Actions UI for up to a year. Failure-debug artifacts are
+      # scoped tighter (30d).
+      - name: Upload evidence pointer
+        if: always() && steps.conformance.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: uat-azure-evidence-pointer-${{ github.run_id }}
+          path: evidence/pointer.yaml
+          # Org policy caps at 90d; anything higher is silently clamped.
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Upload failure debug
+        if: failure() && steps.prep.outcome != 'skipped'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: uat-azure-debug-${{ github.run_id }}
+          path: |
+            snapshot.yaml
+            recipe.yaml
+            dry-run.json
+            report.json
+            evidence-result.json
+            evidence/pointer.yaml
+            train-logs/**
+            serve-logs/**
+          retention-days: 30
+          if-no-files-found: ignore
+
+      # Summary
+      - name: Test Summary
+        if: always()
+        env:
+          SUMMARY_RESERVATION: ${{ inputs.reservation }}
+          SUMMARY_AICR_VERSION: ${{ inputs.aicr_version }}
+          SUMMARY_INTENT: ${{ inputs.intent }}
+          SUMMARY_LIFECYCLE: ${{ inputs.lifecycle }}
+          # Via env, not inline ${{ }} in the run block: github.ref_name can
+          # carry shell-active characters (expression injection); sha is safe
+          # but routed the same way for consistency with the build step.
+          SUMMARY_SHA: ${{ github.sha }}
+          SUMMARY_REF: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## UAT Results (Azure)"
+            echo ""
+            printf '**Reservation:** `%s` · **Intent:** `%s` · **Lifecycle:** `%s`\n' \
+              "$SUMMARY_RESERVATION" "$SUMMARY_INTENT" "$SUMMARY_LIFECYCLE"
+            printf '**Cluster:** `%s`\n' "$DEPLOYMENT_ID"
+            printf '**AICR version:** `%s`\n' "${SUMMARY_AICR_VERSION:-main (build from source)}"
+            printf '**Build:** `%s` (branch: `%s`)\n' "$SUMMARY_SHA" "$SUMMARY_REF"
+            echo ""
+            echo "| Phase | Status |"
+            echo "|-------|--------|"
+            echo "| Pre-batch guard | ${{ steps.guard.outcome }} |"
+            echo "| Dependencies | ${{ steps.deps.outcome }} |"
+            echo "| Config | ${{ steps.config.outcome }} |"
+            echo "| Cluster | ${{ steps.infra.outcome }} |"
+            echo "| Connection | ${{ steps.client.outcome }} |"
+            echo "| Prep | ${{ steps.prep.outcome }} |"
+            echo "| Install | ${{ steps.install.outcome }} |"
+            echo "| Validate (all phases) | ${{ steps.conformance.outcome }} |"
+            echo "| Train | ${{ steps.train.outcome }} |"
+            echo "| Serve | disabled (vLLM excluded from UAT) |"
+            echo "| Verify | ${{ steps.verify.outcome }} |"
+            if [[ -n "${{ steps.evidence_ref.outputs.ref }}" ]]; then
+              echo ""
+              echo "**Evidence (OCI):** \`${{ steps.evidence_ref.outputs.ref }}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Cleanup (after artifacts so a failed cleanup does not lose evidence).
+      # Main cell only — release cells reference shared, permanent released image
+      # tags and must not delete them.
+      - name: Cleanup validator image
+        if: always() && inputs.aicr_version == '' && inputs.skip_tests != true && inputs.lifecycle != 'daytime-down'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Delete UAT-tagged validator + snapshot-agent images to avoid GHCR
+          # clutter. aiperf-bench is included so the tag pushed by the build
+          # step above (#1636) does not leak.
+          for phase in deployment performance conformance aiperf-bench agent; do
+            VERSION_ID=$(gh api \
+              "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions" \
+              --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true
+            if [[ -n "${VERSION_ID}" ]]; then
+              gh api --method DELETE \
+                "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions/${VERSION_ID}" || true
+            fi
+          done
+
+      # Re-authenticate to Azure immediately before teardown: the session
+      # minted at the top of the job has long expired by now (the UAT phases
+      # can run the full job timeout). id-token: write is granted for the
+      # whole job, so azure/login can re-exchange here. Mirrors the AWS
+      # teardown credential refresh.
+      #
+      # Teardown gating (#1275, DC2): tear down for the nightly lifecycle
+      # (unless skip_delete) and for daytime-down (the explicit evening
+      # teardown of the held cluster — daytime-down provisions nothing, so it
+      # does not gate on steps.infra). NEVER for daytime-up, which holds the
+      # cluster for handoff. skip_delete is a nightly-only debugging escape
+      # and is ignored for daytime-down.
+      - name: Re-authenticate to Azure for teardown
+        if: >-
+          always() && (
+            inputs.lifecycle == 'daytime-down' ||
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+          )
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      # Teardown (retry up to 3 times). Runs last so a slow destroy
+      # cannot block evidence upload or summary rendering.
+      #
+      # Self-contained by design: this always() step sets BOTH deployment
+      # fields itself (id + destroy) rather than relying on the Update Config
+      # step, so a failure before Update Config cannot leave the destroy
+      # targeting the committed placeholder id (aicr-uat) instead of this
+      # run's cluster. Its only tool dependencies — yq, docker, az — are all
+      # preinstalled on the ubuntu-latest runner image, so it does not depend
+      # on the setup-build-tools step having run either.
+      - name: Destroy Cluster
+        if: >-
+          always() && (
+            inputs.lifecycle == 'daytime-down' ||
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+          )
+        shell: bash
+        run: |
+          set -euxo pipefail
+          yq -i '.deployment.id = strenv(DEPLOYMENT_ID) | .deployment.destroy = true' "$CLUSTER_CONFIG"
+          cat "$CLUSTER_CONFIG"
+          destroyed=false
+          for attempt in 1 2 3; do
+            echo "Destroy attempt ${attempt}..."
+            if docker run \
+              -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
+              -e AUTO_APPROVE=true \
+              -v "$HOME/.azure:/home/builder/.azure" \
+              "${AKS_ACTUATOR_IMAGE}" apply; then
+              echo "Cluster destroyed successfully"
+              destroyed=true
+              break
+            fi
+            echo "Destroy attempt ${attempt} failed, retrying..."
+            sleep 30
+          done
+          # Fail the step if every attempt failed; otherwise a genuine destroy
+          # failure exits 0 and the GPU node leaks silently.
+          if [ "$destroyed" != true ]; then
+            echo "::error::Cluster ${DEPLOYMENT_ID} destroy failed after 3 attempts; GPU node may be leaking"
+            exit 1
+          fi
+
+  # Ingest the signed UAT evidence bundle into the corroboration bucket.
+  # Runs as its own job (separate runner) only when the run produced a
+  # bundle; the reusable workflow verifies signer + issuer + identity +
+  # registry in a credential-free step before publishing to GCS.
+  ingest-evidence:
+    name: Ingest UAT evidence
+    needs: uat-azure
+    if: needs.uat-azure.outputs.bundle_ref != ''
+    permissions:
+      contents: read
+      id-token: write  # WIF for the publish job
+      packages: read   # GHCR pull for the verify job
+    uses: ./.github/workflows/evidence-ingest.yaml
+    with:
+      bundle_ref: ${{ needs.uat-azure.outputs.bundle_ref }}
+      recipe: aks-h100-${{ inputs.intent }}

--- a/.github/workflows/uat-nightly-batch.yaml
+++ b/.github/workflows/uat-nightly-batch.yaml
@@ -158,13 +158,21 @@ jobs:
           # EACH listed intent (training and/or inference) as its own full CUJ
           # cell per version, dispatched SEQUENTIALLY through the shared
           # per-reservation lease — so both intents run nightly with no
-          # contention and no second cron. The broker resolves an empty list to
-          # the training default, so this is always non-empty; fail closed if it
-          # somehow is not (a broker/registry regression).
-          NIGHTLY_INTENTS_CSV=$(./bin/uat-broker reservations --name "$RESERVATION" | sed -n 's/^nightly-intents=//p')
-          if [[ -z "$NIGHTLY_INTENTS_CSV" ]]; then
-            echo "::error::could not resolve nightly-intents for ${RESERVATION}" >&2
+          # contention and no second cron. The broker resolves an ABSENT
+          # nightly-intents to the training default; an EXPLICIT empty list is
+          # a bring-up opt-out (manual dispatch only) and resolves to an empty
+          # value. Distinguish the two failure shapes: a MISSING key is a
+          # broker/registry regression (fail closed); a present-but-EMPTY
+          # value is the opt-out (skip this leg gracefully).
+          ROW=$(./bin/uat-broker reservations --name "$RESERVATION")
+          if ! grep -q '^nightly-intents=' <<<"$ROW"; then
+            echo "::error::could not resolve nightly-intents for ${RESERVATION} (key missing from broker output)" >&2
             exit 1
+          fi
+          NIGHTLY_INTENTS_CSV=$(sed -n 's/^nightly-intents=//p' <<<"$ROW")
+          if [[ -z "$NIGHTLY_INTENTS_CSV" ]]; then
+            echo "::notice::Reservation ${RESERVATION} opts out of the nightly batch (nightly-intents: []); skipping this leg."
+            exit 0
           fi
           IFS=',' read -r -a intents <<< "$NIGHTLY_INTENTS_CSV"
           echo "Nightly intents for ${RESERVATION}: ${intents[*]}"

--- a/.github/workflows/uat-run.yaml
+++ b/.github/workflows/uat-run.yaml
@@ -43,7 +43,7 @@ on:
   workflow_dispatch:
     inputs:
       reservation:
-        description: 'Reservation name from infra/uat/reservations.yaml (e.g. aws-h100, gcp-h100).'
+        description: 'Reservation name from infra/uat/reservations.yaml (e.g. aws-h100, gcp-h100, azure-h100).'
         type: string
         required: true
       aicr_version:
@@ -158,11 +158,13 @@ jobs:
           go build -o ./bin/uat-broker ./tools/uat-broker
           ./bin/uat-broker reservations --name "$RESERVATION" >> "$GITHUB_OUTPUT"
 
-  # One of run-aws / run-gcp fires based on the resolved cloud (the registry
-  # validates cloud ∈ {aws,gcp}, so exactly one matches). The caller job grants
-  # the permission SUPERSET its callee needs — a reusable workflow's jobs are
-  # ceilinged by the calling job's permissions, and the called pipeline does
-  # OIDC, GHCR push, and (nested) evidence-ingest GCS WIF.
+  # One of run-aws / run-gcp / run-azure fires based on the resolved cloud
+  # (the registry validates cloud membership, so at most one matches; the
+  # unmapped-cloud job below fails closed if a registry cloud has no
+  # run-<cloud> job here yet). The caller job grants the permission SUPERSET
+  # its callee needs — a reusable workflow's jobs are ceilinged by the calling
+  # job's permissions, and the called pipeline does OIDC, GHCR push, and
+  # (nested) evidence-ingest GCS WIF.
   run-aws:
     needs: resolve
     if: needs.resolve.outputs.cloud == 'aws'
@@ -204,3 +206,45 @@ jobs:
       test_config_dir: ${{ needs.resolve.outputs.test_config_dir }}
       skip_delete: ${{ inputs.skip_delete }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  run-azure:
+    needs: resolve
+    if: needs.resolve.outputs.cloud == 'azure'
+    # Superset ceiling for the nested pipeline (a reusable workflow's jobs
+    # cannot exceed the caller's permissions).
+    permissions:
+      contents: read  # checkout inside the called pipeline
+      actions: read  # required by the nested uat-* + evidence-ingest jobs
+      id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
+      packages: write  # push validator + snapshot-agent images to GHCR
+    uses: ./.github/workflows/uat-azure.yaml
+    with:
+      reservation: ${{ inputs.reservation }}
+      aicr_version: ${{ inputs.aicr_version }}
+      intent: ${{ inputs.intent }}
+      lifecycle: ${{ inputs.lifecycle }}
+      cluster_config_path: ${{ needs.resolve.outputs.cluster_config_path }}
+      test_config_dir: ${{ needs.resolve.outputs.test_config_dir }}
+      skip_delete: ${{ inputs.skip_delete }}
+      skip_tests: ${{ inputs.skip_tests }}
+
+  # Fail closed on an unmapped cloud. The broker validates cloud membership
+  # against its own set, but a cloud can be added there (and to the registry)
+  # before its run-<cloud> job exists here — without this job the dispatch
+  # would silently no-op: the lease is taken, no pipeline runs, and the
+  # requester sees a green run that did nothing.
+  unmapped-cloud:
+    needs: resolve
+    if: >-
+      needs.resolve.outputs.cloud != 'aws' &&
+      needs.resolve.outputs.cloud != 'gcp' &&
+      needs.resolve.outputs.cloud != 'azure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on unmapped cloud
+        env:
+          CLOUD: ${{ needs.resolve.outputs.cloud }}
+        run: |
+          set -euo pipefail
+          echo "::error::reservation resolved to cloud '${CLOUD}', which has no run-<cloud> job in uat-run.yaml — add one (see run-azure for the shape)."
+          exit 1

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -51,6 +51,10 @@ security_tools:
 testing_tools:
   # renovate: datasource=github-releases depName=kubernetes/kubernetes depType=testing_tools
   kubectl: 'v1.36.2'
+  # kubelogin: Entra exec-plugin for AKS kubeconfigs, installed by uat-azure.yaml
+  # via `az aks install-cli` (which defaults to latest without an explicit pin).
+  # renovate: datasource=github-releases depName=Azure/kubelogin depType=testing_tools
+  kubelogin: 'v0.2.19'
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind depType=testing_tools
   kind: '0.32.0'
   # renovate-digest: datasource=git-refs depName=nvkind packageName=https://github.com/NVIDIA/nvkind branch=main depType=testing_tools

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -23,7 +23,7 @@ All UAT runs go through one entry point, `uat-run.yaml` — the shared dispatch 
 gh workflow run uat-run.yaml --repo NVIDIA/aicr --ref main -f reservation=aws-h100
 ```
 
-`uat-run.yaml` resolves the reservation row, then invokes the cloud-appropriate reusable pipeline (`uat-aws.yaml` or `uat-gcp.yaml`). A typo'd reservation name fails fast in the resolve step (the `uat-broker` helper exits *not found*). For manual debugging, `skip_tests` and `skip_delete` inputs are available.
+`uat-run.yaml` resolves the reservation row, then invokes the cloud-appropriate reusable pipeline (`uat-aws.yaml`, `uat-gcp.yaml`, or `uat-azure.yaml`). A typo'd reservation name fails fast in the resolve step (the `uat-broker` helper exits *not found*). For manual debugging, `skip_tests` and `skip_delete` inputs are available.
 
 Two further inputs shape the run (both default to the nightly-batch behavior, so the cron needs neither):
 
@@ -58,12 +58,13 @@ An unrecognized `intent` (or a missing sibling config) fails closed in the pipel
 
 ### Nightly intent cadence (both intents, both clouds)
 
-The single nightly cron (`uat-nightly-batch.yaml`, `0 4 * * *`) runs **both intents on every reservation**, so training *and* inference are exercised nightly on both AWS and GCP. (Note: an inference cell currently provisions and validates the inference platform; the `phase_serve` serving-CUJ step itself remains disabled in both cloud workflows pending #1644, so nightly runs do not yet execute the serving request path.) The set of intents per reservation is data — the `nightly-intents` list in `infra/uat/reservations.yaml` (empty defaults to `[training]`):
+The single nightly cron (`uat-nightly-batch.yaml`, `0 4 * * *`) runs **both intents on every nightly-enrolled reservation**, so training *and* inference are exercised nightly on both AWS and GCP (the bring-up `azure-h100` row opts out — see the table below). (Note: an inference cell currently provisions and validates the inference platform; the `phase_serve` serving-CUJ step itself remains disabled in both cloud workflows pending #1644, so nightly runs do not yet execute the serving request path.) The set of intents per reservation is data — the `nightly-intents` list in `infra/uat/reservations.yaml` (absent defaults to `[training]`; an explicit empty list `[]` opts the reservation out of the nightly batch entirely — bring-up mode, manual dispatch only):
 
 | Reservation | Cloud | `nightly-intents` | Nightly CUJs |
 |-------------|-------|-------------------|--------------|
 | `aws-h100` | AWS | `[training, inference]` | `phase_train` + `phase_serve` (serve step disabled pending #1644) |
 | `gcp-h100` | GCP | `[training, inference]` | `phase_train` + `phase_serve` (serve step disabled pending #1644) |
+| `azure-h100` | Azure | `[]` | none — opted out during bring-up |
 
 **How it stays contention-free — serialize, don't add a second cron.** The intents are folded into the existing [version matrix](#the-version-matrix) as extra cells rather than a second scheduled job. The controller's drive loop is **version outer / intent inner**: for each version it dispatches one intent's full provision→CUJ→teardown cell (inference cells currently run provision→validate→teardown; the serve CUJ is disabled pending #1644), waits for it (`gh run watch`), then dispatches the next — all through the *same* per-reservation lease. So the intents serialize naturally, and because `main` runs every intent before any release cell, a time-box drop only ever sheds the oldest *release* cells (never `main`'s inference). This is the deliberate DC3 cadence decision: **never schedule two daily crons against one reservation** — the lease is a single-slot queue (one in-progress + one pending), so a second cron plus an occasional human dispatch on the same reservation is a routine three-contender case whose loser is silently [superseded](#how-queuing-works-the-reservation-lease). One cron dispatching serialized cells sidesteps that entirely.
 
@@ -158,13 +159,15 @@ If the guard trips, tear the daytime cluster down with `lifecycle=daytime-down` 
 
 **GCP — actuator-time failure (decided posture).** `uat-gcp.yaml` has **no** pre-flight capacity/quota assertion, and DC2 deliberately did **not** add one. GCP relies on the GKE actuator failing at provision time if the reservation is exhausted. With the reservation lease serializing contending runs, a provision-time failure means a genuinely undersized/exhausted reservation, not a race — so a symmetric gcloud reservation check would add a second cloud API surface without changing the outcome. This is a recorded decision, not an oversight; there is intentionally no capacity step in the GCP pipeline.
 
+**Azure — quota-backed, GCP posture.** Azure capacity is **subscription quota** (westus `NDSH100v5`), not a reservation object — the registry row carries no `reservation-id` — and `uat-azure.yaml` follows the GCP posture: no pre-flight capacity assertion; the AKS actuator fails loudly at provision time if the quota is exhausted (with the lease serializing contenders, that failure means genuinely exhausted quota, not a race). Auth differs in mechanism, not model: `azure/login` exchanges the GitHub OIDC token against an Entra federated credential and writes the az CLI context to `~/.azure`, which is mounted into the AKS actuator container; because a federated az session cannot self-refresh, each long phase re-runs `azure/login` so no phase runs on an expired token.
+
 ## How queuing works (the reservation lease)
 
 The lease is a GitHub Actions concurrency group keyed by reservation name — `uat-<reservation>` (for example `uat-aws-h100`) — declared on `uat-run.yaml` with `cancel-in-progress: false`. Two runs that target the *same* reservation serialize: the second waits until the first (including its teardown) finishes. Two runs that target *different* reservations share no group and run in parallel, because they are independent hardware.
 
 This replaces the previous behavior, where a second run hitting a busy AWS reservation hard-failed on the capacity check. Now it queues.
 
-**The one-in-progress-plus-one-pending limit.** GitHub concurrency holds at most one in-progress run plus one pending run per group. If a *third* run is queued for a reservation that already has one in-progress and one pending, GitHub cancels the older pending run and the newest takes its place. At launch this is acceptable: there are two reservations, each contended by at most the nightly cron plus an occasional ad-hoc dispatch. A run cancelled this way is *superseded*, not failed. So that a dropped request is never silent, the `uat-superseded-notice.yaml` observer watches for it: triggered on `workflow_run: completed` for `UAT Run`, it classifies a cancelled run that never started a job as a supersede (versus a genuine mid-run cancel) and emits a job-summary entry plus a `::warning`. (The nightly controller reconciles the same signal synchronously for the cells it dispatches; a DC6 regression guard, #1279, will exercise the observer.) If deeper queuing is ever needed (many requesters per reservation), the escalation path is the *Deferred* standing broker service — a pull-based queue rather than GitHub concurrency — recorded in the epic (#1264).
+**The one-in-progress-plus-one-pending limit.** GitHub concurrency holds at most one in-progress run plus one pending run per group. If a *third* run is queued for a reservation that already has one in-progress and one pending, GitHub cancels the older pending run and the newest takes its place. At launch this is acceptable: there are three reservations, each contended by at most the nightly cron (Azure: manual dispatch only during bring-up) plus an occasional ad-hoc dispatch. A run cancelled this way is *superseded*, not failed. So that a dropped request is never silent, the `uat-superseded-notice.yaml` observer watches for it: triggered on `workflow_run: completed` for `UAT Run`, it classifies a cancelled run that never started a job as a supersede (versus a genuine mid-run cancel) and emits a job-summary entry plus a `::warning`. (The nightly controller reconciles the same signal synchronously for the cells it dispatches; a DC6 regression guard, #1279, will exercise the observer.) If deeper queuing is ever needed (many requesters per reservation), the escalation path is the *Deferred* standing broker service — a pull-based queue rather than GitHub concurrency — recorded in the epic (#1264).
 
 ## The version matrix
 
@@ -187,8 +190,8 @@ Reservations are data, not code. To onboard a new reserved pool, add a row to `i
 
 ```yaml
 - name: aws-b200          # the lease key; becomes concurrency group uat-aws-b200
-  cloud: aws              # aws | gcp — selects which pipeline (EKS vs GKE) provisions
-  reservation-id: cr-...  # the cloud capacity-reservation id (GCP uses the full path)
+  cloud: aws              # aws | gcp | azure — selects which pipeline (EKS / GKE / AKS) provisions
+  reservation-id: cr-...  # the cloud capacity-reservation id (GCP uses the full path); OMIT for quota-backed capacity (azure)
   accelerator: b200
   gpu-count: 8
   cluster-config-path: tests/uat/aws/cluster-config-b200.yaml
@@ -197,7 +200,9 @@ Reservations are data, not code. To onboard a new reserved pool, add a row to `i
 
 No broker, workflow, or Go change is needed — the nightly batch enumerates rows from the registry, and `uat-run.yaml` resolves them. The unit of sequencing is the *reservation*, so a new GPU type in an existing cloud simply runs in parallel with the others on its own lease. (Provisioning is per *cloud*: the same `uat-aws.yaml` pipeline provisions any AWS accelerator from the row's `cluster-config-path`; you do not add a per-accelerator workflow.)
 
-The values in this file are identifiers, **not secrets** — a reservation-id grants no access on its own; access to the reserved capacity is governed by cloud IAM/ACLs bound to the CI federation identity (see `infra/uat-aws-account/` and `infra/uat-gcp-account/`). They are safe to commit.
+Onboarding a new *cloud* (rather than a new pool in an existing cloud) is a code change on top of the row: a `run-<cloud>` job in `uat-run.yaml`, a `uat-<cloud>.yaml` pipeline, and account federation under `infra/uat-<cloud>-account/`. During bring-up, set `nightly-intents: []` (explicit empty list — absent defaults to `[training]`) so the reservation is manually dispatchable via `uat-run.yaml` but skipped by the nightly batch; flip it once the pipeline has green runs.
+
+The values in this file are identifiers, **not secrets** — a reservation-id grants no access on its own; access to the reserved capacity is governed by cloud IAM/ACLs bound to the CI federation identity (see `infra/uat-aws-account/`, `infra/uat-gcp-account/`, and `infra/uat-azure-account/`). They are safe to commit.
 
 ## Roadmap
 

--- a/infra/uat-azure-account/README.md
+++ b/infra/uat-azure-account/README.md
@@ -1,0 +1,126 @@
+# Azure Entra ID OIDC Setup for GitHub Actions
+
+Terraform configuration for GitHub Actions → Microsoft Entra ID OIDC federation enabling keyless auth for the Azure UAT pipeline ([`.github/workflows/uat-azure.yaml`](../../.github/workflows/uat-azure.yaml)) that creates ephemeral AKS clusters. The pipeline is invoked through the shared dispatch surface (`uat-run.yaml`) for ad-hoc runs and — once enrolled — via the nightly batch (`uat-nightly-batch.yaml`) on a cron.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.9.5
+- `az login` as a user with:
+  - **Contributor** on the target subscription — to create the identity resource group, managed identity, and federated credentials (no Entra directory role is needed; see Why a Managed Identity below)
+  - **Owner** or **User Access Administrator** on the subscription — only for the three role assignments; without it, apply with `-var manage_role_assignments=false` and have a subscription admin create them (commands under Permissions Granted)
+
+## Why a Managed Identity
+
+The federation subject is a **user-assigned managed identity**, not an app registration: this tenant blocks member app-registration creation (`authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps=false`) and grants no directory roles, so an `azuread_application` apply fails with `Authorization_RequestDenied`. A managed identity is an ARM resource — subscription Contributor suffices — supports the same federated credentials, and `azure/login` consumes its client ID unchanged.
+
+## What This Creates
+
+- **Resource Group**: `aicr-uat-identity-rg` (holds only the pipeline identity)
+- **Managed Identity**: user-assigned, `github-actions-aicr`
+- **Federated Identity Credentials**: two, one per allowed OIDC subject (Entra matches subjects exactly, no wildcards):
+  - `repo:NVIDIA/aicr:ref:refs/heads/main`
+  - `repo:NVIDIA/aicr:ref:refs/heads/test/uat`
+- **Role Assignments** (when `manage_role_assignments=true`): two subscription-scoped roles for the identity — **Contributor** and **Role Based Access Control Administrator** (ABAC-constrained to the three role definitions the pipeline assigns; see Permissions Granted). Data-plane kubectl access is NOT granted here — the pipeline self-assigns **Azure Kubernetes Service RBAC Cluster Admin** per run, scoped to the run's resource group
+
+**No client secret is created** — authentication is OIDC-only (a managed identity cannot even have a secret). GitHub mints a short-lived token per workflow run, `azure/login` exchanges it against the federated credentials above, and the resulting `az` CLI context is what the AKS actuator container consumes.
+
+## Usage
+
+```bash
+cd infra/uat-azure-account
+terraform init
+terraform plan
+terraform apply       # add -var manage_role_assignments=false without Owner/UAA
+terraform output      # IDs needed for the GitHub Actions workflow
+```
+
+## Configuration Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `tenant_id` | Entra ID tenant hosting the managed identity | `43083d15-…` (NVIDIA) |
+| `subscription_id` | Subscription the UAT clusters are provisioned into (`deployment.tenancy` in `tests/uat/azure/cluster-config.yaml`) | `e88faa01-…` |
+| `git_repo` | GitHub repository (format: owner/repo) | `NVIDIA/aicr` |
+| `identity_name` | Name of the user-assigned managed identity | `github-actions-aicr` |
+| `location` | Region for the identity resource group | `westus` |
+| `manage_role_assignments` | Create the subscription role assignments (needs Owner/UAA) | `true` |
+
+## Permissions Granted
+
+- **Contributor** on the whole subscription. The AKS actuator creates resource groups, AKS clusters, VNets, and node pools — there is no pre-created resource group to scope down to. Revisit narrowing to a dedicated resource-group scope if the actuator gains a fixed-RG mode.
+- **Role Based Access Control Administrator** on the subscription, constrained by an ABAC condition to assigning/deleting exactly three role definitions: Network Contributor (`4d97b98b…`, VNet access for the cluster identity) and AcrPull (`7f951dda…`, kubelet image pulls) — the two assignments the actuator's `iam.tf` creates (and removes on destroy) — plus Azure Kubernetes Service RBAC Cluster Admin (`b1ff04bb…`, see next bullet). Contributor alone cannot write role assignments, and the ABAC condition means the pipeline identity still cannot grant itself (or anyone else) any other access.
+- **Azure Kubernetes Service RBAC Cluster Admin** — deliberately NOT a standing subscription-scoped grant. The actuator provisions AKS with Entra RBAC and local accounts disabled, so the pipeline needs a Kubernetes data-plane role for `kubectl` (via kubelogin's `azurecli` mode) — but a subscription-scoped grant would be cluster-admin on every Azure-RBAC cluster in this **shared** (non-UAT-dedicated) subscription. Instead the workflow self-assigns the role per run, scoped to the run's resource group (`uat-azure.yaml` "Grant run-scoped cluster admin", permitted by the ABAC condition above); the assignment is deleted with the resource group at teardown.
+- No Entra directory roles — the pipeline identity cannot manage app registrations, groups, or other directory objects.
+
+**Out-of-band assignment** (when the deployer lacks Owner/UAA and applied with `-var manage_role_assignments=false`) — a subscription admin runs, with `ASSIGNEE=$(terraform output -raw AZURE_PRINCIPAL_ID)` and `SUB=$(terraform output -raw AZURE_SUBSCRIPTION_ID)`:
+
+```bash
+az role assignment create --assignee-object-id "$ASSIGNEE" --assignee-principal-type ServicePrincipal \
+  --role "Contributor" --scope "/subscriptions/$SUB"
+az role assignment create --assignee-object-id "$ASSIGNEE" --assignee-principal-type ServicePrincipal \
+  --role "Role Based Access Control Administrator" --scope "/subscriptions/$SUB" \
+  --condition-version "2.0" \
+  --condition "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {4d97b98b-1d4f-4787-a291-c67834d212e7, 7f951dda-4ed3-4680-a7ca-43fe172d538d, b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {4d97b98b-1d4f-4787-a291-c67834d212e7, 7f951dda-4ed3-4680-a7ca-43fe172d538d, b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b}))"
+```
+
+## State Bootstrap (one-time)
+
+The AKS actuator stores its Terraform state in an `azurerm` backend inside the target subscription (`deployment.state: tenancy` in `tests/uat/azure/cluster-config.yaml`), which is what lets a fresh runner tear down a cluster another run provisioned. That backend is **not** created by the actuator or by this Terraform — bootstrap it once per subscription with the actuator repo's setup tool ([upstream requirement](https://github.com/mchmarny/cluster/blob/main/provider/aks/README.md)):
+
+```bash
+# from a checkout of github.com/mchmarny/cluster, az-logged-in to the UAT subscription
+provider/aks/tools/setup -c <path-to>/tests/uat/azure/cluster-config.yaml
+```
+
+This creates the `cluster-state-rg` resource group, the `clst<subscription-hex>` Storage Account (blob versioning enabled) with a `tfstate` container, and a local `backend.hcl`. The tool is idempotent — re-running against an already-bootstrapped subscription is a no-op.
+
+## GitHub Actions Integration
+
+See [`.github/workflows/uat-azure.yaml`](../../.github/workflows/uat-azure.yaml) for the full workflow. Key auth step:
+
+```yaml
+permissions:
+  id-token: write  # Required for OIDC
+jobs:
+  integration-test-azure:
+    env:
+      AZURE_CLIENT_ID: "<terraform output AZURE_CLIENT_ID>"
+      AZURE_TENANT_ID: "<terraform output AZURE_TENANT_ID>"
+      AZURE_SUBSCRIPTION_ID: "<terraform output AZURE_SUBSCRIPTION_ID>"
+    steps:
+      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+```
+
+The client, tenant, and subscription IDs are identifiers, not secrets — the same posture as the AWS account ID in `uat-aws.yaml`. Access is gated by the federated credential subjects (which repo/ref may exchange a token), not by knowledge of the IDs.
+
+## Security
+
+- **No long-lived credentials** — no client secret exists; OIDC tokens only, time-limited sessions
+- **Repository + branch scoped** — only `repo:NVIDIA/aicr:ref:refs/heads/main` and `repo:NVIDIA/aicr:ref:refs/heads/test/uat` can federate; PR branches, tags, and forks are rejected (Entra subject matching is exact)
+- **Token lifetime** — federated `az` sessions cannot self-refresh (there is no client secret to renew with), so the pipeline re-runs `azure/login` per phase rather than relying on one session for the whole run
+- **Audit trail** — sign-ins and role usage appear in Entra sign-in logs and Azure Activity Log with GitHub OIDC context
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `AZURE_CLIENT_ID` | Managed-identity client ID — `azure/login` `client-id` input |
+| `AZURE_PRINCIPAL_ID` | Managed-identity principal (object) ID — `--assignee-object-id` for out-of-band role assignments |
+| `AZURE_TENANT_ID` | Entra tenant ID — `azure/login` `tenant-id` input |
+| `AZURE_SUBSCRIPTION_ID` | Target subscription — `azure/login` `subscription-id` input |
+
+## State Management
+
+This configuration uses **local state**. The `terraform.tfstate` file is gitignored (root `.gitignore` covers `*.tfstate` / `*.tfstate.*`), matching `infra/uat-aws-account/`. For multi-administrator setups, add an `azurerm` backend.
+
+## Cleanup
+
+```bash
+terraform destroy -var "tenant_id=$(az account show --query tenantId -o tsv)"
+```
+
+Removes the identity resource group, managed identity, federated credentials, and any Terraform-managed role assignments (out-of-band assignments must be removed by an admin). The AKS actuator's own Terraform state storage account (`clst…`) lives in the subscription and is **not** managed here — remove it separately if decommissioning the UAT environment entirely.

--- a/infra/uat-azure-account/federation.tf
+++ b/infra/uat-azure-account/federation.tf
@@ -1,0 +1,125 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GitHub Actions -> Entra workload identity federation for the Azure UAT
+# pipeline (.github/workflows/uat-azure.yaml, invoked via uat-run.yaml).
+#
+# The federation subject is a USER-ASSIGNED MANAGED IDENTITY, not an app
+# registration: this tenant blocks member app-registration creation
+# (authorizationPolicy defaultUserRolePermissions.allowedToCreateApps=false
+# and no directory roles are granted), so an azuread_application apply fails
+# with Authorization_RequestDenied. A managed identity is an ARM resource —
+# subscription Contributor suffices to create it — and supports the same
+# federated credentials; azure/login consumes its client-id unchanged.
+#
+# The workflow authenticates keylessly: GitHub mints an OIDC token,
+# azure/login exchanges it against the federated identity credentials below,
+# and the resulting az CLI context (~/.azure) is what the AKS actuator
+# container consumes. No client secret exists anywhere (a managed identity
+# cannot even have one).
+
+data "azurerm_subscription" "current" {}
+
+# Holds only the pipeline identity — deliberately separate from the
+# run-scoped cluster RGs the actuator creates and destroys.
+resource "azurerm_resource_group" "identity" {
+  name     = "aicr-uat-identity-rg"
+  location = var.location
+}
+
+resource "azurerm_user_assigned_identity" "github_actions" {
+  name                = var.identity_name
+  resource_group_name = azurerm_resource_group.identity.name
+  location            = azurerm_resource_group.identity.location
+}
+
+# One federated credential per allowed subject. Mirrors the AWS trust policy
+# (infra/uat-aws-account/federation.tf): main + the test/uat staging branch.
+# Entra federated credentials match subjects EXACTLY (no wildcards), so each
+# allowed ref is its own resource.
+locals {
+  allowed_subjects = {
+    main     = "repo:${var.git_repo}:ref:refs/heads/main"
+    test-uat = "repo:${var.git_repo}:ref:refs/heads/test/uat"
+  }
+}
+
+resource "azurerm_federated_identity_credential" "github" {
+  for_each = local.allowed_subjects
+
+  # resource_group_name is intentionally omitted (deprecated in azurerm 4.x —
+  # the identity id already carries the RG; removed in v5) and the identity
+  # ref uses user_assigned_identity_id (parent_id is deprecated for the same
+  # removal).
+  name                      = "github-${each.key}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.github_actions.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = "https://token.actions.githubusercontent.com"
+  subject                   = each.value
+}
+
+# --- Role assignments -------------------------------------------------------
+#
+# Creating the assignments below requires subscription Owner /
+# User Access Administrator (or an ABAC grant covering these role
+# definitions). The UAT deployer's own grant is typically the ABAC-scoped
+# RBAC Administrator limited to Network Contributor + AcrPull, which CANNOT
+# create these — set manage_role_assignments=false in that case and have a
+# subscription admin create them out-of-band (exact commands in the README's
+# Permissions Granted section).
+
+# Subscription-scoped Contributor: the AKS actuator creates resource groups,
+# AKS clusters, VNets, and node pools — there is no pre-created resource
+# group to scope down to. (The clst<subscription-hex> state storage account
+# is bootstrapped once, out-of-band, by the actuator's setup tool — see the
+# README's State Bootstrap section.) Revisit narrowing to a dedicated RG
+# scope if the actuator gains a fixed-RG mode. Rationale and the scope
+# trade-off are recorded in the README's Permissions Granted section.
+resource "azurerm_role_assignment" "contributor" {
+  count = var.manage_role_assignments ? 1 : 0
+
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.github_actions.principal_id
+}
+
+# The pipeline needs Microsoft.Authorization/roleAssignments/write — and
+# /delete on destroy — beyond Contributor, for exactly three role
+# definitions:
+#   - Network Contributor (4d97b98b…) and AcrPull (7f951dda…): the two
+#     assignments the actuator's iam.tf creates for the cluster identity
+#     and kubelet.
+#   - Azure Kubernetes Service RBAC Cluster Admin (b1ff04bb…): the pipeline
+#     SELF-ASSIGNS this per run, scoped to the run's resource group
+#     (uat-azure.yaml "Grant run-scoped cluster admin"), because the
+#     actuator provisions AKS with Entra RBAC and local accounts disabled —
+#     without a data-plane role the first kubectl call is Forbidden. A
+#     subscription-scoped grant would be cluster-admin on EVERY Azure-RBAC
+#     cluster in this SHARED subscription; the per-RG self-assignment keeps
+#     the blast radius to the run's own cluster and dies with the RG at
+#     teardown.
+# Grant it least-privilege, as the actuator README prescribes: Role Based
+# Access Control Administrator constrained by an ABAC condition to
+# assigning/deleting ONLY those three role definitions, so the pipeline
+# identity still cannot grant itself (or anyone else) broader access.
+resource "azurerm_role_assignment" "role_assignments_scoped" {
+  count = var.manage_role_assignments ? 1 : 0
+
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Role Based Access Control Administrator"
+  principal_id         = azurerm_user_assigned_identity.github_actions.principal_id
+  condition_version    = "2.0"
+  condition            = "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {4d97b98b-1d4f-4787-a291-c67834d212e7, 7f951dda-4ed3-4680-a7ca-43fe172d538d, b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {4d97b98b-1d4f-4787-a291-c67834d212e7, 7f951dda-4ed3-4680-a7ca-43fe172d538d, b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b}))"
+}

--- a/infra/uat-azure-account/outputs.tf
+++ b/infra/uat-azure-account/outputs.tf
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "AZURE_CLIENT_ID" {
+  description = "Managed-identity client id — azure/login's client-id input."
+  value       = azurerm_user_assigned_identity.github_actions.client_id
+}
+
+output "AZURE_PRINCIPAL_ID" {
+  description = "Managed-identity principal (object) id — the --assignee for out-of-band role assignments when manage_role_assignments=false."
+  value       = azurerm_user_assigned_identity.github_actions.principal_id
+}
+
+output "AZURE_TENANT_ID" {
+  description = "Entra tenant id — azure/login's tenant-id input."
+  value       = var.tenant_id
+}
+
+output "AZURE_SUBSCRIPTION_ID" {
+  description = "Target subscription — azure/login's subscription-id input."
+  value       = var.subscription_id
+}

--- a/infra/uat-azure-account/providers.tf
+++ b/infra/uat-azure-account/providers.tf
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.9.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
+}

--- a/infra/uat-azure-account/variables.tf
+++ b/infra/uat-azure-account/variables.tf
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "tenant_id" {
+  description = "Entra ID tenant that hosts the managed identity. Discover with `az account show --query tenantId -o tsv`."
+  type        = string
+  default     = "43083d15-7273-40c1-b7db-39efd9ccc17a"
+}
+
+variable "subscription_id" {
+  description = "Subscription the UAT clusters are provisioned into — the `deployment.tenancy` value in tests/uat/azure/cluster-config.yaml."
+  type        = string
+  default     = "e88faa01-b4fd-49d3-b934-0ad9f9fca307"
+}
+
+variable "git_repo" {
+  description = "GitHub repository (org/name) allowed to federate."
+  type        = string
+  default     = "NVIDIA/aicr"
+}
+
+variable "identity_name" {
+  description = "Name of the user-assigned managed identity GitHub Actions federates as."
+  type        = string
+  default     = "github-actions-aicr"
+}
+
+variable "location" {
+  description = "Region for the identity resource group (matches the UAT clusters' region)."
+  type        = string
+  default     = "westus"
+}
+
+variable "manage_role_assignments" {
+  description = "Create the subscription role assignments for the pipeline identity. Requires Owner/User Access Administrator; deployers holding only the ABAC-scoped RBAC Administrator grant must set this to false and have a subscription admin create the assignments (see README)."
+  type        = bool
+  default     = true
+}

--- a/infra/uat/reservations.yaml
+++ b/infra/uat/reservations.yaml
@@ -24,16 +24,19 @@
 # NOTE — these values are identifiers, NOT secrets. A reservation-id (and the
 # GCP project path it embeds) grants no access on its own: access to the
 # reserved capacity — and to anything running on it — is governed by cloud
-# IAM/ACLs bound to the CI federation identity (see infra/uat-aws-account/
-# and infra/uat-gcp-account/), not by knowledge of the ID. They are safe to
-# commit; disclosure reveals only internal infra naming, not a way in.
+# IAM/ACLs bound to the CI federation identity (see infra/uat-aws-account/,
+# infra/uat-gcp-account/, and infra/uat-azure-account/), not by knowledge of
+# the ID. They are safe to commit; disclosure reveals only internal infra
+# naming, not a way in.
 #
 # Fields:
 #   name                human-facing reservation / lease key (must be unique)
-#   cloud               aws | gcp
+#   cloud               aws | gcp | azure
 #   reservation-id      the cloud capacity-reservation identifier; GCP uses
 #                       the fully-qualified resource path (matches the value
-#                       embedded in cluster-config-path verbatim)
+#                       embedded in cluster-config-path verbatim); OPTIONAL —
+#                       omitted for quota-backed capacity (azure), where
+#                       subscription quota, not a reservation, backs the nodes
 #   accelerator         GPU accelerator family on the reservation
 #   gpu-count           GPUs per reserved node (forward-looking metadata)
 #   cluster-config-path the github.com/mchmarny/cluster Cluster config the
@@ -44,8 +47,10 @@
 #   nightly-intents     (optional) the recipe intents the NIGHTLY version-matrix
 #                       batch (#1274, DC1) runs on this reservation, as a YAML
 #                       list — [training], [inference], or [training,
-#                       inference]. Empty/absent defaults to [training] (the
-#                       pre-DC3 behavior). DC3 (#1276) sets it to [training,
+#                       inference]. Absent defaults to [training] (the
+#                       pre-DC3 behavior); an explicit empty list ([]) opts the
+#                       reservation out of the nightly batch (bring-up mode —
+#                       manual dispatch only). DC3 (#1276) sets it to [training,
 #                       inference] on BOTH reservations so training and inference
 #                       both run nightly on both clouds. The batch runs the
 #                       intents SEQUENTIALLY within each version cell, through
@@ -87,3 +92,18 @@ reservations:
     test-config-dir: tests/uat/gcp/tests
     nightly-intents: [training, inference]
     daytime-intent: inference
+  - name: azure-h100
+    cloud: azure
+    # No reservation-id: capacity is Azure subscription QUOTA (westus
+    # NDSH100v5), not a capacity reservation. The name is still the lease
+    # key, so contending runs queue exactly as on the reserved clouds; a
+    # quota-exhausted provision fails loudly at actuator apply time (the
+    # same posture as GCP — no pre-flight capacity assertion).
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/azure/cluster-config.yaml
+    test-config-dir: tests/uat/azure/tests
+    # Bring-up phase: explicitly opted OUT of the nightly batch (empty list,
+    # not absent — absent would default to [training]). Manual dispatch via
+    # uat-run.yaml only. Flip to [training] after green manual runs.
+    nightly-intents: []

--- a/pkg/corroborate/classify_test.go
+++ b/pkg/corroborate/classify_test.go
@@ -101,10 +101,12 @@ func TestLoadAllowlist_CanonicalFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAllowlist(recipes/evidence/allowlist.yaml): %v", err)
 	}
-	class, ok := classifySigner(al, ghIssuer,
-		"https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main")
-	if class != ClassFirstParty || !ok {
-		t.Errorf("canonical allowlist classified UAT signer as (%q,%v), want (first-party,true)", class, ok)
+	for _, cloud := range []string{"aws", "gcp", "azure"} {
+		identity := "https://github.com/NVIDIA/aicr/.github/workflows/uat-" + cloud + ".yaml@refs/heads/main"
+		class, ok := classifySigner(al, ghIssuer, identity)
+		if class != ClassFirstParty || !ok {
+			t.Errorf("canonical allowlist classified %s UAT signer as (%q,%v), want (first-party,true)", cloud, class, ok)
+		}
 	}
 }
 

--- a/pkg/evidence/project/classify.go
+++ b/pkg/evidence/project/classify.go
@@ -50,7 +50,7 @@ const (
 const firstPartyIssuer = "https://token.actions.githubusercontent.com"
 
 // firstPartyIdentity matches the SubjectAlternativeName of AICR's own UAT
-// workflows (uat-aws.yaml / uat-gcp.yaml on a branch ref) — the only
+// workflows (uat-aws.yaml / uat-gcp.yaml / uat-azure.yaml on a branch ref) — the only
 // identity the interim heuristic may admit as first-party. Fully anchored
 // (^…$) so neither a look-alike host nor an arbitrary other path/ref under
 // NVIDIA/aicr (e.g. a fork-PR workflow or a non-UAT workflow) can satisfy
@@ -58,7 +58,7 @@ const firstPartyIssuer = "https://token.actions.githubusercontent.com"
 // firstParty entries in recipes/evidence/allowlist.yaml. Used only when no
 // allowlist file is loaded (nil *Allowlist).
 var firstPartyIdentity = regexp.MustCompile(
-	`^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp)\.yaml@refs/heads/.+$`)
+	`^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-(aws|gcp|azure)\.yaml@refs/heads/.+$`)
 
 // Allowlist wraps the shared GP1 allowlist loader (pkg/evidence/allowlist)
 // for the GP2 producer. A nil *Allowlist is valid and applies only the

--- a/pkg/evidence/project/classify_test.go
+++ b/pkg/evidence/project/classify_test.go
@@ -155,10 +155,12 @@ func TestLoadAllowlist_CanonicalFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAllowlist(recipes/evidence/allowlist.yaml): %v", err)
 	}
-	class, ok := al.Classify(ghaIssuer,
-		"https://github.com/NVIDIA/aicr/.github/workflows/uat-gcp.yaml@refs/heads/main")
-	if class != ClassFirstParty || !ok {
-		t.Errorf("canonical allowlist classified UAT signer as (%q,%v), want (first-party,true)", class, ok)
+	for _, cloud := range []string{"aws", "gcp", "azure"} {
+		identity := "https://github.com/NVIDIA/aicr/.github/workflows/uat-" + cloud + ".yaml@refs/heads/main"
+		class, ok := al.Classify(ghaIssuer, identity)
+		if class != ClassFirstParty || !ok {
+			t.Errorf("canonical allowlist classified %s UAT signer as (%q,%v), want (first-party,true)", cloud, class, ok)
+		}
 	}
 }
 
@@ -175,6 +177,7 @@ func TestClassify_NilAllowlist(t *testing.T) {
 		wantAllowed bool
 	}{
 		{"first-party heuristic", ghaIssuer, "https://github.com/NVIDIA/aicr/.github/workflows/uat-aws.yaml@refs/heads/main", ClassFirstParty, true},
+		{"first-party heuristic (azure)", ghaIssuer, "https://github.com/NVIDIA/aicr/.github/workflows/uat-azure.yaml@refs/heads/main", ClassFirstParty, true},
 		{"foreign repo is community", ghaIssuer, "https://github.com/evil/aicr/.github/workflows/x.yaml@refs/heads/main", ClassCommunity, false},
 		{"look-alike host not first-party", ghaIssuer, "https://github.com.evil.example/NVIDIA/aicr/x.yaml", ClassCommunity, false},
 		{"community email", communityIssuer, "yuanchen97@gmail.com", ClassCommunity, false},

--- a/pkg/uatbroker/model.go
+++ b/pkg/uatbroker/model.go
@@ -16,12 +16,13 @@ package uatbroker
 
 // Recognized cloud values for a reservation row.
 const (
-	CloudAWS = "aws"
-	CloudGCP = "gcp"
+	CloudAWS   = "aws"
+	CloudGCP   = "gcp"
+	CloudAzure = "azure"
 )
 
 // validClouds is the set of accepted Reservation.Cloud values.
-var validClouds = map[string]bool{CloudAWS: true, CloudGCP: true}
+var validClouds = map[string]bool{CloudAWS: true, CloudGCP: true, CloudAzure: true}
 
 // Recognized recipe-intent values. The daytime human-access rotation (#1281,
 // DC8) picks one flavor per reservation via Reservation.DaytimeIntent; these
@@ -41,8 +42,12 @@ var validIntents = map[string]bool{IntentTraining: true, IntentInference: true}
 // "uat-<Name>" — to the cloud-specific identifiers and the on-disk
 // cluster/test configuration a UAT run consumes.
 type Reservation struct {
-	Name              string `yaml:"name"`
-	Cloud             string `yaml:"cloud"`
+	Name  string `yaml:"name"`
+	Cloud string `yaml:"cloud"`
+	// ReservationID is the cloud capacity-reservation identifier (GCP uses the
+	// fully-qualified resource path). OPTIONAL: quota-backed reservations
+	// (e.g. Azure subscription quota) have no reservation identifier and omit
+	// it — the Name is still the lease key either way.
 	ReservationID     string `yaml:"reservation-id"`
 	Accelerator       string `yaml:"accelerator"`
 	GPUCount          int    `yaml:"gpu-count"`
@@ -50,14 +55,22 @@ type Reservation struct {
 	TestConfigDir     string `yaml:"test-config-dir"`
 	// NightlyIntents lists the recipe intents the nightly version-matrix batch
 	// (#1274, DC1) runs on this reservation, each a full CUJ per version cell:
-	// "training", "inference", or both. Empty defaults to ["training"] (the
-	// pre-DC3 behavior) — see NightlyIntentsOrDefault. DC3 (#1276) sets it to
+	// "training", "inference", or both. Absent defaults to ["training"]; an
+	// explicit empty list opts out of the nightly batch entirely — see
+	// NightlyIntentsOrDefault. DC3 (#1276) sets it to
 	// [training, inference] on every reservation so both CUJs run nightly on
 	// both clouds; the batch dispatches them SEQUENTIALLY through the shared
 	// per-reservation lease (intent inner-loop, version outer-loop), so there is
 	// never contention and `main` lands both intents before any release cell.
 	// Entries must be recognized intents and unique (a duplicate would
 	// double-run the same cell).
+	//
+	// AUTHORING CAVEAT: to opt out, the value must be an explicit empty
+	// list (`nightly-intents: []`). A bare `nightly-intents:` (YAML null)
+	// decodes to nil — indistinguishable from an absent key — and therefore
+	// opts the reservation INTO the [training] default, provisioning real
+	// GPU capacity. KnownFields cannot catch this (the key is valid);
+	// TestParseRegistryBareNullNightlyIntents locks the behavior.
 	NightlyIntents []string `yaml:"nightly-intents"`
 	// DaytimeIntent opts this reservation into the daytime human-access
 	// rotation (#1281, DC8) and picks the flavor stood up on it during the
@@ -68,13 +81,17 @@ type Reservation struct {
 	DaytimeIntent string `yaml:"daytime-intent"`
 }
 
-// NightlyIntentsOrDefault returns the reservation's nightly-batch intents,
-// defaulting an empty list to [IntentTraining] — the pre-DC3 behavior, so an
-// un-annotated reservation keeps running only the training CUJ nightly. Validate
-// guarantees any listed value is a recognized, non-duplicate intent. The
-// returned slice is a fresh copy the caller may mutate freely.
+// NightlyIntentsOrDefault returns the reservation's nightly-batch intents.
+// An ABSENT nightly-intents field (nil) defaults to [IntentTraining] — the
+// pre-DC3 behavior, so an un-annotated reservation keeps running the training
+// CUJ nightly. An EXPLICIT empty list ([]) is a nightly opt-out and returns
+// empty: the reservation stays manually dispatchable through uat-run.yaml but
+// the nightly batch skips it (used for bring-up of a new cloud before its
+// pipeline has earned nightly enrollment). Validate guarantees any listed
+// value is a recognized, non-duplicate intent. The returned slice is a fresh
+// copy the caller may mutate freely.
 func (r *Reservation) NightlyIntentsOrDefault() []string {
-	if len(r.NightlyIntents) == 0 {
+	if r.NightlyIntents == nil {
 		return []string{IntentTraining}
 	}
 	out := make([]string, len(r.NightlyIntents))

--- a/pkg/uatbroker/registry.go
+++ b/pkg/uatbroker/registry.go
@@ -15,6 +15,8 @@
 package uatbroker
 
 import (
+	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,10 +30,20 @@ import (
 // path cannot OOM the process; the registry is a small hand-edited file.
 const maxRegistryBytes int64 = 1 << 20 // 1 MiB
 
-// ParseRegistry parses and validates a reservations.yaml document.
+// ParseRegistry parses and validates a reservations.yaml document. Decoding
+// is strict (KnownFields): a mistyped key like `nightly-intnts:` must fail
+// the parse rather than silently leave the real field on its default and
+// fail open (e.g. re-enrolling an opted-out row in the nightly batch).
 func ParseRegistry(data []byte) (*Registry, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
 	var reg Registry
-	if err := yaml.Unmarshal(data, &reg); err != nil {
+	if err := dec.Decode(&reg); err != nil {
+		if stderrors.Is(err, io.EOF) {
+			// Empty document: report the canonical "no reservations"
+			// validation error instead of a cryptic EOF.
+			return nil, reg.Validate()
+		}
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "parse reservation registry", err)
 	}
 	if err := reg.Validate(); err != nil {
@@ -60,9 +72,9 @@ func LoadRegistryFile(path string) (*Registry, error) {
 }
 
 // Validate enforces registry invariants: at least one row; every row has the
-// required fields; cloud is recognized; gpu-count is positive; and names are
-// unique (the name is the lease key, so a duplicate would make the lease
-// ambiguous).
+// required fields (reservation-id is optional — quota-backed rows have none);
+// cloud is recognized; gpu-count is positive; and names are unique (the name
+// is the lease key, so a duplicate would make the lease ambiguous).
 func (r *Registry) Validate() error {
 	if len(r.Reservations) == 0 {
 		return errors.New(errors.ErrCodeInvalidRequest, "reservation registry has no reservations")
@@ -83,10 +95,12 @@ func (r *Registry) Validate() error {
 		seen[res.Name] = true
 		if !validClouds[res.Cloud] {
 			return errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("reservation %s has unknown cloud %q (want %s or %s)", res.Name, res.Cloud, CloudAWS, CloudGCP))
+				fmt.Sprintf("reservation %s has unknown cloud %q (want %s, %s, or %s)",
+					res.Name, res.Cloud, CloudAWS, CloudGCP, CloudAzure))
 		}
+		// reservation-id is intentionally NOT required: quota-backed rows
+		// (Azure subscription quota) have no capacity-reservation identifier.
 		for _, f := range []struct{ key, val string }{
-			{"reservation-id", res.ReservationID},
 			{"accelerator", res.Accelerator},
 			{"cluster-config-path", res.ClusterConfigPath},
 			{"test-config-dir", res.TestConfigDir},

--- a/pkg/uatbroker/registry_test.go
+++ b/pkg/uatbroker/registry_test.go
@@ -58,8 +58,43 @@ func TestParseRegistry(t *testing.T) {
 			code:    errors.ErrCodeInvalidRequest,
 		},
 		{
+			// Zero-byte input takes the decoder's io.EOF path and must
+			// surface the canonical "no reservations" validation error.
+			name:    "zero-byte input",
+			yaml:    "",
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
 			name:    "malformed yaml",
 			yaml:    "reservations: [oops",
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			// KnownFields: a mistyped row key must fail the parse, not
+			// silently leave the real field on its default (fail open).
+			name: "mistyped row key fails closed",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    reservation-id: cr-x
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+    nightly-intnts: []
+`,
+			wantErr: true,
+			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "unknown top-level key fails closed",
+			yaml: `
+reservatons:
+  - name: aws-h100
+`,
 			wantErr: true,
 			code:    errors.ErrCodeInvalidRequest,
 		},
@@ -82,8 +117,8 @@ reservations:
 			name: "unknown cloud",
 			yaml: `
 reservations:
-  - name: az-h100
-    cloud: azure
+  - name: foo-h100
+    cloud: foo
     reservation-id: cr-x
     accelerator: h100
     gpu-count: 8
@@ -92,6 +127,35 @@ reservations:
 `,
 			wantErr: true,
 			code:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			// Azure is a recognized cloud (PR: Azure UAT support).
+			name: "azure cloud ok",
+			yaml: `
+reservations:
+  - name: azure-h100
+    cloud: azure
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`,
+			wantErr: false,
+		},
+		{
+			// reservation-id is optional: quota-backed capacity (e.g. Azure
+			// subscription quota) has no capacity-reservation identifier.
+			name: "missing reservation-id ok",
+			yaml: `
+reservations:
+  - name: aws-h100
+    cloud: aws
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+`,
+			wantErr: false,
 		},
 		{
 			name: "missing cluster-config-path",
@@ -454,7 +518,7 @@ func TestCommittedRegistryValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("committed reservations.yaml invalid: %v", err)
 	}
-	want := map[string]string{"aws-h100": CloudAWS, "gcp-h100": CloudGCP}
+	want := map[string]string{"aws-h100": CloudAWS, "gcp-h100": CloudGCP, "azure-h100": CloudAzure}
 	for name, cloud := range want {
 		res, err := reg.Lookup(name)
 		if err != nil {
@@ -501,6 +565,10 @@ func TestCommittedRegistryValid(t *testing.T) {
 	wantNightly := map[string][]string{
 		"aws-h100": {IntentTraining, IntentInference},
 		"gcp-h100": {IntentTraining, IntentInference},
+		// azure-h100 is bring-up-phase: explicitly opted out of the nightly
+		// batch (nightly-intents: []) until the pipeline has green manual
+		// runs; flipped to [training] (then both) in the follow-up PR.
+		"azure-h100": {},
 	}
 	for name, want := range wantNightly {
 		res, lookupErr := reg.Lookup(name)
@@ -515,13 +583,45 @@ func TestCommittedRegistryValid(t *testing.T) {
 	}
 }
 
+// TestParseRegistryBareNullNightlyIntents locks the authoring edge documented
+// on Reservation.NightlyIntents: a bare `nightly-intents:` (YAML null)
+// decodes to nil — indistinguishable from an absent key — so the reservation
+// resolves to the [training] default (opt-IN), and only an explicit `[]`
+// opts out. KnownFields cannot catch this; if this test ever fails because
+// the decode semantics changed, update the field's doc comment too.
+func TestParseRegistryBareNullNightlyIntents(t *testing.T) {
+	const doc = `
+reservations:
+  - name: azure-h100
+    cloud: azure
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: c.yaml
+    test-config-dir: t
+    nightly-intents:
+`
+	reg, err := ParseRegistry([]byte(doc))
+	if err != nil {
+		t.Fatalf("ParseRegistry(bare-null nightly-intents) = %v, want nil error", err)
+	}
+	got := reg.Reservations[0].NightlyIntentsOrDefault()
+	if len(got) != 1 || got[0] != IntentTraining {
+		t.Errorf("NightlyIntentsOrDefault() = %v, want [%s] (bare null must behave as absent)", got, IntentTraining)
+	}
+}
+
 func TestNightlyIntentsOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		set  []string
 		want []string
 	}{
-		{"empty defaults to training", nil, []string{IntentTraining}},
+		// Absent (nil) keeps the pre-DC3 training default.
+		{"nil defaults to training", nil, []string{IntentTraining}},
+		// Explicit empty list is a nightly OPT-OUT, not the default: a
+		// quota-backed bring-up reservation must be manually dispatchable
+		// without being swept into the nightly batch.
+		{"explicit empty list opts out", []string{}, []string{}},
 		{"explicit training only", []string{IntentTraining}, []string{IntentTraining}},
 		{"both intents", []string{IntentTraining, IntentInference}, []string{IntentTraining, IntentInference}},
 		{"inference only", []string{IntentInference}, []string{IntentInference}},
@@ -533,6 +633,15 @@ func TestNightlyIntentsOrDefault(t *testing.T) {
 				t.Errorf("NightlyIntentsOrDefault() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+
+	// Opt-out must be distinguishable from absent at the caller: the broker
+	// prints strings.Join(...) — empty for opt-out — while nil (absent)
+	// resolves to "training". slices.Equal treats nil and []string{} as equal,
+	// so assert the length explicitly.
+	r := Reservation{NightlyIntents: []string{}}
+	if got := r.NightlyIntentsOrDefault(); len(got) != 0 {
+		t.Errorf("explicit empty NightlyIntents = %v, want empty (opt-out)", got)
 	}
 }
 

--- a/recipes/evidence/allowlist.yaml
+++ b/recipes/evidence/allowlist.yaml
@@ -62,6 +62,9 @@ firstParty:
   - label: aicr-uat-gcp
     issuer: https://token.actions.githubusercontent.com
     identityPattern: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-gcp\.yaml@refs/heads/.+$'
+  - label: aicr-uat-azure
+    issuer: https://token.actions.githubusercontent.com
+    identityPattern: '^https://github\.com/NVIDIA/aicr/\.github/workflows/uat-azure\.yaml@refs/heads/.+$'
 
 # Community: individual external contributors, keyed by source slug only.
 # Each commits pointers under recipes/evidence/<recipe>/<src>/ where <src> is

--- a/tests/uat/azure/cluster-config.yaml
+++ b/tests/uat/azure/cluster-config.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: github.com/mchmarny/cluster/v1alpha1
+kind: Cluster
+
+deployment:
+  id: aicr-uat
+  provider: aks
+  tenancy: "e88faa01-b4fd-49d3-b934-0ad9f9fca307"
+  location: westus
+  state: tenancy
+  destroy: false
+  tags:
+    env: demo
+    stack: mini-gpu
+
+cluster:
+  aks:
+    version: "1.35"
+    private:
+      enabled: false
+    controlPlane:
+      authorizedNetworks:
+        - cidr: 216.228.127.128/30  # terraform egress IP is auto-added too
+        - cidr: 52.41.222.58/32
+        - cidr: 54.68.11.139/32
+    adminGroups:
+      - "3366c0b0-9393-418c-aadf-196691840bf7" # edsp-dgxc-argus
+    zones: []  # westus has no availability zones
+
+compute:
+  aks:
+    nodePools:
+      # westus quota: StandardDsv6Family is capped at 200 vCPUs subscription-wide
+      # (shared with other clusters); system + CPU pools below total 32 vCPUs.
+      system:
+        vmSize: Standard_D8s_v6 # 8 vCPU, 32 GiB
+        maxPods: 100  # default is 30, but we need more for GPU workloads
+        size: 3
+        autoscaling:
+          enabled: false
+      workers:
+        - name: cpuworker1
+          vmSize: Standard_D8s_v6 # 8 vCPU, 32 GiB
+          osDiskType: Managed
+          osDiskSizeGb: 200
+          size: 1
+          autoscaling:
+            enabled: false
+          labels:
+            nodeGroup: cpu-worker
+        - name: gpuworker1
+          gpuType: h100  # NDSH100v5 family: 2x96=192 of 1152 vCPUs
+          gpuDriverInstall: false  # no Azure driver — GPU software managed in-cluster (GPU Operator)
+          osDiskSizeGb: 512
+          size: 2
+          autoscaling:
+            enabled: false
+          labels:
+            nodeGroup: gpu-worker

--- a/tools/uat-broker/main_test.go
+++ b/tools/uat-broker/main_test.go
@@ -113,6 +113,40 @@ reservations:
 	}
 }
 
+// TestReservationsResolveNightlyIntentsOptOut asserts an explicit empty
+// nightly-intents list resolves to an EMPTY value (nightly opt-out), while
+// remaining a present key — the nightly batch skips the leg on an empty
+// value but fails closed when the key is missing entirely.
+func TestReservationsResolveNightlyIntentsOptOut(t *testing.T) {
+	const reg = `
+reservations:
+  - name: azure-h100
+    cloud: azure
+    accelerator: h100
+    gpu-count: 8
+    cluster-config-path: tests/uat/azure/cluster-config.yaml
+    test-config-dir: tests/uat/azure/tests
+    nightly-intents: []
+`
+	p := filepath.Join(t.TempDir(), "reservations.yaml")
+	if err := os.WriteFile(p, []byte(reg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, stderr := invoke("", "reservations", "--file", p, "--name", "azure-h100")
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr: %s)", code, stderr)
+	}
+	if !strings.Contains(stdout, "nightly-intents=\n") {
+		t.Errorf("stdout missing empty nightly-intents= line (opt-out)\ngot:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "cloud=azure\n") {
+		t.Errorf("stdout missing cloud=azure\ngot:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "reservation-id=\n") {
+		t.Errorf("stdout missing empty reservation-id= line\ngot:\n%s", stdout)
+	}
+}
+
 func TestReservationsList(t *testing.T) {
 	reg := writeRegistry(t)
 	code, stdout, _ := invoke("", "reservations", "--file", reg, "--list")


### PR DESCRIPTION
## Summary

Adds Azure (AKS) as the third UAT cloud: Entra OIDC account federation (`infra/uat-azure-account/`), a quota-backed `azure-h100` reservation row (manual-dispatch only during bring-up), `run-azure` dispatch + a fail-closed unmapped-cloud guard in `uat-run.yaml`, and a full `uat-azure.yaml` pipeline. PR 1 of 2 — the staged bring-up; PR 2 adds `tests/uat/azure/run` + per-intent test configs and flips nightly enrollment after green manual runs.

## Motivation / Context

Revives the dormant Azure UAT scaffolding (the AKS-adapted CUJ assert files under `tests/uat/azure/tests/` had no workflow referencing them). The committed `tests/uat/azure/cluster-config.yaml` was validated manually against the AKS actuator (clean bring-up on westus NDSH100v5 quota).

Fixes: N/A
Related: #1280 (DC7 revive arm; acceptance completes with PR 2's green run), #1264

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT infrastructure (`infra/uat*`, `.github/workflows/uat-*`, `pkg/uatbroker`, `tools/uat-broker`)

## Implementation Notes

- **Broker semantics** (`pkg/uatbroker`): `azure` is a valid cloud; `reservation-id` is now optional (quota-backed capacity has no reservation object); `nightly-intents` distinguishes absent (nil → `[training]` default, unchanged) from explicit `[]` (nightly opt-out — the bring-up mode). The nightly batch skips opted-out legs gracefully but still fails closed when the broker output key is missing entirely.
- **Fail-closed dispatch**: `uat-run.yaml` gains an `unmapped-cloud` guard job — previously a registry cloud with no `run-<cloud>` job silently no-opped while consuming the reservation lease.
- **Auth model**: GitHub OIDC → Entra federated credential (`azure/login`, SHA-pinned v3.0.0) → az CLI context in `~/.azure`, mounted into the AKS actuator container for apply and destroy. Federated sessions cannot self-refresh, so the pipeline re-runs `azure/login` at each long phase boundary (mirrors the AWS per-stage STS refreshes). Subjects restricted to `main` + `test/uat` refs; no client secret exists.
- **Federation identifiers are live**: `infra/uat-azure-account/` has been `terraform apply`d (managed-identity federation; the tenant blocks app registrations), and `uat-azure.yaml` commits the real `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID` — non-secret identifiers, same posture as the AWS account ID in `uat-aws.yaml` (access is gated by the federated-credential subject pins, not knowledge of the IDs). `./tests/uat/azure/run` and the `h100-<intent>-config.yaml` files ship in PR 2; the `Validate inputs` guard skips the test-config check for `skip_tests` / `daytime-down`, so the burn-in path (manual `uat-run` dispatch with `skip_tests: true`: provision → connect → teardown) works now, and `azure-h100` stays `nightly-intents: []` until PR 2 lands.
- Azure capacity posture: quota-backed, no pre-flight assertion (GCP posture — the actuator fails loudly at provision time); recorded in `docs/contributor/uat.md`.

## Testing

```bash
make qualify        # pass (unit -race, lint, e2e 23/23, scan, license)
make test-coverage  # pass (project floor)
```

Coverage deltas: `pkg/uatbroker` 96.9% → 97.1% (+0.2%); `tools/uat-broker` 91.5% → 91.5% (±0.0%).

New tests: azure-cloud validity, optional reservation-id, nil-vs-empty nightly-intents contract (unit + end-to-end through YAML parsing and the CLI resolver), committed-registry expectations for `azure-h100`.

Post-merge burn-in (manual): `gh workflow run uat-run.yaml -f reservation=azure-h100 -f skip_tests=true` → verify clean teardown (`az group list` shows no `aicr-*` groups). Account setup (terraform apply + role assignments + state bootstrap) is already done.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Azure is inert until the Terraform is applied and IDs are baked in: the reservation row is nightly-opted-out, the daytime rotation excludes it, and the only reachable path is explicit manual dispatch. Existing AWS/GCP pipelines are untouched except comment updates in `uat-run.yaml` / `uat-nightly-batch.yaml`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

