### PR TITLE
fix(validator): warn on unknown check names; fix omitted-checks doc

### DIFF
--- a/docs/integrator/validator-extension.md
+++ b/docs/integrator/validator-extension.md
@@ -129,7 +129,12 @@ validation:
       - my-custom-check        # Your custom validator
 ```
 
-If you omit the `checks` list, all catalog entries for the phase run (embedded + custom).
+Every check to run must be listed explicitly. If you omit the `checks` list (or
+set it to `[]`, which clears any inherited checks), the phase runs **zero**
+validators and is skipped — an empty phase reports as passing, so a missing entry
+is easy to overlook. A declared name that matches no catalog entry for the phase
+is likewise dropped (it logs a warning but does not fail the run), so keep names
+in sync with the `name` fields in `validators/catalog.yaml`.
 
 ### Step 5: Run Validation
 

--- a/pkg/validator/v1/catalog.go
+++ b/pkg/validator/v1/catalog.go
@@ -145,28 +145,38 @@ func (c *ValidatorCatalog) ForPhase(phase Phase) []ValidatorEntry {
 	return result
 }
 
-// FilterEntriesByValidation filters catalog entries based on the validation's declared checks for the given phase.
-// Returns nil if the validation has no phase configuration or no checks declared.
-func FilterEntriesByValidation(entries []ValidatorEntry, phase Phase, validationInput *ValidationInput) []ValidatorEntry {
+// checksForPhase returns the check names declared for phase in the validation
+// input, or nil when the validation has no configuration for that phase.
+func checksForPhase(phase Phase, validationInput *ValidationInput) []string {
 	if validationInput == nil {
 		return nil
 	}
-
-	var phaseChecks []string
 	switch phase {
 	case PhaseDeployment:
 		if validationInput.Config.Deployment != nil {
-			phaseChecks = validationInput.Config.Deployment.Checks
+			return validationInput.Config.Deployment.Checks
 		}
 	case PhasePerformance:
 		if validationInput.Config.Performance != nil {
-			phaseChecks = validationInput.Config.Performance.Checks
+			return validationInput.Config.Performance.Checks
 		}
 	case PhaseConformance:
 		if validationInput.Config.Conformance != nil {
-			phaseChecks = validationInput.Config.Conformance.Checks
+			return validationInput.Config.Conformance.Checks
 		}
 	}
+	return nil
+}
+
+// FilterEntriesByValidation filters catalog entries based on the validation's declared checks for the given phase.
+// Returns nil if the validation has no phase configuration or no checks declared.
+//
+// Declared check names that match no entry are dropped here; use
+// UnmatchedChecks against the full catalog to surface those so a typo'd or
+// misplaced check name does not silently produce an empty (spuriously passing)
+// phase.
+func FilterEntriesByValidation(entries []ValidatorEntry, phase Phase, validationInput *ValidationInput) []ValidatorEntry {
+	phaseChecks := checksForPhase(phase, validationInput)
 
 	// No checks declared for this phase → skip it.
 	if len(phaseChecks) == 0 {
@@ -187,4 +197,68 @@ func FilterEntriesByValidation(entries []ValidatorEntry, phase Phase, validation
 	}
 
 	return filtered
+}
+
+// UnmatchedCheck describes a declared check name that matched no catalog entry
+// in the phase it was declared under.
+type UnmatchedCheck struct {
+	// Name is the declared check name that matched nothing in its phase.
+	Name string
+
+	// Phase is the phase the name was declared under.
+	Phase Phase
+
+	// OtherPhase is non-empty when the name exists in the catalog under a
+	// different phase — a likely misplacement rather than a typo.
+	OtherPhase Phase
+}
+
+// UnmatchedChecks returns the check names declared for phase that match no
+// catalog entry in that phase. It is the complement of
+// FilterEntriesByValidation: the names dropped on the floor. For each unmatched
+// name it records whether the same name exists under a different phase, which
+// distinguishes a misplaced check from an outright typo.
+//
+// The receiver is the full catalog (all phases) so cross-phase matches can be
+// detected. Returns nil when every declared check for the phase resolves.
+func (c *ValidatorCatalog) UnmatchedChecks(phase Phase, validationInput *ValidationInput) []UnmatchedCheck {
+	if c == nil {
+		return nil
+	}
+
+	phaseChecks := checksForPhase(phase, validationInput)
+	if len(phaseChecks) == 0 {
+		return nil
+	}
+
+	// Index catalog entry names by phase for O(1) lookup.
+	namePhases := make(map[string]Phase, len(c.Validators))
+	inPhase := make(map[string]bool)
+	for _, v := range c.Validators {
+		if Phase(v.Phase) == phase {
+			inPhase[v.Name] = true
+			continue
+		}
+		// Record one other phase per name; a name matching the target phase
+		// is never treated as "elsewhere".
+		if _, ok := namePhases[v.Name]; !ok {
+			namePhases[v.Name] = Phase(v.Phase)
+		}
+	}
+
+	var unmatched []UnmatchedCheck
+	seen := make(map[string]bool, len(phaseChecks))
+	for _, name := range phaseChecks {
+		if inPhase[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		unmatched = append(unmatched, UnmatchedCheck{
+			Name:       name,
+			Phase:      phase,
+			OtherPhase: namePhases[name],
+		})
+	}
+
+	return unmatched
 }

--- a/pkg/validator/v1/catalog_test.go
+++ b/pkg/validator/v1/catalog_test.go
@@ -208,3 +208,99 @@ func TestFilterEntriesByValidation_NonExistentCheck(t *testing.T) {
 		t.Errorf("FilterEntriesByValidation(non-existent check) returned %d entries, want 0", len(got))
 	}
 }
+
+func TestUnmatchedChecks(t *testing.T) {
+	catalog := &ValidatorCatalog{
+		Validators: []ValidatorEntry{
+			{Name: "operator-health", Phase: "deployment"},
+			{Name: "expected-resources", Phase: "deployment"},
+			{Name: "nccl-all-reduce-bw", Phase: "performance"},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		phase          Phase
+		checks         []string
+		wantNames      []string
+		wantOtherPhase map[string]Phase
+	}{
+		{
+			name:      "all matched",
+			phase:     PhaseDeployment,
+			checks:    []string{"operator-health", "expected-resources"},
+			wantNames: nil,
+		},
+		{
+			name:      "typo unmatched anywhere",
+			phase:     PhaseDeployment,
+			checks:    []string{"operator-health", "expected-resource"},
+			wantNames: []string{"expected-resource"},
+			wantOtherPhase: map[string]Phase{
+				"expected-resource": "",
+			},
+		},
+		{
+			name:      "declared under wrong phase",
+			phase:     PhaseDeployment,
+			checks:    []string{"nccl-all-reduce-bw"},
+			wantNames: []string{"nccl-all-reduce-bw"},
+			wantOtherPhase: map[string]Phase{
+				"nccl-all-reduce-bw": PhasePerformance,
+			},
+		},
+		{
+			name:      "duplicate unmatched deduped",
+			phase:     PhaseDeployment,
+			checks:    []string{"bogus", "bogus"},
+			wantNames: []string{"bogus"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vi := &ValidationInput{
+				Config: ValidationConfig{
+					Deployment: &ValidationPhase{Checks: nil},
+				},
+			}
+			switch tt.phase {
+			case PhaseDeployment:
+				vi.Config.Deployment = &ValidationPhase{Checks: tt.checks}
+			case PhasePerformance:
+				vi.Config.Performance = &ValidationPhase{Checks: tt.checks}
+			case PhaseConformance:
+				vi.Config.Conformance = &ValidationPhase{Checks: tt.checks}
+			}
+
+			got := catalog.UnmatchedChecks(tt.phase, vi)
+			if len(got) != len(tt.wantNames) {
+				t.Fatalf("UnmatchedChecks() returned %d entries (%v), want %d (%v)",
+					len(got), got, len(tt.wantNames), tt.wantNames)
+			}
+			for i, u := range got {
+				if u.Name != tt.wantNames[i] {
+					t.Errorf("UnmatchedChecks()[%d].Name = %q, want %q", i, u.Name, tt.wantNames[i])
+				}
+				if u.Phase != tt.phase {
+					t.Errorf("UnmatchedChecks()[%d].Phase = %q, want %q", i, u.Phase, tt.phase)
+				}
+				if want, ok := tt.wantOtherPhase[u.Name]; ok && u.OtherPhase != want {
+					t.Errorf("UnmatchedChecks()[%d].OtherPhase = %q, want %q", i, u.OtherPhase, want)
+				}
+			}
+		})
+	}
+}
+
+func TestUnmatchedChecks_NilReceiverAndNoChecks(t *testing.T) {
+	var nilCat *ValidatorCatalog
+	if got := nilCat.UnmatchedChecks(PhaseDeployment, &ValidationInput{}); got != nil {
+		t.Errorf("UnmatchedChecks(nil receiver) = %v, want nil", got)
+	}
+
+	cat := &ValidatorCatalog{Validators: []ValidatorEntry{{Name: "v1", Phase: "deployment"}}}
+	if got := cat.UnmatchedChecks(PhaseDeployment, nil); got != nil {
+		t.Errorf("UnmatchedChecks(nil validationInput) = %v, want nil", got)
+	}
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -266,6 +266,9 @@ func (v *Validator) ValidatePhase(
 	}
 
 	if v.NoCluster {
+		// Warn on unmatched check names even in no-cluster mode so typos are
+		// caught during offline recipe validation, not just live runs.
+		warnUnmatchedChecks(cat, phase, validationInput)
 		return v.phaseSkipped(cat, phase, "skipped - no-cluster mode"), nil
 	}
 
@@ -277,6 +280,23 @@ func (v *Validator) ValidatePhase(
 	defer v.deferClusterCleanup(cs.clientset) //nolint:contextcheck // cleanup uses fresh context
 
 	return v.runPhase(ctx, cs.clientset, cs.factory, cat, phase, validationInput)
+}
+
+// warnUnmatchedChecks emits a structured warning for every declared check name
+// that matched no catalog entry in its phase. A name that exists under a
+// different phase is called out as a likely misplacement; anything else is a
+// probable typo or a check missing from the loaded (possibly --data) catalog.
+// Advisory only — it never fails the run.
+func warnUnmatchedChecks(cat *catalog.ValidatorCatalog, phase Phase, validationInput *v1.ValidationInput) {
+	for _, u := range cat.UnmatchedChecks(phase, validationInput) {
+		if u.OtherPhase != "" {
+			slog.Warn("declared check matches no validator in this phase; it exists under a different phase",
+				"check", u.Name, "phase", u.Phase, "foundInPhase", u.OtherPhase)
+			continue
+		}
+		slog.Warn("declared check matches no validator in the catalog; it will not run",
+			"check", u.Name, "phase", u.Phase)
+	}
 }
 
 // runPhase executes all validators for a single phase sequentially.
@@ -299,6 +319,12 @@ func (v *Validator) runPhase(
 	entries := v1.FilterEntriesByValidation(allEntries, phase, validationInput)
 	slog.Info("running validation phase", "phase", phase,
 		"catalog", len(allEntries), "selected", len(entries))
+
+	// Surface declared check names that matched no catalog entry for this
+	// phase. Silently dropping them lets a typo'd or misplaced check name
+	// (e.g. a performance check declared under deployment) produce an empty,
+	// spuriously-passing phase — the fail-open direction for a gate.
+	warnUnmatchedChecks(cat, phase, validationInput)
 
 	builder := ctrf.NewBuilder("aicr", v.Version, string(phase))
 


### PR DESCRIPTION
## Summary

Make `aicr validate` surface check names that match no validator catalog entry (a typo or a check declared under the wrong phase), and correct the validator-extension doc that described the opposite of the actual omitted-`checks` behavior.

## Motivation / Context

Check selection is a pure name-set intersection in `FilterEntriesByValidation`: it keeps only catalog entries whose `name` appears in a phase's declared `checks`, and drops every unmatched name silently — no error, no warning, no log line. A typo'd or misplaced check name therefore produces an empty, spuriously-*passing* phase — the fail-open direction for a validation gate.

Separately, `docs/integrator/validator-extension.md` Step 4 claimed omitting `checks` runs *all* catalog entries for the phase, when the code returns `nil` (skips the phase, runs zero validators) — the opposite.

Fixes: #1717, #1718
Related: #1703

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- New `ValidatorCatalog.UnmatchedChecks(phase, validationInput)` diffs a phase's declared checks against the full catalog and reports each unmatched name, flagging names that exist under a *different* phase as likely misplacements (distinct from outright typos).
- `runPhase` and the no-cluster path call `warnUnmatchedChecks`, emitting a structured `slog.Warn` per unmatched name so typos are visible during both live and offline (`--no-cluster`) validation.
- **Advisory only** — it never fails the run, mirroring the existing `WarnPhasesAgainstRecipe` posture. Failing closed under a strictness flag was considered (see the issue) but kept out of scope to avoid breaking recipes with pre-existing stale names; the warning is the minimal fix for the silent-drop bug.
- Doc rewritten to state every check must be listed explicitly, that an empty list clears inherited checks and skips the phase, and that unmatched names are dropped with a warning.

## Testing

```bash
go test -race ./pkg/validator/...
golangci-lint run -c .golangci.yaml ./pkg/validator/... ./pkg/validator/v1/...
```

- Added `TestUnmatchedChecks` (all-matched, typo, wrong-phase, dedup) and `TestUnmatchedChecks_NilReceiverAndNoChecks`.
- Full `pkg/validator/...` suite passes with `-race`; lint clean (0 issues).

## Risk Assessment

- [x] **Low** — Additive warning + doc fix, no behavior change to what runs, easy to revert.

**Rollout notes:** N/A — no config or API surface change; new log lines only.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
