### PR TITLE
fix(cli): validate --kubeconfig selects the cluster end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ tags
 .claude/settings.local.json
 .claude/worktrees/
 docs/plans
+docs/superpowers/
 .worktrees/
 
 # Per-clone local agent overlay (see AGENTS.md "Local Overlay" section)

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -832,7 +832,7 @@ aicr validate [flags]
 | `--fail-on-error` | | bool | true | Exit with non-zero status if any constraint fails |
 | `--fail-fast` | | bool | false | Stop after the first phase that fails. By default all phases run and produce results. |
 | `--output` | `-o` | string | stdout | Output destination: file path, ConfigMap URI (`cm://namespace/name`), or stdout |
-| `--kubeconfig` | `-k` | string | ~/.kube/config | Path to kubeconfig file (used when `--recipe`, `--snapshot`, or `--output` is a ConfigMap URI) |
+| `--kubeconfig` | `-k` | string | ~/.kube/config | Path to kubeconfig file selecting the target cluster for **every** Kubernetes operation in the invocation: `cm://` recipe/snapshot/output I/O, snapshot-agent deployment, validation namespace and RBAC, validator Jobs, and cleanup. One invocation targets one cluster. When omitted, default discovery applies (`KUBECONFIG` env, then `~/.kube/config`, then in-cluster). An invalid path fails any run that performs Kubernetes operations; `--no-cluster` dry-runs over local files do not load it. **Changed in v0.18:** validator-engine operations, including validator Jobs, now honor this flag instead of using the default cluster. |
 | `--namespace` | `-n` | string | aicr-validation | Kubernetes namespace for validation Job deployment |
 | `--image` | | string | ghcr.io/nvidia/aicr:latest | Container image for validation Job |
 | `--image-pull-secret` | | string[] | | Image pull secrets for private registries (repeatable) |
@@ -948,7 +948,8 @@ aicr validate \
   --snapshot snapshot.yaml \
   --phase performance
 
-# With custom kubeconfig
+# With custom kubeconfig — selects the cluster for the whole run:
+# cm:// I/O, agent deployment, validator Jobs, and cleanup (#1787)
 aicr validate \
   --recipe recipe.yaml \
   --snapshot cm://gpu-operator/aicr-snapshot \

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -154,16 +154,19 @@ func resolveValidateTolerations(cmd *cli.Command, resolved *config.ValidateResol
 
 // deployAgentForValidation deploys an agent to capture a snapshot and returns the Snapshot.
 // Creates the namespace if it does not exist.
-func deployAgentForValidation(ctx context.Context, cfg *validateAgentConfig) (*snapshotter.Snapshot, string, error) {
-	// Ensure namespace exists before deploying the agent Job.
-	clientset, _, err := k8sclient.GetKubeClient()
+func deployAgentForValidation(ctx context.Context, cfg *validateAgentConfig) (*snapshotter.Snapshot, error) {
+	// Ensure namespace exists before deploying the agent Job. Build the
+	// client from the same explicit kubeconfig the agent deploy below uses
+	// (#1787) — empty delegates to default discovery, so the default path
+	// is unchanged.
+	clientset, _, err := k8sclient.GetKubeClientWithConfig(cfg.kubeconfig)
 	if err != nil {
-		return nil, "", errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to create kubernetes client")
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to create kubernetes client")
 	}
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.namespace}}
 	if _, nsErr := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); nsErr != nil {
 		if !apierrors.IsAlreadyExists(nsErr) {
-			return nil, "", errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", nsErr)
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", nsErr)
 		}
 	}
 
@@ -185,11 +188,10 @@ func deployAgentForValidation(ctx context.Context, cfg *validateAgentConfig) (*s
 
 	snap, err := snapshotter.DeployAndGetSnapshot(ctx, agentConfig)
 	if err != nil {
-		return nil, "", errors.Wrap(errors.ErrCodeInternal, "failed to capture snapshot", err)
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to capture snapshot", err)
 	}
 
-	source := fmt.Sprintf("agent:%s/%s", cfg.namespace, cfg.jobName)
-	return snap, source, nil
+	return snap, nil
 }
 
 // validationConfig holds all parameters for a validation run.
@@ -261,6 +263,12 @@ func runValidation(
 	// validator.With* calls); the image/commit overrides are passed verbatim
 	// (empty string is the validator's "unset" sentinel).
 	opts := []aicr.ValidateOption{
+		// Thread the CLI's resolved kubeconfig so every validator-engine
+		// operation (namespace, RBAC, input/result ConfigMaps, validator
+		// Jobs, watches, cleanup) targets the same cluster as artifact I/O
+		// (#1787). Empty keeps default discovery — the facade skips the
+		// option entirely on "".
+		aicr.WithValidationKubeconfig(cfg.kubeconfig),
 		aicr.WithValidationNamespace(cfg.validationNamespace),
 		aicr.WithValidationRunID(runID),
 		aicr.WithValidationCleanup(cfg.cleanup),
@@ -757,7 +765,7 @@ Run validation without failing on check errors (informational mode):
 				agentCfg := parseValidateAgentConfig(cmd, resolved, shared)
 
 				var deployErr error
-				snap, _, deployErr = deployAgentForValidation(ctx, agentCfg)
+				snap, deployErr = deployAgentForValidation(ctx, agentCfg)
 				if deployErr != nil {
 					return deployErr
 				}

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -387,3 +387,78 @@ func TestValidateCmd_RecipeKindHandling(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateCmd_KubeconfigSelectsValidationCluster is the #1787 regression
+// test: an explicit --kubeconfig must select the cluster for the validator
+// engine itself, not only for cm:// artifact I/O. With local recipe/snapshot
+// files and a nonexistent --kubeconfig path, the run must fail fast on the
+// explicit path — before the fix, the engine silently fell back to default
+// discovery (KUBECONFIG env → ~/.kube/config → in-cluster), so the error
+// (if any) never mentioned the flag path. KUBECONFIG is pinned to a
+// nonexistent temp path so neither branch can ever reach a real cluster.
+//
+// A hydrated RecipeMetadata would fail readiness checks against this minimal
+// snapshot before client construction. This criteria-less RecipeResult keeps
+// readiness a no-op while its inline gpu-operator override supplies the
+// whole-GPU advertiser required by validation-input construction.
+func TestValidateCmd_KubeconfigSelectsValidationCluster(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KUBECONFIG", filepath.Join(tmp, "env-default.kubeconfig"))
+
+	recipePath := filepath.Join(tmp, "recipe.yaml")
+	recipeYAML := "kind: RecipeResult\napiVersion: aicr.run/v1alpha2\nmetadata:\n  version: test\ncomponentRefs:\n  - name: gpu-operator\n    type: Helm\n    source: https://helm.ngc.nvidia.com/nvidia\n    version: v25.10.0\n    overrides:\n      devicePlugin:\n        enabled: true\n"
+	if err := os.WriteFile(recipePath, []byte(recipeYAML), 0o600); err != nil {
+		t.Fatalf("failed to write test recipe file: %v", err)
+	}
+	snapshotPath := filepath.Join(tmp, "snapshot.yaml")
+	if err := os.WriteFile(snapshotPath, []byte("metadata:\n  version: test\n"), 0o600); err != nil {
+		t.Fatalf("failed to write test snapshot file: %v", err)
+	}
+
+	flagPath := filepath.Join(tmp, "explicit-flag.kubeconfig") // intentionally not created
+
+	cmd := validateCmd()
+	err := cmd.Run(t.Context(), []string{"validate",
+		"--recipe", recipePath,
+		"--snapshot", snapshotPath,
+		"--kubeconfig", flagPath,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent --kubeconfig, got nil")
+	}
+	if !strings.Contains(err.Error(), flagPath) {
+		t.Errorf("error must fail on the explicit --kubeconfig path %q, got:\n%v", flagPath, err)
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+	}
+}
+
+// TestDeployAgentForValidation_ExplicitKubeconfigFailsFast covers the #1787
+// live-snapshot path: the preliminary namespace creation must use the same
+// explicit kubeconfig the snapshot agent deploys with — not the process
+// default. A nonexistent explicit path must fail before any cluster contact.
+// KUBECONFIG is pinned to a nonexistent temp path so the pre-fix fallback to
+// default discovery can never reach a real cluster either.
+func TestDeployAgentForValidation_ExplicitKubeconfigFailsFast(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KUBECONFIG", filepath.Join(tmp, "env-default.kubeconfig"))
+
+	flagPath := filepath.Join(tmp, "explicit-flag.kubeconfig") // intentionally not created
+	cfg := &validateAgentConfig{
+		kubeconfig: flagPath,
+		namespace:  "aicr-validation-test",
+		jobName:    "aicr-validate-test",
+	}
+
+	_, err := deployAgentForValidation(t.Context(), cfg)
+	if err == nil {
+		t.Fatal("expected error for nonexistent explicit kubeconfig, got nil")
+	}
+	if !strings.Contains(err.Error(), flagPath) {
+		t.Errorf("error must fail on the explicit kubeconfig path %q, got:\n%v", flagPath, err)
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+	}
+}


### PR DESCRIPTION
## Summary

Make `aicr validate --kubeconfig` select one cluster for artifact I/O, live snapshot capture, validator Jobs, RBAC, results, and cleanup. Document the invocation-wide contract and its v0.18 behavior correction.

## Motivation / Context

The old split allowed one invocation to capture cluster B, run validator Jobs and temporary cluster-admin RBAC on cluster A, then attribute the combined report to B. Explicit kubeconfig paths must fail closed instead of silently falling back to the process-default cluster.

Fixes: #1787
Related: #1735, #1743

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Pass the resolved CLI kubeconfig through `aicr.WithValidationKubeconfig`, reusing the run-scoped validator client path added by #1735.
- Create the live-snapshot namespace with `GetKubeClientWithConfig` so namespace creation and agent deployment target the same cluster.
- Preserve default discovery when the flag is omitted. Validator pods continue using in-cluster ServiceAccount credentials.
- Preserve `ErrCodeInvalidRequest` for unreadable or invalid explicit kubeconfig paths on cluster-contacting runs.
- Remove the helper's unused source-string result to keep affected-package `unparam` lint clean.
- Keep local agent plans/specs out of the repository by ignoring `docs/superpowers/`.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -count=1 -race -v ./pkg/cli/... \
  -run 'TestValidateCmd_KubeconfigSelectsValidationCluster|TestDeployAgentForValidation_ExplicitKubeconfigFailsFast'
golangci-lint run -c .golangci.yaml ./pkg/cli/...
GOFLAGS="-mod=vendor" go test -coverprofile=cover.out ./pkg/cli/...
make test-coverage
unset GITLAB_TOKEN && make qualify
```

- Both #1787 regressions pass without cluster access.
- `pkg/cli`: 73.1% → 73.9% (+0.8 percentage points).
- Project coverage: 80.2% (75% threshold).
- `make qualify`: pass, including 23/23 Chainsaw e2e tests and zero lint issues.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** v0.18 restores the intended single-cluster invariant. The prior implicit split-cluster behavior was a correctness bug and was never a supported workflow.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
