### PR TITLE
evidence(eks): rtx-pro-6000 inference-dynamo recipe evidence

### DIFF
--- a/recipes/evidence/rtx-pro-6000-eks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-3ec33498d3df68b688ae96280634c1a4403b7502a49016be54aecc70b0d2549e.yaml
+++ b/recipes/evidence/rtx-pro-6000-eks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-3ec33498d3df68b688ae96280634c1a4403b7502a49016be54aecc70b0d2549e.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-20T22:33:47Z
+    bundle:
+      digest: sha256:3ec33498d3df68b688ae96280634c1a4403b7502a49016be54aecc70b0d2549e
+      oci: ghcr.io/yuanchen8911/aicr-evidence:rtx-pro-6000-eks-ubuntu-inference-dynamo-a0b50095a5b8
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 2208554439
+recipe: rtx-pro-6000-eks-ubuntu-inference-dynamo
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds a signed recipe-evidence v1 pointer for **rtx-pro-6000-eks-ubuntu-inference-dynamo**, validated end-to-end on a from-scratch bundle deployment on EKS (`b40-aicr`, 2× g7e.48xlarge RTX PRO 6000 Blackwell Server Edition, 8 GPUs each, K8s 1.34, Ubuntu 24.04).

## Motivation / Context

First recipe evidence for the RTX PRO 6000 EKS inference-dynamo recipe. All three phases passed on aicr `v0.17.0-next` (fd4f7a1f):

- **deployment** — 4/4 validators passed
- **conformance** — 11/11 validators passed
- **performance** — inference-perf passed: throughput **77,495 tok/s** (gate ≥ 50,000), TTFT p99 **478.67 ms** (gate ≤ 2,000); Qwen/Qwen3-8B, 8 GPU workers, dynamo-router (least-loaded)

Produced via `aicr validate --phase all --emit-attestation`, published unsigned to the fork's public `ghcr.io/yuanchen8911/aicr-evidence`, then signed by the fork-based `evidence-publish.yaml` workflow (GitHub Actions ambient OIDC — no personal PII; Rekor log index 2208554439).

Fixes: N/A
Related: #1699 (same signer and flow; the community allowlist slug `5bf9e82f…` added there covers this pointer)

## Type of Change

- [x] Other: Evidence submission (recipe-evidence v1 pointer)

## Component(s) Affected

- [x] Other: Recipe evidence (`recipes/evidence/`)

## Implementation Notes

- One signed pointer at its canonical per-source path `recipes/evidence/<recipe>/<source>/<digest>.yaml`.
- No allowlist change needed — the signer slug is already in `community:` (added by #1699).
- The bundle is a content-addressed OCI artifact in the fork's public registry; the pointer carries only the reference + digest.

## Testing

```bash
aicr evidence verify recipes/evidence/rtx-pro-6000-eks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-3ec33498d3df68b688ae96280634c1a4403b7502a49016be54aecc70b0d2549e.yaml
```

- materialize-bundle, signature-verify, predicate-parse, manifest-hash-check all **passed** (bundle valid, exit 0) — same verifier the CI evidence gate runs.
- Evidence generated from a passing `validate --phase all` run (deployment 4/4, conformance 11/11, performance 1/1).
- `make qualify` not run: evidence-only pointer file (no Go/YAML config or docs content change); the evidence-pointer CI gate is the relevant check.

## Risk Assessment

- [x] **Low** — additive evidence data; no code or recipe behavior change.

**Rollout notes:** N/A
