### PR TITLE
fix(nodewright-customizations): bump nvidia-tuned to 0.3.2

### DIFF
--- a/docs/integrator/components/nodewright.md
+++ b/docs/integrator/components/nodewright.md
@@ -75,15 +75,15 @@ The table below is generated from the recipes by `make tuning-docs` — **do not
 
 | Service | Accelerator  | Profile | Setup              | Tuning                  |
 |---------|--------------|---------|--------------------|-------------------------|
-| aks     | a100         | h100    | nvidia-setup 0.5.0 | nvidia-tuned 0.3.1      |
-| aks     | h100         | -       | nvidia-setup 0.5.0 | nvidia-tuned 0.3.1      |
+| aks     | a100         | h100    | nvidia-setup 0.5.0 | nvidia-tuned 0.3.2      |
+| aks     | h100         | -       | nvidia-setup 0.5.0 | nvidia-tuned 0.3.2      |
 | bcm     | *            | h100    | nvidia-setup 0.3.0 | -                       |
 | bcm     | h100         | -       | nvidia-setup 0.3.0 | -                       |
-| eks     | a100         | h100    | nvidia-setup 0.5.0 | nvidia-tuned 0.3.1      |
-| eks     | gb200        | -       | nvidia-setup 0.5.0 | nvidia-tuned 0.3.1      |
-| eks     | h100         | -       | nvidia-setup 0.5.0 | nvidia-tuned 0.3.1      |
-| eks     | h200         | h100    | nvidia-setup 0.5.0 | nvidia-tuned 0.3.1      |
-| eks     | rtx-pro-6000 | generic | -                  | nvidia-tuned 0.3.1      |
+| eks     | a100         | h100    | nvidia-setup 0.5.0 | nvidia-tuned 0.3.2      |
+| eks     | gb200        | -       | nvidia-setup 0.5.0 | nvidia-tuned 0.3.2      |
+| eks     | h100         | -       | nvidia-setup 0.5.0 | nvidia-tuned 0.3.2      |
+| eks     | h200         | h100    | nvidia-setup 0.5.0 | nvidia-tuned 0.3.2      |
+| eks     | rtx-pro-6000 | generic | -                  | nvidia-tuned 0.3.2      |
 | gke     | a100         | h100    | -                  | nvidia-tuning-gke 0.1.2 |
 | gke     | b200         | -       | -                  | nvidia-tuning-gke 0.1.2 |
 | gke     | h100         | -       | -                  | nvidia-tuning-gke 0.1.2 |

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -218,7 +218,7 @@ _No images extracted._
 
 - `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.3.0@sha256:f17c951d60b519d097c20a3d9f49668f043a996adb31b9bb4db24a112a8f60a2`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-setup:0.5.0@sha256:f3994267c9b5e62fb7720012dcd4d473fc2f8474f4276e203bba842c970307ad`
-- `ghcr.io/nvidia/nodewright-packages/nvidia-tuned:0.3.1@sha256:6dedbbb8627dec88acdfd68867f60a3ddca88e5f4c62beddfb704a8e0cfe51d1`
+- `ghcr.io/nvidia/nodewright-packages/nvidia-tuned:0.3.2@sha256:a8bdca40dbe36de9d7a13e6afada49870714784fd9a3b9ce08717d675978c2b6`
 - `ghcr.io/nvidia/nodewright-packages/nvidia-tuning-gke:0.1.2@sha256:6671d49f006afdbeefd8858f1fa1216f7748205bc42edab3340210a2cc459a81`
 - `ghcr.io/nvidia/skyhook-packages/shellscript:1.1.1`
 

--- a/recipes/components/nodewright-customizations/manifests/tuning-generic.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning-generic.yaml
@@ -76,8 +76,8 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
-      version: "0.3.1"
-      containerSHA: sha256:6dedbbb8627dec88acdfd68867f60a3ddca88e5f4c62beddfb704a8e0cfe51d1
+      version: "0.3.2"
+      containerSHA: sha256:a8bdca40dbe36de9d7a13e6afada49870714784fd9a3b9ce08717d675978c2b6
       # Bootloader params in the generic profile (iommu=pt, init_on_alloc=0, ...)
       # require a reboot to take effect.
       interrupt:

--- a/recipes/components/nodewright-customizations/manifests/tuning.yaml
+++ b/recipes/components/nodewright-customizations/manifests/tuning.yaml
@@ -100,8 +100,8 @@ spec:
 
     nvidia-tuned:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
-      version: "0.3.1"
-      containerSHA: sha256:6dedbbb8627dec88acdfd68867f60a3ddca88e5f4c62beddfb704a8e0cfe51d1
+      version: "0.3.2"
+      containerSHA: sha256:a8bdca40dbe36de9d7a13e6afada49870714784fd9a3b9ce08717d675978c2b6
       interrupt:
         type: reboot
       env:
@@ -146,5 +146,5 @@ spec:
         - name: NVIDIA_SETUP_INSTALL_KERNEL
           value: "false"
       dependsOn:
-        nvidia-tuned: "0.3.1"
+        nvidia-tuned: "0.3.2"
 {{- end }}


### PR DESCRIPTION
## Summary

- Bumps `nvidia-tuned` from `0.3.1` to `0.3.2` in both `tuning.yaml` and `tuning-generic.yaml` (version, containerSHA, and `dependsOn` pin).

## Background

nvidia-tuned 0.3.2 (NVIDIA/nodewright-packages#96) removes `isolcpus` from all inference profiles. On AKS H100 nodes the old formula isolated housekeeping cores (including CPU0, the default IRQ target) instead of workload cores, starving network/softirq processing under high-concurrency inference serving:

| Configuration | Throughput | TTFT p99 | Verdict |
|---|---|---|---|
| nvidia-tuned 0.3.1 (with `isolcpus`) | 50,404 tok/s | 6,034 ms | FAIL |
| nvidia-tuned 0.3.2 (`isolcpus` removed) | 148,344 tok/s | 614 ms | PASS |

This is the fix for the AKS H100 UAT `inference-perf` regressions introduced by #1698. See NVIDIA/nodewright-packages#95 for the full root-cause analysis.

## Test plan

- [ ] CI passes
- [ ] AKS H100 UAT `inference-perf` gate passes (TTFT p99 <= 2,000 ms, throughput >= 50,000 tok/s)