### PR TITLE
chore: sweep stale v26.3.2 refs and BOM warning after #1881

### DIFF
--- a/demos/query.md
+++ b/demos/query.md
@@ -38,7 +38,7 @@ aicr query \
   --selector components.gpu-operator.values.driver.version
 ```
 
-> `580.105.08`
+> `580.173.02`
 
 Subtree — full driver block:
 
@@ -52,9 +52,9 @@ aicr query \
 enabled: true
 maxParallelUpgrades: 5
 rdma:
-    enabled: true
+  enabled: false
 useOpenKernelModules: true
-version: 580.105.08
+version: 580.173.02
 ```
 
 ## Differentiation: Same Selector, Different Criteria
@@ -62,18 +62,21 @@ version: 580.105.08
 The interesting part is asking the *same* question against different
 criteria and watching values diverge.
 
-### Driver version differs by accelerator
+### Driver config differs by accelerator
+
+The driver *version* is a single global pin, but GB200 loads custom kernel
+module parameters that H100 doesn't need:
 
 ```shell
 for gpu in h100 gb200; do
-  echo -n "$gpu: "
-  aicr query --service eks --accelerator $gpu --intent training --os ubuntu \
-    --selector components.gpu-operator.values.driver.version 2>/dev/null
+  v=$(aicr query --service eks --accelerator $gpu --intent training --os ubuntu \
+    --selector components.gpu-operator.values.driver.kernelModuleConfig.name 2>/dev/null || echo "unset")
+  echo "$gpu: $v"
 done
 ```
 
-> `h100: 580.105.08`
-> `gb200: 580.173.02`
+> `h100: unset`
+> `gb200: nvidia-kernel-module-params`
 
 ### Constraints diverge by service + OS
 
@@ -107,10 +110,10 @@ aicr query --service gke --accelerator h100 --intent training --os cos \
   value: '>= 1.32'
 ```
 
-L40 relaxes K8s further (older accelerators run on older clusters):
+L40S (on OKE) relaxes K8s further (older accelerators run on older clusters):
 
 ```shell
-aicr query --service eks --accelerator l40 --intent training --os ubuntu \
+aicr query --service oke --accelerator l40s --intent training \
   --selector constraints
 ```
 
@@ -172,7 +175,7 @@ SELECTOR="components.gpu-operator.values.driver.version"
 
 printf "%-8s %-10s %-10s %-8s %s\n" SERVICE ACCEL INTENT OS DRIVER
 for service in eks gke; do
-  for accel in h100 gb200 l40; do
+  for accel in h100 gb200 l40s; do
     for intent in training inference; do
       os=ubuntu; [ "$service" = "gke" ] && os=cos
       v=$(aicr query \
@@ -205,7 +208,7 @@ claude
 
 > What driver version would deploy in EKS with H100 in Ubuntu for training?
 
-> Compare GPU operator driver versions between H100 and GB200 on EKS
+> Compare GPU Operator driver config between H100 and GB200 on EKS
 
 > List all components that ship in EKS H100 inference but not training
 

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -126,7 +126,7 @@ _No images extracted._
 
 ### gpu-operator
 
-- `docker.io/library/busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`
+- `docker.io/library/busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d`
 - `nvcr.io/nvidia/cloud-native/dcgm:4.5.2-1-ubuntu22.04`
 - `nvcr.io/nvidia/cloud-native/gdrdrv:v2.5.2`
 - `nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.4.0`
@@ -190,7 +190,7 @@ _No images extracted._
 
 ### network-operator
 
-- `docker.io/library/busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`
+- `docker.io/library/busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d`
 - `nvcr.io/nvidia/cloud-native/network-operator:v26.1.1`
 - `nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host`
 - `nvcr.io/nvidia/mellanox/doca-driver:doca3.2.0-25.10-1.2.8.0-2`
@@ -248,8 +248,6 @@ _No images extracted._
 - `registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0`
 
 ### prometheus-operator-crds
-
-> Warning: [INTERNAL] helm template failed: signal: killed
 
 _No images extracted._
 

--- a/pkg/bundler/validations/checks.go
+++ b/pkg/bundler/validations/checks.go
@@ -410,7 +410,7 @@ func driverAbsentRemedy(service recipe.CriteriaServiceType, os recipe.CriteriaOS
 				"driver: provision the GPU node pools with the GKE-managed " +
 				"driver install (node pool gpu-driver-version) instead."
 		case recipe.CriteriaOSUbuntu:
-			// The pinned GPU Operator (v26.3.2) supports driver management
+			// The pinned GPU Operator (v26.3.3) supports driver management
 			// on GKE only on Ubuntu node images with containerd.
 			return "On GKE Ubuntu node images the GPU Operator can manage " +
 				"the driver: bundle in GPU-Operator-managed mode: " +
@@ -593,11 +593,11 @@ func effectiveComponentValues(ctx context.Context, recipeResult *recipe.RecipeRe
 // path.Clean'd (trailing-slash spellings compare equal, mirroring
 // pkg/recipe/driver_root_lockstep_test.go), declared empty string →
 // the default (the operator's own transformForDriverInstallDir treats
-// "" identically to the default, gpu-operator v26.3.2). An explicitly
+// "" identically to the default, gpu-operator v26.3.3). An explicitly
 // null or non-map hostPaths section is rejected with a blocking
 // message: Helm null-coalescing deletes a null key together with its
 // chart defaults, so the chart's unconditional .Values.hostPaths.rootFS
-// access (clusterpolicy.yaml, v26.3.2) fails at install. A declared
+// access (clusterpolicy.yaml, v26.3.3) fails at install. A declared
 // value that cleans to a relative path is rejected too — host-path
 // mounts require absolute paths.
 func resolveInstallDir(values map[string]any, componentName string) (string, bool, []string) {
@@ -630,7 +630,7 @@ func resolveInstallDir(values map[string]any, componentName string) (string, boo
 		// rejected rather than silently defaulted: the emitted values
 		// would carry it verbatim, and the pinned ClusterPolicy CRD
 		// types hostPaths.driverInstallDir as a string (gpu-operator
-		// v26.3.2 nvidia.com_clusterpolicies.yaml), so the install
+		// v26.3.3 nvidia.com_clusterpolicies.yaml), so the install
 		// fails while a defaulted check would have validated against
 		// /run/nvidia/driver instead.
 		return installDir, false, []string{fmt.Sprintf(
@@ -643,7 +643,7 @@ func resolveInstallDir(values map[string]any, componentName string) (string, boo
 	if dir == "" {
 		// Intentionally default-equivalent: the operator's own
 		// transformForDriverInstallDir early-returns on "" exactly like
-		// the default (gpu-operator v26.3.2, controllers/object_controls.go).
+		// the default (gpu-operator v26.3.3, controllers/object_controls.go).
 		return installDir, false, nil
 	}
 	cleaned := path.Clean(dir)
@@ -767,7 +767,7 @@ func dynamicOwnershipViolations(bundlerConfig *config.Config, componentName stri
 //     null-coalescing deletes the key together with its chart defaults,
 //     so .Values.<section> is nil at render time and the gpu-operator
 //     templates fail on unconditional field access (e.g.
-//     .Values.driver.manager.repository in _helpers.tpl, v26.3.2) —
+//     .Values.driver.manager.repository in _helpers.tpl, v26.3.3) —
 //     ownership cannot be verified and the install would fail anyway.
 //     A non-boolean toggle is rejected because the chart renders the
 //     value unquoted, so YAML re-typing at install time can flip it to a

--- a/pkg/bundler/validations/checks_test.go
+++ b/pkg/bundler/validations/checks_test.go
@@ -1226,7 +1226,7 @@ func TestCheckDriverOwnershipCoherence(t *testing.T) {
 			// the key together with its chart defaults, so .Values.driver
 			// is nil at render time and the chart's unconditional field
 			// accesses (_helpers.tpl .Values.driver.manager.repository,
-			// v26.3.2) fail at install. Reject rather than default. The
+			// v26.3.3) fail at install. Reject rather than default. The
 			// reachable vector is a top-level --set-json null: the typed
 			// merge assigns it verbatim (mergeTypedValueByPath), while the
 			// recipe-side overlay merge drops nil-valued keys before the
@@ -1253,7 +1253,7 @@ func TestCheckDriverOwnershipCoherence(t *testing.T) {
 			// hostPaths: null is the same hazard as a null driver/toolkit
 			// section: Helm null-coalescing deletes the chart defaults and
 			// clusterpolicy.yaml's unconditional .Values.hostPaths.rootFS
-			// access fails at install (v26.3.2).
+			// access fails at install (v26.3.3).
 			name:         "--set-json hostPaths=null → rejected",
 			recipeResult: result("", aks, gpuOpRef(driverOn())),
 			bundlerConfig: config.NewConfig(config.WithValueOverridesTypedPaths([]config.TypedComponentPath{

--- a/pkg/client/v1/gpu_driver_state.go
+++ b/pkg/client/v1/gpu_driver_state.go
@@ -83,7 +83,7 @@ func driverAbsentRemedy(service recipe.CriteriaServiceType, os recipe.CriteriaOS
 				"driver: provision the GPU node pools with the GKE-managed " +
 				"driver install (node pool gpu-driver-version) instead."
 		case recipe.CriteriaOSUbuntu:
-			// The pinned GPU Operator (v26.3.2) supports driver management
+			// The pinned GPU Operator (v26.3.3) supports driver management
 			// on GKE only on Ubuntu node images with containerd.
 			return "On GKE Ubuntu node images the GPU Operator can manage " +
 				"the driver: bundle in GPU-Operator-managed mode: " +


### PR DESCRIPTION
## Summary

Post-merge cleanup after #1881: regenerate the BOM doc to drop a spurious render-failure warning, refresh stale outputs in `demos/query.md`, and bump remaining v26.3.2 comment references to v26.3.3.

## Motivation / Context

#1881 committed a local `helm template` failure warning into the generated BOM doc, left stale driver outputs in `demos/query.md` (one example was broken outright), and missed version references in comments outside the files it touched.

Fixes: N/A
Related: #1881, #1833

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `demos/query.md`; comment-only updates in `pkg/bundler/validations` and `pkg/client/v1`

## Implementation Notes

- `docs/user/container-images.md`: regenerated via `make bom-docs`. Removes the `[INTERNAL] helm template failed: signal: killed` warning committed under `prometheus-operator-crds` in #1881 (local render artifact, not real drift) and picks up busybox 1.37.0 -> 1.38.0 rendered-image drift in the gpu-operator and network-operator sections (the same drift the weekly bom-refresh job would commit).
- `demos/query.md`: every hardcoded output re-verified against the CLI. Driver outputs updated to 580.173.02 (the documented 580.105.08 predates the unified pin); the "driver version differs by accelerator" example no longer diverges now that a single global pin covers H100/GB200, so it demonstrates GB200's `driver.kernelModuleConfig` instead (output verified verbatim); the L40 constraints example used `l40` on EKS, which no longer resolves, and now uses `l40s` on OKE; the matrix loop uses the real `l40s` enum value.
- Comment sweep (`pkg/bundler/validations/checks.go`, `checks_test.go`, `pkg/client/v1/gpu_driver_state.go`): verified against upstream before bumping. The v26.3.2 -> v26.3.3 chart diff contains no template changes (`clusterpolicy.yaml`, `_helpers.tpl`, CRDs identical) and `controllers/object_controls.go` is unchanged between the tags, so every documented behavior holds for v26.3.3.

## Testing

```bash
make test        # full suite with -race
make lint        # golangci-lint + yamllint
go test -race ./pkg/bundler/validations/... ./pkg/client/v1/... ./tools/bom/...   # includes TestCommittedBOMVersionsMatchRegistry gate
```

Go changes are comment-only: no coverage delta, no new exported functions.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
