### PR TITLE
evidence(aks): h100 managed-driver kubeflow-training + dynamo-inference

### DIFF
--- a/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-b7d3b1c672568329cae994ed4c831af5e569b23209fb81e789d2e2288b44100d.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-b7d3b1c672568329cae994ed4c831af5e569b23209fb81e789d2e2288b44100d.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-22T18:01:25Z
+    bundle:
+      digest: sha256:b7d3b1c672568329cae994ed4c831af5e569b23209fb81e789d2e2288b44100d
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-inference-dynamo-147729815f33
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 36047660
+recipe: h100-aks-ubuntu-inference-dynamo
+schemaVersion: 1.0.0

--- a/recipes/evidence/h100-aks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-dc1670c23bbe6711a6ffd86a49160b06d992c8ff84e8f3303facc54dd7aecb61.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-dc1670c23bbe6711a6ffd86a49160b06d992c8ff84e8f3303facc54dd7aecb61.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-22T18:06:54Z
+    bundle:
+      digest: sha256:dc1670c23bbe6711a6ffd86a49160b06d992c8ff84e8f3303facc54dd7aecb61
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-training-kubeflow-1461e661fe47
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 36047787
+recipe: h100-aks-ubuntu-training-kubeflow
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Signed three-phase recipe evidence for `h100-aks-ubuntu-training-kubeflow` and `h100-aks-ubuntu-inference-dynamo`, captured on an AKS H100 cluster (aicr-test6) running the Azure-managed GPU driver profile from #1756.

## Motivation / Context

Fresh evidence at `main@1179103f` after applying the gpu-operator CDI + toolkit-hardening upgrade (#1756) to the cluster — the first evidence for these recipes on the post-hardening stack. All three phases passed for both recipes:

- **training-kubeflow**: deployment 2m26s, conformance 1m36s, performance (NCCL all-reduce gate) 50s
- **inference-dynamo**: deployment 2m33s, conformance 1m47s, performance 6m00s — 145.3k tokens/sec, TTFT p99 604ms

Fixes: N/A
Related: #1756, #1840 (prior driver-only evidence for the same recipes)

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Other: recipe evidence pointers (`recipes/evidence/`)

## Implementation Notes

Bundles pushed to `ghcr.io/yuanchen8911/aicr-evidence` and signed via the fork `Recipe Evidence: Sign` workflow (allowlisted source slug `5bf9e82f...`, firstParty CI identity — no personal PII in Rekor). Pointer YAMLs are machine-generated and carry no license header, matching every merged pointer.

## Testing

`aicr evidence verify` exits 0 on both pointers locally, which predicts the "Enforce per-source pointer contract" gate passing.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** On merge, Evidence: Ingest publishes to GCS and the dashboard picks both up at validation.aicr.run.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, pointer-only change; evidence verify run instead
- [x] Linter passes (`make lint`) — N/A, pointer-only change
- [x] I did not skip/disable tests to make CI green
- [x] Commits are cryptographically signed