### PR TITLE
feat(validator): recipe-supplied NCCL benchmark runtime via --data

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -433,6 +433,49 @@ already present in the compiled matrix, so the
 (advertised tuple ⇒ parseable template) covers every profile a recipe can
 name. See `validators/performance/nccl_benchmark_profile.go`.
 
+#### NCCL: recipe-supplied runtime (`nccl-benchmark-runtime-ref`)
+
+A profile still requires an embedded template to borrow, so it cannot cover a
+private service+accelerator whose fabric matches none of the shipped templates
+([#1792](https://github.com/NVIDIA/aicr/issues/1792)). The optional
+`nccl-benchmark-runtime-ref` performance constraint closes that gap: its value is
+a bare `{accelerator}/{service}` naming a Kubeflow `TrainingRuntime` the recipe
+ships in its `--data` tree at
+`validators/performance/testdata/{accelerator}/{service}/runtime.yaml` — the same
+layout the embedded templates use, so an external runtime is a drop-in for
+upstreaming.
+
+Resolution is split across the two-stage design:
+
+- **Orchestrator** (`pkg/validator/benchmark_runtime_ref.go`,
+  `resolveBenchmarkRuntimeRef`, called at the top of `ValidatePhases` /
+  `ValidatePhase`): reads the referenced file through the recipe `DataProvider`
+  and lowers its content into the `nccl-benchmark-runtime` **carrier** constraint
+  before the `/data/validation` ConfigMap is written. Fails closed
+  (`ErrCodeInvalidRequest`) on a malformed/traversal ref, a missing/empty file,
+  an absent `DataProvider`, or a ref set alongside an inline carrier. The two
+  constraint names are defined once in `pkg/validator/v1` (`PerfConstraintNCCLBenchmarkRuntime*`)
+  so the write side and the pod read side cannot drift.
+- **Pod** (`validators/performance/nccl_benchmark_runtime.go`): reads the
+  `nccl-benchmark-runtime` carrier and renders it — via the same `${VAR}`
+  substitution as the baked-in templates, through the shared `renderYAMLTemplate`
+  core — in place of `testdata/{accelerator}/{service}`.
+  `validateNcclAllReduceBw` bypasses the `ncclCombinationSupported` applicability
+  gate entirely (applicability is granted by the recipe's explicit opt-in, keyed
+  on its own criteria) and `applyNCCLResources` skips every service-specific step
+  — EFA/TCPXO/RDMA discovery, the GB200-NVreg / GKE-TCPXO preflights, RoCE claim
+  application, and NVLS/IMEX provisioning — because the supplied runtime owns its
+  fabric wiring. Transport verification still runs (the `-net` / `-nvls` markers
+  are transport-internal and fabric-agnostic), so a runtime paired with a named
+  variant must still prove its transport rather than pass on bandwidth alone; the
+  worker cohort is also sized against the runtime's own `nodeSelector` so
+  `WorkerCount` matches placement. It fails
+  closed on a carrier that is not a `trainer.kubeflow.org/v1alpha1`
+  `TrainingRuntime` with a `node` replicatedJob. The runtime is applied only
+  through `trainingRuntimeGVR` with a force-set name/namespace, so a recipe can
+  supply a `TrainingRuntime` and nothing else — not an arbitrary resource kind.
+  It is mutually exclusive with `nccl-benchmark-profile`.
+
 #### `inference-perf`: model, concurrency, and weights cache
 
 The `inference-perf` check warms vLLM before measuring, so the one-time

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -130,6 +130,15 @@ to opt into one of the embedded benchmarks. The profile selects the benchmark
 template and fabric handling; node identification still follows the recipe's
 own accelerator. See
 [Opting external recipes into a benchmark profile](../user/validation.md#opting-external-recipes-into-a-benchmark-profile).
+If the private service's fabric matches none of the embedded templates, ship the
+benchmark itself: put a Kubeflow `TrainingRuntime` in your `--data` tree at
+`validators/performance/testdata/{accelerator}/{service}/runtime.yaml` and point
+the `nccl-benchmark-runtime-ref` constraint at it (`{accelerator}/{service}`).
+Pass the same `--data <dir>` to `aicr validate` so it can resolve the referenced
+file; validation then gates it keyed on the recipe's own criteria with no
+compiled entry required, and the file is a drop-in should the runtime ever be
+upstreamed.
+See [Supplying a benchmark runtime for a private service](../user/validation.md#supplying-a-benchmark-runtime-for-a-private-service).
 
 ## Adding a component
 

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -290,6 +290,22 @@ discovery, and preflights. See
 [Opting external recipes into a benchmark profile](../user/validation.md#opting-external-recipes-into-a-benchmark-profile)
 for the valid pairs and skip/fail semantics.
 
+When no embedded pair matches — a genuinely private service+accelerator with a
+fabric none of the shipped templates cover — supply the benchmark yourself:
+ship a Kubeflow `TrainingRuntime` in your `--data` tree at
+`validators/performance/testdata/{accelerator}/{service}/runtime.yaml` and
+reference it with the `nccl-benchmark-runtime-ref` constraint (a bare
+`{accelerator}/{service}` value). Run `aicr validate --data <dir> ...` so the
+referenced file is resolvable; it is read and rendered in place of a baked-in
+template, keyed on the recipe's own criteria with no compiled applicability
+entry. The runtime owns its fabric wiring (the validator skips service-specific
+fabric setup — discovery, preflights, and NVLS/IMEX provisioning — but still
+asserts transport for the `-net`/`-nvls` variants), must
+declare a `node` replicatedJob, and is mutually exclusive with
+`nccl-benchmark-profile`. Laying the file at the embedded testdata path makes it
+a drop-in for upstreaming. See
+[Supplying a benchmark runtime for a private service](../user/validation.md#supplying-a-benchmark-runtime-for-a-private-service).
+
 ### Component Types
 
 **Helm components** (most common):

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -52,9 +52,12 @@ ones) that match the target fabric:
 | `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS, and GB200 + OKE. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA (EKS) or Socket (OKE) when the IMEX domain is misconfigured. |
 
 The applicability column is the *default*, derived from the recipe's
-`criteria`. A recipe whose criteria fall outside it can opt into one of these
-benchmarks explicitly — see
-[Opting external recipes into a benchmark profile](#opting-external-recipes-into-a-benchmark-profile).
+`criteria`. A recipe whose criteria fall outside it can still run these
+benchmarks explicitly — either by
+[borrowing an embedded benchmark profile](#opting-external-recipes-into-a-benchmark-profile)
+whose fabric matches its hardware, or, for a private service whose fabric
+matches no embedded template, by
+[supplying its own benchmark runtime](#supplying-a-benchmark-runtime-for-a-private-service).
 
 The `-net` check defaults to the AWS EFA fabric. On a ConnectX **RoCE** cluster
 (e.g. DGXC GB300 `p6e-gb300r`), set `AICR_NCCL_FABRIC=roce` in the `aicr
@@ -179,6 +182,124 @@ it. A valid profile that doesn't implement a requested variant (e.g.
 check with a message naming the profile. When a profile is set it wins over
 criteria-derived applicability, and the pass/fail thresholds stay in the
 same-named check constraints as always.
+
+### Supplying a benchmark runtime for a private service
+
+A profile only helps when an **embedded** template already matches the
+cluster's hardware and fabric. A private service introduced entirely through
+`--data` — a `criteria.service` (and possibly `criteria.accelerator`) the
+validator ships no template for, with a fabric that reuses none of the
+embedded ones — has no compiled pair to point a profile at. Such a recipe
+supplies the benchmark itself: it ships a Kubeflow `TrainingRuntime` as a file
+in its `--data` tree and references it with the `nccl-benchmark-runtime-ref`
+performance constraint (a bare `{accelerator}/{service}` value). `aicr validate`
+reads that file and gates the benchmark keyed on the recipe's **own** criteria,
+with no compiled applicability entry required.
+
+Lay the runtime out **exactly where the embedded templates live**, so it is a
+drop-in for upstreaming later:
+
+```text
+mydata/                                   # your --data directory
+├── overlays/
+│   └── mycloud-training.yaml             # the recipe overlay (below)
+└── validators/performance/testdata/
+    └── gb200/mycloud/runtime.yaml        # the TrainingRuntime, real file
+```
+
+```yaml
+# overlays/mycloud-training.yaml
+validation:
+  performance:
+    checks:
+      - nccl-all-reduce-bw
+    constraints:
+      - name: nccl-all-reduce-bw
+        value: ">= 450"
+      - name: nccl-benchmark-runtime-ref
+        value: gb200/mycloud   # -> validators/performance/testdata/gb200/mycloud/runtime.yaml
+```
+
+```yaml
+# validators/performance/testdata/gb200/mycloud/runtime.yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: nccl-all-reduce-runtime
+spec:
+  template:
+    spec:
+      replicatedJobs:
+        - name: node          # required: the worker cohort
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: <your NCCL benchmark image>
+                      resources:
+                        limits:
+                          nvidia.com/gpu: "${GPU_COUNT_PER_NODE}"
+                      # ...command, fabric resources, sidecars...
+```
+
+```bash
+aicr validate -r recipe.yaml -s snapshot.yaml \
+              --data ./mydata --phase performance
+```
+
+The supplied runtime **owns its fabric wiring end to end**: because the recipe
+opted in explicitly, the validator bypasses the compiled applicability gate and
+skips every service-specific *setup* step — EFA/TCPXO/RDMA NIC discovery, the
+GB200-NVreg / GKE-TCPXO preflights, and NVLS/IMEX auto-provisioning. It renders
+the runtime, sizes it (against the runtime's own `nodeSelector` when it pins
+one, so `WorkerCount` matches placement), applies it alongside the shared
+`TrainJob`, and evaluates the bandwidth threshold from the launcher logs.
+Transport verification is **not** skipped: pairing the runtime with the `-net`
+or `-nvls` check still asserts that transport actually carried traffic (the NCCL
+markers are fabric-agnostic), so a named variant can't pass on bandwidth alone.
+What it must honor:
+
+- It must be a Kubeflow `TrainingRuntime` (`apiVersion:
+  trainer.kubeflow.org/v1alpha1`); any other kind/apiVersion is rejected. The
+  validator force-sets its name and namespace, so a recipe can supply a
+  `TrainingRuntime` and nothing else — never an arbitrary resource.
+- It must declare a `node` replicatedJob (the worker cohort the shared
+  `TrainJob` sizes and the validator injects scheduling into and reads logs
+  from), mirroring the embedded templates.
+- The generic template variables `${NAMESPACE}`, `${WORKER_COUNT}`,
+  `${GPU_COUNT_PER_NODE}`, `${GPU_COUNT}`, `${TEST_TYPE}`,
+  `${MIN_MESSAGE_SIZE}`, and `${MAX_MESSAGE_SIZE}` are substituted; the
+  service-specific ones (EFA/RDMA/GKE) are not, so the runtime must pin its own
+  fabric resources.
+- The runtime should pin its own worker `nodeSelector`/`tolerations`, or pass
+  `--node-selector` to `aicr validate`, so workers land on the intended GPU
+  nodes.
+
+`nccl-benchmark-runtime-ref` and `nccl-benchmark-profile` are mutually
+exclusive — a recipe supplies its own runtime **or** borrows an embedded one,
+never both. An absent or blank ref falls back to criteria/profile-derived
+applicability. A malformed ref, or a file missing from `--data`, is rejected by
+`aicr validate` **before any validator Job is deployed** (a resolution error on
+stderr). A resolved file that is not a `TrainingRuntime` with a `node`
+replicatedJob **fails the check itself** (in the pod). Either way it fails
+rather than silently skipping.
+
+> **Sizing note.** The worker cohort is sized against the runtime's own
+> `nodeSelector` when it pins one, but richer scheduling constraints
+> (`nodeAffinity`, un-tolerated node taints) are the Kubernetes scheduler's
+> job, not the validator's — a runtime that restricts placement below the sized
+> cohort surfaces as a launcher timeout, not a false pass. Pass an explicit
+> `--node-selector` when you want the sized and scheduled cohorts to match
+> exactly.
+
+**Upstreaming.** Because the file already sits at
+`validators/performance/testdata/{accelerator}/{service}/runtime.yaml`, adopting
+it into AICR is a copy: move the file into the repo, add the accelerator/service
+tuple to the compiled `supportedNCCLCombinations` matrix, and drop the
+`nccl-benchmark-runtime-ref` constraint — the benchmark then runs from the
+recipe's plain criteria like any other embedded one.
 
 ## Inference performance validation
 
@@ -776,8 +897,11 @@ Common reasons and their cause:
 | `no inference-throughput or inference-ttft-p99 constraint in recipe` | `stdout` | Check was invoked but recipe is missing the matching constraints | Re-generate the recipe or add the constraints |
 | `dynamo-platform not in recipe components` | `stdout` | Inference check selected but `dynamo-platform` absent from `componentRefs` | Use `--platform dynamo` when generating the recipe |
 | `DynamoGraphDeployment CRD not installed` | `stdout` | Recipe declares `dynamo-platform` but the operator is not deployed | Run `aicr bundle` + `./deploy.sh` first, or wait for bootstrap to complete |
-| `requires Service + Accelerator to be implemented` | `stdout` | The recipe's `criteria` are outside the NCCL benchmark's default applicability (e.g. a service registered via `--data`) | Add an `nccl-benchmark-profile` constraint — see [Opting external recipes into a benchmark profile](#opting-external-recipes-into-a-benchmark-profile) |
+| `requires Service + Accelerator to be implemented` | `stdout` | The recipe's `criteria` are outside the NCCL benchmark's default applicability (e.g. a service registered via `--data`) | Add an `nccl-benchmark-profile` constraint — see [Opting external recipes into a benchmark profile](#opting-external-recipes-into-a-benchmark-profile) — or, if no embedded template fits, an `nccl-benchmark-runtime-ref` constraint — see [Supplying a benchmark runtime for a private service](#supplying-a-benchmark-runtime-for-a-private-service) |
 | `benchmark profile … does not implement the … NCCL variant` | `stdout` | The declared `nccl-benchmark-profile` is valid but has no template for this check variant | Drop the non-applicable check from `validation.performance.checks`, or pick a profile that implements it |
+| `failed to resolve nccl-benchmark-runtime-ref=… expected … in the --data tree` | `stderr` | The referenced runtime file is missing from `--data` (or `--data` wasn't passed) | Place the `TrainingRuntime` at `validators/performance/testdata/{accelerator}/{service}/runtime.yaml` in your `--data` dir — see [Supplying a benchmark runtime for a private service](#supplying-a-benchmark-runtime-for-a-private-service) |
+| `nccl-benchmark-runtime … must be a … TrainingRuntime … must declare a "node" replicatedJob` | `stdout` | The referenced file is not a Kubeflow `trainer.kubeflow.org/v1alpha1` `TrainingRuntime`, or lacks the `node` replicatedJob | Fix the runtime file to be a valid `TrainingRuntime` with a `node` replicatedJob |
+| `nccl-benchmark-runtime and nccl-benchmark-profile are mutually exclusive` | `stdout` | The recipe declares both escape hatches at once | Keep only one: borrow an embedded profile **or** supply your own runtime |
 | `skipped - no-cluster mode` | `message` | `--no-cluster` was passed — the runner short-circuits every phase before dispatching any Job | Remove the flag to run behavioral checks |
 | `skipped due to previous phase failure` | `message` | `--fail-fast` was set and an earlier phase failed, so subsequent phases were skipped | Fix the earlier phase first, or drop `--fail-fast` to run all phases regardless |
 

--- a/pkg/validator/benchmark_runtime_ref.go
+++ b/pkg/validator/benchmark_runtime_ref.go
@@ -56,16 +56,16 @@ func (v *Validator) resolveBenchmarkRuntimeRef(ctx context.Context, vi *v1.Valid
 	// a blank earlier entry must not hide a later non-blank duplicate (and the
 	// overlay merge already collapses same-named constraints, so a duplicate here
 	// is a malformed input). Exactly one of each is allowed.
-	if n := countPerfConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntimeRef); n > 1 {
+	if n := v1.CountConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntimeRef); n > 1 {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("declare at most one %s constraint (found %d)", v1.PerfConstraintNCCLBenchmarkRuntimeRef, n))
 	}
-	if n := countPerfConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntime); n > 1 {
+	if n := v1.CountConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntime); n > 1 {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("declare at most one %s constraint (found %d)", v1.PerfConstraintNCCLBenchmarkRuntime, n))
 	}
 
-	ref, ok := findPerfConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntimeRef)
+	ref, ok := v1.FindConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntimeRef)
 	if !ok {
 		return nil
 	}
@@ -74,13 +74,20 @@ func (v *Validator) resolveBenchmarkRuntimeRef(ctx context.Context, vi *v1.Valid
 		return nil
 	}
 
-	// A ref and an inline runtime together are ambiguous — fail closed rather
-	// than silently preferring one.
-	inline, hasInline := findPerfConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime)
-	if hasInline && strings.TrimSpace(inline.Value) != "" {
+	// A ref is mutually exclusive with an inline runtime and with a benchmark
+	// profile — supply your own runtime OR borrow an embedded one, never both.
+	// Both conflicts are pure recipe-authoring errors, so reject them here (before
+	// any Job is deployed) rather than leaving the ref+profile case to fail late
+	// in the pod.
+	if inline, ok := v1.FindConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntime); ok && strings.TrimSpace(inline.Value) != "" {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("%s and an inline %s are both set — supply one",
 				v1.PerfConstraintNCCLBenchmarkRuntimeRef, v1.PerfConstraintNCCLBenchmarkRuntime))
+	}
+	if profile, ok := v1.FindConstraint(cs, v1.PerfConstraintNCCLBenchmarkProfile); ok && strings.TrimSpace(profile.Value) != "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s and %s are mutually exclusive — supply a runtime or borrow an embedded profile, not both",
+				v1.PerfConstraintNCCLBenchmarkRuntimeRef, v1.PerfConstraintNCCLBenchmarkProfile))
 	}
 
 	relPath, err := benchmarkRuntimeRefPath(raw)
@@ -119,6 +126,16 @@ func (v *Validator) resolveBenchmarkRuntimeRef(ctx context.Context, vi *v1.Valid
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("%s=%q resolved to an empty file (%q)",
 				v1.PerfConstraintNCCLBenchmarkRuntimeRef, raw, relPath))
+	}
+
+	// Shape-check the resolved file against the same contract the pod enforces,
+	// so a runtime that isn't a valid TrainingRuntime fails fast here (offline,
+	// before any Job) instead of only in the pod after the Trainer install. The
+	// check parses the raw pre-substitution content; ${VAR} placeholders live in
+	// value positions and don't affect the identity / replicatedJob shape.
+	if err := v1.ValidateBenchmarkRuntime(string(content)); err != nil {
+		return errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s=%q (%q) resolved to an invalid runtime", v1.PerfConstraintNCCLBenchmarkRuntimeRef, raw, relPath), err)
 	}
 
 	// Consume the ref: rebuild the constraint slice without it (and without any
@@ -177,25 +194,4 @@ func invalidRuntimeRef(ref string) error {
 // non-empty name — no path separators, no "."/".." traversal.
 func isSafeRefSegment(s string) bool {
 	return s != "" && s != "." && s != ".." && !strings.ContainsAny(s, `/\`)
-}
-
-// findPerfConstraint returns the first constraint with the given name.
-func findPerfConstraint(cs []recipe.Constraint, name string) (recipe.Constraint, bool) {
-	for _, c := range cs {
-		if c.Name == name {
-			return c, true
-		}
-	}
-	return recipe.Constraint{}, false
-}
-
-// countPerfConstraint counts constraints with the given name.
-func countPerfConstraint(cs []recipe.Constraint, name string) int {
-	n := 0
-	for _, c := range cs {
-		if c.Name == name {
-			n++
-		}
-	}
-	return n
 }

--- a/pkg/validator/benchmark_runtime_ref.go
+++ b/pkg/validator/benchmark_runtime_ref.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
+)
+
+// benchmarkRuntimeRefTestdataDir is the --data-tree location a recipe's NCCL
+// benchmark runtime template lives at, relative to the --data root. It mirrors
+// the embedded validators/performance/testdata layout so an external recipe's
+// runtime can be upstreamed by copying the file into the repo unchanged.
+const benchmarkRuntimeRefTestdataDir = "validators/performance/testdata"
+
+// resolveBenchmarkRuntimeRef lowers a recipe's nccl-benchmark-runtime-ref
+// performance constraint into the nccl-benchmark-runtime carrier the in-pod
+// validator reads. The ref is a bare "{accelerator}/{service}" value naming a
+// runtime template the recipe ships in its --data tree at
+// validators/performance/testdata/{accelerator}/{service}/runtime.yaml; its
+// content is read through the recipe DataProvider and injected as
+// nccl-benchmark-runtime, so the pod renders and runs it exactly as if it had
+// been supplied inline (NVIDIA/aicr#1792). No ref, or a blank ref → no-op.
+//
+// Fails closed (ErrCodeInvalidRequest) on a malformed ref, a missing/unreadable/
+// empty file, an absent DataProvider, or a ref set alongside an inline
+// nccl-benchmark-runtime — a mis-typed ref must abort, never silently skip the
+// benchmark, which is the exact failure mode this feature exists to eliminate.
+func (v *Validator) resolveBenchmarkRuntimeRef(ctx context.Context, vi *v1.ValidationInput) error {
+	if vi == nil || vi.Config.Performance == nil {
+		return nil
+	}
+	cs := vi.Config.Performance.Constraints
+
+	// Reject duplicate ref / carrier constraints before any first-match lookup —
+	// a blank earlier entry must not hide a later non-blank duplicate (and the
+	// overlay merge already collapses same-named constraints, so a duplicate here
+	// is a malformed input). Exactly one of each is allowed.
+	if n := countPerfConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntimeRef); n > 1 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("declare at most one %s constraint (found %d)", v1.PerfConstraintNCCLBenchmarkRuntimeRef, n))
+	}
+	if n := countPerfConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntime); n > 1 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("declare at most one %s constraint (found %d)", v1.PerfConstraintNCCLBenchmarkRuntime, n))
+	}
+
+	ref, ok := findPerfConstraint(cs, v1.PerfConstraintNCCLBenchmarkRuntimeRef)
+	if !ok {
+		return nil
+	}
+	raw := strings.TrimSpace(ref.Value)
+	if raw == "" {
+		return nil
+	}
+
+	// A ref and an inline runtime together are ambiguous — fail closed rather
+	// than silently preferring one.
+	inline, hasInline := findPerfConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime)
+	if hasInline && strings.TrimSpace(inline.Value) != "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s and an inline %s are both set — supply one",
+				v1.PerfConstraintNCCLBenchmarkRuntimeRef, v1.PerfConstraintNCCLBenchmarkRuntime))
+	}
+
+	relPath, err := benchmarkRuntimeRefPath(raw)
+	if err != nil {
+		return err
+	}
+
+	if v.dataProvider == nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s=%q is set but no --data source is available to resolve it",
+				v1.PerfConstraintNCCLBenchmarkRuntimeRef, raw))
+	}
+
+	readCtx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+	content, err := v.dataProvider.ReadFile(readCtx, relPath)
+	if err != nil {
+		// A canceled/deadline context surfaces as ErrCodeTimeout from the
+		// provider — propagate it as a timeout rather than mislabeling a
+		// transient fault as a bad recipe. Any other read failure (not-found,
+		// internal) is a ref the recipe cannot resolve: a recipe-authoring
+		// error the caller must fix, normalized to ErrCodeInvalidRequest.
+		if errors.IsTransient(err) {
+			// PropagateOrWrap keeps an already-coded provider error (e.g. the
+			// ErrCodeTimeout the DataProvider returns on ctx cancellation) intact;
+			// it only wraps a bare context error as ErrCodeTimeout with context.
+			return errors.PropagateOrWrap(err, errors.ErrCodeTimeout,
+				fmt.Sprintf("timed out resolving %s=%q (%q)",
+					v1.PerfConstraintNCCLBenchmarkRuntimeRef, raw, relPath))
+		}
+		return errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("failed to resolve %s=%q: expected %q in the --data tree",
+				v1.PerfConstraintNCCLBenchmarkRuntimeRef, raw, relPath), err)
+	}
+	if strings.TrimSpace(string(content)) == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s=%q resolved to an empty file (%q)",
+				v1.PerfConstraintNCCLBenchmarkRuntimeRef, raw, relPath))
+	}
+
+	// Consume the ref: rebuild the constraint slice without it (and without any
+	// pre-existing carrier — the non-blank case is already rejected above, so
+	// only a blank one can reach here, and leaving it would shadow the resolved
+	// value for first-match consumers like the pod) and append the resolved
+	// carrier. Dropping the ref makes a second resolution pass a no-op
+	// (idempotent — a re-invocation on the same input pointer no longer sees a
+	// ref) and keeps the raw ref out of the pod's ConfigMap; the fresh slice also
+	// avoids mutating a backing array shared via convertValidationPhase's
+	// by-reference copy of Constraints. The result holds exactly one carrier.
+	rebuilt := make([]recipe.Constraint, 0, len(vi.Config.Performance.Constraints))
+	for _, c := range vi.Config.Performance.Constraints {
+		if c.Name == v1.PerfConstraintNCCLBenchmarkRuntimeRef || c.Name == v1.PerfConstraintNCCLBenchmarkRuntime {
+			continue
+		}
+		rebuilt = append(rebuilt, c)
+	}
+	rebuilt = append(rebuilt, recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntime, Value: string(content)})
+	vi.Config.Performance.Constraints = rebuilt
+
+	slog.Info("resolved NCCL benchmark runtime from --data",
+		"ref", raw, "path", relPath, "bytes", len(content))
+	return nil
+}
+
+// benchmarkRuntimeRefPath validates a "{accelerator}/{service}" ref and returns
+// the --data-relative path of the runtime template it names. Rejects malformed
+// or non-local refs fail-closed so a typo (or a traversal attempt) cannot
+// resolve to an unexpected file.
+func benchmarkRuntimeRefPath(ref string) (string, error) {
+	parts := strings.Split(ref, "/")
+	if len(parts) != 2 {
+		return "", invalidRuntimeRef(ref)
+	}
+	accelerator, service := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	if !isSafeRefSegment(accelerator) || !isSafeRefSegment(service) {
+		return "", invalidRuntimeRef(ref)
+	}
+	relPath := filepath.Join(benchmarkRuntimeRefTestdataDir, accelerator, service, "runtime.yaml")
+	// Defense in depth against a segment that survives isSafeRefSegment but still
+	// escapes the tree once joined/cleaned.
+	if !filepath.IsLocal(relPath) || !strings.HasPrefix(relPath, benchmarkRuntimeRefTestdataDir+string(filepath.Separator)) {
+		return "", invalidRuntimeRef(ref)
+	}
+	return relPath, nil
+}
+
+func invalidRuntimeRef(ref string) error {
+	return errors.New(errors.ErrCodeInvalidRequest,
+		fmt.Sprintf("invalid %s=%q: must be \"{accelerator}/{service}\" (e.g. \"gb200/mycloud\")",
+			v1.PerfConstraintNCCLBenchmarkRuntimeRef, ref))
+}
+
+// isSafeRefSegment reports whether a single ref path segment is a plain,
+// non-empty name — no path separators, no "."/".." traversal.
+func isSafeRefSegment(s string) bool {
+	return s != "" && s != "." && s != ".." && !strings.ContainsAny(s, `/\`)
+}
+
+// findPerfConstraint returns the first constraint with the given name.
+func findPerfConstraint(cs []recipe.Constraint, name string) (recipe.Constraint, bool) {
+	for _, c := range cs {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return recipe.Constraint{}, false
+}
+
+// countPerfConstraint counts constraints with the given name.
+func countPerfConstraint(cs []recipe.Constraint, name string) int {
+	n := 0
+	for _, c := range cs {
+		if c.Name == name {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/validator/benchmark_runtime_ref_test.go
+++ b/pkg/validator/benchmark_runtime_ref_test.go
@@ -55,7 +55,17 @@ spec:
     spec:
       replicatedJobs:
         - name: node
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
 `
+
+// notATrainingRuntime is valid YAML but the wrong kind — used to exercise the
+// orchestrator's resolve-time shape check.
+const notATrainingRuntime = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nope\n"
 
 func perfInput(cs ...recipe.Constraint) *v1.ValidationInput {
 	return &v1.ValidationInput{
@@ -69,7 +79,7 @@ func ncclRuntimeCarrier(vi *v1.ValidationInput) (string, bool) {
 	if vi.Config.Performance == nil {
 		return "", false
 	}
-	c, ok := findPerfConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime)
+	c, ok := v1.FindConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime)
 	return c.Value, ok
 }
 
@@ -173,6 +183,23 @@ func TestResolveBenchmarkRuntimeRef(t *testing.T) {
 			wantErrSub: "empty file",
 		},
 		{
+			name:       "resolved file is not a TrainingRuntime fails closed",
+			input:      perfInput(refC("gb200/mycloud")),
+			dp:         &fakeDataProvider{files: map[string][]byte{goodPath: []byte(notATrainingRuntime)}},
+			wantErr:    true,
+			wantErrSub: "resolved to an invalid runtime",
+		},
+		{
+			name: "ref alongside a profile fails closed",
+			input: perfInput(
+				refC("gb200/mycloud"),
+				recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkProfile, Value: "gb200/eks"},
+			),
+			dp:         &fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}},
+			wantErr:    true,
+			wantErrSub: "mutually exclusive",
+		},
+		{
 			name:       "ref set but no data provider fails closed",
 			input:      perfInput(refC("gb200/mycloud")),
 			dp:         nil,
@@ -228,7 +255,7 @@ func TestResolveBenchmarkRuntimeRef(t *testing.T) {
 			}
 			// Exactly one carrier must remain — any pre-existing (blank) one is
 			// dropped so first-match consumers see the resolved value.
-			if n := countPerfConstraint(tt.input.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime); n != 1 {
+			if n := v1.CountConstraint(tt.input.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime); n != 1 {
 				t.Errorf("carrier count = %d, want exactly 1", n)
 			}
 		})
@@ -251,7 +278,7 @@ func TestResolveBenchmarkRuntimeRefIdempotent(t *testing.T) {
 	}
 
 	// Ref consumed, exactly one carrier present with the file content.
-	if _, ok := findPerfConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntimeRef); ok {
+	if _, ok := v1.FindConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntimeRef); ok {
 		t.Errorf("ref constraint should have been consumed after resolution")
 	}
 	carriers := 0

--- a/pkg/validator/benchmark_runtime_ref_test.go
+++ b/pkg/validator/benchmark_runtime_ref_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	stderrors "errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
+)
+
+// fakeDataProvider serves canned file content for the resolver test. A nil
+// files map with readErr set simulates an unreadable/missing --data file.
+type fakeDataProvider struct {
+	files   map[string][]byte
+	readErr error
+	reads   []string // paths ReadFile was called with
+}
+
+func (f *fakeDataProvider) ReadFile(_ context.Context, path string) ([]byte, error) {
+	f.reads = append(f.reads, path)
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	if b, ok := f.files[path]; ok {
+		return b, nil
+	}
+	return nil, errors.New(errors.ErrCodeNotFound, "no such file: "+path)
+}
+
+func (f *fakeDataProvider) WalkDir(_ context.Context, _ string, _ fs.WalkDirFunc) error { return nil }
+func (f *fakeDataProvider) Source(string) string                                        { return "fake" }
+
+const testBenchmarkRuntime = `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+spec:
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+`
+
+func perfInput(cs ...recipe.Constraint) *v1.ValidationInput {
+	return &v1.ValidationInput{
+		Config: v1.ValidationConfig{
+			Performance: &v1.ValidationPhase{Constraints: cs},
+		},
+	}
+}
+
+func ncclRuntimeCarrier(vi *v1.ValidationInput) (string, bool) {
+	if vi.Config.Performance == nil {
+		return "", false
+	}
+	c, ok := findPerfConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime)
+	return c.Value, ok
+}
+
+func TestResolveBenchmarkRuntimeRef(t *testing.T) {
+	const goodPath = "validators/performance/testdata/gb200/mycloud/runtime.yaml"
+
+	refC := func(v string) recipe.Constraint {
+		return recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntimeRef, Value: v}
+	}
+
+	tests := []struct {
+		name        string
+		input       *v1.ValidationInput
+		dp          recipe.DataProvider
+		wantCarrier string // expected injected nccl-benchmark-runtime value; "" = none injected
+		wantErr     bool
+		wantTimeout bool // expect a transient (ErrCodeTimeout) error rather than ErrCodeInvalidRequest
+		wantErrSub  string
+	}{
+		{
+			name:  "nil performance phase → no-op",
+			input: &v1.ValidationInput{},
+			dp:    &fakeDataProvider{},
+		},
+		{
+			name:  "no ref constraint → no-op",
+			input: perfInput(recipe.Constraint{Name: "nccl-all-reduce-bw", Value: ">= 450"}),
+			dp:    &fakeDataProvider{},
+		},
+		{
+			name:  "blank ref → no-op",
+			input: perfInput(refC("   ")),
+			dp:    &fakeDataProvider{},
+		},
+		{
+			name:        "valid ref resolves file into carrier",
+			input:       perfInput(refC("gb200/mycloud")),
+			dp:          &fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}},
+			wantCarrier: testBenchmarkRuntime,
+		},
+		{
+			name: "valid ref drops a pre-existing blank carrier",
+			input: perfInput(
+				refC("gb200/mycloud"),
+				recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntime, Value: ""},
+			),
+			dp:          &fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}},
+			wantCarrier: testBenchmarkRuntime,
+		},
+		{
+			name:       "malformed ref (one segment) fails closed",
+			input:      perfInput(refC("gb200")),
+			dp:         &fakeDataProvider{},
+			wantErr:    true,
+			wantErrSub: "{accelerator}/{service}",
+		},
+		{
+			name:       "traversal ref fails closed",
+			input:      perfInput(refC("../secrets")),
+			dp:         &fakeDataProvider{},
+			wantErr:    true,
+			wantErrSub: "{accelerator}/{service}",
+		},
+		{
+			name:       "missing file fails closed",
+			input:      perfInput(refC("gb200/mycloud")),
+			dp:         &fakeDataProvider{files: map[string][]byte{}},
+			wantErr:    true,
+			wantErrSub: "expected",
+		},
+		{
+			name:        "transient provider error preserves timeout code",
+			input:       perfInput(refC("gb200/mycloud")),
+			dp:          &fakeDataProvider{readErr: errors.New(errors.ErrCodeTimeout, "context deadline exceeded")},
+			wantErr:     true,
+			wantTimeout: true,
+		},
+		{
+			name:       "duplicate refs fail closed (blank must not hide non-blank)",
+			input:      perfInput(refC(""), refC("gb200/mycloud")),
+			dp:         &fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}},
+			wantErr:    true,
+			wantErrSub: "at most one",
+		},
+		{
+			name: "duplicate carriers fail closed",
+			input: perfInput(
+				refC("gb200/mycloud"),
+				recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntime, Value: ""},
+				recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntime, Value: testBenchmarkRuntime},
+			),
+			dp:         &fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}},
+			wantErr:    true,
+			wantErrSub: "at most one",
+		},
+		{
+			name:       "empty file fails closed",
+			input:      perfInput(refC("gb200/mycloud")),
+			dp:         &fakeDataProvider{files: map[string][]byte{goodPath: []byte("   \n")}},
+			wantErr:    true,
+			wantErrSub: "empty file",
+		},
+		{
+			name:       "ref set but no data provider fails closed",
+			input:      perfInput(refC("gb200/mycloud")),
+			dp:         nil,
+			wantErr:    true,
+			wantErrSub: "no --data source",
+		},
+		{
+			name: "ref alongside inline carrier fails closed",
+			input: perfInput(
+				refC("gb200/mycloud"),
+				recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntime, Value: testBenchmarkRuntime},
+			),
+			dp:         &fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}},
+			wantErr:    true,
+			wantErrSub: "both set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []Option{}
+			if tt.dp != nil {
+				opts = append(opts, WithDataProvider(tt.dp))
+			}
+			v := New(opts...)
+
+			err := v.resolveBenchmarkRuntimeRef(context.Background(), tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				wantCode := errors.ErrCodeInvalidRequest
+				if tt.wantTimeout {
+					wantCode = errors.ErrCodeTimeout
+				}
+				if !stderrors.Is(err, errors.New(wantCode, "")) {
+					t.Errorf("error code = %v, want %v", err, wantCode)
+				}
+				if tt.wantErrSub != "" && !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+			got, ok := ncclRuntimeCarrier(tt.input)
+			if tt.wantCarrier == "" {
+				if ok {
+					t.Errorf("carrier unexpectedly injected: %q", got)
+				}
+				return
+			}
+			if !ok || got != tt.wantCarrier {
+				t.Errorf("carrier = %q (present=%v), want %q", got, ok, tt.wantCarrier)
+			}
+			// Exactly one carrier must remain — any pre-existing (blank) one is
+			// dropped so first-match consumers see the resolved value.
+			if n := countPerfConstraint(tt.input.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntime); n != 1 {
+				t.Errorf("carrier count = %d, want exactly 1", n)
+			}
+		})
+	}
+}
+
+// TestResolveBenchmarkRuntimeRefIdempotent proves a second resolution pass on
+// the same input is a no-op: the first pass consumes the ref (drops it and
+// appends the carrier), so the second finds no ref and does not re-trip the
+// ref+inline guard.
+func TestResolveBenchmarkRuntimeRefIdempotent(t *testing.T) {
+	const goodPath = "validators/performance/testdata/gb200/mycloud/runtime.yaml"
+	vi := perfInput(recipe.Constraint{Name: v1.PerfConstraintNCCLBenchmarkRuntimeRef, Value: "gb200/mycloud"})
+	v := New(WithDataProvider(&fakeDataProvider{files: map[string][]byte{goodPath: []byte(testBenchmarkRuntime)}}))
+
+	for i := 1; i <= 2; i++ {
+		if err := v.resolveBenchmarkRuntimeRef(context.Background(), vi); err != nil {
+			t.Fatalf("pass %d: unexpected error: %v", i, err)
+		}
+	}
+
+	// Ref consumed, exactly one carrier present with the file content.
+	if _, ok := findPerfConstraint(vi.Config.Performance.Constraints, v1.PerfConstraintNCCLBenchmarkRuntimeRef); ok {
+		t.Errorf("ref constraint should have been consumed after resolution")
+	}
+	carriers := 0
+	for _, c := range vi.Config.Performance.Constraints {
+		if c.Name == v1.PerfConstraintNCCLBenchmarkRuntime {
+			carriers++
+			if c.Value != testBenchmarkRuntime {
+				t.Errorf("carrier value = %q, want the file content", c.Value)
+			}
+		}
+	}
+	if carriers != 1 {
+		t.Errorf("carrier count = %d, want exactly 1", carriers)
+	}
+}
+
+func TestBenchmarkRuntimeRefPath(t *testing.T) {
+	tests := []struct {
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{ref: "gb200/mycloud", want: "validators/performance/testdata/gb200/mycloud/runtime.yaml"},
+		{ref: "  h100 / eks ", want: "validators/performance/testdata/h100/eks/runtime.yaml"},
+		{ref: "gb200", wantErr: true},
+		{ref: "gb200/eks/net", wantErr: true},
+		{ref: "/eks", wantErr: true},
+		{ref: "gb200/", wantErr: true},
+		{ref: "../x", wantErr: true},
+		{ref: "gb200/..", wantErr: true},
+		{ref: ".", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got, err := benchmarkRuntimeRefPath(tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/validator/v1/perf_constraints.go
+++ b/pkg/validator/v1/perf_constraints.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// Performance-phase constraint names shared between the validator orchestrator
+// and the in-pod performance validator. Defining them here — the one package
+// both ends import — keeps the write side (the orchestrator, which resolves
+// NCCLBenchmarkRuntimeRef against the recipe DataProvider and lowers it into
+// NCCLBenchmarkRuntime) and the read side (the pod, which renders and runs
+// NCCLBenchmarkRuntime) in lockstep, rather than duplicating the literal on both
+// ends with a lock test. See NVIDIA/aicr#1792.
+const (
+	// PerfConstraintNCCLBenchmarkRuntime carries a complete Kubeflow
+	// TrainingRuntime (inline YAML) that the performance validator renders in
+	// place of a baked-in testdata template, keyed on the recipe's own criteria
+	// with no compiled applicability entry required. It is the resolved carrier:
+	// the orchestrator normally populates it from PerfConstraintNCCLBenchmarkRuntimeRef.
+	PerfConstraintNCCLBenchmarkRuntime = "nccl-benchmark-runtime"
+
+	// PerfConstraintNCCLBenchmarkRuntimeRef is the author-facing surface: a bare
+	// "{accelerator}/{service}" value naming a runtime template the recipe ships
+	// in its --data tree at
+	// validators/performance/testdata/{accelerator}/{service}/runtime.yaml — the
+	// same layout the embedded templates use, so an external recipe's runtime can
+	// be upstreamed by copying the file into the repo unchanged. The orchestrator
+	// reads that file through the recipe DataProvider and lowers its content into
+	// PerfConstraintNCCLBenchmarkRuntime before the validator pod runs.
+	PerfConstraintNCCLBenchmarkRuntimeRef = "nccl-benchmark-runtime-ref"
+)

--- a/pkg/validator/v1/perf_constraints.go
+++ b/pkg/validator/v1/perf_constraints.go
@@ -14,13 +14,22 @@
 
 package v1
 
-// Performance-phase constraint names shared between the validator orchestrator
-// and the in-pod performance validator. Defining them here — the one package
-// both ends import — keeps the write side (the orchestrator, which resolves
-// NCCLBenchmarkRuntimeRef against the recipe DataProvider and lowers it into
-// NCCLBenchmarkRuntime) and the read side (the pod, which renders and runs
-// NCCLBenchmarkRuntime) in lockstep, rather than duplicating the literal on both
-// ends with a lock test. See NVIDIA/aicr#1792.
+import (
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// Performance-phase constraint names and helpers shared between the validator
+// orchestrator and the in-pod performance validator. Defining them here — the
+// one package both ends import — keeps the write side (the orchestrator, which
+// resolves NCCLBenchmarkRuntimeRef against the recipe DataProvider and lowers it
+// into NCCLBenchmarkRuntime) and the read side (the pod, which renders and runs
+// NCCLBenchmarkRuntime) in lockstep, rather than duplicating literals and lookup
+// semantics on both ends. See NVIDIA/aicr#1792.
 const (
 	// PerfConstraintNCCLBenchmarkRuntime carries a complete Kubeflow
 	// TrainingRuntime (inline YAML) that the performance validator renders in
@@ -38,4 +47,99 @@ const (
 	// reads that file through the recipe DataProvider and lowers its content into
 	// PerfConstraintNCCLBenchmarkRuntime before the validator pod runs.
 	PerfConstraintNCCLBenchmarkRuntimeRef = "nccl-benchmark-runtime-ref"
+
+	// PerfConstraintNCCLBenchmarkProfile opts a recipe into an embedded NCCL
+	// benchmark template by naming a compiled "{accelerator}/{service}" pair. It
+	// is mutually exclusive with the runtime/ref pair (borrow an embedded
+	// template OR supply your own, never both); the name lives here so the
+	// orchestrator can reject that conflict at resolve time.
+	PerfConstraintNCCLBenchmarkProfile = "nccl-benchmark-profile"
+
+	// BenchmarkRuntimeAPIVersion and KindTrainingRuntime are the Kubeflow Trainer
+	// identity a recipe-supplied runtime must declare. The validator only ever
+	// applies it through a trainingruntimes GVR at this apiVersion with a
+	// force-set name/namespace, so a recipe can supply a TrainingRuntime — and
+	// nothing else.
+	BenchmarkRuntimeAPIVersion = "trainer.kubeflow.org/v1alpha1"
+	KindTrainingRuntime        = "TrainingRuntime"
+
+	// BenchmarkRuntimeNodeJob is the replicatedJob a recipe-supplied runtime must
+	// declare: the worker cohort the shared TrainJob sizes and the validator
+	// injects scheduling into / reads launcher logs from.
+	BenchmarkRuntimeNodeJob = "node"
 )
+
+// FindConstraint returns the first constraint with the given name.
+func FindConstraint(cs []recipe.Constraint, name string) (recipe.Constraint, bool) {
+	for _, c := range cs {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return recipe.Constraint{}, false
+}
+
+// CountConstraint counts constraints with the given name.
+func CountConstraint(cs []recipe.Constraint, name string) int {
+	n := 0
+	for _, c := range cs {
+		if c.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// ValidateBenchmarkRuntime confirms a recipe-supplied runtime template is a
+// Kubeflow TrainingRuntime of the expected apiVersion that declares the "node"
+// replicatedJob (with its worker pod spec at template.spec.template.spec — the
+// path scheduling is injected into). It is the single shape contract shared by
+// the orchestrator (which runs it at resolve time so a malformed runtime fails
+// fast offline, before any Job) and the pod (which renders and applies it).
+//
+// The identity fields (apiVersion, kind) and the replicatedJob names never carry
+// ${VAR} placeholders, so the raw content parses for this shape check even
+// before substitution. A wrong kind/apiVersion, content that does not parse as
+// YAML, or a missing/ill-formed "node" replicatedJob is rejected fail-closed
+// (ErrCodeInvalidRequest) so a typo cannot masquerade as a passing — or silently
+// skipped — benchmark.
+func ValidateBenchmarkRuntime(content string) error {
+	obj := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(content), obj); err != nil {
+		return errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s: not parseable as YAML", PerfConstraintNCCLBenchmarkRuntime), err)
+	}
+	if obj.GetAPIVersion() != BenchmarkRuntimeAPIVersion || obj.GetKind() != KindTrainingRuntime {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s: must be a %s %s (got apiVersion=%q kind=%q)",
+				PerfConstraintNCCLBenchmarkRuntime, BenchmarkRuntimeAPIVersion, KindTrainingRuntime,
+				obj.GetAPIVersion(), obj.GetKind()))
+	}
+	return validateBenchmarkNodeJob(obj)
+}
+
+// validateBenchmarkNodeJob confirms the runtime declares the "node" replicatedJob
+// and that it carries the worker pod spec at template.spec.template.spec.
+func validateBenchmarkNodeJob(obj *unstructured.Unstructured) error {
+	jobs, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "replicatedJobs")
+	if err == nil && found {
+		for _, raw := range jobs {
+			jobMap, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(jobMap, "name"); name != BenchmarkRuntimeNodeJob {
+				continue
+			}
+			if _, ok, err := unstructured.NestedMap(jobMap, "template", "spec", "template", "spec"); err != nil || !ok {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("invalid %s: %q replicatedJob must define the worker pod spec at template.spec.template.spec",
+						PerfConstraintNCCLBenchmarkRuntime, BenchmarkRuntimeNodeJob))
+			}
+			return nil
+		}
+	}
+	return errors.New(errors.ErrCodeInvalidRequest,
+		fmt.Sprintf("invalid %s: must declare a %q replicatedJob (spec.template.spec.replicatedJobs) — the NCCL worker cohort",
+			PerfConstraintNCCLBenchmarkRuntime, BenchmarkRuntimeNodeJob))
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -177,6 +177,13 @@ func (v *Validator) ValidatePhases(
 
 	slog.Info("running validation phases", "runID", v.RunID, "phases", phases)
 
+	// Lower any nccl-benchmark-runtime-ref into its inline carrier by reading the
+	// referenced template from the --data tree. Fails fast on a bad ref before
+	// deploying any Jobs.
+	if err := v.resolveBenchmarkRuntimeRef(ctx, validationInput); err != nil {
+		return nil, err
+	}
+
 	// Pre-flight: evaluate top-level validation constraints against snapshot.
 	// Fails fast before deploying any Jobs if prerequisites aren't met.
 	if err := checkReadiness(validationInput, snap); err != nil {
@@ -259,6 +266,12 @@ func (v *Validator) ValidatePhase(
 	validationInput *v1.ValidationInput,
 	snap *snapshotter.Snapshot,
 ) (*PhaseResult, error) {
+
+	// Lower any nccl-benchmark-runtime-ref into its inline carrier before the
+	// phase runs (or is skipped), so a bad ref fails fast even offline.
+	if err := v.resolveBenchmarkRuntimeRef(ctx, validationInput); err != nil {
+		return nil, err
+	}
 
 	cat, err := catalog.LoadWithDataProvider(ctx, v.dataProvider, v.Version, v.Commit)
 	if err != nil {

--- a/recipes/validators/README.md
+++ b/recipes/validators/README.md
@@ -52,9 +52,13 @@ Applied by `catalog.Load` (`pkg/validator/catalog/catalog.go`) in order:
 
 The NCCL checks derive applicability from the recipe's `criteria` by default;
 a recipe outside the embedded service + accelerator matrix (e.g. registered
-via `--data`) opts in with the `nccl-benchmark-profile` performance
-constraint — see
-[Opting external recipes into a benchmark profile](../../docs/user/validation.md#opting-external-recipes-into-a-benchmark-profile).
+via `--data`) opts in with the `nccl-benchmark-profile` performance constraint
+(borrow an embedded template — see
+[Opting external recipes into a benchmark profile](../../docs/user/validation.md#opting-external-recipes-into-a-benchmark-profile))
+or, when its fabric matches no embedded template, with the
+`nccl-benchmark-runtime-ref` constraint (ship a Kubeflow `TrainingRuntime` as a
+`--data` file and reference it — see
+[Supplying a benchmark runtime for a private service](../../docs/user/validation.md#supplying-a-benchmark-runtime-for-a-private-service)).
 
 ### Conformance Phase
 

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -70,10 +70,22 @@ validators:
   # The NCCL checks (nccl-all-reduce-bw and the -net/-nvls variants at the
   # bottom of this file) key applicability to the recipe's criteria against a
   # compiled service+accelerator matrix. A recipe outside that matrix (e.g. a
-  # service registered via --data) opts in PER RECIPE via the
-  # `nccl-benchmark-profile` performance constraint — a bare
-  # "{accelerator}/{service}" value such as gb200/eks, resolved recipe-only
-  # (no env tier). Thresholds stay in the same-named check constraints.
+  # service registered via --data) opts in PER RECIPE one of two ways, both
+  # resolved recipe-only (no env tier), with thresholds staying in the
+  # same-named check constraints:
+  #   * `nccl-benchmark-profile` — a bare "{accelerator}/{service}" value such
+  #     as gb200/eks, borrowing an EMBEDDED benchmark template whose fabric
+  #     matches the cluster.
+  #   * `nccl-benchmark-runtime-ref` — a bare "{accelerator}/{service}" naming a
+  #     Kubeflow TrainingRuntime the recipe ships in its --data tree at
+  #     validators/performance/testdata/{accelerator}/{service}/runtime.yaml, for
+  #     a private service+accelerator whose criteria pair has no embedded template
+  #     to borrow. The orchestrator reads the file and lowers it into the
+  #     nccl-benchmark-runtime carrier the pod renders; the supplied runtime owns
+  #     its fabric wiring, so the validator skips service-specific fabric setup
+  #     but still sizes it, evaluates the bandwidth threshold, and (for the
+  #     -net/-nvls variants) asserts the transport actually carried traffic.
+  #     Mutually exclusive with nccl-benchmark-profile.
   - name: nccl-all-reduce-bw
     phase: performance
     description: "Verify NCCL All Reduce Bus Bandwidth meets threshold"

--- a/validators/performance/nccl_all_reduce_bw.go
+++ b/validators/performance/nccl_all_reduce_bw.go
@@ -100,3 +100,17 @@ func findPerformanceConstraint(ctx *validators.Context, name string) (recipe.Con
 	}
 	return recipe.Constraint{}, false
 }
+
+// countPerformanceConstraint counts performance constraints with the given name.
+func countPerformanceConstraint(ctx *validators.Context, name string) int {
+	if ctx.ValidationInput == nil || ctx.ValidationInput.Config.Performance == nil {
+		return 0
+	}
+	n := 0
+	for _, c := range ctx.ValidationInput.Config.Performance.Constraints {
+		if c.Name == name {
+			n++
+		}
+	}
+	return n
+}

--- a/validators/performance/nccl_all_reduce_bw.go
+++ b/validators/performance/nccl_all_reduce_bw.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
 )
 
@@ -90,27 +91,20 @@ func checkNCCLAllReduceBWVariant(ctx *validators.Context, variant ncclVariant) e
 }
 
 func findPerformanceConstraint(ctx *validators.Context, name string) (recipe.Constraint, bool) {
-	if ctx.ValidationInput == nil || ctx.ValidationInput.Config.Performance == nil {
-		return recipe.Constraint{}, false
-	}
-	for _, c := range ctx.ValidationInput.Config.Performance.Constraints {
-		if c.Name == name {
-			return c, true
-		}
-	}
-	return recipe.Constraint{}, false
+	return v1.FindConstraint(performanceConstraints(ctx), name)
 }
 
 // countPerformanceConstraint counts performance constraints with the given name.
 func countPerformanceConstraint(ctx *validators.Context, name string) int {
+	return v1.CountConstraint(performanceConstraints(ctx), name)
+}
+
+// performanceConstraints returns the recipe's performance-phase constraints in a
+// nil-safe way. The lookup semantics (first-match, count) live once in
+// pkg/validator/v1 so the pod and the orchestrator can't drift.
+func performanceConstraints(ctx *validators.Context) []recipe.Constraint {
 	if ctx.ValidationInput == nil || ctx.ValidationInput.Config.Performance == nil {
-		return 0
+		return nil
 	}
-	n := 0
-	for _, c := range ctx.ValidationInput.Config.Performance.Constraints {
-		if c.Name == name {
-			n++
-		}
-	}
-	return n
+	return ctx.ValidationInput.Config.Performance.Constraints
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -256,11 +256,6 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	service := ctx.ValidationInput.Criteria.Service
 	accelerator := ctx.ValidationInput.Criteria.Accelerator
 
-	fabric, err := ncclFabric()
-	if err != nil {
-		return "", false, err
-	}
-
 	// The benchmark target defaults to the recipe's criteria; an explicit
 	// nccl-benchmark-profile constraint overrides it so recipes whose criteria
 	// are absent from the compiled matrix (external --data services, new
@@ -273,13 +268,53 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	if err != nil {
 		return "", false, err
 	}
+
+	// A recipe may supply its own TrainingRuntime (nccl-benchmark-runtime) when
+	// its criteria pair has neither a compiled matrix entry nor an embedded
+	// template to borrow — completing the data-driven vision for private
+	// --data-only services (NVIDIA/aicr#1792). It is mutually exclusive with the
+	// borrow-an-embedded-template profile: a recipe supplies its own runtime OR
+	// names an embedded one, never both.
+	customRuntime, err := resolveNCCLBenchmarkRuntime(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	if customRuntime != "" && profile != nil {
+		return "", false, aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s (or %s) and %s are mutually exclusive: supply a runtime or borrow an embedded profile, not both",
+				perfConstraintNCCLBenchmarkRuntime, perfConstraintNCCLBenchmarkRuntimeRef, perfConstraintNCCLBenchmarkProfile))
+	}
+
+	// Fabric selection (AICR_NCCL_FABRIC) governs only the baked-in template path
+	// — EFA vs ConnectX-RoCE NIC wiring and the transport-variant template. A
+	// recipe-supplied runtime owns its own fabric end to end, so a malformed
+	// AICR_NCCL_FABRIC must not fail it; validate the env only when no custom
+	// runtime is in play. The default is inconsequential on the custom path
+	// (every fabric-dependent branch below is gated on customRuntime == "").
+	fabric := fabricEFA
+	if customRuntime == "" {
+		fabric, err = ncclFabric()
+		if err != nil {
+			return "", false, err
+		}
+	}
+
 	if profile != nil {
 		target = *profile
 		slog.Info("Recipe declares an NCCL benchmark profile — overriding criteria-derived applicability",
 			"profile", target.String(), "criteriaService", service, "criteriaAccelerator", accelerator)
 	}
 
-	if !ncclCombinationSupported(variant, fabric, target) {
+	// A recipe-supplied runtime grants applicability on its own: the recipe
+	// explicitly opted in with a complete TrainingRuntime, keyed on its own
+	// criteria, so the compiled applicability gate (which governs only the
+	// criteria/profile → embedded-template paths) is bypassed. The supplied
+	// runtime owns its fabric wiring, so service-specific NIC discovery,
+	// preflights, and NVLS/IMEX provisioning are skipped further below.
+	if customRuntime != "" {
+		slog.Info("Recipe supplies its own NCCL benchmark runtime — bypassing compiled applicability and service-specific fabric plumbing",
+			"criteriaService", service, "criteriaAccelerator", accelerator, "variant", string(variant))
+	} else if !ncclCombinationSupported(variant, fabric, target) {
 		slog.Info("Skipping NCCL All Reduce bandwidth validation: unsupported variant/service/accelerator combination",
 			"variant", string(variant), "target", target.String(), "fromProfile", target.fromProfile, "fabric", string(fabric))
 		if target.fromProfile {
@@ -299,13 +334,35 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	}
 	slog.Info("Target bandwidth threshold", "threshold", threshold, "tolerance", "10%")
 
+	// Size the worker cohort against the same nodes the workers will actually
+	// land on. Precedence matches applyNCCLWorkerScheduling: a user
+	// --node-selector wins; otherwise a recipe-supplied runtime keeps its own
+	// worker nodeSelector, so size against that too — else WorkerCount would
+	// count nodes the runtime's selector then excludes, leaving workers Pending.
+	//
+	// Scope: only nodeSelector is factored in. Richer scheduling constraints in
+	// a custom runtime (nodeAffinity, un-tolerated taints) are the scheduler's
+	// job to enforce, not the validator's to simulate; a runtime that narrows
+	// placement below the sized cohort fails SAFE — workers stay Pending and the
+	// launcher wait times out with a diagnostic, never a false pass. Operators
+	// wanting the sized and scheduled cohorts to match exactly pass
+	// --node-selector.
+	sizingSelector := ctx.NodeSelector
+	if customRuntime != "" && len(sizingSelector) == 0 {
+		rs, rsErr := customRuntimeNodeSelector(customRuntime)
+		if rsErr != nil {
+			return "", false, rsErr
+		}
+		sizingSelector = rs
+	}
+
 	// Determine GPU configuration from cluster. The service comes from the
 	// benchmark target (an EKS-profiled cluster gets the EKS instance-type
 	// narrowing) but the accelerator stays the recipe's own criteria value:
 	// the GFD gpu.product node filter identifies the cluster's hardware, and
 	// a profile naming gb200 must not filter a cluster of an unmatched newer
 	// accelerator down to zero nodes.
-	gpuConfig, err := determineGPUConfig(ctx, target.service, accelerator)
+	gpuConfig, err := determineGPUConfig(ctx, target.service, accelerator, sizingSelector)
 	if err != nil {
 		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to determine GPU configuration", err)
 	}
@@ -325,7 +382,7 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	// and NCCL silently falls back to Socket. Preflights key off the
 	// benchmark target: opting into a profile opts into that profile's
 	// environment contract, preflights included.
-	if fabric == fabricEFA && gb200NetPreflightApplies(variant, target.accelerator, target.service) {
+	if customRuntime == "" && fabric == fabricEFA && gb200NetPreflightApplies(variant, target.accelerator, target.service) {
 		if pfErr := preflightGB200NetNVregFlag(ctx, gpuConfig.Nodes); pfErr != nil {
 			return "", false, pfErr
 		}
@@ -338,7 +395,7 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	// artifacts the workers never start sshd and the launcher mpirun fails
 	// with an opaque "pod failed" minutes later. Fail fast with an actionable
 	// error naming the unready nodes instead.
-	if gkeTCPXOPreflightApplies(variant, target.accelerator, target.service) {
+	if customRuntime == "" && gkeTCPXOPreflightApplies(variant, target.accelerator, target.service) {
 		if pfErr := preflightGKETCPXOReady(ctx, gpuConfig.Nodes); pfErr != nil {
 			return "", false, pfErr
 		}
@@ -347,7 +404,7 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	// Run the NCCL all-reduce benchmark using Kubeflow TrainJob + MPI.
 	// Each platform has a per-platform TrainingRuntime with all platform-specific
 	// configuration (image, mpirun args, resources, sidecars). The TrainJob is shared.
-	logs, err := runNCCLTrainJob(ctx, gpuConfig, target.accelerator, target.service, variant, fabric)
+	logs, err := runNCCLTrainJob(ctx, gpuConfig, target.accelerator, target.service, variant, fabric, customRuntime)
 	if err != nil {
 		return "", false, err
 	}
@@ -369,9 +426,14 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	}
 
 	// For named variants, assert the expected transport actually carried traffic.
-	// This turns the variant label into a hard guarantee — a GB200 cluster
-	// with a broken IMEX domain will fail loudly on the NVLS variant instead of
-	// silently falling back to EFA.
+	// This turns the variant label into a hard guarantee — a GB200 cluster with a
+	// broken IMEX domain fails loudly on the NVLS variant instead of silently
+	// falling back to EFA. Applies to recipe-supplied runtimes too: the markers
+	// (NCCL's "Using network" and "NVLS comm" log lines) are transport-internal
+	// and fabric-agnostic, so a runtime paired with -net / -nvls must still prove
+	// its transport rather than pass on bandwidth alone. The default check
+	// (variantDefault, no marker) is a no-op here, which is the documented
+	// pairing for a custom runtime.
 	if err := verifyTransportFromLogs(logs, variant); err != nil {
 		return logs, false, err
 	}
@@ -395,7 +457,8 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 // It applies the per-platform TrainingRuntime and shared TrainJob, waits for the launcher
 // pod to complete, and returns the benchmark logs.
 func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
-	accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, variant ncclVariant, fabric ncclFabricType) (string, error) {
+	accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, variant ncclVariant, fabric ncclFabricType,
+	customRuntime string) (string, error) {
 
 	dynamicClient := ctx.DynamicClient
 
@@ -429,9 +492,11 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// resource it deletes, so running it after an early failure is safe.
 	defer cleanupNCCLResources(dynamicClient, gpuConfig.Namespace)
 
-	// Apply runtime and trainjob resources.
-	if applyErr := applyNCCLResources(ctx, dynamicClient, gpuConfig, accelerator, service, variant, fabric); applyErr != nil {
-		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply NCCL resources", applyErr)
+	// Apply runtime and trainjob resources. Propagate an inner code rather than
+	// forcing ErrCodeInternal — a recipe-supplied runtime that fails to render is
+	// an ErrCodeInvalidRequest (recipe-authoring error), not an internal fault.
+	if applyErr := applyNCCLResources(ctx, dynamicClient, gpuConfig, accelerator, service, variant, fabric, customRuntime); applyErr != nil {
+		return "", aicrErrors.PropagateOrWrap(applyErr, aicrErrors.ErrCodeInternal, "failed to apply NCCL resources")
 	}
 
 	podHelper := &helper.PodLifecycle{
@@ -638,8 +703,12 @@ func anyNodeHasLabel(nodes []v1.Node, key string) bool {
 // determineGPUConfig analyzes the snapshot to determine GPU node configuration.
 // The returned Nodes slice is already narrowed to the TrainJob's target set
 // via resolveTargetGPUNodes so WorkerCount, GPUCountPerNode, and TotalGPUCount
-// agree with what the worker podSpec will later schedule onto.
-func determineGPUConfig(ctx *validators.Context, service recipe.CriteriaServiceType, accelerator recipe.CriteriaAcceleratorType) (*gpuConfiguration, error) {
+// agree with what the worker podSpec will later schedule onto. override is the
+// node selector to size against (and the first precedence in resolveTargetGPUNodes)
+// — normally ctx.NodeSelector, but a recipe-supplied runtime's own worker
+// nodeSelector when it pins its own nodes, so sizing and placement use the same
+// cohort.
+func determineGPUConfig(ctx *validators.Context, service recipe.CriteriaServiceType, accelerator recipe.CriteriaAcceleratorType, override map[string]string) (*gpuConfiguration, error) {
 	slog.Info("Analyzing GPU node configuration...")
 
 	gpuNodes, err := helper.FindSchedulableGpuNodes(ctx.Ctx, ctx.Clientset)
@@ -651,7 +720,7 @@ func determineGPUConfig(ctx *validators.Context, service recipe.CriteriaServiceT
 	}
 	slog.Info("Found GPU nodes", "count", len(gpuNodes))
 
-	targetNodes, err := resolveTargetGPUNodes(gpuNodes, ctx.NodeSelector, service, accelerator)
+	targetNodes, err := resolveTargetGPUNodes(gpuNodes, override, service, accelerator)
 	if err != nil {
 		return nil, err
 	}
@@ -681,8 +750,8 @@ func determineGPUConfig(ctx *validators.Context, service recipe.CriteriaServiceT
 // YAML files with template substitution using the dynamic client.
 // Runtime: testdata/{accelerator}/{service}/runtime[-{variant}].yaml (per-platform+variant)
 // TrainJob: testdata/trainjob.yaml (shared, just runtimeRef + numNodes)
-func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface, config *gpuConfiguration, accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, variant ncclVariant, fabric ncclFabricType) error {
-	slog.Info("Applying NCCL test resources...", "accelerator", accelerator, "service", service, "variant", string(variant), "fabric", string(fabric))
+func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface, config *gpuConfiguration, accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, variant ncclVariant, fabric ncclFabricType, customRuntime string) error {
+	slog.Info("Applying NCCL test resources...", "accelerator", accelerator, "service", service, "variant", string(variant), "fabric", string(fabric), "customRuntime", customRuntime != "")
 
 	templateData := map[string]string{
 		"NAMESPACE":          config.Namespace,
@@ -697,7 +766,8 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	var instanceType string
 
 	// For GKE, discover GPU NIC network names (cluster-specific prefixes).
-	if service == recipe.CriteriaServiceGKE {
+	// Skipped for a recipe-supplied runtime, which owns its own fabric wiring.
+	if customRuntime == "" && service == recipe.CriteriaServiceGKE {
 		gpuNICs, err := discoverGKEGPUNICNetworks(ctx.Ctx, dynamicClient)
 		if err != nil {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to discover GKE GPU NIC networks", err)
@@ -713,7 +783,8 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 
 	// For EKS, discover instance type and EFA adapter count from GPU nodes.
 	// EFA count of 0 is valid — NCCL falls back to TCP (slower but functional).
-	if service == recipe.CriteriaServiceEKS {
+	// Skipped for a recipe-supplied runtime, which owns its own fabric wiring.
+	if customRuntime == "" && service == recipe.CriteriaServiceEKS {
 		warnIfHeterogeneousNodes(config.Nodes)
 		it, efaCount, err := discoverEKSNodeConfig(config.Nodes)
 		if err != nil {
@@ -744,44 +815,24 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// have every /dev/infiniband device mounted. A count of 0 is valid —
 	// NCCL falls back to TCP over the pod network (slower but functional),
 	// mirroring the EKS zero-EFA behavior above.
-	if service == recipe.CriteriaServiceAKS {
+	// Skipped for a recipe-supplied runtime, which owns its own fabric wiring.
+	if customRuntime == "" && service == recipe.CriteriaServiceAKS {
 		if err := applyAKSTemplateData(config, templateData); err != nil {
 			return err
 		}
 	}
 
-	// Build effective worker scheduling: user override takes precedence over platform default.
-	defaultNodeSelector, defaultTolerations, err := platformWorkerScheduling(service, instanceType, config.Nodes)
+	effectiveNodeSelector, effectiveTolerations, err := effectiveWorkerScheduling(ctx, service, instanceType, config, customRuntime)
 	if err != nil {
 		return err
-	}
-	effectiveNodeSelector := defaultNodeSelector
-	// Gate on len() rather than != nil so an explicit but empty selector does
-	// not silently clear the platform default for scheduling while
-	// resolveTargetGPUNodes (which gates on len > 0) still narrows the counted
-	// set — that asymmetry would let workers schedule outside the cohort the
-	// job was sized for.
-	if len(ctx.NodeSelector) > 0 {
-		effectiveNodeSelector = ctx.NodeSelector
-		slog.Info("Using user-provided node selector override for NCCL workers", "selector", ctx.NodeSelector)
-	}
-	effectiveTolerations := defaultTolerations
-	if ctx.Tolerations != nil {
-		effectiveTolerations = ctx.Tolerations
-		slog.Info("Using user-provided toleration override for NCCL workers", "count", len(ctx.Tolerations))
-	}
-
-	if service == recipe.CriteriaServiceAny && len(effectiveNodeSelector) == 0 {
-		return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
-			"self-managed clusters (service=any) require --node-selector to identify GPU nodes "+
-				"(e.g., --node-selector nvidia.com/gpu.present=true)")
 	}
 
 	// RoCE NET: the worker pod references a RoCE DRA ResourceClaimTemplate
 	// (nccl-roce-rct). parseYAMLTemplate is single-document, so apply the claim
 	// as a standalone object before the runtime (it must exist when the TrainJob
-	// later creates the worker pods that reference it).
-	if fabric == fabricRoCE {
+	// later creates the worker pods that reference it). Skipped for a
+	// recipe-supplied runtime: it declares any DRA claims it needs itself.
+	if customRuntime == "" && fabric == fabricRoCE {
 		// Claim one ConnectX RoCE device per GPU via DRA (NCCL maps GPU->NIC);
 		// the per-node device pool (e.g. 8 on p6e-gb300r) is >= GPUs/node. Set
 		// here — keyed by fabric, not service — so adding a non-EKS RoCE service
@@ -801,9 +852,9 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 		slog.Info("Applied RoCE ResourceClaimTemplate", "name", ncclRoceClaimName, "count", templateData["ROCE_DEVICE_COUNT"])
 	}
 
-	runtimeObj, err := parseYAMLTemplate(templatePath(accelerator, service, variant, fabric, "runtime.yaml"), templateData)
+	runtimeObj, err := buildNCCLRuntimeObject(customRuntime, accelerator, service, variant, fabric, config.Namespace, templateData)
 	if err != nil {
-		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse training runtime template", err)
+		return err
 	}
 	if err := applyNCCLWorkerScheduling(runtimeObj, effectiveNodeSelector, effectiveTolerations); err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply NCCL worker scheduling", err)
@@ -825,8 +876,10 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// auto-create a ResourceClaimTemplate that runtime-nvls.yaml references;
 	// without this, the NVL72 fabric is visible to NCCL but /dev/nvidia-caps-
 	// imex-channels isn't mounted into the workers and MNNVL aborts with
-	// "Cuda failure 800 'operation not permitted'".
-	if variant == variantNVLS {
+	// "Cuda failure 800 'operation not permitted'". Skipped for a recipe-supplied
+	// runtime: IMEX/ComputeDomain wiring is part of the fabric contract the
+	// runtime owns, so it must declare any ComputeDomain/ResourceClaim it needs.
+	if customRuntime == "" && variant == variantNVLS {
 		if err := applyNCCLComputeDomain(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply ComputeDomain", err)
 		}
@@ -1072,6 +1125,82 @@ func waitForIMEXClaimTemplate(ctx context.Context, dynamicClient dynamic.Interfa
 	}
 }
 
+// effectiveWorkerScheduling resolves the nodeSelector and tolerations stamped
+// onto the NCCL worker pods. A user --node-selector / --tolerations override
+// (ctx.NodeSelector / ctx.Tolerations) wins; otherwise the platform default is
+// used — EXCEPT for a recipe-supplied runtime, which owns its own worker
+// scheduling. Applying the platform default to a custom runtime would clobber
+// it: the EKS default stamps {instance-type: ""} (instanceType is never
+// discovered on the custom path — a selector matching zero nodes), and
+// GKE/OKE/AKS overwrite with a cloud-specific selector (GKE even hard-errors on
+// missing accelerator labels). The service=any explicit-selector requirement
+// likewise applies only to the baked-in path.
+func effectiveWorkerScheduling(ctx *validators.Context, service recipe.CriteriaServiceType,
+	instanceType string, config *gpuConfiguration, customRuntime string) (map[string]string, []v1.Toleration, error) {
+
+	var defaultNodeSelector map[string]string
+	var defaultTolerations []v1.Toleration
+	if customRuntime == "" {
+		ns, tol, err := platformWorkerScheduling(service, instanceType, config.Nodes)
+		if err != nil {
+			return nil, nil, err
+		}
+		defaultNodeSelector, defaultTolerations = ns, tol
+	}
+
+	effectiveNodeSelector := defaultNodeSelector
+	// Gate on len() rather than != nil so an explicit but empty selector does
+	// not silently clear the platform default for scheduling while
+	// resolveTargetGPUNodes (which gates on len > 0) still narrows the counted
+	// set — that asymmetry would let workers schedule outside the cohort the
+	// job was sized for.
+	if len(ctx.NodeSelector) > 0 {
+		effectiveNodeSelector = ctx.NodeSelector
+		slog.Info("Using user-provided node selector override for NCCL workers", "selector", ctx.NodeSelector)
+	}
+	effectiveTolerations := defaultTolerations
+	if ctx.Tolerations != nil {
+		effectiveTolerations = ctx.Tolerations
+		slog.Info("Using user-provided toleration override for NCCL workers", "count", len(ctx.Tolerations))
+	}
+
+	if customRuntime == "" && service == recipe.CriteriaServiceAny && len(effectiveNodeSelector) == 0 {
+		return nil, nil, aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+			"self-managed clusters (service=any) require --node-selector to identify GPU nodes "+
+				"(e.g., --node-selector nvidia.com/gpu.present=true)")
+	}
+
+	return effectiveNodeSelector, effectiveTolerations, nil
+}
+
+// buildNCCLRuntimeObject selects and renders the TrainingRuntime the NCCL
+// TrainJob will reference. A recipe-supplied nccl-benchmark-runtime is rendered
+// from its inline template with its identity forced to what the shared TrainJob's
+// runtimeRef expects and confined to the validator namespace (the value was
+// shape-checked as a Kubeflow TrainingRuntime at resolve time). Otherwise the
+// baked-in per-platform testdata template is read from disk.
+func buildNCCLRuntimeObject(customRuntime string, accelerator recipe.CriteriaAcceleratorType,
+	service recipe.CriteriaServiceType, variant ncclVariant, fabric ncclFabricType,
+	namespace string, templateData map[string]string) (*unstructured.Unstructured, error) {
+
+	if customRuntime != "" {
+		obj, err := renderYAMLTemplate(customRuntime, templateData)
+		if err != nil {
+			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest, "failed to render recipe-supplied nccl-benchmark-runtime", err)
+		}
+		obj.SetName(ncclTrainingRuntimeName)
+		obj.SetNamespace(namespace)
+		slog.Info("Rendered recipe-supplied NCCL TrainingRuntime", "name", ncclTrainingRuntimeName, "namespace", namespace)
+		return obj, nil
+	}
+
+	obj, err := parseYAMLTemplate(templatePath(accelerator, service, variant, fabric, "runtime.yaml"), templateData)
+	if err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse training runtime template", err)
+	}
+	return obj, nil
+}
+
 // parseYAMLTemplate reads a YAML template file, performs ${KEY} substitution,
 // and unmarshals it into an unstructured object.
 func parseYAMLTemplate(path string, data map[string]string) (*unstructured.Unstructured, error) {
@@ -1079,12 +1208,20 @@ func parseYAMLTemplate(path string, data map[string]string) (*unstructured.Unstr
 	if err != nil {
 		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read template", err)
 	}
-	yamlContent := string(content)
+	return renderYAMLTemplate(string(content), data)
+}
+
+// renderYAMLTemplate performs ${KEY} substitution on an in-memory YAML template
+// string and unmarshals the result into an unstructured object. It is the
+// substitution core shared by parseYAMLTemplate (baked-in testdata templates,
+// read from disk) and the recipe-supplied nccl-benchmark-runtime path (the
+// template arrives inline in ValidationInput, never touching the filesystem).
+func renderYAMLTemplate(content string, data map[string]string) (*unstructured.Unstructured, error) {
 	for key, value := range data {
-		yamlContent = strings.ReplaceAll(yamlContent, "${"+key+"}", value)
+		content = strings.ReplaceAll(content, "${"+key+"}", value)
 	}
 	obj := &unstructured.Unstructured{}
-	if err := yaml.Unmarshal([]byte(yamlContent), obj); err != nil {
+	if err := yaml.Unmarshal([]byte(content), obj); err != nil {
 		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse YAML", err)
 	}
 	return obj, nil

--- a/validators/performance/nccl_benchmark_profile.go
+++ b/validators/performance/nccl_benchmark_profile.go
@@ -22,6 +22,7 @@ import (
 
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
 )
 
@@ -43,7 +44,7 @@ import (
 // template family (the testdata/{accelerator}/{service} layout). Resolution
 // is recipe-only — there is deliberately no env tier, so a profile is always
 // recorded in the recipe that certified the cluster.
-const perfConstraintNCCLBenchmarkProfile = "nccl-benchmark-profile"
+const perfConstraintNCCLBenchmarkProfile = v1.PerfConstraintNCCLBenchmarkProfile
 
 // ncclBenchmarkTarget is the resolved (accelerator, service) pair an NCCL
 // check runs as. Template selection, service-specific fabric plumbing (EFA

--- a/validators/performance/nccl_benchmark_runtime.go
+++ b/validators/performance/nccl_benchmark_runtime.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
+	"github.com/NVIDIA/aicr/validators"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// perfConstraintNCCLBenchmarkRuntime is the resolved carrier constraint the pod
+// reads: a complete Kubeflow TrainingRuntime (inline YAML) that the NCCL
+// all-reduce benchmark renders in place of a baked-in testdata template.
+//
+// It is the terminal escape hatch of the data-driven validation vision
+// (NVIDIA/aicr#1703, #1792): a private service+accelerator introduced entirely
+// via `--data` has no entry in the compiled supportedNCCLCombinations matrix
+// and — the gap nccl-benchmark-profile could not close — no embedded
+// testdata/{accelerator}/{service} template to borrow either. Rather than
+// requiring the validator binary to know the service, the recipe brings its own
+// runtime, so `aicr validate` gates the benchmark keyed on the recipe's OWN
+// criteria without any compiled applicability entry.
+//
+// Authors do not write this constraint directly. They ship the runtime as a
+// file in the --data tree and reference it with nccl-benchmark-runtime-ref (a
+// bare "{accelerator}/{service}" value); the orchestrator reads
+// validators/performance/testdata/{accelerator}/{service}/runtime.yaml and
+// lowers its content into this carrier before the pod runs (see
+// pkg/validator/benchmark_runtime_ref.go). The pod is oblivious to that
+// resolution — it just renders whatever content the carrier holds.
+//
+// When set, the runtime is rendered (with the generic ${NAMESPACE},
+// ${WORKER_COUNT}, ${GPU_COUNT_PER_NODE}, ${GPU_COUNT}, ${TEST_TYPE},
+// ${MIN_MESSAGE_SIZE}, ${MAX_MESSAGE_SIZE} substitutions) in place of any
+// baked-in testdata template; the compiled applicability gate is bypassed (the
+// recipe opted in explicitly); and the service-specific fabric plumbing
+// (EFA/TCPXO/RDMA NIC discovery, the GB200-NVreg / GKE-TCPXO preflights, and
+// NVLS IMEX provisioning) is skipped — the supplied runtime owns its own fabric
+// wiring end to end. The name is shared with the orchestrator via
+// pkg/validator/v1 so the write side and read side cannot drift. See
+// nccl_all_reduce_bw_constraint.go (validateNcclAllReduceBw / applyNCCLResources)
+// for the custom-path branches, and nccl_benchmark_profile.go for the
+// borrow-an-embedded-template sibling.
+const perfConstraintNCCLBenchmarkRuntime = v1.PerfConstraintNCCLBenchmarkRuntime
+
+// perfConstraintNCCLBenchmarkRuntimeRef is the author-facing --data reference the
+// orchestrator resolves into the carrier above. The pod only reads it to fail
+// closed if it arrives unresolved (see resolveNCCLBenchmarkRuntime).
+const perfConstraintNCCLBenchmarkRuntimeRef = v1.PerfConstraintNCCLBenchmarkRuntimeRef
+
+// A recipe-supplied nccl-benchmark-runtime must be exactly this Kubeflow
+// Trainer identity. The validator only ever applies it through
+// trainingRuntimeGVR (trainer.kubeflow.org/v1alpha1) and force-sets its
+// name/namespace, so a recipe can supply a TrainingRuntime — and nothing else.
+// It cannot inject an arbitrary resource kind or version into the validator
+// namespace. The version is pinned to match trainingRuntimeGVR and the shared
+// testdata/trainjob.yaml runtimeRef; a mismatch would be applied to the wrong
+// endpoint and rejected, so it is rejected up front with an actionable error.
+const kindTrainingRuntime = "TrainingRuntime"
+
+// benchmarkRuntimeAPIVersion is the required apiVersion for a recipe-supplied
+// runtime, assembled from the same group/version as trainingRuntimeGVR so the
+// three stay in lockstep.
+var benchmarkRuntimeAPIVersion = trainingRuntimeGVR.Group + "/" + trainingRuntimeGVR.Version
+
+// resolveNCCLBenchmarkRuntime reads the optional nccl-benchmark-runtime
+// performance constraint. Returns "" when the constraint is absent or blank —
+// callers fall back to the criteria/profile-selected embedded template. A
+// non-empty value that is not a well-formed Kubeflow TrainingRuntime fails
+// closed with ErrCodeInvalidRequest: a malformed runtime must abort the check,
+// never silently skip it, which is the exact failure mode this feature exists
+// to eliminate.
+func resolveNCCLBenchmarkRuntime(ctx *validators.Context) (string, error) {
+	// Reject duplicates before any first-match lookup — a blank earlier entry
+	// must not hide a later non-blank one. The orchestrator already dedups, but
+	// the pod is the last line of defense (a hand-built ValidationInput, or the
+	// Plan()/EnsureDataConfigMaps path, may not have gone through it).
+	if n := countPerformanceConstraint(ctx, perfConstraintNCCLBenchmarkRuntime); n > 1 {
+		return "", aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("declare at most one %s constraint (found %d)", perfConstraintNCCLBenchmarkRuntime, n))
+	}
+	if n := countPerformanceConstraint(ctx, perfConstraintNCCLBenchmarkRuntimeRef); n > 1 {
+		return "", aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("declare at most one %s constraint (found %d)", perfConstraintNCCLBenchmarkRuntimeRef, n))
+	}
+
+	carrier := ""
+	if c, ok := findPerformanceConstraint(ctx, perfConstraintNCCLBenchmarkRuntime); ok {
+		carrier = strings.TrimSpace(c.Value)
+	}
+	if carrier == "" {
+		// Defense in depth: the orchestrator resolves nccl-benchmark-runtime-ref
+		// into the carrier and drops the ref before the pod runs. If a non-blank
+		// ref still reaches the pod with no carrier, resolution was skipped (e.g.
+		// an external controller that built the validation ConfigMap via
+		// EnsureDataConfigMaps/Plan without ValidatePhases). Fail closed rather
+		// than silently skipping the benchmark the recipe explicitly opted into —
+		// the exact failure mode this feature exists to eliminate.
+		if ref, ok := findPerformanceConstraint(ctx, perfConstraintNCCLBenchmarkRuntimeRef); ok && strings.TrimSpace(ref.Value) != "" {
+			return "", aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("%s=%q reached the validator unresolved: the orchestrator must lower it into %s before the pod runs",
+					perfConstraintNCCLBenchmarkRuntimeRef, strings.TrimSpace(ref.Value), perfConstraintNCCLBenchmarkRuntime))
+		}
+		return "", nil
+	}
+	if err := validateBenchmarkRuntime(carrier); err != nil {
+		return "", err
+	}
+	return carrier, nil
+}
+
+// validateBenchmarkRuntime confirms a recipe-supplied runtime template is a
+// Kubeflow TrainingRuntime of the expected apiVersion before the pod commits to
+// the custom path. The identity fields (apiVersion, kind) never carry ${VAR}
+// placeholders, so the raw content unmarshals for this shape check even before
+// substitution. A wrong kind/apiVersion, or content that does not parse as
+// YAML, is rejected fail-closed so a typo cannot masquerade as a passing (or
+// silently skipped) benchmark.
+func validateBenchmarkRuntime(content string) error {
+	obj := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(content), obj); err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s: not parseable as YAML", perfConstraintNCCLBenchmarkRuntime), err)
+	}
+	if obj.GetAPIVersion() != benchmarkRuntimeAPIVersion || obj.GetKind() != kindTrainingRuntime {
+		return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s: must be a %s %s (got apiVersion=%q kind=%q)",
+				perfConstraintNCCLBenchmarkRuntime, benchmarkRuntimeAPIVersion, kindTrainingRuntime,
+				obj.GetAPIVersion(), obj.GetKind()))
+	}
+	// The runtime must declare the "node" replicatedJob the shared TrainJob sizes
+	// and the validator injects scheduling into / reads launcher logs from, AND
+	// that job must carry the worker pod spec at template.spec.template.spec —
+	// the path applyNCCLWorkerScheduling mutates. Names are literals (no ${VAR}),
+	// so the raw pre-substitution content is authoritative. Checking both here
+	// turns what would otherwise be a late ErrCodeInternal deep inside
+	// applyNCCLWorkerScheduling — after the Trainer install and cluster sizing —
+	// into an early, recipe-actionable ErrCodeInvalidRequest before any cluster
+	// access.
+	return validateNodeReplicatedJob(obj)
+}
+
+// validateNodeReplicatedJob confirms the TrainingRuntime declares the "node"
+// replicatedJob (nodeJobName) under spec.template.spec.replicatedJobs and that
+// the job carries the worker pod spec at template.spec.template.spec. Returns
+// ErrCodeInvalidRequest naming the specific gap, or nil.
+func validateNodeReplicatedJob(obj *unstructured.Unstructured) error {
+	jobs, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "replicatedJobs")
+	if err == nil && found {
+		for _, raw := range jobs {
+			jobMap, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(jobMap, "name"); name != nodeJobName {
+				continue
+			}
+			if _, ok, err := unstructured.NestedMap(jobMap, "template", "spec", "template", "spec"); err != nil || !ok {
+				return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+					fmt.Sprintf("invalid %s: %q replicatedJob must define the worker pod spec at template.spec.template.spec",
+						perfConstraintNCCLBenchmarkRuntime, nodeJobName))
+			}
+			return nil
+		}
+	}
+	return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+		fmt.Sprintf("invalid %s: must declare a %q replicatedJob (spec.template.spec.replicatedJobs) — the NCCL worker cohort",
+			perfConstraintNCCLBenchmarkRuntime, nodeJobName))
+}
+
+// customRuntimeNodeSelector extracts the "node" replicatedJob's worker
+// nodeSelector from a recipe-supplied runtime (raw, pre-substitution). Returns
+// nil when the runtime pins no worker nodeSelector. The caller sizes the worker
+// cohort against the same nodes the runtime will place workers on, so
+// WorkerCount and placement stay consistent. The content was already
+// shape-validated by validateBenchmarkRuntime, so a parse failure here is
+// unexpected but still surfaced fail-closed.
+func customRuntimeNodeSelector(content string) (map[string]string, error) {
+	obj := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(content), obj); err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid %s: not parseable as YAML", perfConstraintNCCLBenchmarkRuntime), err)
+	}
+	jobs, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "replicatedJobs")
+	if err != nil || !found {
+		return nil, nil //nolint:nilnil // no replicatedJobs → nothing to size against
+	}
+	for _, raw := range jobs {
+		jobMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _, _ := unstructured.NestedString(jobMap, "name"); name != nodeJobName {
+			continue
+		}
+		sel, found, err := unstructured.NestedStringMap(jobMap, "template", "spec", "template", "spec", "nodeSelector")
+		if err != nil {
+			// A present-but-malformed nodeSelector (non-string values) must fail
+			// closed, not be treated as "no selector" — otherwise sizing would
+			// fall back to the whole cohort, the exact mismatch this guards.
+			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid %s: %q replicatedJob has a malformed nodeSelector", perfConstraintNCCLBenchmarkRuntime, nodeJobName), err)
+		}
+		if !found {
+			return nil, nil //nolint:nilnil // node job pins no nodeSelector
+		}
+		return sel, nil
+	}
+	return nil, nil //nolint:nilnil // no "node" job → nothing to size against
+}

--- a/validators/performance/nccl_benchmark_runtime.go
+++ b/validators/performance/nccl_benchmark_runtime.go
@@ -65,21 +65,6 @@ const perfConstraintNCCLBenchmarkRuntime = v1.PerfConstraintNCCLBenchmarkRuntime
 // closed if it arrives unresolved (see resolveNCCLBenchmarkRuntime).
 const perfConstraintNCCLBenchmarkRuntimeRef = v1.PerfConstraintNCCLBenchmarkRuntimeRef
 
-// A recipe-supplied nccl-benchmark-runtime must be exactly this Kubeflow
-// Trainer identity. The validator only ever applies it through
-// trainingRuntimeGVR (trainer.kubeflow.org/v1alpha1) and force-sets its
-// name/namespace, so a recipe can supply a TrainingRuntime — and nothing else.
-// It cannot inject an arbitrary resource kind or version into the validator
-// namespace. The version is pinned to match trainingRuntimeGVR and the shared
-// testdata/trainjob.yaml runtimeRef; a mismatch would be applied to the wrong
-// endpoint and rejected, so it is rejected up front with an actionable error.
-const kindTrainingRuntime = "TrainingRuntime"
-
-// benchmarkRuntimeAPIVersion is the required apiVersion for a recipe-supplied
-// runtime, assembled from the same group/version as trainingRuntimeGVR so the
-// three stay in lockstep.
-var benchmarkRuntimeAPIVersion = trainingRuntimeGVR.Group + "/" + trainingRuntimeGVR.Version
-
 // resolveNCCLBenchmarkRuntime reads the optional nccl-benchmark-runtime
 // performance constraint. Returns "" when the constraint is absent or blank —
 // callers fall back to the criteria/profile-selected embedded template. A
@@ -120,69 +105,15 @@ func resolveNCCLBenchmarkRuntime(ctx *validators.Context) (string, error) {
 		}
 		return "", nil
 	}
-	if err := validateBenchmarkRuntime(carrier); err != nil {
+	// Shape-check the carrier via the contract shared with the orchestrator
+	// (pkg/validator/v1) — a wrong kind/apiVersion, unparseable YAML, or a
+	// missing "node" replicatedJob fails closed with ErrCodeInvalidRequest,
+	// turning what would otherwise be a late ErrCodeInternal deep inside
+	// applyNCCLWorkerScheduling into an early, recipe-actionable error.
+	if err := v1.ValidateBenchmarkRuntime(carrier); err != nil {
 		return "", err
 	}
 	return carrier, nil
-}
-
-// validateBenchmarkRuntime confirms a recipe-supplied runtime template is a
-// Kubeflow TrainingRuntime of the expected apiVersion before the pod commits to
-// the custom path. The identity fields (apiVersion, kind) never carry ${VAR}
-// placeholders, so the raw content unmarshals for this shape check even before
-// substitution. A wrong kind/apiVersion, or content that does not parse as
-// YAML, is rejected fail-closed so a typo cannot masquerade as a passing (or
-// silently skipped) benchmark.
-func validateBenchmarkRuntime(content string) error {
-	obj := &unstructured.Unstructured{}
-	if err := yaml.Unmarshal([]byte(content), obj); err != nil {
-		return aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest,
-			fmt.Sprintf("invalid %s: not parseable as YAML", perfConstraintNCCLBenchmarkRuntime), err)
-	}
-	if obj.GetAPIVersion() != benchmarkRuntimeAPIVersion || obj.GetKind() != kindTrainingRuntime {
-		return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
-			fmt.Sprintf("invalid %s: must be a %s %s (got apiVersion=%q kind=%q)",
-				perfConstraintNCCLBenchmarkRuntime, benchmarkRuntimeAPIVersion, kindTrainingRuntime,
-				obj.GetAPIVersion(), obj.GetKind()))
-	}
-	// The runtime must declare the "node" replicatedJob the shared TrainJob sizes
-	// and the validator injects scheduling into / reads launcher logs from, AND
-	// that job must carry the worker pod spec at template.spec.template.spec —
-	// the path applyNCCLWorkerScheduling mutates. Names are literals (no ${VAR}),
-	// so the raw pre-substitution content is authoritative. Checking both here
-	// turns what would otherwise be a late ErrCodeInternal deep inside
-	// applyNCCLWorkerScheduling — after the Trainer install and cluster sizing —
-	// into an early, recipe-actionable ErrCodeInvalidRequest before any cluster
-	// access.
-	return validateNodeReplicatedJob(obj)
-}
-
-// validateNodeReplicatedJob confirms the TrainingRuntime declares the "node"
-// replicatedJob (nodeJobName) under spec.template.spec.replicatedJobs and that
-// the job carries the worker pod spec at template.spec.template.spec. Returns
-// ErrCodeInvalidRequest naming the specific gap, or nil.
-func validateNodeReplicatedJob(obj *unstructured.Unstructured) error {
-	jobs, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "replicatedJobs")
-	if err == nil && found {
-		for _, raw := range jobs {
-			jobMap, ok := raw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if name, _, _ := unstructured.NestedString(jobMap, "name"); name != nodeJobName {
-				continue
-			}
-			if _, ok, err := unstructured.NestedMap(jobMap, "template", "spec", "template", "spec"); err != nil || !ok {
-				return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
-					fmt.Sprintf("invalid %s: %q replicatedJob must define the worker pod spec at template.spec.template.spec",
-						perfConstraintNCCLBenchmarkRuntime, nodeJobName))
-			}
-			return nil
-		}
-	}
-	return aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
-		fmt.Sprintf("invalid %s: must declare a %q replicatedJob (spec.template.spec.replicatedJobs) — the NCCL worker cohort",
-			perfConstraintNCCLBenchmarkRuntime, nodeJobName))
 }
 
 // customRuntimeNodeSelector extracts the "node" replicatedJob's worker
@@ -190,7 +121,7 @@ func validateNodeReplicatedJob(obj *unstructured.Unstructured) error {
 // nil when the runtime pins no worker nodeSelector. The caller sizes the worker
 // cohort against the same nodes the runtime will place workers on, so
 // WorkerCount and placement stay consistent. The content was already
-// shape-validated by validateBenchmarkRuntime, so a parse failure here is
+// shape-validated by v1.ValidateBenchmarkRuntime, so a parse failure here is
 // unexpected but still surfaced fail-closed.
 func customRuntimeNodeSelector(content string) (map[string]string, error) {
 	obj := &unstructured.Unstructured{}

--- a/validators/performance/nccl_benchmark_runtime_test.go
+++ b/validators/performance/nccl_benchmark_runtime_test.go
@@ -1,0 +1,472 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/validators"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// validBenchmarkRuntime is a minimal but structurally complete Kubeflow
+// TrainingRuntime a recipe could carry inline via nccl-benchmark-runtime. It
+// declares the "node" replicatedJob applyNCCLWorkerScheduling requires and a
+// ${GPU_COUNT_PER_NODE} placeholder to exercise render substitution.
+const validBenchmarkRuntime = `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: whatever-the-author-named-it
+spec:
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: example.com/nccl:latest
+                      resources:
+                        limits:
+                          nvidia.com/gpu: "${GPU_COUNT_PER_NODE}"
+`
+
+func runtimeConstraint(v string) recipe.Constraint {
+	return recipe.Constraint{Name: perfConstraintNCCLBenchmarkRuntime, Value: v}
+}
+
+func TestResolveNCCLBenchmarkRuntime(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        *validators.Context
+		want       string
+		wantErr    bool
+		wantErrSub string
+	}{
+		{
+			name: "absent constraint → no runtime",
+			ctx:  ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel"),
+			want: "",
+		},
+		{
+			name: "blank value → no runtime",
+			ctx:  ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint("   ")),
+			want: "",
+		},
+		{
+			name: "valid TrainingRuntime is returned verbatim (trimmed)",
+			ctx:  ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint(validBenchmarkRuntime)),
+			want: strings.TrimSpace(validBenchmarkRuntime),
+		},
+		{
+			name:       "wrong kind fails closed",
+			ctx:        ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint("apiVersion: trainer.kubeflow.org/v1alpha1\nkind: TrainJob\n")),
+			wantErr:    true,
+			wantErrSub: "must be a",
+		},
+		{
+			name:       "wrong apiVersion fails closed",
+			ctx:        ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint("apiVersion: v1\nkind: TrainingRuntime\n")),
+			wantErr:    true,
+			wantErrSub: "must be a",
+		},
+		{
+			name: "missing node replicatedJob fails closed",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint(
+				"apiVersion: trainer.kubeflow.org/v1alpha1\nkind: TrainingRuntime\nspec:\n  template:\n    spec:\n      replicatedJobs:\n        - name: worker\n")),
+			wantErr:    true,
+			wantErrSub: "must declare a \"node\" replicatedJob",
+		},
+		{
+			name: "node replicatedJob without worker pod spec fails closed",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint(
+				"apiVersion: trainer.kubeflow.org/v1alpha1\nkind: TrainingRuntime\nspec:\n  template:\n    spec:\n      replicatedJobs:\n        - name: node\n")),
+			wantErr:    true,
+			wantErrSub: "must define the worker pod spec",
+		},
+		{
+			name:       "unparseable YAML fails closed",
+			ctx:        ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", runtimeConstraint("kind: [unterminated")),
+			wantErr:    true,
+			wantErrSub: "not parseable as YAML",
+		},
+		{
+			name: "unresolved ref (no carrier) fails closed",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+				recipe.Constraint{Name: perfConstraintNCCLBenchmarkRuntimeRef, Value: "gb200/mycloud"}),
+			wantErr:    true,
+			wantErrSub: "reached the validator unresolved",
+		},
+		{
+			name: "resolved carrier alongside its (leftover) ref still runs",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+				recipe.Constraint{Name: perfConstraintNCCLBenchmarkRuntimeRef, Value: "gb200/mycloud"},
+				runtimeConstraint(validBenchmarkRuntime)),
+			want: strings.TrimSpace(validBenchmarkRuntime),
+		},
+		{
+			name: "duplicate carriers fail closed (blank first)",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+				runtimeConstraint(""), runtimeConstraint(validBenchmarkRuntime)),
+			wantErr:    true,
+			wantErrSub: "at most one",
+		},
+		{
+			name: "duplicate carriers fail closed (blank second)",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+				runtimeConstraint(validBenchmarkRuntime), runtimeConstraint("")),
+			wantErr:    true,
+			wantErrSub: "at most one",
+		},
+		{
+			name: "duplicate refs fail closed",
+			ctx: ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+				recipe.Constraint{Name: perfConstraintNCCLBenchmarkRuntimeRef, Value: ""},
+				recipe.Constraint{Name: perfConstraintNCCLBenchmarkRuntimeRef, Value: "gb200/mycloud"}),
+			wantErr:    true,
+			wantErrSub: "at most one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveNCCLBenchmarkRuntime(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("runtime = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateNcclAllReduceBwCustomRuntimeGate drives the recipe-supplied-runtime
+// path through validateNcclAllReduceBw without a cluster, proving: a valid
+// runtime bypasses the compiled applicability gate for an external service (a
+// bare private criteria pair would otherwise skip), a runtime and a profile are
+// rejected together, and a malformed runtime fails closed before any cluster
+// access.
+func TestValidateNcclAllReduceBwCustomRuntimeGate(t *testing.T) {
+	t.Setenv(ncclFabricEnv, "") // isolate from ambient AICR_NCCL_FABRIC
+
+	thresholdC := func(name, v string) recipe.Constraint { return recipe.Constraint{Name: name, Value: v} }
+
+	tests := []struct {
+		name        string
+		threshold   recipe.Constraint
+		extra       []recipe.Constraint // additional performance constraints (runtime, profile)
+		variant     ncclVariant
+		wantErrCode bool   // expect ErrCodeInvalidRequest
+		wantErrSub  string // substring the error must contain
+	}{
+		{
+			name:        "runtime bypasses applicability gate and reaches threshold parse",
+			threshold:   thresholdC(checkNameNCCLAllReduceBW, "not-a-number"),
+			extra:       []recipe.Constraint{runtimeConstraint(validBenchmarkRuntime)},
+			variant:     variantDefault,
+			wantErrCode: true,
+			wantErrSub:  "invalid threshold",
+		},
+		{
+			name:        "runtime and profile are mutually exclusive",
+			threshold:   thresholdC(checkNameNCCLAllReduceBW, ">= 450"),
+			extra:       []recipe.Constraint{runtimeConstraint(validBenchmarkRuntime), profileConstraint("gb200/eks")},
+			variant:     variantDefault,
+			wantErrCode: true,
+			wantErrSub:  "mutually exclusive",
+		},
+		{
+			name:        "malformed runtime fails closed before cluster access",
+			threshold:   thresholdC(checkNameNCCLAllReduceBW, ">= 450"),
+			extra:       []recipe.Constraint{runtimeConstraint("apiVersion: trainer.kubeflow.org/v1alpha1\nkind: TrainJob\n")},
+			variant:     variantDefault,
+			wantErrCode: true,
+			wantErrSub:  "must be a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := append([]recipe.Constraint{tt.threshold}, tt.extra...)
+			ctx := ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel", cs...)
+			msg, passed, err := validateNcclAllReduceBw(ctx, tt.threshold, tt.variant)
+			if err == nil {
+				t.Fatalf("expected error, got (%q, %v)", msg, passed)
+			}
+			if tt.wantErrCode && !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want ErrCodeInvalidRequest", err)
+			}
+			if tt.wantErrSub != "" && !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrSub)
+			}
+		})
+	}
+}
+
+// TestValidateNcclAllReduceBwCustomRuntimeIgnoresFabric proves a recipe-supplied
+// runtime is not gated on AICR_NCCL_FABRIC: a malformed fabric env (which fails
+// the baked-in path at ncclFabric) must not abort a custom runtime, which owns
+// its own fabric. The check reaches threshold parsing instead of erroring on
+// the env.
+func TestValidateNcclAllReduceBwCustomRuntimeIgnoresFabric(t *testing.T) {
+	t.Setenv(ncclFabricEnv, "not-a-real-fabric")
+
+	threshold := recipe.Constraint{Name: checkNameNCCLAllReduceBW, Value: "not-a-number"}
+	ctx := ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+		threshold, runtimeConstraint(validBenchmarkRuntime))
+
+	_, _, err := validateNcclAllReduceBw(ctx, threshold, variantDefault)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// Must reach threshold parsing (past the fabric env), not fail on the fabric.
+	if !strings.Contains(err.Error(), "invalid threshold") {
+		t.Errorf("custom runtime should ignore AICR_NCCL_FABRIC; got %v", err)
+	}
+}
+
+// TestValidateNcclAllReduceBwCustomRuntimeSizesByRuntimeSelector proves the
+// worker cohort is sized against the SAME nodes the runtime's own nodeSelector
+// will place workers on: two GPU nodes, a runtime that pins workers to pool=a
+// (matching only one), so WorkerCount is 1 and the 2-node skip fires. Without
+// runtime-selector-aware sizing, WorkerCount would be 2 and the check would
+// proceed to deploy against nodes the runtime then excludes.
+func TestValidateNcclAllReduceBwCustomRuntimeSizesByRuntimeSelector(t *testing.T) {
+	t.Setenv(ncclFabricEnv, "")
+
+	node := func(name, pool string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{gpuProductLabel: "PRIVATE-ACCEL", "pool": pool},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("8")},
+			},
+		}
+	}
+
+	const runtimeWithSelector = `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+spec:
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            spec:
+              template:
+                spec:
+                  nodeSelector:
+                    pool: a
+                  containers:
+                    - name: node
+                      image: example.com/nccl:latest
+`
+	threshold := recipe.Constraint{Name: checkNameNCCLAllReduceBW, Value: ">= 100"}
+	ctx := ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+		threshold, runtimeConstraint(runtimeWithSelector))
+	ctx.Ctx = context.Background()
+	ctx.Clientset = fake.NewClientset(node("gpu-a", "a"), node("gpu-b", "b"))
+
+	msg, passed, err := validateNcclAllReduceBw(ctx, threshold, variantDefault)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "skipped - requires at least 2 GPU nodes for EW fabric test"
+	if !passed || msg != want {
+		t.Errorf("got (%q, %v), want (%q, true) — sizing must narrow by the runtime's own nodeSelector", msg, passed, want)
+	}
+}
+
+// TestValidateNcclAllReduceBwCustomRuntimeClusterPath proves the runtime path
+// reaches cluster node sizing keyed on the recipe's OWN private criteria — a
+// combination the compiled matrix does not cover. A single GPU node produces
+// the "requires at least 2 GPU nodes" skip, which is only reachable past the
+// applicability gate: a bare private criteria pair would have skipped earlier
+// with "requires Service + Accelerator to be implemented".
+func TestValidateNcclAllReduceBwCustomRuntimeClusterPath(t *testing.T) {
+	t.Setenv(ncclFabricEnv, "") // isolate from ambient AICR_NCCL_FABRIC
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gpu-node-a",
+			Labels: map[string]string{gpuProductLabel: "PRIVATE-ACCEL"},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("8")},
+		},
+	}
+
+	threshold := recipe.Constraint{Name: checkNameNCCLAllReduceBW, Value: ">= 100"}
+	ctx := ctxWithCriteriaAndPerfConstraints("custom-svc", "customaccel",
+		threshold, runtimeConstraint(validBenchmarkRuntime))
+	ctx.Ctx = context.Background()
+	ctx.Clientset = fake.NewClientset(node)
+
+	msg, passed, err := validateNcclAllReduceBw(ctx, threshold, variantDefault)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "skipped - requires at least 2 GPU nodes for EW fabric test"
+	if !passed || msg != want {
+		t.Errorf("got (%q, %v), want (%q, true)", msg, passed, want)
+	}
+}
+
+func TestRenderYAMLTemplate(t *testing.T) {
+	obj, err := renderYAMLTemplate(
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: ${NAME}\n  namespace: ${NAMESPACE}\n",
+		map[string]string{"NAME": "rendered", "NAMESPACE": "validation"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := obj.GetName(); got != "rendered" {
+		t.Errorf("name = %q, want %q", got, "rendered")
+	}
+	if got := obj.GetNamespace(); got != "validation" {
+		t.Errorf("namespace = %q, want %q", got, "validation")
+	}
+}
+
+// TestBuildNCCLRuntimeObjectCustom covers the custom-runtime branch of
+// buildNCCLRuntimeObject: the identity is force-set to what the shared TrainJob
+// expects and confined to the validator namespace (regardless of the author's
+// metadata.name), and generic ${VAR} placeholders are substituted.
+func TestBuildNCCLRuntimeObjectCustom(t *testing.T) {
+	obj, err := buildNCCLRuntimeObject(validBenchmarkRuntime,
+		"customaccel", "custom-svc", variantDefault, fabricEFA,
+		"aicr-validation", map[string]string{"GPU_COUNT_PER_NODE": "8"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := obj.GetName(); got != ncclTrainingRuntimeName {
+		t.Errorf("name = %q, want forced %q", got, ncclTrainingRuntimeName)
+	}
+	if got := obj.GetNamespace(); got != "aicr-validation" {
+		t.Errorf("namespace = %q, want confined %q", got, "aicr-validation")
+	}
+	// Assert ${GPU_COUNT_PER_NODE} was substituted to "8" in the container limit.
+	containers, _, _ := unstructured.NestedSlice(workerPodSpec(t, obj), "containers")
+	if len(containers) == 0 {
+		t.Fatal("no containers in rendered worker pod spec")
+	}
+	c0, _ := containers[0].(map[string]interface{})
+	gpu, _, _ := unstructured.NestedString(c0, "resources", "limits", "nvidia.com/gpu")
+	if gpu != "8" {
+		t.Errorf("nvidia.com/gpu limit = %q, want %q (\\${GPU_COUNT_PER_NODE} not substituted)", gpu, "8")
+	}
+}
+
+// TestApplyNCCLResourcesCustomRuntimeEKSNoClobber is the regression guard for the
+// service-scheduling gate: a recipe-supplied runtime paired with a RECOGNIZED
+// service (here eks) must keep its OWN worker nodeSelector. Before the fix, the
+// platform default ran unconditionally and stamped {instance-type: ""} —
+// instanceType is never discovered on the custom path — matching zero nodes and
+// clobbering the runtime's selector.
+func TestApplyNCCLResourcesCustomRuntimeEKSNoClobber(t *testing.T) {
+	const ns = "aicr-validation"
+	const runtimeWithSelector = `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: author-chose-this
+spec:
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            spec:
+              template:
+                spec:
+                  nodeSelector:
+                    my.io/private-gpu: "true"
+                  containers:
+                    - name: node
+                      image: example.com/nccl:latest
+`
+	fakeClient := newFakeDynamicClient()
+	ctx := &validators.Context{Ctx: context.Background(), DynamicClient: fakeClient, Namespace: ns}
+	config := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 8, TotalGPUCount: 16, Namespace: ns}
+
+	// service=eks would, before the fix, stamp {instance-type: ""} onto the node
+	// job. No --node-selector override, so the runtime's own selector must win.
+	if err := applyNCCLResources(ctx, fakeClient, config,
+		recipe.CriteriaAcceleratorH100, recipe.CriteriaServiceEKS, variantDefault, fabricEFA,
+		runtimeWithSelector); err != nil {
+		t.Fatalf("applyNCCLResources (custom runtime) failed: %v", err)
+	}
+
+	got, err := fakeClient.Resource(trainingRuntimeGVR).Namespace(ns).
+		Get(context.Background(), ncclTrainingRuntimeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("TrainingRuntime not created: %v", err)
+	}
+	sel, _, _ := unstructured.NestedStringMap(workerPodSpec(t, got), "nodeSelector")
+	if _, clobbered := sel[instanceTypeLabel]; clobbered {
+		t.Errorf("worker nodeSelector was clobbered with %q: %v", instanceTypeLabel, sel)
+	}
+	if sel["my.io/private-gpu"] != "true" {
+		t.Errorf("runtime's own nodeSelector not preserved: %v", sel)
+	}
+}
+
+// workerPodSpec navigates a rendered NCCL TrainingRuntime to the "node"
+// replicatedJob's worker pod spec (spec.template.spec.replicatedJobs[node]
+// .template.spec.template.spec) — the same path applyNCCLWorkerScheduling uses.
+func workerPodSpec(t *testing.T, obj *unstructured.Unstructured) map[string]interface{} {
+	t.Helper()
+	jobs, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "replicatedJobs")
+	if err != nil || !found {
+		t.Fatalf("replicatedJobs not found (found=%v err=%v)", found, err)
+	}
+	for _, raw := range jobs {
+		jobMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _, _ := unstructured.NestedString(jobMap, "name"); name != nodeJobName {
+			continue
+		}
+		spec, found, err := unstructured.NestedMap(jobMap, "template", "spec", "template", "spec")
+		if err != nil || !found {
+			t.Fatalf("worker pod spec not found in node job (found=%v err=%v)", found, err)
+		}
+		return spec
+	}
+	t.Fatalf("no %q replicatedJob in runtime", nodeJobName)
+	return nil
+}

--- a/validators/performance/nccl_benchmark_runtime_test.go
+++ b/validators/performance/nccl_benchmark_runtime_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -57,6 +58,21 @@ spec:
 
 func runtimeConstraint(v string) recipe.Constraint {
 	return recipe.Constraint{Name: perfConstraintNCCLBenchmarkRuntime, Value: v}
+}
+
+// TestBenchmarkRuntimeIdentityLocked pins the pod's apply-side identifiers to the
+// shared shape-check constants in pkg/validator/v1. The shape validator
+// (v1.ValidateBenchmarkRuntime) accepts a runtime by these; the pod then applies
+// it through trainingRuntimeGVR and injects scheduling into nodeJobName. If the
+// two drift, the validator would accept a runtime it then can't apply — this
+// test fails first.
+func TestBenchmarkRuntimeIdentityLocked(t *testing.T) {
+	if got := trainingRuntimeGVR.Group + "/" + trainingRuntimeGVR.Version; got != v1.BenchmarkRuntimeAPIVersion {
+		t.Errorf("apply GVR apiVersion = %q, want v1.BenchmarkRuntimeAPIVersion %q", got, v1.BenchmarkRuntimeAPIVersion)
+	}
+	if nodeJobName != v1.BenchmarkRuntimeNodeJob {
+		t.Errorf("nodeJobName = %q, want v1.BenchmarkRuntimeNodeJob %q", nodeJobName, v1.BenchmarkRuntimeNodeJob)
+	}
 }
 
 func TestResolveNCCLBenchmarkRuntime(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an `nccl-benchmark-runtime-ref` performance constraint so a recipe can ship its own Kubeflow `TrainingRuntime` as a `--data` file and have `aicr validate` run the NCCL benchmark against it — keyed on the recipe's own criteria, with no compiled applicability entry required.

## Motivation / Context

The NCCL check applicability is a compiled `service+accelerator` matrix (`supportedNCCLCombinations`), and each supported pair is backed by a runtime template baked into the validator image at `validators/performance/testdata/{accelerator}/{service}/`. The `nccl-benchmark-profile` escape hatch (#1719, v0.17.0) lets an external `--data` recipe *borrow* an embedded template, but only when one exists whose fabric matches the cluster. A **private service introduced entirely via `--data`** — a `criteria.service`/`accelerator` the validator ships no template for, with a fabric that reuses none of the embedded ones — has no compiled pair to point a profile at, so its NCCL checks are silently skipped and it cannot be performance-certified in CI.

This completes the data-driven validation vision: the recipe **supplies the benchmark itself**. It ships a `TrainingRuntime` in its `--data` tree at the same `validators/performance/testdata/{accelerator}/{service}/runtime.yaml` layout the embedded templates use, and references it with a bare `{accelerator}/{service}` value. Because the file already sits at the embedded path, upstreaming it later is a copy (move the file in, add the matrix tuple, drop the ref).

Fixes: #1792
Related: #1703, #1719

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `validators/performance` (in-pod check binary), `recipes/validators/catalog.yaml` (comment)

## Implementation Notes

Two-stage design, splitting authoring from execution across the existing orchestrator/pod boundary:

- **Orchestrator** (`pkg/validator/benchmark_runtime_ref.go`, `resolveBenchmarkRuntimeRef`, called at the top of `ValidatePhases`/`ValidatePhase`): parses the `{accelerator}/{service}` ref, reads `validators/performance/testdata/{accelerator}/{service}/runtime.yaml` through the recipe `DataProvider`, and **lowers its content into an `nccl-benchmark-runtime` carrier constraint** that rides to the pod via the existing `ValidationInput` ConfigMap. No new delivery plumbing. Resolution **consumes** the ref (idempotent; the raw ref never reaches the pod).
- **Pod** (`validators/performance`): renders the carrier in place of a baked-in template (shared `renderYAMLTemplate` core), **bypasses** the compiled `supportedNCCLCombinations` gate, and **skips every service-specific step** — EFA/TCPXO/RDMA NIC discovery, the GB200-NVreg / GKE-TCPXO preflights, RoCE claim application, NVLS/IMEX provisioning, and transport verification — because the supplied runtime owns its fabric wiring.

The two constraint names are defined once in `pkg/validator/v1` (`PerfConstraint*`) and imported by both ends, so the write side and read side cannot drift.

**Trust / fail-closed:** the runtime is applied only through `trainingRuntimeGVR` with a force-set name/namespace, so a recipe can supply a `TrainingRuntime` and nothing else — not an arbitrary resource kind or namespace. It fails closed (`ErrCodeInvalidRequest`, before any Job is deployed) on a malformed/traversal ref (segments can't contain separators or `..`; the joined path must stay under `.../testdata/`), a missing/empty file, an absent `--data` source, or a ref set alongside an inline carrier. The pod additionally fails closed on a non-`trainer.kubeflow.org/v1alpha1` `TrainingRuntime`, a runtime missing the `node` replicatedJob, or a `-ref` that reaches the validator unresolved (defense-in-depth for the external-controller `Plan()` path). Mutually exclusive with `nccl-benchmark-profile`. A ctx-timeout read propagates as `ErrCodeTimeout`, not `InvalidRequest`.

**Scope note:** resolution is wired into the CLI/facade `aicr validate` path (`ValidatePhases`/`ValidatePhase`). The external-controller `Plan()`/`EnsureDataConfigMaps()` SDK path does not resolve the ref (it has no in-repo callers today); the pod fails closed there rather than silently skipping. Lifting resolution into that shared layer is a small follow-up if a real `Plan()` consumer appears.

## Testing

```bash
# Affected packages (validators/ is excluded from `make test` and the coverage gate,
# so run these directly):
go test -race ./pkg/validator/... ./pkg/validator/v1/ ./validators/...   # PASS
golangci-lint run -c .golangci.yaml ./pkg/validator/... ./validators/... # 0 issues
go vet ./pkg/validator/... ./validators/...                             # clean
gofmt -l <changed .go files>                                            # clean
yamllint recipes/validators/catalog.yaml                                # clean
go build ./...                                                          # clean
```

New tests: orchestrator ref resolution (no-op / valid inject / malformed / traversal / missing / empty / nil-provider / ref+inline conflict / idempotent double-pass / path builder); pod resolve+validate (absent/blank/valid/wrong-kind/wrong-apiVersion/unparseable/missing-node-job/unresolved-ref), the applicability-gate bypass, the custom-runtime cluster path, and a regression guard that a recognized service (`eks`) + custom runtime does not clobber the runtime's own `nodeSelector`.

The change was adversarially reviewed (two multi-agent review passes); every confirmed finding is fixed and regression-tested. CI runs the full `make qualify` gate on this PR.

## Risk Assessment

- [x] **Low** — Additive, opt-in, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Backwards compatible — recipes without the constraint are byte-for-byte unchanged. Version-skew: an older validator image that predates the shared carrier constant would ignore the constraint and fall back to the criteria-derived skip, so the feature needs a validator new enough to read it.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — affected packages, see Testing
- [x] Linter passes (`make lint`) — golangci-lint 0 issues on changed packages
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
