### PR TITLE
evidence(rke2): vr200 training recipe evidence

### DIFF
--- a/recipes/evidence/vr200-rke2-ubuntu-training/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-d9a6f1c694e17028e89747893d8a74b62c2a3c2583c8070e70c922baaef5f33b.yaml
+++ b/recipes/evidence/vr200-rke2-ubuntu-training/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-d9a6f1c694e17028e89747893d8a74b62c2a3c2583c8070e70c922baaef5f33b.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-21T02:06:37Z
+    bundle:
+      digest: sha256:d9a6f1c694e17028e89747893d8a74b62c2a3c2583c8070e70c922baaef5f33b
+      oci: ghcr.io/yuanchen8911/aicr-evidence:vr200-rke2-ubuntu-training-658a9859332c
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 34893379
+recipe: vr200-rke2-ubuntu-training
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds a signed recipe-evidence v1 pointer for **vr200-rke2-ubuntu-training**, validated end-to-end on a live Vera Rubin NVL72 reference cluster (`vr200-aicr-cluster-2`, 2× VR200 compute trays, 4 GPUs each, RKE2 v1.35.6, Ubuntu 26.04 arm64 with the 64k-page kernel, host-managed R615 driver).

## Motivation / Context

First recipe evidence for the Vera Rubin RKE2 training recipe. Both currently supported phases passed on aicr `v0.17.0`:

- **deployment** — 4/4 validators passed
- **conformance** — 5/5 validators passed
- **performance** — not run: cross-node NCCL performance floors are explicitly deferred while the VR platform is pre-release (runtime images pending)

The vr200 recipe family is staged in the internal AICR catalog and registers the `rke2` service and `vr200` accelerator in the public catalog in the next AICR release; this pointer precedes that publication (the evidence pointer contract keys on recipe name + signer and has no catalog coupling).

Produced via `aicr validate --emit-attestation`, published unsigned to the fork's public `ghcr.io/yuanchen8911/aicr-evidence`, then signed by the fork-based `evidence-publish.yaml` workflow (GitHub Actions ambient OIDC — no personal PII; Rekor log index 34893379).

Fixes: N/A
Related: #1699 (same signer and flow; the community allowlist slug `5bf9e82f…` added there covers this pointer), #1823 (same submission pattern)

## Type of Change

- [x] Other: Evidence submission (recipe-evidence v1 pointer)

## Component(s) Affected

- [x] Other: Recipe evidence (`recipes/evidence/`)

## Implementation Notes

- One signed pointer at its canonical per-source path `recipes/evidence/<recipe>/<source>/<digest>.yaml`.
- No allowlist change needed — the signer slug is already in `community:` (added by #1699).
- The attested recipe embeds a corrected nodewright-operator health check (asserting Deployment `nodewright-controller-manager`, which matches the recipe's pinned chart v0.17.1). The public catalog's copy still asserts the pre-rename `skyhook-operator-controller-manager`; the two-line fix is being filed separately.

## Testing

```bash
aicr evidence verify recipes/evidence/vr200-rke2-ubuntu-training/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-d9a6f1c694e17028e89747893d8a74b62c2a3c2583c8070e70c922baaef5f33b.yaml
```

- materialize-bundle, signature-verify, predicate-parse, manifest-hash-check all **passed** (bundle valid, exit 0) — same verifier the CI evidence gate runs.
- Evidence generated from a passing `validate --phase deployment --phase conformance` run (deployment 4/4, conformance 5/5), including the end-to-end two-node ComputeDomain/IMEX path on the same cluster.
- `make qualify` not run: evidence-only pointer file (no Go/YAML config or docs content change); the evidence-pointer CI gate is the relevant check.

## Risk Assessment

- [x] **Low** — additive evidence data; no code or recipe behavior change.

**Rollout notes:** N/A
