### PR TITLE
ci(uat): refresh evidence dashboard on ingest, name UAT runs by intent

### DIFF
--- a/.github/workflows/evidence-ingest.yaml
+++ b/.github/workflows/evidence-ingest.yaml
@@ -249,6 +249,14 @@ jobs:
   # concurrency group ("pages", cancel-in-progress:false) coalesces the
   # flurry from a multi-cell nightly batch into a single queued rebuild
   # that the newest dispatch supersedes.
+  #
+  # The refresh is BEST-EFFORT: the evidence is already in the bucket and the
+  # dashboard self-heals on the next ingest or push to main, so a transient
+  # dispatch failure must never fail this workflow_call chain — otherwise the
+  # nightly controller would record a fully-successful, multi-hour UAT cell as
+  # a failed leg. The dispatch step retries, then warns (never fails), so
+  # staleness is surfaced but not fatal — the same not-cry-wolf posture as
+  # uat-superseded-notice.yaml.
   # ---------------------------------------------------------------------
   trigger-dashboard:
     name: Trigger dashboard publish
@@ -269,6 +277,17 @@ jobs:
           # Always target main: the dashboard deploys only from the default
           # branch, and the evidence tree it renders is the canonical GCS
           # bucket regardless of which ref this ingest ran on.
-          gh workflow run evidence-dashboard-publish.yaml \
-            --repo "$REPO" --ref main
-          echo "dispatched Evidence: Dashboard Publish on main"
+          #
+          # Bounded retry, then warn-and-succeed: the `if` guard keeps a failed
+          # attempt from tripping `set -e`, and the trailing warning exits 0 so a
+          # best-effort refresh cannot fail the calling UAT run.
+          for attempt in 1 2 3; do
+            if gh workflow run evidence-dashboard-publish.yaml \
+              --repo "$REPO" --ref main; then
+              echo "dispatched Evidence: Dashboard Publish on main"
+              exit 0
+            fi
+            echo "dispatch attempt ${attempt} failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "::warning::could not dispatch Evidence: Dashboard Publish after 3 attempts; the dashboard will refresh on the next ingest or push to main"

--- a/.github/workflows/evidence-ingest.yaml
+++ b/.github/workflows/evidence-ingest.yaml
@@ -229,3 +229,46 @@ jobs:
                 --delete-unmatched-destination-objects \
                 "${run_dir}" "gs://${BUCKET}/results/${rel}"
             done
+
+  # ---------------------------------------------------------------------
+  # Job 3: refresh the published dashboard. Every successful ingest lands
+  # new evidence in GCS, so the GP5 dashboard (evidence-dashboard-publish)
+  # must re-render to surface it — otherwise the site is stale until the
+  # next unrelated push to main. The push-to-main ingest path already
+  # re-triggers the dashboard via its own `push:` trigger, but the
+  # first-party UAT path is a NESTED workflow_call (up to four levels deep:
+  # uat-run -> uat-{aws,gcp,azure} -> evidence-ingest), which emits no
+  # top-level run event and cannot nest a fifth reusable workflow. A
+  # workflow_dispatch decouples cleanly: it starts a fresh top-level run
+  # regardless of how deep this ingest was invoked.
+  #
+  # Held in a SEPARATE job so the GCS-credentialed publish job never also
+  # carries actions:write. `needs: publish` inherits the produced gate — a
+  # skipped/failed publish skips this too, so the dashboard only re-renders
+  # after evidence is actually in the bucket. The dashboard's own
+  # concurrency group ("pages", cancel-in-progress:false) coalesces the
+  # flurry from a multi-cell nightly batch into a single queued rebuild
+  # that the newest dispatch supersedes.
+  # ---------------------------------------------------------------------
+  trigger-dashboard:
+    name: Trigger dashboard publish
+    needs: publish
+    if: github.repository == 'nvidia/aicr'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write  # dispatch evidence-dashboard-publish.yaml
+    steps:
+      - name: Dispatch dashboard publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Always target main: the dashboard deploys only from the default
+          # branch, and the evidence tree it renders is the canonical GCS
+          # bucket regardless of which ref this ingest ran on.
+          gh workflow run evidence-dashboard-publish.yaml \
+            --repo "$REPO" --ref main
+          echo "dispatched Evidence: Dashboard Publish on main"

--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -933,6 +933,7 @@ jobs:
       contents: read
       id-token: write  # WIF for the publish job
       packages: read   # GHCR pull for the verify job
+      actions: write   # dispatch the dashboard-publish refresh after publish
     uses: ./.github/workflows/evidence-ingest.yaml
     with:
       bundle_ref: ${{ needs.uat-aws.outputs.bundle_ref }}

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -886,6 +886,7 @@ jobs:
       contents: read
       id-token: write  # WIF for the publish job
       packages: read   # GHCR pull for the verify job
+      actions: write   # dispatch the dashboard-publish refresh after publish
     uses: ./.github/workflows/evidence-ingest.yaml
     with:
       bundle_ref: ${{ needs.uat-azure.outputs.bundle_ref }}

--- a/.github/workflows/uat-daytime.yaml
+++ b/.github/workflows/uat-daytime.yaml
@@ -189,8 +189,9 @@ jobs:
           dispatch_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RESERVATION}-${ACTION}"
           # aicr_version is left empty (daytime always runs main/tip), so
           # uat-run.yaml's run-name renders '@ main'; the dispatch_key suffix
-          # makes the title globally unique.
-          title="UAT ${RESERVATION} @ main #${dispatch_key}"
+          # makes the title globally unique. MUST match uat-run.yaml's run-name
+          # exactly (now includes intent).
+          title="UAT ${RESERVATION} ${INTENT} @ main #${dispatch_key}"
           echo "::group::${title}"
 
           gh workflow run uat-run.yaml --repo "$REPO" --ref "$REF" \

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -723,6 +723,7 @@ jobs:
       contents: read
       id-token: write  # WIF for the publish job
       packages: read   # GHCR pull for the verify job
+      actions: write   # dispatch the dashboard-publish refresh after publish
     uses: ./.github/workflows/evidence-ingest.yaml
     with:
       bundle_ref: ${{ needs.uat-gcp.outputs.bundle_ref }}

--- a/.github/workflows/uat-nightly-batch.yaml
+++ b/.github/workflows/uat-nightly-batch.yaml
@@ -240,7 +240,8 @@ jobs:
               # cell index increments per (version × intent), so the two intents
               # of one version get distinct keys and distinct run titles.
               dispatch_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RESERVATION}-${cell}"
-              title="UAT ${RESERVATION} @ ${label} #${dispatch_key}"
+              # MUST match uat-run.yaml's run-name exactly (now includes intent).
+              title="UAT ${RESERVATION} ${intent} @ ${label} #${dispatch_key}"
               echo "::group::${title} [intent=${intent}]"
 
               gh workflow run uat-run.yaml --repo "$REPO" --ref "$REF" \

--- a/.github/workflows/uat-run.yaml
+++ b/.github/workflows/uat-run.yaml
@@ -21,7 +21,14 @@ name: UAT Run
 # manual dispatch of the same reservation/version can never be mistaken for the
 # controller's run. A manual dispatch omits the key and the suffix is dropped.
 # Quoted so YAML does not treat the ` #` in the dispatch_key suffix as a comment.
-run-name: "UAT ${{ inputs.reservation }} @ ${{ inputs.aicr_version || 'main' }}${{ inputs.dispatch_key != '' && format(' #{0}', inputs.dispatch_key) || '' }}"
+#
+# The intent (training|inference) is rendered so nightly/daytime runs are
+# self-describing in the Actions list. It defaults to `training` on both the
+# dispatch and call paths, so it is always present. IMPORTANT: the nightly
+# (uat-nightly-batch.yaml) and daytime (uat-daytime.yaml) controllers rebuild
+# this exact title to resolve the run they dispatched — keep their `title=`
+# construction in lockstep with this format string.
+run-name: "UAT ${{ inputs.reservation }} ${{ inputs.intent }} @ ${{ inputs.aicr_version || 'main' }}${{ inputs.dispatch_key != '' && format(' #{0}', inputs.dispatch_key) || '' }}"
 
 # The shared UAT dispatch surface and reservation-lease owner (#1274, DC1).
 # A human (workflow_dispatch) or the nightly batch (workflow_call) requests a
@@ -177,7 +184,7 @@ jobs:
     # cannot exceed the caller's permissions).
     permissions:
       contents: read  # checkout inside the called pipeline
-      actions: read  # required by the nested uat-{aws,gcp} + evidence-ingest jobs
+      actions: write  # nested uat-{aws,gcp} watchers + evidence-ingest dashboard dispatch
       id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
       packages: write  # push validator + snapshot-agent images to GHCR
     uses: ./.github/workflows/uat-aws.yaml
@@ -199,7 +206,7 @@ jobs:
     # cannot exceed the caller's permissions).
     permissions:
       contents: read  # checkout inside the called pipeline
-      actions: read  # required by the nested uat-{aws,gcp} + evidence-ingest jobs
+      actions: write  # nested uat-{aws,gcp} watchers + evidence-ingest dashboard dispatch
       id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
       packages: write  # push validator + snapshot-agent images to GHCR
     uses: ./.github/workflows/uat-gcp.yaml
@@ -220,7 +227,7 @@ jobs:
     # cannot exceed the caller's permissions).
     permissions:
       contents: read  # checkout inside the called pipeline
-      actions: read  # required by the nested uat-* + evidence-ingest jobs
+      actions: write  # nested uat-* watchers + evidence-ingest dashboard dispatch
       id-token: write  # cloud OIDC/WIF: provision, keyless cosign, and GCS evidence publish
       packages: write  # push validator + snapshot-agent images to GHCR
     uses: ./.github/workflows/uat-azure.yaml

--- a/.github/workflows/uat-superseded-notice.yaml
+++ b/.github/workflows/uat-superseded-notice.yaml
@@ -86,8 +86,9 @@ jobs:
           fi
 
           # RUN_TITLE is the triggering run's display title. uat-run.yaml sets a
-          # run-name of "UAT <reservation> @ <version> ..." (#1579), so the title
-          # names the superseded reservation. It is trusted workflow_run metadata
+          # run-name of "UAT <reservation> <intent> @ <version> ..." (#1579), so
+          # the title names the superseded reservation. It is trusted workflow_run
+          # metadata
           # passed via env (never inlined into the script). The step-summary is
           # file content (safe as-is); the ::warning:: command is percent-encoded
           # below since %, CR, and LF are workflow-command metacharacters.

--- a/docs/contributor/evidence-dashboard-publish.md
+++ b/docs/contributor/evidence-dashboard-publish.md
@@ -1,13 +1,19 @@
 # Evidence Dashboard Publish (GP5)
 
 The dashboard-publish pipeline is the repo's **first GitHub Pages** surface.
-On every merge to `main` (and on demand) it regenerates the interim-evidence
-dashboard from the source-keyed evidence tree in GCS and deploys the static
-site to GitHub Pages. It is the consumer end of the chain whose producer is
-[evidence-ingest (GP2)](evidence-ingest.md): ingest writes the tree, publish
-renders and serves it. (For the full `GPn` stage map of the
-evidence-corroboration pipeline, see
+On every merge to `main`, on demand, and after every successful
+[evidence-ingest (GP2)](evidence-ingest.md) run (its `trigger-dashboard` job
+dispatches this workflow), it regenerates the interim-evidence dashboard from
+the source-keyed evidence tree in GCS and deploys the static site to GitHub
+Pages. It is the consumer end of the chain whose producer is evidence-ingest:
+ingest writes the tree, publish renders and serves it. (For the full `GPn`
+stage map of the evidence-corroboration pipeline, see
 [evidence-ingest.md](evidence-ingest.md).)
+
+The `pages` concurrency group (`cancel-in-progress: false`) serializes to one
+running build plus one queued build, the newest dispatch superseding the
+queued one — so the burst of ingests from a multi-cell nightly UAT batch
+coalesces into a single rebuild instead of a backlog.
 
 Fern publishes the product docs to docs.nvidia.com via `publish-fern-docs.yml`;
 that is a separate surface. This workflow is the only one that deploys to

--- a/docs/contributor/evidence-ingest.md
+++ b/docs/contributor/evidence-ingest.md
@@ -69,6 +69,31 @@ The Go pieces:
    `ingest-evidence` job on a successful run, passing the digest-pinned
    ref read from the conformance step's `evidence/pointer.yaml`.
 
+## Dashboard refresh
+
+A successful ingest lands new evidence in the bucket, so the last job,
+`trigger-dashboard`, dispatches
+[`evidence-dashboard-publish.yaml`](evidence-dashboard-publish.md) to
+re-render the site. It runs `needs: publish`, so it inherits the
+`produced == 'true'` gate — a no-op ingest (allowlist-only change, deleted
+pointer) never fires it.
+
+The push-to-`main` ingest path already re-triggers the dashboard through
+that workflow's own `push:` trigger; the dispatch exists for the
+**first-party UAT path**, which reaches this workflow as a nested
+`workflow_call` (`uat-run` → `uat-{aws,gcp,azure}` → `evidence-ingest`,
+already at GitHub's four-level reuse limit). A nested call emits no
+top-level run event and cannot nest a fifth reusable workflow, so a
+`workflow_dispatch` is the only way to start a fresh top-level dashboard
+run from that depth. It needs `actions: write`, threaded down from the
+`uat-run` `run-*` jobs through each cloud pipeline's `ingest-evidence`
+job.
+
+The dashboard's `concurrency: { group: pages, cancel-in-progress: false }`
+serializes to one running build and one queued build, the newest dispatch
+superseding the queued one — so a multi-cell nightly batch collapses its
+flurry of ingests into a single coalesced rebuild rather than a backlog.
+
 ## meta.json
 
 Each run directory carries one `meta.json` (schema


### PR DESCRIPTION
## Summary

Refresh the GP5 evidence dashboard after every successful `evidence-ingest` run, and render the intent in UAT run titles so nightly/daytime runs are self-describing in the Actions list.

## Motivation / Context

First-party UAT evidence reaches `evidence-ingest` as a nested `workflow_call` (`uat-run` → `uat-{aws,gcp,azure}` → `evidence-ingest`) that pushes nothing to `main`, so the published dashboard stayed stale until the next unrelated push to `main`. And every dispatched UAT run rendered the same `UAT <reservation> @ <version>` title regardless of intent, making training vs inference indistinguishable at a glance.

Fixes: N/A
Related: #1402 (GP2 ingest), #1405 (GP5 dashboard), #1275/#1276 (DC2/DC3 intents)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build/CI/tooling
- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: GitHub Actions (UAT + evidence pipeline workflows)

## Implementation Notes

**Dashboard on every ingest.** A new `trigger-dashboard` job in `evidence-ingest.yaml` dispatches `evidence-dashboard-publish.yaml` (`workflow_dispatch`, `--ref main`). It runs `needs: publish`, so it inherits the existing `produced == 'true'` gate — a no-op ingest never fires it. A dispatch (rather than a nested `workflow_call`) is required because the UAT path is already at GitHub's four-level reuse limit and a nested call emits no top-level run event.
  - `actions: write` is threaded from the `uat-run` `run-*` jobs (was `actions: read`) through each cloud pipeline's `ingest-evidence` job so the nested dispatch is permitted. Held in a separate job so the GCS-credentialed publish job never also carries `actions: write`.
  - The **concurrency: 1 + queue + replace-queued** behavior the request asks for is already provided by the dashboard's `concurrency: { group: pages, cancel-in-progress: false }`: one running build + one queued build, newest dispatch superseding the queued one. A multi-cell nightly batch therefore coalesces into a single rebuild instead of a backlog.

**Descriptive UAT run names.** `uat-run.yaml`'s `run-name` now renders `UAT <reservation> <intent> @ <version>`. `intent` defaults to `training` on both the dispatch and call paths, so it is always present. The nightly (`uat-nightly-batch.yaml`) and daytime (`uat-daytime.yaml`) controllers rebuild this exact title to resolve the run they dispatched, so their `title=` construction is updated in lockstep.

## Testing

```bash
actionlint .github/workflows/{evidence-ingest,uat-run,uat-nightly-batch,uat-daytime,uat-aws,uat-gcp,uat-azure}.yaml   # clean (pre-existing SC2016 infos only)
go test ./tools/corroborate/...   # ok (dashboard-publish structural gate unchanged)
```

No Go source changed. The `evidence-dashboard-publish.yaml` structural test in `tools/corroborate` is unaffected (that workflow is not modified).

## Risk Assessment

- [x] **Low** — CI-only wiring; isolated, easy to revert. The run-name/title change is the one coupling to watch (the controllers match on the exact title), kept in lockstep and called out in-comment.

**Rollout notes:** N/A — takes effect on merge; no migration.

## Checklist

- [x] Linter passes (actionlint)
- [x] I did not skip/disable tests to make CI green
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
