### PR TITLE
docs(corroborate): fix evidence-dashboard consensus/facets accuracy

### DIFF
--- a/docs/design/012-recipe-coordinate-mapping.md
+++ b/docs/design/012-recipe-coordinate-mapping.md
@@ -225,9 +225,12 @@ greenfield UI, and an always-on GKE host cluster. Both are built in parallel;
 this ADR's mapping function, taxonomy, and column-metadata schema are shared,
 not duplicated, by both.
 
-- **Same foundation.** GP and TG read the same GCS bucket, the same verified,
-  source-keyed evidence tree, and the same `pkg/recipe.CoordinateFor` mapping
-  (§Mapping rules above). Neither forks the taxonomy.
+- **Same foundation.** GP and TG read the same verified, source-keyed evidence
+  tree and derive coordinates from the same `pkg/recipe.CoordinateFor` mapping
+  (§Mapping rules above). Neither forks the taxonomy. (Whether they share one
+  GCS bucket and publish service account, or stand up their own, is deliberately
+  left open — see the deconfliction note below; the shared contract is the
+  evidence tree and its layout, not a specific bucket.)
 - **Forward-compatible, not throwaway.** GP4's (#1404) coordinate-keyed JSON
   contract (`index.json` + `series/*.json`) is a forward-compatible input to
   TG's workers/API/UI — a future migration consumes GP's already-coordinate-keyed

--- a/docs/user/evidence-dashboard.md
+++ b/docs/user/evidence-dashboard.md
@@ -58,8 +58,10 @@ one consensus grid, version-blind. Selecting a specific `aicr` version switches
 to that version's **strict same-version consensus** — only runs from the same
 release corroborate one another (cross-version agreement is not reproduction),
 scoped latest-per-signer at that version. In both views a signer's older builds
-never dilute its latest, and the strict view additionally keeps a previous
-Kubernetes minor or a different `aicr` version out of a current result.
+never dilute its latest, and the strict view additionally refuses to let a
+different `aicr` release corroborate a current one. (Kubernetes minor is not a
+consensus dimension: the k8s facet only dims mismatched columns for display —
+see [Facets](#facets) — it never removes them from consensus.)
 
 ### The coordinate and stable URLs
 

--- a/docs/user/evidence-dashboard.md
+++ b/docs/user/evidence-dashboard.md
@@ -32,9 +32,9 @@ parallel and is not a replacement or deferral of either surface.
 
 ## How to read it — CSP-first navigation
 
-The dashboard shares the same five-level, CSP-first addressing space as the
-TestGrid. Navigating it follows the same structure documented in
-[TestGrid](./testgrid.md):
+The dashboard shares its first four CSP-first addressing levels with the
+[TestGrid](./testgrid.md); the fifth column is organized per-signer here (see
+[Consensus model](#consensus-model)) rather than per-build:
 
 | Level | Value | Example |
 |-------|-------|---------|
@@ -42,7 +42,7 @@ TestGrid. Navigating it follows the same structure documented in
 | **Dashboard** | accelerator + OS | `h100-ubuntu` |
 | **Tab** | intent, optionally with platform | `training-kubeflow` |
 | **Row** | validation `<phase>/<check>` | `conformance/gpu-operator-ready` |
-| **Source column** | one signer | one allowlisted party |
+| **Source column** | one signer | one allowlisted party (or a verified-but-unknown reported signer) |
 
 From the catalog overview you navigate: pick a group → pick a dashboard → pick
 a tab to reach the **consensus grid** for that recipe. Every cell in the grid
@@ -52,10 +52,14 @@ below). Clicking a dot opens the **per-source drilldown**: that signer's
 build-by-build history for the recipe, with a link to the signed evidence
 artifact for each build.
 
-The facet controls (aicr-version, k8s) let you scope the view; the default
-scope is **latest-per-signer**: for each signer only the most recent
-in-scope build counts toward the consensus. This prevents a stale build from a
-previous Kubernetes minor from silently diluting a current result.
+The facet controls (aicr-version, k8s) let you scope the view. The default is
+the **all-versions** view: each signer's single most recent run is folded into
+one consensus grid, version-blind. Selecting a specific `aicr` version switches
+to that version's **strict same-version consensus** — only runs from the same
+release corroborate one another (cross-version agreement is not reproduction),
+scoped latest-per-signer at that version. In both views a signer's older builds
+never dilute its latest, and the strict view additionally keeps a previous
+Kubernetes minor or a different `aicr` version out of a current result.
 
 ### The coordinate and stable URLs
 
@@ -101,19 +105,31 @@ average. When at least one allowlisted signer passes and at least one fails,
 the grid surfaces the disagreement so a reader can investigate; the only
 way a `CONTESTED` row disappears is by all signers converging on one result.
 
+The five states are computed in two grids. The **default all-versions grid**
+folds each signer's single most recent run version-blind, so `CONFIRMED` there
+means ≥ 2 distinct allowlisted signers passed the row on their latest run —
+which the board flags as weaker than same-version reproduction. Picking an
+`aicr` version (see [Facets](#facets)) switches to that version's **strict
+same-version grid**, where two signers corroborate only if they ran the same
+release; the same row can therefore be `CONFIRMED` in the all-versions grid or
+at one version and `SINGLE` at another.
+
 ### `not-run` is excluded from counting
 
 A signer whose latest in-scope run skipped or left a check pending has a
 `not-run` outcome for that row. `not-run` contributes to neither the pass
 count nor the fail count, so it can neither promote a row to `CONFIRMED` nor
-suppress a `CONTESTED`. A signer with all `not-run` outcomes is omitted from
-the index grid entirely; its full history is still visible in the per-source
-drilldown.
+suppress a `CONTESTED`. A signer that never records a pass or fail — every
+in-scope outcome is `not-run` — is absent from both the index grid and the
+per-source drilldown; `not-run` cells appear in the drilldown only for signers
+that have a pass or fail on some other row or build.
 
 ### Phase rollup
 
-Each recipe tab also shows a per-phase rolled-up state (readiness, deployment,
-performance, conformance). The rollup is **worst-first**: the phase state is the
+Each recipe tab also shows a per-phase rolled-up state (deployment, conformance,
+performance). (Readiness is evaluated inline without containers, so it produces
+no evidence rows and does not appear on the board.) The rollup is
+**worst-first**: the phase state is the
 worst-ranked state among all its rows, in this priority order (worst first):
 
 `CONTESTED` → `FAILING` → `UNTESTED` → `SINGLE` → `CONFIRMED`
@@ -201,17 +217,26 @@ time). A verified-but-unknown community signer can never promote a row to
 
 Two facets let you slice the view:
 
-- **aicr-version** — the `aicr` release that produced the run. UAT normally
-  builds only the current checkout, so the default view is effectively `main`.
-  The facet becomes meaningful when the multi-version pipeline is live.
-- **k8s** (Kubernetes `major.minor`) — the cluster version observed in the
-  run. A result from an old Kubernetes minor is never silently fused with a
-  current-version result; the facet lets you scope to the version you care
-  about, and the **latest-per-signer default** already avoids mixing stale and
-  current results from the same signer without any manual filtering.
+- **aicr-version** — the `aicr` release that produced the run. This is a
+  whole-dashboard **consensus lens**, not a parallel dimming filter: consensus
+  is baked both as a cross-version all-versions grid and per version, and the
+  lens selects which one you see. The default (**all versions**) is the
+  cross-version grid — each signer's single latest run, version-blind; picking a
+  specific version switches every summary (grid, overview, catalog) to that
+  version's strict same-version consensus. In the per-source drilldown the lens
+  hard-**filters** columns to the selected version. Because UAT release cells
+  run several `aicr` releases per coordinate, the lens is already meaningful
+  today.
+- **k8s** (Kubernetes `major.minor`) — the cluster version observed in the run.
+  Unlike the version lens, k8s only **dims** non-matching build columns (in both
+  the matrix and the per-source drilldown) — it never removes them — so an old
+  Kubernetes minor is visually distinguished but never silently fused with a
+  current-version result.
 
-Both facets are parallel: you can combine them to view, for example, only
-results from `v0.42.0` on Kubernetes `1.33`.
+The two controls compose but are not symmetric: the `aicr` version lens chooses
+*which* consensus grid you are viewing (and filters drilldown columns), while
+k8s only dims columns within whatever the lens selected — for example, the
+`v0.42.0` consensus grid with its non-`1.33` columns dimmed.
 
 ## How it relates to TestGrid and Recipe Health
 
@@ -220,8 +245,11 @@ results from `v0.42.0` on Kubernetes `1.33`.
 The evidence corroboration dashboard (GP) and the [AICR TestGrid](./testgrid.md)
 (TG) are **siblings that share the same foundation**:
 
-- They read from the same GCS bucket and the same verified, source-keyed
-  evidence tree.
+- They read the same verified, source-keyed evidence tree in the same layout.
+  (Whether the two surfaces share a single GCS bucket and publish service
+  account, or stand up their own, is an open GP3/TG1 deconfliction tracked in
+  [ADR-012](../design/012-recipe-coordinate-mapping.md) — the shared contract
+  is the evidence tree and its layout, not a specific bucket.)
 - They both derive recipe coordinates from the **single shared mapping
   function** `pkg/recipe.CoordinateFor` (see
   [ADR-012](../design/012-recipe-coordinate-mapping.md)), the anti-drift
@@ -243,9 +271,10 @@ The difference is in the rendering stack:
 
 **RQ1 (#1283) targets this dashboard.** It is the link target today because
 TG4a/TG4b's live API and UI have not shipped yet — not because TG work is
-deferred; the two surfaces are being built in parallel (see above). The
-Recipe Health Evidence column deep-links here:docs/user/testgrid.md `https://validation.aicr.run/#/<group>/<dashboard>/<tab>` —
-this site's origin plus `#/` plus the recipe's `Coordinate.Path()` — built
+deferred; the two surfaces are being built in parallel (see above). Once RQ1
+lands, the Recipe Health Evidence column will deep-link here —
+`https://validation.aicr.run/#/<group>/<dashboard>/<tab>`, i.e. this site's
+origin plus `/#/` plus the recipe's `Coordinate.Path()` — built
 offline from resolved criteria via `pkg/recipe.CoordinateFor`, with no network
 call from the generator. Only recipes with an actual dashboard presence get a
 link; the rest keep an honest `pending` until real-hardware coverage broadens.
@@ -284,8 +313,9 @@ cluster upgrade never breaks it. The cross-link is advisory and
 never a merge gate; the Evidence column links, it never copies this
 dashboard's content.
 
-ADR-009's verify-gated in-cell freshness state (AttestedAt age, unattested-vs-aged
+ADR-009's verify-gated freshness signal (AttestedAt age, unattested-vs-aged
 trust distinction) is a distinct, later refinement that ADR-009 tracks
-independently. It coexists with the deep-link: the link points at the live
-board; an optional freshness annotation can later appear in the same cell
-without changing what the link resolves to.
+independently as a **separate validation-posture (Evidence) column** that carries
+that freshness distinction, not an in-cell state. It coexists with the
+deep-link: the link points at the live board; the column can land later without
+changing what the link resolves to.

--- a/docs/user/testgrid.md
+++ b/docs/user/testgrid.md
@@ -77,8 +77,8 @@ Trust in a column comes from its provenance metadata. Each build column carries 
 ## Interim evidence dashboard
 
 The [Evidence Corroboration Dashboard](./evidence-dashboard.md) is the
-**interim static GitHub Pages surface** for the same evidence. It reads from
-the same GCS bucket and the same verified, source-keyed evidence tree, and
+**interim static GitHub Pages surface** for the same evidence. It reads the
+same verified, source-keyed evidence tree (in the same layout) and
 derives recipe coordinates using the same shared mapping function
 (`pkg/recipe.CoordinateFor`, [ADR-012](../design/012-recipe-coordinate-mapping.md)).
 It is published at [`https://validation.aicr.run`](https://validation.aicr.run)
@@ -92,7 +92,10 @@ other.
 
 The two surfaces share the same foundation:
 
-- Same GCS bucket and verified source-keyed evidence tree.
+- The same verified source-keyed evidence tree, in the same layout. (Whether
+  the two surfaces share one GCS bucket or stand up their own is an open
+  GP3/TG1 deconfliction tracked in ADR-012; the shared contract is the
+  evidence tree, not a specific bucket.)
 - Same recipe→coordinate mapping (`pkg/recipe.CoordinateFor`) — the
   anti-drift guarantee that both surfaces place every recipe in the same
   `<group>/<dashboard>/<tab>`.
@@ -104,8 +107,8 @@ RQ1 (#1283) — the follow-on to #1224's `pending` Evidence column — targets
 the evidence dashboard specifically: it is the link
 target today because TG4a/TG4b's live API and UI have not shipped yet — not
 because TG work is deferred; the two surfaces are being built in parallel
-(see above). The Recipe Health Evidence column deep-links to the dashboard's
-coordinate URL —
+(see above). Once RQ1 lands, the Recipe Health Evidence column will deep-link
+to the dashboard's coordinate URL —
 `https://validation.aicr.run/#/<group>/<dashboard>/<tab>` — built offline
 from resolved criteria via `pkg/recipe.CoordinateFor`. The link is stable
 across Kubernetes upgrades because the Kubernetes version lives in the

--- a/tools/corroborate/docs_golden_test.go
+++ b/tools/corroborate/docs_golden_test.go
@@ -50,15 +50,17 @@ func TestDocsStateNames(t *testing.T) {
 	}
 	doc := string(data)
 
-	// Scope each check to the section that is supposed to define the tokens, so
-	// that deleting the States table or the Source classes table fails this test.
-	// Checking the whole document would let a stray prose mention elsewhere keep
-	// it green even after the defining table was removed.
+	// Scope each check to the section that is supposed to define the tokens, and
+	// assert the token's defining *table row* (a leading "| `<token>` |" cell),
+	// not merely that the token appears somewhere in the section. State/Class
+	// names also recur in the surrounding prose, so a plain substring check would
+	// stay green even if the defining table were deleted — the very drift this
+	// guard exists to catch. Requiring the table row means removing either table
+	// fails the test.
 	consensus := docSection(doc, "Consensus model")
 	if consensus == "" {
 		t.Fatalf("%s: missing \"## Consensus model\" section", evidenceDashboardDoc)
 	}
-	// Every State constant must appear verbatim in the Consensus model section.
 	for _, st := range []corroborate.State{
 		corroborate.StateConfirmed,
 		corroborate.StateSingle,
@@ -66,9 +68,9 @@ func TestDocsStateNames(t *testing.T) {
 		corroborate.StateFailing,
 		corroborate.StateUntested,
 	} {
-		if !strings.Contains(consensus, string(st)) {
-			t.Errorf("%s: missing consensus state %q — add it to the Consensus model section",
-				evidenceDashboardDoc, st)
+		if row := tableRow(string(st)); !strings.Contains(consensus, row) {
+			t.Errorf("%s: Consensus model section is missing the States-table row for %q (expected a cell %q) — the table must define it, not just prose",
+				evidenceDashboardDoc, st, row)
 		}
 	}
 
@@ -76,33 +78,55 @@ func TestDocsStateNames(t *testing.T) {
 	if classes == "" {
 		t.Fatalf("%s: missing \"## Source classes\" section", evidenceDashboardDoc)
 	}
-	// Every Class constant must appear verbatim in the Source classes section.
 	for _, cl := range []corroborate.Class{
 		corroborate.ClassFirstParty,
 		corroborate.ClassCommunity,
 		corroborate.ClassPartner,
 	} {
-		if !strings.Contains(classes, string(cl)) {
-			t.Errorf("%s: missing source class %q — add it to the Source classes section",
-				evidenceDashboardDoc, cl)
+		if row := tableRow(string(cl)); !strings.Contains(classes, row) {
+			t.Errorf("%s: Source classes section is missing the classes-table row for %q (expected a cell %q) — the table must define it, not just prose",
+				evidenceDashboardDoc, cl, row)
 		}
 	}
 }
 
+// tableRow is the leading Markdown-table cell that defines a token, e.g.
+// "| `CONFIRMED` |". Matching this (rather than the bare token) ties the guard
+// to the defining table row, so deleting the table fails the test even though
+// the token still appears in prose.
+func tableRow(token string) string {
+	return "| `" + token + "` |"
+}
+
 // docSection returns the body of the top-level ("## ") Markdown section whose
-// heading text is title, from that heading up to the next top-level heading (or
-// end of document). Nested "### " subsections are kept; other "## " sections are
-// excluded. It returns "" when the section is absent so callers can fail closed
-// rather than silently matching a token that lives in a different section.
+// heading line is exactly "## "+title, from just after that heading line to the
+// next top-level heading line (or end of document). Matching is anchored to
+// whole lines, so a "### "+title subsection, a fenced-code line, or prose that
+// merely mentions the heading text does not match; nested "### " subsections
+// within the section are kept. It returns "" when the section is absent so
+// callers fail closed rather than matching a token from a different section.
 func docSection(doc, title string) string {
 	head := "## " + title
-	start := strings.Index(doc, head)
+	lines := strings.Split(doc, "\n")
+	start := -1
+	for i, ln := range lines {
+		if strings.TrimRight(ln, " \t") == head {
+			start = i + 1
+			break
+		}
+	}
 	if start < 0 {
 		return ""
 	}
-	rest := doc[start+len(head):]
-	if next := strings.Index(rest, "\n## "); next >= 0 {
-		return rest[:next]
+	var b strings.Builder
+	for _, ln := range lines[start:] {
+		// A "## " prefix is exactly two hashes then a space; "### " lines start
+		// with "###" and so are not H2 boundaries.
+		if strings.HasPrefix(strings.TrimRight(ln, " \t"), "## ") {
+			break
+		}
+		b.WriteString(ln)
+		b.WriteByte('\n')
 	}
-	return rest
+	return b.String()
 }

--- a/tools/corroborate/docs_golden_test.go
+++ b/tools/corroborate/docs_golden_test.go
@@ -30,11 +30,13 @@ const docsDir = "../../docs/user"
 // and Class constant.
 const evidenceDashboardDoc = "evidence-dashboard.md"
 
-// TestDocsStateNames is the GP6 drift-guard: it verifies that the
-// consensus-model explainer in docs/user/evidence-dashboard.md names every
-// corroboration State constant and every source Class constant exactly as the
-// Go code spells them, so the docs and the generator can never silently
-// diverge.
+// TestDocsStateNames is the GP6 drift-guard: it verifies that every
+// corroboration State constant appears verbatim in the "Consensus model"
+// section of docs/user/evidence-dashboard.md, and every source Class constant
+// in the "Source classes" section, exactly as the Go code spells them — so the
+// docs and the generator can never silently diverge. Scoping each check to its
+// defining section (not the whole file) means deleting either table fails the
+// test instead of passing on an incidental prose mention elsewhere.
 //
 // If this test fails after a rename in pkg/corroborate, update
 // docs/user/evidence-dashboard.md to match.
@@ -48,7 +50,15 @@ func TestDocsStateNames(t *testing.T) {
 	}
 	doc := string(data)
 
-	// Every State constant must appear verbatim in the consensus-model section.
+	// Scope each check to the section that is supposed to define the tokens, so
+	// that deleting the States table or the Source classes table fails this test.
+	// Checking the whole document would let a stray prose mention elsewhere keep
+	// it green even after the defining table was removed.
+	consensus := docSection(doc, "Consensus model")
+	if consensus == "" {
+		t.Fatalf("%s: missing \"## Consensus model\" section", evidenceDashboardDoc)
+	}
+	// Every State constant must appear verbatim in the Consensus model section.
 	for _, st := range []corroborate.State{
 		corroborate.StateConfirmed,
 		corroborate.StateSingle,
@@ -56,21 +66,43 @@ func TestDocsStateNames(t *testing.T) {
 		corroborate.StateFailing,
 		corroborate.StateUntested,
 	} {
-		if !strings.Contains(doc, string(st)) {
+		if !strings.Contains(consensus, string(st)) {
 			t.Errorf("%s: missing consensus state %q — add it to the Consensus model section",
 				evidenceDashboardDoc, st)
 		}
 	}
 
-	// Every Class constant must appear verbatim in the source-classes section.
+	classes := docSection(doc, "Source classes")
+	if classes == "" {
+		t.Fatalf("%s: missing \"## Source classes\" section", evidenceDashboardDoc)
+	}
+	// Every Class constant must appear verbatim in the Source classes section.
 	for _, cl := range []corroborate.Class{
 		corroborate.ClassFirstParty,
 		corroborate.ClassCommunity,
 		corroborate.ClassPartner,
 	} {
-		if !strings.Contains(doc, string(cl)) {
+		if !strings.Contains(classes, string(cl)) {
 			t.Errorf("%s: missing source class %q — add it to the Source classes section",
 				evidenceDashboardDoc, cl)
 		}
 	}
+}
+
+// docSection returns the body of the top-level ("## ") Markdown section whose
+// heading text is title, from that heading up to the next top-level heading (or
+// end of document). Nested "### " subsections are kept; other "## " sections are
+// excluded. It returns "" when the section is absent so callers can fail closed
+// rather than silently matching a token that lives in a different section.
+func docSection(doc, title string) string {
+	head := "## " + title
+	start := strings.Index(doc, head)
+	if start < 0 {
+		return ""
+	}
+	rest := doc[start+len(head):]
+	if next := strings.Index(rest, "\n## "); next >= 0 {
+		return rest[:next]
+	}
+	return rest
 }


### PR DESCRIPTION
## Summary

Follow-up to #1768 (GP6): corrects documentation defects found in review of the
merged evidence-dashboard docs, and aligns the consensus/facets description with
the dashboard's current cross-version ("all versions") model.

## Motivation / Context

The GP6 docs merged with several accuracy issues (one a garbled text splice on
the public page) and a consensus/facets description that predated the merged
cross-version dashboard work. This sweeps all of them, verified against the
current `pkg/corroborate` code and renderer.

Fixes: N/A
Related: #1768, #1406, #1400

## Type of Change

- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/corroborate` drift-guard test

## Implementation Notes

- **Garbled splice + link:** remove `deep-links here:docs/user/testgrid.md` on
  the public page; make the RQ1 deep-link future-tense; fix the URL join to
  `origin + /#/ + Coordinate.Path()`.
- **Phase rollup:** drop the phantom `readiness` phase; use
  `validator.PhaseOrder` (deployment, conformance, performance); note readiness
  runs inline with no evidence rows / no board presence.
- **Consensus + facets (current model):** describe both the **default
  all-versions** (version-blind) grid and the **strict same-version** grid;
  reframe `aicr-version` as a consensus lens (not a parallel filter) that
  hard-filters drilldown columns, and `k8s` as **dim-only** in both matrix and
  drilldown (fixes a reversed dims-vs-filters claim).
- **not-run:** an all-`not-run` signer is absent from **both** the grid and the
  drilldown.
- **Shared-bucket contradiction:** ADR-012 + both user docs no longer assert a
  shared GCS bucket as settled — it is an open GP3/TG1 deconfliction (the shared
  contract is the evidence tree/layout, not a bucket).
- **ADR-009 freshness:** a separate validation-posture (Evidence) column, not an
  in-cell state.
- **Drift-guard test:** scope the `State`/`Class` checks to their defining
  Markdown sections so deleting a table fails the test instead of passing on an
  incidental prose mention.

All doc claims were cross-checked against `pkg/corroborate` (generate.go,
consensus.go, model.go, classify.go, coordinate.go), the renderer, and
`pkg/validator/phases.go` / ADR-009 / ADR-012.

## Testing

```bash
go test ./tools/corroborate/...            # ok (drift-guard passes, section-scoped)
golangci-lint run -c .golangci.yaml ./tools/corroborate/...   # 0 issues
./tools/check-docs-mdx                      # OK: all doc files are MDX-safe
./tools/check-docs-filenames                # OK: kebab-case
```

## Risk Assessment

- [x] **Low** — Docs plus one test-file change; no product code touched. Easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (hardened the drift-guard)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
