### PR TITLE
docs(demos): add required --os ol to OKE/L40S query example

### DIFF
--- a/demos/query.md
+++ b/demos/query.md
@@ -113,7 +113,7 @@ aicr query --service gke --accelerator h100 --intent training --os cos \
 L40S (on OKE) relaxes K8s further (older accelerators run on older clusters):
 
 ```shell
-aicr query --service oke --accelerator l40s --intent training \
+aicr query --service oke --accelerator l40s --intent training --os ol \
   --selector constraints
 ```
 


### PR DESCRIPTION
## Summary

Add the required `--os ol` to the OKE/L40S query example in `demos/query.md` so the copy-paste command resolves instead of erroring.

## Motivation / Context

#1882 refreshed the demo but the replacement OKE/L40S example omits `--os`. OKE/L40S has only OS-specific overlays (`l40s-oke-training.yaml`, `l40s-oke-inference.yaml`, both `os: ol`) and no OS-agnostic recipe, so `aicr query --service oke --accelerator l40s --intent training` exits with:

```
[INVALID_REQUEST] service 'oke' has no OS-agnostic recipe for accelerator 'l40s'; specify an OS (valid: ol)
```

(`pkg/recipe/metadata_store.go`, covered by `TestBuildRecipeResult_OSRequired`) rather than printing the documented `>= 1.30` constraint. It is the only `aicr query` in the file that omits `--os` — every other example passes `--os ubuntu`/`--os cos`. A reader copying the command hits the error directly.

Fixes: N/A
Related: #1882

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

One-line change: add `--os ol` to the OKE/L40S query. This resolves the `l40s-oke-training` overlay, whose `K8s.server.version` constraint is `>= 1.30` — matching the documented output, so no output text needs to change.

## Testing

Doc-only change (single line in `demos/query.md`); full `make qualify` was not run because tests, e2e, and Go lint cannot regress from a Markdown-only edit.

Verified by inspection against the merged source at `origin/main`:
- `recipes/overlays/l40s-oke-training.yaml` criteria: `service: oke`, `os: ol`, `accelerator: l40s`, `intent: training`; constraint `K8s.server.version: ">= 1.30"`.
- `pkg/recipe/metadata_store.go` emits the OS-required error when a service has only OS-specific overlays and `--os` is omitted.

## Risk Assessment

- [x] **Low** — Isolated single-line doc change, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] I updated docs if user-facing behavior changed
- [x] Commits are cryptographically signed (`git commit -S`)
