### PR TITLE
fix(validator): gate deployment readiness on uniform RDMA fabric

### DIFF
--- a/validators/deployment/expected_resources.go
+++ b/validators/deployment/expected_resources.go
@@ -47,6 +47,7 @@ import (
 const (
 	nodewrightCustomizationsComponent = "nodewright-customizations"
 	draDriverComponent                = "nvidia-dra-driver-gpu"
+	networkOperatorComponent          = "network-operator"
 
 	// draKubeletPluginSuffix is the chart-template-defined name suffix for
 	// the NVIDIA DRA driver's kubelet-plugin DaemonSet. The upstream chart
@@ -84,6 +85,19 @@ const (
 	// (tests/uat/aws/cluster-config.yaml).
 	runtimeRequiredTaintKey   = "skyhook.nvidia.com"
 	runtimeRequiredTaintValue = "runtime-required"
+
+	// nicClusterPolicyManifestMarker identifies the AKS NicClusterPolicy manifest
+	// (recipes/components/network-operator/manifests/nic-cluster-policy-aks.yaml)
+	// among a network-operator ComponentRef's ManifestFiles. Its presence means
+	// the recipe stands up an RDMA fabric (MOFED + rdma-shared-device-plugin), so
+	// a GPU node not yet advertising the shared resource is "still converging",
+	// not "no fabric". OCP wires a different component (network-operator-ocp) and
+	// manifest name and so does not match; kind/talos enable network-operator
+	// without this manifest and are likewise (correctly) not gated. The shared
+	// resource name and the RDMA node label are defined in validators/helper
+	// (AKSRdmaSharedResource, PCIMellanoxPresentLabel) so this gate and the NCCL
+	// consumer cannot drift.
+	nicClusterPolicyManifestMarker = "nic-cluster-policy"
 )
 
 var (
@@ -417,6 +431,10 @@ func verifyGPUReadinessSignals(ctx *validators.Context, refs []recipe.ComponentR
 
 	if ref, ok := findEnabledComponent(refs, draDriverComponent); ok {
 		capture(verifyDRAKubeletPluginReady(ctx, ref.Namespace))
+	}
+
+	if ref, ok := findEnabledComponent(refs, networkOperatorComponent); ok && recipeDeclaresRDMAFabric(ref) {
+		capture(verifyRDMAFabricReady(ctx))
 	}
 
 	return failures, firstStructured
@@ -920,6 +938,141 @@ func draKubeletPluginProbe(ctx *validators.Context, namespace string) (string, e
 	}
 
 	return ds.Name, nil
+}
+
+// recipeDeclaresRDMAFabric reports whether a network-operator ComponentRef
+// stands up an RDMA fabric on this cluster — i.e. it declares the AKS
+// NicClusterPolicy manifest that creates MOFED + the rdma-shared-device-plugin
+// (nicClusterPolicyManifestMarker). When true, a GPU node that does not yet
+// advertise aksRDMASharedResource is "still converging", so verifyRDMAFabricReady
+// waits for it; when false (kind's single-node nvkind, talos' namespace-only
+// ref) there is no shared fabric to gate on and the check is skipped.
+func recipeDeclaresRDMAFabric(ref recipe.ComponentRef) bool {
+	for _, f := range ref.ManifestFiles {
+		if strings.Contains(f, nicClusterPolicyManifestMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+// verifyRDMAFabricReady blocks the deployment gate until the network operator's
+// shared RDMA device (helper.AKSRdmaSharedResource) is allocatable in a uniform,
+// positive count across every Mellanox RDMA-capable GPU node, held continuously for the
+// stability window.
+//
+// Why span the whole RDMA cohort rather than one node: NCCL all-reduce and any
+// other all-to-all fabric test participate every node together, so a single node
+// whose MOFED / rdma-shared-device-plugin has not finished rolling out degrades
+// the whole run. The network operator rolls MOFED out per node and one node can
+// lag another by many minutes (issue #1862), during which the shared resource is
+// present on only a subset of nodes. Gating on uniform allocatable presence stops
+// the downstream NCCL check's uniformFabricResourceCount from failing closed on a
+// transient, self-healing partial rollout, mirroring the DRA kubelet-plugin and
+// Nodewright "stable ≥window" treatment above.
+//
+// Why *this* node set: the probe scopes to schedulable GPU nodes that carry the
+// NicClusterPolicy's own nodeAffinity label (helper.PCIMellanoxPresentLabel) —
+// exactly the cohort the fabric can land on and the NCCL check runs on. A
+// cordoned/draining node, or a GPU node in a non-RDMA (non-Mellanox) pool, never advertises the
+// resource; including it would wedge the gate on a node the workload excludes.
+func verifyRDMAFabricReady(ctx *validators.Context) error {
+	var nodeCount int
+	return pollUntilStable(ctx,
+		fmt.Sprintf("RDMA shared-device fabric (%s) across RDMA GPU nodes", helper.AKSRdmaSharedResource),
+		func() error {
+			count, probeErr := rdmaFabricProbe(ctx)
+			nodeCount = count
+			return probeErr
+		},
+		func() {
+			fmt.Printf("  RDMA fabric (%s): allocatable (uniform) on all %d RDMA GPU node(s) (stable ≥%s)\n",
+				helper.AKSRdmaSharedResource, nodeCount, gpuReadinessStabilityWindow)
+		})
+}
+
+// rdmaFabricProbe does one readiness pass over the Mellanox RDMA-capable GPU cohort:
+// schedulable GPU nodes (via helper.FindSchedulableGpuNodes — cordoned nodes and
+// nodes not yet advertising nvidia.com/gpu are excluded) that also carry the
+// NicClusterPolicy nodeAffinity label helper.PCIMellanoxPresentLabel. It returns
+// nil — plus the cohort size — only when every such node advertises
+// helper.AKSRdmaSharedResource in a uniform, positive count. It fails closed on a
+// List error and when no RDMA GPU node is observed yet: "could not observe the
+// fabric" must never read as "fabric ready". The returned error rides the poll's
+// dwell reset like any other unhealthy sample.
+func rdmaFabricProbe(ctx *validators.Context) (int, error) {
+	listCtx, cancel := ctx.Timeout(defaults.ResourceVerificationTimeout)
+	defer cancel()
+
+	gpuNodes, err := helper.FindSchedulableGpuNodes(listCtx, ctx.Clientset)
+	if err != nil {
+		return 0, errors.Wrap(errors.ErrCodeInternal,
+			"failed to list nodes for the RDMA fabric readiness gate", err)
+	}
+
+	fabric := corev1.ResourceName(helper.AKSRdmaSharedResource)
+	type rdmaNode struct {
+		name  string
+		count int64
+	}
+	var cohort []rdmaNode
+	for i := range gpuNodes {
+		// Honor cancellation while walking a potentially large node list, per
+		// repo CLAUDE.md "Always check ctx.Done() in long-running operations".
+		select {
+		case <-listCtx.Done():
+			return 0, errors.Wrap(errors.ErrCodeTimeout,
+				"canceled while scanning nodes for the RDMA fabric readiness gate", listCtx.Err())
+		default:
+		}
+		node := &gpuNodes[i]
+		if node.Labels[helper.PCIMellanoxPresentLabel] != "true" {
+			continue
+		}
+		var count int64
+		if q, ok := node.Status.Allocatable[fabric]; ok {
+			count = q.Value()
+		}
+		cohort = append(cohort, rdmaNode{name: node.Name, count: count})
+	}
+
+	if len(cohort) == 0 {
+		return 0, errors.New(errors.ErrCodeNotFound,
+			fmt.Sprintf("RDMA fabric gate: no schedulable Mellanox RDMA-capable GPU nodes observed yet (label %s=true)",
+				helper.PCIMellanoxPresentLabel))
+	}
+
+	// Not-ready nodes: the fabric resource is absent or zero — MOFED /
+	// rdma-shared-device-plugin has not finished rolling out on that node.
+	var notReady []string
+	for _, n := range cohort {
+		if n.count <= 0 {
+			notReady = append(notReady, n.name)
+		}
+	}
+	if len(notReady) > 0 {
+		return len(cohort), errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("%s not yet allocatable on %d of %d RDMA GPU node(s): %s "+
+				"(network operator MOFED / rdma-shared-device-plugin still rolling out)",
+				helper.AKSRdmaSharedResource, len(notReady), len(cohort), formatNames(notReady)))
+	}
+
+	// All present and positive: require a uniform count, matching the NCCL
+	// consumer's uniformFabricResourceCount. A skew (e.g. 1000 vs 500) means the
+	// fabric is still settling and the NCCL check would reject it as non-uniform.
+	want := cohort[0].count
+	var skew []string
+	for _, n := range cohort {
+		if n.count != want {
+			skew = append(skew, fmt.Sprintf("%s=%d", n.name, n.count))
+		}
+	}
+	if len(skew) > 0 {
+		return len(cohort), errors.New(errors.ErrCodeInternal,
+			fmt.Sprintf("%s allocatable count is non-uniform across %d RDMA GPU node(s) (want all == %d): %s",
+				helper.AKSRdmaSharedResource, len(cohort), want, formatNames(skew)))
+	}
+	return len(cohort), nil
 }
 
 func formatNames(names []string) string {

--- a/validators/deployment/expected_resources_rdma_test.go
+++ b/validators/deployment/expected_resources_rdma_test.go
@@ -1,0 +1,370 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/validators"
+	"github.com/NVIDIA/aicr/validators/helper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// gpuNode builds a schedulable node. gpu >= 0 advertises that many allocatable
+// nvidia.com/gpu (gpu < 0 omits the resource → a non-GPU node); rdma >= 0 also
+// advertises that many rdma/hca_shared_devices_a (rdma < 0 omits it). The node
+// carries NO Mellanox NIC label by default — use withIB to mark it Mellanox RDMA-capable.
+func gpuNode(name string, gpu, rdma int64) *corev1.Node {
+	alloc := corev1.ResourceList{}
+	if gpu >= 0 {
+		alloc[corev1.ResourceName(helper.GpuResourceName)] = *resource.NewQuantity(gpu, resource.DecimalSI)
+	}
+	if rdma >= 0 {
+		alloc[corev1.ResourceName(helper.AKSRdmaSharedResource)] = *resource.NewQuantity(rdma, resource.DecimalSI)
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NodeStatus{Allocatable: alloc},
+	}
+}
+
+// withMellanoxNIC marks a node Mellanox RDMA-capable (the NicClusterPolicy nodeAffinity label the
+// fabric is placed on), so the RDMA fabric gate includes it in the cohort.
+func withMellanoxNIC(n *corev1.Node) *corev1.Node {
+	if n.Labels == nil {
+		n.Labels = map[string]string{}
+	}
+	n.Labels[helper.PCIMellanoxPresentLabel] = "true"
+	return n
+}
+
+// cordon marks a node unschedulable (draining), which excludes it from the
+// schedulable GPU cohort the gate spans.
+func cordon(n *corev1.Node) *corev1.Node {
+	n.Spec.Unschedulable = true
+	return n
+}
+
+// rdmaGPUNode is the common case: a schedulable, Mellanox RDMA-capable GPU node with `gpu`
+// allocatable GPUs and `rdma` allocatable shared-fabric units (rdma < 0 omits).
+func rdmaGPUNode(name string, gpu, rdma int64) *corev1.Node {
+	return withMellanoxNIC(gpuNode(name, gpu, rdma))
+}
+
+// TestRecipeDeclaresRDMAFabric proves the gate engages only when the
+// network-operator ComponentRef declares the AKS NicClusterPolicy manifest, and
+// discriminates it from near-miss / OCP / non-fabric manifests.
+func TestRecipeDeclaresRDMAFabric(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		manifestFiles []string
+		want          bool
+	}{
+		{
+			name:          "AKS nic-cluster-policy manifest present",
+			manifestFiles: []string{"components/network-operator/manifests/nic-cluster-policy-aks.yaml"},
+			want:          true,
+		},
+		{
+			name: "marker present among several manifests",
+			manifestFiles: []string{
+				"components/network-operator/manifests/nfd-network-rule.yaml",
+				"components/network-operator/manifests/nic-cluster-policy-aks.yaml",
+				"components/network-operator/manifests/nvidia-peermem-reloader.yaml",
+			},
+			want: true,
+		},
+		{
+			name:          "OCP nicclusterpolicy (no hyphens) does not match",
+			manifestFiles: []string{"components/network-operator-ocp/manifests/nicclusterpolicy.yaml"},
+			want:          false,
+		},
+		{
+			name:          "near-miss cluster-policy without nic- prefix does not match",
+			manifestFiles: []string{"components/somewhere/manifests/cluster-policy.yaml"},
+			want:          false,
+		},
+		{
+			name:          "talos namespace-only ref (no fabric)",
+			manifestFiles: []string{"components/network-operator/manifests/talos-namespace.yaml"},
+			want:          false,
+		},
+		{
+			name:          "no manifests",
+			manifestFiles: nil,
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ref := recipe.ComponentRef{Name: networkOperatorComponent, ManifestFiles: tt.manifestFiles}
+			if got := recipeDeclaresRDMAFabric(ref); got != tt.want {
+				t.Fatalf("recipeDeclaresRDMAFabric(%v) = %v, want %v", tt.manifestFiles, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVerifyRDMAFabricReady_Poll drives the fabric readiness poll through a
+// scripted per-node sequence (each entry is the rdma/hca_shared_devices_a
+// allocatable count on gpu-node-1 for one List; -1 => absent, 0 => present-but-
+// zero; the last entry repeats). Node gpu-node-0 always has the fabric.
+func TestVerifyRDMAFabricReady_Poll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		node1RDMA  []int64
+		wantErrSub string // "" => expect success
+		minLists   int
+	}{
+		{
+			name:      "rides through transient partial rollout",
+			node1RDMA: []int64{-1, -1, 1000},
+			minLists:  3,
+		},
+		{
+			name:       "times out while one node's fabric is absent (names the node)",
+			node1RDMA:  []int64{-1},
+			wantErrSub: "not yet allocatable on 1 of 2 RDMA GPU node(s): [gpu-node-1]",
+		},
+		{
+			name:       "times out while one node advertises the fabric as zero (present-but-zero)",
+			node1RDMA:  []int64{0},
+			wantErrSub: "not yet allocatable on 1 of 2 RDMA GPU node(s): [gpu-node-1]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			seq := tt.node1RDMA
+			clientset := k8sfake.NewClientset()
+			var lists int32
+			clientset.PrependReactor("list", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+				idx := int(atomic.AddInt32(&lists, 1)) - 1
+				if idx >= len(seq) {
+					idx = len(seq) - 1
+				}
+				return true, &corev1.NodeList{Items: []corev1.Node{
+					// gpu-node-1 is a degraded 7-GPU node (issue #1858) — proving
+					// the fabric gate spans it regardless of GPU count.
+					*rdmaGPUNode("gpu-node-0", 8, 1000),
+					*rdmaGPUNode("gpu-node-1", 7, seq[idx]),
+				}}, nil
+			})
+			ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+			err := verifyRDMAFabricReady(ctx)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("verifyRDMAFabricReady() error = nil, want error containing %q", tt.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Fatalf("verifyRDMAFabricReady() error = %v, want substring %q", err, tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("verifyRDMAFabricReady() error = %v, want nil (should ride through the transient partial rollout)", err)
+			}
+			if got := int(atomic.LoadInt32(&lists)); got < tt.minLists {
+				t.Fatalf("expected the poll to list nodes at least %d times (through the partial rollout), got %d", tt.minLists, got)
+			}
+		})
+	}
+}
+
+// TestRDMAFabricProbe_FailsClosedOnListError proves a node-list failure is
+// surfaced (not read as "fabric ready"), so the poll fails closed and retries.
+func TestRDMAFabricProbe_FailsClosedOnListError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	clientset.PrependReactor("list", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, stderrors.New("apiserver unavailable")
+	})
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	count, err := rdmaFabricProbe(ctx)
+	if err == nil {
+		t.Fatal("expected an error when listing nodes fails, got nil (must fail closed)")
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 nodes on list error, got %d", count)
+	}
+	if !strings.Contains(err.Error(), "failed to list nodes for the RDMA fabric readiness gate") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRDMAFabricProbe_FailsClosedWithoutRDMANodes proves the probe fails closed
+// (does not vacuously pass) when no schedulable RDMA GPU node is observed — a GPU
+// node without the Mellanox NIC label is not the fabric cohort, and "no cohort" must never
+// read as "fabric ready".
+func TestRDMAFabricProbe_FailsClosedWithoutRDMANodes(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		gpuNode("gpu-node-0", 8, -1), // GPU node but NOT Mellanox-NIC-labeled → not in cohort
+		gpuNode("cpu-node-0", -1, -1),
+	)
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	count, err := rdmaFabricProbe(ctx)
+	if err == nil {
+		t.Fatal("expected an error when no RDMA GPU nodes are present, got nil (must fail closed)")
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 cohort nodes, got %d", count)
+	}
+	if !strings.Contains(err.Error(), "no schedulable Mellanox RDMA-capable GPU nodes observed yet") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRDMAFabricProbe_ExcludesCordonedNonRDMAAndCPU proves the gate scopes to
+// schedulable RDMA GPU nodes only (issue #1862 crux): a cordoned RDMA node, a non-RDMA
+// GPU node, a zero-GPU node, and a CPU node are all excluded — so a node the NCCL
+// check would never run on cannot wedge the gate. Only the one healthy RDMA GPU
+// node is required to (and does) carry the fabric.
+func TestRDMAFabricProbe_ExcludesCordonedNonRDMAAndCPU(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		rdmaGPUNode("rdma-gpu-0", 8, 1000),           // in cohort, fabric ready
+		gpuNode("nordma-gpu-0", 8, -1),               // GPU but no Mellanox NIC label → excluded
+		cordon(rdmaGPUNode("rdma-gpu-drain", 8, -1)), // Mellanox NIC but cordoned → excluded
+		rdmaGPUNode("rdma-zerogpu", 0, -1),           // Mellanox NIC but nvidia.com/gpu:0 → excluded by helper
+		gpuNode("cpu-0", -1, -1),                     // CPU node → excluded
+	)
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	count, err := rdmaFabricProbe(ctx)
+	if err != nil {
+		t.Fatalf("rdmaFabricProbe() error = %v, want nil (only the schedulable RDMA GPU node is required to carry the fabric)", err)
+	}
+	if count != 1 {
+		t.Fatalf("rdmaFabricProbe() cohort size = %d, want 1 (cordoned/non-RDMA/zero-GPU/CPU excluded)", count)
+	}
+}
+
+// TestRDMAFabricProbe_NonUniformCountFails proves the gate matches the NCCL
+// consumer's uniformFabricResourceCount: two RDMA nodes both advertising the
+// fabric but with different counts (1000 vs 500) is "still settling", not ready.
+func TestRDMAFabricProbe_NonUniformCountFails(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		rdmaGPUNode("rdma-gpu-0", 8, 1000),
+		rdmaGPUNode("rdma-gpu-1", 8, 500),
+	)
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	count, err := rdmaFabricProbe(ctx)
+	if err == nil {
+		t.Fatal("expected an error on non-uniform fabric counts, got nil")
+	}
+	if count != 2 {
+		t.Fatalf("expected cohort size 2, got %d", count)
+	}
+	if !strings.Contains(err.Error(), "non-uniform") || !strings.Contains(err.Error(), "rdma-gpu-1=500") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRDMAFabricProbe_PassesWhenUniform proves the probe returns the cohort size
+// and no error once every RDMA GPU node advertises the same positive fabric count.
+func TestRDMAFabricProbe_PassesWhenUniform(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		rdmaGPUNode("rdma-gpu-0", 8, 1000),
+		rdmaGPUNode("rdma-gpu-1", 7, 1000), // degraded 7-GPU node still carries the fabric
+	)
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	count, err := rdmaFabricProbe(ctx)
+	if err != nil {
+		t.Fatalf("rdmaFabricProbe() error = %v, want nil (fabric uniform on all RDMA GPU nodes)", err)
+	}
+	if count != 2 {
+		t.Fatalf("rdmaFabricProbe() cohort size = %d, want 2", count)
+	}
+}
+
+// TestVerifyGPUReadinessSignals_RDMADispatch proves the gate is wired to fire
+// only when the recipe enables network-operator AND declares the nic-cluster-
+// policy manifest — the dispatch conjunction, not just the two predicates in
+// isolation. (a) fabric recipe + a fabric-missing RDMA node → a fabric failure is
+// returned; (b) network-operator without the fabric manifest → the gate never
+// runs even though the same node lacks the fabric.
+func TestVerifyGPUReadinessSignals_RDMADispatch(t *testing.T) {
+	t.Parallel()
+
+	newCtx := func() *validators.Context {
+		clientset := k8sfake.NewClientset(rdmaGPUNode("rdma-gpu-0", 8, -1)) // fabric absent
+		return &validators.Context{Ctx: context.Background(), Clientset: clientset}
+	}
+	const fabricErrFragment = "not yet allocatable"
+
+	t.Run("fires on network-operator + nic-cluster-policy manifest", func(t *testing.T) {
+		t.Parallel()
+		refs := []recipe.ComponentRef{{
+			Name:          networkOperatorComponent,
+			ManifestFiles: []string{"components/network-operator/manifests/nic-cluster-policy-aks.yaml"},
+		}}
+		failures, _ := verifyGPUReadinessSignals(newCtx(), refs)
+		if !containsSubstr(failures, fabricErrFragment) {
+			t.Fatalf("expected a fabric failure in %v", failures)
+		}
+	})
+
+	t.Run("does not fire without the fabric manifest", func(t *testing.T) {
+		t.Parallel()
+		refs := []recipe.ComponentRef{{
+			Name:          networkOperatorComponent,
+			ManifestFiles: []string{"components/network-operator/manifests/talos-namespace.yaml"},
+		}}
+		failures, _ := verifyGPUReadinessSignals(newCtx(), refs)
+		if containsSubstr(failures, fabricErrFragment) {
+			t.Fatalf("fabric gate must not run without the nic-cluster-policy manifest; got %v", failures)
+		}
+	})
+}
+
+func containsSubstr(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/validators/helper/gpu.go
+++ b/validators/helper/gpu.go
@@ -28,6 +28,24 @@ import (
 // GpuResourceName is the Kubernetes resource name for NVIDIA GPUs.
 const GpuResourceName = "nvidia.com/gpu"
 
+// AKSRdmaSharedResource is the extended resource the network operator's
+// rdma-shared-device-plugin publishes on Mellanox RDMA nodes. Its name is pinned
+// by recipes/components/network-operator/manifests/nic-cluster-policy-aks.yaml
+// (resourceName hca_shared_devices_a). The resource is transport-agnostic — the
+// same pool backs InfiniBand and RoCE — so nothing keyed off it is IB-specific.
+// Both the deployment-phase RDMA fabric readiness gate and the NCCL performance
+// consumer key off this exact resource, so it lives here as the single source of
+// truth rather than a duplicated literal in each validator binary.
+const AKSRdmaSharedResource = "rdma/hca_shared_devices_a"
+
+// PCIMellanoxPresentLabel is the NFD feature label marking nodes with a Mellanox
+// (PCI vendor 15b3) NIC — the vendor NFD detects for any ConnectX card, whether
+// it runs InfiniBand or RoCE, so this is an RDMA-capability marker, not an IB
+// one. It is the nodeAffinity the AKS NicClusterPolicy uses to place the RDMA
+// fabric (nic-cluster-policy-aks.yaml), so it identifies exactly the nodes that
+// can ever advertise AKSRdmaSharedResource.
+const PCIMellanoxPresentLabel = "feature.node.kubernetes.io/pci-15b3.present"
+
 // FindSchedulableGpuNodes finds nodes that are schedulable and have allocatable GPU resources.
 func FindSchedulableGpuNodes(ctx context.Context, clientset kubernetes.Interface) ([]v1.Node, error) {
 	nodeList, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/validators/performance/nccl_aks_utils.go
+++ b/validators/performance/nccl_aks_utils.go
@@ -18,18 +18,17 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/NVIDIA/aicr/validators/helper"
 	v1 "k8s.io/api/core/v1"
 )
 
-// aksRdmaSharedResource is the extended resource published by the network
-// operator's rdma-shared-device-plugin on AICR AKS clusters (selector
-// vendors=15b3 drivers=mlx5_core). The resource name hca_shared_devices_a is
-// pinned by recipes/components/network-operator/manifests/
-// nic-cluster-policy-aks.yaml for workload compatibility — keep the two in
-// sync. It is a *shared* device pool: a pod that requests one unit is granted
-// access to every InfiniBand HCA on the node (/dev/infiniband/*), so NCCL
-// workers request exactly 1 regardless of the HCA count.
-const aksRdmaSharedResource = "rdma/hca_shared_devices_a"
+// The shared RDMA resource name (helper.AKSRdmaSharedResource) is a *shared*
+// device pool: a pod that requests one unit is granted access to every
+// InfiniBand HCA on the node (/dev/infiniband/*), so NCCL workers request
+// exactly 1 regardless of the HCA count. The name is defined once in
+// validators/helper so this consumer and the deployment-phase readiness gate
+// cannot drift (both must key off the same resource the
+// nic-cluster-policy-aks.yaml manifest pins).
 
 // applyAKSTemplateData populates the AKS-specific runtime template variables:
 // the ${RDMA_RESOURCE_LIMITS}/${RDMA_RESOURCE_REQUESTS} worker resource lines
@@ -45,7 +44,7 @@ const aksRdmaSharedResource = "rdma/hca_shared_devices_a"
 // closed rather than sizing every worker from the first node.
 func applyAKSTemplateData(config *gpuConfiguration, templateData map[string]string) error {
 	warnIfHeterogeneousNodes(config.Nodes)
-	rdmaCount, err := uniformFabricResourceCount(config.Nodes, v1.ResourceName(aksRdmaSharedResource))
+	rdmaCount, err := uniformFabricResourceCount(config.Nodes, v1.ResourceName(helper.AKSRdmaSharedResource))
 	if err != nil {
 		return err
 	}
@@ -56,9 +55,9 @@ func applyAKSTemplateData(config *gpuConfiguration, templateData map[string]stri
 	if rdmaCount == 0 {
 		templateData["MAX_MESSAGE_SIZE"] = maxMessageSizeTCP
 		slog.Warn("No shared RDMA devices found — NCCL will use TCP (reduced bandwidth)",
-			"resource", aksRdmaSharedResource, "maxMessageSize", maxMessageSizeTCP)
+			"resource", helper.AKSRdmaSharedResource, "maxMessageSize", maxMessageSizeTCP)
 	} else {
-		slog.Info("Discovered AKS shared RDMA device pool", "resource", aksRdmaSharedResource, "allocatable", rdmaCount)
+		slog.Info("Discovered AKS shared RDMA device pool", "resource", helper.AKSRdmaSharedResource, "allocatable", rdmaCount)
 	}
 	return nil
 }
@@ -73,5 +72,5 @@ func buildAKSRdmaResourceLine(rdmaCount int, indent string) string {
 	if rdmaCount == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%s%s: \"1\"", indent, aksRdmaSharedResource)
+	return fmt.Sprintf("%s%s: \"1\"", indent, helper.AKSRdmaSharedResource)
 }

--- a/validators/performance/nccl_aks_utils_test.go
+++ b/validators/performance/nccl_aks_utils_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/validators/helper"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -29,7 +30,7 @@ func TestApplyAKSTemplateData(t *testing.T) {
 	aksNode := func(rdma string) v1.Node {
 		alloc := v1.ResourceList{v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8")}
 		if rdma != "" {
-			alloc[v1.ResourceName(aksRdmaSharedResource)] = resource.MustParse(rdma)
+			alloc[v1.ResourceName(helper.AKSRdmaSharedResource)] = resource.MustParse(rdma)
 		}
 		return v1.Node{Status: v1.NodeStatus{Allocatable: alloc}}
 	}


### PR DESCRIPTION
## Summary

Add an RDMA fabric readiness signal to the deployment `expected-resources` gate so the AKS `nccl-all-reduce-bw` check no longer fails on a transient, per-node MOFED rollout skew.

## Motivation / Context

On AKS the network operator rolls MOFED / the rdma-shared-device-plugin out **per node**, and one GPU node can lag another by many minutes. During that window `rdma/hca_shared_devices_a` is allocatable on only a subset of nodes. The deployment readiness gate certified on network-operator *pod* health only — not on the fabric being uniformly allocatable — so the downstream NCCL check ran against a half-converged fabric and rejected it via `uniformFabricResourceCount` as "present on N of M nodes". A self-healing rollout skew became a hard test failure. Live triage found MOFED converged in ~3–7 min typically but up to ~19 min on an anomalous node; the fabric is uniform once it settles.

Fixes: #1862
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Other: `validators/deployment` (readiness gate), `validators/performance` + `validators/helper` (shared const)

## Implementation Notes

- New `verifyRDMAFabricReady` signal in `validators/deployment/expected_resources.go`, alongside the existing Nodewright and DRA "stable ≥ window" gates, driven by `pollUntilStable`. It certifies only once the shared RDMA resource is allocatable in a **uniform, positive** count across the cohort — matching the NCCL consumer's `uniformFabricResourceCount` so the gate certifies exactly what the workload requires.
- **Engagement is recipe-derived and deployer-neutral:** the gate runs only when the recipe enables `network-operator` with a `nic-cluster-policy` manifest (AKS today). OCP uses a different component/manifest; kind/talos declare no fabric — all correctly skipped. Zero added cost (not even a node list) on EKS/GKE/OCP.
- **Cohort scoping:** reuses `helper.FindSchedulableGpuNodes` (skips cordoned + not-yet-GPU nodes) and filters to the Mellanox `feature.node.kubernetes.io/pci-15b3.present` NodeAffinity label the NicClusterPolicy itself uses — the exact node set the fabric lands on and NCCL runs on. A cordoned, non-Mellanox, or off-pool GPU node therefore can't wedge the gate.
- **Transport-agnostic:** the label (Mellanox vendor 15b3) and the shared RDMA resource cover **InfiniBand and RoCE** alike — nothing here is IB-specific.
- **Single source of truth:** the shared RDMA resource name and Mellanox label live in `validators/helper` (`AKSRdmaSharedResource`, `PCIMellanoxPresentLabel`), referenced by both the gate and `nccl_aks_utils.go` so the "must match" invariant can't drift.
- This change went through a multi-persona + adversarial review; the node-scoping and uniformity behavior above are the result of that pass.

## Testing

```bash
# Affected packages, race detector:
go test ./validators/deployment/... ./validators/performance/... ./validators/helper/... -race
golangci-lint run -c .golangci.yaml ./validators/deployment/... ./validators/performance/... ./validators/helper/...
gofmt -l <changed files>
```

- All affected-package tests pass under `-race`; `golangci-lint` 0 issues; `gofmt` clean.
- Coverage on the new funcs: `recipeDeclaresRDMAFabric` 100%, `verifyRDMAFabricReady` 100%, `rdmaFabricProbe` 97.1%.
- New tests cover: rides-through-transient-partial-rollout, times-out-naming-the-lagging-node, present-but-zero fabric, non-uniform count, cordoned/non-Mellanox/zero-GPU/CPU exclusion, fail-closed on list error and empty cohort, the `verifyGPUReadinessSignals` dispatch conjunction, and marker discrimination (multi-manifest / OCP / near-miss).

## Risk Assessment

- [x] **Low** — Isolated, deployer-neutral (no-op off AKS-RDMA recipes), well-tested, easy to revert.

**Rollout notes:** No user-facing surface (no CLI flag, API, or recipe field). The gate inherits the shared `GPUReadinessTimeout` used by the sibling gates; a fabric slower than that budget fails the deployment check with a clear "not yet allocatable on node X" message (rather than a spurious NCCL failure) and the UAT readiness-gate outer loop retries. Backwards compatible.

## Checklist

- [x] Tests pass locally (`-race`, affected packages)
- [x] Linter passes (`golangci-lint` on affected packages)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed (N/A — internal validator readiness, no user-facing surface)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
