### PR TITLE
fix(cleanup): backstop check namespaces; fence out-of-band installs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -579,6 +579,26 @@ aws ec2 reboot-instances --instance-ids <ids>
 kubectl uncordon <gpu-node>
 ```
 
+### Excluding Out-of-Band Installs from Cleanup
+
+On shared or bring-up clusters, a registry component may be deliberately
+installed and owned outside AICR (for example, nodewright/skyhook installed
+out-of-band by the platform team, with the AICR recipe intentionally excluding
+it). Stock `tools/cleanup` would otherwise destroy such an install three ways:
+the Helm uninstall in its namespace, the CRD pattern match, and the namespace
+deletion. Fence it out of all three phases:
+
+```bash
+tools/cleanup --exclude-ns skyhook --exclude-crd skyhook.nvidia.com
+```
+
+Both flags are repeatable and accept comma-separated values. `--exclude-ns`
+protects a namespace from Helm uninstall and namespace deletion; `--exclude-crd`
+protects CRDs whose name contains the given match from deletion, applied *after*
+pattern matching so a broad pattern (`nvidia.com`) cannot pull an excluded
+group's CRDs (`skyhook.nvidia.com`) back in. Run with `--dry-run` first to
+confirm what will and will not be removed.
+
 ### Debugging Tests
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,12 @@ license-check: ## Check license is approved
         --ignore=github.com/hashicorp/hcl \
         --ignore=$$STDLIB_IGNORE
 
+.PHONY: test-shell
+test-shell: ## Runs shell unit tests (tools/*_test.sh; hermetic, no cluster)
+	@set -e; for t in tools/*_test.sh; do [ -e "$$t" ] || continue; echo "Running $$t..."; bash "$$t"; done
+
 .PHONY: test
-test: ## Runs unit tests with race detector and coverage (use -short to skip integration tests)
+test: test-shell ## Runs unit tests with race detector and coverage (use -short to skip integration tests)
 	@set -e; \
 	echo "Running tests with race detector..."; \
 	KUBEBUILDER_ASSETS=$$(setup-envtest use -p path 2>/dev/null || echo "") \

--- a/tools/cleanup
+++ b/tools/cleanup
@@ -19,11 +19,18 @@
 #   1. Helm releases in known AICR component namespaces
 #   2. `aicr validate` artifacts (namespace, SA, CRB, leftover Jobs/CMs)
 #   3. Custom Resource Definitions owned by AICR components
-#   4. AICR component namespaces (with stuck-finalizer rescue)
+#   4. AICR component + check-created namespaces (with stuck-finalizer rescue)
 #
 # Scope is intentionally narrow: only namespaces and CRDs known to be installed
-# by AICR registry components are touched. Cluster-scoped resources outside the
-# AICR component domains are left alone.
+# by AICR registry components (plus namespaces created by conformance checks)
+# are touched. Cluster-scoped resources outside the AICR component domains are
+# left alone.
+#
+# On shared / bring-up clusters a registry component may be deliberately owned
+# out-of-band (installed by the platform team, excluded from the AICR recipe).
+# Destroying it is data loss AICR does not own, so `--exclude-ns` and
+# `--exclude-crd` fence such installs out of the Helm, CRD, and namespace
+# phases (phase 2 only touches aicr-labelled validator artifacts). See #1672.
 
 set -euo pipefail
 
@@ -35,6 +42,10 @@ DRY_RUN=false
 ASSUME_YES=false
 KEEP_CRDS=false
 KEEP_NAMESPACES=false
+# Namespaces / CRD-name substrings the operator has fenced out of every phase
+# (out-of-band or platform-owned installs). Populated by --exclude-ns/--exclude-crd.
+EXCLUDE_NS=()
+EXCLUDE_CRD=()
 
 usage() {
     cat <<EOF
@@ -43,12 +54,36 @@ Usage: tools/cleanup [options]
 Removes AICR-installed Kubernetes resources from the currently selected cluster.
 
 Options:
-  -n, --dry-run         Print actions without executing
-  -y, --yes             Skip confirmation prompt
-      --keep-crds       Don't delete CRDs (useful when reinstalling same version)
-      --keep-namespaces Don't delete component namespaces
-  -h, --help            Show this help
+  -n, --dry-run             Print actions without executing
+  -y, --yes                 Skip confirmation prompt
+      --keep-crds           Don't delete CRDs (useful when reinstalling same version)
+      --keep-namespaces     Don't delete component namespaces
+      --exclude-ns <ns>     Protect a namespace from Helm uninstall and namespace
+                            deletion (repeatable; comma-separated values accepted)
+      --exclude-crd <match> Protect CRDs whose name contains <match> from deletion
+                            (repeatable; comma-separated values accepted)
+  -h, --help                Show this help
+
+Exclusions fence out-of-band / platform-owned installs that AICR does not own.
+Example: nodewright/skyhook installed out-of-band, excluded from the recipe:
+  tools/cleanup --exclude-ns skyhook --exclude-crd skyhook.nvidia.com
 EOF
+}
+
+# split_csv_append <array-name> <value>: append comma-separated tokens of <value>
+# to the named array, trimming surrounding whitespace and skipping empties so
+# `--exclude-ns 'skyhook, gpu-operator'` protects BOTH (not ' gpu-operator',
+# which would never match and silently leave gpu-operator unprotected).
+split_csv_append() {
+    local __arr="$1" __val="$2" __tok
+    local __ifs="$IFS"
+    IFS=','
+    for __tok in $__val; do
+        __tok="${__tok#"${__tok%%[![:space:]]*}"}"  # strip leading whitespace
+        __tok="${__tok%"${__tok##*[![:space:]]}"}"   # strip trailing whitespace
+        [[ -n "$__tok" ]] && eval "${__arr}+=(\"\$__tok\")"
+    done
+    IFS="$__ifs"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -57,6 +92,12 @@ while [[ $# -gt 0 ]]; do
         -y|--yes) ASSUME_YES=true; shift ;;
         --keep-crds) KEEP_CRDS=true; shift ;;
         --keep-namespaces) KEEP_NAMESPACES=true; shift ;;
+        --exclude-ns)
+            [[ $# -ge 2 && "$2" != -* ]] || err "--exclude-ns requires a namespace argument"
+            split_csv_append EXCLUDE_NS "$2"; shift 2 ;;
+        --exclude-crd)
+            [[ $# -ge 2 && "$2" != -* ]] || err "--exclude-crd requires a match argument"
+            split_csv_append EXCLUDE_CRD "$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) err "unknown flag: $1" ;;
     esac
@@ -94,6 +135,13 @@ AICR_NAMESPACES=(
     topograph
 )
 
+# Namespaces created at runtime by AICR conformance checks (not registry
+# components). These are torn down by the check itself, but an interrupted run
+# leaves them behind, so cleanup deletes them as a backstop. See #1672.
+AICR_CHECK_NAMESPACES=(
+    gang-scheduling-test
+)
+
 # CRD API-group suffixes owned by AICR components. Matched as substrings
 # against `kubectl get crd -o name`. New component groups should be added here.
 AICR_CRD_PATTERNS=(
@@ -121,6 +169,23 @@ ctx="$(kubectl config current-context 2>/dev/null || echo unknown)"
 msg "Target cluster context: ${ctx}"
 if $DRY_RUN; then
     msg "DRY-RUN mode — no changes will be applied."
+fi
+if (( ${#EXCLUDE_NS[@]} > 0 )); then
+    msg "Excluding namespaces (Helm + namespace deletion): ${EXCLUDE_NS[*]}"
+fi
+if (( ${#EXCLUDE_CRD[@]} > 0 )); then
+    msg "Excluding CRDs matching: ${EXCLUDE_CRD[*]}"
+fi
+# --exclude-ns and --exclude-crd are almost always needed as a pair: protecting
+# only the namespace still lets Phase 3 delete the install's cluster-scoped CRDs
+# (cascade-deleting its CRs), and protecting only the CRDs still deletes the
+# namespace. Warn on an asymmetric invocation so a half-fenced install is not
+# silently destroyed.
+if (( ${#EXCLUDE_NS[@]} > 0 )) && (( ${#EXCLUDE_CRD[@]} == 0 )); then
+    log_warning "--exclude-ns given without --exclude-crd: Phase 3 will still delete the install's CRDs (and cascade its CRs). Add --exclude-crd for its API group(s)."
+fi
+if (( ${#EXCLUDE_CRD[@]} > 0 )) && (( ${#EXCLUDE_NS[@]} == 0 )); then
+    log_warning "--exclude-crd given without --exclude-ns: Phase 1/4 will still uninstall Helm releases in and delete the install's namespace. Add --exclude-ns."
 fi
 
 # Detect whether gpu-operator manages the NVIDIA kernel driver on this
@@ -219,11 +284,41 @@ is_aicr_namespace() {
     return 1
 }
 
+# is_excluded_ns <namespace>: true when the operator fenced this namespace out
+# with --exclude-ns.
+is_excluded_ns() {
+    local target="$1" ns
+    (( ${#EXCLUDE_NS[@]} == 0 )) && return 1
+    for ns in "${EXCLUDE_NS[@]}"; do
+        [[ "$target" == "$ns" ]] && return 0
+    done
+    return 1
+}
+
+# is_excluded_crd <crd-name>: true when the CRD name contains any --exclude-crd
+# match. Applied after pattern matching, so a broad pattern (e.g. nvidia.com)
+# cannot pull an excluded group's CRDs (e.g. skyhook.nvidia.com) back in.
+is_excluded_crd() {
+    local target="$1" pat
+    (( ${#EXCLUDE_CRD[@]} == 0 )) && return 1
+    for pat in "${EXCLUDE_CRD[@]}"; do
+        [[ "$target" == *"$pat"* ]] && return 0
+    done
+    return 1
+}
+
+# All namespaces cleanup owns: registry components plus check-created backstops.
+ALL_NAMESPACES=("${AICR_NAMESPACES[@]}" "${AICR_CHECK_NAMESPACES[@]}")
+
 # Phase 1: Uninstall Helm releases in AICR namespaces.
 msg "Phase 1: Uninstalling Helm releases in AICR namespaces..."
 if command -v helm >/dev/null 2>&1; then
     while IFS=$'\t' read -r release ns; do
         [[ -z "$release" || -z "$ns" ]] && continue
+        if is_excluded_ns "$ns"; then
+            msg "  skip (excluded ns): helm release ${release} -n ${ns}"
+            continue
+        fi
         if is_aicr_namespace "$ns"; then
             msg "  helm uninstall ${release} -n ${ns}"
             hm uninstall "$release" -n "$ns" --wait --timeout 2m
@@ -267,12 +362,22 @@ if ! $KEEP_CRDS; then
         for pat in "${AICR_CRD_PATTERNS[@]}"; do
             echo "  match CRDs against pattern: ${pat}"
         done
+        for pat in "${EXCLUDE_CRD[@]:+${EXCLUDE_CRD[@]}}"; do
+            echo "  excluding CRDs matching: ${pat}"
+        done
     else
         all_crds="$(kubectl get crd -o name --request-timeout=30s 2>/dev/null || true)"
         for pat in "${AICR_CRD_PATTERNS[@]}"; do
             # shellcheck disable=SC2086
             matches=$(echo "$all_crds" | grep -F "$pat" || true)
             for crd in $matches; do
+                # Fence out operator-owned CRDs. Checked here (post-match) so a
+                # broad pattern (nvidia.com) cannot pull an excluded group's
+                # CRDs (skyhook.nvidia.com) back in.
+                if is_excluded_crd "$crd"; then
+                    msg "  skip (excluded): $crd"
+                    continue
+                fi
                 # --request-timeout bounds the API call so a wedged apiserver
                 # cannot park this step indefinitely. Don't swallow failures:
                 # a timed-out delete leaves a stale CRD that breaks reinstall,
@@ -289,8 +394,12 @@ fi
 
 # Phase 4: Namespaces.
 if ! $KEEP_NAMESPACES; then
-    msg "Phase 4: Deleting AICR component namespaces..."
-    for ns in "${AICR_NAMESPACES[@]}"; do
+    msg "Phase 4: Deleting AICR component + check namespaces..."
+    for ns in "${ALL_NAMESPACES[@]}"; do
+        if is_excluded_ns "$ns"; then
+            msg "  skip (excluded ns): ${ns}"
+            continue
+        fi
         if $DRY_RUN; then
             echo "  kubectl delete ns ${ns} --ignore-not-found --wait=false"
         else
@@ -305,7 +414,8 @@ if ! $KEEP_NAMESPACES; then
     # finish first, then strip finalizers from residual namespaced objects.
     if ! $DRY_RUN; then
         sleep 10
-        for ns in "${AICR_NAMESPACES[@]}"; do
+        for ns in "${ALL_NAMESPACES[@]}"; do
+            is_excluded_ns "$ns" && continue
             kubectl get ns "$ns" >/dev/null 2>&1 || continue
             phase="$(kubectl get ns "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")"
             [[ "$phase" != "Terminating" ]] && continue

--- a/tools/cleanup_test.sh
+++ b/tools/cleanup_test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit harness for tools/cleanup exclusion + backstop behavior.
+# Run directly: bash tools/cleanup_test.sh
+# Wired into CI via `make test` (test-shell target).
+#
+# Hermetic: stubs `kubectl` and `helm` on PATH and drives the script under
+# --dry-run, so no cluster is required and no resource is ever touched. The
+# assertions guard the safety-critical logic (which installs get fenced out)
+# that protects out-of-band installs from data loss. See #1672.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLEANUP="${SCRIPT_DIR}/cleanup"
+
+# --- Stub kubectl/helm/sleep on PATH ------------------------------------------
+# All three log their args to $KLOG/$HLOG when set, so the live (--yes) path can
+# assert which resources actually received destructive calls.
+# kubectl: context name for detection; `get crd` returns an excluded and a
+# non-excluded CRD; `get ns` reports existence + a Terminating phase so the
+# phase-4 finalizer rescue engages; `api-resources`/`get configmaps` feed that
+# rescue one patchable object. helm: `ls` (phase 1) returns two releases — one
+# out-of-band, one AICR-owned; `list` (driver probe) returns nothing so the
+# cluster is treated as non-driver-managed. sleep: instant (skips phase-4 wait).
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+
+cat >"${STUB_DIR}/kubectl" <<'STUB'
+#!/usr/bin/env bash
+[[ -n "${KLOG:-}" ]] && printf '%s\n' "$*" >>"${KLOG}"
+if [[ "$1" == "config" && "$2" == "current-context" ]]; then echo "stub-ctx"; exit 0; fi
+if [[ "$1" == "api-resources" ]]; then echo "configmaps"; exit 0; fi
+if [[ "$1" == "get" ]]; then
+    case "$2" in
+        crd)
+            printf '%s\n' \
+                "customresourcedefinition.apiextensions.k8s.io/clusterpolicies.nvidia.com" \
+                "customresourcedefinition.apiextensions.k8s.io/nodes.skyhook.nvidia.com"
+            ;;
+        ns|namespace)
+            for a in "$@"; do [[ "$a" == *status.phase* ]] && { echo "Terminating"; exit 0; }; done
+            ;;
+        configmaps) echo "configmap/stub-cm" ;;
+    esac
+    exit 0
+fi
+exit 0
+STUB
+
+cat >"${STUB_DIR}/helm" <<'STUB'
+#!/usr/bin/env bash
+[[ -n "${HLOG:-}" ]] && printf '%s\n' "$*" >>"${HLOG}"
+if [[ "$1" == "ls" ]]; then
+    printf 'NAME\tNAMESPACE\tREVISION\n'
+    printf 'nodewright\tskyhook\t1\n'
+    printf 'gpu-operator\tgpu-operator\t1\n'
+fi
+exit 0
+STUB
+
+cat >"${STUB_DIR}/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+chmod +x "${STUB_DIR}/kubectl" "${STUB_DIR}/helm" "${STUB_DIR}/sleep"
+export PATH="${STUB_DIR}:${PATH}"
+
+# run <args...>: capture combined stdout+stderr into $OUT and exit code into $RC.
+OUT=""
+RC=0
+run() {
+    OUT="$("${CLEANUP}" "$@" 2>&1)"
+    RC=$?
+}
+
+fails=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1 — $2"; fails=$((fails + 1)); }
+
+check_contains() { # <name> <needle>
+    if [[ "${OUT}" == *"$2"* ]]; then pass "$1"; else fail "$1" "expected to contain: $2"; fi
+}
+check_absent() { # <name> <needle>
+    if [[ "${OUT}" != *"$2"* ]]; then pass "$1"; else fail "$1" "expected NOT to contain: $2"; fi
+}
+check_rc() { # <name> <want_rc>
+    if [[ "${RC}" == "$2" ]]; then pass "$1"; else fail "$1" "want rc=$2 got rc=${RC}"; fi
+}
+check_rc_nonzero() { # <name>
+    if [[ "${RC}" != "0" ]]; then pass "$1"; else fail "$1" "want nonzero rc, got 0"; fi
+}
+
+# 1. Repeatable + comma-separated --exclude-ns parse into the exclusion set.
+run --dry-run --exclude-ns a,b --exclude-ns c --exclude-crd x
+check_contains "csv-and-repeat-ns-parsed" "Excluding namespaces (Helm + namespace deletion): a b c"
+
+# 2. Phase 1: an excluded namespace's Helm release is skipped; a non-excluded
+#    AICR release is still uninstalled.
+run --dry-run --exclude-ns skyhook --exclude-crd skyhook.nvidia.com
+check_contains "phase1-excluded-release-skipped" "skip (excluded ns): helm release nodewright -n skyhook"
+check_contains "phase1-nonexcluded-release-uninstalled" "helm uninstall gpu-operator -n gpu-operator"
+
+# 3. Phase 4: excluded namespace is preserved; the check-created backstop
+#    namespace is still deleted.
+check_contains "phase4-excluded-ns-skipped" "skip (excluded ns): skyhook"
+check_absent   "phase4-excluded-ns-not-deleted" "kubectl delete ns skyhook "
+check_contains "phase4-check-backstop-deleted" "kubectl delete ns gang-scheduling-test"
+
+# 4. Phase 3: excluded CRD match is echoed under dry-run.
+check_contains "phase3-excluded-crd-echoed" "excluding CRDs matching: skyhook.nvidia.com"
+
+# 5. Asymmetric invocation warns (ns without crd, and crd without ns).
+run --dry-run --exclude-ns skyhook
+check_contains "warn-ns-without-crd" "given without --exclude-crd"
+run --dry-run --exclude-crd skyhook.nvidia.com
+check_contains "warn-crd-without-ns" "given without --exclude-ns"
+
+# 6. Symmetric invocation does NOT warn.
+run --dry-run --exclude-ns skyhook --exclude-crd skyhook.nvidia.com
+check_absent "no-warn-when-paired" "given without"
+
+# 7. Missing / flag-shaped argument fails closed.
+run --dry-run --exclude-ns
+check_rc_nonzero "missing-exclude-ns-arg-fails"
+run --dry-run --exclude-ns --yes
+check_rc_nonzero "flag-shaped-exclude-ns-arg-fails"
+
+# 8. No-exclusion path runs cleanly under set -u (empty arrays).
+run --dry-run
+check_rc "no-flags-dry-run-succeeds" 0
+check_contains "no-flags-backstop-present" "kubectl delete ns gang-scheduling-test"
+
+# 9. Whitespace-padded CSV tokens are trimmed (both are protected).
+run --dry-run --exclude-ns 'skyhook, gpu-operator'
+check_contains "csv-trims-whitespace" "Excluding namespaces (Helm + namespace deletion): skyhook gpu-operator"
+
+# 10. Live (--yes) path: exercise the real destructive branches with logging
+#     stubs and assert excluded resources NEVER receive delete/patch calls
+#     (dry-run cannot reach is_excluded_crd or the finalizer-rescue skip).
+has()    { if [[ "$2" == *"$3"* ]]; then pass "$1"; else fail "$1" "expected to contain: $3"; fi; }
+has_not() { if [[ "$2" != *"$3"* ]]; then pass "$1"; else fail "$1" "expected NOT to contain: $3"; fi; }
+
+KLOG="$(mktemp)"; HLOG="$(mktemp)"
+KLOG="${KLOG}" HLOG="${HLOG}" "${CLEANUP}" --yes \
+    --exclude-ns skyhook --exclude-crd skyhook.nvidia.com >/dev/null 2>&1
+klog="$(cat "${KLOG}")"; hlog="$(cat "${HLOG}")"
+rm -f "${KLOG}" "${HLOG}"
+
+# CRD phase: non-excluded CRD deleted; the excluded group is never touched even
+# though the broad nvidia.com pattern matches it.
+has     "live-crd-nonexcluded-deleted" "${klog}" "delete customresourcedefinition.apiextensions.k8s.io/clusterpolicies.nvidia.com"
+has_not "live-nothing-skyhook-in-kubectl" "${klog}" "skyhook"
+# Namespace phase: backstop deleted; excluded namespace neither deleted nor
+# finalizer-patched (the has_not above already covers skyhook end-to-end).
+has     "live-backstop-ns-deleted" "${klog}" "delete ns gang-scheduling-test"
+# Finalizer rescue actually engaged on a non-excluded Terminating namespace.
+has     "live-finalizer-rescue-ran" "${klog}" "patch configmap/stub-cm -n gang-scheduling-test"
+# Helm phase: AICR-owned release uninstalled; out-of-band release left alone.
+has     "live-helm-nonexcluded-uninstalled" "${hlog}" "uninstall gpu-operator"
+has_not "live-helm-excluded-untouched" "${hlog}" "nodewright"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All cleanup exclusion tests passed"

--- a/validators/conformance/gang_scheduling_check.go
+++ b/validators/conformance/gang_scheduling_check.go
@@ -180,10 +180,17 @@ func CheckGangScheduling(ctx *validators.Context) error {
 	defer func() { //nolint:contextcheck // Fresh context: parent may be canceled during cleanup
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 		defer cleanupCancel()
-		cleanupGangTestResources(cleanupCtx, ctx.Clientset, dynClient, run)
+		nsErr := cleanupGangTestResources(cleanupCtx, ctx.Clientset, dynClient, run)
+		result := "Deleted gang test pods, PodGroup, and the gang-scheduling-test namespace."
+		if nsErr != nil {
+			// Report the real outcome: a failed namespace delete leaves residue,
+			// so don't record a false success (tools/cleanup is the backstop).
+			result = fmt.Sprintf(
+				"Deleted gang test pods and PodGroup; namespace deletion FAILED (residue may remain, rerun tools/cleanup): %v",
+				nsErr)
+		}
 		recordRawTextArtifact(ctx, "Delete test namespace",
-			"kubectl delete namespace gang-scheduling-test --ignore-not-found",
-			"Deleted gang test pods and PodGroup; namespace retained intentionally to keep cleanup bounded.")
+			"kubectl delete namespace gang-scheduling-test --ignore-not-found", result)
 	}()
 
 	recordRawTextArtifact(ctx, "Apply test manifest",
@@ -421,7 +428,12 @@ func validateGangPatterns(pods [gangMinMembers]*corev1.Pod, run *gangTestRun) (*
 
 // cleanupGangTestResources removes test resources. Best-effort: errors are ignored.
 // The namespace is intentionally NOT deleted — namespace deletion can hang on DRA finalizers.
-func cleanupGangTestResources(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, run *gangTestRun) {
+// cleanupGangTestResources tears down the gang test pods, PodGroup, and
+// namespace best-effort. It returns the namespace deletion error (nil on
+// success) so the caller can record the true outcome instead of a false
+// success; pod/PodGroup deletes stay best-effort as the namespace delete
+// subsumes them.
+func cleanupGangTestResources(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, run *gangTestRun) error {
 	// Delete pods first (releases claim reservations).
 	for i := range gangMinMembers {
 		_ = k8s.IgnoreNotFound(clientset.CoreV1().Pods(gangTestNamespace).Delete(
@@ -438,6 +450,21 @@ func cleanupGangTestResources(ctx context.Context, clientset kubernetes.Interfac
 	// Delete PodGroup.
 	_ = k8s.IgnoreNotFound(dynClient.Resource(podGroupGVR).Namespace(gangTestNamespace).Delete(
 		ctx, run.groupName, metav1.DeleteOptions{}))
+	// Delete the namespace so a cluster reset leaves no residue. Pods and the
+	// PodGroup are already gone, so this is a single bounded (background
+	// propagation) API call. tools/cleanup lists gang-scheduling-test as a
+	// backstop for interrupted runs; deleting it here is the primary path.
+	//
+	// Use a dedicated deadline rather than the shared cleanup ctx: a pod stuck
+	// on a finalizer can burn the whole budget in the waits above, and starving
+	// this delete is precisely the leak we are fixing.
+	nsCtx, nsCancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
+	defer nsCancel()
+	//nolint:contextcheck // fresh deadline so an earlier stuck wait cannot starve namespace teardown
+	if err := k8s.IgnoreNotFound(clientset.CoreV1().Namespaces().Delete(nsCtx, gangTestNamespace, metav1.DeleteOptions{})); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to delete gang test namespace", err)
+	}
+	return nil
 }
 
 // buildPodGroup returns the unstructured PodGroup for the gang scheduling test.

--- a/validators/conformance/gang_scheduling_check_test.go
+++ b/validators/conformance/gang_scheduling_check_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestCleanupGangTestResourcesDeletesNamespace verifies the check tears down
+// its own gang-scheduling-test namespace, so a "complete" tools/cleanup run
+// (or a fresh install) is not left with residue. See issue #1672.
+func TestCleanupGangTestResourcesDeletesNamespace(t *testing.T) {
+	run, err := newGangTestRun()
+	if err != nil {
+		t.Fatalf("newGangTestRun: %v", err)
+	}
+
+	objs := make([]runtime.Object, 0, 1+gangMinMembers)
+	objs = append(objs, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: gangTestNamespace}})
+	for i := range gangMinMembers {
+		objs = append(objs, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: run.pods[i], Namespace: gangTestNamespace},
+		})
+	}
+	clientset := k8sfake.NewSimpleClientset(objs...)
+
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{podGroupGVR: "PodGroupList"},
+	)
+
+	if err := cleanupGangTestResources(context.Background(), clientset, dynClient, run); err != nil {
+		t.Fatalf("cleanupGangTestResources returned error: %v", err)
+	}
+
+	if _, err := clientset.CoreV1().Namespaces().Get(
+		context.Background(), gangTestNamespace, metav1.GetOptions{}); !k8serrors.IsNotFound(err) {
+		t.Fatalf("namespace %s still present after cleanup: err=%v", gangTestNamespace, err)
+	}
+}


### PR DESCRIPTION
## Summary

Stops `tools/cleanup` from missing the `gang-scheduling-test` namespace and from destroying out-of-band / operator-owned installs during a live cluster reset.

## Motivation / Context

Two gaps surfaced during a live cluster reset:

1. The gang-scheduling conformance check creates a `gang-scheduling-test` namespace that survived a "complete" cleanup: the Go check retained it intentionally, and cleanup's namespace list did not include it.
2. `tools/cleanup` had no way to protect a registry component that is deliberately installed and owned outside AICR (in our case nodewright/skyhook, installed out-of-band by the platform team, excluded from the AICR recipe). Stock cleanup destroyed such an install three ways: Helm uninstall in its namespace, CRD pattern match (the broad `nvidia.com` pattern also matches `skyhook.nvidia.com`), and namespace deletion. That is data loss for an install AICR does not own.

Fixes: #1672
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/cleanup`, `validators/conformance`

## Implementation Notes

**Namespace leak (two-sided fix):**
- `validators/conformance/gang_scheduling_check.go`: `cleanupGangTestResources` now deletes the `gang-scheduling-test` namespace after pods and the PodGroup are gone. It is a single bounded background-propagation call under `defaults.K8sCleanupTimeout`, so cleanup stays bounded.
- `tools/cleanup`: new `AICR_CHECK_NAMESPACES=(gang-scheduling-test)` list, merged into phase 4 as a backstop for interrupted runs.

**Exclusions for out-of-band installs:**
- New repeatable, comma-separated `--exclude-ns <ns>` and `--exclude-crd <match>` flags.
  - `--exclude-ns` skips phase 1 (Helm uninstall) and phase 4 (namespace deletion + finalizer rescue).
  - `--exclude-crd` skips matching CRDs in phase 3, applied *after* pattern matching so the broad `nvidia.com` pattern cannot pull `skyhook.nvidia.com` CRDs back in.
- Both flags are echoed in the preamble and honored under `--dry-run` for a pre-flight preview.
- Warns on an asymmetric invocation (only one of the pair), since fencing just the namespace still lets phase 3 cascade-delete the install's CRs.

The prior workaround now reduces to:
```bash
tools/cleanup --exclude-ns skyhook --exclude-crd skyhook.nvidia.com
```

## Testing

```bash
shellcheck -x tools/cleanup                                       # clean
golangci-lint run -c .golangci.yaml ./validators/conformance/...  # 0 issues
go test -race ./validators/conformance/ -count=1                  # PASS
```

Manual `--dry-run` verification: exclusions echoed and applied in phases 1/3/4; excluded namespace skipped while the `gang-scheduling-test` backstop is still deleted; asymmetric-flag warnings fire; missing/flag-shaped values are rejected; the no-flag path runs cleanly under `set -u` (macOS bash 3.2).

Not run locally: the full `make qualify` (e2e + Grype scan need cluster/network access unavailable in this environment). The only Go surface touched is `validators/conformance`, covered above with `-race` and lint; `tools/cleanup` is a bash script covered by shellcheck and dry-run exercises. A new unit test (`gang_scheduling_check_test.go`) covers the namespace teardown, raising coverage on the previously-untested cleanup path.

## Risk Assessment

- [x] **Low** — Isolated change to a dev/reset tool plus one conformance-check cleanup path; additive flags with safe defaults; easy to revert.

**Rollout notes:** Backwards compatible. Default behavior is unchanged except that phase 4 now also deletes `gang-scheduling-test` (a check-created namespace) and the gang check tears down its own namespace. New flags are opt-in.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — ran `go test -race ./validators/conformance/`; full `make test` not run (see Testing)
- [x] Linter passes (`make lint`) — ran `golangci-lint` on the affected package + `shellcheck`; full `make lint` not run (see Testing)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
