### PR TITLE
chore: base AICR containers on nvcr.io/nvidia/distroless/static

### DIFF
--- a/.github/actions/aicr-build/build-validator-images.sh
+++ b/.github/actions/aicr-build/build-validator-images.sh
@@ -45,11 +45,11 @@ for phase in ${PHASES//,/ }; do
     exit 1
   fi
   docker build -t "ko.local/aicr-validators/${phase}:latest" -f - . <<DOCKERFILE
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 COPY dist/validator/${phase} /${phase}
 COPY validators/${phase}/testdata /app/testdata
 WORKDIR /app
-USER nonroot
+USER nvs
 ENTRYPOINT ["/${phase}"]
 DOCKERFILE
   timeout 600 kind load docker-image "ko.local/aicr-validators/${phase}:latest" --name "${KIND_CLUSTER_NAME}" || {

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -87,12 +87,12 @@ runs:
           done
           for phase in deployment performance conformance; do
             docker build -t "localhost:5001/aicr-validators/${phase}:latest" -f - . <<DOCKERFILE
-        FROM gcr.io/distroless/static-debian12:nonroot
+        FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
         COPY dist/validator/${phase} /${phase}
         COPY validators/${phase}/testdata /app/testdata
         COPY dist/validator/chainsaw /usr/local/bin/chainsaw
         WORKDIR /app
-        USER nonroot
+        USER nvs
         ENTRYPOINT ["/${phase}"]
         DOCKERFILE
             docker push "localhost:5001/aicr-validators/${phase}:latest"

--- a/.github/workflows/vuln-scan-images.yaml
+++ b/.github/workflows/vuln-scan-images.yaml
@@ -92,7 +92,8 @@ jobs:
         env:
           GOFLAGS: -mod=vendor
           KO_DOCKER_REPO: ghcr.io/nvidia/aicrd
-          KO_DEFAULTBASEIMAGE: gcr.io/distroless/static:nonroot
+          # Base image inherited from .ko.yaml (nvcr.io/nvidia/distroless/static),
+          # same as the aicr build above.
         run: |
           set -euo pipefail
           ko build ./cmd/aicrd \

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -166,10 +166,11 @@ kos:
     build: aicr
     repositories:
       - ghcr.io/nvidia/aicr
-    # No base_image: ko uses its default static, distroless base
-    # (cgr.dev/chainguard/static). The aicr CLI/agent is pure Go and discovers
-    # the GPU SKU driver-free via NFD/PCI, so it no longer needs nvidia-smi or
-    # the CUDA base image (and its CVE surface).
+    # NVIDIA's static distroless base (replaces ko's chainguard default). The
+    # aicr CLI/agent is pure Go and discovers the GPU SKU driver-free via
+    # NFD/PCI, so it no longer needs nvidia-smi or the CUDA base image (and its
+    # CVE surface).
+    base_image: nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
     platforms:
       - linux/amd64
       - linux/arm64
@@ -185,10 +186,11 @@ kos:
     build: aicrd
     repositories:
       - ghcr.io/nvidia/aicrd
-    # No base_image: aicrd intentionally uses ko's default static, distroless
-    # base (cgr.dev/chainguard/static), same as aicr above. It runs as the
-    # nonroot user 65532 by default, preserving the security posture of the
-    # previous gcr.io/distroless/static:nonroot base (also UID 65532).
+    # NVIDIA's static distroless base, same as aicr above. ko stamps its default
+    # nonroot user (UID 65532) numerically, preserving the unprivileged security
+    # posture of the previous gcr.io/distroless/static:nonroot base (also UID
+    # 65532); the base image's own nvs (UID 1000) account is unused here.
+    base_image: nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
     platforms:
       - linux/amd64
       - linux/arm64

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# No defaultBaseImage: the aicr CLI/agent is a pure-Go binary that discovers
-# the GPU SKU driver-free via NFD/PCI, so it no longer needs nvidia-smi or the
-# CUDA base (and its recurring CVE surface). With no override, ko uses its
-# default static, distroless base image (cgr.dev/chainguard/static).
+# The aicr CLI/agent is a pure-Go binary that discovers the GPU SKU driver-free
+# via NFD/PCI, so it needs neither nvidia-smi nor the CUDA base (and its
+# recurring CVE surface). It runs on NVIDIA's own static distroless base rather
+# than ko's default (cgr.dev/chainguard/static). ko still stamps its default
+# nonroot user (UID 65532) numerically, so it runs unprivileged regardless of
+# the base image's own nvs (UID 1000) account. This defaultBaseImage applies to
+# `ko build` CLI invocations (e.g. the vuln-scan workflow); goreleaser's kos
+# entries pin the same image explicitly via base_image.
+defaultBaseImage: nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -173,8 +173,9 @@ testing:
   gpu_operator_chart_version: 'v25.10.1'
   # Base image for the CI smoke-test snapshot-agent image. The agent binary is
   # static Go and detects GPUs driver-free via NFD/PCI, so it no longer needs a
-  # CUDA base / nvidia-smi. Matches ko's default static base for the aicr image.
-  snapshot_agent_base_image: 'cgr.dev/chainguard/static:latest'
+  # CUDA base / nvidia-smi. Matches the NVIDIA static distroless base used for
+  # the aicr image (see .ko.yaml).
+  snapshot_agent_base_image: 'nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69'
 
   # Component test harness configuration
   # Used by tools/component-test/ scripts to validate individual components

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,16 +172,16 @@ Published to GitHub Container Registry (`ghcr.io/nvidia/`):
 
 | Image | Base | Description |
 |-------|------|-------------|
-| `aicr` | `nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04` | CLI with CUDA runtime |
-| `aicrd` | `gcr.io/distroless/static:nonroot` | Minimal API server |
+| `aicr` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Pure-Go CLI/agent (driver-free GPU discovery) |
+| `aicrd` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Minimal API server |
 
 Published to GitHub Container Registry (`ghcr.io/nvidia/aicr-validators/`):
 
 | Image | Base | Description |
 |-------|------|-------------|
-| `deployment` | `gcr.io/distroless/static-debian12:nonroot` | Deployment validator |
-| `performance` | `gcr.io/distroless/static-debian12:nonroot` | Performance validator |
-| `conformance` | `gcr.io/distroless/static-debian12:nonroot` | Conformance validator |
+| `deployment` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Deployment validator |
+| `performance` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Performance validator |
+| `conformance` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Conformance validator |
 | `aiperf-bench` | `python:3.12-slim` | AIPerf benchmark runner |
 
 Stable releases promote `vX.Y.Z` and `latest`; prereleases promote their

--- a/cmd/gate/Dockerfile
+++ b/cmd/gate/Dockerfile
@@ -46,7 +46,7 @@ RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -extldflags '-static' -X main.version=${VERSION}" \
     -o /out/gate ./cmd/gate
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 
 COPY --from=builder /out/gate /gate
 COPY --from=chainsaw /ko-app/chainsaw /usr/local/bin/chainsaw
@@ -56,5 +56,7 @@ COPY --from=chainsaw /ko-app/chainsaw /usr/local/bin/chainsaw
 # points here; see cmd/gate/main.go (defaultChainsawConfig).
 COPY cmd/gate/chainsaw-config.yaml /etc/chainsaw/config.yaml
 
-USER nonroot
+# nvs (UID 1000) is the sole nonroot user shipped in the NVIDIA distroless
+# static base; it has no "nonroot"/65532 user like the previous distroless bases.
+USER nvs
 ENTRYPOINT ["/gate"]

--- a/validators/conformance/Dockerfile
+++ b/validators/conformance/Dockerfile
@@ -24,9 +24,10 @@ COPY recipes/ recipes/
 
 RUN CGO_ENABLED=0 go build -o /out/conformance ./validators/conformance
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 
 COPY --from=builder /out/conformance /conformance
 
-USER nonroot
+# nvs (UID 1000) is the sole nonroot user in the NVIDIA distroless static base.
+USER nvs
 ENTRYPOINT ["/conformance"]

--- a/validators/deployment/Dockerfile
+++ b/validators/deployment/Dockerfile
@@ -32,11 +32,12 @@ COPY validators/ validators/
 
 RUN CGO_ENABLED=0 go build -o /out/deployment ./validators/deployment
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 
 COPY --from=builder /out/deployment /deployment
 COPY --from=builder /src/validators/deployment/testdata /app/testdata
 
 WORKDIR /app
-USER nonroot
+# nvs (UID 1000) is the sole nonroot user in the NVIDIA distroless static base.
+USER nvs
 ENTRYPOINT ["/deployment"]

--- a/validators/performance/Dockerfile
+++ b/validators/performance/Dockerfile
@@ -24,11 +24,12 @@ COPY recipes/ recipes/
 
 RUN CGO_ENABLED=0 go build -o /out/performance ./validators/performance
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 
 COPY --from=builder /out/performance /performance
 COPY --from=builder /src/validators/performance/testdata /app/testdata
 
 WORKDIR /app
-USER nonroot
+# nvs (UID 1000) is the sole nonroot user in the NVIDIA distroless static base.
+USER nvs
 ENTRYPOINT ["/performance"]


### PR DESCRIPTION
## Summary

Base every AICR-built container on NVIDIA's own `nvcr.io/nvidia/distroless/static:v4.0.0`, replacing ko's Chainguard default (`cgr.dev/chainguard/static`) and Google distroless (`gcr.io/distroless/static-debian12:nonroot`).

## Motivation / Context

Standardize the distroless base for all AICR images onto NVIDIA's supported distroless static image instead of third-party bases.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: build/release config (`.ko.yaml`, `.goreleaser.yaml`, CI actions, gate image)

## Implementation Notes

- **ko images (`aicr`, `aicrd`)**: `base_image` pinned in `.goreleaser.yaml`; `defaultBaseImage` added to `.ko.yaml` so `ko build` CLI paths (e.g. the vuln-scan workflow) pick it up. Dropped the stale `KO_DEFAULTBASEIMAGE: gcr.io/distroless/static:nonroot` override in `vuln-scan-images.yaml` so `aicrd` inherits the same base as `aicr`.
- **Dockerfile images** (`gate`, `deployment`/`performance`/`conformance` validators) and the inline CI validator + snapshot-agent images: `FROM` swap.
- **`USER nonroot` → `USER nvs`**: the nvcr base ships only user `nvs` (UID 1000) and has no `nonroot`/`65532` account, so leaving `USER nonroot` would fail pod startup with "unable to find user nonroot". Verified against the image's `/etc/passwd` and by building a probe image (`Config.User` resolves to `nvs`). The ko-built `aicr`/`aicrd` still run as UID 65532 numerically (ko stamps that regardless of base), so their unprivileged posture is unchanged.
- `.settings.yaml` `snapshot_agent_base_image` and the `RELEASING.md` base-image table updated (the table also had pre-existing drift listing `aicr` on a CUDA base).
- **Deliberately out of scope:** `.openvex.json` names the old `aicrd` base in a CVE-2026-45447 (openssl) suppression. Distroless carries no openssl, so this base swap only shrinks the scan surface and the statement stays inert rather than wrong; rewriting it belongs to the OpenVEX-maintenance workflow as a follow-up.

## Testing

```bash
goreleaser check          # config valid (only pre-existing brews deprecation)
yamllint <changed yaml>   # clean
docker build FROM nvcr.io/nvidia/distroless/static:v4.0.0 + USER nvs  # builds; user resolves to nvs
```

No Go source changed.

## Risk Assessment

- [x] **Low** — Isolated base-image swap, easy to revert.

**Rollout notes:** No API/behavior change. Pods that previously relied on the base default user now run as `nvs` (UID 1000) instead of `nonroot` (UID 65532); still unprivileged. Any downstream `securityContext.runAsUser` pins are numeric and unaffected.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
