### PR TITLE
fix(oci): restore layer title annotation for file-store unpack

### DIFF
--- a/pkg/oci/archive.go
+++ b/pkg/oci/archive.go
@@ -161,6 +161,17 @@ func buildDeterministicTarGzipWithDependencies(
 		Annotations: map[string]string{
 			file.AnnotationDigest: tarDigester.Digest().String(),
 			file.AnnotationUnpack: "true",
+			// AnnotationTitle names the on-disk destination an ORAS file
+			// store (oras.Copy into file.New(dir)) unpacks this layer to.
+			// The generic archive packs the source tree at the tar root,
+			// so the store must unpack it into its own root (".") — without
+			// this the store treats the layer as an unnamed blob and writes
+			// NOTHING to disk, and a downstream file-store pull (e.g. the
+			// evidence verifier's materialize step) sees an empty directory
+			// and fails "does not contain a recognizable summary bundle".
+			// The Helm path sets its own title (the chart dir); only this
+			// generic path regressed when the annotation was dropped.
+			ociv1.AnnotationTitle: ".",
 		},
 	}
 	if err := verifyArchiveDescriptor(ctx, layout.child, name, descriptor, deps); err != nil {

--- a/pkg/oci/archive_test.go
+++ b/pkg/oci/archive_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/file"
 
 	apperrors "github.com/NVIDIA/aicr/pkg/errors"
 )
@@ -85,6 +86,43 @@ func TestPackage_SourceFilesArchiveContainsOnlyFrozenSortedSelection(t *testing.
 	}
 	if _, ok := files["other.txt"]; ok {
 		t.Fatal("archive included an unselected file")
+	}
+}
+
+// TestBuildDeterministicTarGzipSetsFileStoreUnpackTitle locks the two layer
+// annotations an ORAS file store needs to MATERIALIZE the layer to disk on
+// pull. oras.Copy into a file.New(dir) store unpacks a layer into the path
+// named by org.opencontainers.image.title (here ".", the store root) when
+// io.deis.oras.content.unpack is "true"; WITHOUT the title annotation the
+// store treats the layer as an unnamed blob and writes NOTHING to disk, so a
+// downstream file-store pull (e.g. the evidence verifier's materialize step)
+// sees an empty directory. Regression guard for the generic archive path —
+// dropping the title annotation broke every `main` UAT verify (issue #1793).
+func TestBuildDeterministicTarGzipSetsFileStoreUnpackTitle(t *testing.T) {
+	sourceDir := t.TempDir()
+	outputDir := t.TempDir()
+	writeSourceFixture(t, sourceDir)
+	safeOCITempRoot(t)
+	prepared, err := preparePackageSource(context.Background(), sourceDir, outputDir, "", nil)
+	if err != nil {
+		t.Fatalf("preparePackageSource() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := prepared.Close(); closeErr != nil {
+			t.Error(closeErr)
+		}
+	})
+	layout := newTestOwnedLayout(t, outputDir)
+	_, desc, err := buildDeterministicTarGzip(context.Background(), prepared, layout, archiveOptions{})
+	if err != nil {
+		t.Fatalf("buildDeterministicTarGzip() error = %v", err)
+	}
+	if got := desc.Annotations[ociv1.AnnotationTitle]; got != "." {
+		t.Errorf("layer %q annotation = %q, want %q — an ORAS file store unpacks into this path; "+
+			"empty means the layer is never written to disk on pull", ociv1.AnnotationTitle, got, ".")
+	}
+	if got := desc.Annotations[file.AnnotationUnpack]; got != "true" {
+		t.Errorf("layer %q annotation = %q, want \"true\"", file.AnnotationUnpack, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Restore the `org.opencontainers.image.title` annotation on the **generic** OCI archive layer, so an ORAS file store can materialize the layer to disk on pull. Fixes the evidence-verify regression that broke **every `@ main` UAT cell** (all clouds, both intents).

## Motivation / Context

Fixes: #1793

Since #1758 (generic-path packaging rewrite), UAT `verify` fails on every `@ main` cell — AWS/GCP/Azure, training + inference — at the `materialize-bundle` step:

```
[INVALID_REQUEST] pulled artifact does not contain a recognizable summary bundle
```

`@ v0.17.0` cells pass. I pulled both artifacts from GHCR and diffed them — **the bundle content is identical and correct** (`recipe.yaml` + `manifest.json` at the tar root in both). The only difference is one layer annotation:

| layer annotation | v0.17.0 ✅ | `main` ❌ |
|---|---|---|
| `io.deis.oras.content.unpack` | `"true"` | `"true"` |
| **`org.opencontainers.image.title`** | **`"."`** | **absent** |

The verifier materializes bundles with an ORAS **file store** (`oras.Copy(…, file.New(tmp), …)`, `pkg/evidence/verifier/fetch.go`). ORAS writes/unpacks each layer to disk using `org.opencontainers.image.title` as the destination path. With `title:"."` + `unpack:"true"` it unpacks the tar into the store root (markers land at root); with the title **absent** the layer is an unnamed blob and is **never written to disk** → empty dir → `resolveBundleDir` fails.

#1758's generic-path rewrite dropped the annotation (`pkg/oci/archive.go`); the Helm path still sets its own title (`pkg/oci/helm.go`), which is why only the generic (evidence/bundle) path regressed. The removed doc comment in #1758 notes the title annotation "materializing as a literal filename" — but the verifier's file-store pull *depends* on it, so it must stay.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Core libraries (`pkg/oci`)
- [x] Other: evidence verification (consumer)

## Implementation Notes

One line: re-add `ociv1.AnnotationTitle: "."` to the generic layer descriptor in `pkg/oci/archive.go`, restoring v0.17.0 behavior. Plus a regression test (`TestBuildDeterministicTarGzipSetsFileStoreUnpackTitle`) asserting both the `unpack` and `title` annotations, verified to fail without the fix (`title=""`) and pass with it.

@mchmarny — flagging you as the #1758 author in case dropping the title was deliberate (the removed comment suggests a stray-`.`-file concern); if so, the alternative would be teaching the verifier's materialize step to extract the layer without relying on the ORAS file-store title convention. Restoring the annotation is the minimal fix that matches the last-known-good behavior.

## Testing

```bash
go test -race ./pkg/oci/... ./pkg/evidence/... ./pkg/bundler/attestation/...   # pass
golangci-lint run -c .golangci.yaml ./pkg/oci/...                              # 0 issues
```
(Note: `TestHelmV4_2_3ExplicitVersionPull` fails identically on clean `origin/main` — a local helm-binary version mismatch, unrelated to this change.)

## Risk Assessment

- [x] **Low** — One additive annotation restoring v0.17.0 behavior; generic-path artifacts now materialize on file-store pull as they did before #1758. Helm path untouched. Reversible.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
