### PR TITLE
fix(validator): gate GPU readiness on runtime-required taint clearance

### DIFF
--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -57,6 +57,32 @@ const (
 	draKubeletPluginSuffix = "-kubelet-plugin"
 
 	nodewrightCompleteState = "complete"
+
+	// runtimeRequiredTaintKey / runtimeRequiredTaintValue identify the
+	// workload-gate taint the nodewright (skyhook) operator manages for Skyhook
+	// CRs with runtimeRequired: true (see tuning.yaml `runtimeRequired: true`).
+	//
+	// Why gate on this taint and not status.status: a GPU node joins carrying
+	// this NoSchedule taint, and the operator removes it once *all*
+	// runtime-required Skyhooks targeting that node are complete *on that node*
+	// (per-node, not per-package). Unlike status.status — an aggregate over
+	// (packages × matching nodes) that re-opens to in_progress on every package
+	// reboot and each newly-joined node — the taint is applied once and removed
+	// once as the monotone terminal step, so "taint absent" is a durable
+	// "done, won't reboot again" signal rather than a probabilistic settling
+	// heuristic (see issue #1775). Note the operator re-applies the taint across
+	// reboots only when configured with REAPPLY_ON_REBOOT/reapplyOnReboot=true
+	// (the gke-cos and bcm overlays); on those the taint flaps like the status
+	// and the stability window rides through it, so gating on the taint is never
+	// weaker than gating on the status.
+	//
+	// Values match the skyhook chart's default
+	// controllerManager.manager.env.runtimeRequiredTaint
+	// (skyhook.nvidia.com=runtime-required:NoSchedule), which AICR ships
+	// unchanged and the UAT GPU node pools pre-taint with verbatim
+	// (tests/uat/aws/cluster-config.yaml).
+	runtimeRequiredTaintKey   = "skyhook.nvidia.com"
+	runtimeRequiredTaintValue = "runtime-required"
 )
 
 var (
@@ -437,27 +463,66 @@ func verifyNodewrightReady(ctx *validators.Context, ref recipe.ComponentRef) err
 		return err
 	}
 
-	// Poll status.status until every expected Skyhook CR reports "complete"
-	// continuously for the stability window, or the budget elapses. status.status
-	// is non-monotonic during tuning: a reboot (or a newly-joined GPU node)
-	// re-opens it to in_progress, so a single sample is not terminal. Polling
-	// rides through the reboot flaps rather than failing the whole deployment
-	// phase on a transient in_progress. See pkg/defaults GPUReadiness* for sizing.
+	// Poll two signals until both hold continuously for the stability window, or
+	// the budget elapses:
+	//
+	//  1. Every expected Skyhook CR reports status.status == "complete".
+	//  2. No node still carries the runtime-required NoSchedule taint the
+	//     operator removes as its monotone terminal step.
+	//
+	// status.status alone is non-monotonic during tuning: a reboot (or a
+	// newly-joined GPU node) re-opens it to in_progress, and — worse — it can
+	// momentarily read "complete" in the lull between two package reboots while
+	// tuning is still in flight, which is exactly how the gate certified a
+	// cluster ready and then had tuning re-open post-gate (issue #1775). Adding
+	// the taint gate closes that hole: during such a lull the runtime-required
+	// taint is still present, so the probe stays unhealthy until tuning is truly
+	// done on every node. Polling rides through the reboot flaps rather than
+	// failing the deployment phase on a transient in_progress / re-taint. See
+	// pkg/defaults GPUReadiness* for sizing.
 	return pollUntilStable(ctx,
-		fmt.Sprintf("%d expected Nodewright(s)", len(expectedNames)),
+		fmt.Sprintf("%d expected Nodewright(s) + runtime-required taint clearance", len(expectedNames)),
 		func() error {
-			failures := nodewrightStatusFailures(ctx, dynClient, expectedNames)
+			// The Skyhook status Gets and the node-list taint scan are
+			// independent read-only calls, so fan them out (per repo CLAUDE.md
+			// "Sequential calls to N independent read-only K8s APIs → fan-out
+			// with errgroup") rather than paying both round-trips serially every
+			// poll iteration.
+			var statusFailures, taintFailures []string
+			var taintErr error
+			g := new(errgroup.Group)
+			g.Go(func() error {
+				statusFailures = nodewrightStatusFailures(ctx, dynClient, expectedNames)
+				return nil
+			})
+			g.Go(func() error {
+				taintFailures, taintErr = runtimeRequiredTaintFailures(ctx)
+				return nil
+			})
+			_ = g.Wait()
+
+			if taintErr != nil {
+				// A transient node-list failure (e.g. an apiserver hiccup while
+				// a GPU node reboots) must not be read as "taint absent". Return
+				// it so the poll resets the dwell and retries — fail closed.
+				return taintErr
+			}
+			failures := make([]string, 0, len(statusFailures)+len(taintFailures))
+			failures = append(failures, statusFailures...)
+			failures = append(failures, taintFailures...)
 			if len(failures) == 0 {
 				return nil
 			}
 			return errors.New(errors.ErrCodeInternal,
-				fmt.Sprintf("%d of %d expected Nodewright(s) not ready:\n  %s",
-					len(failures), len(expectedNames), strings.Join(failures, "\n  ")))
+				fmt.Sprintf("%d Nodewright readiness signal(s) not settled:\n  %s",
+					len(failures), strings.Join(failures, "\n  ")))
 		},
 		func() {
 			for _, name := range expectedNames {
 				fmt.Printf("  Nodewright %s: %s (stable ≥%s)\n", name, nodewrightCompleteState, gpuReadinessStabilityWindow)
 			}
+			fmt.Printf("  Nodewright runtime-required taint (%s=%s:%s): cleared from all nodes (stable ≥%s)\n",
+				runtimeRequiredTaintKey, runtimeRequiredTaintValue, corev1.TaintEffectNoSchedule, gpuReadinessStabilityWindow)
 		})
 }
 
@@ -513,6 +578,60 @@ func nodewrightStatusFailure(verifyCtx context.Context, dynClient dynamic.Interf
 		return fmt.Sprintf("Nodewright %s: status=%s (want %s)", name, status, nodewrightCompleteState)
 	}
 	return ""
+}
+
+// runtimeRequiredTaintFailures lists cluster nodes and returns a failure string
+// for each that still carries the nodewright (skyhook) runtime-required
+// NoSchedule taint — the durable "tuning not yet complete on this node" signal
+// (see runtimeRequiredTaintKey). An empty slice means the taint is cleared from
+// every node (or was never applied, e.g. a Skyhook without runtimeRequired:
+// true), so this gate is a no-op when the recipe does not opt into the feature.
+//
+// A List error (transient apiserver failure, RBAC gap) is returned so the
+// caller fails closed: "could not list nodes" must never be read as "taint
+// absent". The error rides through the poll's dwell reset like any other
+// unhealthy sample.
+func runtimeRequiredTaintFailures(ctx *validators.Context) ([]string, error) {
+	listCtx, cancel := ctx.Timeout(defaults.ResourceVerificationTimeout)
+	defer cancel()
+
+	nodes, err := ctx.Clientset.CoreV1().Nodes().List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal,
+			"failed to list nodes for the nodewright runtime-required taint gate", err)
+	}
+
+	var failures []string
+	for i := range nodes.Items {
+		// Honor cancellation while walking a potentially large node list, per
+		// repo CLAUDE.md "Always check ctx.Done() in long-running operations".
+		select {
+		case <-listCtx.Done():
+			return nil, errors.Wrap(errors.ErrCodeTimeout,
+				"canceled while scanning nodes for the nodewright runtime-required taint gate", listCtx.Err())
+		default:
+		}
+		node := &nodes.Items[i]
+		for j := range node.Spec.Taints {
+			if isRuntimeRequiredTaint(&node.Spec.Taints[j]) {
+				failures = append(failures, fmt.Sprintf(
+					"node %s: still carries the runtime-required taint %s=%s:%s (nodewright tuning not complete on this node)",
+					node.Name, runtimeRequiredTaintKey, runtimeRequiredTaintValue, corev1.TaintEffectNoSchedule))
+				break
+			}
+		}
+	}
+	return failures, nil
+}
+
+// isRuntimeRequiredTaint reports whether t is the nodewright (skyhook)
+// runtime-required workload-gate taint. It matches on key+value and requires the
+// NoSchedule effect so an unrelated taint that happens to share the key cannot
+// mask an in-flight tuning.
+func isRuntimeRequiredTaint(t *corev1.Taint) bool {
+	return t.Key == runtimeRequiredTaintKey &&
+		t.Value == runtimeRequiredTaintValue &&
+		t.Effect == corev1.TaintEffectNoSchedule
 }
 
 // expectedNodewrightNames derives the set of Nodewright CR names that this

--- a/validators/deployment/expected_resources_poll_test.go
+++ b/validators/deployment/expected_resources_poll_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	stderrors "errors"
 	"os"
 	"strings"
 	"sync"
@@ -27,6 +28,7 @@ import (
 	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -101,6 +103,101 @@ func TestVerifyNodewrightReady_Poll(t *testing.T) {
 				t.Fatalf("expected the poll to sample the CR at least %d times (through the reboot), got %d", tt.minGets, got)
 			}
 		})
+	}
+}
+
+// TestVerifyNodewrightReady_RidesThroughRuntimeRequiredTaint proves the taint
+// gate is polled, not sampled once: with every expected Skyhook CR already
+// "complete", the check still stays closed while a node carries the
+// runtime-required taint and only passes once the operator removes it (the
+// monotone terminal step). The last-observed taint is surfaced when it never
+// clears within the budget.
+func TestVerifyNodewrightReady_RidesThroughRuntimeRequiredTaint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		tainted    []bool // per-List: whether gpu-node-0 still carries the taint (last repeats)
+		wantErrSub string // "" => expect success
+		minLists   int
+	}{
+		{
+			name:     "rides through a lingering taint that clears",
+			tainted:  []bool{true, true, false},
+			minLists: 3,
+		},
+		{
+			name:       "times out while the taint persists",
+			tainted:    []bool{true},
+			wantErrSub: "node gpu-node-0: still carries the runtime-required taint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ref := recipe.ComponentRef{Name: nodewrightCustomizationsComponent, Namespace: "skyhook", ManifestFiles: []string{testNodewrightManifest}}
+			// Skyhook CR is always complete; the taint is the only gating signal.
+			dyn := newFlippingDynamicClient("tuning", []string{nodewrightCompleteState})
+			ctx := newDeploymentTestContextWithDynamic(t,
+				[]runtime.Object{activeNamespace("skyhook")}, dyn, []recipe.ComponentRef{ref})
+
+			taintSeq := tt.tainted
+			var lists int32
+			ctx.Clientset.(*k8sfake.Clientset).PrependReactor("list", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+				idx := int(atomic.AddInt32(&lists, 1)) - 1
+				if idx >= len(taintSeq) {
+					idx = len(taintSeq) - 1
+				}
+				node := nodeWithTaints("gpu-node-0")
+				if taintSeq[idx] {
+					node = nodeWithRuntimeRequiredTaint("gpu-node-0")
+				}
+				return true, &corev1.NodeList{Items: []corev1.Node{*node}}, nil
+			})
+
+			err := verifyNodewrightReady(ctx, ref)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("verifyNodewrightReady() error = nil, want error containing %q", tt.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Fatalf("verifyNodewrightReady() error = %v, want substring %q", err, tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("verifyNodewrightReady() error = %v, want nil (should ride through the lingering taint)", err)
+			}
+			if got := int(atomic.LoadInt32(&lists)); got < tt.minLists {
+				t.Fatalf("expected the poll to list nodes at least %d times (through the taint), got %d", tt.minLists, got)
+			}
+		})
+	}
+}
+
+// TestRuntimeRequiredTaintFailures_FailsClosedOnListError proves a node-list
+// failure is surfaced (not read as "taint absent"), so the poll fails closed and
+// retries rather than certifying readiness on missing data.
+func TestRuntimeRequiredTaintFailures_FailsClosedOnListError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	clientset.PrependReactor("list", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, stderrors.New("apiserver unavailable")
+	})
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	failures, err := runtimeRequiredTaintFailures(ctx)
+	if err == nil {
+		t.Fatal("expected an error when listing nodes fails, got nil (must fail closed)")
+	}
+	if failures != nil {
+		t.Fatalf("expected nil failures on list error, got %v", failures)
+	}
+	if !strings.Contains(err.Error(), "failed to list nodes for the nodewright runtime-required taint gate") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/validators/deployment/expected_resources_test.go
+++ b/validators/deployment/expected_resources_test.go
@@ -326,6 +326,73 @@ func TestCheckExpectedResources_IgnoresStaleUnrelatedNodewright(t *testing.T) {
 	}
 }
 
+// TestCheckExpectedResources_FailsWhenRuntimeRequiredTaintPresent proves the
+// readiness gate stays closed while a GPU node still carries the nodewright
+// runtime-required NoSchedule taint, even though every expected Skyhook CR
+// already reports status.status == "complete". This is the issue #1775 race:
+// status.status momentarily reads "complete" in the lull between two package
+// reboots, but the durable taint is still present because tuning is not truly
+// done on the node.
+func TestCheckExpectedResources_FailsWhenRuntimeRequiredTaintPresent(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("skyhook"),
+			nodeWithRuntimeRequiredTaint("gpu-node-0"),
+		},
+		[]runtime.Object{
+			nodewrightWithStatus("tuning", nodewrightCompleteState),
+		},
+		[]recipe.ComponentRef{
+			{Name: nodewrightCustomizationsComponent, Namespace: "skyhook", ManifestFiles: []string{testNodewrightManifest}},
+		},
+	)
+
+	err := checkExpectedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error while a node still carries the runtime-required taint")
+		return
+	}
+	if !strings.Contains(err.Error(), "node gpu-node-0: still carries the runtime-required taint") {
+		t.Fatalf("expected runtime-required taint failure, got: %v", err)
+		return
+	}
+}
+
+// TestCheckExpectedResources_PassesWhenRuntimeRequiredTaintCleared proves the
+// gate opens once the taint is removed from every node — including nodes that
+// carry only unrelated taints, which must not gate.
+func TestCheckExpectedResources_PassesWhenRuntimeRequiredTaintCleared(t *testing.T) {
+	t.Parallel()
+
+	ctx := newDeploymentTestContext(t,
+		[]runtime.Object{
+			activeNamespace("skyhook"),
+			// A GPU node whose tuning finished (taint removed) but still carries
+			// the workload dedication taint it was provisioned with.
+			nodeWithTaints("gpu-node-0", corev1.Taint{
+				Key: "dedicated", Value: "user-workload", Effect: corev1.TaintEffectNoSchedule,
+			}),
+			// A control-plane node with the standard master taint.
+			nodeWithTaints("control-plane-0", corev1.Taint{
+				Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule,
+			}),
+		},
+		[]runtime.Object{
+			nodewrightWithStatus("tuning", nodewrightCompleteState),
+		},
+		[]recipe.ComponentRef{
+			{Name: nodewrightCustomizationsComponent, Namespace: "skyhook", ManifestFiles: []string{testNodewrightManifest}},
+		},
+	)
+
+	if err := checkExpectedResources(ctx); err != nil {
+		t.Fatalf("checkExpectedResources() error = %v, want nil once the runtime-required taint is cleared", err)
+		return
+	}
+}
+
 // TestCheckExpectedResources_FailsWhenNoExpectedNodewrightNames pins the
 // fail-closed behavior when an enabled nodewright-customizations ref declares
 // no manifest files (or the manifests contain no Nodewright CRs). Rather than
@@ -694,6 +761,50 @@ func TestExtractNodewrightNamesFromManifest_TuningGke(t *testing.T) {
 	}
 }
 
+// TestIsRuntimeRequiredTaint pins the matcher: only the exact key+value with the
+// NoSchedule effect gates. A taint that shares the key but differs in value or
+// effect must not be mistaken for an in-flight tuning (or the gate would block
+// forever on an unrelated taint).
+func TestIsRuntimeRequiredTaint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		taint corev1.Taint
+		want  bool
+	}{
+		{
+			name:  "exact runtime-required NoSchedule",
+			taint: corev1.Taint{Key: runtimeRequiredTaintKey, Value: runtimeRequiredTaintValue, Effect: corev1.TaintEffectNoSchedule},
+			want:  true,
+		},
+		{
+			name:  "right key+value but NoExecute effect",
+			taint: corev1.Taint{Key: runtimeRequiredTaintKey, Value: runtimeRequiredTaintValue, Effect: corev1.TaintEffectNoExecute},
+			want:  false,
+		},
+		{
+			name:  "right key but different value",
+			taint: corev1.Taint{Key: runtimeRequiredTaintKey, Value: "something-else", Effect: corev1.TaintEffectNoSchedule},
+			want:  false,
+		},
+		{
+			name:  "unrelated dedication taint",
+			taint: corev1.Taint{Key: "dedicated", Value: "user-workload", Effect: corev1.TaintEffectNoSchedule},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isRuntimeRequiredTaint(&tt.taint); got != tt.want {
+				t.Errorf("isRuntimeRequiredTaint(%+v) = %v, want %v", tt.taint, got, tt.want)
+			}
+		})
+	}
+}
+
 func stringSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -1051,6 +1162,24 @@ func unreadyDaemonSet(namespace, name string, desired, ready int32) *appsv1.Daem
 			NumberReady:            ready,
 		},
 	}
+}
+
+// nodeWithTaints builds a Node fixture carrying the given taints.
+func nodeWithTaints(name string, taints ...corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Taints: taints},
+	}
+}
+
+// nodeWithRuntimeRequiredTaint builds a Node fixture carrying the nodewright
+// runtime-required NoSchedule taint the readiness gate blocks on.
+func nodeWithRuntimeRequiredTaint(name string) *corev1.Node {
+	return nodeWithTaints(name, corev1.Taint{
+		Key:    runtimeRequiredTaintKey,
+		Value:  runtimeRequiredTaintValue,
+		Effect: corev1.TaintEffectNoSchedule,
+	})
 }
 
 // nodewrightWithStatus builds a Nodewright fixture. Nodewright is a cluster-scoped CR,


### PR DESCRIPTION
## Summary

Gate the deployment-phase GPU readiness check on the durable **runtime-required taint** being cleared, not just the non-monotonic `Skyhook status.status`.

## Motivation / Context

The readiness gate keyed off `Skyhook status.status`, which is non-monotonic during nodewright tuning: it aggregates over (packages × GPU nodes) and re-opens to `in_progress` on each package reboot, and can momentarily read `complete` in the lull between two package reboots while tuning is still in flight. The gate could therefore certify a cluster "ready" and then have tuning re-open, producing intermittent downstream failures in the conformance phase (RCA of the two UAT-AWS `expected-resources` failures behind runs `29393800033` / `29402956254`).

The durable terminal signal is the `skyhook.nvidia.com=runtime-required:NoSchedule` taint the nodewright (skyhook) operator applies when a GPU node joins and removes **once per node** when every `runtimeRequired: true` skyhook completes on that node. Per the operator's `runtime_required` docs, that removal is a per-node monotone terminal step that bridges the package reboots (it flaps only when `reapplyOnReboot=true`, which the failing `tuning.yaml` recipe does not set — only the `gke-cos`/`bcm` overlays do, and there the existing stability window rides through). So "taint absent + stable" is a stronger "done, won't reboot again" signal than the status. This resolves the open question in the issue.

Fixes: #1775
Related: #1764 (debug bundle that captured the taint timeline)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Other: `validators/deployment` (deployment-phase readiness pre-flight) + its tests

## Implementation Notes

- `verifyNodewrightReady` now polls **two** signals to stability instead of one: every expected Skyhook CR `status.status == complete` **and** no node still carries the runtime-required NoSchedule taint. During the between-reboot lull the taint is still present, so the probe stays unhealthy until tuning is truly done on every node.
- A node-list error is returned so the poll **fails closed** (resets its dwell and retries) — "could not list nodes" must never be read as "taint absent".
- When the Skyhook CRD is not registered, the check still skips early, so a cluster without the operator is unaffected.
- Scoped to the Go pre-flight (the gate the UAT runner loop actually blocks on). Fixing it also fixes the downstream chainsaw `validate-skyhook-cr-complete` failure, since the Go gate and chainsaw run back-to-back in one `checkExpectedResources` — the CR is stably `complete` by the time chainsaw runs. The chainsaw assert and stability window (issue directions 2/3, framed as optional) are intentionally left unchanged.

## Testing

```bash
go test -race ./validators/deployment/...              # ok
golangci-lint run -c .golangci.yaml ./validators/deployment/...   # 0 issues
```

New tests: taint matcher table test; gate fails while a node is tainted despite `status: complete` (the race); gate passes once cleared while ignoring unrelated taints; poll rides through a lingering-then-cleared taint and times out while it persists; node-list error fails closed. New functions are 100% covered.

## Risk Assessment

- [x] **Low** — Isolated to the deployment-phase readiness pre-flight, additive (strictly stricter) gating, well-tested, easy to revert. No user-facing surface changes.

**Rollout notes:** N/A. The gate can only stay closed *longer* than before (until the taint clears); it never opens earlier. Clusters without the skyhook operator/CRD are unaffected (early skip).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — internal readiness-gate behavior, no user-facing surface)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
