### PR TITLE
fix(test): scrub inherited VAULT_* env in vault KMS e2e runner

### DIFF
--- a/tests/chainsaw/signing/bundle-attestation-vault/README.md
+++ b/tests/chainsaw/signing/bundle-attestation-vault/README.md
@@ -120,6 +120,18 @@ AICR_BIN=/path/to/aicr \
     --selector 'requires=openbao'
 ```
 
+> **Scrub inherited `VAULT_*` env when driving the suite by hand.** The key is
+> provisioned in the root namespace, but the `vault/api` client inside `aicr` and
+> `cosign` auto-reads a family of `VAULT_*` / `BAO_*` vars from the environment.
+> The common trap is `VAULT_NAMESPACE` (e.g. from a real-Vault config): it sends
+> an `X-Vault-Namespace` header, the key read resolves in a non-existent
+> namespace, and namespace-aware OpenBAO returns 404 — surfacing as the
+> misleading `could not read data from transit key path`. A stray `VAULT_CACERT`,
+> proxy, or `BAO_ADDR` can misdirect the connection the same way. `run.sh` clears
+> all of these for you (keeping only `VAULT_ADDR` / `VAULT_TOKEN` /
+> `VAULT_KMS_KEY`); the raw `chainsaw test` invocation above does not, so unset
+> them first — at minimum `unset VAULT_NAMESPACE BAO_NAMESPACE`.
+
 ## CI
 
 Workflow: `.github/workflows/vault-kms-e2e.yaml`

--- a/tests/chainsaw/signing/bundle-attestation-vault/run.sh
+++ b/tests/chainsaw/signing/bundle-attestation-vault/run.sh
@@ -94,6 +94,27 @@ VAULT_ADDR="http://127.0.0.1:${OPENBAO_PORT}"
 # work). Exported so the provider inside the aicr binary and the chainsaw suite
 # reach the same server.
 export VAULT_ADDR VAULT_TOKEN
+
+# Scrub any inherited Vault client configuration from a developer's real-Vault
+# setup, keeping only the addr/token/key this runner manages. The HashiCorp
+# vault/api client baked into aicr and cosign auto-reads a family of VAULT_* /
+# BAO_* env vars (VAULT_NAMESPACE, VAULT_CACERT, VAULT_CLIENT_CERT,
+# VAULT_SKIP_VERIFY, VAULT_*_PROXY, timeouts, and the BAO_* aliases). Against
+# this dev-mode OpenBAO those quietly break the run: VAULT_NAMESPACE=dgx-devops,
+# say, makes the key read resolve in a non-existent namespace and namespace-aware
+# OpenBAO returns 404 — surfacing as the misleading "could not read data from
+# transit key path" (real HashiCorp Vault OSS ignores namespaces and CI sets
+# none, so only a local run is affected); a stray VAULT_CACERT/BAO_ADDR can
+# redirect or fail the connection the same way. Transit is provisioned over the
+# root namespace via curl (which ignores these), so pin the client to match by
+# clearing everything except VAULT_ADDR / VAULT_TOKEN / VAULT_KMS_KEY.
+for _vault_env in $(env | sed -n 's/^\(VAULT_[A-Z0-9_]*\)=.*/\1/p; s/^\(BAO_[A-Z0-9_]*\)=.*/\1/p'); do
+  case "${_vault_env}" in
+    VAULT_ADDR | VAULT_TOKEN | VAULT_KMS_KEY) ;;
+    *) unset "${_vault_env}" ;;
+  esac
+done
+unset _vault_env
 # Transit key name; the KMS URI is hashivault://<key>.
 VAULT_KMS_KEY="${VAULT_KMS_KEY:-aicr}"
 export VAULT_KMS_KEY


### PR DESCRIPTION
## Summary

Scrub inherited `VAULT_*` / `BAO_*` environment variables in the Vault (OpenBAO) KMS e2e runner so a developer's real-Vault shell config (most commonly `VAULT_NAMESPACE`) no longer breaks local runs. Keeps only the `VAULT_ADDR` / `VAULT_TOKEN` / `VAULT_KMS_KEY` the runner manages.

## Motivation / Context

The runner provisions the Transit engine + key in the **root** namespace via `curl` (which ignores `VAULT_NAMESPACE`), but the HashiCorp `vault/api` client baked into `aicr` **and** `cosign` auto-reads a family of `VAULT_*` / `BAO_*` env vars and sends e.g. `X-Vault-Namespace`. A developer with `VAULT_NAMESPACE=dgx-devops` set hits a misleading failure — the key read resolves in a non-existent namespace and namespace-aware OpenBAO returns 404, surfacing as `[SERVICE_UNAVAILABLE] failed to read KMS public key: could not read data from transit key path`. Real HashiCorp Vault OSS ignores namespaces (Enterprise-only) and CI sets none, so this only bites local runs — which is why it wasn't caught earlier.

Found while validating air-gapped signing/verification for the v0.18.0-rc1 release. The product feature (`hashivault://` signing/verify) is unaffected: it works against real HashiCorp Vault and in CI. This is purely test-runner robustness.

Fixes: #1894
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tests/chainsaw/signing/bundle-attestation-vault` e2e runner + README

## Implementation Notes

The scrub is a small loop that enumerates inherited `VAULT_*` / `BAO_*` names and unsets all but `VAULT_ADDR` / `VAULT_TOKEN` / `VAULT_KMS_KEY`, so user-provided token/key overrides still work while namespace, TLS (`VAULT_CACERT`, `VAULT_CLIENT_CERT`, `VAULT_SKIP_VERIFY`), proxy, timeout, and `BAO_*` alias vars are cleared. The README gains a note telling anyone driving the suite via the raw `chainsaw test` invocation (which bypasses `run.sh`) to clear the vars themselves.

## Testing

```bash
bash -n   tests/chainsaw/signing/bundle-attestation-vault/run.sh   # syntax OK
shellcheck -S warning tests/chainsaw/signing/bundle-attestation-vault/run.sh   # clean
```

Behavioral verification of the scrub loop in isolation: keeps `VAULT_ADDR`/`VAULT_TOKEN`/`VAULT_KMS_KEY`, clears `VAULT_NAMESPACE`/`VAULT_CACERT`/`BAO_ADDR`/`BAO_NAMESPACE`.

End-to-end proof — full suite run with the offending env **deliberately set** (the exact condition that failed before this change):

```
VAULT_NAMESPACE=dgx-devops VAULT_CACERT=/nonexistent/ca.pem \
AICR_BIN=<attested v0.18.0-rc1> AICR_ATTESTED=true AICR_IDENTITY_REGEXP='...on-tag...' \
  tests/chainsaw/signing/bundle-attestation-vault/run.sh
# -> bundle-with-kms-signing DONE (no "could not read data"); Passed 1, Failed 0
# -> Vault KMS E2E: PASSED
```

Shell-only change to a test-harness script; no Go/product code touched. The `vault-kms-e2e.yaml` workflow re-runs the full suite on this PR.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — test-runner only; no product or CI-workflow behavior changes (CI never set these vars).

## Checklist

- [x] Tests pass locally (full vault e2e suite passes with the offending env set)
- [x] Linter passes (`shellcheck` clean; `bash -n` OK)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (verified via the e2e suite with the failing env reproduced)
- [x] I updated docs if user-facing behavior changed (runner README)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)