### PR TITLE
fix(validator): capture NCCL bandwidth via termination message (rotation-proof)

### DIFF
--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1357,7 +1357,32 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get pod logs", err)
 	}
 
-	return logs, nil
+	// Append the launcher's termination message. The GKE launcher writes the NCCL
+	// results rows there explicitly, and unlike the streamed log it survives
+	// kubelet container-log rotation — the massive NCCL/TCPXO teardown spam can
+	// rotate the results table out of the segment GetPodLogs returns, leaving only
+	// the teardown tail (issue #1712). parseBandwidthFromLogs keys on the last
+	// matching row, so appending the termination message makes it the
+	// rotation-proof source of truth while the streamed log remains available for
+	// transport verification and diagnostics. Empty for launchers that don't write
+	// results there (other platforms), leaving behavior unchanged.
+	term := launcherTerminationTail(ctx.Ctx, ctx.Clientset, ctx.Namespace, launcherPod.Name)
+	if term != "" {
+		slog.Info("Appending launcher termination message (rotation-proof results)", "termBytes", len(term))
+	}
+	return appendTerminationResults(logs, term), nil
+}
+
+// appendTerminationResults appends the launcher termination message (the
+// rotation-proof NCCL results the launcher wrote to /dev/termination-log) to the
+// streamed log. parseBandwidthFromLogs keys on the last matching row, so the
+// appended results become the source of truth; an empty term leaves logs
+// unchanged (launchers that don't write results there).
+func appendTerminationResults(logs, term string) string {
+	if term == "" {
+		return logs
+	}
+	return logs + "\n" + term
 }
 
 // ncclLauncherLogComplete reports whether a launcher log contains the NCCL

--- a/validators/performance/nccl_termination_append_test.go
+++ b/validators/performance/nccl_termination_append_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+// resultsRows is a two-row NCCL results block (largest size last) as it would be
+// written to /dev/termination-log by the launcher. launcherTerminationTail (the
+// read half of the success-path append) is covered by TestLauncherTerminationTail
+// in nccl_all_reduce_bw_constraint_test.go; these cover the append half.
+const resultsRows = " 8589934592    2147483648     float     sum      -1   48298   177.85  333.47      0   48292   177.87  333.51      0\n" +
+	"17179869184    4294967296     float     sum      -1    95340  180.20  337.87      0    95495  179.90  337.32      0"
+
+func TestAppendTerminationResults(t *testing.T) {
+	tests := []struct {
+		name string
+		logs string
+		term string
+		want string
+	}{
+		{"empty term leaves logs unchanged", "streamed log", "", "streamed log"},
+		{"non-empty term appended after newline", "streamed log", "term", "streamed log\nterm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendTerminationResults(tt.logs, tt.term); got != tt.want {
+				t.Errorf("appendTerminationResults(%q, %q) = %q, want %q", tt.logs, tt.term, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAppendTerminationResultsRecoversRotatedBandwidth ties the append helper to
+// the parser: a teardown-only (rotated) streamed log plus the termination
+// message must parse to the largest-row bandwidth — the recovery the success
+// path relies on.
+func TestAppendTerminationResultsRecoversRotatedBandwidth(t *testing.T) {
+	rotated := "node-0-0:870:938 [0] NCCL INFO NET/FasTrak: SCTP Closed\n" +
+		"node-0-0:870:938 [0] NCCL INFO NET/FasTrak: Socket closed, handler exiting."
+
+	// Sanity: the rotated log alone has no parseable results.
+	if _, err := parseBandwidthFromLogs(rotated); err == nil {
+		t.Fatal("expected rotated (teardown-only) log to fail bandwidth parsing")
+	}
+
+	bw, err := parseBandwidthFromLogs(appendTerminationResults(rotated, resultsRows))
+	if err != nil {
+		t.Fatalf("expected bandwidth recovered from appended termination message, got %v", err)
+	}
+	if bw != 337.87 {
+		t.Errorf("expected largest-row busbw 337.87, got %v", bw)
+	}
+}

--- a/validators/performance/testdata/h100/gke/runtime.yaml
+++ b/validators/performance/testdata/h100/gke/runtime.yaml
@@ -87,8 +87,34 @@ spec:
                   env:
                   - name: LD_LIBRARY_PATH
                     value: "/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda/lib64"
+                  # Wrap mpirun so the NCCL results rows land in the termination
+                  # message on success — rotation-proof, unlike the streamed log.
+                  # The NCCL/TCPXO teardown spam can rotate the results table out
+                  # of the log segment GetPodLogs returns (issue #1712); the Go
+                  # side appends this message so parseBandwidthFromLogs recovers
+                  # the bandwidth. tee keeps live stdout intact; only the results
+                  # rows (not the teardown) go to /dev/termination-log, under the
+                  # ~4KiB kubelet cap. `bash -c '<script>' bash "$@"` runs the
+                  # mpirun args below verbatim as positional params.
                   command:
-                  - /usr/local/mpi/bin/mpirun
+                  - /bin/bash
+                  - -c
+                  - |
+                    set -o pipefail
+                    /usr/local/mpi/bin/mpirun "$@" 2>&1 | tee /tmp/nccl-results.out
+                    rc=${PIPESTATUS[0]}
+                    # Write results ONLY on success (rc==0). A partial-failure run
+                    # can print early rows then abort; a non-empty termination file
+                    # would suppress FallbackToLogsOnError's failure tail (#1651).
+                    # Any failure leaves the file empty so kubelet uses the log tail.
+                    # Data rows are "<size> <count> <type> ..."; the summary is
+                    # "# Avg bus bandwidth"; teardown spam matches neither.
+                    if [ "$rc" -eq 0 ]; then
+                      pat='^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+[[:alpha:]]+|Avg bus bandwidth'
+                      grep -E "$pat" /tmp/nccl-results.out 2>/dev/null | tail -c 3900 > /dev/termination-log 2>/dev/null || true
+                    fi
+                    exit "$rc"
+                  - bash
                   args:
                   - -np
                   - "${GPU_COUNT}"
@@ -131,17 +157,17 @@ spec:
                   # set explicitly for compatibility with non-privileged environments.
                   - -x
                   - LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64
-                  # INFO (was WARN) so a failed run surfaces the exact NCCL/FastRak
-                  # init path — with WARN we only saw the shim's config-checker
-                  # warnings, not the fatal abort. Scoped to INIT,NET,ENV,GRAPH to
-                  # keep the volume manageable within the launcher log tail while
-                  # covering the FastRak/TCPXO transport bring-up where the failure
-                  # occurs. Rank stdout streams back through mpirun to the launcher,
-                  # so this lands in the captured launcher diagnostics.
+                  # WARN (reverted from #1647's INFO): at INFO the NCCL/TCPXO
+                  # teardown emits tens of thousands of NET/FasTrak lines that
+                  # overflow kubelet's containerLogMaxSize and rotate the results
+                  # table out of the retrievable log (#1712). The RxDM/gVNIC failure
+                  # that motivated INFO is resolved; results are now captured
+                  # rotation-proof via the termination message (#1713), and #1651's
+                  # FallbackToLogsOnError still surfaces the failure tail. To debug a
+                  # new FastRak/TCPXO connection failure, re-enable INFO ad hoc:
+                  #   -x NCCL_DEBUG=INFO -x NCCL_DEBUG_SUBSYS=INIT,NET,ENV,GRAPH
                   - -x
-                  - NCCL_DEBUG=INFO
-                  - -x
-                  - NCCL_DEBUG_SUBSYS=INIT,NET,ENV,GRAPH
+                  - NCCL_DEBUG=WARN
                   - -x
                   - NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
                   - -x


### PR DESCRIPTION
## Summary

Make `nccl-all-reduce-bw` bandwidth retrieval **rotation-proof**: the GKE launcher writes the NCCL results rows to `/dev/termination-log`, and the Go success path appends that termination message so `parseBandwidthFromLogs` (which keys on the last matching row) recovers the bandwidth even when kubelet log rotation evicts the results table from the streamed log.

## Motivation / Context

The flake (`could not find bandwidth value in logs` on a **succeeded** launcher pod) is caused by **kubelet container-log rotation**. The launcher emits the results table, then tens of thousands of NCCL/TCPXO teardown INFO lines (amplified by #1647's `NCCL_DEBUG=INFO`) cross `containerLogMaxSize`; kubelet rotates the container log, and `GetPodLogs` (no `--previous`) returns only the current segment — the ~7 KB teardown tail. The results table is evicted into a rotated segment the logs API won't return.

Confirmed on UAT run `aicr-29071029719` (with #1691 merged): the re-read loop ran 5 attempts, each `logBytes=6956` — stable, never grew — then #1691's diagnostics dumped the log, showing **only** the teardown tail (`Destroy COMPLETE`, `SCTP Closed`, `Socket closed`), no results table. A healthy run's log is ~8.4 MB: table at line ~16.5k, then ~70k teardown lines. Re-reading can't recover a rotated-out table, so this is the real fix.

Fixes: #1712
Related: #1690/#1691 (diagnosability + streaming-race re-read — surfaced this root cause), #1651 (termination message on failure), #1647 (`NCCL_DEBUG=INFO`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`) — NCCL performance validator (`validators/performance`) + GKE runtime template

## Implementation Notes

- **Template (`testdata/h100/gke/runtime.yaml`):** the launcher container now runs `bash -c '<script>' bash "$@"`, which preserves the mpirun args **verbatim** as positional params (35 args unchanged). The script `tee`s output (live stdout intact), then `grep`s just the results rows + `Avg bus bandwidth` summary — never the teardown spam — into `/dev/termination-log`, bounded to `tail -c 3900` (under the 4 KiB kubelet cap; keeps the largest-size rows the parser needs). Exit code is mpirun's, so JobSet success/failure is preserved. On failure grep writes nothing, so the existing `FallbackToLogsOnError` still captures the failure tail (#1651).
- **Go (`nccl_all_reduce_bw_constraint.go`):** on the success path, append the launcher termination message (via the existing `launcherTerminationTail`) to the retrieved log. Because `parseBandwidthFromLogs` uses the last match, the appended rotation-proof rows win; the streamed log stays for `verifyTransportFromLogs` and diagnostics. Empty for launchers that don't write results there, so other platforms are unchanged.
- GKE-only for now (the confirmed case). Extending the wrapper to EKS/OKE/etc. is a follow-up if they exhibit the same rotation.
- **Signal nuance:** the launcher's PID 1 is now `bash` running an mpirun pipeline, so a pod SIGTERM hits bash rather than mpirun directly. Acceptable for a short-lived benchmark job the check tears down explicitly; noted for reviewers.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race ./validators/performance/... ./pkg/defaults/...
golangci-lint run -c .golangci.yaml ./validators/performance/...
yamllint validators/performance/testdata/h100/gke/runtime.yaml
```

- New test `TestParseBandwidthRecoversFromAppendedTerminationMessage`: a rotated (teardown-only) log fails to parse; appending a results-bearing termination message recovers `337.87 GB/s`.
- Package tests pass with `-race`; lint + yamllint clean; YAML validated (35 mpirun args preserved).
- **Needs a GKE UAT run to validate the template change end-to-end** (can't exercise the launcher on GPU hardware locally).
- `make qualify` run locally.

## Risk Assessment

- [x] **Low** — Go change is additive and no-op where no termination message is written; template change preserves the mpirun args verbatim and the failure path. Confined to the GKE NCCL launcher.

**Rollout notes:** No user-facing surface change. Validate with a GKE UAT run.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`) — plus yamllint on the template
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (internal fix)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
