### PR TITLE
fix(recipes): raise nvidia-setup-full resources for EFA DKMS build

### DIFF
--- a/recipes/components/nodewright-customizations/manifests/tuning.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning.yaml
@@ -126,10 +126,17 @@ spec:
       interrupt:
         type: reboot
       resources:
-        cpuLimit: 4000m
-        cpuRequest: 2000m
-        memoryLimit: 8192Mi
-        memoryRequest: 4096Mi
+        # Elevated from 4000m/8192Mi for the EFA DKMS build. efa_installer.sh's
+        # "Inspecting kernel" autoconf is a highly parallel kernel-module build;
+        # inside the skyhook chroot nproc reports the host core count, so make -j
+        # oversubscribes. Under the prior 4 CPU / 8Gi cgroup it was CFS-throttled
+        # and its feature probes were starved/OOM-killed, so efa misdetected the
+        # kernel and emitted compat shims that fail to compile on 6.17. More CPU
+        # and memory headroom lets the probes complete and detect correctly.
+        cpuLimit: 8000m
+        cpuRequest: 4000m
+        memoryLimit: 16384Mi
+        memoryRequest: 8192Mi
       configMap:
         {{- if $cust.service }}
         service: {{ $cust.service }}


### PR DESCRIPTION
## Summary

Raise the `nvidia-setup-full` package's cgroup resources (`cpuLimit 4000m → 8000m`, `cpuRequest 2000m → 4000m`, `memoryLimit 8192Mi → 16384Mi`, `memoryRequest 4096Mi → 8192Mi`) so the EFA DKMS build has enough CPU/memory to complete inside the skyhook pod.

## Motivation / Context

On eks gb200 (and h100) `nvidia-setup-full` runs `efa_installer.sh`, whose "Inspecting kernel" autoconf is a highly parallel kernel-module build. Inside the skyhook chroot `nproc` reports the host core count (~72 on Grace), so `make -j` oversubscribes the pod cgroup. Under the prior **4 CPU / 8Gi** limit the build was CFS-throttled and its feature probes were starved/OOM-killed, so `efa` misdetected the 6.17 kernel and emitted compat shims that fail to compile — the `efa` DKMS build returns error 2 and aborts the whole apply.

Verified on a gb200 node: the same `dkms build -m efa -v 3.1.0 -k 6.17.0-1019-aws-64k` configures in **~3.4s and succeeds unconstrained**, but under a `systemd-run` cgroup matching the pod (`CPUQuota=200% MemoryMax=8G`) it is **killed during kernel inspection**; capping `-j` via `taskset` also fixes it. More CPU/memory headroom lets the probes complete and detect correctly.

Fixes: N/A
Related: NVIDIA/nodewright-packages#94

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — the `nodewright-customizations` tuning manifest

## Implementation Notes

- Only `nvidia-setup-full` is bumped; `nvidia-setup-kernel` is left unchanged (it installs the kernel and reboots, it does not build EFA).
- A durable alternative — capping the EFA build's `-j` to the pod CPU quota inside `nodewright-packages/nvidia-setup` — is worth doing separately so the build can't oversubscribe regardless of the CR limits; this PR raises the ceiling now.

## Testing

```bash
# targeted checks (manifest value-only change)
```

- Confirmed the change targets only `nvidia-setup-full` (kernel package untouched) and that no golden/chainsaw assert pins the resource values.
- Comment + four numeric values only; no template structure changed. The `bundle-templates/nodewright-customizations` chainsaw tests and `make qualify` in CI validate the rendered Skyhook CR.

## Risk Assessment

- [x] **Low** — Isolated manifest change, easy to revert.

**Rollout notes:** takes effect on the next bundle/apply; existing nodes pick it up on re-apply with the higher limits.
