### PR TITLE
fix(validator): validate NCCL fabric resource homogeneity across nodes

### DIFF
--- a/validators/performance/nccl_aks_utils.go
+++ b/validators/performance/nccl_aks_utils.go
@@ -31,25 +31,24 @@ import (
 // workers request exactly 1 regardless of the HCA count.
 const aksRdmaSharedResource = "rdma/hca_shared_devices_a"
 
-// discoverAKSRdmaCount reads the allocatable rdma-shared-device-plugin
-// resource count from a GPU node. 0 is valid (network-operator RDMA shared
-// device plugin not installed) — NCCL falls back to TCP over the pod network,
-// mirroring the EKS zero-EFA behavior. On ND-series InfiniBand SKUs
-// (e.g. Standard_ND96isr_H100_v5) the plugin advertises a large shared pool
-// (allocatable "1k" = 1000).
-func discoverAKSRdmaCount(node v1.Node) int {
-	rdmaQuantity := node.Status.Allocatable[v1.ResourceName(aksRdmaSharedResource)]
-	return int(rdmaQuantity.Value())
-}
-
 // applyAKSTemplateData populates the AKS-specific runtime template variables:
 // the ${RDMA_RESOURCE_LIMITS}/${RDMA_RESOURCE_REQUESTS} worker resource lines
-// discovered from the first target node, with the same TCP fallback the EKS
-// zero-EFA path uses (reduced max message size) when the RDMA shared device
-// plugin is absent.
-func applyAKSTemplateData(config *gpuConfiguration, templateData map[string]string) {
+// derived from the shared RDMA pool count validated as uniform across all
+// target GPU nodes, with the same TCP fallback the EKS zero-EFA path uses
+// (reduced max message size) when the RDMA shared device plugin is absent.
+//
+// A count of 0 is valid (network-operator RDMA shared device plugin not
+// installed) when uniform — NCCL falls back to TCP over the pod network,
+// mirroring the EKS zero-EFA behavior. On ND-series InfiniBand SKUs
+// (e.g. Standard_ND96isr_H100_v5) the plugin advertises a large shared pool
+// (allocatable "1k" = 1000). A mixed/partial rollout across the cohort fails
+// closed rather than sizing every worker from the first node.
+func applyAKSTemplateData(config *gpuConfiguration, templateData map[string]string) error {
 	warnIfHeterogeneousNodes(config.Nodes)
-	rdmaCount := discoverAKSRdmaCount(config.Nodes[0])
+	rdmaCount, err := uniformFabricResourceCount(config.Nodes, v1.ResourceName(aksRdmaSharedResource))
+	if err != nil {
+		return err
+	}
 	// Indentation matches the resource block position in runtime.yaml.
 	const rdmaIndent = "                      "
 	templateData["RDMA_RESOURCE_LIMITS"] = buildAKSRdmaResourceLine(rdmaCount, rdmaIndent)
@@ -61,6 +60,7 @@ func applyAKSTemplateData(config *gpuConfiguration, templateData map[string]stri
 	} else {
 		slog.Info("Discovered AKS shared RDMA device pool", "resource", aksRdmaSharedResource, "allocatable", rdmaCount)
 	}
+	return nil
 }
 
 // buildAKSRdmaResourceLine returns the YAML line requesting one unit of the

--- a/validators/performance/nccl_aks_utils_test.go
+++ b/validators/performance/nccl_aks_utils_test.go
@@ -15,104 +15,73 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func TestDiscoverAKSRdmaCount(t *testing.T) {
-	tests := []struct {
-		name string
-		node v1.Node
-		want int
-	}{
-		{
-			// Standard_ND96isr_H100_v5 with the network-operator
-			// rdma-shared-device-plugin: allocatable is advertised as "1k"
-			// (the shared pool size), which resource.Quantity parses as 1000.
-			name: "ND96isr_H100_v5 with shared RDMA pool",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"node.kubernetes.io/instance-type": "Standard_ND96isr_H100_v5",
-					},
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName("nvidia.com/gpu"):      resource.MustParse("8"),
-						v1.ResourceName(aksRdmaSharedResource): resource.MustParse("1k"),
-					},
-				},
-			},
-			want: 1000,
-		},
-		{
-			name: "no RDMA shared device plugin (falls back to TCP)",
-			node: v1.Node{
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
-					},
-				},
-			},
-			want: 0,
-		},
-		{
-			name: "no allocatable at all",
-			node: v1.Node{},
-			want: 0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := discoverAKSRdmaCount(tt.node); got != tt.want {
-				t.Errorf("discoverAKSRdmaCount() = %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestApplyAKSTemplateData(t *testing.T) {
 	const rdmaLine = `                      rdma/hca_shared_devices_a: "1"`
+	// aksNode builds a GPU node whose shared RDMA pool allocatable is the given
+	// Quantity string, or omits the resource entirely when rdma is empty.
+	aksNode := func(rdma string) v1.Node {
+		alloc := v1.ResourceList{v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8")}
+		if rdma != "" {
+			alloc[v1.ResourceName(aksRdmaSharedResource)] = resource.MustParse(rdma)
+		}
+		return v1.Node{Status: v1.NodeStatus{Allocatable: alloc}}
+	}
 	tests := []struct {
 		name           string
-		allocatable    v1.ResourceList
+		nodes          []v1.Node
+		wantErr        bool
+		wantErrMsg     string
 		wantLine       string
 		wantMaxMsgSize string
 	}{
 		{
-			name: "shared RDMA pool present keeps IB message size",
-			allocatable: v1.ResourceList{
-				v1.ResourceName("nvidia.com/gpu"):      resource.MustParse("8"),
-				v1.ResourceName(aksRdmaSharedResource): resource.MustParse("1k"),
-			},
+			// Standard_ND96isr_H100_v5 advertises the shared pool as "1k" (1000);
+			// a worker still requests exactly one unit.
+			name:           "uniform shared RDMA pool keeps IB message size",
+			nodes:          []v1.Node{aksNode("1k"), aksNode("1k")},
 			wantLine:       rdmaLine,
 			wantMaxMsgSize: maxMessageSize,
 		},
 		{
-			name: "no RDMA pool falls back to TCP with reduced message size",
-			allocatable: v1.ResourceList{
-				v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
-			},
+			name:           "uniform absent RDMA falls back to TCP",
+			nodes:          []v1.Node{aksNode(""), aksNode("")},
 			wantLine:       "",
 			wantMaxMsgSize: maxMessageSizeTCP,
+		},
+		{
+			name:       "mixed RDMA rollout fails closed",
+			nodes:      []v1.Node{aksNode("1k"), aksNode("")},
+			wantErr:    true,
+			wantErrMsg: "present on 1 of 2 target GPU nodes",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &gpuConfiguration{
-				WorkerCount:     2,
+				WorkerCount:     len(tt.nodes),
 				GPUCountPerNode: 8,
-				TotalGPUCount:   16,
-				Nodes: []v1.Node{
-					{Status: v1.NodeStatus{Allocatable: tt.allocatable}},
-					{Status: v1.NodeStatus{Allocatable: tt.allocatable}},
-				},
+				TotalGPUCount:   8 * len(tt.nodes),
+				Nodes:           tt.nodes,
 			}
 			templateData := map[string]string{"MAX_MESSAGE_SIZE": maxMessageSize}
-			applyAKSTemplateData(config, templateData)
+			err := applyAKSTemplateData(config, templateData)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applyAKSTemplateData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
 			if got := templateData["RDMA_RESOURCE_LIMITS"]; got != tt.wantLine {
 				t.Errorf("RDMA_RESOURCE_LIMITS = %q, want %q", got, tt.wantLine)
 			}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -693,7 +693,7 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// EFA count of 0 is valid — NCCL falls back to TCP (slower but functional).
 	if service == recipe.CriteriaServiceEKS {
 		warnIfHeterogeneousNodes(config.Nodes)
-		it, efaCount, err := discoverEKSNodeConfig(config.Nodes[0])
+		it, efaCount, err := discoverEKSNodeConfig(config.Nodes)
 		if err != nil {
 			return err
 		}
@@ -723,7 +723,9 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// NCCL falls back to TCP over the pod network (slower but functional),
 	// mirroring the EKS zero-EFA behavior above.
 	if service == recipe.CriteriaServiceAKS {
-		applyAKSTemplateData(config, templateData)
+		if err := applyAKSTemplateData(config, templateData); err != nil {
+			return err
+		}
 	}
 
 	// Build effective worker scheduling: user override takes precedence over platform default.

--- a/validators/performance/nccl_eks_utils.go
+++ b/validators/performance/nccl_eks_utils.go
@@ -43,21 +43,77 @@ func warnIfHeterogeneousNodes(nodes []v1.Node) {
 	}
 }
 
-// discoverEKSNodeConfig reads the instance type label and EFA adapter count
-// from a GPU node. Returns an error if the label is missing. EFA count of 0
-// is valid (device plugin not installed — NCCL falls back to TCP).
-func discoverEKSNodeConfig(node v1.Node) (string, int, error) {
-	instanceType := node.Labels["node.kubernetes.io/instance-type"]
+// efaResourceName is the EFA extended resource published by the AWS EFA
+// Kubernetes device plugin on EKS GPU nodes.
+const efaResourceName = v1.ResourceName("vpc.amazonaws.com/efa")
+
+// discoverEKSNodeConfig reads the instance type label (from the first target
+// node) and the EFA adapter count validated as uniform across all target GPU
+// nodes. Returns an error if the instance-type label is missing or if the EFA
+// count is not uniform across the cohort (partial device-plugin rollout). An
+// EFA count of 0 is valid when uniform (device plugin not installed — NCCL
+// falls back to TCP).
+func discoverEKSNodeConfig(nodes []v1.Node) (string, int, error) {
+	if len(nodes) == 0 {
+		return "", 0, aicrErrors.New(aicrErrors.ErrCodeInternal,
+			"no target GPU nodes for EKS discovery")
+	}
+
+	instanceType := nodes[0].Labels["node.kubernetes.io/instance-type"]
 	if instanceType == "" {
 		return "", 0, aicrErrors.New(aicrErrors.ErrCodeInternal,
 			"GPU node missing node.kubernetes.io/instance-type label")
 	}
 
-	efaResource := v1.ResourceName("vpc.amazonaws.com/efa")
-	efaQuantity := node.Status.Allocatable[efaResource]
-	efaCount := int(efaQuantity.Value())
+	efaCount, err := uniformFabricResourceCount(nodes, efaResourceName)
+	if err != nil {
+		return "", 0, err
+	}
 
 	return instanceType, efaCount, nil
+}
+
+// uniformFabricResourceCount returns the allocatable count of an extended
+// fabric resource (EFA on EKS, the shared RDMA pool on AKS) across the full set
+// of resolved target GPU nodes, requiring every node to advertise the SAME
+// count. NCCL sizes every worker identically, so deriving the count from only
+// the first node silently mis-sizes the fabric request during a partial
+// device-plugin rollout or a mixed-instance cohort.
+//
+// A uniform count is returned as-is; a uniform zero is valid and selects the
+// existing TCP fallback. A disagreement across nodes (mixed/partial rollout)
+// returns an error so the validator fails closed and the operator re-runs once
+// the cluster has converged.
+func uniformFabricResourceCount(nodes []v1.Node, resource v1.ResourceName) (int, error) {
+	if len(nodes) == 0 {
+		return 0, aicrErrors.New(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("no target GPU nodes to inspect for %s", resource))
+	}
+
+	firstQuantity := nodes[0].Status.Allocatable[resource]
+	first := int(firstQuantity.Value())
+
+	present := 0
+	uniform := true
+	for i := range nodes {
+		quantity := nodes[i].Status.Allocatable[resource]
+		count := int(quantity.Value())
+		if count > 0 {
+			present++
+		}
+		if count != first {
+			uniform = false
+		}
+	}
+
+	if !uniform {
+		return 0, aicrErrors.New(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("%s present on %d of %d target GPU nodes — cluster still converging "+
+				"or device plugin not fully rolled out; re-run once uniform",
+				resource, present, len(nodes)))
+	}
+
+	return first, nil
 }
 
 // buildEFAResourceLine returns the YAML line for EFA resource requests/limits

--- a/validators/performance/nccl_eks_utils_test.go
+++ b/validators/performance/nccl_eks_utils_test.go
@@ -23,87 +23,83 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// eksNode builds an EKS GPU node with the given instance type and EFA count.
+// A negative efa omits the EFA resource entirely (device plugin absent).
+func eksNode(name, instanceType string, efa int) v1.Node {
+	labels := map[string]string{}
+	if instanceType != "" {
+		labels["node.kubernetes.io/instance-type"] = instanceType
+	}
+	alloc := v1.ResourceList{
+		v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+	}
+	if efa >= 0 {
+		alloc[efaResourceName] = *resource.NewQuantity(int64(efa), resource.DecimalSI)
+	}
+	return v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Status:     v1.NodeStatus{Allocatable: alloc},
+	}
+}
+
 func TestDiscoverEKSNodeConfig(t *testing.T) {
 	tests := []struct {
 		name         string
-		node         v1.Node
+		nodes        []v1.Node
 		wantInstance string
 		wantEFA      int
 		wantErr      bool
 		wantErrMsg   string
 	}{
 		{
-			name: "p5.48xlarge with 32 EFA",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"node.kubernetes.io/instance-type": "p5.48xlarge",
-					},
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName("nvidia.com/gpu"):        resource.MustParse("8"),
-						v1.ResourceName("vpc.amazonaws.com/efa"): resource.MustParse("32"),
-					},
-				},
+			name: "uniform p5.48xlarge with 32 EFA",
+			nodes: []v1.Node{
+				eksNode("n1", "p5.48xlarge", 32),
+				eksNode("n2", "p5.48xlarge", 32),
 			},
 			wantInstance: "p5.48xlarge",
 			wantEFA:      32,
 		},
 		{
-			name: "p4d.24xlarge with 4 EFA",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"node.kubernetes.io/instance-type": "p4d.24xlarge",
-					},
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName("nvidia.com/gpu"):        resource.MustParse("8"),
-						v1.ResourceName("vpc.amazonaws.com/efa"): resource.MustParse("4"),
-					},
-				},
-			},
+			name:         "single node p4d.24xlarge with 4 EFA",
+			nodes:        []v1.Node{eksNode("n1", "p4d.24xlarge", 4)},
 			wantInstance: "p4d.24xlarge",
 			wantEFA:      4,
 		},
 		{
-			name: "missing instance type label",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{},
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName("vpc.amazonaws.com/efa"): resource.MustParse("32"),
-					},
-				},
-			},
+			name:       "missing instance type label",
+			nodes:      []v1.Node{eksNode("n1", "", 32)},
 			wantErr:    true,
 			wantErrMsg: "missing node.kubernetes.io/instance-type label",
 		},
 		{
-			name: "no EFA adapters (falls back to TCP)",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"node.kubernetes.io/instance-type": "p5.48xlarge",
-					},
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
-					},
-				},
+			name: "uniform zero EFA (falls back to TCP)",
+			nodes: []v1.Node{
+				eksNode("n1", "p5.48xlarge", 0),
+				eksNode("n2", "p5.48xlarge", -1),
 			},
 			wantInstance: "p5.48xlarge",
 			wantEFA:      0,
 		},
+		{
+			name: "mixed EFA counts fail closed",
+			nodes: []v1.Node{
+				eksNode("n1", "p5.48xlarge", 32),
+				eksNode("n2", "p5.48xlarge", 0),
+			},
+			wantErr:    true,
+			wantErrMsg: "present on 1 of 2 target GPU nodes",
+		},
+		{
+			name:       "no target nodes",
+			nodes:      []v1.Node{},
+			wantErr:    true,
+			wantErrMsg: "no target GPU nodes for EKS discovery",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			instanceType, efaCount, err := discoverEKSNodeConfig(tt.node)
+			instanceType, efaCount, err := discoverEKSNodeConfig(tt.nodes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("discoverEKSNodeConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -119,6 +115,76 @@ func TestDiscoverEKSNodeConfig(t *testing.T) {
 			}
 			if efaCount != tt.wantEFA {
 				t.Errorf("efaCount = %d, want %d", efaCount, tt.wantEFA)
+			}
+		})
+	}
+}
+
+func TestUniformFabricResourceCount(t *testing.T) {
+	const res = v1.ResourceName("example.com/fabric")
+	node := func(count int) v1.Node {
+		alloc := v1.ResourceList{}
+		if count >= 0 {
+			alloc[res] = *resource.NewQuantity(int64(count), resource.DecimalSI)
+		}
+		return v1.Node{Status: v1.NodeStatus{Allocatable: alloc}}
+	}
+	tests := []struct {
+		name       string
+		nodes      []v1.Node
+		want       int
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:  "uniform nonzero",
+			nodes: []v1.Node{node(32), node(32)},
+			want:  32,
+		},
+		{
+			name:  "uniform zero (resource present, value 0)",
+			nodes: []v1.Node{node(0), node(0)},
+			want:  0,
+		},
+		{
+			name:  "uniform absent (resource missing)",
+			nodes: []v1.Node{node(-1), node(-1)},
+			want:  0,
+		},
+		{
+			name:       "mixed present and absent",
+			nodes:      []v1.Node{node(32), node(-1)},
+			wantErr:    true,
+			wantErrMsg: "present on 1 of 2 target GPU nodes",
+		},
+		{
+			name:       "mixed nonzero counts",
+			nodes:      []v1.Node{node(32), node(16), node(32)},
+			wantErr:    true,
+			wantErrMsg: "present on 3 of 3 target GPU nodes",
+		},
+		{
+			name:       "no nodes",
+			nodes:      []v1.Node{},
+			wantErr:    true,
+			wantErrMsg: "no target GPU nodes to inspect",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := uniformFabricResourceCount(tt.nodes, res)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("uniformFabricResourceCount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("uniformFabricResourceCount() = %d, want %d", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Make the NCCL all-reduce performance validator validate fabric device-plugin resource homogeneity across the full resolved target GPU node set (EKS EFA and AKS shared RDMA), failing closed on a mixed/partial rollout instead of silently sizing every worker from `config.Nodes[0]`.

## Motivation / Context

The validator derived the fabric resource count from only the first resolved GPU node and applied it to every worker in the TrainJob:

- EKS — `discoverEKSNodeConfig(config.Nodes[0])` read `vpc.amazonaws.com/efa`
- AKS — `discoverAKSRdmaCount(config.Nodes[0])` read `rdma/hca_shared_devices_a`

`warnIfHeterogeneousNodes` only *warns* on `instance-type` label mismatch — it never checked the fabric resource itself. On a mixed or partially-rolled-out node set (device plugin present on some target nodes but not others) this applied one node's fabric assumption to all workers, producing a confusing unschedulable/bandwidth failure rather than a clear diagnostic.

Fixes: #1710
Related: #1695

This is the follow-up carved out of PR #1695 (AKS H100 NCCL support): the homogeneity gate was deliberately deferred there to keep that PR scoped to enabling the AKS path, and to cover EKS symmetrically rather than fixing only AKS.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`)

<!-- Specifically validators/performance NCCL all-reduce utilities. -->

## Implementation Notes

- New shared helper `uniformFabricResourceCount(nodes, resource)` in `nccl_eks_utils.go` scans all `config.Nodes`, requires the extended-resource allocatable count to be uniform across the cohort, and returns it. A uniform zero is valid and preserves the existing TCP fallback (reduced max message size). A disagreement returns a `pkg/errors` `ErrCodeInternal` with a clear message: `<resource> present on X of Y target GPU nodes — cluster still converging or device plugin not fully rolled out; re-run once uniform`.
- Parameterized by resource name so EKS (`vpc.amazonaws.com/efa`) and AKS (`rdma/hca_shared_devices_a`) reuse the same logic without duplicating the scan/verify.
- `discoverEKSNodeConfig` now takes the full `[]v1.Node` (instance type still from the first node; EFA count via the shared helper). `applyAKSTemplateData` now returns an `error`; the single-node `discoverAKSRdmaCount` is removed (superseded by the helper). Both call sites in `nccl_all_reduce_bw_constraint.go` propagate the error so the validator fails closed.

## Testing

```bash
unset GITLAB_TOKEN
go test -race ./validators/performance/...
golangci-lint run -c .golangci.yaml ./validators/performance/...
make qualify
make test-coverage
```

- `go test -race ./validators/performance/...`: pass (full package passes with sandbox network access for the unrelated httptest port-bind test).
- `golangci-lint ./validators/performance/...`: 0 issues.
- `make qualify`: test + lint + e2e (23/23 e2e tests pass) all green. `make scan` reports pre-existing upstream dependency CVEs only (`golang.org/x/net`, `stdlib` go1.26.x, `runc`); this change adds no dependencies, so the scan finding is pre-existing on `main` and unrelated.
- `make test-coverage`: passed — total 78.8% (threshold 75%).
- Coverage delta (`validators/performance`): 50.7% → 51.0% (package). New/changed funcs `uniformFabricResourceCount`, `discoverEKSNodeConfig`, `applyAKSTemplateData` are each at 100%.
- Added/extended table-driven tests: uniform-nonzero (proceed), uniform-zero (TCP fallback), mixed present/absent and mixed-nonzero (fail closed), and the empty-node-set guard, for both EKS and AKS.

## Risk Assessment

- [x] **Low** — Isolated change to the NCCL performance validator; well-tested; easy to revert. Uniform (converged) clusters behave identically to before; only mixed/partial rollouts now fail closed with a clear diagnostic instead of a confusing downstream failure.

**Rollout notes:** N/A — no API, recipe, or dependency changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — no user-facing surface changed)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
