### PR TITLE
fix(corroborate): partial phase rollup + show untested categories

### DIFF
--- a/docs/user/evidence-dashboard.md
+++ b/docs/user/evidence-dashboard.md
@@ -137,8 +137,21 @@ worst-ranked state among all its rows, in this priority order (worst first):
 `CONTESTED` → `FAILING` → `UNTESTED` → `SINGLE` → `CONFIRMED`
 
 A single `CONTESTED` row forces the whole phase to `CONTESTED`; a phase with
-all-`CONFIRMED` rows rolls up to `CONFIRMED`. A phase with no rows (because the
-recipe declares no checks for it) rolls up to `UNTESTED`.
+all-`CONFIRMED` rows rolls up to `CONFIRMED`.
+
+Worst-first has one exception, `PARTIAL`. A phase with a mix of passing
+(`CONFIRMED`/`SINGLE`) and not-yet-run (`UNTESTED`) rows — but nothing failing
+or contested — would be dragged all the way to `UNTESTED` by the precedence
+above, hiding the coverage it does have. That mixed state rolls up to `PARTIAL`
+instead: passing where it ran, but not every row has run. Real problems still
+win — `CONTESTED` and `FAILING` outrank `UNTESTED`, so a phase only reaches
+`PARTIAL` when nothing failed. (`PARTIAL` is a rollup state only; individual
+rows never carry it.)
+
+A phase with no rows — because the recipe declares no checks for it, or no
+signer has run any of them yet — rolls up to `UNTESTED` and is still shown on
+the board as an untested coverage gap rather than omitted, so a category nobody
+has run is visible instead of silently missing.
 
 ## Source classes
 

--- a/pkg/corroborate/consensus.go
+++ b/pkg/corroborate/consensus.go
@@ -39,6 +39,12 @@ const (
 	// StateUntested means no allowlisted signer ran the row — a coverage gap,
 	// distinct from FAILING.
 	StateUntested State = "UNTESTED"
+
+	// StatePartial is a phase- and recipe-level rollup only, never a per-row
+	// state: some rows are corroborated as passing but others have not been run,
+	// so the category has real coverage that a plain UNTESTED rollup would hide.
+	// See RollupPhase.
+	StatePartial State = "PARTIAL"
 )
 
 // Result is a single signer's bucketed outcome for one row, after mapping the
@@ -194,15 +200,30 @@ func priorityOf(st State) int {
 // RollupPhase folds a set of row states into a single phase state using the
 // worst-first precedence. An empty set (no rows in the phase) rolls up to
 // UNTESTED.
+//
+// A phase with a mix of passing and not-yet-run rows would be dragged all the
+// way to UNTESTED by the worst-first precedence, hiding the coverage it does
+// have. That mixed state rolls up to PARTIAL instead. Real problems still win:
+// CONTESTED and FAILING outrank UNTESTED, so the worst is only UNTESTED here
+// when nothing failed — and PARTIAL is used only when some row is positive.
 func RollupPhase(states []State) State {
 	if len(states) == 0 {
 		return StateUntested
 	}
 	worst := states[0]
+	hasPositive := false
+	for _, st := range states {
+		if st == StateConfirmed || st == StateSingle {
+			hasPositive = true
+		}
+	}
 	for _, st := range states[1:] {
 		if priorityOf(st) < priorityOf(worst) {
 			worst = st
 		}
+	}
+	if worst == StateUntested && hasPositive {
+		return StatePartial
 	}
 	return worst
 }

--- a/pkg/corroborate/consensus_test.go
+++ b/pkg/corroborate/consensus_test.go
@@ -169,11 +169,14 @@ func TestRollupPhase(t *testing.T) {
 	}{
 		{"empty rolls up untested", nil, StateUntested},
 		{"single confirmed", []State{StateConfirmed}, StateConfirmed},
-		{"untested outranks confirmed", []State{StateConfirmed, StateConfirmed, StateUntested}, StateUntested},
+		{"all untested stays untested", []State{StateUntested, StateUntested}, StateUntested},
+		{"confirmed plus untested is partial", []State{StateConfirmed, StateConfirmed, StateUntested}, StatePartial},
+		{"single plus untested is partial", []State{StateSingle, StateUntested}, StatePartial},
 		{"single outranks confirmed", []State{StateConfirmed, StateSingle}, StateSingle},
-		{"failing outranks untested", []State{StateUntested, StateFailing}, StateFailing},
+		{"failing plus untested is not partial", []State{StateUntested, StateFailing}, StateFailing},
+		{"failing plus passing plus untested stays failing", []State{StateConfirmed, StateUntested, StateFailing}, StateFailing},
 		{"contested outranks failing", []State{StateFailing, StateContested}, StateContested},
-		{"contested wins over everything", []State{StateConfirmed, StateSingle, StateUntested, StateFailing, StateContested}, StateContested},
+		{"contested wins even with passing and untested", []State{StateConfirmed, StateSingle, StateUntested, StateFailing, StateContested}, StateContested},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/corroborate/generate.go
+++ b/pkg/corroborate/generate.go
@@ -741,7 +741,11 @@ func registerSource(sources map[string]Source, run *signerRun) {
 // identity's runs (newest-first), pre-reduced in buildRecipe so a signer that
 // submitted under two IDHashes contributes one column series, not two.
 func buildSeries(agg *recipeAgg, gridSigners map[string]struct{}, rowKeys []rowKey, runsByID map[string][]*signerRun) Series {
+	// rowKeys is the all-build union, already ordered by PhaseOrder then name.
+	// names drives the per-build Results maps; rows carries the phase-aware union
+	// the drilldown renders from (so older-build-only phases are still shown).
 	names := make([]string, 0, len(rowKeys))
+	rows := make([]SeriesRow, 0, len(rowKeys))
 	nameSeen := map[string]struct{}{}
 	for _, rk := range rowKeys {
 		if _, ok := nameSeen[rk.name]; ok {
@@ -749,6 +753,7 @@ func buildSeries(agg *recipeAgg, gridSigners map[string]struct{}, rowKeys []rowK
 		}
 		nameSeen[rk.name] = struct{}{}
 		names = append(names, rk.name)
+		rows = append(rows, SeriesRow{Name: rk.name, Phase: rk.phase})
 	}
 
 	builds := make(map[string][]SeriesBuild)
@@ -780,7 +785,7 @@ func buildSeries(agg *recipeAgg, gridSigners map[string]struct{}, rowKeys []rowK
 		health[id] = computeHealth(cols, names)
 	}
 
-	return Series{Recipe: agg.name, Builds: builds, Health: health}
+	return Series{Recipe: agg.name, Rows: rows, Builds: builds, Health: health}
 }
 
 // computeHealth derives a signer's run-health summary across its build columns.

--- a/pkg/corroborate/generate_test.go
+++ b/pkg/corroborate/generate_test.go
@@ -537,6 +537,79 @@ func TestGenerateSeries(t *testing.T) {
 	if s.Health[srcNVIDIA].FlakePct != 100 {
 		t.Errorf("nvidia flakePct = %d, want 100", s.Health["a1nvidia"].FlakePct)
 	}
+
+	// Older-build-only phase: nvidia's OLDER build ran conformance/gpu-operator-
+	// conformance and no signer's latest run has a conformance row. The
+	// phase-aware all-build union (Series.Rows) must still carry it so the
+	// drilldown renders the historical row instead of hiding it / mislabeling the
+	// phase "not run".
+	var confRow *SeriesRow
+	for i := range s.Rows {
+		if s.Rows[i].Name == "gpu-operator-conformance" {
+			confRow = &s.Rows[i]
+			break
+		}
+	}
+	if confRow == nil {
+		t.Fatalf("series rows missing older-build-only conformance row; got %+v", s.Rows)
+	}
+	if confRow.Phase != "conformance" {
+		t.Errorf("older-build-only row phase = %q, want conformance", confRow.Phase)
+	}
+	// Its historical result survives on the older nvidia build; the newest build,
+	// which never ran conformance, reports not-run.
+	if got := nv[1].Results["gpu-operator-conformance"]; got != "pass" {
+		t.Errorf("older nvidia conformance = %q, want pass", got)
+	}
+	if got := nv[0].Results["gpu-operator-conformance"]; got != "not-run" {
+		t.Errorf("newest nvidia conformance = %q, want not-run", got)
+	}
+}
+
+// TestGenerateOlderOnlyPhaseAbsentFromCombinedGrid confirms an older-build-only
+// phase row is absent from the default combined (all-versions) grid the
+// drilldown would otherwise render from, while still appearing in the older
+// version's grid — the exact gap Series.Rows closes for the drilldown.
+func TestGenerateOlderOnlyPhaseAbsentFromCombinedGrid(t *testing.T) {
+	out, _ := generateInto(t, filepath.Join("testdata", "allowlist.yaml"))
+	data, err := os.ReadFile(filepath.Join(out, "data", "index.json"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatalf("parse index: %v", err)
+	}
+	tab := findTab(t, idx, "h100-eks-ubuntu-training-kubeflow")
+	if tab.Combined == nil {
+		t.Fatal("recipe has no combined grid")
+	}
+	if tabHasRow(tab.Combined, "gpu-operator-conformance") {
+		t.Error("combined all-versions grid unexpectedly contains older-build-only conformance row")
+	}
+	// It is present in the older version's strict grid, proving the fixture is a
+	// genuine older-build-only phase (not simply missing everywhere).
+	if !anyVersionHasRow(tab, "gpu-operator-conformance") {
+		t.Error("no per-version grid carries the older-build-only conformance row")
+	}
+}
+
+func tabHasRow(v *TabVersion, name string) bool {
+	for _, r := range v.Tests {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func anyVersionHasRow(tab Tab, name string) bool {
+	for i := range tab.Versions {
+		if tabHasRow(&tab.Versions[i], name) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCompatibleMetaSchema(t *testing.T) {

--- a/pkg/corroborate/model.go
+++ b/pkg/corroborate/model.go
@@ -207,11 +207,27 @@ type Series struct {
 	// Recipe is the overlay metadata.name.
 	Recipe string `json:"recipe"`
 
+	// Rows is the phase-aware union of every row across ALL builds, ordered by
+	// PhaseOrder then CTRF name. The drilldown renders its rows from this rather
+	// than the latest combined grid, so a phase whose rows ran only in older
+	// builds is still shown (with its historical result) instead of collapsing
+	// to a "not run" placeholder.
+	Rows []SeriesRow `json:"rows"`
+
 	// Builds maps each signer-id-hash to its build columns, newest first.
 	Builds map[string][]SeriesBuild `json:"builds"`
 
 	// Health maps each signer-id-hash to its derived run-health summary.
 	Health map[string]SeriesHealth `json:"health"`
+}
+
+// SeriesRow is one row of the all-build union: a CTRF name and the phase it
+// belongs to. Historical-only rows (present in older builds but dropped from
+// every signer's latest run) appear here even though they are absent from the
+// latest combined grid.
+type SeriesRow struct {
+	Name  string `json:"name"`
+	Phase string `json:"phase"`
 }
 
 // SeriesBuild is one signer run rendered as a build column.

--- a/pkg/corroborate/renderer/index.html
+++ b/pkg/corroborate/renderer/index.html
@@ -986,10 +986,10 @@ const STATE_META = {
   CONTESTED:{ cls:"st-contested", ic:"⚠",  label:"CONTESTED",   desc:"sources disagree — inspect the runs" },
   FAILING:  { cls:"st-failing",   ic:"✗",  label:"FAILING",     desc:"corroborated as failing" },
   UNTESTED: { cls:"st-untested",  ic:"–",  label:"UNTESTED",    desc:"no evidence yet" },
-  // PARTIAL is an overview-only recipe rollup: corroborated on the phases that
-  // ran, but not all phases are covered (e.g. a runner without the hardware for
-  // performance). Never a per-row or per-phase state — see rollupRecipe.
-  PARTIAL:  { cls:"st-partial",   ic:"◐",  label:"PARTIAL",     desc:"passing where tested, but not all phases have run" },
+  // PARTIAL is a rollup-only state (phase or recipe), never a per-row state:
+  // corroborated where it ran, but some rows/phases have not been run yet (e.g.
+  // a runner without the hardware for performance). See rollupPhase/rollupRecipe.
+  PARTIAL:  { cls:"st-partial",   ic:"◐",  label:"PARTIAL",     desc:"passing where tested, but not everything has run" },
 };
 const STATE_COLOR = {
   CONFIRMED:"var(--confirmed)", SINGLE:"var(--single)", CONTESTED:"var(--contested)",
@@ -1108,14 +1108,20 @@ function consensusOf(test){
   return { state: test._consensus, passAllow, failAllow, reported: test._reported };
 }
 function rollupPhase(tests){
-  let chosen = null, anyTest = false, pass = 0, fail = 0, reported = 0;
+  let chosen = null, anyTest = false, pass = 0, fail = 0, reported = 0, positive = 0;
   for (const t of tests){
     anyTest = true;
     const c = consensusOf(t);
     pass += c.passAllow; fail += c.failAllow; reported += c.reported;
+    if (c.state === "CONFIRMED" || c.state === "SINGLE") positive++;
     if (chosen === null || PHASE_PRIORITY.indexOf(c.state) < PHASE_PRIORITY.indexOf(chosen)) chosen = c.state;
   }
   if (!anyTest) chosen = "UNTESTED";
+  // A phase with some passing rows but others not yet run would otherwise be
+  // dragged to UNTESTED by its not-run rows, hiding the coverage it does have.
+  // Surface that as PARTIAL. CONTESTED/FAILING outrank UNTESTED, so chosen is
+  // only UNTESTED here when nothing failed. Mirrors Go RollupPhase.
+  if (chosen === "UNTESTED" && positive > 0) chosen = "PARTIAL";
   return { state: chosen, pass, fail, reported, total: pass + fail };
 }
 function rollupRecipe(recipe){
@@ -1944,10 +1950,13 @@ function renderMatrix(recipe){
   const tbody = document.createElement("tbody");
   PHASES.forEach(ph => {
     let tests = aTests.filter(t => t.phase === ph);
-    if (tests.length === 0) return;
+    // An empty phase (no rows at all) is still shown as an UNTESTED coverage gap
+    // rather than hidden, so a category nobody has run is visible instead of
+    // silently missing.
+    const empty = tests.length === 0;
     tests = sortTests(tests);
 
-    const rollState = aRollup[ph] || rollupPhase(tests).state; // baked Go state (active version)
+    const rollState = aRollup[ph] || (empty ? "UNTESTED" : rollupPhase(tests).state); // baked Go state (active version)
     const phaseKey = `${recipe.name}/${ph}`;
     const collapsed = collapsedPhases.has(phaseKey);
 
@@ -1959,7 +1968,7 @@ function renderMatrix(recipe){
     inner.className = "phase-sec-inner" + (collapsed ? " collapsed" : "");
     inner.innerHTML =
       `<span class="ptw">▾</span><span class="pname">${ph}</span>` +
-      `<span class="pmeta">${tests.length} test${tests.length>1?"s":""} · rollup ${rollState}</span>`;
+      `<span class="pmeta">${empty ? "not run" : tests.length + " test" + (tests.length>1?"s":"")} · rollup ${rollState}</span>`;
     inner.tabIndex = 0;
     inner.setAttribute("role", "button");
     inner.setAttribute("aria-expanded", String(!collapsed));
@@ -1975,6 +1984,34 @@ function renderMatrix(recipe){
     tbody.appendChild(secTr);
 
     if (collapsed) return;
+
+    if (empty){
+      // Placeholder row for a category with no runs: an UNTESTED consensus badge
+      // and empty tiles across every source column.
+      const tr = document.createElement("tr");
+      tr.className = "trow";
+      const tdTest = document.createElement("td");
+      tdTest.className = "cell-test";
+      tdTest.textContent = "(no tests run)";
+      tr.appendChild(tdTest);
+      const tdCons = document.createElement("td");
+      tdCons.className = "cell-cons";
+      const consWrap = document.createElement("span");
+      consWrap.className = "cons-cell";
+      consWrap.appendChild(badgeEl("UNTESTED", 0, 0, 0));
+      tdCons.appendChild(consWrap);
+      tr.appendChild(tdCons);
+      cols.forEach(({src}) => {
+        const td = document.createElement("td");
+        td.className = "cell-src";
+        const meta = SOURCES[src];
+        if (meta && !meta.allowlisted) td.classList.add("reported-col");
+        td.appendChild(tileEl("empty"));
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+      return;
+    }
 
     tests.forEach(test => {
       const c = consensusOf(test);
@@ -2130,7 +2167,16 @@ async function openTimeSeries(recipe, src, focusTest){
   // body grid — recipe's FULL union test list × builds (results default not-run).
   // paint() rebuilds the table so collapsible phase sections can re-render
   // without re-fetching the series.
-  const tests = recipe.tests;
+  //
+  // Rows come from the phase-aware ALL-build union (series.rows), not the latest
+  // combined grid (recipe.tests): a phase whose rows ran only in older builds is
+  // absent from every signer's latest run, so rendering from recipe.tests would
+  // drop those rows and mislabel the phase "not run" even though the series still
+  // holds their historical result. Fall back to recipe.tests for series data
+  // written before the rows field existed.
+  const tests = (series.rows && series.rows.length)
+    ? series.rows.map(r => ({ name: r.name, phase: r.phase }))
+    : recipe.tests;
   function paint(){
     host.innerHTML = "";
     // AICR version filtered this source down to nothing — say so rather than
@@ -2187,7 +2233,8 @@ async function openTimeSeries(recipe, src, focusTest){
     const tbody = document.createElement("tbody");
     PHASES.forEach(ph => {
       const phaseTests = tests.filter(t => t.phase === ph);
-      if (phaseTests.length === 0) return;
+      // Show an empty phase as an UNTESTED coverage gap instead of hiding it.
+      const empty = phaseTests.length === 0;
       const phaseKey = `${recipe.name}/${src}/${ph}`;
       const collapsed = collapsedTsPhases.has(phaseKey);
 
@@ -2199,7 +2246,7 @@ async function openTimeSeries(recipe, src, focusTest){
       inner.className = "phase-sec-inner" + (collapsed ? " collapsed" : "");
       inner.innerHTML =
         `<span class="ptw">▾</span><span class="pname">${esc(ph)}</span>` +
-        `<span class="pmeta">${phaseTests.length} test${phaseTests.length>1?"s":""}</span>`;
+        `<span class="pmeta">${empty ? "not run" : phaseTests.length + " test" + (phaseTests.length>1?"s":"")}</span>`;
       inner.tabIndex = 0;
       inner.setAttribute("role", "button");
       inner.setAttribute("aria-expanded", String(!collapsed));
@@ -2216,13 +2263,38 @@ async function openTimeSeries(recipe, src, focusTest){
 
       if (collapsed) return;
 
+      if (empty){
+        // Placeholder row for a category this source never ran: empty tiles
+        // across every build column.
+        const tr = document.createElement("tr");
+        tr.className = "ts-row";
+        const td0 = document.createElement("td");
+        td0.className = "ts-name ts-name-norun";
+        td0.innerHTML = `<span class="norun-tag">no tests run</span>`;
+        tr.appendChild(td0);
+        for (let b = 0; b < vn; b++){
+          const td = document.createElement("td");
+          td.className = "ts-cell" + (dimCol[b] ? " dimcol" : "");
+          td.appendChild(tileEl("not-run"));
+          tr.appendChild(td);
+        }
+        tbody.appendChild(tr);
+        return;
+      }
+
       phaseTests.forEach(test => {
         const tr = document.createElement("tr");
         tr.className = "ts-row";
         if (focusTest && test.name === focusTest) tr.style.boxShadow = "inset 3px 0 0 var(--green)";
         const td0 = document.createElement("td");
         td0.className = "ts-name";
-        const neverRan = resultFor(test, src) === null;
+        // "Not reported by this source" is derived from the source's own build
+        // columns (not recipe.tests runs), so it is correct for historical-only
+        // rows that have no entry in the latest combined grid.
+        const neverRan = !vcols.some(bm => {
+          const r = bm.results && bm.results[test.name];
+          return r === "pass" || r === "fail";
+        });
         if (neverRan){
           td0.classList.add("ts-name-norun");
           td0.innerHTML = `${esc(test.name)}<span class="norun-tag">not reported by this source</span>`;

--- a/pkg/corroborate/testdata/gcs/results/eks/h100-ubuntu/training-kubeflow/a1nvidia/run-2026-06-10T0100/ctrf/conformance.json
+++ b/pkg/corroborate/testdata/gcs/results/eks/h100-ubuntu/training-kubeflow/a1nvidia/run-2026-06-10T0100/ctrf/conformance.json
@@ -1,0 +1,32 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-06-10T01:00:00Z",
+  "generatedBy": "aicr validate",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "v0.14.0"
+    },
+    "summary": {
+      "tests": 1,
+      "passed": 1,
+      "failed": 0,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1781053200000,
+      "stop": 1781053500000
+    },
+    "tests": [
+      {
+        "name": "gpu-operator-conformance",
+        "status": "passed",
+        "duration": 1000,
+        "suite": [
+          "conformance"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Two evidence-dashboard category (phase) rollup fixes: mixed passing/untested categories now roll up to `PARTIAL` instead of `UNTESTED`, and an entirely-untested category is shown as an untested coverage gap instead of being omitted from the board.

## Motivation / Context

On the corroboration dashboard, a category like `conformance` with some rows tested-and-passing and others not yet run was dragged all the way to `UNTESTED` by the worst-first rollup precedence, hiding the coverage it did have. Separately, a category with no rows at all was dropped from the recipe matrix and per-source drilldown entirely, so a category nobody has run appeared silently missing rather than as a visible gap.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: evidence corroboration dashboard (`pkg/corroborate`, renderer)

## Implementation Notes

- **`PARTIAL` phase rollup** — `RollupPhase` (Go, authoritative in `pkg/corroborate/consensus.go`) and the renderer's `rollupPhase` now promote a category to `PARTIAL` when the worst state is `UNTESTED` but at least one row is passing (`CONFIRMED`/`SINGLE`). `CONTESTED` and `FAILING` still outrank `UNTESTED`, so a phase only reaches `PARTIAL` when nothing failed; an all-untested phase stays `UNTESTED`. `PARTIAL` remains a rollup-only state — individual rows never carry it. The overview grid picks this up automatically via the baked Go `PhaseRollup`.
- **Show empty categories** — the recipe matrix and per-source drilldown previously did `if (tests.length === 0) return;`, omitting empty phases. They now render the phase header plus an `UNTESTED` placeholder row (empty/not-run tiles across all columns).
- Updated `docs/user/evidence-dashboard.md` Phase rollup section for both behaviors.

## Testing

```bash
go test ./pkg/corroborate/...
golangci-lint run -c .golangci.yaml ./pkg/corroborate/...
gofmt -l pkg/corroborate/
```

`TestRollupPhase` updated: the former "untested outranks confirmed" case now asserts `PARTIAL`, with added cases covering partial/failing/contested combinations with untested rows. Package tests pass, lint reports 0 issues, gofmt clean.

## Risk Assessment

- [x] **Low** — Isolated to dashboard rollup/rendering; no change to evidence data, consensus counting, or verification. Easy to revert.

**Rollout notes:** N/A — the dashboard re-renders from existing evidence; no migration.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
