### PR TITLE
evidence(aks): h100-aks-ubuntu training + inference-dynamo recipe evidence

### DIFF
--- a/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-ca96cea68b11cd3b5f0dbad677d40365287fce8e0a5412b32861888d335c5bdc.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-ca96cea68b11cd3b5f0dbad677d40365287fce8e0a5412b32861888d335c5bdc.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-23T17:21:08Z
+    bundle:
+      digest: sha256:ca96cea68b11cd3b5f0dbad677d40365287fce8e0a5412b32861888d335c5bdc
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-inference-dynamo-47fa942d8117
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 37336989
+recipe: h100-aks-ubuntu-inference-dynamo
+schemaVersion: 1.0.0

--- a/recipes/evidence/h100-aks-ubuntu-training/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-c51d0f2dd75b9f397ddc9713150159553f4a8d15982095ea52a28872d7eef479.yaml
+++ b/recipes/evidence/h100-aks-ubuntu-training/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-c51d0f2dd75b9f397ddc9713150159553f4a8d15982095ea52a28872d7eef479.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-07-23T17:00:38Z
+    bundle:
+      digest: sha256:c51d0f2dd75b9f397ddc9713150159553f4a8d15982095ea52a28872d7eef479
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-aks-ubuntu-training-d836f2ecb370
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 37337053
+recipe: h100-aks-ubuntu-training
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds signed recipe-evidence pointers for two AKS/H100 recipes, captured on a real Azure H100 cluster (aicr-test6, 2× Standard_ND96isr_H100_v5) with `aicr v0.18.0-rc1`.

- `h100-aks-ubuntu-training`
- `h100-aks-ubuntu-inference-dynamo`

## Motivation / Context

Fresh three-phase evidence for the v0.18.0-rc1 release candidate on AKS. Both recipes were deployed to a clean cluster and validated end-to-end.

Fixes: N/A
Related: #1699, #1823

## Type of Change

- [x] Other: recipe evidence (signed pointers)

## Component(s) Affected

- [x] Other: `recipes/evidence/`

## Implementation Notes

Validation results (all `exit 0`):

- **Training** — deployment 4/4, conformance 8/8, performance **NCCL all-reduce-bw** passed.
- **Inference (dynamo)** — deployment 4/4, conformance 10/10, performance **inference-perf** passed: 144,879 tok/s, 549 ms TTFT p99 (within the overlay's Azure smoke gate).

Bundles were emitted with `aicr validate --emit-attestation`, pushed unsigned to GHCR, then signed by the fork's `Recipe Evidence: Sign` workflow (GitHub Actions OIDC, community slug `5bf9e82f…`, already in `allowlist.yaml`). `aicr evidence verify` passes on both (exit 0).

## Testing

`aicr evidence verify` exit 0 on both pointers (predicts the per-source pointer contract gate passing). Pointer YAMLs are machine-generated and carry no license header (consistent with all merged evidence pointers).

## Risk Assessment

- [x] **Low** — additive, machine-generated signed pointers under `recipes/evidence/`; no code or recipe changes.

**Rollout notes:** On merge, `Evidence: Ingest` publishes to the dashboard (validation.aicr.run).

## Checklist

- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
