### PR TITLE
docs(bom): regenerate container images for upstream ubuntu drift

### DIFF
--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -121,7 +121,7 @@ _No images extracted._
 
 - `gcr.io/gke-release/nri-device-injector:1.0.25-gke.6@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c`
 - `gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830`
-- `ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90`
+- `ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb`
 - `us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3f39455a2ea35e844e0fc92564ca5629f6b03250fde40e8160719dae4`
 
 ### gpu-operator


### PR DESCRIPTION
## Summary

Regenerate `docs/user/container-images.md` via `make bom-docs` to pick up upstream base-image drift: the `gke-nccl-tcpxo` section's `ubuntu` image moved from `24.04` to `26.04` (digest updated accordingly). No chart pins changed.

## Motivation / Context

The BOM is rendered fresh from each Helm chart's actual templates, so an unbumped pin can still pick up upstream image drift. This drift has been showing up as a pre-existing delta in unrelated PRs' local `make bom-docs` runs (most recently while verifying #1756); it belongs to `main` as its own regen commit rather than riding along in a feature PR.

Fixes: N/A
Related: #1756

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Single-line change in the auto-generated section: `ubuntu:24.04@sha256:4fbb8e6a…` → `ubuntu:26.04@sha256:3131b4cc…` under `### gke-nccl-tcpxo`. Prose sections untouched.

## Testing

```bash
unset GITLAB_TOKEN && make bom-docs   # clean regen; only the ubuntu line changed
make bom-check                        # "docs/user/container-images.md is up to date"
```

Doc-only change to an auto-generated file; per the repo's doc-only verification rule, the scoped checks above (`make bom-docs` + `make bom-check`) are the accepted gate — tests, e2e, and Go lint cannot regress from a regenerated Markdown table, so full `make qualify` was skipped.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
