### PR TITLE
feat(bundle): air-gapped signing with --tlog-upload=false

### DIFF
--- a/docs/contributor/rekor-v2-signing.md
+++ b/docs/contributor/rekor-v2-signing.md
@@ -114,6 +114,16 @@ TUF v2 config (default), then a Rekor v1 URL.
   `KMSAttester` builds its transparency policy through the same
   `transparencyForOptions` path as keyless signing, so both stay in lockstep. A
   KMS v2 entry carries public-key verification material (no Fulcio certificate).
+- `--tlog-upload=false` (KMS only) skips the Rekor upload entirely for fully
+  offline / air-gapped signing (#409). It sets `ResolveOptions.DisableTLogUpload`,
+  which wires `NewKMSAttester(..., WithoutTransparencyLog())`; the attester's
+  `HasRekorEntry()` then reports false and `Attest` attaches no transparency log.
+  The flag is rejected on the keyless path, because keyless OIDC signing needs
+  Fulcio and Rekor network access, and is mutually exclusive with `--rekor-url`
+  and `--signing-config`: those select a transparency-log target, which cannot be
+  reconciled with writing no entry (the no-tlog policy would silently override
+  them, so it fails closed instead). Verify such a bundle with
+  `aicr verify --key <uri> --insecure-ignore-tlog`.
 
 `--rekor-url` and `--signing-config` are mutually exclusive, so an operator's
 private Rekor is never silently overridden by the v2 default.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1275,6 +1275,7 @@ aicr bundle [flags]
 | `--rekor-url` | | string | Sign the `--attest` bundle to **Rekor v1** at this URL instead of the **Rekor v2 default** (a private Sigstore instance, or the public-good v1 URL). Must be an absolute `https://` URL with no embedded credentials. Also reads `AICR_REKOR_URL`. Independent of `--fulcio-url`. Mutually exclusive with `--signing-config`. |
 | `--signing-config` | | string | Sign the `--attest` bundle with a custom Sigstore signing config JSON instead of the default Rekor v2 config (advanced — e.g. an edited config or a private v2 instance). Also reads `AICR_SIGNING_CONFIG`. Mutually exclusive with `--rekor-url`. |
 | `--signing-key` | | string | Sign the `--attest` bundle with a KMS-backed key instead of keyless OIDC, for CI/CD environments without OIDC (Jenkins, internal pipelines). Takes a KMS URI; supported schemes are `awskms://`, `gcpkms://`, `azurekms://`, and `hashivault://`. Like keyless signing, KMS signs to Rekor v2 by default; opt out with `--rekor-url` (v1) or `--signing-config` (custom). Mutually exclusive with `--identity-token`, `--oidc-device-flow`, and `--fulcio-url` (the keyless-only flags); passing both is a validation error. See [KMS-Backed Signing](#kms-backed-signing). |
+| `--tlog-upload` | | bool | Upload the signature to the Rekor transparency log (default: `true`). Set `--tlog-upload=false` to skip the Rekor upload for fully offline / air-gapped signing; this requires `--signing-key` (KMS), because keyless OIDC signing needs Fulcio and Rekor network access to mint a verifiable certificate. Mutually exclusive with `--rekor-url` and `--signing-config` (both select where the transparency-log entry goes, which contradicts writing none). Verify the resulting bundle offline with `aicr verify --key <public-key.pem> --insecure-ignore-tlog`; use a local PEM public key for a fully offline verify, since a KMS `--key` URI still makes a live `GetPublicKey` call. See [KMS-Backed Signing](#kms-backed-signing). |
 | `--yes` | `--assume-yes` | bool | Skip the interactive confirmation shown before keyless signing publishes your OIDC identity (browser/device-code paths only; the banner is still printed). Reads `AICR_ASSUME_YES`. See [Privacy: identity in keyless signatures](#privacy-identity-in-keyless-signatures). |
 
 `--image-refs` writes the published digest through a mode-`0600` temporary
@@ -2337,6 +2338,25 @@ Like keyless signing, KMS signs to **Rekor v2** by default. Opt out with
 `--rekor-url` to log to a Rekor v1 instance (private or public-good), or
 `--signing-config` to use a custom signing config; the two opt-outs are mutually
 exclusive with each other but both compose with `--signing-key`.
+
+For a fully offline / air-gapped signing host that cannot reach any Rekor
+instance, add `--tlog-upload=false`. KMS signing then skips the transparency-log
+upload entirely and the bundle carries no Rekor entry:
+
+```shell
+aicr bundle --recipe recipe.yaml --attest \
+  --signing-key awskms://arn:aws:kms:us-east-1:123456789012:key/abcd-1234 \
+  --tlog-upload=false \
+  --output ./bundles
+```
+
+`--tlog-upload=false` requires `--signing-key`; it is rejected on the keyless
+path, because keyless OIDC signing needs Fulcio and Rekor network access to mint
+a verifiable certificate. Verify an air-gapped bundle offline with
+`aicr verify --key <public-key.pem> --insecure-ignore-tlog`, which skips the
+transparency-log lookup that would otherwise require network access. Use a local
+PEM public key (exported once with `cosign public-key --key <kms-uri>`) for a
+fully offline verify: a KMS `--key` URI still makes a live `GetPublicKey` call.
 
 The resulting bundle uses the same Sigstore bundle format as keyless signing,
 but its verification material is the signing key's public key rather than a

--- a/pkg/bundler/attestation/kms.go
+++ b/pkg/bundler/attestation/kms.go
@@ -40,8 +40,19 @@ type KMSAttester struct {
 
 	// tlog, when non-nil, overrides the transparency policy that Attest would
 	// otherwise compute from target. Used to inject a no-tlog policy for offline
-	// testing, and reserved for a future --tlog-upload=false opt-out (#409).
+	// testing, and wired to the --tlog-upload=false opt-out via
+	// WithoutTransparencyLog for offline / air-gapped signing (#409).
 	tlog TransparencyPolicy
+}
+
+// KMSAttesterOption customizes a KMSAttester at construction time.
+type KMSAttesterOption func(*KMSAttester)
+
+// WithoutTransparencyLog makes the attester skip the Rekor upload (offline /
+// air-gapped signing, #409). The resulting attester's HasRekorEntry reports
+// false and Attest writes no transparency-log entry.
+func WithoutTransparencyLog() KMSAttesterOption {
+	return func(k *KMSAttester) { k.tlog = NewNoTLogPolicy() }
 }
 
 // NewKMSAttester returns a KMSAttester for keyURI. Like keyless signing, KMS
@@ -51,12 +62,20 @@ type KMSAttester struct {
 // SignOptionsFromResolve so the KMS path shares the keyless path's signing-target
 // mapping. The transparency-log entry carries public-key verification material
 // (no Fulcio certificate). See #1650.
-func NewKMSAttester(keyURI string, target SignOptions) *KMSAttester {
-	return &KMSAttester{
+//
+// opts customize the attester; WithoutTransparencyLog opts out of the Rekor
+// upload for offline / air-gapped signing (#409). With no options the Rekor
+// upload behavior is unchanged.
+func NewKMSAttester(keyURI string, target SignOptions, opts ...KMSAttesterOption) *KMSAttester {
+	k := &KMSAttester{
 		keyURI:   keyURI,
 		identity: NewKMSIdentity(keyURI),
 		target:   target,
 	}
+	for _, opt := range opts {
+		opt(k)
+	}
+	return k
 }
 
 // Attest creates a DSSE-signed in-toto SLSA provenance statement for the given

--- a/pkg/bundler/attestation/kms_test.go
+++ b/pkg/bundler/attestation/kms_test.go
@@ -33,6 +33,33 @@ func TestKMSAttesterContract(t *testing.T) {
 	}
 }
 
+// TestKMSAttesterWithoutTransparencyLog verifies the functional option opts the
+// attester out of the Rekor upload: HasRekorEntry reports false, while a
+// default (no-option) attester still reports true. See #409.
+func TestKMSAttesterWithoutTransparencyLog(t *testing.T) {
+	const keyURI = "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k"
+
+	cases := []struct {
+		name      string
+		opts      []KMSAttesterOption
+		wantRekor bool
+	}{
+		{"default records a Rekor entry", nil, true},
+		{"WithoutTransparencyLog records no entry", []KMSAttesterOption{WithoutTransparencyLog()}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewKMSAttester(keyURI, SignOptions{UseTUFSigningConfig: true}, tc.opts...)
+			if a.HasRekorEntry() != tc.wantRekor {
+				t.Errorf("HasRekorEntry() = %v, want %v", a.HasRekorEntry(), tc.wantRekor)
+			}
+			if a.Identity() != keyURI {
+				t.Errorf("Identity = %q, want %q", a.Identity(), keyURI)
+			}
+		})
+	}
+}
+
 // TestKMSAttesterAttest exercises Attest end-to-end offline by injecting a
 // fake key-based identity (local ECDSA signer, no cert provider) and the
 // no-tlog policy, so no KMS provider or Rekor call is made. It asserts the
@@ -62,5 +89,11 @@ func TestKMSAttesterAttest(t *testing.T) {
 	}
 	if b.GetVerificationMaterial().GetPublicKey() == nil {
 		t.Error("want public-key verification material for KMS signing")
+	}
+	// The no-tlog policy must produce a bundle with no transparency-log entries:
+	// assert directly on Attest's output (HasRekorEntry only reports the policy
+	// choice, not the emitted bundle).
+	if got := len(b.GetVerificationMaterial().GetTlogEntries()); got != 0 {
+		t.Errorf("no-tlog KMS attestation carries %d tlog entries, want 0", got)
 	}
 }

--- a/pkg/bundler/attestation/resolver.go
+++ b/pkg/bundler/attestation/resolver.go
@@ -75,6 +75,18 @@ type ResolveOptions struct {
 	// CLI boundary (pkg/cli). See issue #407.
 	SigningKey string
 
+	// DisableTLogUpload skips the Rekor transparency-log upload for KMS
+	// (SigningKey) signing, enabling fully offline / air-gapped bundle
+	// attestation (#409). The zero value (false) is the safe default: a caller
+	// constructing ResolveOptions without setting it still gets a Rekor entry.
+	//
+	// It affects ONLY the KMS path. Keyless (OIDC) signing ignores this field
+	// and always uploads to Rekor, because keyless needs Fulcio + Rekor network
+	// access to produce a verifiable certificate; that is a fail-safe. The CLI
+	// boundary (pkg/cli) rejects DisableTLogUpload without a SigningKey so a
+	// keyless caller cannot silently expect an offline signature.
+	DisableTLogUpload bool
+
 	// PromptWriter receives user-facing prompts emitted by the interactive
 	// and device-code flows (verification URL + short code). Pass os.Stderr
 	// for typical CLI behavior, io.Discard to suppress, or nil (treated as
@@ -167,7 +179,11 @@ func ResolveAttester(ctx context.Context, opts ResolveOptions) (Attester, error)
 		return NewNoOpAttester(), nil
 	}
 	if opts.SigningKey != "" {
-		return NewKMSAttester(opts.SigningKey, SignOptionsFromResolve("", opts)), nil
+		var kopts []KMSAttesterOption
+		if opts.DisableTLogUpload {
+			kopts = append(kopts, WithoutTransparencyLog())
+		}
+		return NewKMSAttester(opts.SigningKey, SignOptionsFromResolve("", opts), kopts...), nil
 	}
 	token, err := ResolveOIDCToken(ctx, opts)
 	if err != nil {
@@ -195,7 +211,11 @@ func ResolveAttesterLazy(_ context.Context, opts ResolveOptions) (Attester, erro
 		return NewNoOpAttester(), nil
 	}
 	if opts.SigningKey != "" {
-		return NewKMSAttester(opts.SigningKey, SignOptionsFromResolve("", opts)), nil
+		var kopts []KMSAttesterOption
+		if opts.DisableTLogUpload {
+			kopts = append(kopts, WithoutTransparencyLog())
+		}
+		return NewKMSAttester(opts.SigningKey, SignOptionsFromResolve("", opts), kopts...), nil
 	}
 	return NewLazyKeylessAttester(opts), nil
 }

--- a/pkg/bundler/attestation/resolver_test.go
+++ b/pkg/bundler/attestation/resolver_test.go
@@ -240,6 +240,75 @@ func TestResolveAttesterLazyKMS(t *testing.T) {
 	}
 }
 
+// TestResolveAttesterDisableTLogUpload verifies DisableTLogUpload wires the
+// no-tlog override onto the KMS attester (offline / air-gapped signing) for
+// both the eager and lazy resolvers, and only when SigningKey is set. Keyless
+// signing (SigningKey empty) ignores the flag and always uploads. See #409.
+func TestResolveAttesterDisableTLogUpload(t *testing.T) {
+	const keyURI = "awskms://arn:aws:kms:us-east-1:111:key/abc"
+
+	resolvers := []struct {
+		name    string
+		resolve func(ResolveOptions) (Attester, error)
+	}{
+		{"eager", func(o ResolveOptions) (Attester, error) {
+			return ResolveAttester(context.Background(), o)
+		}},
+		{"lazy", func(o ResolveOptions) (Attester, error) {
+			return ResolveAttesterLazy(context.Background(), o)
+		}},
+	}
+
+	cases := []struct {
+		name      string
+		opts      ResolveOptions
+		wantKMS   bool // attester must (KMS) / must not (keyless) be a *KMSAttester
+		wantRekor bool // expected HasRekorEntry()
+	}{
+		{
+			// KMS + DisableTLogUpload:true → no Rekor entry.
+			name:      "kms uploads disabled",
+			opts:      ResolveOptions{Attest: true, SigningKey: keyURI, DisableTLogUpload: true},
+			wantKMS:   true,
+			wantRekor: false,
+		},
+		{
+			// KMS + DisableTLogUpload:false (default) → Rekor entry.
+			name:      "kms default uploads",
+			opts:      ResolveOptions{Attest: true, SigningKey: keyURI},
+			wantKMS:   true,
+			wantRekor: true,
+		},
+		{
+			// Keyless (no SigningKey) + DisableTLogUpload:true → still a keyless
+			// attester that always uploads; the flag is ignored on this path.
+			name:      "keyless ignores disable and uploads",
+			opts:      ResolveOptions{Attest: true, IdentityToken: "tok", DisableTLogUpload: true},
+			wantKMS:   false,
+			wantRekor: true,
+		},
+	}
+
+	for _, r := range resolvers {
+		t.Run(r.name, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					att, err := r.resolve(tc.opts)
+					if err != nil {
+						t.Fatalf("resolve: %v", err)
+					}
+					if _, ok := att.(*KMSAttester); ok != tc.wantKMS {
+						t.Fatalf("attester type = %T, want *KMSAttester: %v", att, tc.wantKMS)
+					}
+					if att.HasRekorEntry() != tc.wantRekor {
+						t.Errorf("HasRekorEntry() = %v, want %v", att.HasRekorEntry(), tc.wantRekor)
+					}
+				})
+			}
+		})
+	}
+}
+
 // TestResolveAttesterLazy_DefersTokenResolution verifies the lazy entry
 // point does not touch the OIDC chain at construction time. Constructing
 // a lazy attester with a pre-canceled context plus a forced device-flow

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -99,6 +99,13 @@ type bundleCmdOptions struct {
 	// azurekms:// | hashivault://). Mutually exclusive with the keyless-only flags. See #407.
 	signingKey string
 
+	// tlogUpload controls the Rekor transparency-log upload for KMS signing.
+	// Default true (upload). Setting it false with --signing-key produces a
+	// fully offline / air-gapped signature (no Rekor entry); false without
+	// --signing-key is rejected because keyless OIDC signing requires Fulcio +
+	// Rekor network access. See #409.
+	tlogUpload bool
+
 	// oidcDeviceFlow opts in to the OAuth 2.0 Device Authorization Grant flow
 	// (RFC 8628) for headless hosts where a browser callback is unavailable.
 	oidcDeviceFlow bool
@@ -188,14 +195,18 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		certificateIdentityRegexp: stringFlagOrConfig(cmd, "certificate-identity-regexp", resolved.CertIDRegexp),
 		identityToken:             cmd.String(flagIdentityToken),
 		signingKey:                stringFlagOrConfig(cmd, flagSigningKey, resolved.SigningKey),
-		oidcDeviceFlow:            boolFlagOrConfig(cmd, flagOIDCDeviceFlow, resolved.OIDCDeviceFlow),
-		assumeYes:                 cmd.Bool(flagAssumeYes),
-		fulcioURL:                 stringFlagOrConfig(cmd, flagFulcioURL, resolved.FulcioURL),
-		rekorURL:                  stringFlagOrConfig(cmd, flagRekorURL, resolved.RekorURL),
-		signingConfigPath:         cmd.String(flagSigningConfig),
-		insecureTLS:               boolFlagOrConfig(cmd, flagInsecureTLS, resolved.InsecureTLS),
-		plainHTTP:                 boolFlagOrConfig(cmd, flagPlainHTTP, resolved.PlainHTTP),
-		imageRefsPath:             stringFlagOrConfig(cmd, "image-refs", resolved.ImageRefs),
+		// tlogUpload reads the flag directly (not via boolFlagOrConfig): a config
+		// default of false would silently disable the transparency log for every
+		// bundle, the exact fail-open this flag exists to prevent. Keep it flag-only.
+		tlogUpload:        cmd.Bool(flagTLogUpload),
+		oidcDeviceFlow:    boolFlagOrConfig(cmd, flagOIDCDeviceFlow, resolved.OIDCDeviceFlow),
+		assumeYes:         cmd.Bool(flagAssumeYes),
+		fulcioURL:         stringFlagOrConfig(cmd, flagFulcioURL, resolved.FulcioURL),
+		rekorURL:          stringFlagOrConfig(cmd, flagRekorURL, resolved.RekorURL),
+		signingConfigPath: cmd.String(flagSigningConfig),
+		insecureTLS:       boolFlagOrConfig(cmd, flagInsecureTLS, resolved.InsecureTLS),
+		plainHTTP:         boolFlagOrConfig(cmd, flagPlainHTTP, resolved.PlainHTTP),
+		imageRefsPath:     stringFlagOrConfig(cmd, "image-refs", resolved.ImageRefs),
 	}
 
 	// Rekor v2 is the default for both keyless and KMS --attest signing: the
@@ -416,7 +427,50 @@ func parseBundleCmdOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) (*bundleCmd
 		return nil, err
 	}
 
+	// Reject --tlog-upload=false without --signing-key (air-gapped signing is a
+	// KMS-only capability) or combined with a Rekor/signing-config target.
+	if err := validateTLogUpload(opts); err != nil {
+		return nil, err
+	}
+
 	return opts, nil
+}
+
+// validateTLogUpload rejects --tlog-upload=false unless --signing-key (KMS) is
+// set, and rejects it when combined with a transparency-log target flag.
+//
+// Skipping the Rekor transparency-log upload is only meaningful for KMS-backed
+// signing; keyless OIDC signing requires Fulcio + Rekor network access to mint a
+// verifiable certificate, so an air-gapped keyless signature is not achievable
+// and the request is rejected rather than silently ignored.
+//
+// --tlog-upload=false is also mutually exclusive with --rekor-url and
+// --signing-config: those select WHERE the transparency-log entry goes, which
+// directly contradicts "do not write one". WithoutTransparencyLog overrides the
+// target policy that --rekor-url / --signing-config would otherwise build (see
+// KMSAttester.Attest), so accepting both would silently discard the operator's
+// chosen endpoint. Fail closed instead.
+func validateTLogUpload(opts *bundleCmdOptions) error {
+	if opts.tlogUpload {
+		return nil
+	}
+	if opts.signingKey == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"--"+flagTLogUpload+"=false (air-gapped signing) applies only to KMS attestation and "+
+				"requires --attest with --"+flagSigningKey+"; keyless OIDC signing needs "+
+				"Fulcio/Rekor network access")
+	}
+	if opts.rekorURL != "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"--"+flagTLogUpload+"=false is mutually exclusive with --"+flagRekorURL+
+				": one skips the transparency log, the other selects a Rekor endpoint")
+	}
+	if opts.signingConfigPath != "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"--"+flagTLogUpload+"=false is mutually exclusive with --"+flagSigningConfig+
+				": one skips the transparency log, the other selects a signing config")
+	}
+	return nil
 }
 
 // validateSigningKeyExclusivity rejects --signing-key combined with any
@@ -828,6 +882,18 @@ Package with explicit tag (overrides CLI version):
 			&cli.StringFlag{
 				Name:     flagSigningKey,
 				Usage:    "Sign --attest bundles with a KMS-backed key (awskms:// | gcpkms:// | azurekms:// | hashivault://) instead of keyless OIDC, for CI/CD without OIDC. Mutually exclusive with --identity-token, --oidc-device-flow, --fulcio-url. Like keyless, KMS signs to Rekor v2 by default; opt out with --rekor-url (v1) or --signing-config (custom). Verify the resulting bundle with `aicr verify --key <uri>`.",
+				Category: catDeployment,
+			},
+			&cli.BoolFlag{
+				Name:  flagTLogUpload,
+				Value: true,
+				Usage: "Upload the KMS signature to the Rekor transparency log (default: true). " +
+					"Set --tlog-upload=false to skip the Rekor upload for fully offline / air-gapped " +
+					"signing; this requires --signing-key (KMS) because keyless OIDC signing needs " +
+					"Fulcio + Rekor network access. Verify the resulting bundle offline with " +
+					"`aicr verify --key <public-key.pem> --insecure-ignore-tlog`; use a local PEM " +
+					"public key for a fully offline verify, since a KMS --key URI still makes a live " +
+					"GetPublicKey call to resolve the key.",
 				Category: catDeployment,
 			},
 			&cli.BoolFlag{
@@ -1304,6 +1370,7 @@ func bundleOIDCResolveOptions(opts *bundleCmdOptions) attestation.ResolveOptions
 		Attest:              opts.attest,
 		IdentityToken:       opts.identityToken,
 		SigningKey:          opts.signingKey,
+		DisableTLogUpload:   !opts.tlogUpload,
 		AmbientURL:          os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
 		AmbientToken:        os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
 		DeviceFlow:          opts.oidcDeviceFlow,

--- a/pkg/cli/bundle_test.go
+++ b/pkg/cli/bundle_test.go
@@ -667,6 +667,81 @@ func TestParseBundleCmdOptions_SigningKey(t *testing.T) {
 	}
 }
 
+// TestParseBundleCmdOptions_TLogUpload verifies the --tlog-upload flag wiring:
+// it defaults to true when absent, is rejected when set false without
+// --signing-key (air-gapped signing is KMS-only), and is accepted false with
+// --signing-key. See #409.
+func TestParseBundleCmdOptions_TLogUpload(t *testing.T) {
+	const key = "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k"
+	tmp := t.TempDir()
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("kind: Recipe\n"), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	out := filepath.Join(tmp, "out")
+
+	tests := []struct {
+		name          string
+		args          []string
+		wantErr       bool
+		wantTLogValue bool // only checked when wantErr is false
+	}{
+		{
+			name:          "default (flag absent) is true",
+			args:          []string{"--recipe", recipePath, "--output", out, "--attest"},
+			wantTLogValue: true,
+		},
+		{
+			name:    "tlog-upload=false without signing-key is rejected",
+			args:    []string{"--recipe", recipePath, "--output", out, "--attest", "--tlog-upload=false"},
+			wantErr: true,
+		},
+		{
+			name:          "tlog-upload=false with signing-key is accepted",
+			args:          []string{"--recipe", recipePath, "--output", out, "--attest", "--signing-key", key, "--tlog-upload=false"},
+			wantTLogValue: false,
+		},
+		{
+			name:    "tlog-upload=false with rekor-url is rejected (contradictory targets)",
+			args:    []string{"--recipe", recipePath, "--output", out, "--attest", "--signing-key", key, "--tlog-upload=false", "--rekor-url", "https://rekor.example.com"},
+			wantErr: true,
+		},
+		{
+			name:    "tlog-upload=false with signing-config is rejected (contradictory targets)",
+			args:    []string{"--recipe", recipePath, "--output", out, "--attest", "--signing-key", key, "--tlog-upload=false", "--signing-config", filepath.Join(tmp, "sc.json")},
+			wantErr: true,
+		},
+		{
+			name:          "tlog-upload=true with signing-key is accepted",
+			args:          []string{"--recipe", recipePath, "--output", out, "--attest", "--signing-key", key, "--tlog-upload=true"},
+			wantTLogValue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := tryCaptureBundleOpts(t, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+				}
+				return
+			}
+			if opts.tlogUpload != tt.wantTLogValue {
+				t.Errorf("tlogUpload = %v, want %v", opts.tlogUpload, tt.wantTLogValue)
+			}
+			// DisableTLogUpload on the resolve options is the negation.
+			ro := bundleOIDCResolveOptions(opts)
+			if ro.DisableTLogUpload == tt.wantTLogValue {
+				t.Errorf("DisableTLogUpload = %v, want %v", ro.DisableTLogUpload, !tt.wantTLogValue)
+			}
+		})
+	}
+}
+
 func TestResolveBundleOCIChartVersion(t *testing.T) {
 	tmp := t.TempDir()
 	recipePath := filepath.Join(tmp, "recipe.yaml")

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -53,6 +53,7 @@ const (
 	flagSigningConfig     = "signing-config"
 	flagEmitSigningConfig = "emit-signing-config"
 	flagSigningKey        = "signing-key"
+	flagTLogUpload        = "tlog-upload"
 	flagInsecureTLS       = "insecure-tls"
 	flagPlainHTTP         = "plain-http"
 	flagPush              = "push"


### PR DESCRIPTION
## Summary

Add a `--tlog-upload` flag (bool, default `true`) to `aicr bundle`. Setting `--tlog-upload=false` makes KMS-backed signing skip the Rekor transparency-log upload, enabling fully offline / air-gapped bundle attestation. Keyless (OIDC) signing with `--tlog-upload=false` is rejected, because keyless requires Fulcio + Rekor network access.

## Motivation / Context

Fully disconnected (air-gapped) environments cannot upload to any transparency log, public or private. Combined with KMS-backed signing (#407), this flag makes fully offline bundle attestation possible: no operational metadata leaves the network perimeter.

Fixes: #409
Related: #407 (KMS signing, dependency), #1154 (offline verification, the verify-side counterpart)

> **Land-together dependency:** the offline bundle this produces is verified by the `aicr verify --key ... --insecure-ignore-tlog` flag added in #1154. This PR's docs/help reference that flag, so the two should merge as a pair (this one first or together). Neither changes the other's code, so there is no merge conflict beyond non-overlapping sections of `docs/user/cli-reference.md`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

- Reuses the existing offline scaffolding: `NewNoTLogPolicy()` (a `TransparencyPolicy` with no logs) and `KMSAttester`'s `tlog` override field were already in place for this issue.
- Adds a `WithoutTransparencyLog()` functional option on `NewKMSAttester` (variadic `opts ...KMSAttesterOption`), matching the codebase's `With*` convention.
- `ResolveOptions.DisableTLogUpload` uses a **safe zero value**: false means upload. A caller constructing `ResolveOptions` without setting it still gets a Rekor entry. Only the KMS path honors it; the keyless path ignores it and always uploads (fail-safe).
- Validation (`validateTLogUpload`): `--tlog-upload=false` requires `--signing-key`, and is mutually exclusive with `--rekor-url` / `--signing-config` (those select *where* the tlog entry goes, which contradicts "write none" — rejected rather than silently dropped).
- Flag is deliberately not config/env-wired: a config default of `false` would silently disable the transparency log for every bundle, the exact fail-open this flag guards against.

## Testing

```bash
go test -race ./pkg/cli/... ./pkg/bundler/attestation/...
golangci-lint run -c .golangci.yaml ./pkg/cli/... ./pkg/bundler/attestation/...
```

- New tests: `TestKMSAttesterWithoutTransparencyLog`, `TestResolveAttesterDisableTLogUpload` (eager + lazy resolver paths; KMS+disable → no Rekor entry, KMS default → Rekor entry, keyless+disable → still uploads), `TestParseBundleCmdOptions_TLogUpload` (default true; false without `--signing-key` rejected; false with `--rekor-url`/`--signing-config` rejected; accepted with `--signing-key`).
- `golangci-lint`: 0 issues on all changed packages.

## Risk Assessment

- [x] **Low** — Additive flag with a default that preserves current behavior (upload). Only the explicit opt-out changes signing behavior, and only on the KMS path.

**Rollout notes:** Backwards compatible; default `--tlog-upload=true` is a no-op relative to today. Verify air-gapped bundles with `aicr verify --key <uri> --insecure-ignore-tlog` (#1154).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
