### PR TITLE
fix(bundler): cover recipe.yaml with bundle checksums

### DIFF
--- a/demos/bundle-attestation-demo-slides.html
+++ b/demos/bundle-attestation-demo-slides.html
@@ -191,7 +191,7 @@
     </table>
     <div class="grid2">
       <div class="mini"><h4>Without attestation</h4><p>Bundle is just files. <code class="inl">checksums.txt</code> catches accidental corruption, nothing else.</p></div>
-      <div class="mini"><h4>With <code class="inl">--attest</code></h4><p>The files listed in <code class="inl">checksums.txt</code> are cryptographically bound to the creator <em>and</em> the binary that produced it (recipe.yaml excluded, #1549). Recursive provenance.</p></div>
+      <div class="mini"><h4>With <code class="inl">--attest</code></h4><p>The generated payload files listed in <code class="inl">checksums.txt</code>, including <code class="inl">recipe.yaml</code>, are cryptographically bound to the creator <em>and</em> the binary that produced it. Recursive provenance.</p></div>
     </div>
   </div>
 </section>
@@ -233,7 +233,7 @@
           <text x="46" y="214">recipe.yaml &#183; deploy.sh &#183; README.md</text>
           <text x="46" y="234">&lt;component&gt;/values.yaml &#183; ...</text>
           <text x="46" y="266" fill="#9aa7b4">checksums.txt</text>
-          <text x="46" y="282" fill="#6b7785" font-size="11">(SHA256 of the listed files; recipe.yaml excluded — #1549)</text>
+          <text x="46" y="282" fill="#6b7785" font-size="11">(SHA256 of every generated payload file)</text>
         </g>
         <rect class="node-g" x="432" y="170" width="398" height="186" rx="9"/>
         <text class="ttl-g nlabel" x="448" y="194">attestation/</text>

--- a/demos/bundle-attestation-demo.sh
+++ b/demos/bundle-attestation-demo.sh
@@ -233,7 +233,7 @@ run bash -c "set -o pipefail; '$AICR' verify '$BUNDLE' --format json | jq '{ tru
 # --- tamper -------------------------------------------------------------------
 
 banner "Tamper-evident: mutate a content file, verify fails"
-note "The signature's subject is the digest of checksums.txt, which pins every file it lists (recipe.yaml is not yet covered, #1549)."
+note "The signature's subject is the digest of checksums.txt, which pins every generated payload file, including recipe.yaml."
 note "Mutating any file listed in checksums.txt breaks its checksum; mutating checksums.txt breaks the signature."
 # Pick a file the bundle is guaranteed to contain. README.md is always present.
 TAMPER_TARGET="$BUNDLE/README.md"

--- a/demos/bundle-attestation.md
+++ b/demos/bundle-attestation.md
@@ -3,12 +3,12 @@
 Bundle attestation provides cryptographic proof of **who** created a deployment
 bundle and **which AICR CLI** built it. When `aicr bundle --attest` runs, the
 CLI signs the bundle's `checksums.txt` (which inventories the deployment
-payload; `recipe.yaml` is currently excluded, #1549, and the attestation files
-are verified separately) using [Sigstore](https://www.sigstore.dev/) and
+payload, including `recipe.yaml`; the attestation files are verified separately)
+using [Sigstore](https://www.sigstore.dev/) and
 generates SLSA Build Provenance v1 metadata. Anyone can later verify the
 bundle with `aicr verify` to confirm:
 
-* The files listed in `checksums.txt` haven't been tampered with (recipe.yaml is excluded, #1549).
+* The generated payload files listed in `checksums.txt`, including `recipe.yaml`, haven't been tampered with.
 * It was created by a trusted identity.
 * It was built by an attested NVIDIA-CI-released AICR CLI.
 
@@ -88,7 +88,7 @@ permissions.
 
 ```text
 my-bundle/
-├── checksums.txt                          # SHA256 of every listed file (excludes recipe.yaml, #1549)
+├── checksums.txt                          # SHA256 of every generated payload file
 ├── recipe.yaml                            # canonical post-resolution recipe
 ├── deploy.sh                              # automation script
 ├── README.md                              # deployment guide
@@ -105,10 +105,9 @@ The two attestations together form the chain that makes `verified` reachable:
 
 * **`bundle-attestation.sigstore.json`** — Sigstore Bundle (DSSE + Fulcio cert
   + Rekor inclusion proof). Its in-toto subject is the SHA256 of
-  `checksums.txt`, so signing this one file transitively pins every content
-  file that `checksums.txt` lists. The signer identity is the creator's OIDC
-  identity. (Caveat: `recipe.yaml` is currently written *after* `checksums.txt`
-  and is not yet covered — tracked in #1549.)
+  `checksums.txt`, so signing this one file transitively pins every generated
+  payload file that `checksums.txt` lists, including `recipe.yaml`. The signer
+  identity is the creator's OIDC identity.
 * **`aicr-attestation.sigstore.json`** — the SLSA Build Provenance attestation
   *of the AICR CLI binary that produced the bundle*, copied in at bundle time.
   Its signer identity is NVIDIA CI (`https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@...`).
@@ -143,7 +142,7 @@ Bundle verification: PASSED
 
 Five gates run, top to bottom:
 
-1. **Checksums** — every file listed in `checksums.txt` is hashed and compared (recipe.yaml is not yet listed — #1549).
+1. **Checksums** — every generated payload file listed in `checksums.txt`, including `recipe.yaml`, is hashed and compared.
 2. **Bundle signature** — the Sigstore Bundle is verified against the trusted root.
 3. **Bundle predicate** — the in-toto subject is checked against the actual `checksums.txt` digest.
 4. **Binary attestation chain** — `aicr-attestation.sigstore.json` is verified and its subject is checked against the CLI binary digest claimed in the bundle predicate.

--- a/demos/cuj2-demo.md
+++ b/demos/cuj2-demo.md
@@ -37,8 +37,8 @@
   │  recipe.yaml ──▶ bundle/                                               │
   │    ├── deploy.sh        (root automation script)                       │
   │    ├── README.md        (root deployment guide)                        │
-  │    ├── checksums.txt    (SHA256 of listed files; excludes recipe.yaml) │
-  │    ├── recipe.yaml      (resolved recipe; not yet in checksums, #1549) │
+  │    ├── checksums.txt    (SHA256 of all generated payload files)        │
+  │    ├── recipe.yaml      (resolved recipe; covered by checksums)        │
   │    ├── 001-agentgateway-crds/              (agentgateway.dev CRDs)     │
   │    ├── 002-agentgateway-crds-post/         (Gateway API + Inf-Ext CRDs)│
   │    ├── 003-aws-ebs-csi-driver/             (EBS storage)               │

--- a/demos/images/data.md
+++ b/demos/images/data.md
@@ -42,8 +42,7 @@ Visual: File system tree structure showing multiple component folders
 bundle/
 ├── deploy.sh                     # root automation script (executable)
 ├── README.md                     # root deployment guide
-├── checksums.txt                 # SHA256 of the listed bundle files (recipe.yaml is written
-│                                 # afterward and is not yet covered — see issue #1549)
+├── checksums.txt                 # SHA256 of every generated payload file
 ├── recipe.yaml                   # canonical post-resolution recipe
 ├── NNN-cert-manager/             # each folder is prefixed with its NNN deployment-order
 │   ├── install.sh                # index (computed from the dependency graph — e.g. cert-manager

--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -385,8 +385,8 @@ RecipeResult
                                    CR, for components that ship one)
          - go:embed templates  -> per-component install.sh, and the root
                                    README.md + deploy.sh
+  -> write canonical recipe.yaml
   -> compute root checksums.txt over every emitted file
-     (recipe.yaml is written afterward and is not covered, #1549)
 ```
 
 `pkg/bundler/registry` exists but is **not** used by the production path: the
@@ -507,7 +507,8 @@ The `deploymentOrder` field in recipes specifies component deployment sequence. 
 bundle-output/
 ├── README.md                    # Root deployment guide with ordered steps
 ├── deploy.sh                    # Automation script (0755)
-├── checksums.txt                # SHA256 of all listed files (recipe.yaml excluded, #1549)
+├── recipe.yaml                  # Canonical post-resolution recipe
+├── checksums.txt                # SHA256 of all generated payload files
 ├── 001-cert-manager/
 │   ├── install.sh               # Per-folder install script (0755)
 │   ├── values.yaml              # Static Helm values
@@ -584,7 +585,7 @@ spec:
 │ Complete Bundle + Deploy Flow                                │
 ├──────────────────────────────────────────────────────────────┤
 │                                                              │
-│  aicr bundle -r recipe.yaml --deployer argocd \            │
+│  aicr bundle -r recipe.yaml --deployer argocd \              │
 │    --repo https://github.com/my-org/my-repo.git -o ./out     │
 │                                                              │
 │  1. Parse recipe                                             │
@@ -599,13 +600,13 @@ spec:
 │     └─ network-operator → values.yaml, manifests/            │
 │                                                              │
 │  4. Run deployer (argocd) → numbered NNN-<name>/ folders     │
-│     ├─ 001-cert-manager/application.yaml (wave: 0)          │
-│     ├─ 002-gpu-operator/application.yaml (wave: 1)          │
-│     └─ 003-network-operator/application.yaml (wave: 2)      │
+│     ├─ 001-cert-manager/application.yaml (wave: 0)           │
+│     ├─ 002-gpu-operator/application.yaml (wave: 1)           │
+│     └─ 003-network-operator/application.yaml (wave: 2)       │
 │     └─ app-of-apps.yaml (bundle root, uses --repo URL)       │
 │                                                              │
 │  5. Generate checksums                                       │
-│     └─ checksums.txt (root; all listed files, no recipe.yaml)│
+│     └─ checksums.txt (root; all emitted Argo CD files)       │
 │                                                              │
 └──────────────────────────────────────────────────────────────┘
 ```

--- a/docs/integrator/openshift.md
+++ b/docs/integrator/openshift.md
@@ -146,7 +146,7 @@ ocp-bundle/
 ├── undeploy.sh                             # Cleanup script
 ├── README.md                               # Bundle documentation
 ├── recipe.yaml                             # Recipe used to generate bundle
-├── checksums.txt                           # SHA256 of all listed files (recipe.yaml excluded, #1549)
+├── checksums.txt                           # SHA256 of all generated payload files, including recipe.yaml
 │
 │   # ── Per-operator three-folder cycle ──
 │

--- a/docs/integrator/supply-chain-verification.md
+++ b/docs/integrator/supply-chain-verification.md
@@ -305,8 +305,8 @@ release.
 ### Bundle attestation
 
 When `aicr bundle` runs with `--attest`, it signs the bundle using Sigstore
-keyless OIDC, binding the bundle creator's identity to the files listed in `checksums.txt`
-(recipe.yaml is currently excluded, #1549) and the binary that produced it (via
+keyless OIDC, binding the bundle creator's identity to the generated payload
+files listed in `checksums.txt`, including `recipe.yaml` in Helm bundles, and the binary that produced it (via
 `resolvedDependencies`). Attestation is opt-in; bundles are unsigned by
 default. The bundle output includes `bundle-attestation.sigstore.json`
 (SLSA Build Provenance v1 for the bundle) and a copy of the binary's

--- a/docs/user/artifact-verification.md
+++ b/docs/user/artifact-verification.md
@@ -53,7 +53,7 @@ aicr verify ./my-bundle
 
 Under the hood this runs three checks:
 
-1. **Checksums**: every file listed in `checksums.txt` is hashed and matched (recipe.yaml is not yet listed — #1549).
+1. **Checksums**: every generated payload file listed in `checksums.txt`, including `recipe.yaml` in Helm bundles, is hashed and matched.
 2. **Bundle attestation**: the bundle's signature is verified against the Sigstore trusted root.
 3. **Binary attestation**: the provenance chain is verified with identity pinned to NVIDIA CI.
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1747,7 +1747,7 @@ Use `--dynamic` for values that genuinely vary per cluster — cluster names, su
 | Cluster-specific value (varies per deployment) | `--dynamic` | `--dynamic alloy:clusterName` |
 | Static override (same for all deployments of this bundle) | `--set` | `--set gpuoperator:driver.version=580.105.08` |
 
-> **Attestation scope:** Dynamic values are supplied at install time and are **not covered by `--attest`**. Attestation binds the files listed in `checksums.txt` (recipe.yaml excluded, #1549), not operator-provided overrides. If you need to constrain dynamic values at deploy time, use admission control or Argo sync hooks — see [Attestation Scope](#attestation-scope).
+> **Attestation scope:** Dynamic values are supplied at install time and are **not covered by `--attest`**. Attestation binds the generated payload files listed in `checksums.txt`, including `recipe.yaml` in Helm bundles, not operator-provided overrides. If you need to constrain dynamic values at deploy time, use admission control or Argo sync hooks — see [Attestation Scope](#attestation-scope).
 
 ```shell
 --dynamic component:path.to.field
@@ -2169,7 +2169,7 @@ When `--attest` is passed, the bundle command performs five steps:
 1. **Verifies the binary attestation file exists** — The running `aicr` binary must have a valid SLSA provenance file (`aicr-attestation.sigstore.json`) alongside it, included by the install script from a release archive. If missing, the command fails immediately with guidance on how to install correctly.
 2. **Acquires a signing credential** — in the default keyless mode this is an OIDC token (see [OIDC Token Sources](#oidc-token-sources) below); with `--signing-key` this step instead resolves the KMS key and no OIDC token is acquired (see [KMS-Backed Signing](#kms-backed-signing)).
 3. **Verifies the binary's own attestation** — Cryptographically verifies the SLSA provenance binds to the running binary and was signed by NVIDIA CI. This ensures only NVIDIA-built binaries can produce attested bundles.
-4. **Signs the bundle** — Creates a SLSA Build Provenance v1 in-toto statement binding the creator's identity to the files listed in `checksums.txt` (recipe.yaml is currently excluded, #1549) and the binary that produced it.
+4. **Signs the bundle** — Creates a SLSA Build Provenance v1 in-toto statement binding the creator's identity to the generated payload files listed in `checksums.txt`, including `recipe.yaml` in Helm bundles, and the binary that produced it.
 5. **Writes attestation files** — `attestation/bundle-attestation.sigstore.json` and `attestation/aicr-attestation.sigstore.json` are added to the bundle output.
 
 Attestation is opt-in; bundles are unsigned by default. By default, signing uses Sigstore keyless signing (Fulcio CA + Rekor transparency log) and records the entry in **Rekor v2** (the signing config is fetched from Sigstore's TUF repository, so shard rotation is handled automatically; a cold cache is fetched on demand). Verifying such bundles with `aicr verify` needs only the `aicr` binary; verifying them with `cosign verify-blob-attestation` needs Cosign v3.0.1+. For CI/CD environments without OIDC, pass `--signing-key` to sign with a cloud KMS key instead; see [KMS-Backed Signing](#kms-backed-signing) below. For verification, see [`aicr verify`](#aicr-verify).
@@ -2296,7 +2296,7 @@ HashiCorp Vault (`hashivault://`) is not supported: its client libraries are MPL
 
 ##### Attestation Scope
 
-Attestation binds the files listed in `checksums.txt` (recipe.yaml is currently excluded, #1549; the attestation files are verified separately) — defaults, dynamic-value stubs, and any external `--data` files copied into the bundle. It does **not** bind install-time values supplied via `helm --set`, a user-provided `-f extra.yaml`, or Argo `Application.spec.source.helm.parameters`. That boundary is intentional: dynamic values are the operator's domain by design.
+Attestation binds the generated payload files listed in `checksums.txt` — including `recipe.yaml` in Helm bundles, defaults, dynamic-value stubs, and any external `--data` files copied into the bundle. The attestation files are verified separately. It does **not** bind install-time values supplied via `helm --set`, a user-provided `-f extra.yaml`, or Argo `Application.spec.source.helm.parameters`. That boundary is intentional: dynamic values are the operator's domain by design.
 
 If you need to enforce specific install-time values (e.g., pinning `driver.version`), that is a **policy concern**, not an attestation one. Use admission control (Kyverno, Gatekeeper) or Argo sync hooks to reject deployments that violate the policy. `aicr verify` checks bundle integrity and provenance; it does not evaluate install-time value constraints.
 

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -70,8 +70,13 @@ func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
 	return data, nil
 }
 
-// digestAlgoSHA256 is the algorithm key used in attestation digest maps.
-const digestAlgoSHA256 = "sha256"
+const (
+	// digestAlgoSHA256 is the algorithm key used in attestation digest maps.
+	digestAlgoSHA256 = "sha256"
+
+	// recipeFileName is the resolved recipe copied into Helm bundles.
+	recipeFileName = "recipe.yaml"
+)
 
 // errCtxKeyComponent is the structured-error context key carrying the
 // component name in bundle value-override failures.
@@ -470,6 +475,7 @@ func (b *DefaultBundler) buildDeployer(ctx context.Context, recipeResult *recipe
 			ComponentValues:        componentValues,
 			Version:                b.Config.Version(),
 			IncludeChecksums:       b.Config.IncludeChecksums(),
+			RecipeFile:             recipeFileName,
 			ComponentPreManifests:  componentPreManifests,
 			ComponentPostManifests: componentPostManifests,
 			ComponentReadiness:     componentReadiness,
@@ -567,6 +573,15 @@ func (b *DefaultBundler) argoDeployerOptions() (*config.ArgoDeployerOptions, err
 // runDeployer executes a deployer and builds the result output.
 // dataFiles is the list of external data file paths already copied by Make().
 func (b *DefaultBundler) runDeployer(ctx context.Context, d deployer.Deployer, recipeResult *recipe.RecipeResult, dir string, dataFiles []string, start time.Time) (*result.Output, error) {
+	// Helm bundles include the resolved recipe. Write it before generation so
+	// the Helm deployer can include it in checksums.txt and the resulting
+	// attestation chain.
+	if b.Config.Deployer() == config.DeployerHelm {
+		if _, writeErr := b.writeRecipeFile(recipeResult, dir); writeErr != nil {
+			return nil, errors.PropagateOrWrap(writeErr, errors.ErrCodeInternal, "failed to write recipe file")
+		}
+	}
+
 	output, err := d.Generate(ctx, dir)
 	if err != nil {
 		if _, ok := stderrors.AsType[*errors.StructuredError](err); ok {
@@ -577,16 +592,6 @@ func (b *DefaultBundler) runDeployer(ctx context.Context, d deployer.Deployer, r
 
 	totalFiles := len(output.Files)
 	totalSize := output.TotalSize
-
-	// Write recipe file (helm-only, preserves original behavior)
-	if b.Config.Deployer() == config.DeployerHelm {
-		recipeSize, writeErr := b.writeRecipeFile(recipeResult, dir)
-		if writeErr != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to write recipe file", writeErr)
-		}
-		totalFiles++
-		totalSize += recipeSize
-	}
 
 	// Attest bundle (skips internally when not configured)
 	attestFiles, err := b.attestBundle(ctx, dir, dataFiles, recipeResult)
@@ -1872,7 +1877,7 @@ func (b *DefaultBundler) writeRecipeFile(recipeResult *recipe.RecipeResult, dir 
 		return 0, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to serialize recipe")
 	}
 
-	recipePath, joinErr := deployer.SafeJoin(dir, "recipe.yaml")
+	recipePath, joinErr := deployer.SafeJoin(dir, recipeFileName)
 	if joinErr != nil {
 		return 0, errors.Wrap(errors.ErrCodeInternal, "unsafe recipe file path", joinErr)
 	}

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -30,9 +30,11 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/NVIDIA/aicr/pkg/bundler/checksum"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocd"
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/argocdhelm"
+	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
 	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -279,6 +281,65 @@ func TestMake_Success(t *testing.T) {
 	// Verify output summary (3 root + 2 components × multiple files >= 7)
 	if output.TotalFiles < 7 {
 		t.Errorf("expected at least 7 files, got %d", output.TotalFiles)
+	}
+}
+
+// TestMake_RecipeCoveredByChecksums verifies the resolved recipe participates
+// in the generated bundle's integrity chain. A recipe written after checksum
+// generation can be tampered with while Verify still reports success.
+func TestMake_RecipeCoveredByChecksums(t *testing.T) {
+	bundler, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	recipeResult := &recipe.RecipeResult{
+		APIVersion: "aicr.run/v1alpha2",
+		Kind:       "Recipe",
+		Criteria: &recipe.Criteria{
+			Service:     "eks",
+			Accelerator: "gb200",
+			Intent:      "training",
+			OS:          "ubuntu",
+		},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "gpu-operator",
+				Version: "v25.3.3",
+				Type:    "helm",
+				Source:  "https://helm.ngc.nvidia.com/nvidia",
+			},
+		},
+		DeploymentOrder: []string{"gpu-operator"},
+	}
+
+	bundleDir := t.TempDir()
+	if _, err = bundler.Make(context.Background(), recipeResult, bundleDir); err != nil {
+		t.Fatalf("Make() error = %v", err)
+	}
+
+	checksums, err := os.ReadFile(filepath.Join(bundleDir, checksum.ChecksumFileName))
+	if err != nil {
+		t.Fatalf("read %s: %v", checksum.ChecksumFileName, err)
+	}
+	if !strings.Contains(string(checksums), "  "+recipeFileName+"\n") {
+		t.Fatalf("%s does not cover %s:\n%s", checksum.ChecksumFileName, recipeFileName, checksums)
+	}
+
+	recipePath := filepath.Join(bundleDir, recipeFileName)
+	if err = os.WriteFile(recipePath, []byte("tampered: true\n"), 0600); err != nil {
+		t.Fatalf("tamper %s: %v", recipeFileName, err)
+	}
+
+	verifyResult, err := verifier.Verify(context.Background(), bundleDir, nil)
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if verifyResult.ChecksumsPassed {
+		t.Fatalf("Verify() passed after %s was tampered with", recipeFileName)
+	}
+	if !strings.Contains(strings.Join(verifyResult.Errors, "\n"), recipeFileName) {
+		t.Errorf("Verify() errors do not identify %s: %v", recipeFileName, verifyResult.Errors)
 	}
 }
 

--- a/pkg/bundler/deployer/helm/helm.go
+++ b/pkg/bundler/deployer/helm/helm.go
@@ -77,6 +77,10 @@ type Generator struct {
 	// IncludeChecksums indicates whether to generate a checksums.txt file.
 	IncludeChecksums bool
 
+	// RecipeFile is the resolved recipe path relative to the output directory.
+	// When set, the file is included in the generated output and checksums.
+	RecipeFile string
+
 	// ComponentPreManifests maps component name → manifest path → content
 	// for manifests that apply BEFORE each component's primary chart.
 	// Forwarded to localformat.Options.ComponentPreManifests. Populated
@@ -208,6 +212,14 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	}
 	output.Files = append(output.Files, deployPath)
 	output.TotalSize += deploySize
+
+	// Include the resolved recipe written by the bundler before generation so
+	// checksums.txt covers the configuration used to produce this bundle.
+	if g.RecipeFile != "" {
+		if err := output.AddDataFiles(outputDir, []string{g.RecipeFile}); err != nil {
+			return nil, err
+		}
+	}
 
 	// Include external data files in the file list (for checksums)
 	if err := output.AddDataFiles(outputDir, g.DataFiles); err != nil {

--- a/pkg/bundler/deployer/helm/helm_test.go
+++ b/pkg/bundler/deployer/helm/helm_test.go
@@ -75,6 +75,10 @@ func TestGenerate_ContextCancellation(t *testing.T) {
 func TestGenerate_WithChecksums(t *testing.T) {
 	ctx := context.Background()
 	outputDir := t.TempDir()
+	recipeFile := "recipe.yaml"
+	if err := os.WriteFile(filepath.Join(outputDir, recipeFile), []byte("apiVersion: aicr.run/v1alpha2\nkind: Recipe\n"), 0600); err != nil {
+		t.Fatalf("write %s: %v", recipeFile, err)
+	}
 
 	g := &Generator{
 		RecipeResult: createTestRecipeResult(),
@@ -84,6 +88,7 @@ func TestGenerate_WithChecksums(t *testing.T) {
 		},
 		Version:          "v1.0.0",
 		IncludeChecksums: true,
+		RecipeFile:       recipeFile,
 	}
 
 	output, err := g.Generate(ctx, outputDir)
@@ -105,6 +110,7 @@ func TestGenerate_WithChecksums(t *testing.T) {
 	for _, want := range []string{
 		"README.md",
 		"deploy.sh",
+		recipeFile,
 		filepath.Join("001-cert-manager", "values.yaml"),
 	} {
 		if !strings.Contains(str, want) {
@@ -128,6 +134,26 @@ func TestGenerate_WithChecksums(t *testing.T) {
 	lastFile := output.Files[len(output.Files)-1]
 	if !strings.HasSuffix(lastFile, "checksums.txt") {
 		t.Errorf("expected last file to be checksums.txt, got %s", lastFile)
+	}
+}
+
+func TestGenerate_MissingRecipeFile(t *testing.T) {
+	g := &Generator{
+		RecipeResult: createTestRecipeResult(),
+		ComponentValues: map[string]map[string]any{
+			"cert-manager": {},
+			"gpu-operator": {},
+		},
+		Version:    "v1.0.0",
+		RecipeFile: "recipe.yaml",
+	}
+
+	_, err := g.Generate(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("Generate() with missing recipe file expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to stat data file") {
+		t.Errorf("Generate() error = %v, want missing file context", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Include the resolved Helm bundle `recipe.yaml` in `checksums.txt` by writing and tracking it before checksum finalization. Add generated-bundle tamper regression coverage and update the documented attestation boundary.

## Motivation / Context

Helm bundles wrote `recipe.yaml` after `checksums.txt`, so modifying the resolved recipe did not fail `aicr verify` and was not transitively pinned by the bundle attestation.

Fixes #1549
Related: #1547

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Serialize the resolved Helm recipe before deployer generation.
- Pass the recipe path to the Helm generator so it participates in the generated file list, size accounting, checksum manifest, and downstream attestation chain.
- Verify an actual generated bundle lists `recipe.yaml` and rejects post-generation recipe tampering.
- Remove the temporary `#1549` caveats from user, integrator, and demo documentation.

Non-Helm deployer layouts remain unchanged because they do not emit a resolved `recipe.yaml` today.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -run '^TestMake_RecipeCoveredByChecksums$' ./pkg/bundler
GOFLAGS="-mod=vendor" go test ./pkg/bundler/...
GOFLAGS="-mod=vendor" go test -coverprofile=/tmp/aicr/issue-1549-cover.out ./pkg/bundler/...
golangci-lint run --timeout=10m -c .golangci.yaml ./pkg/bundler/...
unset GITLAB_TOKEN && make test-coverage
unset GITLAB_TOKEN && make qualify
```

All commands passed. Combined `pkg/bundler/...` coverage remained 80.3% (80.3% baseline to 80.3% current), while `pkg/bundler/deployer/helm` increased from 83.7% to 84.2%. Project-wide coverage passed at 78.8% against the 75% floor. Qualification passed race tests, vet, lint, repository consistency checks, all 23 Chainsaw e2e suites, vulnerability scanning, and license checks.

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Backward compatible. Newly generated Helm bundles bind `recipe.yaml` into `checksums.txt`; existing bundles retain their original checksum scope.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
