### PR TITLE
feat(uat): capture GPU driver state on shortfall in debug bundle

### DIFF
--- a/tests/uat/lib/collect-debug.sh
+++ b/tests/uat/lib/collect-debug.sh
@@ -44,6 +44,12 @@
 # PUBLIC repo (downloadable per the repo's artifact access) — treat it as
 # sensitive. Redaction is deliberately not attempted (fragile); the namespace
 # allowlist is the primary mitigation.
+#
+# On a GPU-count shortfall the bundle also carries driver-level state obtained by
+# `kubectl exec` (read-only) into the on-node nvidia-dcgm pod: GPU UUIDs, PCI bus
+# IDs, board serial numbers, and NVIDIA-driver `dmesg` (NVRM/Xid) lines. These
+# are hardware identifiers / driver diagnostics — no Secrets, and intentionally
+# captured for RMA (issue #1860) — but treated as sensitive like the rest.
 
 # Directory the bundle is written into (relative to $PWD, matching serve-logs/
 # and train-logs/); the workflow adds `cluster-debug/**` to the upload artifact.
@@ -80,6 +86,20 @@ CLUSTER_DEBUG_CLUSTER_RESOURCES="${CLUSTER_DEBUG_CLUSTER_RESOURCES:-skyhooks.sky
 # step-level timeout and starve later, higher-value sections (per-namespace pod
 # logs). 30s is generous for a single Get/describe.
 CLUSTER_DEBUG_CMD_TIMEOUT="${CLUSTER_DEBUG_CMD_TIMEOUT:-30}"
+
+# Extended resource used to identify GPU nodes and their advertised GPU count in
+# the GPU driver-state capture. Overridable for a non-standard device plugin.
+CLUSTER_DEBUG_GPU_RESOURCE="${CLUSTER_DEBUG_GPU_RESOURCE:-nvidia.com/gpu}"
+
+# Namespace whose on-node nvidia-dcgm pod the shortfall capture exec's for
+# nvidia-smi/dmesg. Overridable for a non-standard GPU-operator install.
+CLUSTER_DEBUG_GPU_NAMESPACE="${CLUSTER_DEBUG_GPU_NAMESPACE:-gpu-operator}"
+
+# Cap on how many short GPU nodes get the (bounded, per-node) driver-level exec
+# capture, so the section cannot starve the later per-namespace log collection on
+# a pathological large-pool shortfall. UAT pools are 2 nodes today (≤1 can be
+# short), so this is defensive headroom; the always-emitted census is uncapped.
+CLUSTER_DEBUG_GPU_MAX_NODES="${CLUSTER_DEBUG_GPU_MAX_NODES:-3}"
 
 # _cd_bounded runs an EXTERNAL command under CLUSTER_DEBUG_CMD_TIMEOUT when the
 # coreutils `timeout` is present (Linux CI runners), else runs it directly so the
@@ -153,6 +173,104 @@ capture_skyhook_snapshot() {
   return 0
 }
 
+# _cd_gpu_driver_state writes a per-GPU-node census of advertised GPUs and, when
+# any GPU node advertises fewer than the cohort max (a capacity shortfall — e.g.
+# an H100 node enumerating 7 of 8 GPUs), captures DRIVER-LEVEL state on each short
+# node: nvidia-smi -L, per-GPU PCI/serial, the host NVIDIA PCI census, and dmesg
+# NVRM/Xid lines. The Kubernetes API only shows the *symptom* (allocatable count);
+# this exec-based capture — via the privileged on-node nvidia-dcgm pod — is what
+# turns "one GPU missing, cause unknown" into "GPU at PCI 000a failed driver
+# probe", diagnosable after the cluster is gone. The expensive exec path runs
+# ONLY on a detected shortfall; the census itself is always emitted. A
+# gpu-shortfall.txt marker is written on shortfall so the condition is greppable.
+# Best-effort, self-bounding; never fails the run. Requires jq (already a hard
+# dep of this collector).
+_cd_gpu_driver_state() {
+  # Subshell + `set +e` isolates errexit from the caller (same rationale as
+  # capture_skyhook_snapshot); all `local`s are declared here at the top, not
+  # inside the piped `{ … } | tee` block (whose subshell context is portable-safe
+  # for reads but not for declarations on every bash).
+  (
+    set +e
+    command -v kubectl >/dev/null 2>&1 || exit 0
+    command -v jq >/dev/null 2>&1 || exit 0
+    mkdir -p "${CLUSTER_DEBUG_DIR}"
+    local out="${CLUSTER_DEBUG_DIR}/gpu-driver-state.txt"
+    local res="${CLUSTER_DEBUG_GPU_RESOURCE}"
+    local census maxc short node pod
+
+    local ns="${CLUSTER_DEBUG_GPU_NAMESPACE}"
+    census="$(_cd_bounded kubectl get nodes -o json 2>/dev/null \
+      | jq -r --arg r "${res}" '.items[]
+          | select(.status.allocatable[$r] != null)
+          | "\(.metadata.name) \(.status.allocatable[$r])"' 2>/dev/null)"
+    # NOTE: "cohort max" is computed across ALL GPU nodes, with no per-product /
+    # per-pool segmentation. Correct for UAT's homogeneous single-SKU GPU pools;
+    # a heterogeneous pool (e.g. a 1-GPU utility node beside 8-GPU workers) would
+    # false-flag the smaller node as short. Best-effort diagnostics, so the only
+    # cost of a false positive is one extra bounded exec + a marker.
+    maxc="$(printf '%s\n' "${census}" | awk '{if($2+0>m)m=$2+0}END{print m+0}')"
+    short="$(printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && $2+0 < m {print $1}')"
+
+    local captured=0
+    echo "::group::Collect GPU driver state"
+    {
+      echo "##### GPU driver state @ $(date -u +%Y-%m-%dT%H:%M:%SZ) #####"
+      echo "----- GPU census (node  allocatable ${res}) -----"
+      if [[ -z "${census}" ]]; then
+        echo "(no nodes advertise ${res})"
+      else
+        printf '%s\n' "${census}"
+      fi
+      echo
+      if [[ -n "${short}" ]]; then
+        echo "----- GPU-count SHORTFALL: node(s) below cohort max ${maxc} -----"
+        printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && $2+0 < m {print "  "$1" advertises "$2"/"m}'
+        echo
+        # shellcheck disable=SC2086 # intentional word-split of the node list
+        for node in ${short}; do
+          if [[ "${captured}" -ge "${CLUSTER_DEBUG_GPU_MAX_NODES}" ]]; then
+            echo "(reached CLUSTER_DEBUG_GPU_MAX_NODES=${CLUSTER_DEBUG_GPU_MAX_NODES}; remaining short nodes not exec'd)"
+            break
+          fi
+          captured=$((captured + 1))
+          pod="$(_cd_bounded kubectl get pods -n "${ns}" --field-selector "spec.nodeName=${node}" -o name 2>/dev/null | grep -E 'nvidia-dcgm' | grep -v exporter | head -1)"
+          [[ -z "${pod}" ]] && pod="$(_cd_bounded kubectl get pods -n "${ns}" --field-selector "spec.nodeName=${node}" -o name 2>/dev/null | grep -E 'nvidia-dcgm-exporter' | head -1)"
+          pod="${pod#pod/}"
+          echo "===== driver-level state: node ${node} (short) ====="
+          if [[ -z "${pod}" ]]; then
+            echo "(no on-node nvidia-dcgm pod in ${ns} ns; cannot exec nvidia-smi/dmesg)"
+          else
+            echo "# via pod/${pod} (ns ${ns})"
+            echo "----- nvidia-smi -L -----"
+            _cd_bounded kubectl exec -n "${ns}" "${pod}" -- nvidia-smi -L 2>&1 || true
+            echo "----- nvidia-smi --query-gpu=index,pci.bus_id,serial,uuid (csv) -----"
+            _cd_bounded kubectl exec -n "${ns}" "${pod}" -- nvidia-smi --query-gpu=index,pci.bus_id,serial,uuid --format=csv 2>&1 || true
+            echo "----- host NVIDIA PCI functions (vendor 0x10de) -----"
+            # shellcheck disable=SC2016 # $f must expand in the remote pod's shell, not here
+            _cd_bounded kubectl exec -n "${ns}" "${pod}" -- sh -c 'for f in /sys/bus/pci/devices/*/vendor; do grep -q 0x10de "$f" 2>/dev/null && dirname "$f"; done' 2>&1 || true
+            echo "----- dmesg NVRM/Xid (tail 40) -----"
+            _cd_bounded kubectl exec -n "${ns}" "${pod}" -- sh -c 'dmesg 2>/dev/null | grep -iE "NVRM|Xid" | tail -40' 2>&1 || true
+          fi
+          echo
+        done
+      elif [[ -n "${census}" ]]; then
+        echo "----- No GPU-count shortfall (all GPU nodes advertise ${maxc}) -----"
+      fi
+    } | tee "${out}"
+    echo "::endgroup::"
+
+    if [[ -n "${short}" ]]; then
+      {
+        echo "GPU-count shortfall @ $(date -u +%Y-%m-%dT%H:%M:%SZ); cohort max=${maxc}"
+        printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && $2+0 < m {print $1" "$2"/"m}'
+      } > "${CLUSTER_DEBUG_DIR}/gpu-shortfall.txt" 2>/dev/null || true
+    fi
+    exit 0
+  )
+  return 0
+}
+
 # _cd_section runs a labeled command group, teeing to both the step log (folded
 # in an Actions ::group::) and a file in the bundle. The command is bounded by
 # CLUSTER_DEBUG_CMD_TIMEOUT (via _cd_bounded), so a single hung call can't starve
@@ -214,6 +332,9 @@ collect_cluster_debug() {
     # the readiness-gate status.status progression (written during phase_install)
     # and any inline skyhook-at-failure snapshot(s).
     [[ -f "${CLUSTER_DEBUG_GATE_LOG}" ]] && echo "readinessGateSeries: $(basename "${CLUSTER_DEBUG_GATE_LOG}")"
+    # GPU census is always emitted below; gpu-shortfall.txt appears only when a
+    # node is short of its peers (driver-level nvidia-smi/dmesg capture follows).
+    echo "gpuDriverState: gpu-driver-state.txt (gpu-shortfall.txt present iff a GPU-count shortfall was detected)"
     local snap
     for snap in "${CLUSTER_DEBUG_DIR}"/skyhook-at-failure-*.txt; do
       [[ -f "${snap}" ]] && echo "skyhookAtFailure: $(basename "${snap}")"
@@ -244,6 +365,11 @@ collect_cluster_debug() {
     _cd_node_reboot_fingerprint
     echo
   } | tee -a "${CLUSTER_DEBUG_DIR}/node-reboot-fingerprint.txt"
+  # GPU census + driver-level capture on a capacity shortfall (a node short of
+  # its peers). Routed directly (a shell function `timeout` cannot invoke); it
+  # bounds its own kubectl/exec internally and only pays the exec cost when a
+  # shortfall is present.
+  _cd_gpu_driver_state
   # Events across all namespaces: node Reboot/NotReady, pod evictions (the run-2
   # "pod for job not found" cause), FailedScheduling, etc.
   _cd_section "events (all namespaces, by time)" events.txt \


### PR DESCRIPTION
## Summary

Add a GPU driver-state capture to the UAT failure debug bundle: a per-node GPU census, and — on a capacity shortfall (a node short of its peers) — `nvidia-smi -L`, per-GPU PCI/serial, host PCI census, and `dmesg` NVRM/Xid from the on-node `nvidia-dcgm` pod.

## Motivation / Context

The debug bundle captured GPU state only through the Kubernetes API (`kubectl describe nodes`), which shows the *symptom* of a degraded node (allocatable `nvidia.com/gpu` below its peers) but nothing about *why*. Root-causing a node that enumerates 7 of 8 GPUs (a real recurring Azure H100 failure) required hand-exec'ing the on-node `nvidia-dcgm` pod for `nvidia-smi`/`dmesg` — impossible once the cluster is torn down. This capture makes that state part of the bundle, turning "one GPU missing, cause unknown" into "GPU at PCI `000a` failed driver probe" — including the PCI slot / serial / Xid an Azure RMA needs.

Fixes: #1860
Related: N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix

## Component(s) Affected

- [x] Other: UAT tooling (`tests/uat/lib/collect-debug.sh`)

## Implementation Notes

- `_cd_gpu_driver_state`: always emits a per-node GPU census (cheap — one `kubectl get nodes`); the expensive exec path runs **only on a shortfall** (a node below the cohort max). Writes a greppable `gpu-shortfall.txt` marker and a `gpu-driver-state.txt`; the MANIFEST points readers at it.
- **Bounded and fail-safe:** every call is `_cd_bounded` (per-command timeout) and best-effort (`( set +e … ); return 0`) — it never fails the run or delays teardown. The per-node exec loop is capped at `CLUSTER_DEBUG_GPU_MAX_NODES` (default 3) so it can't starve the later per-namespace log collection on a pathological large-pool shortfall (UAT pools are 2 nodes today, so ≤1 can be short — this is defensive headroom).
- **Read-only + privacy:** all exec'd commands are read-only (enumerate/query/`dmesg` grep); no Secrets are read; the Privacy header documents the new hardware-ID capture (UUID/PCI/serial/dmesg — hardware identifiers, not credentials).
- Overridable via `CLUSTER_DEBUG_GPU_RESOURCE` / `CLUSTER_DEBUG_GPU_NAMESPACE` / `CLUSTER_DEBUG_GPU_MAX_NODES`. Reviewed via a multi-persona + adversarial pass (correctness/bash, security/privacy, operability); the node cap, MANIFEST pointer, Privacy-header note, and heterogeneous-pool caveat are results of that pass.

## Testing

```bash
shellcheck -s bash tests/uat/lib/collect-debug.sh
bash -n tests/uat/lib/collect-debug.sh
```

- `shellcheck` clean, `bash -n` syntax OK.
- End-to-end functional smoke test with a faked `kubectl` (under real bash): verified the census, shortfall detection (7/8 named), driver-level capture on the short node, CPU-node exclusion, the uniform-cluster no-op (no exec, no marker), and the node cap (`CLUSTER_DEBUG_GPU_MAX_NODES=1` with 2 short nodes → one captured, the rest noted and skipped).
- Live-validated the same `nvidia-dcgm`-pod exec path (nvidia-smi / dmesg / PCI census) on a real AKS `driver.enabled=false` cluster while root-causing the Azure 7/8 fault.

## Risk Assessment

- [x] **Low** — Additive, best-effort diagnostics collector; runs only on failure, before teardown; cannot fail the run.

**Rollout notes:** No product behavior change; only enriches the failure debug bundle. N/A migration.

## Checklist

- [x] Tests pass locally (`shellcheck` + `bash -n` + functional smoke test)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (functional smoke test; no unit-test harness exists for this collector)
- [x] I updated docs (the collector's in-file Privacy/header documentation)
- [x] Changes follow existing patterns in the codebase (`_cd_bounded`, `( set +e )` subshell, best-effort contract)
- [x] Commits are cryptographically signed (`git commit -S`)
