### PR TITLE
fix(evidence): propagate CNCF section failures

### DIFF
--- a/docs/conformance/cncf/index.md
+++ b/docs/conformance/cncf/index.md
@@ -95,6 +95,14 @@ names are `dra`, `gang`, `secure`, `accelerator-metrics`, `service-metrics`,
 > type (NIM inference, Dynamo inference, or Kubeflow training) and collects
 > appropriate metrics and operator evidence.
 
+Each section writes exactly one **PASS**, **SKIP**, or **FAIL** verdict.
+**SKIP** marks an absent optional prerequisite (no inference gateway, no
+supported operator, an unsupported cluster-autoscaling provider, or an
+operator present with no workload to reconcile) and is not a failure. A
+**FAIL** — an unhealthy present capability, a failed query, or a missing/
+malformed verdict — fails closed and makes the collection exit non-zero, so a
+recorded section failure is no longer masked as overall success.
+
 ### Two Modes
 
 | | `aicr validate --phase conformance` | `--cncf-submission` |

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -536,6 +536,22 @@ Valid feature names (from `pkg/evidence/cncf/collector.go`):
 | `pod-autoscaling` | HPA-driven pod autoscaling: external GPU metric + behavioral scale-up/down test (pod-scoped custom metrics collected best-effort — absent for DRA-allocated GPUs, not a failure) |
 | `cluster-autoscaling` | Karpenter (preferred) or EKS managed node-group autoscaling fallback |
 
+### Evidence verdicts and exit status
+
+Each collected feature records exactly one verdict in its evidence file:
+
+- **PASS** — the capability was exercised and behaved as expected.
+- **SKIP** — an optional prerequisite is absent (e.g. no inference gateway,
+  no supported operator, an unsupported cluster-autoscaling provider, or an
+  operator that is installed but has no workload to reconcile). A SKIP is not
+  a failure.
+- **FAIL** — a present capability was unhealthy, a required query failed, or
+  the evidence file carried no single valid verdict (fail closed).
+
+A **FAIL** in any feature makes `--cncf-submission` exit non-zero, so a
+submission that records a genuine failure no longer reports overall success.
+Absent optional prerequisites remain successful SKIPs and do not fail the run.
+
 ## Emitting recipe evidence
 
 When a recipe PR targets hardware AICR maintainers cannot independently

--- a/pkg/evidence/cncf/result_propagation_test.go
+++ b/pkg/evidence/cncf/result_propagation_test.go
@@ -1,0 +1,481 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cncf
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+const resultPropagationHarness = `#!/usr/bin/env bash
+source "${SCRIPT_DIR}/collect-evidence.sh"
+
+kubectl() {
+    [ "${1:-}" = "cluster-info" ]
+}
+
+detect_cluster_info() {
+    CLUSTER_DESC="test-cluster"
+    CLUSTER_K8S_VERSION="v1.test"
+    CLUSTER_PLATFORM="linux/amd64"
+    CLUSTER_OS_IMAGE="test-os"
+}
+
+mode="fixture"
+if [ -f "${SCRIPT_DIR}/mode" ]; then
+    IFS= read -r mode < "${SCRIPT_DIR}/mode"
+fi
+
+case "${mode}" in
+    fixture)
+        collect_gateway() {
+            if [ -f "${SCRIPT_DIR}/fixture.md" ]; then
+                cp "${SCRIPT_DIR}/fixture.md" "${EVIDENCE_DIR}/inference-gateway.md"
+            fi
+            if [ -f "${SCRIPT_DIR}/collector-fail" ]; then
+                return 7
+            fi
+            return 0
+        }
+        SECTION="gateway"
+        ;;
+    gateway-absent)
+        SECTION="gateway"
+        ;;
+    operator-absent)
+        SECTION="operator"
+        ;;
+    operator-dynamo-no-dgd)
+        # Dynamo operator is installed but no DynamoGraphDeployment exists and the
+        # DGD query itself succeeds: an absent inference workload is an absent
+        # prerequisite (SKIP), not a failure.
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *"dynamo-platform-dynamo-operator-controller-manager"*) echo "dynamo-operator 1/1" ;;
+                *" dynamographdeployments "*) return 0 ;;
+            esac
+            return 0
+        }
+        SECTION="operator"
+        ;;
+    operator-dynamo-query-failed)
+        # Dynamo operator is installed but the DGD query fails: preserve the
+        # fail-closed behavior instead of treating the failed query as zero rows.
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *"dynamo-platform-dynamo-operator-controller-manager"*) echo "dynamo-operator 1/1" ;;
+                *" dynamographdeployments "*) return 1 ;;
+            esac
+            return 0
+        }
+        SECTION="operator"
+        ;;
+    autoscaler-absent)
+        SECTION="cluster-autoscaling"
+        ;;
+    dynamo-unhealthy)
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *" --no-headers "*) echo "dynamo-worker Pending" ;;
+            esac
+            return 0
+        }
+        sleep() { return 0; }
+        collect_service_metrics() {
+            EVIDENCE_FILE="${EVIDENCE_DIR}/ai-service-metrics.md"
+            collect_service_metrics_dynamo
+        }
+        SECTION="service-metrics"
+        ;;
+    nim-unhealthy)
+        collect_service_metrics() {
+            EVIDENCE_FILE="${EVIDENCE_DIR}/ai-service-metrics.md"
+            collect_service_metrics_nim
+        }
+        SECTION="service-metrics"
+        ;;
+    dynamo-prometheus-unavailable)
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            if [[ "$*" == *"component-type=worker"* && "$*" == *"--field-selector=status.phase=Running"* ]]; then
+                echo "worker"
+            elif [[ "$*" == *"component-type=frontend"* && "$*" == *"--field-selector=status.phase=Running"* ]]; then
+                echo "frontend"
+            elif [[ " $* " == *" --no-headers "* ]]; then
+                echo "dynamo-worker Running"
+            elif [[ " $* " == *" port-forward "* ]]; then
+                return 1
+            fi
+            return 0
+        }
+        sleep() { return 0; }
+        wait_for_port() { return 1; }
+        collect_service_metrics() {
+            EVIDENCE_FILE="${EVIDENCE_DIR}/ai-service-metrics.md"
+            collect_service_metrics_dynamo
+        }
+        SECTION="service-metrics"
+        ;;
+    trainer-prometheus-unavailable)
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            if [[ "$*" == *"jsonpath={.status.phase}"* ]]; then
+                echo "Running"
+            elif [[ " $* " == *" port-forward "* ]]; then
+                return 1
+            fi
+            return 0
+        }
+        sleep() { return 0; }
+        wait_for_port() { return 1; }
+        collect_service_metrics() {
+            EVIDENCE_FILE="${EVIDENCE_DIR}/ai-service-metrics.md"
+            collect_service_metrics_trainer
+        }
+        SECTION="service-metrics"
+        ;;
+    *)
+        echo "unknown test mode: ${mode}" >&2
+        exit 2
+        ;;
+esac
+
+main_rc=0
+main || main_rc=$?
+{
+    printf '%b' "${CHECK_RESULTS}"
+    printf 'main_rc:%s\n' "${main_rc}"
+} > "${SCRIPT_DIR}/result.txt"
+exit "${main_rc}"
+`
+
+// TestEvidenceResultPropagatesThroughCollector executes the shipped evidence
+// script in a subprocess while replacing only the cluster-facing functions.
+// This covers the complete result path without a Kubernetes cluster or GPU:
+// markdown verdict parsing, main's summary/exit decision, and runSection's
+// conversion of a nonzero script exit into a collector error.
+func TestEvidenceResultPropagatesThroughCollector(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("bash not available; skipping evidence result subprocess test")
+	}
+
+	tests := []struct {
+		name           string
+		mode           string
+		displayName    string
+		fixture        string
+		writeFixture   bool
+		collectorFails bool
+		staleOutput    bool
+		wantStatus     string
+		wantEvidence   string
+		// singleVerdictFile, when set, is an evidence artifact (relative to the
+		// evidence dir) that must contain exactly one column-zero "**Result:"
+		// verdict line — the invariant evidence_result relies on. Only set for
+		// section collectors that emit their own verdict, not for injected
+		// fixtures that deliberately carry zero or multiple verdicts.
+		singleVerdictFile string
+		wantErr           bool
+	}{
+		{
+			name:         "pass",
+			fixture:      "# Evidence\n\n**Result: PASS** — checks passed\n",
+			writeFixture: true,
+			wantStatus:   "PASS",
+		},
+		{
+			name:         "partial pass preserves pass semantics",
+			fixture:      "# Evidence\n\n**Result: PASS (partial)** — partial evidence accepted\n",
+			writeFixture: true,
+			wantStatus:   "PASS",
+		},
+		{
+			name:         "explicit skip",
+			fixture:      "# Evidence\n\n**Result: SKIP** — optional prerequisite absent\n",
+			writeFixture: true,
+			wantStatus:   "SKIP",
+		},
+		{
+			name:              "absent gateway emits explicit skip",
+			mode:              "gateway-absent",
+			displayName:       "Inference Gateway",
+			wantStatus:        "SKIP",
+			singleVerdictFile: "inference-gateway.md",
+		},
+		{
+			name:              "absent operator emits explicit skip",
+			mode:              "operator-absent",
+			displayName:       "Robust AI Operator",
+			wantStatus:        "SKIP",
+			singleVerdictFile: "robust-operator.md",
+		},
+		{
+			name:              "present operator without DynamoGraphDeployment skips",
+			mode:              "operator-dynamo-no-dgd",
+			displayName:       "Robust AI Operator",
+			wantStatus:        "SKIP",
+			singleVerdictFile: "robust-operator.md",
+		},
+		{
+			name:              "operator DGD query failure fails closed",
+			mode:              "operator-dynamo-query-failed",
+			displayName:       "Robust AI Operator",
+			wantStatus:        "FAIL",
+			singleVerdictFile: "robust-operator.md",
+			wantErr:           true,
+		},
+		{
+			name:              "absent autoscaler emits explicit skip",
+			mode:              "autoscaler-absent",
+			displayName:       "Cluster Autoscaling",
+			wantStatus:        "SKIP",
+			singleVerdictFile: "cluster-autoscaling.md",
+		},
+		{
+			name: "fail is not masked by overview prose",
+			fixture: "# Evidence\n\n## Summary\n\n" +
+				"6. **Result: PASS**\n\n**Result: FAIL** — live check failed\n",
+			writeFixture: true,
+			wantStatus:   "FAIL",
+			wantErr:      true,
+		},
+		{
+			name:       "missing file fails closed",
+			wantStatus: "FAIL",
+			wantErr:    true,
+		},
+		{
+			name:        "stale result is removed before missing-file failure",
+			staleOutput: true,
+			wantStatus:  "FAIL",
+			wantErr:     true,
+		},
+		{
+			name:         "missing verdict fails closed",
+			fixture:      "# Evidence\n\nChecks ended without a verdict.\n",
+			writeFixture: true,
+			wantStatus:   "FAIL",
+			wantErr:      true,
+		},
+		{
+			name:         "unknown verdict fails closed",
+			fixture:      "# Evidence\n\n**Result: UNKNOWN**\n",
+			writeFixture: true,
+			wantStatus:   "FAIL",
+			wantErr:      true,
+		},
+		{
+			name: "valid plus unknown verdict fails closed",
+			fixture: "# Evidence\n\n**Result: PASS**\n" +
+				"**Result: UNKNOWN**\n",
+			writeFixture: true,
+			wantStatus:   "FAIL",
+			wantErr:      true,
+		},
+		{
+			name:         "malformed verdict fails closed",
+			fixture:      "# Evidence\n\n**Result: PASS** unexpected trailing text\n",
+			writeFixture: true,
+			wantStatus:   "FAIL",
+			wantErr:      true,
+		},
+		{
+			name: "multiple verdicts fail closed",
+			fixture: "# Evidence\n\n**Result: PASS**\n" +
+				"**Result: SKIP** — conflicting verdict\n",
+			writeFixture: true,
+			wantStatus:   "FAIL",
+			wantErr:      true,
+		},
+		{
+			name:           "collector subprocess failure overrides pass",
+			fixture:        "# Evidence\n\n**Result: PASS**\n",
+			writeFixture:   true,
+			collectorFails: true,
+			wantStatus:     "FAIL",
+			wantErr:        true,
+		},
+		{
+			name:              "present but unhealthy Dynamo is fail",
+			mode:              "dynamo-unhealthy",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+		{
+			name:              "present but unhealthy NIM is fail",
+			mode:              "nim-unhealthy",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+		{
+			name:              "Dynamo Prometheus connection failure is explicit fail",
+			mode:              "dynamo-prometheus-unavailable",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			wantEvidence:      "**Result: FAIL** — Could not connect to Prometheus.",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+		{
+			name:              "trainer Prometheus connection failure is explicit fail",
+			mode:              "trainer-prometheus-unavailable",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			wantEvidence:      "**Result: FAIL** — Could not connect to Prometheus.",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			outputDir := filepath.Join(dir, "evidence")
+			if err := os.MkdirAll(outputDir, 0o755); err != nil {
+				t.Fatalf("create output directory: %v", err)
+			}
+
+			libraryPath := filepath.Join(dir, "collect-evidence.sh")
+			if err := os.WriteFile(libraryPath, collectScript, 0o700); err != nil { //nolint:gosec // test script needs execute permission
+				t.Fatalf("write embedded evidence script: %v", err)
+			}
+			harnessPath := filepath.Join(dir, "result-harness.sh")
+			if err := os.WriteFile(harnessPath, []byte(resultPropagationHarness), 0o700); err != nil { //nolint:gosec // test harness needs execute permission
+				t.Fatalf("write result harness: %v", err)
+			}
+			if tt.writeFixture {
+				if err := os.WriteFile(filepath.Join(dir, "fixture.md"), []byte(tt.fixture), 0o600); err != nil {
+					t.Fatalf("write evidence fixture: %v", err)
+				}
+			}
+			if tt.mode != "" {
+				if err := os.WriteFile(filepath.Join(dir, "mode"), []byte(tt.mode+"\n"), 0o600); err != nil {
+					t.Fatalf("write harness mode: %v", err)
+				}
+			}
+			if tt.mode == "trainer-prometheus-unavailable" {
+				manifestDir := filepath.Join(dir, "manifests")
+				if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+					t.Fatalf("create manifest directory: %v", err)
+				}
+				manifestPath := filepath.Join(manifestDir, "trainer-pytorch-test.yaml")
+				if err := os.WriteFile(manifestPath, []byte("---\n"), 0o600); err != nil {
+					t.Fatalf("write trainer manifest fixture: %v", err)
+				}
+			}
+			if tt.collectorFails {
+				if err := os.WriteFile(filepath.Join(dir, "collector-fail"), nil, 0o600); err != nil {
+					t.Fatalf("write collector failure marker: %v", err)
+				}
+			}
+			if tt.staleOutput {
+				stale := []byte("# Stale evidence\n\n**Result: PASS**\n")
+				if err := os.WriteFile(filepath.Join(outputDir, "inference-gateway.md"), stale, 0o600); err != nil {
+					t.Fatalf("write stale evidence: %v", err)
+				}
+			}
+
+			collector := NewCollector(outputDir)
+			err := collector.runSection(context.Background(), harnessPath, dir, "result-fixture")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("runSection() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				var structuredErr *errors.StructuredError
+				if !stderrors.As(err, &structuredErr) {
+					t.Fatalf("runSection() error is %T, want *errors.StructuredError", err)
+				}
+				if structuredErr.Code != errors.ErrCodeInternal {
+					t.Errorf("runSection() error code = %s, want %s", structuredErr.Code, errors.ErrCodeInternal)
+				}
+			}
+
+			result, readErr := os.ReadFile(filepath.Join(dir, "result.txt"))
+			if readErr != nil {
+				t.Fatalf("read harness result: %v", readErr)
+			}
+			wantRC := 0
+			if tt.wantErr {
+				wantRC = 1
+			}
+			displayName := tt.displayName
+			if displayName == "" {
+				displayName = "Inference Gateway"
+			}
+			want := displayName + ":" + tt.wantStatus + "\nmain_rc:" + strconv.Itoa(wantRC) + "\n"
+			if got := string(result); got != want {
+				t.Errorf("result = %q, want %q", got, want)
+			}
+			if tt.wantEvidence != "" {
+				evidencePath := filepath.Join(outputDir, "ai-service-metrics.md")
+				evidence, evidenceErr := os.ReadFile(evidencePath)
+				if evidenceErr != nil {
+					t.Fatalf("read evidence artifact: %v", evidenceErr)
+				}
+				if !strings.Contains(string(evidence), tt.wantEvidence) {
+					t.Errorf("evidence does not contain %q", tt.wantEvidence)
+				}
+			}
+			if tt.singleVerdictFile != "" {
+				evidencePath := filepath.Join(outputDir, tt.singleVerdictFile)
+				evidence, evidenceErr := os.ReadFile(evidencePath)
+				if evidenceErr != nil {
+					t.Fatalf("read evidence artifact %s: %v", tt.singleVerdictFile, evidenceErr)
+				}
+				if got := countColumnZeroVerdicts(string(evidence)); got != 1 {
+					t.Errorf("evidence %s has %d column-zero **Result: verdicts, want exactly 1", tt.singleVerdictFile, got)
+				}
+			}
+		})
+	}
+}
+
+// countColumnZeroVerdicts counts lines that begin at column zero with the
+// "**Result:" verdict marker — the same anchoring evidence_result() uses to
+// ignore numbered overview prose. Section collectors must emit exactly one so
+// the parser never fails closed on a healthy check.
+func countColumnZeroVerdicts(evidence string) int {
+	count := 0
+	for _, line := range strings.Split(evidence, "\n") {
+		if strings.HasPrefix(line, "**Result:") {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/evidence/cncf/scripts/collect-evidence.sh
+++ b/pkg/evidence/cncf/scripts/collect-evidence.sh
@@ -120,22 +120,72 @@ wait_for_port() {
 # Format: "name:status" entries separated by newlines.
 CHECK_RESULTS=""
 
+# Parse the single authoritative verdict from an evidence file. Verdict lines
+# begin at column zero so numbered prose such as "6. **Result: PASS**" in a
+# section overview cannot mask the result written after the checks run.
+#
+# Every collector must write exactly one PASS, SKIP, or FAIL verdict. Missing,
+# unknown, or conflicting verdicts fail closed; optional prerequisites are
+# represented by an explicit SKIP in the evidence file.
+evidence_result() {
+    local evidence_path="$1"
+
+    if [ ! -f "${evidence_path}" ]; then
+        return 1
+    fi
+
+    local result_count=0 result_line="" status=""
+    while IFS= read -r line; do
+        case "${line}" in
+            '**Result:'*)
+                result_count=$((result_count + 1))
+                result_line="${line}"
+                ;;
+        esac
+    done < "${evidence_path}"
+
+    if [ "${result_count}" -ne 1 ]; then
+        return 1
+    fi
+
+    status=$(printf '%s\n' "${result_line}" | sed -nE \
+        's/^\*\*Result:[[:space:]]*(PASS|SKIP|FAIL)([[:space:]]+\([^*]+\))?\*\*([[:space:]]+—.*)?[[:space:]]*$/\1/p')
+    if [ -z "${status}" ]; then
+        return 1
+    fi
+
+    echo "${status}"
+}
+
 # Run a collector and record its result based on the evidence file it produces.
 # Usage: run_check "DRA Support" "dra-support" collect_dra
 run_check() {
     local display_name="$1" file_key="$2" collector_fn="$3"
     local evidence_path="${EVIDENCE_DIR}/${file_key}.md"
+    local collector_rc=0 status=""
 
-    "${collector_fn}"
-
-    if [ ! -f "${evidence_path}" ]; then
-        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:SKIP\n"
-    elif grep -q "Result: PASS" "${evidence_path}" 2>/dev/null; then
-        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:PASS\n"
-    elif grep -q "Result: FAIL" "${evidence_path}" 2>/dev/null; then
+    # Do not let an artifact from a prior run satisfy the current check.
+    if ! rm -f "${evidence_path}"; then
+        log_error "Could not remove stale evidence for ${display_name}: ${evidence_path}"
         CHECK_RESULTS="${CHECK_RESULTS}${display_name}:FAIL\n"
+        return 1
+    fi
+
+    "${collector_fn}" || collector_rc=$?
+
+    if [ "${collector_rc}" -ne 0 ]; then
+        log_error "Collector for ${display_name} exited with status ${collector_rc}"
+        status="FAIL"
+    elif ! status=$(evidence_result "${evidence_path}"); then
+        log_error "Evidence for ${display_name} has no single valid PASS/SKIP/FAIL result: ${evidence_path}"
+        status="FAIL"
+    fi
+
+    CHECK_RESULTS="${CHECK_RESULTS}${display_name}:${status}\n"
+    if [ "${status}" = "FAIL" ]; then
+        return 1
     else
-        CHECK_RESULTS="${CHECK_RESULTS}${display_name}:UNKNOWN\n"
+        return 0
     fi
 }
 
@@ -1355,7 +1405,7 @@ EOF
             deployed_dynamo=true
         else
             log_warn "No Dynamo workload running and manifest not found at ${manifest}"
-            echo "**Result: SKIP** — No Dynamo workload found. Deploy vllm-agg.yaml first." >> "${EVIDENCE_FILE}"
+            echo "**Result: SKIP (prerequisite absent)** — no Dynamo workload or deployment manifest was found." >> "${EVIDENCE_FILE}"
             return
         fi
     fi
@@ -1379,8 +1429,8 @@ EOF
     done
 
     if [ "${workload_ready}" != "true" ]; then
-        log_warn "Dynamo workload not ready in ${NS} after 5 minutes, skipping service metrics"
-        echo "**Result: SKIP** — Dynamo workload not ready in ${NS}. Deploy vllm-agg.yaml first." >> "${EVIDENCE_FILE}"
+        log_warn "Dynamo workload not ready in ${NS} after 5 minutes"
+        echo "**Result: FAIL** — Dynamo workload is present but did not become ready in ${NS}." >> "${EVIDENCE_FILE}"
         return
     fi
 
@@ -1538,7 +1588,7 @@ for r in data['data']['result']:
         fi
     else
         echo "" >> "${EVIDENCE_FILE}"
-        echo "**WARNING:** Could not port-forward to Prometheus" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — Could not connect to Prometheus." >> "${EVIDENCE_FILE}"
     fi
     kill "${pf_pid}" 2>/dev/null || true
 
@@ -1583,8 +1633,8 @@ EOF
         --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
 
     if [ -z "${nim_pod}" ]; then
-        log_warn "No running NIM pod found in ${NS}"
-        echo "**Result: SKIP** — No running NIM pod found in ${NS}." >> "${EVIDENCE_FILE}"
+        log_warn "NIM workload is present but has no running pod in ${NS}"
+        echo "**Result: FAIL** — NIM workload is present but has no running pod in ${NS}." >> "${EVIDENCE_FILE}"
         return
     fi
 
@@ -1803,7 +1853,7 @@ EOF
         deployed_training=true
     else
         log_warn "trainer-pytorch-test.yaml not found at ${train_manifest}"
-        echo "**Result: SKIP** — Training manifest not found." >> "${EVIDENCE_FILE}"
+        echo "**Result: SKIP (prerequisite absent)** — training manifest not found." >> "${EVIDENCE_FILE}"
         return
     fi
 
@@ -1943,7 +1993,7 @@ EOF
         fi
     else
         echo "" >> "${EVIDENCE_FILE}"
-        echo "**WARNING:** Could not port-forward to Prometheus" >> "${EVIDENCE_FILE}"
+        echo "**Result: FAIL** — Could not connect to Prometheus." >> "${EVIDENCE_FILE}"
     fi
     kill "${pf_pid}" 2>/dev/null || true
 
@@ -1963,6 +2013,8 @@ collect_gateway() {
 
     # Skip if agentgateway is not installed (training clusters don't have inference gateway)
     if ! kubectl get deploy -n agentgateway-system --no-headers 2>/dev/null | grep -q .; then
+        write_section_header "Inference API Gateway (agentgateway)"
+        echo "**Result: SKIP (prerequisite absent)** — agentgateway is not installed." >> "${EVIDENCE_FILE}"
         log_info "Inference gateway evidence collection skipped — agentgateway not installed."
         return
     fi
@@ -2072,6 +2124,8 @@ collect_operator() {
     elif kubectl get deploy -n kubeflow kubeflow-trainer-controller-manager --no-headers 2>/dev/null | grep -q .; then
         collect_operator_kubeflow
     else
+        write_section_header "Robust AI Operator"
+        echo "**Result: SKIP (prerequisite absent)** — no supported Dynamo, NIM, or Kubeflow Trainer operator is installed." >> "${EVIDENCE_FILE}"
         log_info "Robust operator evidence collection skipped — no supported operator found."
         return
     fi
@@ -2416,23 +2470,33 @@ INVALID_CR
         echo "WARNING: Webhook did not reject the invalid resource." >> "${EVIDENCE_FILE}"
     fi
 
-    # Verdict — require DGD + healthy workload pods; webhook rejection strengthens but is optional
+    # Verdict — require DGD + healthy workload pods; webhook rejection strengthens but is optional.
+    # Distinguish a failed DGD query (fail closed) from a successful query returning
+    # zero rows: an absent inference workload is an absent prerequisite (SKIP), not a
+    # failure, because a stock inference recipe deploys the operator but no persistent
+    # DynamoGraphDeployment (the service-metrics section deploys and cleans up its own).
     echo "" >> "${EVIDENCE_FILE}"
-    local dgd_count
-    dgd_count=$(kubectl get dynamographdeployments -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    local dgd_query_ok=true dgd_count=0 dgd_out
+    if dgd_out=$(kubectl get dynamographdeployments -A --no-headers 2>/dev/null); then
+        dgd_count=$(printf '%s' "${dgd_out}" | grep -c . || true)
+    else
+        dgd_query_ok=false
+    fi
     local running_pods
     running_pods=$(kubectl get pods -n dynamo-workload -l nvidia.com/dynamo-graph-deployment-name --no-headers 2>/dev/null | grep -c "Running" || true)
     local webhook_ok
     webhook_ok=$(echo "${webhook_result}" | grep -ci "denied\|forbidden\|invalid\|error" || true)
 
-    if [ "${dgd_count}" -gt 0 ] && [ "${running_pods}" -gt 0 ] && [ "${webhook_ok}" -gt 0 ]; then
+    if [ "${dgd_query_ok}" != "true" ]; then
+        echo "**Result: FAIL** — DynamoGraphDeployment query failed (fail closed); rerun against a reachable API server." >> "${EVIDENCE_FILE}"
+    elif [ "${dgd_count}" -gt 0 ] && [ "${running_pods}" -gt 0 ] && [ "${webhook_ok}" -gt 0 ]; then
         echo "**Result: PASS** — Dynamo operator running, webhooks operational (rejection verified), CRDs registered, DynamoGraphDeployment reconciled with ${running_pods} healthy workload pod(s)." >> "${EVIDENCE_FILE}"
     elif [ "${dgd_count}" -gt 0 ] && [ "${running_pods}" -gt 0 ]; then
         echo "**Result: PASS** — Dynamo operator running, CRDs registered, DynamoGraphDeployment reconciled with ${running_pods} healthy workload pod(s)." >> "${EVIDENCE_FILE}"
     elif [ "${dgd_count}" -gt 0 ]; then
         echo "**Result: FAIL** — DynamoGraphDeployment found but no healthy workload pods." >> "${EVIDENCE_FILE}"
     else
-        echo "**Result: FAIL** — No DynamoGraphDeployment found." >> "${EVIDENCE_FILE}"
+        echo "**Result: SKIP (prerequisite absent)** — Dynamo operator present but no DynamoGraphDeployment exists; deploy an inference workload (e.g. demos/workloads/inference/vllm-agg.yaml) to exercise operator reconciliation." >> "${EVIDENCE_FILE}"
     fi
 
     log_info "Robust operator evidence collection complete."
@@ -2613,8 +2677,8 @@ autoscaler that manages node pool scaling based on workload demand.
 EOF
         collect_gke_autoscaling_evidence
     else
+        echo "**Result: SKIP (prerequisite absent)** — no supported EKS or GKE cluster-autoscaling prerequisite was detected (providerID=${provider_id:-<empty>})." >> "${EVIDENCE_FILE}"
         log_info "Cluster autoscaling evidence collection skipped — unknown provider (providerID=${provider_id})."
-        rm -f "${EVIDENCE_FILE}"
         return
     fi
 
@@ -2954,15 +3018,22 @@ main() {
     echo ""
     echo "  Total: $((passed + failed + skipped)) | Passed: ${passed} | Failed: ${failed} | Skipped: ${skipped}"
     echo ""
+
+    if [ "${failed}" -ne 0 ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Hidden subcommand for unit tests (pkg/evidence/cncf/claim_shape_test.go):
 # print the version-correct ResourceClaim YAML and exit without contacting a
 # cluster. Not part of the documented section interface.
 # Usage: collect-evidence.sh emit-claim <version> [name] [namespace] [deviceclass]
-if [ "${SECTION}" = "emit-claim" ]; then
-    emit_resourceclaim_yaml "${2:-}" "${3:-gpu-claim}" "${4:-dra-test}" "${5:-gpu.nvidia.com}"
-    exit $?
-fi
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    if [ "${SECTION}" = "emit-claim" ]; then
+        emit_resourceclaim_yaml "${2:-}" "${3:-gpu-claim}" "${4:-dra-test}" "${5:-gpu.nvidia.com}"
+        exit $?
+    fi
 
-main
+    main
+fi


### PR DESCRIPTION
## Summary

Propagate failed CNCF evidence sections to the existing Go collector instead of returning success with failed submission artifacts. Add explicit skip evidence for absent optional prerequisites and fail closed on missing or malformed verdicts.

## Motivation / Context

The evidence script recorded section outcomes only in Markdown, so a genuine `Result: FAIL` never reached `failed_sections` or the CLI exit status. Optional components also need a distinct skip path so stock clusters do not fail simply because an inference gateway, supported operator, or cloud autoscaler is absent.

Fixes: #1692
Related: #1694

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: CNCF evidence collector (`pkg/evidence/cncf`)

## Implementation Notes

Each section must now write exactly one authoritative `PASS`, `SKIP`, or `FAIL` verdict. Stale artifacts are removed before collection, and missing, unknown, conflicting, or malformed verdicts fail closed. Gateway, operator, and unsupported cloud-autoscaler prerequisites emit explicit skip artifacts; present but unhealthy workloads remain failures.

The parser remains compatible with Bash 3.2. A failed section is retained in the summary and makes the script return nonzero, which lets the existing Go collector add it to `failed_sections` without changing the Go interface.

## Testing

```bash
make test
go test -race -count=1 ./pkg/evidence/cncf/...
golangci-lint run ./pkg/evidence/cncf/...
bash -n pkg/evidence/cncf/scripts/collect-evidence.sh
git diff --check HEAD^
```

- `make test`: passed with the race detector; repository coverage 77.9% (75% required).
- Final package race suite: passed; package coverage increased from 69.0% to 70.7%.
- `golangci-lint` 2.12.2: zero issues.
- ShellCheck produced no new diagnostics relative to `main`.
- `make qualify` was not repeated in the pinned Go container because it did not include the repository's external tool suite. The affected final test, lint, syntax, and diff gates above were rerun.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration is required. Automation that previously accepted failed evidence will now receive the intended nonzero result; absent optional prerequisites remain successful skips. One behavior change to note: Prometheus port-forward failure in the Dynamo, NIM, and trainer service-metrics paths now records **Result: FAIL** (previously an uncounted WARNING), so a cluster where Prometheus is unreachable will surface a section failure — confirm submission clusters have a reachable Prometheus. A Dynamo operator present with no DynamoGraphDeployment is treated as SKIP (absent prerequisite), not FAIL.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

