### PR TITLE
feat(validator): configurable inference-perf router mode

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -455,6 +455,7 @@ default** (`Qwen/Qwen3-8B` at 256/GPU). A non-positive / non-integer
 |----------|---------|--------|
 | `AICR_INFERENCE_PERF_CONCURRENCY_PER_GPU` | `256` | Concurrent requests per GPU; total is this × free GPUs on the chosen node. Prefer the per-accelerator `inference-concurrency-per-gpu` recipe constraint over this global knob. |
 | `AICR_INFERENCE_PERF_MODEL` | `Qwen/Qwen3-8B` | Hugging Face model ID to benchmark. Override per accelerator via the `inference-model` recipe constraint. |
+| `AICR_INFERENCE_PERF_ROUTER_MODE` | `least-loaded` | Dynamo frontend routing strategy (`DYN_ROUTER_MODE`): one of `kv`, `round-robin`, `random`, `power-of-two`, `least-loaded`, `device-aware-weighted` (upstream's `direct` is excluded — it needs per-request worker IDs the benchmark never sends). Lets a characterization run A/B strategies without rebuilding the image. Consumed only when `inference-routing-mode` is `dynamo-router`; in `gateway-epp` mode the EPP selects endpoints and the value is unused. A **set** value is validated in either mode — an unknown value fails closed with `ErrCodeInvalidRequest` rather than being silently ignored (the routing mode is a recipe decision, so a typo must not pass under one recipe and abort under another). |
 | `AICR_INFERENCE_PERF_WORKLOAD_READY_TIMEOUT` | `10m` | Wait for the `DynamoGraphDeployment` to become ready (image pull + model load + worker health). Large models load slower — raise this **and** the catalog entry's `timeout` in tandem, or the parent deadline caps it. |
 | `AICR_INFERENCE_PERF_HEALTH_TIMEOUT` | `5m` | Wait for the endpoint to serve a real chat-completion *after* the workload reports Ready. Concurrent first-load from one RWO cache PVC can push first-serve past 5m; raise it (bounded by the catalog `timeout`). |
 | `AICR_INFERENCE_PERF_MODEL_CACHE_SIZE` | `100Gi` (on) | The PVC-backed model-weights cache is **on by default**. Set a different K8s quantity to resize, or a disable sentinel (`off`/`0`/`none`/`disabled`) to turn it off and download from HF directly. |
@@ -517,8 +518,9 @@ run-to-run TTFT fluctuation (see NVIDIA/aicr#1192):
   counts (stddev 0), a pinned prompt pool, and greedy decoding
   (`temperature: 0`). Input determinism stabilizes *throughput*; it does not
   remove system-side p99 jitter at the knee.
-- **Routing matters.** The inference-perf workload uses Dynamo's load-aware
-  least-loaded router (`DYN_ROUTER_MODE=least-loaded`), which balances by each
+- **Routing matters.** The inference-perf workload defaults to Dynamo's
+  load-aware least-loaded router (`DYN_ROUTER_MODE=least-loaded`; override via
+  the `AICR_INFERENCE_PERF_ROUTER_MODE` knob above), which balances by each
   worker's active in-flight load so a transiently-slow worker stops receiving
   its full share — mitigating the stochastic EKS H100 worker-stall / throughput
   degradation at the saturation knee (issue #1197). Frontend-to-worker

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -123,6 +123,10 @@ validators:
     #   AICR_INFERENCE_PERF_INPUT_TOKENS_MEAN        (default 128)
     #   AICR_INFERENCE_PERF_OUTPUT_TOKENS_MEAN       (default 128)
     #   AICR_INFERENCE_PERF_MODEL                    (default Qwen/Qwen3-8B; HF model ID)
+    #   AICR_INFERENCE_PERF_ROUTER_MODE              (default least-loaded; Dynamo frontend
+    #     DYN_ROUTER_MODE for the benchmark workload: kv, round-robin, random, power-of-two,
+    #     least-loaded, or device-aware-weighted. Consumed only in dynamo-router routing mode;
+    #     a set value is validated in either mode and an unknown value fails closed.)
     #   AICR_INFERENCE_PERF_WORKLOAD_READY_TIMEOUT   (default 10m; Go duration. Large models
     #     load slower — raise this AND the `timeout` field above in tandem, since the parent
     #     check deadline derives from `timeout`.)

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -172,6 +172,19 @@ const (
 	// knob it is bounded by the parent check deadline (AICR_CHECK_TIMEOUT, from
 	// the catalog entry's `timeout`), which must be raised in tandem.
 	envHealthTimeout = "AICR_INFERENCE_PERF_HEALTH_TIMEOUT"
+	// envRouterMode overrides the Dynamo frontend routing strategy
+	// (DYN_ROUTER_MODE) the benchmark workload runs with, for characterizing
+	// alternative strategies without rebuilding the validator image (issue
+	// #1374). Default dynRouterModeDefault (least-loaded, see issue #1197);
+	// validated against the Dynamo frontend enum by resolveRouterMode, failing
+	// closed with ErrCodeInvalidRequest on a typo. Only CONSUMED on the
+	// `dynamo-router` routing path — in `gateway-epp` mode the EPP performs
+	// endpoint selection and the worker frontend sidecars run in direct mode.
+	// A set value is still VALIDATED in either mode (validatePerfTuningEnvs):
+	// the routing mode comes from the recipe, not from whoever set this env,
+	// so mode-gated validation would let the same typo pass silently under one
+	// recipe and abort under another. Set-but-invalid always fails closed.
+	envRouterMode = "AICR_INFERENCE_PERF_ROUTER_MODE"
 
 	// perfConstraintModel / perfConstraintConcurrency / perfConstraintRoutingMode
 	// name recipe performance.constraints entries that configure the benchmark
@@ -264,6 +277,40 @@ const (
 	inferenceRoutingModeGatewayEPP   inferenceRoutingMode = "gateway-epp"
 )
 
+// dynRouterModeDefault is the Dynamo frontend routing strategy interpolated
+// into the deployment template as ${ROUTER_MODE}. Least-loaded balances by
+// each worker's active in-flight load rather than KV-overlap, so a
+// transiently-slow worker stops receiving its full share — mitigating the
+// stochastic EKS H100 worker-stall at the saturation knee (issue #1197).
+// Override via AICR_INFERENCE_PERF_ROUTER_MODE (issue #1374).
+const dynRouterModeDefault = "least-loaded"
+
+// dynRouterModes is the curated subset of the upstream DYN_ROUTER_MODE
+// choices (Dynamo v1.2.1 router_args.py) that the benchmark supports; the
+// order here is the order shown in the resolveRouterMode error message.
+// Upstream's `direct` mode is deliberately excluded: it requires an
+// externally supplied worker ID per request, and AICR's AIPerf invocation
+// sends no routing hints — the workload would deploy and then fail opaquely
+// mid-run. resolveRouterMode fails closed on anything outside this list so a
+// catalog/env typo surfaces up front instead of minutes into the run.
+var dynRouterModes = []string{
+	"kv",
+	"round-robin",
+	"random",
+	"power-of-two",
+	"least-loaded",
+	"device-aware-weighted",
+}
+
+// dynRouterModeSet is the lookup form of dynRouterModes.
+var dynRouterModeSet = func() map[string]bool {
+	s := make(map[string]bool, len(dynRouterModes))
+	for _, m := range dynRouterModes {
+		s[m] = true
+	}
+	return s
+}()
+
 // GVRs for Dynamo, KAI Scheduler, and Gateway API resources.
 var (
 	dynamoDeploymentGVR = schema.GroupVersionResource{
@@ -337,6 +384,7 @@ type inferenceWorkloadConfig struct {
 	modelCacheSize         string // PVC size (e.g. "100Gi") enabling the model-weights cache; empty = disabled
 	modelCacheStorageClass string // StorageClass for the cache PVC; empty = cluster default
 	routingMode            inferenceRoutingMode
+	routerMode             string // Dynamo frontend DYN_ROUTER_MODE (dynamo-router path only); env > default (see resolveRouterMode)
 
 	// gpuAllocMode is the cluster's detected GPU allocation capability
 	// (allocmode.Detect), probed once per run. Carried for evidence output
@@ -683,6 +731,11 @@ func buildInferenceConfig(ctx *validators.Context, mode *allocmode.Mode) (*infer
 		return nil, err
 	}
 
+	routerMode, err := resolveRouterMode()
+	if err != nil {
+		return nil, err
+	}
+
 	runID := deriveRunID()
 	config := &inferenceWorkloadConfig{
 		runID:                  runID,
@@ -695,6 +748,7 @@ func buildInferenceConfig(ctx *validators.Context, mode *allocmode.Mode) (*infer
 		modelCacheSize:         cacheSize,
 		modelCacheStorageClass: strings.TrimSpace(os.Getenv(envModelCacheStorageClass)),
 		routingMode:            routingMode,
+		routerMode:             routerMode,
 		gpuAllocMode:           mode,
 		draWorkerWiring:        draWiring,
 	}
@@ -1570,6 +1624,7 @@ func deployInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadC
 	templateData := map[string]string{
 		"NAMESPACE":           config.namespace,
 		"MODEL":               config.model,
+		"ROUTER_MODE":         config.routerMode,
 		"GPU_COUNT":           strconv.Itoa(config.gpuCount),
 		"DEPLOYMENT_NAME":     inferenceDeploymentName,
 		"QUEUE_NAME":          inferenceQueueName,
@@ -1607,7 +1662,8 @@ func deployInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadC
 		return errors.Wrap(errors.ErrCodeInternal, "failed to apply DynamoGraphDeployment", err)
 	}
 	slog.Info("Applied DynamoGraphDeployment",
-		"name", inferenceDeploymentName, "gpuWorkers", config.gpuCount)
+		"name", inferenceDeploymentName, "gpuWorkers", config.gpuCount,
+		"routingMode", config.routingMode, "routerMode", config.routerMode)
 
 	// Wait for the deployment to become ready.
 	if err := waitForDynamoDeploymentReady(ctx, config); err != nil {
@@ -2618,6 +2674,29 @@ func getOwnPullSecrets(ctx *validators.Context) []v1.LocalObjectReference {
 	return out
 }
 
+// resolveRouterMode returns the Dynamo frontend routing strategy
+// (DYN_ROUTER_MODE) for the benchmark workload: AICR_INFERENCE_PERF_ROUTER_MODE
+// when set (trimmed), else dynRouterModeDefault. The value is validated
+// against the Dynamo frontend enum (dynRouterModes) and fails closed with
+// ErrCodeInvalidRequest on anything else — an unknown mode would otherwise
+// surface as an opaque frontend failure minutes into the run. The value is
+// CONSUMED only on the dynamo-router path — the gateway-epp template carries
+// no ${ROUTER_MODE} placeholder (worker sidecars run in direct mode there) —
+// but this resolver also runs in upfront validation (validatePerfTuningEnvs)
+// in either mode, so a set-but-invalid value fails closed even under
+// gateway-epp (see envRouterMode for why validation is not mode-gated).
+func resolveRouterMode() (string, error) {
+	raw := strings.TrimSpace(os.Getenv(envRouterMode))
+	if raw == "" {
+		return dynRouterModeDefault, nil
+	}
+	if !dynRouterModeSet[raw] {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s %q: must be one of %s", envRouterMode, raw, strings.Join(dynRouterModes, ", ")))
+	}
+	return raw, nil
+}
+
 // resolveInferenceModel returns the Hugging Face model ID used for the
 // benchmark. Override via AICR_INFERENCE_PERF_MODEL to characterize a larger
 // model (e.g., Qwen/Qwen3-32B) without rebuilding the validator image; unset or
@@ -2664,9 +2743,10 @@ func resolveModel(ctx *validators.Context) string {
 
 // resolveRoutingMode returns where routing decisions are made for the
 // benchmark workload. The default `dynamo-router` mode keeps routing in the
-// Dynamo frontend, which uses load-aware least-loaded routing
-// (DYN_ROUTER_MODE=least-loaded) — see the deployment template and issue
-// #1197. `gateway-epp` switches to Gateway API Inference Extension: EPP
+// Dynamo frontend, whose strategy defaults to load-aware least-loaded routing
+// (DYN_ROUTER_MODE, overridable via AICR_INFERENCE_PERF_ROUTER_MODE — see
+// resolveRouterMode, the deployment template, and issues #1197/#1374).
+// `gateway-epp` switches to Gateway API Inference Extension: EPP
 // performs KV-aware endpoint selection and worker frontend sidecars run in
 // direct mode so they honor EPP's routing headers. The sidecars do not relay
 // local vLLM ZMQ KV events onto NATS; that relay is handled by the worker
@@ -2772,6 +2852,9 @@ func validatePerfTuningEnvs() error {
 		return err
 	}
 	if _, _, err := parseModelCacheSize(os.Getenv(envModelCacheSize)); err != nil {
+		return err
+	}
+	if _, err := resolveRouterMode(); err != nil {
 		return err
 	}
 	return nil

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -772,6 +772,7 @@ func TestParseDynamoTemplate_ScalarModelStaysString(t *testing.T) {
 			obj, err := parseYAMLTemplate(deployPath, map[string]string{
 				"NAMESPACE":       "aicr-test",
 				"MODEL":           model,
+				"ROUTER_MODE":     dynRouterModeDefault,
 				"GPU_COUNT":       "1",
 				"DEPLOYMENT_NAME": "aicr-inference",
 			})
@@ -800,6 +801,35 @@ func TestParseDynamoTemplate_ScalarModelStaysString(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseDynamoTemplate_RouterModeSubstituted guards the ${ROUTER_MODE}
+// placeholder in testdata/inference/dynamo-deployment.yaml: the Frontend's
+// DYN_ROUTER_MODE env must carry the resolved strategy verbatim. If someone
+// hardcodes the value again (dropping the placeholder), this fails.
+func TestParseDynamoTemplate_RouterModeSubstituted(t *testing.T) {
+	deployPath := filepath.Join("testdata", "inference", "dynamo-deployment.yaml")
+	obj, err := parseYAMLTemplate(deployPath, map[string]string{
+		"NAMESPACE":       "aicr-test",
+		"MODEL":           "Qwen/Qwen3-8B",
+		"ROUTER_MODE":     "kv",
+		"GPU_COUNT":       "1",
+		"DEPLOYMENT_NAME": "aicr-inference",
+	})
+	if err != nil {
+		t.Fatalf("parseYAMLTemplate() error: %v", err)
+	}
+	envs := componentContainerEnv(t, obj, "Frontend", mainContainerName)
+	for _, e := range envs {
+		m, ok := e.(map[string]interface{})
+		if ok && m["name"] == "DYN_ROUTER_MODE" {
+			if got := m["value"]; got != "kv" {
+				t.Errorf("DYN_ROUTER_MODE = %v, want %q", got, "kv")
+			}
+			return
+		}
+	}
+	t.Fatal("DYN_ROUTER_MODE env not found in Frontend envs")
 }
 
 func componentContainerEnv(t *testing.T, obj *unstructured.Unstructured, componentName, containerName string) []interface{} {
@@ -975,6 +1005,7 @@ func clearTuningEnvs(t *testing.T) {
 		envConcurrencyPerGPU, envWarmupPerConcurrency, envMinRequests,
 		envRequestsPerConcurrency, envInputTokensMean, envOutputTokensMean,
 		envModel, envWorkloadReadyTimeout, envHealthTimeout, envModelCacheSize,
+		envRouterMode,
 	} {
 		t.Setenv(e, "")
 	}
@@ -1173,6 +1204,68 @@ func TestValidatePerfTuningEnvs(t *testing.T) {
 			t.Errorf("unexpected error for valid cache size: %v", err)
 		}
 	})
+	t.Run("unknown router mode → ErrCodeInvalidRequest", func(t *testing.T) {
+		clearTuningEnvs(t)
+		t.Setenv(envRouterMode, "fastest") // not a Dynamo frontend strategy
+		err := validatePerfTuningEnvs()
+		if err == nil {
+			t.Fatal("expected an error for an unknown router-mode knob")
+		}
+		if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+			t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+		}
+	})
+	t.Run("valid router mode → ok", func(t *testing.T) {
+		clearTuningEnvs(t)
+		t.Setenv(envRouterMode, "kv")
+		if err := validatePerfTuningEnvs(); err != nil {
+			t.Errorf("unexpected error for valid router mode: %v", err)
+		}
+	})
+}
+
+// TestResolveRouterMode verifies the DYN_ROUTER_MODE knob: unset/empty/
+// whitespace falls back to the least-loaded default, every Dynamo frontend
+// strategy is accepted (trimmed), and anything else fails closed with
+// ErrCodeInvalidRequest so a catalog/env typo aborts before deploy.
+func TestResolveRouterMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		want    string
+		wantErr bool
+	}{
+		{"unset → default", "", dynRouterModeDefault, false},
+		{"whitespace → default", "   ", dynRouterModeDefault, false},
+		{"kv", "kv", "kv", false},
+		{"round-robin", "round-robin", "round-robin", false},
+		{"random", "random", "random", false},
+		{"power-of-two", "power-of-two", "power-of-two", false},
+		{"least-loaded", "least-loaded", "least-loaded", false},
+		{"device-aware-weighted", "device-aware-weighted", "device-aware-weighted", false},
+		{"trimmed", "  kv  ", "kv", false},
+		{"unknown → error", "fastest", "", true},
+		{"direct excluded → error", "direct", "", true},
+		{"case-sensitive → error", "KV", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envRouterMode, tt.val)
+			got, err := resolveRouterMode()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveRouterMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resolveRouterMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 // TestResolveInferenceModel verifies the model knob: unset/empty/whitespace

--- a/validators/performance/testdata/inference/dynamo-deployment.yaml
+++ b/validators/performance/testdata/inference/dynamo-deployment.yaml
@@ -52,15 +52,18 @@ spec:
                   # boolean-like name that passes validateModelID) parses as a
                   # string, not int/bool/null, after ${MODEL} substitution.
                   value: "${MODEL}"
-                # Least-loaded routing balances by each worker's active
-                # in-flight load rather than KV-overlap, so a transiently-slow
-                # worker stops receiving its full share. This mitigates the
-                # stochastic EKS H100 worker-stall / throughput degradation at
-                # the saturation knee (see issue #1197): capacity-blind and
-                # KV-overlap routing both let a backed-up worker accumulate
-                # requests, spiking TTFT p99 to 4-77s.
+                # Routing strategy for the Dynamo frontend, substituted from
+                # AICR_INFERENCE_PERF_ROUTER_MODE (default least-loaded, enum
+                # validated by resolveRouterMode; issue #1374). Least-loaded
+                # balances by each worker's active in-flight load rather than
+                # KV-overlap, so a transiently-slow worker stops receiving its
+                # full share. This mitigates the stochastic EKS H100
+                # worker-stall / throughput degradation at the saturation knee
+                # (see issue #1197): capacity-blind and KV-overlap routing both
+                # let a backed-up worker accumulate requests, spiking TTFT p99
+                # to 4-77s.
                 - name: DYN_ROUTER_MODE
-                  value: least-loaded
+                  value: ${ROUTER_MODE}
                 - name: HF_TOKEN
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Summary

Adds `AICR_INFERENCE_PERF_ROUTER_MODE` so the inference-perf validator's Dynamo frontend routing strategy (`DYN_ROUTER_MODE`) can be selected per run — replacing the hardcoded value in the deployment template — following the existing `AICR_INFERENCE_PERF_*` methodology-knob pattern.

## Motivation / Context

Dynamo v1.2 ships several frontend routing strategies (`kv`, `round-robin`, `random`, `power-of-two`, `least-loaded`, `device-aware-weighted`; upstream's `direct` is deliberately excluded — it needs per-request worker IDs the benchmark never sends), but the benchmark workload's strategy was compiled into the validator image, so characterizing an alternative required an image rebuild. The default remains `least-loaded` (the shipped default since #1399 / #1197); this knob only changes how a characterization run can deviate from it.

Fixes: #1374
Related: #1399, #1197

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Other: `validators/performance`

## Implementation Notes

- `resolveRouterMode()` resolves env > compiled default (`least-loaded`) and validates against the Dynamo frontend enum; an unknown value fails closed with `ErrCodeInvalidRequest` in `validatePerfTuningEnvs`, before the multi-minute workload deploys — consistent with the other perf knobs.
- The dynamo-router deployment template's `DYN_ROUTER_MODE` value became a `${ROUTER_MODE}` placeholder, substituted per run. The gateway-epp template intentionally carries no placeholder: in that mode EPP performs endpoint selection and worker frontend sidecars run in direct mode, so the knob has no effect there.
- Knob values are enum-constrained, so no quoting/scalar hazards in the template (unlike `${MODEL}`).
- Docs: new row in the `docs/contributor/validator.md` env-knob table.

## Testing

```bash
go test -race ./validators/performance/   # ok
golangci-lint run -c .golangci.yaml ./validators/performance/...   # 0 issues
yamllint -c .yamllint.yaml validators/performance/testdata/inference/dynamo-deployment.yaml   # clean
```

New coverage: table-driven `TestResolveRouterMode` (defaults, all six supported modes, trimming, unknown/`direct`/case-sensitivity fail-closed), `TestValidatePerfTuningEnvs` router-mode subtests, and `TestParseDynamoTemplate_RouterModeSubstituted` guarding the template placeholder.

WIP: full `make qualify` and the coverage-gate comparison against main have not run yet — will complete before marking ready for review.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No behavior change when the env var is unset (default identical to current hardcoded value). Catalog/env-only knob; no recipe or API surface change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)

