### PR TITLE
feat(config): add KMS signingKey to AICRConfig bundle attestation

### DIFF
--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -144,6 +144,7 @@ spec:
       oidcDeviceFlow: false
       fulcioURL: ""                  # private Sigstore overrides; empty = public good
       rekorURL: ""
+      signingKey: ""                 # KMS key ref (awskms:// | gcpkms:// | ...); empty = keyless OIDC
     registry:                        # OCI transport for oci:// push
       insecureTLS: false
       plainHTTP: false
@@ -231,10 +232,11 @@ Inputs to `aicr bundle`.
 | `deployment.vendorCharts` | bool | Vendor charts into the bundle |
 | `deployment.appName` | string | Argo CD parent `Application` name override (multi-bundle installs sharing a namespace) |
 | `scheduling.*` | object | `systemNodeSelector`/`Tolerations`, `acceleratedNodeSelector`/`Tolerations`, `workloadGate`, `workloadSelector`, `nodes`, `storageClass`. Selectors are YAML maps; tolerations use the CLI's `key=value:effect` strings |
-| `attestation.enabled` | bool | Keyless-sign the bundle |
+| `attestation.enabled` | bool | Enable bundle attestation (signing); keyless OIDC by default, KMS-backed when `signingKey` is set |
 | `attestation.certificateIdentityRegexp` | string | Expected signer identity |
 | `attestation.oidcDeviceFlow` | bool | Device-code flow for headless signing |
 | `attestation.fulcioURL` / `.rekorURL` | string | Private Sigstore endpoints; empty = public-good defaults |
+| `attestation.signingKey` | string | KMS key reference for key-based signing (`awskms://` \| `gcpkms://` \| `azurekms://` \| `hashivault://`); empty = keyless OIDC. Mutually exclusive with the keyless-only inputs (`oidcDeviceFlow`, `fulcioURL`, `--identity-token`) |
 | `registry.insecureTLS` / `.plainHTTP` | bool | OCI transport options for push |
 
 When `output.imageRefs` is set, AICR writes the published OCI digest through a

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1331,6 +1331,13 @@ spec:
       # be absolute https:// URLs with no embedded credentials.
       fulcioURL: https://fulcio.internal.example.com
       rekorURL: https://rekor.internal.example.com
+      # Optional KMS-backed signing (awskms:// | gcpkms:// | azurekms:// |
+      # hashivault://): a durable, non-secret key reference that replaces
+      # keyless OIDC. Mirrors --signing-key (the flag wins when both are set).
+      # Mutually exclusive with the keyless-only inputs above (fulcioURL,
+      # oidcDeviceFlow) and the runtime-only --identity-token, so it is shown
+      # commented out here as the alternative to the keyless block.
+      # signingKey: awskms://alias/aicr-signing
     registry:
       insecureTLS: false
       plainHTTP: false
@@ -2312,6 +2319,14 @@ aicr bundle --recipe recipe.yaml --attest \
   --signing-key awskms://arn:aws:kms:us-east-1:123456789012:key/abcd-1234 \
   --output ./bundles
 ```
+
+Because a KMS key reference is durable and non-secret, it can live in a
+version-controlled `--config` file as `spec.bundle.attestation.signingKey`
+instead of on the command line (the `--signing-key` flag wins when both are
+set). As with the flag, signing only runs when attestation is enabled, so a
+config-only KMS workflow must also set `spec.bundle.attestation.enabled: true`
+(the config equivalent of `--attest`); `signingKey` alone with `enabled: false`
+produces no attestation. See [Bundle Config File Mode](#bundle-config-file-mode).
 
 `--signing-key` is mutually exclusive with the keyless-only flags
 `--identity-token`, `--oidc-device-flow`, and `--fulcio-url`. Passing

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -187,7 +187,7 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		serial:                    cmd.Bool("serial"),
 		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", resolved.CertIDRegexp),
 		identityToken:             cmd.String(flagIdentityToken),
-		signingKey:                cmd.String(flagSigningKey),
+		signingKey:                stringFlagOrConfig(cmd, flagSigningKey, resolved.SigningKey),
 		oidcDeviceFlow:            boolFlagOrConfig(cmd, flagOIDCDeviceFlow, resolved.OIDCDeviceFlow),
 		assumeYes:                 cmd.Bool(flagAssumeYes),
 		fulcioURL:                 stringFlagOrConfig(cmd, flagFulcioURL, resolved.FulcioURL),
@@ -435,14 +435,27 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 // and config) rather than cmd.IsSet alone, so a config-sourced keyless option
 // cannot bypass the check and then be silently ignored by the KMS path.
 func validateSigningKeyExclusivity(cmd *cli.Command, opts *bundleCmdOptions) error {
-	// A set-but-empty --signing-key would otherwise fall through to keyless
-	// resolution silently; reject it so the misconfiguration fails fast.
-	if cmd.IsSet(flagSigningKey) && strings.TrimSpace(opts.signingKey) == "" {
-		return errors.New(errors.ErrCodeInvalidRequest, "--"+flagSigningKey+" must not be empty")
-	}
-	if opts.signingKey == "" {
+	// A signing key that is present but blank must not reach the KMS resolver:
+	// it selects the KMS path (non-empty opts.signingKey) yet fails late at
+	// sign time with an opaque key-URI error. Reject it up front, naming the
+	// source the caller actually used. An explicit blank --signing-key flag is
+	// caught via cmd.IsSet; a whitespace-only config value (cmd.IsSet is false)
+	// is caught by the non-empty-but-blank check.
+	trimmed := strings.TrimSpace(opts.signingKey)
+	if trimmed == "" {
+		if cmd.IsSet(flagSigningKey) {
+			return errors.New(errors.ErrCodeInvalidRequest, "--"+flagSigningKey+" must not be empty")
+		}
+		if opts.signingKey != "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				"spec.bundle.attestation.signingKey must not be blank")
+		}
 		return nil // keyless mode; no exclusivity to enforce
 	}
+	// Normalize the confirmed-non-blank key so surrounding whitespace (e.g. from
+	// a YAML block-scalar config value) does not reach the KMS URI parser and
+	// fail late at sign time.
+	opts.signingKey = trimmed
 	conflicts := []struct {
 		name   string
 		active bool

--- a/pkg/cli/config_e2e_test.go
+++ b/pkg/cli/config_e2e_test.go
@@ -283,6 +283,113 @@ spec:
 	}
 }
 
+// TestBundleCmd_SigningKeyFromConfig verifies the KMS --signing-key is
+// config-driven: a config-sourced spec.bundle.attestation.signingKey lands on
+// the resolved options, the CLI flag wins over the config value, and a
+// config-sourced signingKey combined with a config-sourced keyless input
+// (fulcioURL) is rejected by the mutual-exclusion guard through the resolved
+// layer (cmd.IsSet is false for both, so only resolved opts catch it). See #1566.
+func TestBundleCmd_SigningKeyFromConfig(t *testing.T) {
+	const configKey = "awskms://alias/aicr-signing"
+	const flagKey = "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k"
+
+	writeConfig := func(t *testing.T, attestation string) string {
+		t.Helper()
+		tmp := t.TempDir()
+		recipePath := filepath.Join(tmp, "recipe.yaml")
+		if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+			t.Fatalf("write recipe: %v", err)
+		}
+		cfgPath := filepath.Join(tmp, "config.yaml")
+		cfg := fmt.Sprintf(`kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+spec:
+  bundle:
+    input:
+      recipe: %s
+    attestation:
+      enabled: true
+%s`, recipePath, attestation)
+		if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		return cfgPath
+	}
+
+	// Success cases: how a config-sourced signingKey resolves onto opts,
+	// including CLI precedence and whitespace trimming.
+	successTests := []struct {
+		name        string
+		attestation string
+		extraArgs   []string
+		want        string
+	}{
+		{
+			name:        "config-sourced signingKey flows to opts",
+			attestation: "      signingKey: " + configKey + "\n",
+			want:        configKey,
+		},
+		{
+			name:        "CLI flag wins over config signingKey",
+			attestation: "      signingKey: " + configKey + "\n",
+			extraArgs:   []string{"--signing-key", flagKey},
+			want:        flagKey,
+		},
+		{
+			name:        "config signingKey surrounding whitespace is trimmed",
+			attestation: "      signingKey: \"  " + configKey + "  \"\n",
+			want:        configKey,
+		},
+	}
+	for _, tt := range successTests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgPath := writeConfig(t, tt.attestation)
+			opts := captureBundleOpts(t, append([]string{"--config", cfgPath}, tt.extraArgs...))
+			if opts.signingKey != tt.want {
+				t.Errorf("signingKey = %q, want %q", opts.signingKey, tt.want)
+			}
+		})
+	}
+
+	// Rejection cases: a config-sourced signingKey that conflicts with a
+	// config-sourced keyless input must be caught through the resolved layer
+	// (cmd.IsSet is false for both), and a blank config signingKey must fail
+	// fast rather than reaching the KMS resolver. See #1566.
+	rejectTests := []struct {
+		name        string
+		attestation string
+		wantErrSub  string
+	}{
+		{
+			name:        "config signingKey with config fulcioURL is rejected",
+			attestation: "      signingKey: " + configKey + "\n      fulcioURL: https://fulcio.internal.example.com\n",
+			wantErrSub:  "mutually exclusive",
+		},
+		{
+			name:        "config signingKey with config oidcDeviceFlow is rejected",
+			attestation: "      signingKey: " + configKey + "\n      oidcDeviceFlow: true\n",
+			wantErrSub:  "mutually exclusive",
+		},
+		{
+			name:        "blank config signingKey is rejected",
+			attestation: "      signingKey: \"   \"\n",
+			wantErrSub:  "must not be blank",
+		},
+	}
+	for _, tt := range rejectTests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgPath := writeConfig(t, tt.attestation)
+			_, err := tryCaptureBundleOpts(t, []string{"--config", cfgPath})
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Errorf("error %q must contain %q", err.Error(), tt.wantErrSub)
+			}
+		})
+	}
+}
+
 // TestBundleCmd_FlagOverridesEverySection verifies that for each major
 // section, a CLI flag wins over the same field in --config.
 func TestBundleCmd_FlagOverridesEverySection(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -210,6 +210,15 @@ type AttestationSpec struct {
 	// log. Empty leaves the public defaults in place. See issue #408.
 	FulcioURL string `yaml:"fulcioURL,omitempty" json:"fulcioURL,omitempty"`
 	RekorURL  string `yaml:"rekorURL,omitempty" json:"rekorURL,omitempty"`
+
+	// SigningKey selects KMS-backed (key-based) signing instead of keyless
+	// OIDC. A non-empty value is a durable, non-secret KMS key reference
+	// (awskms:// | gcpkms:// | azurekms:// | hashivault://) — analogous to
+	// FulcioURL/RekorURL, it belongs in version-controlled config. Mutually
+	// exclusive with the keyless-only inputs (IdentityToken, OIDCDeviceFlow,
+	// FulcioURL). Mirrors the --signing-key CLI flag; the flag wins when both
+	// are set. See issue #407.
+	SigningKey string `yaml:"signingKey,omitempty" json:"signingKey,omitempty"`
 }
 
 // RegistrySpec captures OCI-registry transport options for bundle push.

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -30,4 +30,8 @@
 //
 // Secrets (notably the cosign identity token) are not part of the schema;
 // they must be supplied via environment variables or dedicated CLI flags.
+// Durable, non-secret references are in scope by contrast: the private
+// Sigstore endpoints (spec.bundle.attestation.fulcioURL / rekorURL) and the
+// KMS signing-key reference (spec.bundle.attestation.signingKey) all belong
+// in version-controlled config even though they configure signing.
 package config

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -113,6 +113,11 @@ type BundleResolved struct {
 	// public-good Sigstore default in place.
 	RekorURL string
 
+	// SigningKey is spec.bundle.attestation.signingKey; a durable, non-secret
+	// KMS key reference that selects KMS-backed signing. Empty leaves keyless
+	// OIDC signing in place. See #407.
+	SigningKey string
+
 	// InsecureTLS is spec.bundle.registry.insecureTLS.
 	InsecureTLS bool
 
@@ -236,19 +241,8 @@ func (b *BundleSpec) Resolve() (*BundleResolved, error) {
 		}
 	}
 
-	if b.Attestation != nil {
-		out.Attest = b.Attestation.Enabled
-		out.CertIDRegexp = b.Attestation.CertificateIdentityRegexp
-		out.OIDCDeviceFlow = b.Attestation.OIDCDeviceFlow
-		// Validate the signing endpoints at the conversion boundary so a
-		// malformed config value fails here with spec-path attribution
-		// (and is caught for non-CLI callers of Resolve too), rather than
-		// only later in CLI flag parsing.
-		if err := validateAttestationEndpoints(b.Attestation); err != nil {
-			return nil, err
-		}
-		out.FulcioURL = b.Attestation.FulcioURL
-		out.RekorURL = b.Attestation.RekorURL
+	if err := resolveAttestation(b.Attestation, out); err != nil {
+		return nil, err
 	}
 
 	if b.Registry != nil {
@@ -257,6 +251,27 @@ func (b *BundleSpec) Resolve() (*BundleResolved, error) {
 	}
 
 	return out, nil
+}
+
+// resolveAttestation projects the bundle attestation spec onto the resolved
+// output. It is a no-op when a is nil (the section is optional). Signing
+// endpoints are validated at this conversion boundary so a malformed config
+// value fails here with spec-path attribution (and is caught for non-CLI
+// callers of Resolve too), rather than only later in CLI flag parsing.
+func resolveAttestation(a *AttestationSpec, out *BundleResolved) error {
+	if a == nil {
+		return nil
+	}
+	if err := validateAttestationEndpoints(a); err != nil {
+		return err
+	}
+	out.Attest = a.Enabled
+	out.CertIDRegexp = a.CertificateIdentityRegexp
+	out.OIDCDeviceFlow = a.OIDCDeviceFlow
+	out.FulcioURL = a.FulcioURL
+	out.RekorURL = a.RekorURL
+	out.SigningKey = a.SigningKey
+	return nil
 }
 
 // validateAttestationEndpoints rejects malformed private Sigstore endpoints in

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -249,6 +249,7 @@ func TestBundleResolve_AllFieldsPopulated(t *testing.T) {
 			OIDCDeviceFlow:            true,
 			FulcioURL:                 "https://fulcio.internal.example.com",
 			RekorURL:                  "https://rekor.internal.example.com",
+			SigningKey:                "awskms://alias/aicr-signing",
 		},
 		Registry: &config.RegistrySpec{InsecureTLS: true, PlainHTTP: true},
 	}
@@ -307,6 +308,9 @@ func TestBundleResolve_AllFieldsPopulated(t *testing.T) {
 	}
 	if got.FulcioURL != "https://fulcio.internal.example.com" || got.RekorURL != "https://rekor.internal.example.com" {
 		t.Errorf("Sigstore URLs: got fulcio=%q rekor=%q", got.FulcioURL, got.RekorURL)
+	}
+	if got.SigningKey != "awskms://alias/aicr-signing" {
+		t.Errorf("SigningKey: got %q", got.SigningKey)
 	}
 	if !got.InsecureTLS || !got.PlainHTTP {
 		t.Errorf("Registry: got insecure=%v plain=%v", got.InsecureTLS, got.PlainHTTP)


### PR DESCRIPTION
## Summary

Add `spec.bundle.attestation.signingKey` to `AICRConfig` so a `--config`-driven `aicr bundle` can produce a KMS-signed bundle, closing the last gap between the CLI `--signing-key` flag and the config file.

## Motivation / Context

`AICRConfig` (`--config`) already exposes the keyless private-Sigstore signing inputs (`fulcioURL` / `rekorURL` / `certificateIdentityRegexp` / `oidcDeviceFlow` / `enabled`) but not the KMS `--signing-key`. A KMS key reference (e.g. `awskms://alias/aicr-signing`) is a durable, non-secret value, exactly analogous to `fulcioURL` / `rekorURL` (wired by #408), so it belongs in a version-controlled, reproducible config. This was the only gap preventing the KMS path from being fully `--config`-driven.

The ephemeral OIDC identity token stays out of config by design (runtime-supplied secret).

Fixes: #1566
Related: #407 (KMS signing foundation), #408 (fulcio/rekor config wiring — the analog)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/config` (AICRConfig schema)

## Implementation Notes

- Added `SigningKey string` to `AttestationSpec` (`pkg/config/config.go`) and surfaced it on `BundleResolved` (`pkg/config/resolve.go`).
- Switched the CLI wiring from `cmd.String(flagSigningKey)` to `stringFlagOrConfig(cmd, flagSigningKey, resolved.SigningKey)`, so the `--signing-key` flag wins over config (consistent with `fulcioURL` / `rekorURL`).
- The mutual-exclusion guard (`validateSigningKeyExclusivity`) already evaluates the resolved `opts`, so it now catches a config-sourced `signingKey` conflicting with a config-sourced `fulcioURL` / `oidcDeviceFlow`, which previously could bypass it.
- A present-but-blank signing key (explicit empty `--signing-key`, or a whitespace-only config value) now fails fast with a clear error instead of reaching the KMS resolver and failing late at sign time.
- Extracted the attestation projection into a `resolveAttestation` helper (behavior-preserving; keeps `Resolve` under the funlen limit).

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/config/... ./pkg/cli/...   # 0 issues
go test -race ./pkg/config/... ./pkg/cli/...                          # pass
```

- `pkg/config/resolve_test.go`: `SigningKey` now covered by `TestBundleResolve_AllFieldsPopulated`.
- `pkg/cli/config_e2e_test.go`: new `TestBundleCmd_SigningKeyFromConfig` — config value flows to opts, CLI flag wins over config, and a table-driven rejection set covers config `signingKey` + config `fulcioURL`, config `signingKey` + config `oidcDeviceFlow`, and a blank config key.
- Coverage: `pkg/config` 93.0%, `pkg/cli` 72.3% (change only adds tests).

## Risk Assessment

- [x] **Low** — Additive, optional config field; no change to the signing library or default behavior. Easy to revert.

**Rollout notes:** Backwards compatible. The field is optional and `omitempty`; existing configs and CLI usage are unaffected. When both `--signing-key` and `spec.bundle.attestation.signingKey` are set, the flag wins.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
