### PR TITLE
fix(snapshot): fail closed on unusable --snapshot input (#1888)

### DIFF
--- a/pkg/cli/diff_test.go
+++ b/pkg/cli/diff_test.go
@@ -430,7 +430,8 @@ func writeMinimalSnapshot(t *testing.T, dir, name string) string {
 	content := `kind: Snapshot
 apiVersion: aicr.run/v1alpha2
 metadata: {}
-measurements: []
+measurements:
+  - type: K8s
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to write snapshot: %v", err)

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -188,6 +188,22 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 			return nil, applyErr
 		}
 
+		// Fail closed when the snapshot (plus any config/CLI criteria) yields no
+		// recognizable dimension. A criteria(any) here means the measurements
+		// identify nothing to specialize on — resolving it would silently emit
+		// the generic fallback recipe with exit 0 (issue #1888). This mirrors
+		// the Specificity guard on the non-snapshot path below and is the
+		// semantic backstop for measurements that pass the loader's structural
+		// gate but carry no usable signal (unknown/empty measurement type, or a
+		// recognized type with no criteria-relevant content).
+		if criteria.Specificity() == 0 {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("snapshot %q yielded no recognizable criteria (criteria(any)); its measurements "+
+					"identify no service, accelerator, intent, os, or platform — recapture with \"aicr snapshot\", "+
+					"or state criteria explicitly via --service/--accelerator/--intent/--os/--platform/--nodes or --config",
+					snapFilePath))
+		}
+
 		slog.Info("building recipe from snapshot", "criteria", criteria.String())
 		// ResolveRecipeFromSnapshot builds the constraint evaluator
 		// internally (constraints.Evaluate against snap), mirroring the

--- a/pkg/cli/recipe_test.go
+++ b/pkg/cli/recipe_test.go
@@ -16,6 +16,8 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -687,6 +689,69 @@ func TestRecipeCmd_NoCriteriaValidation(t *testing.T) {
 	expectedMsg := "no criteria provided"
 	if !strings.Contains(err.Error(), expectedMsg) {
 		t.Errorf("error = %v, want error containing %q", err, expectedMsg)
+	}
+}
+
+// TestRecipeCmd_UnusableSnapshotRejected covers issue #1888: a snapshot that
+// passes the loader's structural gate but whose measurements identify no
+// criteria dimension must fail closed with INVALID_REQUEST, not silently emit
+// the generic criteria(any) fallback recipe with exit 0. The Specificity guard
+// in buildRecipeFromCmdWithConfig is the semantic backstop for measurements
+// with an unknown type, a whitespace-only type, or a recognized type carrying
+// no criteria-relevant content.
+func TestRecipeCmd_UnusableSnapshotRejected(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlContent string
+	}{
+		{"unknown measurement type", "kind: Snapshot\nmeasurements:\n  - type: Bogus\n"},
+		{"whitespace-only measurement type", "kind: Snapshot\nmeasurements:\n  - type: \"  \"\n"},
+		{"recognized type without content", "kind: Snapshot\nmeasurements:\n  - type: K8s\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			snapFile := filepath.Join(dir, "snapshot.yaml")
+			if err := os.WriteFile(snapFile, []byte(tt.yamlContent), 0o600); err != nil {
+				t.Fatalf("failed to write test snapshot file: %v", err)
+			}
+
+			err := recipeCmd().Run(context.Background(), []string{"recipe", "--snapshot", snapFile})
+			if err == nil {
+				t.Fatal("expected error for unusable snapshot, got nil")
+			}
+			if !strings.Contains(err.Error(), "no recognizable criteria") {
+				t.Errorf("error = %v, want error containing %q", err, "no recognizable criteria")
+			}
+			if !strings.Contains(err.Error(), "criteria(any)") {
+				t.Errorf("error = %v, want error containing %q", err, "criteria(any)")
+			}
+		})
+	}
+}
+
+// TestRecipeCmd_UnusableSnapshotWithOverrideProceeds confirms the criteria(any)
+// guard runs AFTER config/CLI criteria are applied (issue #1888): an explicit
+// override supplies specificity, so the same otherwise-unusable snapshot is no
+// longer rejected by the guard. Resolution may still fail on its own merits
+// (e.g. the empty snapshot failing an overlay constraint), but never with the
+// criteria(any) guard — that is the boundary this test locks in.
+func TestRecipeCmd_UnusableSnapshotWithOverrideProceeds(t *testing.T) {
+	dir := t.TempDir()
+	snapFile := filepath.Join(dir, "snapshot.yaml")
+	// A recognized-but-empty K8s measurement yields criteria(any) on its own.
+	if err := os.WriteFile(snapFile, []byte("kind: Snapshot\nmeasurements:\n  - type: K8s\n"), 0o600); err != nil {
+		t.Fatalf("failed to write test snapshot file: %v", err)
+	}
+
+	err := recipeCmd().Run(context.Background(), []string{
+		"recipe", "--snapshot", snapFile,
+		"--service", "eks", "--accelerator", "h100", "--intent", "training",
+		"--os", "ubuntu", "--platform", "kubeflow",
+	})
+	if err != nil && strings.Contains(err.Error(), "no recognizable criteria") {
+		t.Errorf("criteria(any) guard fired despite explicit criteria override: %v", err)
 	}
 }
 

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -411,7 +411,7 @@ func TestValidateCmd_KubeconfigSelectsValidationCluster(t *testing.T) {
 		t.Fatalf("failed to write test recipe file: %v", err)
 	}
 	snapshotPath := filepath.Join(tmp, "snapshot.yaml")
-	if err := os.WriteFile(snapshotPath, []byte("metadata:\n  version: test\n"), 0o600); err != nil {
+	if err := os.WriteFile(snapshotPath, []byte("kind: Snapshot\nmetadata:\n  version: test\nmeasurements:\n  - type: K8s\n"), 0o600); err != nil {
 		t.Fatalf("failed to write test snapshot file: %v", err)
 	}
 

--- a/pkg/snapshotter/loader.go
+++ b/pkg/snapshotter/loader.go
@@ -31,13 +31,28 @@ func LoadFromFile(ctx context.Context, path string) (*Snapshot, error) {
 }
 
 // LoadFromFileWithKubeconfig reads a snapshot from path using kubeconfig for
-// cm:// resolution, then rejects a snapshot stamped with an apiVersion this
-// build does not understand.
+// cm:// resolution, then rejects a document that is not a snapshot this build
+// can consume.
 //
-// An empty apiVersion is tolerated (older snapshots predate the field); a
-// non-empty unknown value means the snapshot was produced by an incompatible
-// aicr version, so we fail closed rather than risk a schema mismatch during
-// validation.
+// Deserialization is non-strict, so any YAML mapping decodes into a Snapshot
+// with zero-value fields. Without an identity gate a wrong file (typo'd path,
+// an AICRConfig, arbitrary YAML) would decode into an empty Snapshot, derive
+// criteria(any), and silently emit a fallback recipe with exit 0. We fail
+// closed instead, in identity → version → content order:
+//
+//   - A non-empty kind other than Snapshot (e.g. AICRConfig) is the wrong
+//     document type. An empty kind is tolerated because older snapshots predate
+//     the field.
+//   - A non-empty apiVersion this build does not understand means the snapshot
+//     came from an incompatible aicr version, so we fail closed rather than
+//     risk a schema mismatch during validation. An empty apiVersion is
+//     tolerated for the same backward-compatibility reason.
+//   - A document with no usable measurement — regardless of kind — cannot be
+//     distinguished from empty cluster state and would still derive
+//     criteria(any). A measurement is usable only if it is non-nil and carries
+//     a type; fingerprinting ignores nil and typeless entries alike. This gate
+//     backstops a correctly stamped but empty (kind: Snapshot, measurements: [])
+//     file as well as slices of only nil (- null) or typeless (- {}) entries.
 func LoadFromFileWithKubeconfig(ctx context.Context, path, kubeconfig string) (*Snapshot, error) {
 	snap, err := serializer.FromFileWithKubeconfigContext[Snapshot](ctx, path, kubeconfig)
 	if err != nil {
@@ -45,11 +60,30 @@ func LoadFromFileWithKubeconfig(ctx context.Context, path, kubeconfig string) (*
 			fmt.Sprintf("failed to load snapshot from %q", path))
 	}
 
+	if snap.Kind != "" && snap.Kind != header.KindSnapshot {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("file %q has kind %q, but a %q is required; "+
+				"run \"aicr snapshot\" to capture cluster state first",
+				path, snap.Kind, header.KindSnapshot))
+	}
+
 	if snap.APIVersion != "" && !header.IsSupportedAPIVersion(snap.APIVersion) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("snapshot file has apiVersion %q, which this aicr build does not support (expected %q); "+
 				"recapture the snapshot with a matching aicr version",
 				snap.APIVersion, header.GroupVersion))
+	}
+
+	usable := 0
+	for _, m := range snap.Measurements {
+		if m != nil && m.Type != "" {
+			usable++
+		}
+	}
+	if usable == 0 {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("file %q contains no usable measurements and is not a valid snapshot; "+
+				"run \"aicr snapshot\" to capture cluster state first", path))
 	}
 
 	return snap, nil

--- a/pkg/snapshotter/loader_test.go
+++ b/pkg/snapshotter/loader_test.go
@@ -44,12 +44,12 @@ func TestLoadFromFile(t *testing.T) {
 		},
 		{
 			name:        "supported apiVersion loads",
-			yamlContent: "kind: Snapshot\napiVersion: " + FullAPIVersion + "\nmeasurements: []\n",
+			yamlContent: "kind: Snapshot\napiVersion: " + FullAPIVersion + "\nmeasurements:\n  - type: K8s\n",
 			wantErr:     false,
 		},
 		{
 			name:        "empty apiVersion allowed for backward compat",
-			yamlContent: "kind: Snapshot\nmeasurements: []\n",
+			yamlContent: "kind: Snapshot\nmeasurements:\n  - type: K8s\n",
 			wantErr:     false,
 		},
 		{
@@ -65,6 +65,46 @@ func TestLoadFromFile(t *testing.T) {
 			wantErr:     true,
 			errContain:  `apiVersion "aicr.run/v1alpha1"`,
 			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:        "wrong kind rejected",
+			yamlContent: "kind: AICRConfig\napiVersion: " + FullAPIVersion + "\nspec:\n  foo: bar\n",
+			wantErr:     true,
+			errContain:  `has kind "AICRConfig"`,
+			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:        "arbitrary YAML with no kind and no measurements rejected",
+			yamlContent: "foo: bar\n",
+			wantErr:     true,
+			errContain:  "no usable measurements",
+			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:        "kind Snapshot with empty measurements rejected",
+			yamlContent: "kind: Snapshot\napiVersion: " + FullAPIVersion + "\nmeasurements: []\n",
+			wantErr:     true,
+			errContain:  "no usable measurements",
+			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:        "snapshot with only a nil measurement entry rejected",
+			yamlContent: "kind: Snapshot\nmeasurements:\n  - null\n",
+			wantErr:     true,
+			errContain:  "no usable measurements",
+			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:        "snapshot with only a typeless measurement object rejected",
+			yamlContent: "kind: Snapshot\nmeasurements:\n  - {}\n",
+			wantErr:     true,
+			errContain:  "no usable measurements",
+			wantCode:    errors.ErrCodeInvalidRequest,
+		},
+		{
+			name:        "kind-less snapshot with measurements allowed for backward compat",
+			yamlContent: "measurements:\n  - type: K8s\n",
+			wantErr:     false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Make `aicr recipe --snapshot` (and the shared snapshot loader) fail closed when the input is not a usable snapshot, instead of silently deriving `criteria(any)` and emitting the generic fallback recipe with exit 0.

## Motivation / Context

`aicr recipe --snapshot <file>` (also `aicr validate --snapshot` and `aicr diff`) deserialize the file non-strictly, so ANY YAML mapping decodes into a `Snapshot` with zero-value fields. A wrong `--snapshot` — a typo'd path, an `AICRConfig` document, arbitrary YAML like `foo: bar`, or a partially/hand-authored snapshot whose measurements carry no recognizable signal — decoded into an effectively empty `Snapshot`, derived `criteria(any)`, and shipped a generic fallback recipe while the user believed it came from their cluster state.

Fixes: #1888
Related: #1717 (same fail-open family — unknown check names, since fixed)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] CLI (`cmd/aicr`, `pkg/cli`)

## Implementation Notes

Two complementary gates now fail closed with `INVALID_REQUEST` (exit 2):

**1. Loader identity/version/content gate** — `LoadFromFileWithKubeconfig`, the chokepoint shared by `recipe --snapshot`, `validate --snapshot`, and `diff`:
- non-empty `kind` other than `Snapshot` (e.g. `AICRConfig`) → rejected (empty kind tolerated for older snapshots);
- unsupported `apiVersion` → rejected;
- no usable (non-nil, typed) measurement → rejected.

**2. Criteria-specificity guard on the recipe path** — `query.go`, mirroring the guard the criteria-flag path already has: after deriving criteria from the snapshot and applying any config/CLI criteria, reject when the result is `criteria(any)`.

The second gate is the **enclosing invariant** for the issue's core symptom ("silently emits criteria(any) recipe"). It catches measurements that pass the loader's structural gate but carry no usable signal — an unknown or whitespace-only measurement type, or a recognized type (`K8s`) with no criteria-relevant content — regardless of how the empty fingerprint arose. It runs before recipe resolution, so snapshot-derived criteria relaxation and user-supplied `--config`/flag criteria are unaffected.

This is deliberately **not** more measurement-structure validation in the loader (e.g. `measurement.ParseType` + content checks) — a semantic "does this snapshot yield a usable recipe query?" guard at the derivation site is one check that covers every variant, rather than enumerating malformed shapes.

## Testing

```bash
go test ./pkg/snapshotter/... ./pkg/cli/... ./pkg/evidence/... ./pkg/component/...   # pass
golangci-lint run -c .golangci.yaml ./pkg/snapshotter/... ./pkg/cli/...              # 0 issues
```

End-to-end with a locally built binary (all exit 2 with `INVALID_REQUEST`; valid mock snapshot exits 0):

```
foo: bar                                 -> not a valid snapshot
kind: AICRConfig ...                     -> wrong kind
kind: Snapshot / measurements: []        -> no usable measurements
measurements: [null] / [{}]              -> no usable measurements
kind: Snapshot / - type: Bogus           -> criteria(any) guard
kind: Snapshot / - type: "  "            -> criteria(any) guard
kind: Snapshot / - type: K8s (no data)   -> criteria(any) guard
valid mock snapshot                      -> exit 0 (resolves normally)
```

`LoadFromFileWithKubeconfig` coverage 100%; new regression tests in `loader_test.go` (empty/nil/typeless) and `recipe_test.go` (unknown/whitespace/empty-content → `no recognizable criteria`).

## Risk Assessment

- [x] **Low** — Two isolated gates, fully tested, easy to revert. Only rejects inputs that previously produced a meaningless fallback recipe.

**Rollout notes:** Backward compatible — real snapshots (kind-stamped, or kind-less carrying measurements that identify a dimension) still load and resolve unchanged. Only non-snapshot documents and snapshots that yield `criteria(any)` newly fail closed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A — fail-closed on invalid input, actionable error messages)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
