### PR TITLE
fix(recipe): require Kubernetes 1.34 for EKS GB200 training

### DIFF
--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -62,7 +62,7 @@ are pulled in at bundle time, not at recipe resolution.
 | **Kind** | `ComponentRegistry` | `RecipeMetadata` | `RecipeMixin` |
 | **Carries criteria?** | No | Yes (`spec.criteria`) | No (rejected at load) |
 | **Carries `base`?** | No | Yes (single-parent chain) | No |
-| **Example** | "make `gpu-operator` available, default to chart v25.10.1" | "for `eks` + `gb200` + `training` + `ubuntu`, pin K8s ≥ 1.32.4" | "for any overlay opting in via `mixins: [os-ubuntu]`, require Ubuntu 24.04" |
+| **Example** | "make `gpu-operator` available, default to chart v25.10.1" | "for `eks` + `gb200` + `training` + `ubuntu`, pin K8s ≥ 1.34" | "for any overlay opting in via `mixins: [os-ubuntu]`, require Ubuntu 24.04" |
 
 Rule of thumb: a change targeting *all* recipes goes in registry; a
 change targeting *one* cluster shape goes in an overlay; a change
@@ -140,7 +140,7 @@ spec:
     # platform: kubeflow         # optional 6th dimension
   constraints:                   # OS/K8s/GPU/SystemD constraints
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
   componentRefs: []              # overrides on inherited components
   validation:                    # per-phase validation config
     readiness:   { ... }

--- a/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
+++ b/examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
@@ -35,9 +35,9 @@ criteria:
 # Constraints validated during readiness phase
 constraints:
   - name: K8s.server.version
-    value: '>= 1.32.4'
+    value: '>= 1.34'
     severity: error
-    remediation: "Upgrade Kubernetes to version 1.32.4 or later"
+    remediation: "Upgrade Kubernetes to version 1.34 or later"
   - name: OS.release.ID
     value: ubuntu
     severity: error

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -2119,6 +2119,79 @@ func TestLoadMetadataStore_ConcurrentSameProviderIsCached(t *testing.T) {
 	}
 }
 
+// TestGB200EKSTrainingFloor verifies that the fully resolved GB200 EKS training
+// recipes require Kubernetes 1.34 for the GA resource.k8s.io/v1 API used by the
+// NVLS performance validation path.
+func TestGB200EKSTrainingFloor(t *testing.T) {
+	ctx := context.Background()
+	store, err := loadMetadataStore(ctx)
+	if err != nil {
+		t.Fatalf("failed to load metadata store: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		criteria *Criteria
+	}{
+		{
+			name: "gb200 eks training",
+			criteria: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorGB200,
+				Intent:      CriteriaIntentTraining,
+			},
+		},
+		{
+			name: "gb200 eks ubuntu training",
+			criteria: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorGB200,
+				Intent:      CriteriaIntentTraining,
+				OS:          CriteriaOSUbuntu,
+			},
+		},
+		{
+			name: "gb200 eks ubuntu kubeflow training",
+			criteria: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorGB200,
+				Intent:      CriteriaIntentTraining,
+				OS:          CriteriaOSUbuntu,
+				Platform:    CriteriaPlatformKubeflow,
+			},
+		},
+		{
+			name: "gb200 eks ubuntu slurm training",
+			criteria: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorGB200,
+				Intent:      CriteriaIntentTraining,
+				OS:          CriteriaOSUbuntu,
+				Platform:    CriteriaPlatformSlurm,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := store.BuildRecipeResult(ctx, tt.criteria)
+			if err != nil {
+				t.Fatalf("BuildRecipeResult failed: %v", err)
+			}
+			var k8sFloor string
+			for _, constraint := range result.Constraints {
+				if constraint.Name == testK8sVersionConstant {
+					k8sFloor = constraint.Value
+					break
+				}
+			}
+			if k8sFloor != ">= 1.34" {
+				t.Errorf("K8s.server.version floor = %q, want %q", k8sFloor, ">= 1.34")
+			}
+		})
+	}
+}
+
 // TestGB200OKEFloorNotClobbered is a regression test for the GB200 OKE K8s floor
 // clobber: when oke-ol-training (>= 1.30, accelerator-generic) co-matched
 // gb200-oke-training (>= 1.34) as a sibling leaf, the last-writer-wins constraint

--- a/recipes/overlays/gb200-eks-training.yaml
+++ b/recipes/overlays/gb200-eks-training.yaml
@@ -29,8 +29,13 @@ spec:
   # Specific constraints for GB200 on EKS training workloads
   # Constraint names use fully qualified measurement paths: {type}.{subtype}.{key}
   constraints:
+    # GB200 NVLS performance validation provisions the IMEX channel through a
+    # DRA ComputeDomain that requires the GA resource.k8s.io/v1 API, which
+    # ships in Kubernetes 1.34+. Floor the recipe there so a DRA-incapable
+    # cluster is rejected up front instead of failing the performance phase
+    # at runtime when the v1 ResourceClaimTemplate never reconciles.
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
 
   componentRefs:
     # GB200+EKS GPU Operator prerequisites. Keep in sync with the same block

--- a/recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml
@@ -36,7 +36,9 @@ spec:
 
   # GB200 + EKS specific constraints (not covered by mixin)
   constraints:
+    # GB200 NVLS performance validation needs the GA resource.k8s.io/v1 DRA
+    # API (Kubernetes 1.34+); keep this leaf aligned with gb200-eks-training.
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
 
   componentRefs: []

--- a/recipes/overlays/gb200-eks-ubuntu-training.yaml
+++ b/recipes/overlays/gb200-eks-ubuntu-training.yaml
@@ -34,8 +34,10 @@ spec:
 
   # GB200 + EKS specific constraints (not covered by mixin)
   constraints:
+    # GB200 NVLS performance validation needs the GA resource.k8s.io/v1 DRA
+    # API (Kubernetes 1.34+); keep this leaf aligned with gb200-eks-training.
     - name: K8s.server.version
-      value: ">= 1.32.4"
+      value: ">= 1.34"
 
   componentRefs: []
 


### PR DESCRIPTION
## Summary

Raise the EKS GB200 training Kubernetes floor to 1.34 so recipes reject clusters that do not serve the GA resource.k8s.io/v1 DRA API required by NVLS validation. Add resolved-recipe regression coverage across the OS-agnostic, Ubuntu, Kubeflow, and Slurm resolution paths.

## Motivation / Context

The current 1.32.4 floor allows recipe validation to pass before the NVLS performance phase fails while waiting for a v1 ResourceClaimTemplate that Kubernetes versions before 1.34 do not serve.

Fixes: #1255
Related: #1233

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Set `K8s.server.version` to `>= 1.34` in the base, Ubuntu, and Kubeflow EKS GB200 training overlays, matching the OKE GB200 precedent; the Slurm leaf was already correct.
- Extend the table-driven `BuildRecipeResult` regression test across the OS-agnostic, Ubuntu, Kubeflow, and Slurm resolution paths.
- Sync the resolved GB200 EKS example recipe, remediation text, and contributor recipe examples to the 1.34 floor.
- Known follow-up: the committed signed evidence pointer for `gb200-eks-ubuntu-training` becomes digest-stale with this change (the PR evidence gate reports the mismatch; warning-only by design, ADR-007). The evidence will be regenerated on a Kubernetes 1.34 cluster and re-signed with a non-personal identity (GitHub noreply / CI OIDC) in a follow-up.
- `make bom-docs` regenerated the BOM successfully and produced no documentation diff.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race -v ./pkg/recipe/... -run "^TestGB200EKSTrainingFloor$"
yamllint -c .yamllint.yaml recipes/overlays/gb200-eks-training.yaml recipes/overlays/gb200-eks-ubuntu-training.yaml recipes/overlays/gb200-eks-ubuntu-training-kubeflow.yaml examples/recipes/eks-gb200-ubuntu-training-with-validation.yaml
golangci-lint run -c .golangci.yaml ./pkg/recipe/...
GOFLAGS="-mod=vendor" go test -coverprofile=/tmp/aicr/issue-1255-cover.out ./pkg/recipe/...
unset GITLAB_TOKEN && make test-coverage
make bom-docs
unset GITLAB_TOKEN && make qualify
```

All commands passed. `pkg/recipe/...` coverage is unchanged from `origin/main`: 87.4656% to 87.4656% (0.0 percentage points). Project-wide coverage passed at 78.8% against the 75% floor. Qualification passed all race-tested unit tests, lint and consistency checks, 23 chainsaw e2e suites, and the vulnerability scan.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Clusters running Kubernetes earlier than 1.34 are rejected during recipe constraint validation instead of failing later in NVLS performance validation. No migration or feature flag is required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
