### PR TITLE
fix(nfd): raise topology-updater memory limit for high-core GPU nodes

### DIFF
--- a/recipes/components/nfd/values.yaml
+++ b/recipes/components/nfd/values.yaml
@@ -42,6 +42,22 @@ topologyUpdater:
   # mounting kubelet state files (TLS material, pod manifests,
   # checkpoint data) into the TU container.
   kubeletStateDir: ""
+  # Raise the topology-updater memory limit above the chart default
+  # (60Mi). topologyUpdater is only enabled on GPU-node recipes, whose
+  # workers are high-core (e.g. 144-vCPU GB200/Grace, 192-vCPU p5). The
+  # Go binary leaves GOMAXPROCS=nproc, so the runtime sizes for every
+  # core and the pod-resources/NUMA scan over a large multi-NUMA node
+  # pushes the working set past 60Mi → OOMKilled → CrashLoopBackOff (seen
+  # on GB200/EKS, 144-vCPU nodes). A core-count-independent limit bump is
+  # the deterministic fix — same class as the aws-ebs-csi sidecar OOM
+  # (#1693). Requests raised too so the DaemonSet keeps Burstable QoS with
+  # headroom.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
 
 # GC enabled for cleanup of stale NodeFeature/NodeResourceTopology CRs
 gc:


### PR DESCRIPTION
## Summary

The NFD `topology-updater` inherits the upstream chart's default memory limit (60Mi), which OOMKills it on high-core GPU nodes → `CrashLoopBackOff`. This sets a `topologyUpdater.resources` override in the `nfd` component values (limit 60Mi→256Mi, request 40Mi→128Mi).

## Motivation / Context

`topologyUpdater` is only enabled on GPU-node recipes (gb200, h100-bcm/aks, h200-eks, b200-gke, l40s-oke), whose workers are high-core — e.g. 144-vCPU GB200/Grace, 192-vCPU p5. The topology-updater is a Go binary that leaves `GOMAXPROCS=nproc`, so the runtime sizes for every core, and the pod-resources / NUMA scan over a large multi-NUMA node pushes the working set past the 60Mi limit → **OOMKilled (exit 137) → CrashLoopBackOff**.

Observed live on a GB200/EKS UAT cluster (144-vCPU workers): both `nfd-node-feature-discovery-topology-updater` pods crashlooping, 7+ restarts, `lastState.terminated.reason=OOMKilled`. This is the same class as the `aws-ebs-csi` node-sidecar OOM fixed in #1693 (high-core GPU node + tiny-limit Go sidecar + `GOMAXPROCS=nproc`); a core-count-independent limit bump is the deterministic fix.

Fixes: N/A
Related: #1693 (same OOM class, aws-ebs-csi sidecars)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Recipe engine / data (`recipes/components/nfd/values.yaml`)

## Implementation Notes

Set `topologyUpdater.resources` in `recipes/components/nfd/values.yaml`:

```yaml
resources:
  requests:
    cpu: 50m
    memory: 128Mi   # was 40Mi (chart default)
  limits:
    memory: 256Mi   # was 60Mi (chart default) — the OOM ceiling
```

Placed in the base component values (not a single overlay) because every recipe that flips `topologyUpdater.enable: true` is a high-core GPU-node recipe with the same exposure. Chose a limit bump over pinning `GOMAXPROCS` (the TU chart doesn't cleanly expose the env, and a limit bump is core-count-independent — the #1693 lesson).

`make bom-docs` produces no image change from this diff (resources-only); the only BOM drift it surfaced was an unrelated pre-existing `ubuntu:24.04→26.04` bump in a GKE recipe, left out of this PR.

## Testing

```bash
go test ./pkg/recipe/... ./pkg/bundler/... ./pkg/component/...   # ok
yamllint recipes/components/nfd/values.yaml                       # clean
```

**Live-validated on GB200/EKS (144-vCPU workers).** After patching the running DaemonSet to the new limits:
- topology-updater pods: **1/1 Running, 0 restarts** (were OOMKilled/CrashLoopBackOff at 60Mi)
- `NodeResourceTopology` CRs published for both GPU nodes — TU healthy *and* functional, not just alive.

So unlike #1693 (which was justified deductively), this fix is confirmed by reproduction-and-repair on the affected hardware.

## Risk Assessment

- [x] **Low** — values-only limit increase on an optional DaemonSet; no image/version/component-set change, easy to revert.

**Rollout notes:** Takes effect on the next bundle render for topologyUpdater-enabled recipes. Backwards compatible.

## Checklist

- [x] Tests pass locally (recipe/bundler/component)
- [x] Linter passes (yamllint)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — n/a (values-only; validated live on cluster)
- [x] I updated docs if user-facing behavior changed — n/a
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
