### PR TITLE
docs(validate): scope --fail-on-error; fix exit-code & CTRF-suite docs (#1889)

### DIFF
--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -367,11 +367,17 @@ aicr validate \
 Results are emitted in [CTRF](https://ctrf.io/) (Common Test Report Format)
 JSON: a top-level `summary` (test counts and start/stop timestamps) plus a
 `tests` array where each entry carries a `name`, `status`
-(passed/failed/skipped), `suite` (the phase — readiness, deployment,
-performance, conformance), and `stdout` lines with the per-check evidence. For
-a worked example of the full report and how performance checks such as
-`inference-perf` surface their measured values, see
+(passed/failed/skipped/other), `suite` (the phase — deployment, performance,
+conformance), and `stdout` lines with the per-check evidence. For a worked
+example of the full report and how performance checks such as `inference-perf`
+surface their measured values, see
 [Emitting recipe evidence for a PR](../user/validation.md#emitting-recipe-evidence).
+
+The readiness pre-flight is not a CTRF suite. It runs before any phase or report
+is constructed, so a readiness failure exits 2 (see below) and produces **no
+CTRF output**. Once phases run, the report carries an entry for every requested
+phase — including phases reported `skipped` (for example, all of them under
+`--no-cluster`, or phases after the first failure under `--fail-fast`).
 
 ### CI/CD Integration
 
@@ -383,9 +389,12 @@ aicr validate \
     --recipe recipe.yaml \
     --snapshot cm://gpu-operator/aicr-snapshot
 
-# Exit code: 0 = all passed; 8 (ExitInternal, from ErrCodeInternal) when
-#   one or more phases did not pass
-# Use --fail-on-error=false for informational mode without failing
+# Exit code: 0 = all phases passed or were skipped; 8 (ExitInternal, from
+#   ErrCodeInternal) when one or more phases reported failed or other;
+#   2 (ExitInvalidInput) when a readiness pre-flight constraint is not met
+#   (always fails closed, see below)
+# Use --fail-on-error=false for informational mode without failing on phase
+#   checks. The readiness pre-flight still exits 2 regardless of the flag.
 ```
 
 ## Stage 4: Bundle (Data Packaging)

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -844,7 +844,7 @@ aicr validate [flags]
 | `--snapshot` | `-s` | string | | Path/URI to snapshot file containing measurements (omit to capture live) |
 | `--config` | | string | | Path or HTTP/HTTPS URL to an AICRConfig file (YAML/JSON). CLI flags override values from this file. See [Validate Config File Mode](#validate-config-file-mode). |
 | `--phase` | | string[] | all | Validation phase to run: deployment, performance, conformance, all (repeatable) |
-| `--fail-on-error` | | bool | true | Exit with non-zero status if any constraint fails |
+| `--fail-on-error` | | bool | true | Exit with non-zero status if any phase check reports `failed` or `other` (crash/OOM/timeout). Scopes to phase checks only — the readiness pre-flight always fails closed with exit 2 regardless of this flag (see the readiness note under [Validation Phases](#validation-phases)). |
 | `--fail-fast` | | bool | false | Stop after the first phase that fails. By default all phases run and produce results. |
 | `--output` | `-o` | string | stdout | Output destination: file path, ConfigMap URI (`cm://namespace/name`), or stdout |
 | `--kubeconfig` | `-k` | string | ~/.kube/config | Path to kubeconfig file selecting the target cluster for **every** Kubernetes operation in the invocation: `cm://` recipe/snapshot/output I/O, snapshot-agent deployment, validation namespace and RBAC, validator Jobs, and cleanup. One invocation targets one cluster. When omitted, default discovery applies (`KUBECONFIG` env, then `~/.kube/config`, then in-cluster). An invalid path fails any run that performs Kubernetes operations; `--no-cluster` dry-runs over local files do not load it. **Changed in v0.18:** validator-engine operations, including validator Jobs, now honor this flag instead of using the default cluster. |
@@ -890,7 +890,7 @@ Validation can be run in different phases to validate different aspects of the d
 | `conformance` | Validates workload-specific requirements and conformance | Before running production workloads |
 | `all` | Runs all phases sequentially; results collected regardless of failures | Complete end-to-end validation |
 
-> **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs.
+> **Note:** Readiness constraints (K8s version, OS, kernel) are always evaluated implicitly before any phase runs. If readiness fails, validation stops before deploying any Jobs and exits 2 (`INVALID_REQUEST`). This gate always fails closed — `--fail-on-error=false` scopes to phase check results and does not downgrade a readiness failure.
 >
 > **Version skew:** Snapshots and recipes record the `aicr` version that produced them. When the recipe, the snapshot, and the running binary report different release versions, `validate` logs a single advisory warning (`version skew detected across validate inputs`) naming all three. This is a debugging breadcrumb — mixing artifacts from different versions can surface as confusing failures — and does **not** fail the command. Dev (`dev`) and pre-release (`-next`) builds are ignored to avoid noise.
 >
@@ -1050,7 +1050,7 @@ spec:
       requireGpu: true
     execution:
       phases: [deployment, conformance]
-      failOnError: true                  # default true; set false to report only
+      failOnError: true                  # default; false = don't fail on phase-check results (readiness pre-flight still exits 2)
       noCluster: false
       noCleanup: false
       timeout: 10m
@@ -1175,10 +1175,10 @@ Results are output in CTRF (Common Test Report Format) — an industry-standard 
 **Exit Codes:**
 | Code | Description |
 |------|-------------|
-| `0` | All checks passed |
-| `2` | Invalid input (bad flags, missing recipe) |
+| `0` | All phases passed or were skipped (also returned under `--fail-on-error=false` even when phases report `failed`/`other`) |
+| `2` | Invalid input (bad flags, missing recipe), or a readiness pre-flight constraint not met — the readiness gate always fails closed here regardless of `--fail-on-error` |
 | `5` | Timeout (validator section or context deadline exceeded) |
-| `8` | One or more checks failed (when `--fail-on-error` is set) |
+| `8` | One or more phase checks reported `failed` or `other` (crash/OOM/deadline) — when `--fail-on-error` is set |
 
 ---
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -518,8 +518,9 @@ The inference validator has three explicit skip guards so it never runs where
 it can't succeed. Each produces a `status: skipped` CTRF entry with a specific
 reason. Skipped checks are **not** failures: the validator container exits
 with code 2 internally (mapped to CTRF `skipped`), but `aicr validate` itself
-exits **0** for skipped/passed/other phases — a skipped inference check never
-drives a non-zero CLI exit on its own.
+exits **0** for a skipped or passed phase — a skipped inference check never
+drives a non-zero CLI exit on its own. (A phase that reports `failed` or `other`
+exits 8 by default, and is informational only under `--fail-on-error=false`.)
 
 | Guard | Trigger | Skip message |
 |-------|---------|--------------|
@@ -819,7 +820,9 @@ without needing cluster access.
 
 ## CI/CD integration
 
-`aicr validate` exits non-zero when any phase fails. CTRF JSON is emitted to
+By default `aicr validate` exits non-zero when any phase reports `failed` or
+`other` (set `--fail-on-error=false` to report those results and exit 0 anyway;
+the readiness pre-flight still exits 2 regardless). CTRF JSON is emitted to
 stdout (or to `--output <file>`), so a pipeline can gate promotion on both the
 exit code and the structured report:
 
@@ -835,14 +838,14 @@ error codes (see [`pkg/errors/exitcode.go`](https://github.com/NVIDIA/aicr/blob/
 
 | Code | Meaning |
 |------|---------|
-| `0` | All phases reported status `passed`, `skipped`, or `other` |
-| `2` | Invalid input or request (`ErrCodeInvalidRequest`) — bad CLI flag, malformed argument, or a validator rejecting a recipe value (e.g., an inference constraint that uses the wrong comparator direction) |
+| `0` | All phases reported status `passed` or `skipped` |
+| `2` | Invalid input or request (`ErrCodeInvalidRequest`) — bad CLI flag, malformed argument, a validator rejecting a recipe value (e.g., an inference constraint that uses the wrong comparator direction), or a **readiness pre-flight** constraint not met. The readiness gate always fails closed with this code, even under `--fail-on-error=false` |
 | `5` | CLI-layer timeout *before* a check runs — snapshot-agent Job never completes within `--timeout`, or the validator Job as a whole exceeds its wait deadline |
-| `8` | One or more phases reported status `failed`, **including per-check internal timeouts** (e.g., DynamoGraphDeployment not ready within `InferenceWorkloadReadyTimeout`) |
+| `8` | One or more phases reported status `failed` **or** `other` (a check that crashed, hit an OOM, or exceeded `activeDeadlineSeconds`), including per-check internal timeouts (e.g., DynamoGraphDeployment not ready within `InferenceWorkloadReadyTimeout`). Suppressed by `--fail-on-error=false` |
 
-> **Important:** two quirks to be aware of when gating a pipeline on exit code:
+> **Important:** two subtleties to be aware of when gating a pipeline on exit code:
 >
-> 1. Only phase status `failed` drives a non-zero exit. A phase whose status is `other` (check crashed, pod OOM, `activeDeadlineSeconds` exceeded) **still produces exit 0**. Pipelines that need to catch those outcomes must inspect the CTRF report and look at per-phase status or the `summary.other` count, not rely on exit code alone.
+> 1. Both `failed` and `other` are blocking. A phase whose status is `other` (check crashed, pod OOM, `activeDeadlineSeconds` exceeded) drives the same non-zero exit as `failed` — an inconclusive check fails closed rather than passing silently. `--fail-on-error=false` suppresses **both** result-driven exits (the run reports the outcomes in the CTRF report and exits 0); it does not distinguish `failed` from `other`.
 > 2. Exit 5 is narrower than it sounds. A timeout **inside** a check's own logic (DynamoGraphDeployment not ready, inference endpoint never healthy, AIPerf Job pod-wait deadline) surfaces as a failed phase, not as a structured `ErrCodeTimeout`, so the CLI exits **8**. Only timeouts at the CLI-to-cluster layer (snapshot-agent wait, validator-Job wait) retain their `ErrCodeTimeout` classification all the way through to exit 5.
 
 Scripts that gate on validation outcome should treat **any non-zero code** as
@@ -855,6 +858,15 @@ For informational-only runs (report results without failing the build):
 aicr validate ... --fail-on-error=false
 ```
 
+`--fail-on-error=false` scopes to **phase check results**: a deployment,
+performance, or conformance phase that reports `failed` or `other` is recorded
+in the CTRF report and the run exits 0. It does not relax the readiness
+pre-flight — if a readiness constraint
+(K8s version, OS, kernel) is not met, the run still fails closed with exit 2
+before any phase executes. In `--no-cluster` mode this is the dominant path,
+since all phase checks report `skipped` and readiness is the only inline
+constraint evaluation.
+
 ## Troubleshooting
 
 ### Readiness pre-flight fails
@@ -864,6 +876,10 @@ The CLI logs each readiness constraint comparison before any phase runs:
 ```text
 readiness constraint failed: name=K8s.server.version expected=">= 1.34" actual=v1.33.0-eks-abc
 ```
+
+The run stops before deploying any Jobs and exits 2 (`INVALID_REQUEST`). This is
+intentional fail-closed behavior: readiness gates whether the validators can run
+at all, so it is terminal regardless of `--fail-on-error` (see above).
 
 Fix: upgrade the cluster, or pick a recipe whose readiness constraints match
 the cluster's actual versions.

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -406,9 +406,11 @@ func validateCmdFlags() []cli.Flag {
 			Category: catValidationControl,
 		},
 		&cli.BoolFlag{
-			Name:     "fail-on-error",
-			Value:    true,
-			Usage:    "Exit with non-zero status if any check fails validation",
+			Name:  "fail-on-error",
+			Value: true,
+			Usage: "Exit with non-zero status if any phase check reports failed or other " +
+				"(crash/OOM/timeout). Does not affect the readiness pre-flight, which always " +
+				"fails closed with exit 2 when a prerequisite constraint (e.g. K8s version) is not met",
 			Category: catValidationControl,
 		},
 		&cli.BoolFlag{
@@ -600,7 +602,9 @@ Run specific phases:
 Save CTRF report to file:
   aicr validate -r recipe.yaml -s snapshot.yaml --output report.json
 
-Run validation without failing on check errors (informational mode):
+Run validation without failing on phase check errors (informational mode).
+Note: the readiness pre-flight still fails closed with exit 2 if a prerequisite
+constraint (e.g. K8s version) is not met — --fail-on-error scopes to phase checks:
   aicr validate -r recipe.yaml -s snapshot.yaml --fail-on-error=false
 `,
 		Flags: validateCmdFlags(),


### PR DESCRIPTION
## Summary

Document that `aicr validate --fail-on-error` scopes to phase check results only — the readiness pre-flight is intentionally terminal and always fails closed with exit 2 — and fix two adjacent inaccuracies in the same exit-code / CTRF documentation.

## Motivation / Context

`--fail-on-error=false` is named/documented as informational mode, but a readiness pre-flight failure (e.g. K8s server version below the recipe minimum) terminates the run with exit 2 (`INVALID_REQUEST`) before any phase runs — the flag is silently ignored for the pre-flight. This is intentional fail-closed design (readiness gates whether the validators can run at all), but the flag's help text and the CLI reference never stated that scope. In `--no-cluster` mode this is the dominant failure path, since all phase checks report `skipped` and readiness is the only inline constraint evaluation.

Fixes: #1889

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`) — flag Usage / help text only
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Chose to document the existing fail-closed contract rather than change behavior — making readiness bypassable would contradict the project's fail-closed principle for pre-flight gates (a failing prerequisite must not masquerade as a passing run).

- **`--fail-on-error` scope** — flag Usage and the informational-mode help/docs now scope the flag to phase check results and note readiness is terminal at exit 2 regardless. Exit-code tables and readiness notes updated in `cli-reference.md`, `validation.md`, `data-flow.md`.
- **`other`-status exit code** — corrected a pre-existing error in the same exit-code table: phase status `other` (crash / OOM / `activeDeadlineSeconds`) is blocking and drives exit 8 like `failed` (`ctrf.IsFailingStatus` covers both). The old docs wrongly claimed `other` produced exit 0. `--fail-on-error=false` suppresses both result-driven exits.
- **CTRF suite list** — removed `readiness` from the CTRF `suite` list in `data-flow.md`. Readiness runs before any phase or report is constructed, so a readiness failure produces no CTRF output; valid suites are deployment, performance, conformance.

## Testing

```bash
go build ./pkg/cli/... && go test ./pkg/cli/...   # pass
golangci-lint run -c .golangci.yaml ./pkg/cli/...  # 0 issues
aicr validate --help   # renders the clarified flag text
```

Confirmed against a locally built binary: with a sub-minimum K8s-version snapshot, `aicr validate --no-cluster --fail-on-error=false` exits 2 with `readiness check failed`. The `other`-status and CTRF-suite claims were verified by reading `pkg/cli/validate.go`, `pkg/validator/ctrf/types.go` (`IsFailingStatus`), `pkg/validator/validator.go` (`checkReadiness` / `ValidatePhases`), and `pkg/validator/phases.go`.

Doc content plus Go help-string literals — no logic change, so no test/coverage impact. Anchor link `#validation-phases` verified against the target heading.

## Risk Assessment

- [x] **Low** — No behavior change; documentation and help-string literals only.

**Rollout notes:** N/A — no behavior change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — no logic change)
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
