### PR TITLE
feat(recipe-health): deep-link Evidence to dashboard + link-check bot

### DIFF
--- a/.github/workflows/testgrid-link-check.yaml
+++ b/.github/workflows/testgrid-link-check.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Weekly link-integrity check for the recipe-health Evidence deep-links
+# (RQ2 / #1284).
+#
+# Structurally a clone of bom-refresh.yaml (weekly schedule + workflow_dispatch,
+# read-only GITHUB_TOKEN, ubuntu-latest, timeout-minutes) with one deliberate
+# divergence: it never opens a PR and never edits a doc. Instead it runs
+# tools/testgrid-link-check, which reads the committed dashboard presence
+# manifest (pkg/testgrid/presence.yaml — the coordinates RQ1 deep-links) and
+# fetches the live dashboard data with a bounded, origin-pinned HTTP client
+# (off-origin redirects refused), then emits a Markdown report to
+# $GITHUB_STEP_SUMMARY. A linked coordinate the live dashboard no longer serves
+# is reported as a dead-link warning; a coordinate not yet linked is expected
+# and not a warning.
+#
+# Advisory only, mirroring the warning-only recipe-evidence gate: it never
+# blocks a merge (the job exits 0 even when warnings exist). Coordinate
+# resolution against the live SPA is necessarily separate from lychee, which
+# runs --offline and excludes design/ (fern-docs-ci.yaml) and so resolves no
+# dynamic URLs at all — this is the right home, not a lychee tweak.
+
+name: TestGrid Link Check
+
+on:
+  schedule:
+    # Mondays 07:00 UTC, offset from bom-refresh (06:00) and recipe-health-refresh
+    # (06:30) so the three weekly jobs do not contend for runners at the same minute.
+    - cron: "0 7 * * 1"
+  workflow_dispatch: {}
+
+# Serialize runs so a manual workflow_dispatch cannot race a scheduled run.
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Verify recipe-health Evidence deep-links against the live dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: ${{ steps.versions.outputs.go }}
+          cache: false
+
+      # No Helm setup: this job only reads an embedded manifest and fetches one
+      # JSON document — it templates no chart and touches no cluster.
+
+      - name: Check Evidence deep-links and write report to step summary
+        env:
+          GOFLAGS: -mod=vendor
+        # The tool exits 0 even when it finds dead links (warning-only), so the
+        # job never fails the weekly run; the report is the signal.
+        run: |
+          go run ./tools/testgrid-link-check -report-out "$GITHUB_STEP_SUMMARY"

--- a/docs/user/recipe-health.md
+++ b/docs/user/recipe-health.md
@@ -29,7 +29,13 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 
 **Coverage** is a descriptor — it is *never* graded, so a deliberately minimal recipe is never penalized for declaring fewer checks. It is a compact per-phase summary of the **declared** validation checks, in the form `R:n D:n P:n C:n` — the count of named checks declared for the readiness, deployment, performance, and conformance phases respectively.
 
-**Evidence** is a literal `pending` for every recipe today. No conformance attestations exist yet, so the column is honestly uniform: it reports the absence of evidence rather than overstating what is known. A differentiated, evidence-derived column lands once the first signed attestation does.
+**Evidence** deep-links each recipe that has a live dashboard presence to its coordinate on the AICR evidence dashboard at [validation.aicr.run](https://validation.aicr.run) (`/#/<group>/<dashboard>/<tab>`, where `group` is the service, `dashboard` is `<accelerator>-<os>`, and `tab` is `<intent>[-<platform>]`). A recipe without a presence stays a literal `pending` — the column reports the absence of live posture rather than overstating what is known. Today the dashboard covers only the UAT-driven coordinates, so most rows are `pending` until real-hardware coverage broadens; this matrix does not gate on that.
+
+The link is constructed **hermetically and deterministically** from the recipe's resolved criteria using the shared `pkg/recipe.CoordinateFor` mapping — the generator makes no network call, and the coordinate carries **no Kubernetes version**, so a link is stable across k8s-version rolls. The Evidence cell is a link and nothing more: it points at the live board and carries **no** pass/fail state or count. Which recipes are linked is driven by a committed presence manifest (`pkg/testgrid/presence.yaml`); a weekly, warning-only bot keeps it honest by reporting any link that no longer resolves against the live dashboard data (it never blocks merges or edits this doc).
+
+> **Community-source posture is author-asserted provenance, not independently-verified correctness.** A coordinate's tab placement and any community-sourced results on the dashboard are declared by the signing author; corroboration counts agreement at the same AICR version but does not itself certify runtime correctness. Read the linked board accordingly.
+
+The deep-link is the current Evidence rendering. It is distinct from — and coexists with — [ADR-009](../design/009-recipe-health-tracking.md)'s deferred, verify-gated *in-cell freshness* state (`unattested` vs aged, derived from a signed attestation's `AttestedAt`): the link points at the live board, and an optional freshness token can later annotate the same cell without replacing the link. See also the [coverage matrix](coverage-matrix.md) for the complementary breadth view.
 
 {/* BEGIN AICR-HEALTH */}
 ## Summary
@@ -50,8 +56,8 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 | rtx-pro-6000-any | — | rtx-pro-6000 | — | — | — | pass | R:0 D:4 P:0 C:0 | pending |
 | monitoring-hpa | — | — | — | — | — | pass | R:0 D:0 P:0 C:0 | pending |
 | a100-aks-ubuntu-training-kubeflow | aks | a100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
-| h100-aks-ubuntu-inference-dynamo | aks | h100 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
-| h100-aks-ubuntu-training-kubeflow | aks | h100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:1 C:10 | pending |
+| h100-aks-ubuntu-inference-dynamo | aks | h100 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | [aks/h100-ubuntu/inference-dynamo](https://validation.aicr.run/#/aks/h100-ubuntu/inference-dynamo) |
+| h100-aks-ubuntu-training-kubeflow | aks | h100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:1 C:10 | [aks/h100-ubuntu/training-kubeflow](https://validation.aicr.run/#/aks/h100-ubuntu/training-kubeflow) |
 | h100-aks-ubuntu-training-slurm | aks | h100 | ubuntu | training | slurm | pass | R:0 D:4 P:0 C:11 | pending |
 | bcm-inference | bcm | — | — | inference | — | pass | R:0 D:0 P:0 C:5 | pending |
 | h100-bcm-ubuntu-training | bcm | h100 | ubuntu | training | — | pass | R:0 D:4 P:0 C:5 | pending |
@@ -59,9 +65,9 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 | gb200-eks-ubuntu-inference-dynamo | eks | gb200 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:10 | pending |
 | gb200-eks-ubuntu-training-kubeflow | eks | gb200 | ubuntu | training | kubeflow | pass | R:0 D:4 P:2 C:8 | pending |
 | gb200-eks-ubuntu-training-slurm | eks | gb200 | ubuntu | training | slurm | pass | R:0 D:4 P:0 C:10 | pending |
-| h100-eks-ubuntu-inference-dynamo | eks | h100 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
+| h100-eks-ubuntu-inference-dynamo | eks | h100 | ubuntu | inference | dynamo | pass | R:0 D:4 P:1 C:11 | [eks/h100-ubuntu/inference-dynamo](https://validation.aicr.run/#/eks/h100-ubuntu/inference-dynamo) |
 | h100-eks-ubuntu-inference-nim | eks | h100 | ubuntu | inference | nim | pass | R:0 D:4 P:0 C:11 | pending |
-| h100-eks-ubuntu-training-kubeflow | eks | h100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:1 C:10 | pending |
+| h100-eks-ubuntu-training-kubeflow | eks | h100 | ubuntu | training | kubeflow | pass | R:0 D:4 P:1 C:10 | [eks/h100-ubuntu/training-kubeflow](https://validation.aicr.run/#/eks/h100-ubuntu/training-kubeflow) |
 | h100-eks-ubuntu-training-slurm | eks | h100 | ubuntu | training | slurm | pass | R:0 D:4 P:0 C:11 | pending |
 | h200-eks-inference | eks | h200 | — | inference | — | pass | R:0 D:4 P:0 C:5 | pending |
 | h200-eks-training | eks | h200 | — | training | — | pass | R:0 D:4 P:1 C:10 | pending |
@@ -70,8 +76,8 @@ The matrix is computed **hermetically and offline**: every signal is a pure read
 | a100-gke-cos-training-kubeflow | gke | a100 | cos | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
 | b200-gke-cos-inference-dynamo | gke | b200 | cos | inference | dynamo | pass | R:0 D:4 P:0 C:11 | pending |
 | b200-gke-cos-training-kubeflow | gke | b200 | cos | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |
-| h100-gke-cos-inference-dynamo | gke | h100 | cos | inference | dynamo | pass | R:0 D:4 P:1 C:11 | pending |
-| h100-gke-cos-training-kubeflow | gke | h100 | cos | training | kubeflow | pass | R:0 D:4 P:1 C:10 | pending |
+| h100-gke-cos-inference-dynamo | gke | h100 | cos | inference | dynamo | pass | R:0 D:4 P:1 C:11 | [gke/h100-cos/inference-dynamo](https://validation.aicr.run/#/gke/h100-cos/inference-dynamo) |
+| h100-gke-cos-training-kubeflow | gke | h100 | cos | training | kubeflow | pass | R:0 D:4 P:1 C:10 | [gke/h100-cos/training-kubeflow](https://validation.aicr.run/#/gke/h100-cos/training-kubeflow) |
 | h100-gke-cos-training-slurm | gke | h100 | cos | training | slurm | pass | R:0 D:4 P:0 C:11 | pending |
 | h100-kind-inference-dynamo | kind | h100 | — | inference | dynamo | pass | R:0 D:4 P:0 C:11 | pending |
 | h100-kind-training-kubeflow | kind | h100 | — | training | kubeflow | pass | R:0 D:4 P:0 C:10 | pending |

--- a/pkg/corroborate/generate.go
+++ b/pkg/corroborate/generate.go
@@ -59,16 +59,19 @@ var rendererHTML []byte
 const platformNone = "(none)"
 
 // Facet axis keys, emitted in index.json's criteria map and each tab's coord.
+// Exported so external consumers that read a Tab.Coord map (e.g. pkg/testgrid)
+// share this single source of truth for the key spelling rather than
+// hand-writing string literals that could silently drift.
 const (
-	axisService     = "service"
-	axisAccelerator = "accelerator"
-	axisOS          = "os"
-	axisIntent      = "intent"
-	axisPlatform    = "platform"
+	AxisService     = "service"
+	AxisAccelerator = "accelerator"
+	AxisOS          = "os"
+	AxisIntent      = "intent"
+	AxisPlatform    = "platform"
 )
 
 // criteriaAxes is the fixed facet-axis order emitted in index.json.
-var criteriaAxes = []string{axisService, axisAccelerator, axisOS, axisIntent, axisPlatform}
+var criteriaAxes = []string{AxisService, AxisAccelerator, AxisOS, AxisIntent, AxisPlatform}
 
 // Options configures Generate.
 type Options struct {
@@ -844,7 +847,7 @@ func assembleGroups(builts []recipeTab) []Group {
 		}
 		da := groupMap[svc][dash]
 		if da == nil {
-			da = &dashAgg{accelerator: b.tab.Coord[axisAccelerator], os: b.tab.Coord[axisOS]}
+			da = &dashAgg{accelerator: b.tab.Coord[AxisAccelerator], os: b.tab.Coord[AxisOS]}
 			groupMap[svc][dash] = da
 		}
 		da.tabs = append(da.tabs, b.tab)
@@ -869,7 +872,7 @@ func assembleGroups(builts []recipeTab) []Group {
 		for _, dk := range dashKeys {
 			da := dashes[dk]
 			sort.Slice(da.tabs, func(i, j int) bool {
-				return da.tabs[i].Coord[axisIntent]+"-"+da.tabs[i].Coord[axisPlatform] < da.tabs[j].Coord[axisIntent]+"-"+da.tabs[j].Coord[axisPlatform]
+				return da.tabs[i].Coord[AxisIntent]+"-"+da.tabs[i].Coord[AxisPlatform] < da.tabs[j].Coord[AxisIntent]+"-"+da.tabs[j].Coord[AxisPlatform]
 			})
 			dashboards = append(dashboards, Dashboard{Accelerator: da.accelerator, OS: da.os, Tabs: da.tabs})
 		}
@@ -892,25 +895,25 @@ func phaseRollup(statesByPhase map[string][]State) map[string]string {
 // emitted as "" (the renderer treats it as the (none) facet).
 func coordMap(c recipe.Criteria) map[string]string {
 	return map[string]string{
-		axisService:     string(c.Service),
-		axisAccelerator: string(c.Accelerator),
-		axisOS:          string(c.OS),
-		axisIntent:      string(c.Intent),
-		axisPlatform:    string(c.Platform),
+		AxisService:     string(c.Service),
+		AxisAccelerator: string(c.Accelerator),
+		AxisOS:          string(c.OS),
+		AxisIntent:      string(c.Intent),
+		AxisPlatform:    string(c.Platform),
 	}
 }
 
 // recordPresent tracks which criteria values actually appear, for the facet
 // dropdowns.
 func recordPresent(present map[string]map[string]struct{}, c recipe.Criteria) {
-	present[axisService][string(c.Service)] = struct{}{}
-	present[axisAccelerator][string(c.Accelerator)] = struct{}{}
-	present[axisOS][string(c.OS)] = struct{}{}
-	present[axisIntent][string(c.Intent)] = struct{}{}
+	present[AxisService][string(c.Service)] = struct{}{}
+	present[AxisAccelerator][string(c.Accelerator)] = struct{}{}
+	present[AxisOS][string(c.OS)] = struct{}{}
+	present[AxisIntent][string(c.Intent)] = struct{}{}
 	if p := string(c.Platform); p != "" {
-		present[axisPlatform][p] = struct{}{}
+		present[AxisPlatform][p] = struct{}{}
 	} else {
-		present[axisPlatform][platformNone] = struct{}{}
+		present[AxisPlatform][platformNone] = struct{}{}
 	}
 }
 
@@ -922,11 +925,11 @@ func criteriaValues(present map[string]map[string]struct{}) map[string][]string 
 	platformVals := append([]string{}, recipe.GetCriteriaPlatformTypes()...)
 	platformVals = append(platformVals, platformNone)
 	canonical := map[string][]string{
-		axisService:     recipe.GetCriteriaServiceTypes(),
-		axisAccelerator: recipe.GetCriteriaAcceleratorTypes(),
-		axisOS:          recipe.GetCriteriaOSTypes(),
-		axisIntent:      recipe.GetCriteriaIntentTypes(),
-		axisPlatform:    platformVals,
+		AxisService:     recipe.GetCriteriaServiceTypes(),
+		AxisAccelerator: recipe.GetCriteriaAcceleratorTypes(),
+		AxisOS:          recipe.GetCriteriaOSTypes(),
+		AxisIntent:      recipe.GetCriteriaIntentTypes(),
+		AxisPlatform:    platformVals,
 	}
 	out := make(map[string][]string, len(criteriaAxes))
 	for _, axis := range criteriaAxes {

--- a/pkg/testgrid/doc.go
+++ b/pkg/testgrid/doc.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testgrid maps a recipe's canonical coordinate to the AICR evidence
+// dashboard (validation.aicr.run) and answers "does this coordinate have a
+// dashboard presence?" — the two facts RQ1 (#1283) and RQ2 (#1284) share.
+//
+// It is deliberately thin and owns no mapping of its own: the recipe →
+// coordinate mapping is pkg/recipe.CoordinateFor (the single shared function
+// consumed by GP4/GP5/TG2/RQ1). testgrid only adds the dashboard host, the
+// hash-routed deep-link scheme built around Coordinate.Path, and the committed
+// presence manifest.
+//
+// Two presence sources, one spelling of a coordinate path:
+//
+//   - Committed (hermetic): presence.yaml, embedded here and read offline by
+//     the recipe-health generator so link *construction* never touches the
+//     network. LoadPresence exposes it as a Presence set.
+//   - Live: the published data/index.json the dashboard renderer boots from.
+//     LivePaths extracts the present coordinate paths from a parsed index so
+//     the warning-only link-check bot can compare the committed links against
+//     what the dashboard actually serves.
+package testgrid

--- a/pkg/testgrid/presence.yaml
+++ b/pkg/testgrid/presence.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dashboard presence manifest (RQ1 / #1283).
+#
+# The committed set of TestGrid/validation.aicr.run coordinate paths that
+# currently carry at least one real presence on the evidence dashboard. The
+# recipe-health generator (tools/health) reads this list to decide which
+# Evidence cells become a deterministic deep-link into the dashboard and which
+# stay an honest `pending` — it stays hermetic (no network) because presence is
+# read from this committed file, never fetched.
+#
+# Each entry is a "<group>/<dashboard>/<tab>" coordinate path, exactly as
+# pkg/recipe.CoordinateFor(criteria).Path() renders it: group=service,
+# dashboard=<accelerator>-<os>, tab=<intent>[-<platform>].
+#
+# Today the dashboard only covers the UAT-driven recipes; most recipes stay
+# `pending` until real-hardware coverage broadens. This file is the single
+# source of truth for "linked" — the weekly, warning-only testgrid-link-check
+# bot (RQ2 / #1284) fetches the live dashboard data and warns when an entry
+# here no longer resolves, keeping the manifest honest without blocking merges.
+#
+# To add a coordinate: confirm https://validation.aicr.run/#/<path> shows real
+# data, then add the path below (keep the list sorted), then run
+# `make recipe-health-docs` and commit the regenerated
+# docs/user/recipe-health.md in the same PR — the Evidence link only lands once
+# the committed matrix is regenerated (recipe-health-check is advisory, not in
+# the merge gate, so a presence-only edit would otherwise leave the doc stale
+# until the weekly refresh PR picks it up).
+coordinates:
+  - aks/h100-ubuntu/inference-dynamo
+  - aks/h100-ubuntu/training-kubeflow
+  - eks/h100-ubuntu/inference-dynamo
+  - eks/h100-ubuntu/training-kubeflow
+  - gke/h100-cos/inference-dynamo
+  - gke/h100-cos/training-kubeflow

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testgrid
+
+import (
+	"bytes"
+	_ "embed"
+	stderrors "errors"
+	"io"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/aicr/pkg/corroborate"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// Origin is the AICR evidence dashboard's public origin. It is the single
+// pinned host every consumer builds links against and the link-check bot pins
+// its resolution to; a coordinate path is appended to it, never interpolated
+// from recipe/overlay content, so the target can never be steered off-origin.
+const Origin = "https://validation.aicr.run"
+
+// DataURL is the published boot payload the dashboard renderer fetches on load
+// (index.json under the site's data/ directory). It is the same-origin data
+// source the warning-only link-check bot reads to learn which coordinates the
+// live dashboard actually serves — the hash fragment in a deep-link is client
+// side only, so a GET on the fragment URL cannot reveal coordinate presence.
+const DataURL = Origin + "/data/index.json"
+
+// linkFragmentPrefix is the hash-route prefix of the hash-routed static SPA:
+// a deep-link is Origin + "/#/" + Coordinate.Path().
+const linkFragmentPrefix = "/#/"
+
+// LinkFor returns the dashboard deep-link for a coordinate: the pinned Origin
+// plus the hash route for the coordinate's canonical path. Construction is
+// pure and offline — the same coordinate always yields the same byte-stable
+// link — so the recipe-health generator stays hermetic.
+func LinkFor(co recipe.Coordinate) string {
+	return Origin + linkFragmentPrefix + co.Path()
+}
+
+// presenceManifest is the committed dashboard presence list, embedded so the
+// recipe-health generator reads it offline (never over the network).
+//
+//go:embed presence.yaml
+var presenceManifest []byte
+
+// presenceDoc is the on-disk shape of presence.yaml.
+type presenceDoc struct {
+	Coordinates []string `yaml:"coordinates"`
+}
+
+// Presence is the committed set of coordinate paths that currently carry a
+// dashboard presence. It answers Has(coordinate) for the generator and exposes
+// its Paths for the link-check bot.
+type Presence struct {
+	paths map[string]struct{}
+}
+
+// LoadPresence parses the embedded presence manifest. It fails closed on a
+// malformed manifest or a malformed coordinate path rather than silently
+// treating a broken file as "nothing is present", which would drop every
+// Evidence link without warning. The decoder is strict (KnownFields) and an
+// absent or empty `coordinates` list is rejected, so a typo such as
+// `coordinate:` cannot load an empty presence set and make the whole matrix
+// fall back to `pending`.
+func LoadPresence() (*Presence, error) {
+	return parsePresence(presenceManifest)
+}
+
+// parsePresence decodes and validates a presence manifest. It is separated from
+// LoadPresence so the malformed-input regressions can drive it with bytes the
+// embedded (always-valid) manifest cannot exercise.
+func parsePresence(manifest []byte) (*Presence, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(manifest))
+	dec.KnownFields(true)
+	var doc presenceDoc
+	if err := dec.Decode(&doc); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "parse testgrid presence manifest", err)
+	}
+	// The manifest is a single document. A trailing `---` with extra (possibly
+	// malformed) content would otherwise be silently ignored after the first
+	// doc decodes, so require the stream to end here.
+	if err := dec.Decode(new(presenceDoc)); !stderrors.Is(err, io.EOF) {
+		return nil, errors.New(errors.ErrCodeInternal,
+			"testgrid presence manifest must contain exactly one YAML document")
+	}
+	if len(doc.Coordinates) == 0 {
+		return nil, errors.New(errors.ErrCodeInternal,
+			"testgrid presence manifest has no coordinates (missing or empty \"coordinates\" list)")
+	}
+
+	paths := make(map[string]struct{}, len(doc.Coordinates))
+	for _, p := range doc.Coordinates {
+		if err := validatePath(p); err != nil {
+			return nil, err
+		}
+		if _, dup := paths[p]; dup {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				"testgrid presence manifest has duplicate coordinate "+quote(p))
+		}
+		paths[p] = struct{}{}
+	}
+	return &Presence{paths: paths}, nil
+}
+
+// validatePath rejects a manifest entry that is not a well-formed
+// "<group>/<dashboard>/<tab>" coordinate path — three non-empty segments and
+// no leading, trailing, or interior empty segment. A malformed entry would let
+// a typo silently never match any recipe.
+func validatePath(p string) error {
+	segments := strings.Split(p, "/")
+	if len(segments) != 3 {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"testgrid presence path "+quote(p)+" must have exactly three segments (<group>/<dashboard>/<tab>)")
+	}
+	for _, s := range segments {
+		if s == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				"testgrid presence path "+quote(p)+" has an empty segment")
+		}
+	}
+	return nil
+}
+
+func quote(s string) string { return "\"" + s + "\"" }
+
+// Has reports whether the coordinate has a committed dashboard presence.
+func (p *Presence) Has(co recipe.Coordinate) bool {
+	_, ok := p.paths[co.Path()]
+	return ok
+}
+
+// Paths returns the committed coordinate paths, sorted, for deterministic
+// iteration by the link-check bot.
+func (p *Presence) Paths() []string {
+	out := make([]string, 0, len(p.paths))
+	for path := range p.paths {
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LivePaths extracts the set of coordinate paths present in a parsed dashboard
+// index. It reuses pkg/recipe.CoordinateFor as the single source of truth for
+// how a coordinate path is spelled, so the live and committed sides can never
+// drift on path formatting. A tab whose coordinate does not resolve to a
+// concrete path (an "any"/empty required dimension the dashboard should never
+// emit) is skipped rather than mis-placed.
+func LivePaths(idx *corroborate.Index) map[string]struct{} {
+	present := make(map[string]struct{})
+	if idx == nil {
+		return present
+	}
+	for _, group := range idx.Groups {
+		for _, dashboard := range group.Dashboards {
+			for _, tab := range dashboard.Tabs {
+				co, err := recipe.CoordinateFor(criteriaFromCoord(tab.Coord))
+				if err != nil {
+					continue
+				}
+				present[co.Path()] = struct{}{}
+			}
+		}
+	}
+	return present
+}
+
+// criteriaFromCoord rebuilds resolved Criteria from a tab's coord map so
+// CoordinateFor can re-derive the canonical path. The axis keys come from
+// corroborate's exported constants (the same ones its generator writes into
+// each Tab.Coord), so a future axis rename fails to compile here instead of
+// silently yielding an empty coordinate.
+func criteriaFromCoord(coord map[string]string) *recipe.Criteria {
+	return &recipe.Criteria{
+		Service:     recipe.CriteriaServiceType(coord[corroborate.AxisService]),
+		Accelerator: recipe.CriteriaAcceleratorType(coord[corroborate.AxisAccelerator]),
+		OS:          recipe.CriteriaOSType(coord[corroborate.AxisOS]),
+		Intent:      recipe.CriteriaIntentType(coord[corroborate.AxisIntent]),
+		Platform:    recipe.CriteriaPlatformType(coord[corroborate.AxisPlatform]),
+	}
+}

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testgrid
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/corroborate"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+func TestLinkFor(t *testing.T) {
+	co := recipe.Coordinate{Group: "eks", Dashboard: "h100-ubuntu", Tab: "training-kubeflow"}
+	want := "https://validation.aicr.run/#/eks/h100-ubuntu/training-kubeflow"
+	if got := LinkFor(co); got != want {
+		t.Errorf("LinkFor() = %q, want %q", got, want)
+	}
+	// Construction is pure — no map/clock/registry — so identical input yields
+	// identical output by the compiler's guarantees; the golden assertion above
+	// is the determinism check.
+}
+
+func TestLoadPresence(t *testing.T) {
+	p, err := LoadPresence()
+	if err != nil {
+		t.Fatalf("LoadPresence() error = %v", err)
+	}
+	paths := p.Paths()
+	if len(paths) == 0 {
+		t.Fatal("LoadPresence() returned no coordinates")
+	}
+	// Paths must come back sorted (deterministic bot iteration).
+	if !sort.StringsAreSorted(paths) {
+		t.Errorf("Paths() not sorted: %v", paths)
+	}
+	// Every committed path must be well-formed and Has() must agree with Paths().
+	for _, path := range paths {
+		segs := strings.Split(path, "/")
+		if len(segs) != 3 {
+			t.Errorf("committed path %q is not 3 segments", path)
+			continue
+		}
+		co := recipe.Coordinate{Group: segs[0], Dashboard: segs[1], Tab: segs[2]}
+		if !p.Has(co) {
+			t.Errorf("Has(%q) = false, but path is in the manifest", path)
+		}
+	}
+}
+
+func TestParsePresenceRejectsMalformed(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		wantErr  bool
+	}{
+		{"valid", "coordinates:\n  - eks/h100-ubuntu/training\n", false},
+		{"unknown key (typo)", "coordinate:\n  - eks/h100-ubuntu/training\n", true},
+		{"absent coordinates list", "other: 1\n", true},
+		{"empty coordinates list", "coordinates: []\n", true},
+		{"malformed coordinate path", "coordinates:\n  - eks/h100-ubuntu\n", true},
+		{"duplicate coordinate", "coordinates:\n  - eks/h100-ubuntu/training\n  - eks/h100-ubuntu/training\n", true},
+		{"trailing second document", "coordinates:\n  - eks/h100-ubuntu/training\n---\ngarbage: [\n", true},
+		{"not yaml", "\t- : :\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parsePresence([]byte(tt.manifest))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePresence() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPresenceHas(t *testing.T) {
+	p, err := LoadPresence()
+	if err != nil {
+		t.Fatalf("LoadPresence() error = %v", err)
+	}
+	tests := []struct {
+		name string
+		co   recipe.Coordinate
+		want bool
+	}{
+		{"present (UAT-covered)", recipe.Coordinate{Group: "eks", Dashboard: "h100-ubuntu", Tab: "training-kubeflow"}, true},
+		{"absent (no dashboard presence)", recipe.Coordinate{Group: "eks", Dashboard: "gb200-ubuntu", Tab: "training-slurm"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.Has(tt.co); got != tt.want {
+				t.Errorf("Has(%v) = %v, want %v", tt.co, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLivePaths(t *testing.T) {
+	idx := &corroborate.Index{
+		Groups: []corroborate.Group{
+			{
+				Service: "eks",
+				Dashboards: []corroborate.Dashboard{
+					{
+						Accelerator: "h100",
+						OS:          "ubuntu",
+						Tabs: []corroborate.Tab{
+							{Coord: map[string]string{
+								"service": "eks", "accelerator": "h100", "os": "ubuntu",
+								"intent": "training", "platform": "kubeflow",
+							}},
+							// A bare-intent tab (no platform).
+							{Coord: map[string]string{
+								"service": "eks", "accelerator": "h100", "os": "ubuntu",
+								"intent": "inference",
+							}},
+							// A malformed tab (missing os) is skipped, not mis-placed.
+							{Coord: map[string]string{
+								"service": "eks", "accelerator": "h100", "intent": "training",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := LivePaths(idx)
+	want := map[string]struct{}{
+		"eks/h100-ubuntu/training-kubeflow": {},
+		"eks/h100-ubuntu/inference":         {},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LivePaths() = %v, want %v", keys(got), keys(want))
+	}
+}
+
+func TestLivePathsNil(t *testing.T) {
+	if got := LivePaths(nil); len(got) != 0 {
+		t.Errorf("LivePaths(nil) = %v, want empty", got)
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"well-formed", "eks/h100-ubuntu/training", false},
+		{"too few segments", "eks/h100-ubuntu", true},
+		{"too many segments", "eks/h100/ubuntu/training", true},
+		{"empty interior segment", "eks//training", true},
+		{"trailing empty segment", "eks/h100-ubuntu/", true},
+		{"leading empty segment", "/h100-ubuntu/training", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/health/main.go
+++ b/tools/health/main.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/health"
+	"github.com/NVIDIA/aicr/pkg/testgrid"
 	"github.com/NVIDIA/aicr/tools/internal/docgen"
 )
 
@@ -79,6 +80,14 @@ func run(ctx context.Context, outDir, summaryOut, aicrVersion string, determinis
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "compute recipe health")
 	}
 
+	// Presence is read from the committed manifest embedded in pkg/testgrid, so
+	// the Evidence deep-links are constructed offline and the run stays
+	// hermetic — no dashboard fetch.
+	presence, err := testgrid.LoadPresence()
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "load testgrid presence")
+	}
+
 	if mkErr := os.MkdirAll(outDir, 0o755); mkErr != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "mkdir out-dir", mkErr)
 	}
@@ -89,6 +98,7 @@ func run(ctx context.Context, outDir, summaryOut, aicrVersion string, determinis
 			AICRVersion:   aicrVersion,
 			Deterministic: deterministic,
 			NoTitle:       noTitle,
+			Presence:      presence,
 		})
 	}); err != nil {
 		return err

--- a/tools/health/main_test.go
+++ b/tools/health/main_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/health"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/testgrid"
 )
 
 // budgetCeiling is the compute-budget gate referenced by the ADR-009 epic
@@ -144,6 +145,105 @@ func TestRenderMatrixByteStable(t *testing.T) {
 	}
 	if !bytes.Equal(a.Bytes(), b.Bytes()) {
 		t.Errorf("deterministic output differs across runs:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", a.String(), b.String())
+	}
+}
+
+// TestEvidenceCell asserts the Evidence-column rendering: a present coordinate
+// becomes a deep-link with no status/count token; everything else is pending.
+func TestEvidenceCell(t *testing.T) {
+	presence, err := testgrid.LoadPresence()
+	if err != nil {
+		t.Fatalf("LoadPresence() error = %v", err)
+	}
+
+	// A committed-present coordinate (eks / h100-ubuntu / training-kubeflow).
+	present := &recipe.Criteria{
+		Service:     recipe.CriteriaServiceEKS,
+		Accelerator: recipe.CriteriaAcceleratorH100,
+		OS:          recipe.CriteriaOSUbuntu,
+		Intent:      recipe.CriteriaIntentTraining,
+		Platform:    recipe.CriteriaPlatformKubeflow,
+	}
+	// Same coordinate but no platform — a distinct, not-present tab.
+	absentTab := &recipe.Criteria{
+		Service:     recipe.CriteriaServiceEKS,
+		Accelerator: recipe.CriteriaAcceleratorH100,
+		OS:          recipe.CriteriaOSUbuntu,
+		Intent:      recipe.CriteriaIntentTraining,
+	}
+	// A wildcard/absent required dimension has no concrete coordinate.
+	noCoord := &recipe.Criteria{Accelerator: recipe.CriteriaAcceleratorH100}
+
+	tests := []struct {
+		name     string
+		crit     *recipe.Criteria
+		presence *testgrid.Presence
+		want     string
+	}{
+		{
+			name:     "present renders deep-link",
+			crit:     present,
+			presence: presence,
+			want:     "[eks/h100-ubuntu/training-kubeflow](https://validation.aicr.run/#/eks/h100-ubuntu/training-kubeflow)",
+		},
+		{"absent coordinate is pending", absentTab, presence, evidencePending},
+		{"unmappable criteria is pending", noCoord, presence, evidencePending},
+		{"nil presence degrades to pending", present, nil, evidencePending},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evidenceCell(tt.crit, tt.presence)
+			if got != tt.want {
+				t.Errorf("evidenceCell() = %q, want %q", got, tt.want)
+			}
+			// The Evidence cell must never carry a status/count token.
+			for _, banned := range []string{"pass", "fail", "warn", "P:", "C:"} {
+				if got != evidencePending && strings.Contains(got, banned) {
+					t.Errorf("evidence cell %q leaked a status/count token %q", got, banned)
+				}
+			}
+		})
+	}
+}
+
+// TestRenderMatrixLinksPresentCoordinate asserts the full matrix render emits a
+// deep-link for a present recipe while other recipes stay pending.
+func TestRenderMatrixLinksPresentCoordinate(t *testing.T) {
+	presence, err := testgrid.LoadPresence()
+	if err != nil {
+		t.Fatalf("LoadPresence() error = %v", err)
+	}
+	report := &health.Report{
+		SchemaVersion: health.SchemaVersion,
+		Combos: []health.ComboHealth{
+			{
+				Criteria: &recipe.Criteria{
+					Service:     recipe.CriteriaServiceEKS,
+					Accelerator: recipe.CriteriaAcceleratorH100,
+					OS:          recipe.CriteriaOSUbuntu,
+					Intent:      recipe.CriteriaIntentTraining,
+					Platform:    recipe.CriteriaPlatformKubeflow,
+				},
+				LeafOverlay: "h100-eks-ubuntu-training-kubeflow",
+				Structure:   health.StructureHealth{Status: health.StatusPass},
+			},
+			{
+				Criteria:    &recipe.Criteria{Accelerator: recipe.CriteriaAcceleratorH100},
+				LeafOverlay: "h100-any",
+				Structure:   health.StructureHealth{Status: health.StatusPass},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := renderMatrix(&buf, report, markdownOptions{Deterministic: true, NoTitle: true, Presence: presence}); err != nil {
+		t.Fatalf("renderMatrix() error = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[eks/h100-ubuntu/training-kubeflow](https://validation.aicr.run/#/eks/h100-ubuntu/training-kubeflow)") {
+		t.Errorf("present recipe missing deep-link:\n%s", out)
+	}
+	if !strings.Contains(out, "| h100-any | — | h100 | — | — | — | pass | — | pending |") {
+		t.Errorf("unmappable recipe should stay pending:\n%s", out)
 	}
 }
 

--- a/tools/health/markdown.go
+++ b/tools/health/markdown.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/health"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/testgrid"
 )
 
 // detailDimensions is the fixed render order for the per-dimension structural
@@ -43,16 +44,25 @@ var detailDimensions = []string{
 // from a graded pass/warn/fail/unknown.
 const dimNotScored = "—"
 
-// evidencePending is the literal value rendered in the Evidence column for
-// every recipe in V1. No attestations exist yet (recipes/evidence/ is empty),
-// so the column is uniformly pending and never overstates what is known. The
-// hand-written doc header explains why; see ADR-009 §3.
+// evidencePending is the value rendered in the Evidence column for a recipe
+// that has no dashboard presence yet (RQ1 / #1283). Most recipes are pending
+// today — the dashboard only covers the UAT-driven coordinates — so the column
+// never overstates what is known: absence of a link is an honest "no live
+// posture yet", not a claim. Recipes with a committed presence render a
+// deterministic deep-link instead; see evidenceCell. The hand-written doc
+// header explains the column; see ADR-009 §3 and #1283.
 const evidencePending = "pending"
 
 // markdownOptions configures matrix rendering.
 type markdownOptions struct {
 	// AICRVersion labels the run in the non-deterministic generated-stamp line.
 	AICRVersion string
+
+	// Presence is the committed dashboard presence set. A recipe whose resolved
+	// coordinate is present renders a deep-link in the Evidence column; the rest
+	// render evidencePending. A nil Presence renders every recipe pending (the
+	// pre-RQ1 behavior), so rendering degrades safely if the manifest is absent.
+	Presence *testgrid.Presence
 
 	// Deterministic suppresses per-run metadata (the generated timestamp) so
 	// the output is byte-stable and committable.
@@ -105,7 +115,7 @@ func renderMatrix(w io.Writer, report *health.Report, opts markdownOptions) erro
 	}
 
 	writeSummary(sw, report)
-	writeMatrix(sw, report)
+	writeMatrix(sw, report, opts.Presence)
 
 	if sw.err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to write recipe-health markdown", sw.err)
@@ -136,7 +146,7 @@ func writeSummary(sw *stickyWriter, report *health.Report) {
 }
 
 // writeMatrix emits the per-recipe matrix table.
-func writeMatrix(sw *stickyWriter, report *health.Report) {
+func writeMatrix(sw *stickyWriter, report *health.Report, presence *testgrid.Presence) {
 	fmt.Fprintf(sw, "## Recipes\n\n")
 	fmt.Fprintln(sw, "| Recipe | Service | Accelerator | OS | Intent | Platform | Status | Coverage | Evidence |")
 	fmt.Fprintln(sw, "|--------|---------|-------------|----|--------|----------|--------|----------|----------|")
@@ -151,10 +161,32 @@ func writeMatrix(sw *stickyWriter, report *health.Report) {
 			dimCell(string(crit.Platform)),
 			c.Structure.Status,
 			coverageCell(c.Structure.Coverage),
-			evidencePending,
+			evidenceCell(crit, presence),
 		)
 	}
 	fmt.Fprintln(sw)
+}
+
+// evidenceCell renders the Evidence column for one recipe. It emits a
+// deterministic Markdown deep-link into the dashboard only when the recipe
+// resolves to a concrete coordinate that has a committed dashboard presence;
+// otherwise it renders evidencePending. Link construction is pure and offline
+// (pkg/testgrid.LinkFor over pkg/recipe.CoordinateFor), so the generator stays
+// hermetic and byte-deterministic. The cell never carries a status or a
+// pass/fail/count token — it points at the live board and nothing more, per
+// #1283 (RQ2 owns keeping the link honest; #1224 owns any later freshness
+// token). A recipe with a wildcard/absent required dimension (e.g. a100-any)
+// has no concrete coordinate and stays pending.
+func evidenceCell(crit *recipe.Criteria, presence *testgrid.Presence) string {
+	if presence == nil {
+		return evidencePending
+	}
+	co, err := recipe.CoordinateFor(crit)
+	if err != nil || !presence.Has(co) {
+		return evidencePending
+	}
+	path := co.Path()
+	return fmt.Sprintf("[%s](%s)", path, testgrid.LinkFor(co))
 }
 
 // dimCell renders a single criteria dimension. An unspecified dimension ("any"

--- a/tools/testgrid-link-check/check.go
+++ b/tools/testgrid-link-check/check.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/testgrid"
+)
+
+// state is a link's classification against the live dashboard data.
+type state string
+
+const (
+	// stateResolved: RQ1 linked this coordinate and the live dashboard serves
+	// data for it — the link is good.
+	stateResolved state = "resolved"
+
+	// stateMissingButPresent: RQ1 linked this coordinate but the live dashboard
+	// no longer serves data for it — a dead Evidence link. This is the only
+	// warning the bot raises. It never blocks a merge; it prompts a maintainer
+	// to drop or re-confirm the entry in pkg/testgrid/presence.yaml.
+	stateMissingButPresent state = "missing-but-present"
+
+	// stateNotYetLinked: the live dashboard serves a coordinate that RQ1 has not
+	// linked yet (the committed manifest lags real coverage). Expected and
+	// informational — the publish/ingest lag is normal — not a warning.
+	stateNotYetLinked state = "not-yet-linked"
+)
+
+// result is one coordinate's classification.
+type result struct {
+	Path  string
+	State state
+}
+
+// classify compares the committed presence paths (the links RQ1 emits) against
+// the coordinate paths the live dashboard actually serves, and returns one
+// result per coordinate in deterministic (state, then path) order:
+//
+//   - committed ∩ live      → resolved
+//   - committed \ live      → missing-but-present (warn: dead link)
+//   - live \ committed      → not-yet-linked (ok: coverage grew, manifest lags)
+//
+// Both inputs are plain sets, so the comparison is pure and fully unit-testable
+// without any network.
+func classify(committed []string, live map[string]struct{}) []result {
+	committedSet := make(map[string]struct{}, len(committed))
+	var results []result
+
+	for _, path := range committed {
+		committedSet[path] = struct{}{}
+		st := stateMissingButPresent
+		if _, ok := live[path]; ok {
+			st = stateResolved
+		}
+		results = append(results, result{Path: path, State: st})
+	}
+
+	for path := range live {
+		if _, ok := committedSet[path]; !ok {
+			results = append(results, result{Path: path, State: stateNotYetLinked})
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].State != results[j].State {
+			return results[i].State < results[j].State
+		}
+		return results[i].Path < results[j].Path
+	})
+	return results
+}
+
+// warnCount returns the number of dead-link warnings in results.
+func warnCount(results []result) int {
+	n := 0
+	for _, r := range results {
+		if r.State == stateMissingButPresent {
+			n++
+		}
+	}
+	return n
+}
+
+// renderReport writes the Markdown report the workflow appends to
+// $GITHUB_STEP_SUMMARY. It is deterministic for a given (committed, live) pair
+// and carries no timestamp, so a dry run is byte-reproducible. The report
+// always renders — even with zero warnings — so the weekly run leaves an
+// audit trail either way.
+func renderReport(w io.Writer, results []result) error {
+	sw := &stickyWriter{w: w}
+
+	warns := warnCount(results)
+	fmt.Fprintf(sw, "## TestGrid link check\n\n")
+	fmt.Fprintf(sw, "Verifies each Evidence deep-link in `docs/user/recipe-health.md` still "+
+		"resolves against the live dashboard data at [%s](%s). Advisory only — never blocks merges, "+
+		"never edits the doc.\n\n", testgrid.Origin, testgrid.DataURL)
+
+	if warns == 0 {
+		fmt.Fprintf(sw, "✅ **No dead links.** Every linked coordinate resolves.\n\n")
+	} else {
+		fmt.Fprintf(sw, "⚠️ **%d dead link(s).** A recipe links a coordinate the live dashboard no longer "+
+			"serves — drop or re-confirm the entry in `pkg/testgrid/presence.yaml`.\n\n", warns)
+	}
+
+	fmt.Fprintln(sw, "| Coordinate | State |")
+	fmt.Fprintln(sw, "|------------|-------|")
+	for _, r := range results {
+		fmt.Fprintf(sw, "| `%s` | %s |\n", r.Path, stateLabel(r.State))
+	}
+	fmt.Fprintln(sw)
+
+	if sw.err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "write testgrid link-check report", sw.err)
+	}
+	return nil
+}
+
+// stateLabel renders a state with a leading glyph for the report.
+func stateLabel(st state) string {
+	switch st {
+	case stateResolved:
+		return "✅ resolved"
+	case stateMissingButPresent:
+		return "⚠️ missing-but-present (dead link)"
+	case stateNotYetLinked:
+		return "· not-yet-linked (expected)"
+	default:
+		return string(st)
+	}
+}
+
+// stickyWriter remembers the first write error so callers check once at the
+// end. Mirrors the helper in tools/health.
+type stickyWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (s *stickyWriter) Write(p []byte) (int, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	n, err := s.w.Write(p)
+	if err != nil {
+		s.err = err
+	}
+	return n, err
+}

--- a/tools/testgrid-link-check/check_test.go
+++ b/tools/testgrid-link-check/check_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func liveSet(paths ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		m[p] = struct{}{}
+	}
+	return m
+}
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name      string
+		committed []string
+		live      map[string]struct{}
+		want      map[string]state
+	}{
+		{
+			name:      "resolved when committed link is live",
+			committed: []string{"eks/h100-ubuntu/training-kubeflow"},
+			live:      liveSet("eks/h100-ubuntu/training-kubeflow"),
+			want:      map[string]state{"eks/h100-ubuntu/training-kubeflow": stateResolved},
+		},
+		{
+			name:      "missing-but-present when committed link has no live data",
+			committed: []string{"eks/h100-ubuntu/training-kubeflow"},
+			live:      liveSet(),
+			want:      map[string]state{"eks/h100-ubuntu/training-kubeflow": stateMissingButPresent},
+		},
+		{
+			name:      "not-yet-linked when live coordinate is not committed",
+			committed: []string{},
+			live:      liveSet("gke/h100-cos/training-kubeflow"),
+			want:      map[string]state{"gke/h100-cos/training-kubeflow": stateNotYetLinked},
+		},
+		{
+			name:      "mixed set classifies each coordinate independently",
+			committed: []string{"eks/h100-ubuntu/training-kubeflow", "aks/h100-ubuntu/inference-dynamo"},
+			live:      liveSet("eks/h100-ubuntu/training-kubeflow", "gke/h100-cos/training-kubeflow"),
+			want: map[string]state{
+				"eks/h100-ubuntu/training-kubeflow": stateResolved,
+				"aks/h100-ubuntu/inference-dynamo":  stateMissingButPresent,
+				"gke/h100-cos/training-kubeflow":    stateNotYetLinked,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classify(tt.committed, tt.live)
+			if len(got) != len(tt.want) {
+				t.Fatalf("classify() returned %d results, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for _, r := range got {
+				if want, ok := tt.want[r.Path]; !ok || want != r.State {
+					t.Errorf("classify()[%q] = %q, want %q", r.Path, r.State, want)
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyDeterministicOrder(t *testing.T) {
+	committed := []string{"eks/h100-ubuntu/training-kubeflow", "aks/h100-ubuntu/inference-dynamo"}
+	live := liveSet("eks/h100-ubuntu/training-kubeflow", "zke/h100-cos/training-kubeflow")
+	a := classify(committed, live)
+	b := classify(committed, live)
+	if len(a) != len(b) {
+		t.Fatalf("length mismatch")
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("classify() order not deterministic at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+	// Ordered by state then path: missing-but-present, then not-yet-linked, then resolved.
+	if a[0].State != stateMissingButPresent || a[len(a)-1].State != stateResolved {
+		t.Errorf("unexpected ordering: %+v", a)
+	}
+}
+
+func TestWarnCount(t *testing.T) {
+	results := []result{
+		{Path: "a", State: stateResolved},
+		{Path: "b", State: stateMissingButPresent},
+		{Path: "c", State: stateNotYetLinked},
+		{Path: "d", State: stateMissingButPresent},
+	}
+	if got := warnCount(results); got != 2 {
+		t.Errorf("warnCount() = %d, want 2", got)
+	}
+}
+
+func TestRenderReport(t *testing.T) {
+	const coord = "eks/h100-ubuntu/training-kubeflow"
+	tests := []struct {
+		name        string
+		live        map[string]struct{}
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "clean run renders no-dead-links banner",
+			live:        liveSet(coord),
+			wantContain: []string{"No dead links"},
+			wantAbsent:  []string{"⚠️ **"},
+		},
+		{
+			name:        "dead link renders warning banner and row",
+			live:        liveSet(),
+			wantContain: []string{"1 dead link(s)", "missing-but-present"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := renderReport(&buf, classify([]string{coord}, tt.live)); err != nil {
+				t.Fatalf("renderReport() error = %v", err)
+			}
+			out := buf.String()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(out, want) {
+					t.Errorf("report missing %q, got:\n%s", want, out)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("report unexpectedly contains %q, got:\n%s", absent, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderReportDeterministic(t *testing.T) {
+	results := classify(
+		[]string{"eks/h100-ubuntu/training-kubeflow", "aks/h100-ubuntu/inference-dynamo"},
+		liveSet("eks/h100-ubuntu/training-kubeflow"),
+	)
+	var a, b bytes.Buffer
+	if err := renderReport(&a, results); err != nil {
+		t.Fatalf("renderReport() first error = %v", err)
+	}
+	if err := renderReport(&b, results); err != nil {
+		t.Fatalf("renderReport() second error = %v", err)
+	}
+	if !bytes.Equal(a.Bytes(), b.Bytes()) {
+		t.Errorf("report is not byte-deterministic:\n--- a ---\n%s\n--- b ---\n%s", a.String(), b.String())
+	}
+	// Report must never carry a timestamp (byte-reproducible dry-run).
+	if strings.Contains(a.String(), "Generated") {
+		t.Errorf("report leaked a timestamp:\n%s", a.String())
+	}
+}

--- a/tools/testgrid-link-check/main.go
+++ b/tools/testgrid-link-check/main.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command testgrid-link-check is the warning-only, weekly bot (RQ2 / #1284)
+// that verifies the Evidence deep-links the recipe-health matrix emits (RQ1 /
+// #1283) still resolve against the live evidence dashboard.
+//
+// It reads the committed presence manifest (the set of coordinates RQ1 links),
+// fetches the dashboard's published data (data/index.json) with a bounded HTTP
+// client pinned to the dashboard origin (off-origin redirects refused), and
+// reports any linked coordinate the live data no longer serves as a dead-link
+// warning. A coordinate the dashboard serves but RQ1 has not linked yet is
+// expected, not a warning. The report is Markdown for $GITHUB_STEP_SUMMARY.
+//
+// It is advisory: it never blocks a merge and never edits the doc, so it always
+// exits 0 — a fetch failure or a dead link is reported, not fatal. Structurally
+// a clone of .github/workflows/bom-refresh.yaml minus the create-pull-request
+// step (report-only, contents: read).
+//
+// Usage: testgrid-link-check [-report-out <path>] [-index-file <path>]
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/NVIDIA/aicr/pkg/corroborate"
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/testgrid"
+)
+
+func main() {
+	os.Exit(realMain())
+}
+
+// realMain runs the check and returns a process exit code. It returns non-zero
+// only for an internal failure (a broken embedded manifest, an unwritable
+// report path) — never for a dead link or a failed dashboard fetch, which are
+// reported and exit 0 to preserve the warning-only contract.
+func realMain() int {
+	var (
+		reportOut string
+		indexFile string
+	)
+	flag.StringVar(&reportOut, "report-out", "", "path to write the Markdown report (default: stdout)")
+	flag.StringVar(&indexFile, "index-file", "", "read live dashboard data from a local file instead of fetching (offline dry-run)")
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, reportOut, indexFile); err != nil {
+		slog.Error("testgrid-link-check failed", "error", err)
+		return 1
+	}
+	return 0
+}
+
+func run(ctx context.Context, reportOut, indexFile string) error {
+	presence, err := testgrid.LoadPresence()
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "load testgrid presence")
+	}
+	committed := presence.Paths()
+
+	live, fetchErr := loadLive(ctx, indexFile)
+	if fetchErr != nil {
+		// A failed fetch is reported, not fatal: without live data the bot cannot
+		// classify links, but it must not fail the (warning-only) job. Emit a note
+		// and exit 0.
+		slog.Warn("could not load live dashboard data; skipping link classification", "error", fetchErr)
+		return writeReport(reportOut, func(w io.Writer) error {
+			return renderFetchFailure(w, fetchErr)
+		})
+	}
+
+	results := classify(committed, live)
+	if n := warnCount(results); n > 0 {
+		slog.Warn("dead Evidence links found (advisory)", "count", n)
+	} else {
+		slog.Info("all Evidence links resolve", "linked", len(committed))
+	}
+	return writeReport(reportOut, func(w io.Writer) error {
+		return renderReport(w, results)
+	})
+}
+
+// loadLive returns the set of coordinate paths the live dashboard serves,
+// either from a local file (offline dry-run) or by fetching the pinned origin.
+func loadLive(ctx context.Context, indexFile string) (map[string]struct{}, error) {
+	var idx *corroborate.Index
+	var err error
+	if indexFile != "" {
+		idx, err = readIndexFile(indexFile)
+	} else {
+		idx, err = fetchIndex(ctx, newPinnedClient(), testgrid.DataURL)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return testgrid.LivePaths(idx), nil
+}
+
+// readIndexFile decodes a dashboard index from a local file, bounding the read
+// so an attacker-influenced path cannot OOM the process.
+func readIndexFile(path string) (*corroborate.Index, error) {
+	f, err := os.Open(path) //nolint:gosec // operator-supplied dry-run path
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeNotFound, "open index file", err)
+	}
+	defer func() { _ = f.Close() }()
+	return decodeIndex(io.LimitReader(f, defaults.HTTPResponseBodyLimit+1))
+}
+
+// fetchIndex fetches and decodes the dashboard index from dataURL using the
+// supplied bounded, redirect-hardened client. The URL and client are injected
+// so the pinned production origin is set by the sole caller (loadLive) and
+// tests can drive the same path against a local server.
+func fetchIndex(ctx context.Context, client *http.Client, dataURL string) (*corroborate.Index, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dataURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "build index request", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeUnavailable, "fetch dashboard index", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errors.New(errors.ErrCodeUnavailable,
+			fmt.Sprintf("dashboard index returned HTTP %d", resp.StatusCode))
+	}
+	return decodeIndex(io.LimitReader(resp.Body, defaults.HTTPResponseBodyLimit+1))
+}
+
+// decodeIndex reads a bounded body and decodes it as a dashboard index,
+// rejecting a body that exceeds the limit rather than trusting a hostile size.
+func decodeIndex(r io.Reader) (*corroborate.Index, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "read dashboard index", err)
+	}
+	if int64(len(data)) > defaults.HTTPResponseBodyLimit {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "dashboard index exceeds size limit")
+	}
+	var idx corroborate.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "decode dashboard index", err)
+	}
+	return &idx, nil
+}
+
+// newPinnedClient returns an HTTP client bounded by the repo's HTTP timeout and
+// hardened against SSRF/redirect steering: it refuses any redirect that leaves
+// the pinned dashboard origin — a different host or a scheme downgrade to plain
+// HTTP — so even if a link target ever became influenced by recipe/overlay
+// content the weekly bot cannot be walked off-origin or downgraded to plaintext.
+func newPinnedClient() *http.Client {
+	return &http.Client{
+		Timeout: defaults.HTTPClientTimeout,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if req.URL.Scheme != "https" {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					"refusing scheme-downgrade redirect to "+req.URL.Scheme)
+			}
+			if req.URL.Host != originHost() {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					"refusing off-origin redirect to "+req.URL.Host)
+			}
+			return nil
+		},
+	}
+}
+
+// originHost is the host component of the pinned dashboard origin. Parsing the
+// shared constant keeps the allowlist in lockstep with the link scheme.
+func originHost() string {
+	u, err := url.Parse(testgrid.Origin)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// writeReport renders the report to reportOut (stdout when empty). The file is
+// opened for append, not truncate: the workflow points reportOut at
+// $GITHUB_STEP_SUMMARY, whose contract is append (matching tools/health), so
+// the bot never clobbers output another step may have written. A writable
+// file's Close error is captured so a flush failure is not silently dropped.
+func writeReport(reportOut string, render func(io.Writer) error) (err error) {
+	if reportOut == "" {
+		return render(os.Stdout)
+	}
+	f, openErr := os.OpenFile(reportOut, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec // operator-supplied output path
+	if openErr != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "open report file", openErr)
+	}
+	defer func() {
+		closeErr := f.Close()
+		if err == nil && closeErr != nil {
+			err = errors.Wrap(errors.ErrCodeInternal, "close report file", closeErr)
+		}
+	}()
+	return render(f)
+}
+
+// renderFetchFailure emits a report noting the live data could not be loaded,
+// so the (warning-only) run still leaves an audit trail and exits 0.
+func renderFetchFailure(w io.Writer, cause error) error {
+	sw := &stickyWriter{w: w}
+	fmt.Fprintf(sw, "## TestGrid link check\n\n")
+	fmt.Fprintf(sw, "⚠️ Could not load live dashboard data from [%s](%s): `%s`.\n\n",
+		testgrid.Origin, testgrid.DataURL, cause)
+	fmt.Fprintf(sw, "Link classification was skipped this run. This is advisory only — no merge is blocked.\n\n")
+	if sw.err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "write fetch-failure report", sw.err)
+	}
+	return nil
+}

--- a/tools/testgrid-link-check/main_test.go
+++ b/tools/testgrid-link-check/main_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+)
+
+const sampleIndex = `{
+  "schema": "aicr-corroboration/v1",
+  "groups": [
+    {
+      "service": "eks",
+      "dashboards": [
+        {
+          "accelerator": "h100",
+          "os": "ubuntu",
+          "tabs": [
+            {"recipe": "h100-eks-ubuntu-training-kubeflow",
+             "coord": {"service":"eks","accelerator":"h100","os":"ubuntu","intent":"training","platform":"kubeflow"}}
+          ]
+        }
+      ]
+    }
+  ]
+}`
+
+func TestOriginHost(t *testing.T) {
+	if got := originHost(); got != "validation.aicr.run" {
+		t.Errorf("originHost() = %q, want validation.aicr.run", got)
+	}
+}
+
+func TestCheckRedirectRefusesOffOrigin(t *testing.T) {
+	client := newPinnedClient()
+	if client.CheckRedirect == nil {
+		t.Fatal("pinned client has no CheckRedirect guard")
+	}
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{"same-origin redirect allowed", "https://validation.aicr.run/data/other.json", false},
+		{"off-origin redirect refused", "https://evil.example.com/data/index.json", true},
+		{"look-alike host refused", "https://validation.aicr.run.evil.com/x", true},
+		{"scheme downgrade to http refused", "http://validation.aicr.run/data/index.json", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.rawURL, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			err = client.CheckRedirect(req, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckRedirect(%q) error = %v, wantErr %v", tt.rawURL, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeIndex(t *testing.T) {
+	oversized := strings.Repeat("a", int(defaults.HTTPResponseBodyLimit)+1)
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"valid", sampleIndex, false},
+		{"oversized body rejected", oversized, true},
+		{"malformed json rejected", "{not json", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, err := decodeIndex(strings.NewReader(tt.body))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("decodeIndex() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && (len(idx.Groups) != 1 || idx.Groups[0].Service != "eks") {
+				t.Errorf("decodeIndex() did not parse groups: %+v", idx.Groups)
+			}
+		})
+	}
+}
+
+func TestReadIndexFile(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "index.json")
+	if err := os.WriteFile(good, []byte(sampleIndex), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"valid file", good, false},
+		{"missing file", filepath.Join(dir, "nope.json"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, err := readIndexFile(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readIndexFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && len(idx.Groups) != 1 {
+				t.Errorf("readIndexFile() parsed %d groups, want 1", len(idx.Groups))
+			}
+		})
+	}
+}
+
+// TestRunOfflineDryRun exercises the full run() over a local fixture and
+// asserts it writes a deterministic report and returns no error (exit 0).
+func TestRunOfflineDryRun(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "index.json")
+	if err := os.WriteFile(indexPath, []byte(sampleIndex), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	reportPath := filepath.Join(dir, "report.md")
+
+	if err := run(context.Background(), reportPath, indexPath); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	report, err := os.ReadFile(reportPath) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	got := string(report)
+	// The committed eks training-kubeflow link resolves against the fixture; the
+	// other committed links (not in the fixture) are dead-link warnings.
+	if !strings.Contains(got, "`eks/h100-ubuntu/training-kubeflow` | ✅ resolved") {
+		t.Errorf("expected resolved row, got:\n%s", got)
+	}
+	if !strings.Contains(got, "dead link(s)") {
+		t.Errorf("expected dead-link warnings for uncovered committed links, got:\n%s", got)
+	}
+}
+
+// TestRunFetchFailureExitsZero asserts an unreadable live source produces a
+// fetch-failure report and no error (warning-only: exit 0).
+func TestRunFetchFailureExitsZero(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.md")
+
+	err := run(context.Background(), reportPath, filepath.Join(dir, "missing.json"))
+	if err != nil {
+		t.Fatalf("run() with unreadable live source must not error (warning-only), got %v", err)
+	}
+	report, err := os.ReadFile(reportPath) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(report), "Could not load live dashboard data") {
+		t.Errorf("expected fetch-failure note, got:\n%s", report)
+	}
+}
+
+func TestFetchIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name:    "2xx with body",
+			handler: func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(sampleIndex)) },
+			wantErr: false,
+		},
+		{
+			name:    "non-2xx rejected",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			idx, err := fetchIndex(context.Background(), srv.Client(), srv.URL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("fetchIndex() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && len(idx.Groups) != 1 {
+				t.Errorf("fetchIndex() parsed %d groups, want 1", len(idx.Groups))
+			}
+		})
+	}
+}
+
+func TestWriteReportToStdout(t *testing.T) {
+	// Empty reportOut renders to stdout; assert the branch runs without error.
+	err := writeReport("", func(w io.Writer) error {
+		_, wErr := w.Write([]byte("ok"))
+		return wErr
+	})
+	if err != nil {
+		t.Errorf("writeReport(stdout) error = %v", err)
+	}
+}
+
+func TestStateLabel(t *testing.T) {
+	tests := map[state]string{
+		stateResolved:          "resolved",
+		stateMissingButPresent: "missing-but-present",
+		stateNotYetLinked:      "not-yet-linked",
+		state("unknown"):       "unknown",
+	}
+	for st, want := range tests {
+		if got := stateLabel(st); !strings.Contains(got, want) {
+			t.Errorf("stateLabel(%q) = %q, want to contain %q", st, got, want)
+		}
+	}
+}
+
+func TestRealMainOffline(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "index.json")
+	if err := os.WriteFile(indexPath, []byte(sampleIndex), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	reportPath := filepath.Join(dir, "report.md")
+
+	withArgs(t, "testgrid-link-check", "-index-file", indexPath, "-report-out", reportPath)
+	if code := realMain(); code != 0 {
+		t.Errorf("realMain() = %d, want 0 (warning-only)", code)
+	}
+	if _, err := os.Stat(reportPath); err != nil {
+		t.Errorf("realMain() did not write the report: %v", err)
+	}
+}
+
+// withArgs swaps os.Args and resets the global flag set for one realMain call,
+// restoring both when the test ends.
+func withArgs(t *testing.T, args ...string) {
+	t.Helper()
+	orig := os.Args
+	origFlags := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = orig
+		flag.CommandLine = origFlags
+	})
+	os.Args = args
+	flag.CommandLine = flag.NewFlagSet(args[0], flag.ContinueOnError)
+}

--- a/tools/testgrid-link-check/workflow_test.go
+++ b/tools/testgrid-link-check/workflow_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// workflowPath is the RQ2 link-check workflow relative to this package.
+const workflowPath = "../../.github/workflows/testgrid-link-check.yaml"
+
+// linkCheckWorkflow is the subset of the workflow YAML the warning-only
+// contract is asserted against. actionlint (merge-gate.yaml) covers syntax;
+// this test pins the invariants the linter cannot express: read-only token, no
+// pull-request write, weekly schedule + dispatch, and the report-only run.
+type linkCheckWorkflow struct {
+	On          map[string]yaml.Node   `yaml:"on"`
+	Permissions map[string]string      `yaml:"permissions"`
+	Jobs        map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Permissions map[string]string `yaml:"permissions"`
+	Steps       []workflowStep    `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Uses string `yaml:"uses"`
+	Run  string `yaml:"run"`
+}
+
+func loadLinkCheckWorkflow(t *testing.T) linkCheckWorkflow {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(workflowPath))
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	var wf linkCheckWorkflow
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+	return wf
+}
+
+func TestWorkflowIsWarningOnlyAndReadOnly(t *testing.T) {
+	wf := loadLinkCheckWorkflow(t)
+
+	// Top-level token is read-only: contents is read, and no scope is write —
+	// a future `pull-requests: write` (or any other write) must fail this test.
+	if got := wf.Permissions["contents"]; got != "read" {
+		t.Errorf("top-level contents permission = %q, want read", got)
+	}
+	for scope, level := range wf.Permissions {
+		if level == "write" {
+			t.Errorf("top-level permission %q = write; the link-check bot must stay read-only", scope)
+		}
+	}
+
+	// Triggers: weekly schedule + manual dispatch (clone of bom-refresh).
+	if _, ok := wf.On["schedule"]; !ok {
+		t.Error("workflow is missing the weekly `schedule` trigger")
+	}
+	if _, ok := wf.On["workflow_dispatch"]; !ok {
+		t.Error("workflow is missing the `workflow_dispatch` trigger")
+	}
+
+	// Exactly one job, and it must not escalate to any write permission — the
+	// bot never opens a PR or edits the doc.
+	for name, job := range wf.Jobs {
+		for perm, level := range job.Permissions {
+			if level == "write" {
+				t.Errorf("job %q grants %s: write; the link-check bot must stay read-only", name, perm)
+			}
+		}
+		for _, step := range job.Steps {
+			if strings.Contains(step.Uses, "create-pull-request") {
+				t.Errorf("job %q uses create-pull-request; the link-check bot must never open a PR", name)
+			}
+		}
+	}
+}
+
+func TestWorkflowRunsLinkCheckToStepSummary(t *testing.T) {
+	wf := loadLinkCheckWorkflow(t)
+	var found bool
+	for _, job := range wf.Jobs {
+		for _, step := range job.Steps {
+			if strings.Contains(step.Run, "tools/testgrid-link-check") {
+				found = true
+				// Require the exact flag pairing, not merely both strings present:
+				// a step that wrote to stdout and mentioned GITHUB_STEP_SUMMARY
+				// elsewhere would otherwise pass while breaking report delivery.
+				if !strings.Contains(step.Run, `-report-out "$GITHUB_STEP_SUMMARY"`) {
+					t.Errorf(`link-check step must pass -report-out "$GITHUB_STEP_SUMMARY", got: %q`, step.Run)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("workflow never invokes tools/testgrid-link-check")
+	}
+}


### PR DESCRIPTION
## Summary

Turn the recipe-health matrix's `pending` Evidence column into deterministic deep-links into the evidence dashboard (validation.aicr.run) for recipes with a real dashboard presence (RQ1), and add a weekly, warning-only bot that verifies those links still resolve (RQ2).

## Motivation / Context

The Evidence column was a uniform literal `pending`. RQ1 makes it a stable, hermetic deep-link to each recipe's dashboard coordinate; RQ2 keeps those links honest without ever blocking a merge.

Fixes: #1283, #1284
Related: #1265 (parent), #1400 (dashboard)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`) — consumes shared `CoordinateFor` (no change to it)
- [x] Docs/examples (`docs/`)
- [x] Other: new `pkg/testgrid`, `tools/testgrid-link-check`, `tools/health` rendering, CI workflow

## Implementation Notes

**Scope pivot (per the issue comments):** links target the live GitHub Pages dashboard `validation.aicr.run`, not the deferred live TestGrid. Because the dashboard is a hash-routed SPA (a `GET` on the `/#/` fragment can't reveal coordinate presence), the RQ2 bot checks presence in the published `data/index.json`, not the fragment URL.

- **`pkg/testgrid`** (new): dashboard origin, hash-route link scheme (`LinkFor` over the shared `pkg/recipe.CoordinateFor`), the committed presence manifest `presence.yaml` (the 6 UAT-covered coordinates today), and `LivePaths` to read present coordinates from a parsed index. The generator reads the embedded manifest, so link construction is fully offline/hermetic and byte-deterministic; the coordinate carries no k8s version, so links survive version rolls.
- **RQ1 — `tools/health`:** the Evidence cell renders `[<path>](<link>)` for a recipe whose resolved coordinate is present, else honest `pending`. No status/count token. `docs/user/recipe-health.md` prose rewritten to explain the link, the author-asserted-provenance caveat, and coexistence with ADR-009's deferred in-cell freshness state; cross-links to the coverage matrix and dashboard.
- **RQ2 — `tools/testgrid-link-check` + `.github/workflows/testgrid-link-check.yaml`:** a clone of `bom-refresh` minus the PR step — weekly cron + dispatch, `contents: read`, report to `$GITHUB_STEP_SUMMARY`, always exits 0. Bounded HTTP client pinned to the dashboard origin with off-origin redirects refused and a `LimitReader`-bounded body. Classifies each linked coordinate `resolved` / `missing-but-present` (warn: dead link) / `not-yet-linked` (expected, not a warning). A Go workflow-structure test enforces the read-only / no-`create-pull-request` contract.

## Testing

```bash
go test -race ./pkg/testgrid/... ./tools/testgrid-link-check/... ./tools/health/...
golangci-lint run -c .golangci.yaml ./pkg/testgrid/... ./tools/testgrid-link-check/... ./tools/health/...
make recipe-health-check   # matrix is fresh
```

- All new tests pass with `-race`; `golangci-lint`, `go vet`, `yamllint`, and `actionlint` clean.
- Coverage: `pkg/testgrid` 94.6%, `tools/testgrid-link-check` 87.9%, `tools/health` 82.8% — all above the 75% floor, no new exported func at 0%.
- Verified all 6 committed links resolve against the **live** dashboard (`-index-file` fixture and real fetch).

## Risk Assessment

- [x] **Low** — Additive: new package + tool + advisory workflow; the only behavior change is doc rendering, and it degrades to `pending` if the manifest is absent.

**Rollout notes:** N/A. The bot is report-only and never blocks merges.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
