### PR TITLE
perf(ci): cross-compile validator images to skip QEMU on arm64

### DIFF
--- a/validators/conformance/Dockerfile
+++ b/validators/conformance/Dockerfile
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pin the builder stage to the build host's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested $TARGETARCH with Go's own toolchain, rather
+# than running an emulated (QEMU) builder for foreign platforms. Multi-arch
+# GB200 UAT builds (linux/amd64,linux/arm64 on an amd64 runner) previously
+# executed the arm64 `go build` under emulation (~15 min); cross-compiling on
+# the native builder brings it back to native speed. The final distroless stage
+# is a COPY-only layer, so it needs no emulation for the target arch.
 ARG GO_VERSION=1.26.3
-FROM golang:${GO_VERSION}-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -22,7 +29,8 @@ COPY pkg/ pkg/
 COPY validators/ validators/
 COPY recipes/ recipes/
 
-RUN CGO_ENABLED=0 go build -o /out/conformance ./validators/conformance
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/conformance ./validators/conformance
 
 FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 

--- a/validators/deployment/Dockerfile
+++ b/validators/deployment/Dockerfile
@@ -20,8 +20,15 @@
 # v1alpha1.Test AST and dispatches assert/error to kyverno-json's
 # checks.Check engine, so the external binary is no longer needed.
 
+# Pin the builder stage to the build host's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested $TARGETARCH with Go's own toolchain, rather
+# than running an emulated (QEMU) builder for foreign platforms. Multi-arch
+# GB200 UAT builds (linux/amd64,linux/arm64 on an amd64 runner) previously
+# executed the arm64 `go build` under emulation (~15 min); cross-compiling on
+# the native builder brings it back to native speed. The final distroless stage
+# is a COPY-only layer, so it needs no emulation for the target arch.
 ARG GO_VERSION=1.26.3
-FROM golang:${GO_VERSION}-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -30,7 +37,8 @@ COPY pkg/ pkg/
 COPY recipes/ recipes/
 COPY validators/ validators/
 
-RUN CGO_ENABLED=0 go build -o /out/deployment ./validators/deployment
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/deployment ./validators/deployment
 
 FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 

--- a/validators/performance/Dockerfile
+++ b/validators/performance/Dockerfile
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pin the builder stage to the build host's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested $TARGETARCH with Go's own toolchain, rather
+# than running an emulated (QEMU) builder for foreign platforms. Multi-arch
+# GB200 UAT builds (linux/amd64,linux/arm64 on an amd64 runner) previously
+# executed the arm64 `go build` under emulation (~15 min); cross-compiling on
+# the native builder brings it back to native speed. The final distroless stage
+# is a COPY-only layer, so it needs no emulation for the target arch.
 ARG GO_VERSION=1.26.3
-FROM golang:${GO_VERSION}-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -22,7 +29,8 @@ COPY pkg/ pkg/
 COPY validators/ validators/
 COPY recipes/ recipes/
 
-RUN CGO_ENABLED=0 go build -o /out/performance ./validators/performance
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/performance ./validators/performance
 
 FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 


### PR DESCRIPTION
## Summary

Cross-compile the Go validator images (`deployment`, `performance`, `conformance`) instead of building them under QEMU emulation, cutting the multi-arch (GB200) validator build time by ~8×.

## Motivation / Context

The GB200 UAT path (`uat-aws.yaml`) builds validator images multi-arch (`linux/amd64,linux/arm64`, since Grace is arm64) on an amd64 GitHub runner. The Dockerfiles ran `RUN … go build` *inside* the target-arch builder stage, so the arm64 leg executed under QEMU emulation — ~15 min per image vs ~2 min native. Four images built sequentially made the `Build and push validator images` step take ~53 min ([run 29543277605](https://github.com/NVIDIA/aicr/actions/runs/29543277605)).

The fix mirrors what the snapshot-agent build already does (`ko` cross-compiles natively) and what `on-push.yaml` achieves via native arm64 runners: never emulate the Go compile. Pinning the builder stage to `$BUILDPLATFORM` and cross-compiling via `$TARGETARCH` keeps the compile native while still emitting an arm64 binary; the final distroless stage is COPY-only, so it needs no emulation.

Fixes: N/A
Related: #1774

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Other: `validators/*/Dockerfile` (container build)

## Implementation Notes

- `FROM --platform=$BUILDPLATFORM golang:… AS builder` pins the builder to the host arch (native); `ARG TARGETOS TARGETARCH` + `GOOS=$TARGETOS GOARCH=$TARGETARCH go build` cross-compiles to the requested platform.
- `aiperf-bench` (Python) is intentionally unchanged — it has no Go build step; its arm64 layer is a small `pip install` and not worth restructuring.
- No workflow changes: the existing `docker buildx build --platform=$BUILD_PLATFORMS` step in `uat-aws.yaml` picks up the improvement automatically. `on-push.yaml` (native per-arch runners) is unaffected — the change is a no-op there since `$BUILDPLATFORM` already equals the runner's arch.

## Testing

Validated empirically on a fork before this PR — same amd64 runner, `--no-cache`, multi-arch `linux/amd64,linux/arm64`, `deployment` validator, `--target builder` to isolate the `go build`:

| Build | Wall time |
|---|---|
| Baseline (emulated arm64) | **1061s** (~17.7 min) |
| Cross-compile | **126s** (~2.1 min) |

BuildKit reported the patched arm64 stage as `[linux/amd64->arm64 builder] RUN … GOARCH=arm64 go build` — native builder, no emulation. `performance` + `conformance` also built cross-compiled successfully.

```bash
make qualify
```

## Risk Assessment

- [x] **Low** — Isolated Dockerfile change, no Go/logic change, trivially revertible. Produces byte-for-byte the same runtime images (same binaries, same distroless base), only the build path changes.

**Rollout notes:** None. First GB200 nightly after merge exercises it.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (Dockerfile-only build-path change)
- [ ] I updated docs if user-facing behavior changed — N/A (no user-facing behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
