### PR TITLE
evidence(aks): h100 driver-only inference + training recipe evidence

### DIFF
--- a/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-edc042d2e32d58bde9bb0e7cfdaa14568a13c144fdf0869958a4d582f3fc8cfc.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-edc042d2e32d58bde9bb0e7cfdaa14568a13c144fdf0869958a4d582f3fc8cfc.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-21T19:45:26Z
+    bundle:
+      digest: sha256:edc042d2e32d58bde9bb0e7cfdaa14568a13c144fdf0869958a4d582f3fc8cfc
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-inference-dynamo-e3ef293218ba
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 35699965
+recipe: h100-aks-ubuntu-inference-dynamo
+schemaVersion: 1.0.0

--- a/recipes/evidence/h100-aks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-7bfed65fb09c14c6e6cbe87a68e0810a7d24178e0e83d1691c020556c92dbbd8.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-7bfed65fb09c14c6e6cbe87a68e0810a7d24178e0e83d1691c020556c92dbbd8.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-21T20:01:47Z
+    bundle:
+      digest: sha256:7bfed65fb09c14c6e6cbe87a68e0810a7d24178e0e83d1691c020556c92dbbd8
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-training-kubeflow-f8beb4f6c93c
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 35700091
+recipe: h100-aks-ubuntu-training-kubeflow
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Signed recipe-evidence for the AKS Azure-managed **driver-only** GPU profile introduced in #1756, validated end-to-end on aicr-test6 (2× `Standard_ND96isr_H100_v5`, node image `AKSUbuntu-2404gen2containerd-202606.19.0`, preinstalled driver 580.126.09).

Two recipes, full three-phase validation with attestation:

- **`h100-aks-ubuntu-inference-dynamo`** — deployment 4/4, conformance 15/16 (1 skip: cluster-autoscaling, no Karpenter), `inference-perf` 147.6k tok/s / TTFT p99 564 ms.
- **`h100-aks-ubuntu-training-kubeflow`** — deployment 4/4, conformance 14/15 (1 skip), NCCL all-reduce 157.5 GB/s.

Both runs pass `secure-accelerator-access`, confirming the device-isolation hardening in #1756 closes the driver-only GPU-exposure gap.

## Signing

Signed by the fork's `Recipe Evidence: Sign` CI workflow using ambient GitHub Actions OIDC (firstParty, non-personal identity); issuer `token.actions.githubusercontent.com`. Community source slug `5bf9e82f0e90a11528ac85f4bcb866c8`. Bundles pushed to `ghcr.io/yuanchen8911/aicr-evidence`. Local `aicr evidence verify` passes for both pointers (Rekor indices 35699965 / 35700091).

## Related

- #1756 (introduces the AKS driver-only profile these recipes validate)

Note: evidence pointer YAMLs are machine-generated and carry no license header (consistent with all merged evidence pointers).