### PR TITLE
evidence(rke2): vr200 inference-dynamo recipe evidence

### DIFF
--- a/recipes/evidence/vr200-rke2-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-fbd7e54a9c0bc2599234d248c022b471bbd2fdf9b913241ec35b5a08fa87f6ed.yaml
+++ b/recipes/evidence/vr200-rke2-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-fbd7e54a9c0bc2599234d248c022b471bbd2fdf9b913241ec35b5a08fa87f6ed.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-21T20:19:59Z
+    bundle:
+      digest: sha256:fbd7e54a9c0bc2599234d248c022b471bbd2fdf9b913241ec35b5a08fa87f6ed
+      oci: ghcr.io/yuanchen8911/aicr-evidence:vr200-rke2-ubuntu-inference-dynamo-000230ce3072
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 35703222
+recipe: vr200-rke2-ubuntu-inference-dynamo
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds a signed recipe-evidence v1 pointer for **vr200-rke2-ubuntu-inference-dynamo**, validated end-to-end on a live Vera Rubin NVL72 reference cluster (`vr200-aicr-cluster-2`, 2× VR200 compute trays, 4 GPUs each, RKE2 v1.35.6, Ubuntu 26.04 arm64 with the 64k-page kernel, host-managed R615 driver).

## Motivation / Context

First recipe evidence for the Vera Rubin RKE2 inference-dynamo recipe, and companion to #1827 (the training recipe evidence from the same cluster). Run on aicr `v0.17.0` with `--phase all`:

- **deployment** — 4/4 validators passed
- **conformance** — 6/6 validators passed (including the platform checks `inference-gateway` and `robust-controller`)
- **performance** — skipped by the recipe's own design: no VR-measured inference-perf floor exists yet while the platform is pre-release

The dynamo platform components (agentgateway v2.2.1, grove v0.1.0-alpha.8, dynamo-platform 1.2.1 with NATS JetStream) were deployed from the rendered bundle onto the existing VR runtime stack. RKE2-specific prerequisites documented in the recipe were applied: a default StorageClass (local-path-provisioner) for the NATS JetStream PVC, and the TLSRoute `v1alpha2` served-version patch required because RKE2's bundled traefik owns the Gateway API CRDs — the recipe's inline RKE2 health-check gate asserts exactly this condition.

Produced via `aicr validate --emit-attestation`, published unsigned to the fork's public `ghcr.io/yuanchen8911/aicr-evidence`, then signed by the fork-based `evidence-publish.yaml` workflow (GitHub Actions ambient OIDC — no personal PII; Rekor log index 35703222).

Fixes: N/A
Related: #1699 (allowlisted signer slug `5bf9e82f…`), #1827 (vr200 training evidence, same cluster and flow)

## Type of Change

- [x] Other: Evidence submission (recipe-evidence v1 pointer)

## Component(s) Affected

- [x] Other: Recipe evidence (`recipes/evidence/`)

## Implementation Notes

- One signed pointer at its canonical per-source path `recipes/evidence/<recipe>/<source>/<digest>.yaml`.
- No allowlist change needed — the signer slug is already in `community:` (added by #1699).
- The attested recipe embeds a nodewright-operator health check adjusted to this cluster's out-of-band nodewright install (deployment name `nodewright-controller-manager`; see #1828 for the analysis — cluster drift, not a catalog change).

## Testing

```bash
aicr evidence verify recipes/evidence/vr200-rke2-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-fbd7e54a9c0bc2599234d248c022b471bbd2fdf9b913241ec35b5a08fa87f6ed.yaml
```

- materialize-bundle, signature-verify, predicate-parse, manifest-hash-check all **passed** (bundle valid, exit 0) — same verifier the CI evidence gate runs.
- Evidence generated from a passing `validate --phase all` run (deployment 4/4, conformance 6/6, performance skipped — no checks defined for this recipe).
- `make qualify` not run: evidence-only pointer file (no Go/YAML config or docs content change); the evidence-pointer CI gate is the relevant check.

## Risk Assessment

- [x] **Low** — additive evidence data; no code or recipe behavior change.

**Rollout notes:** N/A
