### PR TITLE
Accept renamed nvidia-smi banner fields

### DIFF
--- a/validators/deployment/nvidia_smi.go
+++ b/validators/deployment/nvidia_smi.go
@@ -169,24 +169,40 @@ func getLogSnippet(logs string, maxLines int) string {
 }
 
 func verifyNvidiaSMILogs(podLogs string, pod *v1.Pod) error {
-	requiredStrings := []string{
-		"NVIDIA-SMI",
-		"Driver Version:",
-		"CUDA Version:",
-		gpuCheckSuccessMsg,
+	requiredMarkerGroups := [][]string{
+		{"NVIDIA-SMI"},
+		{"Driver Version:", "KMD Version:"},
+		{"CUDA Version:", "CUDA UMD Version:"},
+		{gpuCheckSuccessMsg},
 	}
 
+	// Match case-insensitively: the renamed banner fields are only documented
+	// via `nvidia-smi --version` deprecation text, which spells them lowercase
+	// ("KMD version"), and no captured plain-`nvidia-smi` banner pins the
+	// exact casing of the table header (issue #1667). Case-insensitivity
+	// accepts either spelling — and future casing tweaks — without false
+	// positives: the verified log is only nvidia-smi output plus the success
+	// echo. The diagnostic below keeps the canonical casing for readability.
+	logsLower := strings.ToLower(podLogs)
+
 	var missing []string
-	for _, required := range requiredStrings {
-		if !strings.Contains(podLogs, required) {
-			missing = append(missing, required)
+	for _, markerGroup := range requiredMarkerGroups {
+		found := false
+		for _, marker := range markerGroup {
+			if strings.Contains(logsLower, strings.ToLower(marker)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, strings.Join(markerGroup, " or "))
 		}
 	}
 
 	if len(missing) > 0 {
 		return errors.New(errors.ErrCodeInternal,
-			fmt.Sprintf("log verification failed for pod %s/%s: missing %v",
-				pod.Namespace, pod.Name, missing))
+			fmt.Sprintf("log verification failed for pod %s/%s: missing [%s]",
+				pod.Namespace, pod.Name, strings.Join(missing, "; ")))
 	}
 
 	return nil

--- a/validators/deployment/nvidia_smi_test.go
+++ b/validators/deployment/nvidia_smi_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVerifyNvidiaSMILogs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		logs    string
+		wantErr string
+	}{
+		{
+			name: "accepts legacy banner fields",
+			logs: "NVIDIA-SMI\nDriver Version: 570.86.15\nCUDA Version: 12.8\n" + gpuCheckSuccessMsg,
+		},
+		{
+			name: "accepts renamed banner fields",
+			logs: "NVIDIA-SMI\nKMD Version: 580.65.06\nCUDA UMD Version: 13.0\n" + gpuCheckSuccessMsg,
+		},
+		{
+			// Representative table-banner layout of a renamed-field driver
+			// branch (see issue #1667): single header row, pipe-delimited,
+			// fields separated by padding rather than newlines.
+			name: "accepts renamed banner in table layout",
+			logs: "| NVIDIA-SMI 610.43.02              KMD Version: 610.43.02     CUDA UMD Version: 13.3     |\n" +
+				gpuCheckSuccessMsg,
+		},
+		{
+			name: "accepts mixed legacy and renamed banner fields",
+			logs: "NVIDIA-SMI\nDriver Version: 570.86.15\nCUDA UMD Version: 13.0\n" + gpuCheckSuccessMsg,
+		},
+		{
+			// The renamed fields are documented only via `nvidia-smi
+			// --version` deprecation text, which spells them lowercase
+			// ("KMD version"); no fixture pins the table banner's casing
+			// (issue #1667), so matching is case-insensitive.
+			name: "accepts lowercase renamed banner fields",
+			logs: "NVIDIA-SMI\nKMD version: 580.65.06\nCUDA UMD version: 13.0\n" + gpuCheckSuccessMsg,
+		},
+		{
+			name: "accepts uppercase legacy banner fields",
+			logs: "NVIDIA-SMI\nDRIVER VERSION: 570.86.15\nCUDA VERSION: 12.8\n" + gpuCheckSuccessMsg,
+		},
+		{
+			name:    "rejects logs missing both driver banner alternatives",
+			logs:    "NVIDIA-SMI\nCUDA UMD Version: 13.0\n" + gpuCheckSuccessMsg,
+			wantErr: "[INTERNAL] log verification failed for pod aicr-validation/nvidia-smi-verify-test: missing [Driver Version: or KMD Version:]",
+		},
+		{
+			name:    "rejects logs missing both CUDA banner alternatives",
+			logs:    "NVIDIA-SMI\nKMD Version: 580.65.06\n" + gpuCheckSuccessMsg,
+			wantErr: "[INTERNAL] log verification failed for pod aicr-validation/nvidia-smi-verify-test: missing [CUDA Version: or CUDA UMD Version:]",
+		},
+		{
+			name:    "separates multiple missing marker groups",
+			logs:    "NVIDIA-SMI\n" + gpuCheckSuccessMsg,
+			wantErr: "[INTERNAL] log verification failed for pod aicr-validation/nvidia-smi-verify-test: missing [Driver Version: or KMD Version:; CUDA Version: or CUDA UMD Version:]",
+		},
+		{
+			name:    "rejects logs missing NVIDIA-SMI marker",
+			logs:    "Driver Version: 570.86.15\nCUDA Version: 12.8\n" + gpuCheckSuccessMsg,
+			wantErr: "[INTERNAL] log verification failed for pod aicr-validation/nvidia-smi-verify-test: missing [NVIDIA-SMI]",
+		},
+		{
+			name:    "rejects logs missing success marker",
+			logs:    "NVIDIA-SMI\nDriver Version: 570.86.15\nCUDA Version: 12.8\n",
+			wantErr: "[INTERNAL] log verification failed for pod aicr-validation/nvidia-smi-verify-test: missing [" + gpuCheckSuccessMsg + "]",
+		},
+	}
+
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "aicr-validation", Name: "nvidia-smi-verify-test"}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyNvidiaSMILogs(tt.logs, pod)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("verifyNvidiaSMILogs() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("verifyNvidiaSMILogs() error = nil, want %q", tt.wantErr)
+			}
+			if err.Error() != tt.wantErr {
+				t.Fatalf("verifyNvidiaSMILogs() error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Accept both legacy and renamed NVIDIA driver banner fields when verifying `nvidia-smi` logs. Add table-driven regression coverage for both formats and for missing driver/CUDA alternatives.

## Motivation / Context

Newer drivers report `KMD Version:` and `CUDA UMD Version:` instead of the legacy `Driver Version:` and `CUDA Version:` fields. The validator currently treats healthy GPU nodes using the renamed fields as failures.

Fixes: #1667
Related: N/A

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

`verifyNvidiaSMILogs` now evaluates required markers as any-of groups. The NVIDIA-SMI and success markers remain mandatory, while either the legacy or renamed form satisfies each driver and CUDA version group. The renamed-field regression fixture uses a representative NVIDIA-SMI 610.43.02 table banner (`KMD Version:` / `CUDA UMD Version:`) modeled on the renamed-field driver output described in #1667. Matching is case-insensitive: the renamed fields' casing is otherwise documented only via `nvidia-smi --version` deprecation text (lowercase "KMD version"), so casing variants across driver branches cannot reintroduce the false negative; diagnostics keep canonical casing. Missing-marker diagnostics separate multiple unsatisfied groups with semicolons.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race -v ./validators/deployment/...
GOFLAGS="-mod=vendor" go test -coverprofile=/tmp/aicr/pr-1748-current.out ./validators/deployment/...
golangci-lint run --allow-parallel-runners -c .golangci.yaml ./validators/deployment/...
make test-coverage
unset GITLAB_TOKEN && make qualify
```

- Deployment validator tests passed under the race detector.
- `validators/deployment` coverage: 48.3% → 50.8% (+2.5 percentage points); `verifyNvidiaSMILogs`: 100%.
- Affected-package lint: 0 issues.
- Project coverage gate: 78.8% (75% required).
- Full qualification: passed at 78.8% coverage, including 23/23 e2e tests and vulnerability/license checks.

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Backward compatible; existing `Driver Version:` and `CUDA Version:` banners remain accepted. No migration or feature flag is required.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)


