### PR TITLE
chore(recipes): bump NFD to v0.19.0

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -50,7 +50,7 @@ Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev
 | network-operator | helm | nvidia/network-operator | 26.1.1 | 5 |
 | network-operator-ocp | manifest | — | — | 0 |
 | network-operator-ocp-olm | manifest | — | — | 0 |
-| nfd | helm | node-feature-discovery | 0.18.3 | 1 |
+| nfd | helm | node-feature-discovery | 0.19.0 | 1 |
 | nfd-ocp | manifest | — | — | 0 |
 | nfd-ocp-olm | manifest | — | — | 0 |
 | nodewright-customizations | manifest | — | — | 5 |
@@ -193,7 +193,7 @@ _No images extracted._
 
 ### nfd
 
-- `registry.k8s.io/nfd/node-feature-discovery:v0.18.3`
+- `registry.k8s.io/nfd/node-feature-discovery:v0.19.0`
 
 ### nfd-ocp
 

--- a/recipes/components/nfd-ocp/values.yaml
+++ b/recipes/components/nfd-ocp/values.yaml
@@ -46,7 +46,6 @@ workerConfig:
           - "vendor"
 
 # --- Fields present in nfd/values.yaml but NOT in NodeFeatureDiscovery CR ---
-# enableNodeFeatureApi: Helm chart setting; OCP operator enables this by default.
 # master.enable: OCP operator always deploys the master controller.
 # worker.enable: OCP operator always deploys the worker DaemonSet.
 # topologyUpdater.createCRDs: OCP operator manages CRDs via OLM.

--- a/recipes/components/nfd/values.yaml
+++ b/recipes/components/nfd/values.yaml
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 # Node Feature Discovery standalone deployment
-# NFD v0.18.3 — shared by gpu-operator and network-operator
-
-# Enable NodeFeature API (CRD-based feature publishing)
-enableNodeFeatureApi: true
+# NFD v0.19.0 — shared by gpu-operator and network-operator
+#
+# The v0.19.0 chart carries the topology-updater pods list/watch RBAC
+# required by its node-scoped Pod informer (upstream action-required
+# item) — no AICR-side RBAC configuration is needed.
 
 # Explicitly pin master/worker enable so behavior doesn't drift with
 # upstream chart defaults on future chart upgrades.

--- a/recipes/overlays/base.yaml
+++ b/recipes/overlays/base.yaml
@@ -28,7 +28,7 @@ spec:
     - name: nfd
       type: Helm
       source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-      version: 0.18.3
+      version: 0.19.0
       valuesFile: components/nfd/values.yaml
 
     - name: cert-manager

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -50,7 +50,7 @@ components:
     helm:
       defaultRepository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
       defaultChart: node-feature-discovery
-      defaultVersion: "0.18.3"
+      defaultVersion: "0.19.0"
       defaultNamespace: node-feature-discovery
     nodeScheduling:
       system:

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling-nfd.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-scheduling-nfd.yaml
@@ -25,9 +25,6 @@
 apiVersion: helm/v1
 kind: Values
 
-# ── NodeFeature API enabled ──────────────────────────────────────────
-enableNodeFeatureApi: true
-
 # ── Scheduling: master on system nodes ───────────────────────────────
 master:
   nodeSelector:

--- a/tests/chainsaw/cli/cuj1-training/assert-bundle-topology-nfd.yaml
+++ b/tests/chainsaw/cli/cuj1-training/assert-bundle-topology-nfd.yaml
@@ -49,6 +49,3 @@ master:
   enable: true
 gc:
   enable: true
-
-# ── NodeFeature API must be enabled (the NRT publication path) ──────
-enableNodeFeatureApi: true


### PR DESCRIPTION
## Summary

Bumps the Node Feature Discovery component chart from v0.18.3 to v0.19.0 (registry pin, base-overlay pin, values header), drops the dead `enableNodeFeatureApi` values key (exists in neither chart version) together with the two chainsaw asserts that asserted it, and regenerates the container-images BOM.

## Motivation / Context

NFD v0.19.0 was released with two action-required items, both dispositioned here:

- **topology-updater RBAC** (`pods` list/watch for the new node-scoped Pod informer): ships in the chart itself — verified by rendering the v0.19.0 chart with AICR's values (`pods: get/list/watch` present in the topology-updater ClusterRole). All 24 TU-enabled overlays pick it up with no AICR-side RBAC change.
- **Removal of `env`/`expandenv`/`getHostByName` NodeFeatureRule template functions**: grep-verified unused across `recipes/` (the only shipped NodeFeatureRule uses `matchFeatures` only).

### Upstream v0.19.0 disposition (verified against upstream, not assumed)

| Item | AICR impact | Evidence |
|---|---|---|
| topology-updater RBAC (`pods` list/watch) | Delivered by the chart bump itself; AICR does not set `topologyUpdater.rbac.create: false`, so all 24 TU-enabled overlays pick it up | Rendered `templates/clusterrole.yaml` at tag v0.19.0 with AICR values |
| Removed `env`/`expandenv`/`getHostByName` template functions | No usage; the only shipped NodeFeatureRule (`nfd-network-rule.yaml`) uses `matchFeatures` only | Tree-wide grep of `recipes/` clean |
| `values.schema.json` (new in 0.19.0) | Permissive (no `additionalProperties: false`); every key AICR sets exists in it | Fetched schema at tag v0.19.0 |
| `enableNodeFeatureApi` | Exists in **neither** 0.18.3 nor 0.19.0 chart values — dead key, removed along with the chainsaw asserts that asserted it | Chart values at both tags |
| New surface (`worker.ownerRefs`, `core.noPublishFeatures`, `cpu-cpuid.X86_64_V1..V4`) | Not plumbed (YAGNI); chart defaults correct, `valueOverrideKeys: [nfd]` allows per-recipe overrides | — |

Fixes: N/A
Related: NFD v0.19.0 release — https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.19.0

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: recipes data (`recipes/registry.yaml`, `recipes/overlays/base.yaml`, `recipes/components/nfd/values.yaml`, `recipes/components/nfd-ocp/values.yaml` comment), chainsaw asserts (`tests/chainsaw/cli/cuj1-training/`), BOM (`docs/user/container-images.md`). Review update: session design/plan docs dropped from the PR per review — disposition table folded into this description.

## Implementation Notes

- `enableNodeFeatureApi: true` was a no-op in AICR: the key exists in neither the 0.18.3 nor the 0.19.0 chart values (v0.19.0 ships a permissive `values.schema.json`; every key AICR sets is present in it). Removing it required also removing the two cuj1-training chainsaw asserts that asserted the dead key — kyverno-json fails an assert on an absent key, and the asserts were checking a value no chart version ever consumed.
- New v0.19.0 surface (`worker.ownerRefs`, `core.noPublishFeatures`, `cpu-cpuid.X86_64_V1..V4` labels) is deliberately not plumbed into AICR values (chart defaults are correct; `valueOverrideKeys: [nfd]` already allows per-recipe overrides).
- Go library pins (`sigs.k8s.io/node-feature-discovery` v0.18.3 in go.mod, used by the snapshot collector's local PCI/kernel detection) are intentionally unchanged; a follow-up issue will track that bump separately.

## Testing

```bash
unset GITLAB_TOKEN
make lint   # rc=0 (golangci-lint 0 issues, yamllint, ADR-006 chart-pin check)
make test   # rc=0 (race detector; 78.2% total coverage; zero FAILs)
make e2e    # rc=0 (23/23 chainsaw tests, incl. assert-bundle-{topology,scheduling}-nfd)
make bom-check  # rc=0 (committed BOM matches fresh re-render)
helm template nfd node-feature-discovery --repo https://kubernetes-sigs.github.io/node-feature-discovery/charts \
  --version 0.19.0 -f recipes/components/nfd/values.yaml --set topologyUpdater.enable=true
# → topology-updater ClusterRole grants pods get/list/watch (the v0.19.0 action-required RBAC)
```

`make scan` not run locally; no Go/image inputs changed. Coverage gate N/A (no Go changes).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Deploying bundles built from this recipe upgrades NFD to v0.19.0; the chart carries the required topology-updater RBAC update, so no manual RBAC action is needed. N/A otherwise.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
