### PR TITLE
fix(ci): guard UAT image cleanup on numeric version id

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -691,10 +691,15 @@ jobs:
           # clutter. aiperf-bench is included so the tag pushed by the build
           # step above (#1636) does not leak.
           for phase in deployment performance conformance aiperf-bench agent; do
+            # gh api prints the raw error body to stdout on a 404 (a phase whose
+            # package was never pushed — e.g. agent, which the build loop above
+            # does not build) and skips --jq, so VERSION_ID can capture a JSON
+            # blob with control chars. Require a numeric id before deleting so
+            # the 404 body, the empty case, and multi-line output all fail closed.
             VERSION_ID=$(gh api \
               "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions" \
               --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true
-            if [[ -n "${VERSION_ID}" ]]; then
+            if [[ "${VERSION_ID}" =~ ^[0-9]+$ ]]; then
               gh api --method DELETE \
                 "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions/${VERSION_ID}" || true
             fi

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -769,10 +769,15 @@ jobs:
           # clutter. aiperf-bench is included so the tag pushed by the build
           # step above (#1636) does not leak.
           for phase in deployment performance conformance aiperf-bench agent; do
+            # gh api prints the raw error body to stdout on a 404 (a phase whose
+            # package was never pushed — e.g. agent, which the build loop above
+            # does not build) and skips --jq, so VERSION_ID can capture a JSON
+            # blob with control chars. Require a numeric id before deleting so
+            # the 404 body, the empty case, and multi-line output all fail closed.
             VERSION_ID=$(gh api \
               "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions" \
               --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true
-            if [[ -n "${VERSION_ID}" ]]; then
+            if [[ "${VERSION_ID}" =~ ^[0-9]+$ ]]; then
               gh api --method DELETE \
                 "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions/${VERSION_ID}" || true
             fi

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -606,10 +606,15 @@ jobs:
           # clutter. aiperf-bench is included so the tag pushed by the build
           # step above (#1636) does not leak.
           for phase in deployment performance conformance aiperf-bench agent; do
+            # gh api prints the raw error body to stdout on a 404 (a phase whose
+            # package was never pushed — e.g. agent, which the build loop above
+            # does not build) and skips --jq, so VERSION_ID can capture a JSON
+            # blob with control chars. Require a numeric id before deleting so
+            # the 404 body, the empty case, and multi-line output all fail closed.
             VERSION_ID=$(gh api \
               "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions" \
               --jq ".[] | select(.metadata.container.tags[] == \"${VALIDATOR_TAG}\") | .id" 2>/dev/null) || true
-            if [[ -n "${VERSION_ID}" ]]; then
+            if [[ "${VERSION_ID}" =~ ^[0-9]+$ ]]; then
               gh api --method DELETE \
                 "repos/${{ github.repository }}/packages/container/aicr-validators%2F${phase}/versions/${VERSION_ID}" || true
             fi


### PR DESCRIPTION
## Summary

Guard the end-of-run UAT validator-image cleanup on a numeric package-version id so a `gh api` 404 body can no longer be fed into the DELETE URL.

## Motivation / Context

Every UAT run ends with a step that deletes the `uat-<run_id>`-tagged validator images. It loops over phases `deployment performance conformance aiperf-bench agent`, but `agent` is never built by the build loop (which builds only `deployment performance conformance aiperf-bench`), and other phases 404 on runs that skipped them. On an error status `gh api` skips `--jq` and prints the raw JSON error body to **stdout**, which the `2>/dev/null || true` capture lands in `VERSION_ID`. The old `[[ -n "${VERSION_ID}" ]]` guard then passed and fed that multi-line JSON blob into the DELETE URL, so every run logged:

```
parse "repos/NVIDIA/aicr/packages/container/aicr-validators%2Fdeployment/versions/{\r\n  \"message\": \"Not Found\",...}": net/url: invalid control character in URL
```

The cleanup still worked for images that existed; the errors were noise, but noise that obscured real failures in the step.

Fixes: N/A
Related: #1636

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT workflows (`.github/workflows/uat-aws.yaml`, `.github/workflows/uat-gcp.yaml`)

## Implementation Notes

Changed the guard from a non-empty check to `[[ "${VERSION_ID}" =~ ^[0-9]+$ ]]`. The GitHub package-version API returns `.id` as a JSON integer, so on success `VERSION_ID` is bare digits and legitimate deletes are unaffected. The numeric guard fails closed on the three cases that should be skipped: the 404 JSON body (multi-line, control chars), the empty "no matching tag" case, and any multi-line jq output (e.g. if two versions ever shared a tag). Added a comment explaining the `gh api`-on-error stdout behavior and why `agent` reliably 404s.

## Testing

```bash
yamllint .github/workflows/uat-aws.yaml .github/workflows/uat-gcp.yaml  # clean
```

Workflow-only change (no Go sources touched), so the Go test/lint gates in `make qualify` do not apply. Verified `gh api` prints the 404 body to stdout and that the new regex rejects it while matching a bare integer id.

## Risk Assessment

- [x] **Low** — Isolated change to a best-effort cleanup step, trivially revertible

**Rollout notes:** N/A — takes effect on the next UAT run.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (yamllint)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (workflow shell guard)
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
