### PR TITLE
feat(uat): Azure AKS UAT phase runner + intent configs (2/2)

### DIFF
--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -71,14 +71,14 @@ jobs:
     if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
     # Budget = uncapped non-UAT steps (build, validator image push, AKS
-    # provisioning, evidence upload ~30m) + UAT phase steps (prep 15 + install 60
+    # provisioning, evidence upload ~30m) + UAT phase steps (prep 15 + install 90
     # + validate 40 + the intent-selected CUJ (train 25 OR serve 40) + verify 5
-    # = up to 160) + the always()-run Destroy Cluster teardown (3 retries, ~10m
+    # = up to 190) + the always()-run Destroy Cluster teardown (3 retries, ~10m
     # each = up to ~40m). Only one of train/serve runs per intent, so the budget
     # counts the larger (serve). The teardown MUST fit in this budget: a job-level
     # timeout cancels pending always() steps, so an undersized cap would skip
-    # teardown and leak the GPU node. 160 UAT + ~30 setup + ~40 teardown = ~230,
-    # so 270 leaves the teardown ample headroom even on a worst-case phase run.
+    # teardown and leak the GPU node. 190 UAT + ~30 setup + ~40 teardown = ~260,
+    # so 270 leaves the teardown headroom even on a worst-case phase run.
     timeout-minutes: 270
     permissions:
       contents: read
@@ -551,20 +551,22 @@ jobs:
       - name: UAT - install (helmfile apply)
         id: install
         if: steps.prep.outcome == 'success'
-        # Capped at 60m — the federated az session CANNOT self-refresh
-        # (client-credentials grant, no refresh token), and its access token
-        # lives ~60-75m. kubelogin's azurecli mode pulls tokens from that
-        # session on every kubectl call, so a step longer than one token
-        # lifetime starts failing auth mid-phase with no way to re-mint
-        # (azure/login only runs between steps). Matches the AWS/GCP install
-        # caps. The helmfile apply (HELMFILE_TIMEOUT_SECONDS, 20m) and the
-        # readiness gate budget inside tests/uat/azure/run must together fit
-        # under this cap; widening it for slow cold-GPU bring-up requires the
-        # readiness loop to re-login mid-phase first (az login
-        # --federated-token with a freshly minted ACTIONS_ID_TOKEN — planned
-        # alongside the run script in PR 2/2). Do NOT copy a >60m phase
-        # budget to future clouds without that mid-phase re-auth.
-        timeout-minutes: 60
+        # helmfile apply (up to HELMFILE_TIMEOUT_SECONDS, 20m) + the post-install
+        # readiness gate, which runs `aicr validate --phase deployment` until it
+        # passes READINESS_CONSECUTIVE_PASSES times (up to READINESS_TIMEOUT_SECONDS,
+        # 60m, spanning nodewright tuning + reboots, which can run past 30m on a
+        # cold GPU node). Sized to exceed one helmfile attempt + the full gate
+        # window (20 + 60 = 80, + margin) so the gate's own fail-closed path runs
+        # before GitHub Actions kills the step.
+        #
+        # This exceeds one federated access-token lifetime (~60-75m) ON
+        # PURPOSE: a federated az session cannot self-refresh, so the
+        # readiness gate in tests/uat/azure/run re-logins IN-LOOP every
+        # AZ_RELOGIN_INTERVAL_SECONDS (az login --federated-token with a
+        # freshly minted ACTIONS_ID_TOKEN, then an eager AKS-audience token
+        # mint — see az_federated_relogin). Do NOT copy a >60m phase budget
+        # to future clouds without that mid-phase re-auth.
+        timeout-minutes: 90
         shell: bash
         env:
           AICR_BIN: ${{ github.workspace }}/aicr

--- a/tests/uat/azure/run
+++ b/tests/uat/azure/run
@@ -1,0 +1,799 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# UAT runner. Codifies the workflow demonstrated in
+# demos/cuj1-training.md against the AKS cluster provisioned by
+# ../cluster-config.yaml, and is invoked phase-by-phase from
+# .github/workflows/uat-azure.yaml so per-phase failures surface in the
+# GitHub Actions UI.
+#
+# Usage:
+#   AICR_BIN=./aicr RUN_ID=12345 ./run <phase> <test-config.yaml>
+#
+# Phases:
+#   prep         snapshot + recipe + dry-run validate + bundle
+#   install      helmfile apply (deploys gpu-operator, kubeflow/dynamo, ...)
+#   conformance  validate ALL phases (deployment + conformance + performance)
+#                + emit signed evidence bundle
+#   train        submit TrainJob, wait for completion, capture logs
+#                (intent=training CUJ)
+#   serve        deploy a DynamoGraphDeployment, wait for readiness, hit the
+#                OpenAI-compatible endpoint, assert a completion, capture logs
+#                (intent=inference CUJ — the DC3 counterpart of `train`)
+#   verify       aicr evidence verify against the signed bundle
+#   all          run every phase in order (for local reproduction); the CUJ
+#                phase is chosen by the config's recipe intent — `train` for
+#                training, `serve` for inference
+#
+# Required env:
+#   AICR_BIN    Path to the aicr binary
+#   RUN_ID      Per-run correlation tag (`run-<id>`) applied to the evidence
+#               push target (e.g. ${{ github.run_id }} in CI, or `local-$(date +%s)`)
+#
+# Working files are written to $PWD: snapshot.yaml, recipe.yaml, bundle/,
+# dry-run.json, report.json, evidence/, evidence-result.json, train-logs/.
+
+set -euo pipefail
+
+phase="${1:-}"
+config="${2:-}"
+
+if [[ -z "${phase}" || -z "${config}" ]]; then
+  echo "Usage: $0 <phase> <test-config.yaml>" >&2
+  echo "Phases: prep | install | conformance | train | serve | verify | all" >&2
+  exit 2
+fi
+
+if [[ ! -f "${config}" ]]; then
+  echo "test-config not found: ${config}" >&2
+  exit 2
+fi
+
+: "${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+: "${RUN_ID:?Set RUN_ID (workflow passes \${{ github.run_id }}; locally use local-\$(date +%s))}"
+
+# Train-job knobs (overridable for local reproduction or future inference variant).
+TRAINJOB_NAMESPACE="${TRAINJOB_NAMESPACE:-kubeflow}"
+TRAINJOB_NAME="${TRAINJOB_NAME:-pytorch-mnist}"
+TRAINJOB_IMAGE="${TRAINJOB_IMAGE:-kubeflow/pytorch-dist-mnist:v1-9e12c68}"
+TRAINJOB_TIMEOUT_SECONDS="${TRAINJOB_TIMEOUT_SECONDS:-1200}" # 20 min
+HELMFILE_TIMEOUT_SECONDS="${HELMFILE_TIMEOUT_SECONDS:-1200}" # 20 min
+# Budget for the post-install readiness gate (see phase_install), which runs
+# `aicr validate --phase deployment` until it passes READINESS_CONSECUTIVE_PASSES
+# times in a row. This is the gate window ONLY -- it is entered AFTER helmfile
+# apply returns, so the workflow install step must budget helmfile + this. It
+# must span nodewright (skyhook) node tuning -- which REBOOTS the GPU node and
+# re-inits the gpu-operator operands after the operator first reports ready (each
+# validate run now polls internally, up to GPUReadinessTimeout, to ride through a
+# reboot) -- plus cold-boot GPU-operator convergence
+# (driver/toolkit/device-plugin/DCGM) and prometheus-adapter APIService
+# aggregation, across the required consecutive passes. Sized at 60m because
+# nodewright (skyhook) tuning plus its reboot cycles alone can run past 30m on a
+# cold GPU node (the earlier 30m budget timed out purely waiting on tuning), and
+# the gate must still have room to observe the required consecutive passes after
+# tuning settles. Fails closed if exceeded.
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-3600}" # 60 min
+# The gate requires the deployment phase to pass this many times CONSECUTIVELY
+# before declaring readiness. A single pass proves "converged at instant T", not
+# "will stay converged": nodewright (skyhook) tuning reboots the GPU node more
+# than once (the tuning packages carry interrupt: reboot) and re-opens
+# status=in_progress after each reboot and for each newly-joined GPU node, so a
+# pass can land in a lull between reboot cycles. Requiring N consecutive passes,
+# spaced by the retry sleep, ensures the reboots have settled before the
+# conformance phase (`--phase all`) runs -- any regression resets the counter.
+READINESS_CONSECUTIVE_PASSES="${READINESS_CONSECUTIVE_PASSES:-2}"
+# Azure-only (no AWS/GCP sibling): how often the readiness gate refreshes the
+# federated az session. A CI federated session cannot self-refresh — the
+# GitHub OIDC assertion azure/login stores is valid ~5 MINUTES and access
+# tokens ~60-75m — so a gate that can run to READINESS_TIMEOUT_SECONDS after
+# a 20m helmfile apply outlives the token minted at the install step's login
+# (AADSTS700024; see az_federated_relogin). 25m keeps every cached token
+# comfortably inside its lifetime with margin for a slow validate attempt.
+AZ_RELOGIN_INTERVAL_SECONDS="${AZ_RELOGIN_INTERVAL_SECONDS:-1500}" # 25 min
+
+# Inference-serve knobs (phase_serve; overridable for local reproduction). The
+# defaults mirror the served DynamoGraphDeployment in demos/cuj2-inference.md
+# (demos/workloads/inference/vllm-agg.yaml) so CI and the demo stay in lockstep.
+SERVE_NAMESPACE="${SERVE_NAMESPACE:-dynamo-workload}"
+SERVE_NAME="${SERVE_NAME:-vllm-agg}"
+SERVE_QUEUE="${SERVE_QUEUE:-dynamo}"
+SERVE_MODEL="${SERVE_MODEL:-Qwen/Qwen3-0.6B}"
+SERVE_RUNTIME_IMAGE="${SERVE_RUNTIME_IMAGE:-nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1}"
+# GPU worker placement. The demo pins nodeGroup=gpu-worker; both UAT clusters
+# label their GPU pool the same way (tests/uat/*/cluster-config.yaml), so the
+# default lands the decode worker on the GPU node on either cloud.
+SERVE_GPU_NODE_SELECTOR_KEY="${SERVE_GPU_NODE_SELECTOR_KEY:-nodeGroup}"
+SERVE_GPU_NODE_SELECTOR_VALUE="${SERVE_GPU_NODE_SELECTOR_VALUE:-gpu-worker}"
+SERVE_FRONTEND_PORT="${SERVE_FRONTEND_PORT:-8000}"
+# Readiness budget: image pull of the multi-GB vllm-runtime + model download +
+# engine warmup on a cold GPU node. Generous; fails closed if exceeded.
+SERVE_READY_TIMEOUT_SECONDS="${SERVE_READY_TIMEOUT_SECONDS:-1800}" # 30 min
+SERVE_REQUEST_TIMEOUT_SECONDS="${SERVE_REQUEST_TIMEOUT_SECONDS:-120}" # 2 min
+
+# Per-run OCI tag. The committed config carries the stable per-recipe repo
+# only; we apply a `:run-${RUN_ID}` tag idempotently, stripping any existing
+# `:run-…` tag first so re-running a phase from the same workspace (or with a
+# changed RUN_ID) does not double-append. The repo stays stable across runs so
+# `oras repo tags` lists run history; each run is addressable by tag and pinned
+# immutably by digest. An explicit tag also suppresses the aicr
+# `<recipe-slug>-<fingerprint>` tag derivation, which would re-duplicate the
+# coordinate dims the repo path already carries.
+# Refresh the federated az session mid-phase. In CI the session minted by
+# azure/login cannot self-refresh (client-credentials grant, no refresh
+# token): once its access tokens expire, kubectl/aicr calls fail with
+# AADSTS700024 and NO amount of retrying recovers — a fresh GitHub OIDC
+# assertion must be redeemed. GitHub permits minting ID tokens repeatedly, so
+# re-login in place: mint a fresh ACTIONS_ID_TOKEN, az login with it, then
+# EAGERLY warm the kubelogin audience (the AKS AAD server app) — the
+# assertion is only ~5-minute valid, so the token must be minted now, not
+# lazily when kubelogin next misses its cache. No-op outside CI (local user
+# az sessions self-refresh) and when the AZURE_* identifiers are absent.
+AKS_SERVER_APP_ID="6dae42f8-4368-4678-94ff-3960e28e3630"
+az_federated_relogin() {
+  if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${AZURE_CLIENT_ID:-}" \
+    || -z "${AZURE_TENANT_ID:-}" || -z "${AZURE_SUBSCRIPTION_ID:-}" ]]; then
+    return 0
+  fi
+  local oidc_token
+  oidc_token="$(curl -fsSL --retry 3 \
+    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange" | jq -r .value)"
+  az login --service-principal \
+    --username "${AZURE_CLIENT_ID}" \
+    --tenant "${AZURE_TENANT_ID}" \
+    --federated-token "${oidc_token}" \
+    --output none
+  az account set --subscription "${AZURE_SUBSCRIPTION_ID}" --output none
+  az account get-access-token --resource "${AKS_SERVER_APP_ID}" --output none
+  echo "federated az session refreshed (ARM + AKS audiences)"
+}
+
+inject_push_target() {
+  local current repo expected
+  current="$(yq '.spec.validate.evidence.attestation.push' "${config}")"
+  repo="${current%%:run-*}"
+  expected="${repo}:run-${RUN_ID}"
+  if [[ "${current}" != "${expected}" ]]; then
+    yq -i ".spec.validate.evidence.attestation.push = \"${expected}\"" "${config}"
+  fi
+  echo "evidence push target: $(yq '.spec.validate.evidence.attestation.push' "${config}")"
+}
+
+phase_prep() {
+  # Capture cluster state on snapshot failure so the post-mortem has
+  # actual pod scheduling / image pull / event data instead of just the
+  # generic "pod did not become ready" timeout the aicr CLI prints.
+  local snapshot_ns
+  snapshot_ns="$(yq '.spec.snapshot.agent.namespace // "aicr-validation"' "${config}")"
+  echo "::group::Snapshot live cluster"
+  if ! "${AICR_BIN}" snapshot --config "${config}"; then
+    echo "::endgroup::"
+    echo "::group::Snapshot failure debug"
+    echo "--- nodes ---"
+    kubectl get nodes -o wide --show-labels 2>&1 || true
+    echo "--- node taints ---"
+    kubectl get nodes -o json 2>/dev/null | \
+      jq -r '.items[] | "\(.metadata.name)\n  taints: \(.spec.taints // [])\n  conditions: \([.status.conditions[] | select(.type == "Ready") | .status])"' || true
+    echo "--- pods in ${snapshot_ns} ---"
+    kubectl get pods -n "${snapshot_ns}" -o wide 2>&1 || true
+    for p in $(kubectl get pods -n "${snapshot_ns}" -o name 2>/dev/null); do
+      echo "--- describe ${p} ---"
+      kubectl describe -n "${snapshot_ns}" "${p}" 2>&1 || true
+      echo "--- logs ${p} (all containers, last 50 lines) ---"
+      kubectl logs -n "${snapshot_ns}" "${p#pod/}" --all-containers --tail=50 2>&1 || true
+    done
+    echo "::endgroup::"
+    exit 1
+  fi
+  test -f snapshot.yaml
+  echo "::endgroup::"
+
+  echo "::group::Generate recipe"
+  "${AICR_BIN}" recipe --config "${config}"
+  test -f recipe.yaml
+  echo "::endgroup::"
+
+  echo "::group::Validate (dry-run, --no-cluster)"
+  "${AICR_BIN}" validate \
+    --config "${config}" \
+    --phase deployment \
+    --no-cluster \
+    --output dry-run.json
+  test -f dry-run.json
+  echo "::endgroup::"
+
+  echo "::group::Generate bundle"
+  "${AICR_BIN}" bundle --config "${config}"
+  test -f bundle/helmfile.yaml || {
+    echo "expected bundle/helmfile.yaml (deployer: helmfile) — got:" >&2
+    ls -la bundle >&2 || true
+    exit 1
+  }
+  echo "::endgroup::"
+}
+
+phase_install() {
+  command -v helmfile >/dev/null || { echo "helmfile not on PATH" >&2; exit 1; }
+  command -v helm     >/dev/null || { echo "helm not on PATH"     >&2; exit 1; }
+
+  # Read helm-diff version from the single source of truth (.settings.yaml).
+  local SCRIPT_DIR
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local REPO_ROOT="${SCRIPT_DIR}/../../.."
+  local HELM_DIFF_VERSION
+  HELM_DIFF_VERSION="$(yq -r '.testing_tools.helm_diff' "${REPO_ROOT}/.settings.yaml")"
+
+  echo "::group::Install helm-diff plugin (${HELM_DIFF_VERSION})"
+  # Check installed version; reinstall if missing or at a different version so the
+  # .settings.yaml pin is always effective (not just "any version is fine").
+  local installed_ver
+  installed_ver="$(helm plugin list 2>/dev/null | awk '$1=="diff" {print $2}')"
+  if [[ "${installed_ver}" == "${HELM_DIFF_VERSION#v}" ]]; then
+    echo "helm-diff ${HELM_DIFF_VERSION} already installed"
+  else
+    if [[ -n "${installed_ver}" ]]; then
+      echo "helm-diff ${installed_ver} installed; removing to pin ${HELM_DIFF_VERSION}"
+      helm plugin remove diff
+    fi
+    # Install from the signed release tarball (helm-diff's recommended Helm 4
+    # method). Helm 4 verifies plugin provenance by default (--verify=true):
+    # the .prov signature is checked against a keyring. Import the maintainer's
+    # release key, pin it to the published fingerprint (fail closed on
+    # mismatch), export it to a legacy keyring, and verify against it.
+    #
+    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/keyring are
+    # removed on every path — including a set -e (L41) abort, where a RETURN
+    # trap would not fire. The subshell keeps the trap and temp vars scoped to
+    # this block without disturbing the parent shell's traps.
+    (
+      HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
+      GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
+      HELM_DIFF_KEYRING="$(mktemp)"
+      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_KEYRING}"' EXIT
+      curl -fsSL "https://github.com/databus23.gpg" | gpg --import
+      if ! gpg --with-colons --fingerprint \
+          | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
+        echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
+        exit 1
+      fi
+      gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
+      helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
+        --keyring "${HELM_DIFF_KEYRING}"
+    )
+  fi
+  echo "::endgroup::"
+
+  # Retry helmfile apply on transient cluster-API errors (control-plane
+  # warmup, throttling, etc.). helmfile is idempotent — re-running on a
+  # partial-install state converges on the desired set. The 3 attempts SHARE a
+  # single HELMFILE_TIMEOUT_SECONDS wall-clock budget (each attempt is capped at
+  # the remaining budget, like the readiness gate below), not a full budget each:
+  # transient errors fail fast so sharing leaves ample time for retries, while a
+  # genuine hang cannot stretch install to 3x the budget. This bounds worst-case
+  # install (helmfile + gate) within the workflow step's timeout-minutes.
+  local helmfile_deadline=$(( SECONDS + HELMFILE_TIMEOUT_SECONDS ))
+  local success=false helm_remaining
+  for attempt in 1 2 3; do
+    if (( SECONDS >= helmfile_deadline )); then
+      # Distinguish a budget-starved run (a slow-but-progressing apply consumed
+      # the shared window) from a genuine 3-strike failure: log why attempts
+      # 2-3 never launched.
+      echo "helmfile shared ${HELMFILE_TIMEOUT_SECONDS}s budget exhausted after attempt $(( attempt - 1 )); not starting attempt ${attempt}"
+      break
+    fi
+    helm_remaining=$(( helmfile_deadline - SECONDS ))
+    (( helm_remaining < 1 )) && helm_remaining=1
+    echo "::group::helmfile apply attempt ${attempt}/3 (timeout ${helm_remaining}s of ${HELMFILE_TIMEOUT_SECONDS}s shared budget)"
+    if ( cd bundle && timeout "${helm_remaining}" helmfile apply --skip-diff-on-install ); then
+      success=true
+      echo "::endgroup::"
+      break
+    fi
+    echo "helmfile apply attempt ${attempt} failed"
+    echo "::endgroup::"
+    if (( attempt < 3 )); then
+      echo "waiting 30s before retry"
+      sleep 30
+    fi
+  done
+  if [[ "${success}" != "true" ]]; then
+    echo "::error::helmfile apply failed after 3 attempts" >&2
+    exit 1
+  fi
+
+  echo "::group::Cluster state post-install"
+  kubectl get nodes -o wide
+  kubectl get pods -A | grep -Ev '\s+Running\s+|\s+Completed\s+' || true
+  echo "::endgroup::"
+
+  # Readiness gate: run the deployment validation phase -- the authoritative
+  # expected-resources / ClusterPolicy / DRA / nodewright checks the later
+  # `--phase all` run gates on -- in a retry loop until it passes
+  # READINESS_CONSECUTIVE_PASSES times in a row. `helmfile apply` returns before
+  # operator-driven convergence, and nodewright (skyhook) reboots the GPU node
+  # AFTER gpu-operator first reports ready, re-initing the operands; proxy
+  # signals (ClusterPolicy=ready, Skyhook status.status) read that transient
+  # state as "done" prematurely, so we gate on the real check. A SINGLE pass only
+  # proves "converged at instant T" -- skyhook tuning reboots the node more than
+  # once and re-opens status=in_progress between cycles, so a lone pass can land
+  # in a lull. Requiring consecutive passes (each spaced by the retry sleep, and
+  # each riding through a transient in_progress via expected-resources' own poll)
+  # ensures the reboots have settled before conformance runs. Any failure resets
+  # the streak. Fail-closed: the install fails if the streak is never reached
+  # within the budget.
+  #
+  # Run against a copy of the config with spec.validate.evidence stripped so the
+  # gate never emits/pushes an evidence bundle -- that is the conformance phase's
+  # job (phase_conformance, `--phase all`).
+  local gate_config gate_log
+  gate_config="$(mktemp)"
+  gate_log="$(mktemp)"
+  yq 'del(.spec.validate.evidence)' "${config}" > "${gate_config}"
+  local ready_deadline=$(( SECONDS + READINESS_TIMEOUT_SECONDS ))
+  local attempt=1 streak=0 ready=false remaining
+  local last_relogin=${SECONDS}
+  echo "::group::Readiness gate: validate --phase deployment x${READINESS_CONSECUTIVE_PASSES} consecutive (timeout ${READINESS_TIMEOUT_SECONDS}s)"
+  # Check the deadline BEFORE each attempt so no validation run is launched once
+  # the budget is spent (a single run can itself take minutes). The last
+  # attempt's output is captured in gate_log for the failure diagnostic rather
+  # than re-running validate past the deadline.
+  while (( SECONDS < ready_deadline )); do
+    # Keep the federated az session alive across the gate window (see
+    # az_federated_relogin) — the gate's validate runs and any kubectl the
+    # checks spawn authenticate through it via kubelogin's azurecli mode.
+    # A transient re-login failure must not kill the gate: the current
+    # cached tokens stay valid for a while, so warn and retry on the next
+    # attempt (the timer only advances on success).
+    if (( SECONDS - last_relogin >= AZ_RELOGIN_INTERVAL_SECONDS )); then
+      if az_federated_relogin; then
+        last_relogin=${SECONDS}
+      else
+        echo "::warning::federated az re-login failed; retrying on the next gate attempt"
+      fi
+    fi
+    # Bound each attempt with `timeout` (like the helmfile retry above) so a hung
+    # validate cannot block past the deadline -- the loop only re-checks
+    # ready_deadline between attempts. Cap at the remaining budget so no single
+    # attempt overruns the gate window. Clamp to >= 1: SECONDS is re-read here and
+    # can tick to ready_deadline between the while guard and this line, and
+    # `timeout 0` means "no timeout" (runs forever) -- the exact hang we guard.
+    remaining=$(( ready_deadline - SECONDS ))
+    (( remaining < 1 )) && remaining=1
+    if timeout "${remaining}" "${AICR_BIN}" validate --config "${gate_config}" --phase deployment --output /dev/null > "${gate_log}" 2>&1; then
+      streak=$(( streak + 1 ))
+      echo "deployment phase passed (attempt ${attempt}, streak ${streak}/${READINESS_CONSECUTIVE_PASSES})"
+      if (( streak >= READINESS_CONSECUTIVE_PASSES )); then
+        ready=true
+        break
+      fi
+    else
+      # A regression (e.g. nodewright flipped back to in_progress on a reboot)
+      # invalidates the streak -- start over.
+      if (( streak > 0 )); then
+        echo "deployment phase regressed after ${streak} consecutive pass(es); resetting streak"
+      fi
+      streak=0
+      echo "deployment phase not ready (attempt ${attempt})"
+    fi
+    attempt=$(( attempt + 1 ))
+    sleep 15
+  done
+  if [[ "${ready}" != true ]]; then
+    echo "::error::deployment readiness gate did not reach ${READINESS_CONSECUTIVE_PASSES} consecutive passes within ${READINESS_TIMEOUT_SECONDS}s (last streak ${streak}); last attempt output:" >&2
+    cat "${gate_log}" >&2 || true
+    rm -f "${gate_config}" "${gate_log}"
+    echo "::endgroup::"
+    exit 1
+  fi
+  rm -f "${gate_config}" "${gate_log}"
+  echo "deployment readiness gate passed (${READINESS_CONSECUTIVE_PASSES} consecutive, ${attempt} attempt(s))"
+  echo "::endgroup::"
+}
+
+phase_conformance() {
+  inject_push_target
+  # Run ALL validation phases, not just conformance. The deployment phase is
+  # the readiness barrier this UAT was missing: its health-check asserts poll
+  # (chainsaw assert, ~6m budget) until the GPU stack converges — gpu-operator
+  # ClusterPolicy reaches state=ready, the DRA kubelet-plugin DaemonSet is
+  # fully rolled out, and nodewright node tuning completes. The helmfile bundle
+  # (unlike the helm deploy.sh, which `kubectl wait`s on these) returns from
+  # `helmfile apply` as soon as each release's own resources are ready, leaving
+  # operator-driven work in flight; running conformance alone then validated a
+  # not-yet-converged cluster and failed. The deployment phase gates that
+  # convergence deployer-agnostically. The performance phase's only check,
+  # nccl-all-reduce-bw, needs >=2 GPU nodes for its East-West fabric test and
+  # is now active: the cluster-config provisions 2 GPU nodes (gpu-worker
+  # size: 2, fixed). If the pool is ever scaled back to a single
+  # GPU node, the check skips gracefully (skip != fail) rather than failing.
+  # Evidence is rendered/attested from the merged multi-phase report, so the
+  # signed bundle covers all phases.
+  echo "::group::Validate (all phases) + emit signed evidence"
+  "${AICR_BIN}" validate \
+    --config "${config}" \
+    --phase all \
+    --output report.json
+  echo "::endgroup::"
+
+  if [[ ! -f ./evidence/pointer.yaml ]]; then
+    echo "evidence pointer not emitted at ./evidence/pointer.yaml" >&2
+    ls -la ./evidence >&2 || true
+    exit 1
+  fi
+  echo "evidence pointer:"
+  cat ./evidence/pointer.yaml
+
+  # First-party platform sanity check. The emitted bundle's TestGrid tab
+  # coordinate is derived from the recipe's author-declared `platform`
+  # (inference→dynamo, training→kubeflow) and is NOT captured by the
+  # fingerprint — pkg/fingerprint/match.go treats the platform dimension as
+  # uncaptured — so a mis-declared platform would silently route evidence to
+  # the wrong tab. Cross-check that the platform operator's workload CRD is
+  # actually installed on the cluster the bundle deployed, so the declared
+  # coordinate matches the deployed component set. Unknown/other platforms are
+  # skipped (no false failure), a known platform whose CRD is absent fails closed.
+  echo "::group::Platform coordinate sanity check"
+  local platform crd
+  platform="$(yq -r '.criteria.platform // ""' recipe.yaml)"
+  case "${platform}" in
+    dynamo)   crd="dynamographdeployments.nvidia.com" ;;
+    kubeflow) crd="trainjobs.trainer.kubeflow.org" ;;
+    *)
+      echo "recipe declares platform '${platform}': no workload-CRD cross-check wired for it (skipping)"
+      echo "::endgroup::"
+      return 0
+      ;;
+  esac
+  if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
+    echo "::error::recipe declares platform=${platform} but its workload CRD ${crd} is not installed — the emitted evidence would map to the wrong TestGrid tab" >&2
+    kubectl get crd 2>&1 | head -50 >&2 || true
+    exit 1
+  fi
+  echo "platform=${platform}: workload CRD ${crd} present"
+  echo "::endgroup::"
+}
+
+phase_train() {
+  echo "::group::Submit TrainJob"
+  kubectl apply -f - <<EOF
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: ${TRAINJOB_NAME}
+  namespace: ${TRAINJOB_NAMESPACE}
+spec:
+  trainer:
+    numNodes: 2
+    image: ${TRAINJOB_IMAGE}
+    command:
+      - python3
+      - /opt/mnist/src/mnist.py
+      - --epochs=1
+    resourcesPerNode:
+      requests:
+        nvidia.com/gpu: 1
+      limits:
+        nvidia.com/gpu: 1
+  runtimeRef:
+    name: torch-distributed
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+EOF
+  echo "::endgroup::"
+
+  echo "::group::Wait for TrainJob completion (timeout ${TRAINJOB_TIMEOUT_SECONDS}s)"
+  local deadline=$(( SECONDS + TRAINJOB_TIMEOUT_SECONDS ))
+  local complete="" failed=""
+  while (( SECONDS < deadline )); do
+    complete="$(kubectl get trainjob "${TRAINJOB_NAME}" -n "${TRAINJOB_NAMESPACE}" \
+      -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)"
+    failed="$(kubectl get trainjob "${TRAINJOB_NAME}" -n "${TRAINJOB_NAMESPACE}" \
+      -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)"
+    if [[ "${complete}" == "True" ]]; then
+      echo "TrainJob Complete=True"
+      break
+    fi
+    if [[ "${failed}" == "True" ]]; then
+      echo "TrainJob Failed=True" >&2
+      kubectl describe trainjob "${TRAINJOB_NAME}" -n "${TRAINJOB_NAMESPACE}" >&2 || true
+      mkdir -p train-logs
+      kubectl logs -n "${TRAINJOB_NAMESPACE}" -l "job-name=${TRAINJOB_NAME}-node-0" \
+        --all-containers --tail=-1 > train-logs/"${TRAINJOB_NAME}".log 2>&1 || true
+      exit 1
+    fi
+    sleep 15
+  done
+  if [[ "${complete}" != "True" ]]; then
+    echo "TrainJob did not complete within ${TRAINJOB_TIMEOUT_SECONDS}s" >&2
+    kubectl describe trainjob "${TRAINJOB_NAME}" -n "${TRAINJOB_NAMESPACE}" >&2 || true
+    exit 1
+  fi
+  echo "::endgroup::"
+
+  echo "::group::Capture TrainJob logs"
+  mkdir -p train-logs
+  kubectl logs -n "${TRAINJOB_NAMESPACE}" -l "job-name=${TRAINJOB_NAME}-node-0" \
+    --all-containers --tail=-1 > train-logs/"${TRAINJOB_NAME}".log 2>&1 || true
+  wc -l train-logs/"${TRAINJOB_NAME}".log || true
+  echo "::endgroup::"
+}
+
+# serve_debug dumps the served-workload state (DGD, pods, describe, events,
+# logs) into serve-logs/ and the step log so a failed or successful phase_serve
+# is diagnosable from the uploaded artifacts. Best-effort; never fails the run.
+serve_debug() {
+  mkdir -p serve-logs
+  {
+    echo "--- dynamographdeployments ---"
+    kubectl get dynamographdeployments -n "${SERVE_NAMESPACE}" -o yaml 2>&1 || true
+    echo "--- pods ---"
+    kubectl get pods -n "${SERVE_NAMESPACE}" -o wide 2>&1 || true
+    echo "--- describe pods ---"
+    kubectl describe pods -n "${SERVE_NAMESPACE}" 2>&1 || true
+    echo "--- events ---"
+    kubectl get events -n "${SERVE_NAMESPACE}" --sort-by=.lastTimestamp 2>&1 || true
+    echo "--- logs (all pods, all containers, last 200 lines) ---"
+    for p in $(kubectl get pods -n "${SERVE_NAMESPACE}" -o name 2>/dev/null); do
+      echo "=== ${p} ==="
+      kubectl logs -n "${SERVE_NAMESPACE}" "${p#pod/}" --all-containers --tail=200 2>&1 || true
+    done
+  } | tee serve-logs/"${SERVE_NAME}".log
+}
+
+phase_serve() {
+  # Deploy the served inference graph (Dynamo) — the intent=inference CUJ, the
+  # DC3 counterpart of phase_train. Mirrors the DynamoGraphDeployment in
+  # demos/cuj2-inference.md (demos/workloads/inference/vllm-agg.yaml): the KAI
+  # queue and a two-component (Frontend + decode Worker) graph serving an
+  # OpenAI-compatible endpoint. The worker requests its GPU as a scalar
+  # nvidia.com/gpu limit — the device-plugin production default (#1327).
+  #
+  # Tolerations are a portable SUPERSET of the taints across the UAT clusters
+  # (AWS and GKE GPU pools use different `dedicated` values — the AKS pool
+  # carries only nvidia.com/gpu; the DRA/gpu-operator
+  # adds nvidia.com/gpu). Tolerating a taint a node does not carry is a no-op, so
+  # one list schedules correctly on either cloud. The Frontend deliberately omits
+  # the nvidia.com/gpu toleration so it stays OFF the scarce GPU nodes.
+  echo "::group::Deploy DynamoGraphDeployment (${SERVE_NAME} in ${SERVE_NAMESPACE})"
+  kubectl apply -f - <<EOF
+apiVersion: scheduling.run.ai/v2
+kind: Queue
+metadata:
+  name: ${SERVE_QUEUE}
+spec:
+  parentQueue: default-parent-queue
+  resources:
+    gpu: {limit: -1, overQuotaWeight: 1, quota: 0}
+    cpu: {limit: -1, overQuotaWeight: 1, quota: 0}
+    memory: {limit: -1, overQuotaWeight: 1, quota: 0}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${SERVE_NAMESPACE}
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${SERVE_NAME}
+  namespace: ${SERVE_NAMESPACE}
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          tolerations:
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoExecute}
+            - {key: dedicated, operator: Equal, value: gpu-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: system-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: system-workload, effect: NoExecute}
+          containers:
+            - name: main
+              image: ${SERVE_RUNTIME_IMAGE}
+              env:
+                - {name: SERVED_MODEL_NAME, value: ${SERVE_MODEL}}
+                - {name: DYN_ROUTER_MODE, value: kv}
+    - name: VllmDecodeWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 2Gi
+      podTemplate:
+        spec:
+          nodeSelector:
+            ${SERVE_GPU_NODE_SELECTOR_KEY}: ${SERVE_GPU_NODE_SELECTOR_VALUE}
+          tolerations:
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoSchedule}
+            - {key: dedicated, operator: Equal, value: worker-workload, effect: NoExecute}
+            - {key: dedicated, operator: Equal, value: gpu-workload, effect: NoSchedule}
+            - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+          containers:
+            - name: main
+              image: ${SERVE_RUNTIME_IMAGE}
+              workingDir: /workspace/examples/backends/vllm
+              command: ["python3", "-m", "dynamo.vllm"]
+              args:
+                - --model
+                - ${SERVE_MODEL}
+                - --kv-events-config
+                - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}'
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+EOF
+  echo "::endgroup::"
+
+  echo "::group::Wait for DynamoGraphDeployment readiness (timeout ${SERVE_READY_TIMEOUT_SECONDS}s)"
+  local deadline=$(( SECONDS + SERVE_READY_TIMEOUT_SECONDS ))
+  local ready=false pods_json total ready_count
+  while (( SECONDS < deadline )); do
+    pods_json="$(kubectl get pods -n "${SERVE_NAMESPACE}" -o json 2>/dev/null || echo '{}')"
+    # Fail closed as soon as a workload pod is unrecoverable so a bad image or
+    # crash loop surfaces immediately instead of burning the whole readiness
+    # budget. Two cases: a terminal phase=Failed, OR a container wedged in an
+    # image-pull / crash-loop / config-error waiting state — the latter keep the
+    # pod in phase=Running/Pending, so they must be checked explicitly (a
+    # multi-GB vllm-runtime pull that 404s would otherwise wait out the full
+    # SERVE_READY_TIMEOUT_SECONDS).
+    bad="$(echo "${pods_json}" | jq -r '
+      .items[]? as $p
+      | ( [ ($p.status.containerStatuses // [])[]?, ($p.status.initContainerStatuses // [])[]?
+            | .state.waiting.reason // empty ]
+          + (if $p.status.phase == "Failed" then ["phase=Failed"] else [] end) )[]
+      | select(. == "phase=Failed" or . == "ImagePullBackOff" or . == "ErrImagePull"
+               or . == "CrashLoopBackOff" or . == "InvalidImageName"
+               or . == "CreateContainerConfigError")' 2>/dev/null | head -n1)"
+    if [[ -n "${bad}" ]]; then
+      echo "a workload pod is unrecoverable (${bad}); not waiting out the readiness budget" >&2
+      break
+    fi
+    # Ready when at least one pod exists and every pod reports Ready=True.
+    total="$(echo "${pods_json}" | jq '[.items[]?] | length')"
+    ready_count="$(echo "${pods_json}" | jq '[.items[]? | select(.status.conditions[]? | select(.type=="Ready" and .status=="True"))] | length')"
+    if [[ "${total}" -gt 0 && "${total}" == "${ready_count}" ]]; then
+      ready=true
+      break
+    fi
+    echo "workload not ready (${ready_count}/${total} pods Ready); retrying in 15s..."
+    sleep 15
+  done
+  echo "::endgroup::"
+
+  if [[ "${ready}" != true ]]; then
+    echo "::error::DynamoGraphDeployment ${SERVE_NAME} did not become ready within ${SERVE_READY_TIMEOUT_SECONDS}s" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+
+  echo "::group::Query the OpenAI-compatible endpoint"
+  local svc="${SERVE_NAME}-frontend"
+  if ! kubectl get svc -n "${SERVE_NAMESPACE}" "${svc}" >/dev/null 2>&1; then
+    echo "::error::frontend service ${svc} not found in ${SERVE_NAMESPACE}" >&2
+    kubectl get svc -n "${SERVE_NAMESPACE}" >&2 || true
+    echo "::endgroup::"
+    exit 1
+  fi
+  # Port-forward the frontend and issue a sample chat completion. The forwarder
+  # is a background child; kill it on every exit path so a failing assertion
+  # does not leak the port-forward (belt-and-braces to the script exit, which
+  # would also reap it).
+  kubectl port-forward -n "${SERVE_NAMESPACE}" "svc/${svc}" \
+    "${SERVE_FRONTEND_PORT}:${SERVE_FRONTEND_PORT}" >/dev/null 2>&1 &
+  local pf_pid=$!
+  local up=false resp="" rc=0
+  for _ in $(seq 1 30); do
+    if curl -fsS "http://localhost:${SERVE_FRONTEND_PORT}/v1/models" >/dev/null 2>&1; then
+      up=true
+      break
+    fi
+    sleep 2
+  done
+  if [[ "${up}" == true ]]; then
+    resp="$(curl -sS --max-time "${SERVE_REQUEST_TIMEOUT_SECONDS}" \
+      -X POST "http://localhost:${SERVE_FRONTEND_PORT}/v1/chat/completions" \
+      -H 'Content-Type: application/json' \
+      -d "{\"model\":\"${SERVE_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"What is Kubernetes?\"}],\"max_tokens\":64}")" || rc=$?
+  fi
+  kill "${pf_pid}" 2>/dev/null || true
+  wait "${pf_pid}" 2>/dev/null || true
+  echo "::endgroup::"
+
+  if [[ "${up}" != true ]]; then
+    echo "::error::frontend endpoint ${svc} did not accept connections within the port-forward window" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+  echo "completion response:"
+  echo "${resp}"
+  # Assert a valid, non-empty OpenAI-compatible chat completion.
+  if [[ "${rc}" -ne 0 ]] || \
+     ! echo "${resp}" | jq -e '.choices[0].message.content | type == "string" and (length > 0)' >/dev/null 2>&1; then
+    echo "::error::inference request did not return a valid chat completion (curl rc=${rc})" >&2
+    echo "::group::Serve failure debug"
+    serve_debug
+    echo "::endgroup::"
+    exit 1
+  fi
+  echo "served inference OK: /v1/chat/completions returned a non-empty completion"
+
+  echo "::group::Capture serve logs"
+  serve_debug >/dev/null
+  wc -l serve-logs/"${SERVE_NAME}".log || true
+  echo "::endgroup::"
+}
+
+phase_verify() {
+  echo "::group::Bootstrap Sigstore TUF root"
+  "${AICR_BIN}" trust update
+  echo "::endgroup::"
+
+  # Pin the expected signer when EXPECTED_ISSUER / EXPECTED_IDENTITY_REGEXP
+  # are set (CI sets them to the workflow's OIDC identity). Without pinning,
+  # any Fulcio-signed payload would pass verification — useful for local
+  # dev where the signing identity is the user, mandatory in CI.
+  local args=(evidence verify ./evidence/pointer.yaml)
+  if [[ -n "${EXPECTED_ISSUER:-}" ]]; then
+    args+=(--expected-issuer "${EXPECTED_ISSUER}")
+  fi
+  if [[ -n "${EXPECTED_IDENTITY_REGEXP:-}" ]]; then
+    args+=(--expected-identity-regexp "${EXPECTED_IDENTITY_REGEXP}")
+  fi
+  args+=(-o evidence-result.json -t json)
+
+  echo "::group::Verify signed evidence bundle"
+  "${AICR_BIN}" "${args[@]}"
+  echo "::endgroup::"
+
+  local exit_code
+  exit_code="$(jq -r '.exit' evidence-result.json)"
+  echo "evidence verify exit code: ${exit_code}"
+  if [[ "${exit_code}" != "0" ]]; then
+    cat evidence-result.json
+    exit 1
+  fi
+}
+
+case "${phase}" in
+  prep)        phase_prep ;;
+  install)     phase_install ;;
+  conformance) phase_conformance ;;
+  train)       phase_train ;;
+  serve)       phase_serve ;;
+  verify)      phase_verify ;;
+  all)
+    # The CUJ phase is chosen by the config's recipe intent so `run all`
+    # reproduces the right end-to-end flow: serve for inference, train
+    # otherwise. Defaults to training if the intent is unset.
+    phase_prep; phase_install; phase_conformance
+    intent="$(yq -r '.spec.recipe.criteria.intent // "training"' "${config}")"
+    case "${intent}" in
+      inference) phase_serve ;;
+      *)         phase_train ;;
+    esac
+    phase_verify
+    ;;
+  *)
+    echo "unknown phase: ${phase}" >&2
+    echo "Phases: prep | install | conformance | train | serve | verify | all" >&2
+    exit 2
+    ;;
+esac

--- a/tests/uat/azure/tests/h100-inference-config.yaml
+++ b/tests/uat/azure/tests/h100-inference-config.yaml
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AICRConfig consumed by `aicr {snapshot,recipe,bundle,validate} --config`.
+#
+# The inference sibling of `h100-training-config.yaml` (#1275, DC2). The UAT
+# pipeline selects between the two by the `intent` input: an `intent=inference`
+# dispatch resolves this file, an `intent=training` (the default) dispatch the
+# training one. Both drive the SAME AKS cluster (`../cluster-config.yaml`) —
+# the GPU pool count comes from the reservation row and the pool sizes are
+# fixed per cluster-config, so only the recipe criteria (and the evidence push
+# target) differ by intent.
+#
+# The served inference workload itself (phase_serve) is out of scope here and
+# owned by DC3; this config stands up and validates the inference stack
+# (dynamo platform + KAI scheduler + DRA driver) the way the training config
+# stands up the training stack.
+#
+# Scheduling note: see `h100-training-config.yaml` — GPU pool carries only
+# `nvidia.com/gpu=present:NoSchedule`; AICR system components target the
+# CPU worker pool (the AKS system pool is CriticalAddonsOnly).
+#
+# Deliberately NO value overrides, although the manual AKS validation bundled
+# with two `--set-json` flags:
+#   - gpuoperator:toolkit.env RUNTIME_CONFIG_SOURCE=file — already baked into
+#     the recipe's gpu-operator values (values-aks.yaml; #1689), so the
+#     override was redundant.
+#   - agentgateway:allowedSourceRanges=[<NVIDIA egress CIDR>] — admits the
+#     operator's VPN to the inference LoadBalancer. CI never crosses the LB
+#     (phase_serve uses kubectl port-forward), and an empty value is NOT
+#     open: the bundler injects the private RFC1918 ranges (#1373). Humans
+#     who want VPN access to a daytime cluster bundle manually with the
+#     override.
+#
+# `spec.validate.evidence.attestation.push` carries the stable per-recipe
+# repo only; `../run` appends a `:run-${RUN_ID}` tag at runtime so each UAT
+# execution publishes a uniquely traceable, digest-addressed point under one
+# stable repo (`oras repo tags` lists run history). Consumers pin immutably
+# via `@sha256:…`.
+kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: aks-h100-inference-uat
+
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - nvidia.com/gpu=present:NoSchedule
+
+  recipe:
+    criteria:
+      service: aks
+      accelerator: h100
+      os: ubuntu
+      intent: inference
+      platform: dynamo
+    output:
+      path: recipe.yaml
+
+  bundle:
+    input:
+      recipe: recipe.yaml
+    output:
+      target: ./bundle
+    deployment:
+      deployer: helmfile
+    scheduling:
+      acceleratedNodeSelector:
+        nodeGroup: gpu-worker
+      acceleratedNodeTolerations:
+        - nvidia.com/gpu=present:NoSchedule
+      systemNodeSelector:
+        nodeGroup: cpu-worker
+      # Consume the cluster's default StorageClass rather than hardcoding a
+      # name: AKS always ships `managed-csi` annotated as the default, so an
+      # empty value binds PVCs to it automatically on any AKS cluster.
+      storageClass: ""
+
+  validate:
+    execution:
+      # The deployment phase is the readiness barrier (gpu-operator ClusterPolicy
+      # reaches state=ready, the DRA kubelet-plugin DaemonSet rolls out, nodewright
+      # node tuning completes). failFast stops the run if that phase fails, so the
+      # conformance/performance phases are not evaluated against a not-yet-converged
+      # cluster — which previously surfaced as misleading accelerator-metrics /
+      # ai-service-metrics / pod-autoscaling failures. The `../run` readiness gate
+      # gives the operator-driven stack time to converge before validate, so on a
+      # healthy cluster the deployment phase passes and all phases still run.
+      failFast: true
+    input:
+      recipe: recipe.yaml
+      snapshot: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      tolerations:
+        - nvidia.com/gpu=present:NoSchedule
+    evidence:
+      attestation:
+        # Setting `out` enables emit. The push target below is the stable
+        # per-recipe repo; ../run appends a `:run-${RUN_ID}` tag for per-run
+        # isolation. Consumers pin immutably via the artifact digest.
+        out: ./evidence
+        push: ghcr.io/nvidia/aicr-evidence/h100-aks-ubuntu-inference-dynamo

--- a/tests/uat/azure/tests/h100-training-config.yaml
+++ b/tests/uat/azure/tests/h100-training-config.yaml
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AICRConfig consumed by `aicr {snapshot,recipe,bundle,validate} --config`.
+#
+# Drives the AKS H100 training UAT — codifies the workflow demonstrated in
+# `demos/cuj1-training.md` against the cluster provisioned by
+# `../cluster-config.yaml`. Scheduling fields match that cluster's node
+# labels/taints.
+#
+# Scheduling note: the AKS actuator taints GPU pools with
+# `nvidia.com/gpu=present:NoSchedule` (the only taint on the pool — no
+# `dedicated=*` values like AWS/GKE), and the AKS SYSTEM pool carries
+# `CriticalAddonsOnly=true:NoSchedule` so only cluster addons land there;
+# AICR system components therefore target the dedicated CPU worker pool
+# (`nodeGroup: cpu-worker`), not the system pool.
+#
+# `spec.validate.evidence.attestation.push` carries the stable per-recipe
+# repo only; `../run` appends a `:run-${RUN_ID}` tag at runtime so each UAT
+# execution publishes a uniquely traceable, digest-addressed point under one
+# stable repo (`oras repo tags` lists run history). Consumers pin immutably
+# via `@sha256:…`.
+kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: aks-h100-training-uat
+
+spec:
+  snapshot:
+    output:
+      path: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      nodeSelector:
+        nodeGroup: gpu-worker
+      tolerations:
+        - nvidia.com/gpu=present:NoSchedule
+
+  recipe:
+    criteria:
+      service: aks
+      accelerator: h100
+      os: ubuntu
+      intent: training
+      platform: kubeflow
+    output:
+      path: recipe.yaml
+
+  bundle:
+    input:
+      recipe: recipe.yaml
+    output:
+      target: ./bundle
+    deployment:
+      deployer: helmfile
+    scheduling:
+      acceleratedNodeSelector:
+        nodeGroup: gpu-worker
+      acceleratedNodeTolerations:
+        - nvidia.com/gpu=present:NoSchedule
+      systemNodeSelector:
+        nodeGroup: cpu-worker
+      # Consume the cluster's default StorageClass rather than hardcoding a
+      # name: AKS always ships `managed-csi` annotated as the default, so an
+      # empty value binds PVCs to it automatically on any AKS cluster.
+      storageClass: ""
+
+  validate:
+    execution:
+      # The deployment phase is the readiness barrier (gpu-operator ClusterPolicy
+      # reaches state=ready, the DRA kubelet-plugin DaemonSet rolls out, nodewright
+      # node tuning completes). failFast stops the run if that phase fails, so the
+      # conformance/performance phases are not evaluated against a not-yet-converged
+      # cluster — which previously surfaced as misleading accelerator-metrics /
+      # ai-service-metrics / pod-autoscaling failures. The `../run` readiness gate
+      # gives the operator-driven stack time to converge before validate, so on a
+      # healthy cluster the deployment phase passes and all phases still run.
+      failFast: true
+    input:
+      recipe: recipe.yaml
+      snapshot: snapshot.yaml
+    agent:
+      namespace: aicr-validation
+      tolerations:
+        - nvidia.com/gpu=present:NoSchedule
+    evidence:
+      attestation:
+        # Setting `out` enables emit. The push target below is the stable
+        # per-recipe repo; ../run appends a `:run-${RUN_ID}` tag for per-run
+        # isolation. Consumers pin immutably via the artifact digest.
+        out: ./evidence
+        push: ghcr.io/nvidia/aicr-evidence/h100-aks-ubuntu-training-kubeflow


### PR DESCRIPTION
## Summary

Completes the Azure AKS UAT pipeline started in #1709 (2/2): the phase runner (`tests/uat/azure/run`), the per-intent AICRConfig pair (`h100-{training,inference}-config.yaml`), and the `install` step re-widened to 90m now that the readiness gate can keep the federated az session alive mid-phase.

## Motivation / Context

PR #1709 shipped the account federation, dispatch surface, and pipeline; the burn-in path (provision → connect → destroy) is green on main as of run 29122546423. This PR adds what a full (non-`skip_tests`) run needs.

The runner is a port of the AWS/GCP siblings (byte-identical there apart from comments) with one Azure-only addition: a federated az session cannot self-refresh (5-minute OIDC assertion, ~60–75m access tokens — the AADSTS700024 failure diagnosed during burn-in), and the post-install readiness gate can outlive one token. The gate therefore re-logins in-loop every `AZ_RELOGIN_INTERVAL_SECONDS` (25m): mint a fresh `ACTIONS_ID_TOKEN`, `az login --federated-token`, then eagerly warm the AKS-audience token (the assertion is only 5-minute valid, so the mint cannot be deferred to kubelogin's next cache miss). Transient re-login failures warn and retry rather than killing the gate.

The configs codify the manually validated AKS commands (aicr-test5): system components on the `cpu-worker` pool (the AKS system pool carries `CriticalAddonsOnly`), GPU toleration `nvidia.com/gpu=present:NoSchedule` only. Deliberately no value overrides — the toolkit `RUNTIME_CONFIG_SOURCE` env is baked into `values-aks.yaml` (#1689), and the empty `agentgateway:allowedSourceRanges` receives the bundler's RFC1918 injection (#1373), sufficient because `phase_serve` reaches the endpoint via `kubectl port-forward`, never the LoadBalancer. The NVIDIA-egress override from the manual validation is a human/VPN concern, documented in the inference config.

Fixes: N/A
Related: #1709, #1275, #1276

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT pipeline (`tests/uat/azure/`, `.github/workflows/uat-azure.yaml`)

## Implementation Notes

- `azure-h100` stays `nightly-intents: []` (bring-up, manual dispatch only) until a green manual full run; flipping it is a follow-up one-liner in `infra/uat/reservations.yaml`.
- Runner divergence from siblings is limited to the re-login machinery and three cloud-specific comments — kept diffable on purpose.

## Testing

```bash
bash -n tests/uat/azure/run && shellcheck -x tests/uat/azure/run   # clean
yamllint -c .yamllint.yaml tests/uat/azure/tests/*.yaml .github/workflows/uat-azure.yaml  # clean
actionlint .github/workflows/uat-azure.yaml  # no new findings
```

- Local end-to-end smoke of both configs against a freshly built `aicr`: `recipe --config` resolves (training: 13 components, inference: 16) and `bundle --config` renders; the inference bundle's rendered gateway carries the RFC1918 `loadBalancerSourceRanges` and the gpu-operator values carry `RUNTIME_CONFIG_SOURCE` — matching the validated manual bundles without overrides.
- No Go changes; coverage gate N/A.
- Post-merge: manual `uat-run` dispatch (full run, no `skip_tests`) is the acceptance test before nightly enrollment.

## Risk Assessment

- [x] **Low** — Additive files plus a timeout widening; the burn-in path is unaffected, and a revert restores the 60m cap.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — no Go changes
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — CI tooling; validated by dispatch)
- [x] I updated docs if user-facing behavior changed (N/A — contributor docs already describe the per-intent config contract)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (git commit -S)
