### PR TITLE
fix(validate): never emit evidence in --no-cluster dry-run mode

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -832,7 +832,7 @@ aicr validate [flags]
 | `--timeout` | | duration | 5m | Timeout for validation Job completion |
 | `--no-cleanup` | | bool | false | Skip removal of Job and RBAC resources on completion |
 | `--require-gpu` | | bool | false | Require GPU resources on the validation pod |
-| `--no-cluster` | | bool | false | Skip cluster access (test mode): skips RBAC and Job deployment, reports checks as skipped |
+| `--no-cluster` | | bool | false | Skip cluster access (test mode): skips RBAC and Job deployment, reports checks as skipped. An offline dry-run does not sign or push a recipe-evidence attestation, so `--emit-attestation`/`--push` and `spec.validate.evidence.attestation` are ignored in this mode. Cannot be combined with `--cncf-submission` (that collector requires a live cluster); `--evidence-dir` conformance markdown is still rendered locally |
 | `--evidence-dir` | | string | | Directory to write conformance evidence artifacts |
 | `--cncf-submission` | | bool | false | Generate CNCF conformance submission artifacts |
 | `--feature` | `-f` | string[] | | CNCF evidence-collection feature(s) to scope (repeatable). Valid names: `dra-support`, `gang-scheduling`, `secure-access`, `accelerator-metrics`, `ai-service-metrics`, `inference-gateway`, `robust-operator`, `pod-autoscaling`, `cluster-autoscaling`. Empty selects all features. |

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -617,6 +617,10 @@ Run validation without failing on check errors (informational mode):
 			evidenceDir := stringFlagOrConfig(cmd, "evidence-dir", cncfCfg.Dir)
 			cncfSubmission := boolFlagOrConfig(cmd, "cncf-submission", cncfCfg.CNCFSubmission)
 			features := stringSliceFlagOrConfig(cmd, "feature", cncfCfg.Features)
+			// Resolved once here (flag > config) and reused by the guards below and
+			// the mode banner further down.
+			noCluster := boolFlagOrConfig(cmd, "no-cluster", resolved.NoCluster)
+			explicitAttest := cmd.IsSet("emit-attestation") || cmd.IsSet(flagPush)
 
 			// Validate flag combinations.
 			if cncfSubmission && evidenceDir == "" {
@@ -624,6 +628,27 @@ Run validation without failing on check errors (informational mode):
 			}
 			if len(features) > 0 && !cncfSubmission {
 				return errors.New(errors.ErrCodeInvalidRequest, "--feature requires --cncf-submission")
+			}
+			// --cncf-submission deploys GPU workloads and collects behavioral
+			// evidence against the active kube-context, so it is incompatible with
+			// the offline --no-cluster dry-run. The short-circuit below reaches the
+			// live-cluster collector directly, bypassing the noCluster handling
+			// further down, so reject the combination here rather than silently
+			// contacting the cluster.
+			if cncfSubmission && noCluster {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					"--cncf-submission cannot be combined with --no-cluster: the behavioral evidence collector requires a live cluster")
+			}
+			// An explicit --emit-attestation/--push is a request to sign and
+			// (optionally) push an attestation; --no-cluster is an offline dry-run
+			// whose checks are all skipped, so the two conflict. Reject the
+			// explicit combination rather than warn-and-ignore an explicit CLI flag
+			// (repo rule) — consistent with the --cncf-submission guard above. A
+			// config-driven spec.validate.evidence.attestation is still silently
+			// suppressed in --no-cluster mode by evidenceConfigForRunMode below.
+			if noCluster && explicitAttest {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					"--emit-attestation/--push cannot be combined with --no-cluster: an offline dry-run must not sign or push an attestation")
 			}
 
 			// Short-circuit: --cncf-submission bypasses normal validation and runs
@@ -657,7 +682,6 @@ Run validation without failing on check errors (informational mode):
 
 			failOnError := boolFlagOrConfig(cmd, "fail-on-error", derefBoolOr(resolved.FailOnError, true))
 			failFast := boolFlagOrConfig(cmd, "fail-fast", derefBoolOr(resolved.FailFast, false))
-			noCluster := boolFlagOrConfig(cmd, "no-cluster", resolved.NoCluster)
 
 			// Mode banner: make it explicit whether this run touches a live
 			// cluster (issue #1383). --no-cluster is an offline dry-run that
@@ -758,7 +782,7 @@ Run validation without failing on check errors (informational mode):
 					"cleanupHint", "kubectl delete clusterrolebinding -l app.kubernetes.io/name=aicr-validator")
 			}
 
-			evidenceCfg := buildRecipeEvidenceConfig(cmd, resolved)
+			evidenceCfg := evidenceConfigForRunMode(noCluster, buildRecipeEvidenceConfig(cmd, resolved))
 
 			return runValidation(ctx, client, rec, snap, validationConfig{
 				phases:                phases,

--- a/pkg/cli/validate_evidence.go
+++ b/pkg/cli/validate_evidence.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"log/slog"
 	"os"
 
 	"github.com/urfave/cli/v3"
@@ -80,6 +81,28 @@ func buildRecipeEvidenceConfig(cmd *cli.Command, resolved *config.ValidateResolv
 		OIDCResolve: oidcResolveOptionsFromFlags(cmd),
 		AssumeYes:   cmd.Bool(flagAssumeYes),
 	}
+}
+
+// evidenceConfigForRunMode suppresses CONFIG-DRIVEN recipe-evidence emission in
+// --no-cluster mode. (An explicit --emit-attestation/--push alongside
+// --no-cluster is rejected upstream with ErrCodeInvalidRequest — an explicit CLI
+// flag must not be warn-and-ignored; this path handles only
+// spec.validate.evidence.attestation resolved from config.) An offline dry-run
+// reports every check as "skipped", so an emitted attestation would attest to
+// nothing. Worse, when the config sets attestation.{out,push} (as the UAT test
+// configs do), a dry-run would sign and push a bundle to the same OCI repo the
+// authoritative live-cluster validate later pushes to — leaving two
+// independently-signed bundles whose digests differ, which breaks `aicr evidence
+// verify`: the signed subject no longer matches the pulled run-tagged artifact.
+// A dry-run must never emit signed evidence, so drop the config and log once.
+// Returns cfg unchanged for a live-cluster run (including cfg == nil).
+func evidenceConfigForRunMode(noCluster bool, cfg *recipeEvidenceConfig) *recipeEvidenceConfig {
+	if noCluster && cfg != nil {
+		slog.Warn("skipping evidence emission: --no-cluster is an offline dry-run and must not sign or push an attestation",
+			"emitAttestation", cfg.OutDir, "push", cfg.Push)
+		return nil
+	}
+	return cfg
 }
 
 // oidcResolveOptionsFromFlags builds the keyless-signing OIDC resolution

--- a/pkg/cli/validate_evidence_test.go
+++ b/pkg/cli/validate_evidence_test.go
@@ -189,3 +189,33 @@ func TestBuildRecipeEvidenceConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestEvidenceConfigForRunMode(t *testing.T) {
+	cfg := &recipeEvidenceConfig{
+		OutDir: "/tmp/out",
+		Push:   "ghcr.io/nvidia/aicr-evidence/example",
+	}
+	tests := []struct {
+		name      string
+		noCluster bool
+		cfg       *recipeEvidenceConfig
+		wantNil   bool
+	}{
+		{"live cluster keeps emit config", false, cfg, false},
+		{"no-cluster drops emit config", true, cfg, true},
+		{"live cluster nil stays nil", false, nil, true},
+		{"no-cluster nil stays nil", true, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evidenceConfigForRunMode(tt.noCluster, tt.cfg)
+			if (got == nil) != tt.wantNil {
+				t.Fatalf("evidenceConfigForRunMode() nil = %v, want nil = %v", got == nil, tt.wantNil)
+			}
+			// A live-cluster run must pass the config through unchanged.
+			if !tt.noCluster && tt.cfg != nil && got != tt.cfg {
+				t.Errorf("live-cluster run mutated the evidence config: got %+v, want %+v", got, tt.cfg)
+			}
+		})
+	}
+}

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/NVIDIA/aicr/pkg/errors"
 	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 )
 
@@ -205,6 +207,12 @@ func TestValidateCmd_CNCFSubmissionFlagValidation(t *testing.T) {
 			wantErr:    true,
 			errContain: "unknown feature",
 		},
+		{
+			name:       "cncf-submission with no-cluster",
+			args:       []string{"aicr", "validate", "--cncf-submission", "--evidence-dir", "/tmp/test", "--no-cluster"},
+			wantErr:    true,
+			errContain: "--cncf-submission cannot be combined with --no-cluster",
+		},
 	}
 
 	for _, tt := range tests {
@@ -221,10 +229,53 @@ func TestValidateCmd_CNCFSubmissionFlagValidation(t *testing.T) {
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if tt.wantErr && tt.errContain != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.errContain) {
+			if tt.wantErr {
+				// Every flag-combination rejection in this command is a
+				// well-formed-but-invalid request, so assert the structured
+				// code (not just the message text) — a wrong code would map to
+				// the wrong HTTP status / exit behavior for library callers.
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+				}
+				if tt.errContain != "" && (err == nil || !strings.Contains(err.Error(), tt.errContain)) {
 					t.Errorf("error = %v, want error containing %q", err, tt.errContain)
 				}
+			}
+		})
+	}
+}
+
+// TestValidateCmd_NoClusterEvidenceFlags asserts that explicitly requesting an
+// attestation (--emit-attestation / --push) alongside the offline --no-cluster
+// dry-run is rejected with ErrCodeInvalidRequest, rather than warn-and-ignored.
+// (Config-driven suppression is a separate path — see evidenceConfigForRunMode.)
+func TestValidateCmd_NoClusterEvidenceFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "emit-attestation with no-cluster",
+			args: []string{"aicr", "validate", "--no-cluster", "--emit-attestation", "/tmp/out"},
+		},
+		{
+			name: "push with no-cluster",
+			args: []string{"aicr", "validate", "--no-cluster", "--emit-attestation", "/tmp/out", "--push", "ghcr.io/x/y"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := validateCmd()
+			app := &cli.Command{Name: "aicr", Commands: []*cli.Command{cmd}}
+			err := app.Run(t.Context(), tt.args)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+			}
+			if !strings.Contains(err.Error(), "cannot be combined with --no-cluster") {
+				t.Errorf("error = %v, want a combined-with-no-cluster message", err)
 			}
 		})
 	}

--- a/tests/uat/lib/phases.sh
+++ b/tests/uat/lib/phases.sh
@@ -170,11 +170,30 @@ phase_prep() {
   echo "::endgroup::"
 
   echo "::group::Validate (dry-run, --no-cluster)"
-  "${AICR_BIN}" validate \
-    --config "${config}" \
-    --phase deployment \
-    --no-cluster \
-    --output dry-run.json
+  # Validate against a copy of the config with spec.validate.evidence stripped so
+  # the offline dry-run cannot emit/sign/push an evidence bundle. --no-cluster
+  # reports every check as "skipped", so an attestation would attest to nothing;
+  # worse, with evidence.attestation.{out,push} set (as UAT configs are) the
+  # dry-run would sign and push a bundle to the same OCI repo the conformance
+  # phase's authoritative validate later pushes to, leaving two independently-
+  # signed bundles and breaking `evidence verify` (signed subject != pulled
+  # run-tagged digest). Mirrors the readiness-gate strip in phase_conformance.
+  # Belt-and-suspenders with the CLI's own --no-cluster guard: this keeps prep
+  # safe even against an older released aicr that lacks that guard.
+  # Run in a subshell with an EXIT trap so the temp config is removed on every
+  # exit path (normal return, set -e abort on validate failure, interrupt),
+  # mirroring the signing subshell below. A non-zero validate rc propagates out
+  # of the subshell and aborts prep under set -e, as before.
+  (
+    prep_config="$(mktemp)"
+    trap 'rm -f "${prep_config}"' EXIT
+    yq 'del(.spec.validate.evidence)' "${config}" > "${prep_config}"
+    "${AICR_BIN}" validate \
+      --config "${prep_config}" \
+      --phase deployment \
+      --no-cluster \
+      --output dry-run.json
+  )
   test -f dry-run.json
   echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

`validate --no-cluster` (an offline dry-run) still emitted and signed a full evidence bundle when the config set `spec.validate.evidence.attestation.*`, writing `attestation.intoto.jsonl` into the shared evidence output dir. In the UAT flow this lets the prep phase's leftover signature get packed into the authoritative run-tag artifact, which breaks `aicr evidence verify` and the `Evidence: Ingest` job with a signed-subject/pulled-digest mismatch.

## Motivation / Context

The UAT emit output dir is `attestation.out: ./evidence`, shared across phases in the runner workspace.

1. `prep` runs `validate --no-cluster` (dry-run, all checks `skipped`). It still honored the config's evidence block, signed a bundle to the aicr content-hash tag (`…-59266d32abc3`, digest `d3466f4c…`), and left `attestation.intoto.jsonl` (subject = `d3466f4c…`) in `./evidence/`.
2. `conformance` then runs the authoritative `validate --phase all`, which re-packs `./evidence/` into the `run-<id>` artifact (`2a486d77…`). The closed-world pack sweeps in prep's stale `attestation.intoto.jsonl`, so **the run-tag artifact embeds a signature for a foreign subject** (`d3466f4c…`, not `2a486d77…`).
3. Normally the conformance emit's own Sigstore **referrer overwrites** the staged attestation at verify time, masking this. On the failing run the referrer push hit GHCR timeouts and never attached, so `MaterializeBundle` found no referrer to overwrite the embedded stale file, and `VerifySignature` read the embedded `d3466f4c` attestation → mismatch.

Directly confirmed against the registry:
- `oras pull …@sha256:2a486d77…` → the artifact **embeds `attestation.intoto.jsonl`**, and its DSSE payload signs subject `d3466f4c…` (prep's content-tag ref).
- `oras discover …@sha256:2a486d77…` → **zero referrers** (the conformance signature never attached).

This is why it is intermittent / "new": it needs prep's stale attestation (present on every emit-enabled config) **and** the conformance referrer failing to attach (a GHCR write hiccup). Healthy runs overwrite the stale file via the referrer and pass — which is why the H100/release cells are green. Observed on run 29611408651 (verify) and 29619695743 (ingest). An offline dry-run over an all-`skipped` run attests to nothing, so it should never sign or write an attestation in the first place.

Fixes: N/A
Related: #1793 (@main verify regression since #1758 closed-world pack)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT harness (`tests/uat/lib/phases.sh`)

## Implementation Notes

Two layers so a dry-run can never leave a signed attestation behind:

1. **CLI (authoritative):** `evidenceConfigForRunMode` drops the recipe-evidence config whenever `--no-cluster` is set, so an offline dry-run can never sign, push, or write `attestation.intoto.jsonl`, regardless of config. Logs once when it suppresses emission.
2. **UAT harness (belt-and-suspenders):** the `prep` phase validates against a config copy with `spec.validate.evidence` stripped (mirroring the readiness-gate strip already used in the conformance phase). Keeps `prep` safe even against an older released `aicr` that predates the CLI guard.

With prep no longer emitting, `./evidence/` holds no stale attestation for the conformance pack to embed, so the run-tag artifact carries only its own signature. Producer-side fix — no change needed in verify/ingest.

Possible follow-up (out of scope): have the emit exclude any pre-existing `attestation.intoto.jsonl` from the pack, and/or have `MaterializeBundle` prefer the referrer over an embedded attestation — defense-in-depth against any stray signed file in the output dir.

## Testing

```bash
go build ./pkg/cli/...
go test ./pkg/cli/ -count=1            # ok (incl. new TestEvidenceConfigForRunMode)
golangci-lint run -c .golangci.yaml ./pkg/cli/...   # 0 issues
shellcheck -x tests/uat/lib/phases.sh  # clean (SC1091 info only)
```

Added `TestEvidenceConfigForRunMode` covering live-cluster pass-through, `--no-cluster` suppression, and nil-in/nil-out. Verified the mechanism against the live registry with `oras pull` / `oras discover` (see Motivation).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Behavior change is limited to `--no-cluster` runs, which are dry-runs that should not have been producing evidence; live-cluster validate (the only path that emits authoritative evidence) is unchanged. Backwards compatible.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — ran `go test ./pkg/cli/`
- [x] Linter passes (`make lint`) — `golangci-lint` 0 issues on `pkg/cli`
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
