### PR TITLE
fix(rekor-monitor): separate infra noise from security alerts

### DIFF
--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -23,10 +23,19 @@
 #   - Identity: scan entries added since the last checkpoint for AICR's release
 #     signing identity. An entry under that identity that a release did not
 #     produce signals OIDC/key compromise.
-# On any failure (consistency break, scan error, or matched identity) the monitor
-# exits non-zero and this workflow both opens a tracking issue (mentioning the
-# maintainers group) and posts a Slack alert (via the SLACK_SERVICE webhook); a
-# later clean run closes the issue. Note: a workflow that fails to *start*
+# The monitor exits non-zero on any failure and prints a CLASSIFICATION line, and
+# this workflow branches notifications on it so infra flakiness never pages like a
+# security event:
+#   - tamper / identity (a real consistency break or an unexplained identity hit):
+#     open a security tracking issue (mentioning the maintainers group) and post a
+#     Slack alert (via the SLACK_SERVICE webhook).
+#   - operational (Sigstore/Rekor/TUF/GitHub-API trouble, or a crash before any
+#     classification): no page. Only after three consecutive failed scheduled runs
+#     does it open a low-urgency "degraded" issue; a single blip stays quiet.
+# The job still goes red on every failure. A later clean run closes both the
+# security and degraded issues. Known release tags are fetched first and passed to
+# the tool (--known-tags-file) so an entry under the release identity that a real
+# tag produced is not flagged. Note: a workflow that fails to *start*
 # (startup_failure) cannot alert on itself, so an external liveness check
 # (dead-man's-switch) is tracked as a follow-up.
 #
@@ -54,12 +63,22 @@
 # .github/workflows/on-tag.yaml): the GitHub Actions OIDC SAN for on-tag.yaml,
 # issued by token.actions.githubusercontent.com.
 #
-# Triage when this opens an issue:
-#   - Identity hit: cross-check the entry's log index and timestamp against known
-#     release runs. If unrecognized, treat as potential OIDC/key compromise and
-#     begin incident response.
-#   - Consistency failure: re-run to rule out a transient network/log error; a
-#     persistent break is a tamper signal: escalate to Sigstore.
+# Triage, by classification:
+#   - Identity hit (security issue + page): known release tags are already
+#     excluded via --known-tags-file, so a hit means an entry under the release
+#     identity for a tag with *no corresponding release* (or an entry that failed
+#     verification). Cross-check the entry's log index and timestamp against known
+#     release runs; if unrecognized, treat as potential OIDC/key compromise and
+#     begin incident response. Residual gap: an attacker re-signing an *existing*
+#     release tag would be suppressed (a per-tag entry-count/provenance check is a
+#     follow-up).
+#   - Tamper / consistency failure (security issue + page): the Merkle consistency
+#     proof failed. Re-run once to rule out a corrupt cached proof; a persistent
+#     break is a tamper signal: escalate to Sigstore.
+#   - Operational / degraded (no page): a red hourly job with no issue is a
+#     transient infra blip (Sigstore/Rekor/TUF/GitHub-API) that self-heals. A
+#     "degraded" issue appears only after three consecutive failed runs and needs
+#     no action unless it persists.
 
 name: Rekor Monitor
 
@@ -80,6 +99,7 @@ env:
   # v1 checkpoint is simply ignored; no migration needed.
   ARTIFACT_NAME: rekor-v2-checkpoint
   ALERT_TITLE: "Rekor v2 monitor: release identity / log consistency alert"
+  DEGRADED_TITLE: "Rekor v2 monitor: degraded (unable to complete)"
   # Maintainers group notified on an alert (GitHub team; issues cannot be
   # assigned to a team, so it is @-mentioned in the issue body instead).
   MAINTAINERS_TEAM: "@nvidia/aicr-maintainer"
@@ -129,28 +149,84 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          id="$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
-            | jq -rs '[.[].artifacts[]
+          # Writes each attempt to OUTFILE.part and publishes it only on success,
+          # so a failed attempt's HTTP-error body never leaks downstream and a
+          # binary payload (the artifact zip) round-trips intact. Recovers 5xx/429
+          # and connection failures alike.
+          gh_api_retry() {  # usage: gh_api_retry OUTFILE api-args...
+            local out="$1"; shift
+            local attempt
+            for attempt in 1 2 3; do
+              if gh api "$@" > "${out}.part"; then
+                mv "${out}.part" "${out}"
+                return 0
+              fi
+              echo "::warning::gh api failed (attempt ${attempt}/3): $*"
+              sleep $(( attempt * 3 ))
+            done
+            rm -f "${out}.part"
+            echo "::error::gh api failed after 3 attempts: $*"
+            return 1
+          }
+          gh_api_retry artifacts.json --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100"
+          id="$(jq -rs '[.[].artifacts[]
                 | select(.expired == false)
                 | select(.workflow_run.head_branch == "main")
                 | select(.workflow_run.head_repository_id == .workflow_run.repository_id)]
-              | sort_by(.created_at) | last | .id // empty')"
+              | sort_by(.created_at) | last | .id // empty' artifacts.json)"
           if [ -z "${id}" ]; then
             echo "No prior checkpoint artifact from this repository on main; treating this as the first run."
             exit 0
           fi
-          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" > checkpoint.zip
+          gh_api_retry checkpoint.zip "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip"
           echo "Fetched checkpoint artifact ${id}."
 
-      - name: Monitor Rekor v2 (consistency + identity)
+      - name: Fetch known release tags
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          gh_api_retry() {  # usage: gh_api_retry OUTFILE api-args...
+            local out="$1"; shift
+            local attempt
+            for attempt in 1 2 3; do
+              if gh api "$@" > "${out}.part"; then
+                mv "${out}.part" "${out}"
+                return 0
+              fi
+              echo "::warning::gh api failed (attempt ${attempt}/3): $*"
+              sleep $(( attempt * 3 ))
+            done
+            rm -f "${out}.part"
+            echo "::error::gh api failed after 3 attempts: $*"
+            return 1
+          }
+          # All tags in this repo. The identity SAN references @refs/tags/<tag>,
+          # so a tag's existence is the correlation key for "a release produced
+          # this entry". One tag per line.
+          gh_api_retry tags.json --paginate "repos/${GITHUB_REPOSITORY}/tags?per_page=100"
+          jq -rs '[.[][].name] | .[]' tags.json > known-tags.txt
+          echo "Fetched $(wc -l < known-tags.txt) known release tags."
+
+      - name: Monitor Rekor v2 (consistency + identity)
+        id: monitor
+        run: |
+          set -uo pipefail
+          set +e
           GOFLAGS="-mod=vendor" go run ./tools/rekor-monitor \
             --file "${CHECKPOINT_FILE}" \
             --restore-zip checkpoint.zip \
             --cert-subject "${CERT_SUBJECT}" \
-            --cert-issuer "${CERT_ISSUER}"
+            --cert-issuer "${CERT_ISSUER}" \
+            --known-tags-file known-tags.txt | tee monitor.out
+          code=${PIPESTATUS[0]}
+          class="$(grep -oE '^CLASSIFICATION=[a-z]+' monitor.out | tail -n1 | cut -d= -f2)"
+          # A crash before any CLASSIFICATION line (build error, OOM) is treated
+          # as operational: infra trouble must never masquerade as a security hit.
+          [ -n "${class}" ] || class="operational"
+          echo "classification=${class}" >> "$GITHUB_OUTPUT"
+          exit "${code}"
 
       - name: Persist checkpoint
         if: ${{ !cancelled() }}
@@ -163,16 +239,14 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-      - name: Open alert issue on failure
+      - name: Open security alert issue
         id: alert_issue
-        if: ${{ failure() }}
+        if: ${{ failure() && (steps.monitor.outputs.classification == 'tamper' || steps.monitor.outputs.classification == 'identity') }}
         env:
           GH_TOKEN: ${{ github.token }}
+          CLASSIFICATION: ${{ steps.monitor.outputs.classification }}
         run: |
           set -euo pipefail
-          # Reuse an already-open alert issue (dedup) and surface its URL so the
-          # Slack step can link to it. GitHub title search is phrase-based, so
-          # filter to an exact title match before picking one.
           existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
             --search "in:title \"${ALERT_TITLE}\"" --json title,url \
             | jq -r --arg t "${ALERT_TITLE}" '[.[] | select(.title == $t)] | .[0].url // empty')"
@@ -182,18 +256,23 @@ jobs:
             exit 0
           fi
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          if [ "${CLASSIFICATION}" = "tamper" ]; then
+            detail="the Rekor v2 **consistency proof failed** (the log's Merkle root did not verify as append-only)."
+            detail="${detail} This is a tamper signal: **escalate to Sigstore** and do not advance the checkpoint."
+            detail="${detail} Re-run once to rule out a corrupt cached proof; a persistent failure is a genuine break."
+          else
+            detail="an entry was found under **AICR's release signing identity for a tag with no corresponding release** (or an entry that failed verification)."
+            detail="${detail} Known release tags are already excluded, so treat this as potential **OIDC/key compromise** and begin incident response:"
+            detail="${detail} cross-check the entry's log index and timestamp in the run logs against known release runs."
+          fi
           {
-            echo "${MAINTAINERS_TEAM}: the Rekor v2 monitor failed on [run ${GITHUB_RUN_ID}](${run_url})."
+            echo "${MAINTAINERS_TEAM}: the Rekor v2 monitor flagged a security signal on [run ${GITHUB_RUN_ID}](${run_url})."
             echo
-            echo "This means a consistency break, a scan error, or an entry under"
-            echo "AICR's release signing identity that no release produced. Triage"
-            echo "the matched entry's log index and timestamp against known release"
-            echo "runs; an unrecognized entry should be treated as potential"
-            echo "OIDC/key compromise. See the run logs and the triage notes in the"
-            echo "workflow header (\`.github/workflows/rekor-monitor.yaml\`)."
+            echo "${detail}"
             echo
-            echo "This issue auto-closes on the next clean run; a persistent"
-            echo "failure is worth investigating."
+            echo "See the run logs and the triage notes in the workflow header (\`.github/workflows/rekor-monitor.yaml\`)."
+            echo
+            echo "This issue auto-closes on the next clean run."
           } > alert-body.md
           url="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
             --title "${ALERT_TITLE}" \
@@ -202,13 +281,14 @@ jobs:
           echo "Opened alert issue: ${url}"
           echo "url=${url}" >> "$GITHUB_OUTPUT"
 
-      - name: Post Slack alert on failure
-        if: ${{ failure() }}
+      - name: Post Slack alert on security finding
+        if: ${{ failure() && (steps.monitor.outputs.classification == 'tamper' || steps.monitor.outputs.classification == 'identity') }}
         env:
           # Slack incoming-webhook path suffix; same secret the release and
           # vuln-scan workflows use. Unset in forks, so this no-ops there.
           SLACK_SERVICE: ${{ secrets.SLACK_SERVICE }}
           ISSUE_URL: ${{ steps.alert_issue.outputs.url }}
+          CLASSIFICATION: ${{ steps.monitor.outputs.classification }}
         run: |
           set -euo pipefail
           if [ -z "${SLACK_SERVICE:-}" ]; then
@@ -217,9 +297,8 @@ jobs:
           fi
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           # To ping a Slack usergroup, prepend "<!subteam^GROUP_ID> " below.
-          text=":rotating_light: *Rekor v2 monitor alert*: a consistency break, scan error,"
-          text="${text} or an entry under the AICR release identity that no release produced."
-          text="${text} Needs maintainer triage. <${run_url}|View run>"
+          text=":rotating_light: *Rekor v2 monitor: ${CLASSIFICATION} signal*: needs maintainer triage."
+          text="${text} <${run_url}|View run>"
           if [ -n "${ISSUE_URL:-}" ]; then
             text="${text} · <${ISSUE_URL}|tracking issue>"
           fi
@@ -228,6 +307,60 @@ jobs:
             --data @slack-payload.json \
             "https://hooks.slack.com/services/${SLACK_SERVICE}"
           echo "Posted Slack alert."
+
+      - name: Open degraded issue if operational failure is persistent
+        # Inverse of the security allowlist: any failure that is NOT a confirmed
+        # tamper/identity signal is operational. This deliberately also covers an
+        # EMPTY classification, i.e. a step BEFORE the monitor failed (tags fetch,
+        # checkpoint fetch) so the monitor never ran and printed no CLASSIFICATION.
+        # Those GitHub-API/upstream outages are exactly what the degraded path is
+        # for; without this they would keep the job red hourly yet never surface a
+        # calm tracking issue. The two gates stay mutually exclusive and together
+        # partition every failure() case.
+        if: ${{ failure() && steps.monitor.outputs.classification != 'tamper' && steps.monitor.outputs.classification != 'identity' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Persistence via run history: only escalate once this run plus the two
+          # prior scheduled runs all concluded failure. A single blip stays quiet
+          # (job is red, but no issue/Slack) and self-heals next hour. The artifact
+          # API is one of the flaky deps we are hardening, so we intentionally do
+          # NOT use a state-file counter here.
+          # The API returns completed runs most-recent-first (this in-progress run
+          # is excluded), so index("success") is the count of consecutive leading
+          # failures; `// length` handles the all-failures window. This is a true
+          # consecutive streak, not a plain failure count: [fail,success,fail]
+          # yields 1 (stays quiet), not 2.
+          streak="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/rekor-monitor.yaml/runs?event=schedule&status=completed&per_page=3" \
+            | jq -r '[.workflow_runs[].conclusion] | (index("success") // length)')"
+          # This run is not yet "completed" in the API, so 2 consecutive prior
+          # failures + this one = 3 consecutive = persistent.
+          if [ "${streak}" -lt 2 ]; then
+            echo "Operational failure but not yet persistent (prior failures: ${streak}); staying quiet."
+            exit 0
+          fi
+          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+            --search "in:title \"${DEGRADED_TITLE}\"" --json title,url \
+            | jq -r --arg t "${DEGRADED_TITLE}" '[.[] | select(.title == $t)] | .[0].url // empty')"
+          if [ -n "${existing}" ]; then
+            echo "Degraded issue already open: ${existing}"
+            exit 0
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          detail="This is an **operational** problem (Sigstore/Rekor/TUF reachability or the GitHub API), **not** a security finding: no tamper or identity signal was detected."
+          detail="${detail} No maintainer action is required unless it persists; the check will resume automatically when upstream recovers."
+          {
+            echo "The Rekor v2 monitor has been **unable to complete** for 3+ consecutive hourly runs (latest: [run ${GITHUB_RUN_ID}](${run_url}))."
+            echo
+            echo "${detail}"
+            echo
+            echo "This issue auto-closes on the next clean run."
+          } > degraded-body.md
+          gh issue create --repo "${GITHUB_REPOSITORY}" \
+            --title "${DEGRADED_TITLE}" \
+            --label "area/ci" \
+            --body-file degraded-body.md
 
       - name: Close alert issue on success
         if: ${{ success() }}
@@ -248,4 +381,18 @@ jobs:
                 gh issue close "$n" --repo "${GITHUB_REPOSITORY}" \
                   --comment "Rekor v2 monitor completed cleanly on run ${GITHUB_RUN_ID}; auto-closing." \
                   || echo "::warning::failed to close alert issue #${n}"
+              done
+          # Same for the degraded (operational) issue: a clean run means the
+          # monitor completed, so any open degraded tracker is stale.
+          gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+            --search "in:title \"${DEGRADED_TITLE}\"" --json number,title \
+            | jq -r --arg t "${DEGRADED_TITLE}" '.[] | select(.title == $t) | .number' \
+            | while read -r n; do
+                [ -n "$n" ] || continue
+                # Tolerate a per-issue close failure (transient API error, rate
+                # limit, already-closed race): it must not abort the loop or fail
+                # this step and flip a clean monitor run to "failed".
+                gh issue close "$n" --repo "${GITHUB_REPOSITORY}" \
+                  --comment "Rekor v2 monitor completed cleanly on run ${GITHUB_RUN_ID}; auto-closing." \
+                  || echo "::warning::failed to close degraded issue #${n}"
               done

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -57,13 +57,40 @@ transparency log (where AICR release signing writes since
 [#1650](https://github.com/NVIDIA/aicr/issues/1650)). In one job it checks two
 things: that the log stays append-only (consistency), and that no entry appears
 under AICR's release signing identity that a release did not produce (identity).
-On any failure it opens a tracking issue; a later clean run closes it.
+
+The monitor classifies every failure and the workflow branches on it, so infra
+flakiness never pages like a security event. A tamper (consistency break) or
+identity failure opens a security tracking issue that mentions the maintainers
+and posts a Slack page. An operational failure (Sigstore/Rekor/TUF/GitHub-API
+trouble) pages no one: a single red hourly job with no issue is a transient blip
+that self-heals, and only after three consecutive failed runs does a calm
+`area/ci` "degraded" issue open. The job still goes red on any failure, and a
+later clean run closes both the security and degraded issues.
 
 This protects the trust root every AICR consumer depends on: the release
 binaries, the signed recipe catalog, and the container images all chain to that
-one identity. When the workflow files an issue, follow the triage steps in the
-workflow file's header comment; an unrecognized identity hit should be treated
-as potential OIDC/key compromise.
+one identity. When the workflow files a security issue, follow the triage steps
+in the workflow file's header comment; an unrecognized identity hit should be
+treated as potential OIDC/key compromise.
+
+### Known-release correlation (why a release no longer pages)
+
+The identity scan matches every entry under the release SAN, which includes
+every legitimate release: each real release signs an entry under exactly that
+identity, so a naive scan would page on every tag. To separate real releases
+from an attacker, the workflow first fetches the repo's release tags and passes
+them to the tool via `--known-tags-file`. The tool then suppresses any identity
+match whose certificate SAN carries an `@refs/tags/<tag>` that is a known
+release, so only an entry for a tag with **no corresponding release** alerts.
+
+The suppression is fail-closed: an unknown tag or a malformed SAN still alerts,
+an *empty* allowlist file disables suppression (so every match alerts), and a
+*missing* allowlist file is a hard error that fails the run (exit 2, surfaced as
+operational). A broken correlation input can never silently silence a real hit. One residual gap is accepted: an attacker who
+re-signs an *existing* release tag is suppressed, because that tag is on the
+allowlist. Closing it needs a per-tag entry-count or provenance check (how many
+entries a known tag is expected to have), tracked as a follow-up in
+[#1887](https://github.com/NVIDIA/aicr/issues/1887).
 
 ### Why v2, and why identity monitoring is feasible now
 

--- a/tools/rekor-monitor/README.md
+++ b/tools/rekor-monitor/README.md
@@ -1,8 +1,9 @@
 # rekor-monitor: AICR release-signer transparency-log monitor (Rekor v2)
 
 Watches the Rekor **v2** transparency log for AICR's release supply chain. On
-each run it does two checks and exits non-zero if either is unhappy (so the
-calling workflow can alert):
+each run it does two checks and, if either is unhappy, exits non-zero and prints
+a `CLASSIFICATION=` line so the calling workflow can alert and branch on
+severity (see "Exit status and classification" below):
 
 - **Consistency**: proves the log stayed append-only from the last checkpoint
   to the current tree head (an O(log n) tile proof). Its main job here is to
@@ -12,8 +13,12 @@ calling workflow can alert):
   standard append-only tamper check, though ecosystem witnesses are the primary
   guarantee of that.
 - **Identity**: scans the entries added since the last checkpoint for AICR's
-  release signing identity. An entry under that identity that no release
-  produced signals OIDC/key compromise. This is the AICR-specific check.
+  release signing identity. An entry under that identity for a tag with no
+  corresponding release signals OIDC/key compromise. This is the AICR-specific
+  check. Matches whose `@refs/tags/<tag>` is a known release are suppressed as
+  expected signings (see `--known-tags-file`), so a legitimate release does not
+  alert; an unknown tag, a malformed SAN, or a missing allowlist still alert
+  (fail closed).
 
 It is run hourly by `.github/workflows/rekor-monitor.yaml`.
 
@@ -63,7 +68,8 @@ go run ./tools/rekor-monitor \
   --file checkpoint_v2.txt \
   --restore-zip checkpoint.zip \
   --cert-subject '^https://github\.com/NVIDIA/aicr/\.github/workflows/on-tag\.yaml@refs/tags/.*$' \
-  --cert-issuer '^https://token\.actions\.githubusercontent\.com$'
+  --cert-issuer '^https://token\.actions\.githubusercontent\.com$' \
+  --known-tags-file known-tags.txt
 ```
 
 | Flag | Purpose |
@@ -72,7 +78,19 @@ go run ./tools/rekor-monitor \
 | `--restore-zip` | Optional GitHub-artifact zip to seed `--file` from before monitoring. Missing file = first run. |
 | `--cert-subject` | Regex for the monitored certificate SAN. Empty = consistency-only (no identity scan). |
 | `--cert-issuer` | Regex for the monitored certificate issuer (requires `--cert-subject`). |
+| `--known-tags-file` | Optional file of newline-separated known release tags. Identity matches whose `@refs/tags/<tag>` is listed are suppressed as expected releases; empty/omitted disables suppression (all matches alert). |
 | `--user-agent` | User-Agent for requests to the log. |
 
-Exit status: `0` clean; non-zero on a consistency break, a scan error, or an
-identity match.
+## Exit status and classification
+
+The process prints a final `CLASSIFICATION=<value>` line to stdout and exits:
+
+| Exit | Classification | Meaning |
+|------|----------------|---------|
+| `0` | `clean` | Consistency verified and no unexpected identity entry; the cursor advanced. |
+| `1` | `tamper` | The consistency (Merkle) proof failed: the log did not verify as append-only. |
+| `1` | `identity` | An entry under the release identity for a tag with no corresponding release (or an entry that failed verification). |
+| `3` | `operational` | Could not complete the check (Sigstore/Rekor/TUF/network trouble, or a timeout). Operational errors are retried a few times before this is returned. |
+| `2` | (none) | Invalid arguments. |
+
+Only `tamper` and `identity` are security signals; the calling workflow pages maintainers on those and treats `operational` as infrastructure noise.

--- a/tools/rekor-monitor/doc.go
+++ b/tools/rekor-monitor/doc.go
@@ -47,6 +47,11 @@
 //
 // run() (main.go) is the orchestration: restore -> resolve -> read ->
 // consistency -> identity -> persist -> report. It is a single-shot job (run
-// once, exit): exit 0 on a clean run, non-zero on a consistency break, a scan
-// error, or an identity match, so the calling workflow can alert.
+// once, exit). realMain classifies a failure and maps it to an exit code so the
+// workflow can distinguish a security signal from infrastructure noise: 0 clean,
+// 1 security (tamper = a failed consistency proof, or identity = an entry under
+// the release identity for a tag with no corresponding release), 3 operational
+// (transport/timeout/setup, retried a few times first), 2 invalid arguments. It
+// also prints a CLASSIFICATION=<value> line for the workflow to branch on.
+// Identity matches for known release tags are suppressed via --known-tags-file.
 package main

--- a/tools/rekor-monitor/main.go
+++ b/tools/rekor-monitor/main.go
@@ -16,13 +16,17 @@ package main
 
 import (
 	"context"
+	stderrors "errors"
 	"flag"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/transparency-dev/merkle/proof"
 )
 
 // defaultTimeout bounds a single monitor pass (TUF fetch, shard discovery,
@@ -55,6 +59,15 @@ type options struct {
 	// means "first run" (no prior artifact); a present-but-unusable zip is an
 	// error, so we never silently reset the cursor and stop scanning identity.
 	restoreZip string
+	// knownTagsFile, when set, is a file of newline-separated release tags that
+	// legitimately signed under the monitored identity. Identity-scan matches
+	// whose SAN tag is in this set are expected releases and are suppressed;
+	// everything else still alerts. Empty disables suppression (all matches
+	// alert). See #1887.
+	knownTagsFile string
+	// knownTags is the resolved allowlist (loaded from knownTagsFile in realMain,
+	// before the retry loop). Nil/empty disables suppression.
+	knownTags map[string]bool
 }
 
 func parseFlags(args []string) (options, error) {
@@ -66,6 +79,7 @@ func parseFlags(args []string) (options, error) {
 	fs.StringVar(&opts.userAgent, "user-agent", "aicr-rekor-v2-monitor", "User-Agent for requests to the log")
 	fs.DurationVar(&opts.timeout, "timeout", defaultTimeout, "maximum duration for the whole monitor pass")
 	fs.StringVar(&opts.restoreZip, "restore-zip", "", "path to a GitHub-artifact zip to extract the prior checkpoint from before monitoring (missing file = first run)")
+	fs.StringVar(&opts.knownTagsFile, "known-tags-file", "", "path to a newline-separated file of known release tags; identity matches for these tags are suppressed as expected releases (empty disables suppression)")
 	if err := fs.Parse(args); err != nil {
 		return options{}, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse flags", err)
 	}
@@ -78,6 +92,41 @@ func parseFlags(args []string) (options, error) {
 		return options{}, errors.New(errors.ErrCodeInvalidRequest, "--timeout must be positive")
 	}
 	return opts, nil
+}
+
+// maxKnownTagsFileBytes bounds the known-tags file read. Even a decade of
+// releases is a few KiB; this simply prevents a pathological or
+// attacker-influenced path from ballooning memory.
+const maxKnownTagsFileBytes = 1 << 20 // 1 MiB
+
+// loadKnownTags reads a newline-separated file of release tags into a set. An
+// empty path returns an empty (non-nil) set, disabling suppression. Blank lines
+// and surrounding whitespace are ignored. A set path that cannot be read is an
+// error: the workflow always writes the file, so a missing one is a real
+// failure, not a silent "suppress nothing".
+func loadKnownTags(path string) (map[string]bool, error) {
+	known := map[string]bool{}
+	if path == "" {
+		return known, nil
+	}
+	f, err := os.Open(path) //nolint:gosec // path is a workflow-controlled argument
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to open known-tags file", err)
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(io.LimitReader(f, maxKnownTagsFileBytes+1))
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read known-tags file", err)
+	}
+	if int64(len(data)) > maxKnownTagsFileBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "known-tags file exceeds size limit")
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if tag := strings.TrimSpace(line); tag != "" {
+			known[tag] = true
+		}
+	}
+	return known, nil
 }
 
 // run performs one monitor pass: it wires up the checkpoint store and the
@@ -94,7 +143,7 @@ func run(ctx context.Context, opts options, w io.Writer) error {
 	}
 	defer mon.cleanup() // remove the temp Fulcio CA files
 
-	return observe(ctx, mon, store, w)
+	return observe(ctx, mon, store, opts.knownTags, w)
 }
 
 // observe runs one consistency + identity pass and persists the cursor. It takes
@@ -103,7 +152,7 @@ func run(ctx context.Context, opts options, w io.Writer) error {
 // unit-testable without network access. It returns a non-nil error on a
 // consistency break, a scan error, or an identity finding, so the caller exits
 // non-zero and the workflow alerts.
-func observe(ctx context.Context, mon monitorChecks, store checkpointStore, w io.Writer) error {
+func observe(ctx context.Context, mon monitorChecks, store checkpointStore, knownTags map[string]bool, w io.Writer) error {
 	prev, err := store.read()
 	if err != nil {
 		return err
@@ -135,6 +184,7 @@ func observe(ctx context.Context, mon monitorChecks, store checkpointStore, w io
 				// The window is unverified; return before advancing.
 				return scanErr
 			}
+			found = filterKnownReleases(found, knownTags)
 			out.scanned = true
 			out.from, out.to = start+1, end // inclusive range actually covered
 			out.found, out.failed = found, failed
@@ -158,29 +208,113 @@ func observe(ctx context.Context, mon monitorChecks, store checkpointStore, w io
 	return nil
 }
 
+// classification labels a terminal monitor error by whether it is a genuine
+// security signal (tamper or a positive finding) or an operational failure that
+// a retry could clear. The workflow branches its alerting on this.
+type classification string
+
+const (
+	classClean       classification = "clean"
+	classTamper      classification = "tamper"
+	classIdentity    classification = "identity"
+	classOperational classification = "operational"
+)
+
+// classify maps a non-nil terminal error to its classification. Only the two
+// unambiguous compromise signals are security-classified: a consistency break
+// (tamper) and a positive finding via ErrCodeConflict (identity match or an
+// entry that failed verification). Everything else (transport, setup, timeout,
+// and even a malformed-but-not-mismatch consistency proof) is operational, so an
+// infrastructure blip never pages maintainers. A real log rewrite manifests as
+// proof.RootMismatchError, which stays reachable through the wrap chain via
+// Unwrap.
+func classify(err error) classification {
+	var mismatch proof.RootMismatchError
+	if stderrors.As(err, &mismatch) {
+		return classTamper
+	}
+	if stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
+		return classIdentity
+	}
+	return classOperational
+}
+
 // runFunc is the signature of the monitor pass; injectable so realMain's
 // flag/timeout/exit-code handling is testable without the network-backed run.
 type runFunc func(context.Context, options, io.Writer) error
 
 func main() {
-	os.Exit(realMain(os.Args[1:], run))
+	os.Exit(realMain(os.Args[1:], run, os.Stdout))
 }
 
-// realMain parses args, bounds the pass with a timeout, runs it, and returns the
-// process exit code. Keeping os.Exit out of the body lets the deferred cancel()
-// run (os.Exit would skip it); taking runFn makes the wrapper testable.
-func realMain(args []string, runFn runFunc) int {
+// realMain parses args, bounds the pass with a timeout, runs it (retrying
+// operational failures via runWithRetry), and returns the process exit code:
+// 0 clean, 1 security (tamper/identity), 3 operational, 2 bad args. It prints a
+// machine-readable CLASSIFICATION=<value> line to w so the workflow can branch
+// its alerting without re-deriving intent from a stack trace.
+func realMain(args []string, runFn runFunc, w io.Writer) int {
 	opts, err := parseFlags(args)
 	if err != nil {
 		slog.Error("invalid arguments", "error", err)
 		return 2
 	}
+	tags, err := loadKnownTags(opts.knownTagsFile)
+	if err != nil {
+		slog.Error("invalid known-tags file", "error", err)
+		return 2
+	}
+	opts.knownTags = tags
 	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
 	defer cancel()
-	if err := runFn(ctx, opts, os.Stdout); err != nil {
-		slog.Error("rekor v2 monitor detected an issue or failed", "error", err)
-		return 1
+
+	runErr := runWithRetry(ctx, opts, w, runFn)
+	if runErr == nil {
+		fmt.Fprintf(w, "CLASSIFICATION=%s\n", classClean)
+		slog.Info("rekor v2 monitor completed cleanly")
+		return 0
 	}
-	slog.Info("rekor v2 monitor completed cleanly")
-	return 0
+	class := classify(runErr)
+	fmt.Fprintf(w, "CLASSIFICATION=%s\n", class)
+	slog.Error("rekor v2 monitor detected an issue or failed", "classification", class, "error", runErr)
+	if class == classOperational {
+		return 3
+	}
+	return 1
+}
+
+const (
+	// maxPassAttempts bounds how many times a single monitor invocation retries
+	// an operational (transient) failure before giving up. A security
+	// classification is never retried — it is deterministic, and retrying only
+	// delays the maintainer page.
+	maxPassAttempts = 3
+	// retryBackoff is the fixed delay between operational retries. Kept modest
+	// relative to the pass timeout so three attempts cannot approach the
+	// deadline; a stalled network call is bounded by the context, not this sleep.
+	retryBackoff = 100 * time.Millisecond
+)
+
+// runWithRetry runs the monitor pass, retrying only operational failures up to
+// maxPassAttempts. It is safe to re-run a pass because observe() advances the
+// checkpoint cursor solely on a fully clean pass, so a failed attempt leaves no
+// partial state. The last error is returned for the caller to classify.
+func runWithRetry(ctx context.Context, opts options, w io.Writer, runFn runFunc) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxPassAttempts; attempt++ {
+		lastErr = runFn(ctx, opts, w)
+		if lastErr == nil || classify(lastErr) != classOperational {
+			return lastErr
+		}
+		if attempt == maxPassAttempts {
+			break
+		}
+		slog.Warn("operational failure; retrying monitor pass",
+			"attempt", attempt, "maxAttempts", maxPassAttempts, "error", lastErr)
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(errors.ErrCodeTimeout, "monitor retry cancelled", ctx.Err())
+		case <-time.After(retryBackoff):
+		}
+	}
+	return lastErr
 }

--- a/tools/rekor-monitor/main_test.go
+++ b/tools/rekor-monitor/main_test.go
@@ -15,30 +15,181 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	stderrors "errors"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/transparency-dev/merkle/proof"
 )
 
 func TestRealMain(t *testing.T) {
 	ok := func(context.Context, options, io.Writer) error { return nil }
-	fail := func(context.Context, options, io.Writer) error { return stderrors.New("boom") }
+	tamper := func(context.Context, options, io.Writer) error {
+		return errors.Wrap(errors.ErrCodeInternal, "consistency verification failed",
+			fmt.Errorf("consistency check failed: %w", proof.RootMismatchError{}))
+	}
+	identity := func(context.Context, options, io.Writer) error {
+		return errors.New(errors.ErrCodeConflict, "1 match")
+	}
+	operational := func(context.Context, options, io.Writer) error {
+		return errors.New(errors.ErrCodeUnavailable, "shards down")
+	}
 	tests := []struct {
-		name string
-		args []string
-		run  runFunc
-		want int
+		name      string
+		args      []string
+		run       runFunc
+		wantCode  int
+		wantLine  string // substring expected in stdout; "" to skip
+		wantEmpty bool   // assert nothing was written to w (no classification leak)
 	}{
-		{name: "bad args -> 2", args: []string{"--nope"}, run: ok, want: 2},
-		{name: "run error -> 1", args: nil, run: fail, want: 1},
-		{name: "clean -> 0", args: nil, run: ok, want: 0},
+		{"bad args -> 2", []string{"--nope"}, ok, 2, "", true},
+		{"clean -> 0", nil, ok, 0, "CLASSIFICATION=clean", false},
+		{"tamper -> 1", nil, tamper, 1, "CLASSIFICATION=tamper", false},
+		{"identity -> 1", nil, identity, 1, "CLASSIFICATION=identity", false},
+		{"operational -> 3", nil, operational, 3, "CLASSIFICATION=operational", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := realMain(tt.args, tt.run); got != tt.want {
-				t.Errorf("realMain() = %d, want %d", got, tt.want)
+			var buf bytes.Buffer
+			if got := realMain(tt.args, tt.run, &buf); got != tt.wantCode {
+				t.Errorf("realMain() = %d, want %d", got, tt.wantCode)
+			}
+			if tt.wantLine != "" && !strings.Contains(buf.String(), tt.wantLine) {
+				t.Errorf("stdout %q missing %q", buf.String(), tt.wantLine)
+			}
+			if tt.wantEmpty && buf.Len() != 0 {
+				t.Errorf("stdout = %q, want empty (no classification leak)", buf.String())
+			}
+		})
+	}
+}
+
+func TestRealMainBadKnownTagsFile(t *testing.T) {
+	calls := 0
+	fn := func(context.Context, options, io.Writer) error { calls++; return nil }
+	code := realMain([]string{"--known-tags-file", "/nonexistent/does-not-exist"}, fn, io.Discard)
+	if code != 2 {
+		t.Errorf("code = %d, want 2", code)
+	}
+	if calls != 0 {
+		t.Errorf("run func called %d times, want 0 (fail fast before running)", calls)
+	}
+}
+
+func TestRunWithRetry(t *testing.T) {
+	t.Run("retries operational then succeeds", func(t *testing.T) {
+		calls := 0
+		fn := func(context.Context, options, io.Writer) error {
+			calls++
+			if calls < 3 {
+				return errors.New(errors.ErrCodeUnavailable, "blip")
+			}
+			return nil
+		}
+		if err := runWithRetry(context.Background(), options{}, io.Discard, fn); err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("does not retry a security classification", func(t *testing.T) {
+		calls := 0
+		fn := func(context.Context, options, io.Writer) error {
+			calls++
+			return errors.New(errors.ErrCodeConflict, "identity hit")
+		}
+		err := runWithRetry(context.Background(), options{}, io.Discard, fn)
+		if err == nil {
+			t.Fatal("err = nil, want conflict")
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (no retry on security)", calls)
+		}
+	})
+
+	t.Run("gives up after max attempts on persistent operational", func(t *testing.T) {
+		calls := 0
+		fn := func(context.Context, options, io.Writer) error {
+			calls++
+			return errors.New(errors.ErrCodeUnavailable, "down")
+		}
+		if err := runWithRetry(context.Background(), options{}, io.Discard, fn); err == nil {
+			t.Fatal("err = nil, want operational error after retries")
+		}
+		if calls != maxPassAttempts {
+			t.Errorf("calls = %d, want %d", calls, maxPassAttempts)
+		}
+	})
+
+	t.Run("cancelled context returns operational after one attempt", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		fn := func(context.Context, options, io.Writer) error {
+			calls++
+			return errors.New(errors.ErrCodeUnavailable, "blip")
+		}
+		err := runWithRetry(ctx, options{}, io.Discard, fn)
+		if err == nil {
+			t.Fatal("err = nil, want cancellation error")
+		}
+		if classify(err) != classOperational {
+			t.Errorf("classify = %q, want operational", classify(err))
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("does not retry a tamper classification", func(t *testing.T) {
+		calls := 0
+		fn := func(context.Context, options, io.Writer) error {
+			calls++
+			return errors.Wrap(errors.ErrCodeInternal, "consistency verification failed",
+				fmt.Errorf("consistency check failed: %w", proof.RootMismatchError{}))
+		}
+		err := runWithRetry(context.Background(), options{}, io.Discard, fn)
+		if err == nil {
+			t.Fatal("err = nil, want tamper error")
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (no retry on security)", calls)
+		}
+	})
+}
+
+func TestClassify(t *testing.T) {
+	wrappedTamper := errors.Wrap(errors.ErrCodeInternal, "consistency verification failed",
+		fmt.Errorf("consistency check failed: %w", proof.RootMismatchError{
+			ExpectedRoot: []byte{1}, CalculatedRoot: []byte{2},
+		}))
+	tests := []struct {
+		name string
+		err  error
+		want classification
+	}{
+		{"tamper: root mismatch (wrapped)", wrappedTamper, classTamper},
+		{"identity: conflict", errors.New(errors.ErrCodeConflict, "1 match"), classIdentity},
+		{"operational: unavailable", errors.New(errors.ErrCodeUnavailable, "shards"), classOperational},
+		{"operational: timeout", errors.New(errors.ErrCodeTimeout, "stall"), classOperational},
+		{"operational: malformed proof (not mismatch)", errors.Wrap(errors.ErrCodeInternal, "consistency verification failed", fmt.Errorf("building consistency proof: %w", stderrors.New("empty proof"))), classOperational},
+		{"operational: plain error", stderrors.New("boom"), classOperational},
+		{"nil error -> operational", nil, classOperational},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classify(tt.err); got != tt.want {
+				t.Errorf("classify() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -46,13 +197,14 @@ func TestRealMain(t *testing.T) {
 
 func TestParseFlags(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        []string
-		wantErr     bool
-		wantFile    string
-		wantSubject string
-		wantIssuer  string
-		wantTimeout time.Duration
+		name              string
+		args              []string
+		wantErr           bool
+		wantFile          string
+		wantSubject       string
+		wantIssuer        string
+		wantTimeout       time.Duration
+		wantKnownTagsFile string
 	}{
 		{
 			name:        "defaults",
@@ -67,6 +219,13 @@ func TestParseFlags(t *testing.T) {
 			wantSubject: "^sub$",
 			wantIssuer:  "^iss$",
 			wantTimeout: 30 * time.Second,
+		},
+		{
+			name:              "known tags file",
+			args:              []string{"--known-tags-file", "tags.txt"},
+			wantFile:          "checkpoint_v2.txt",
+			wantTimeout:       defaultTimeout,
+			wantKnownTagsFile: "tags.txt",
 		},
 		{
 			name:    "issuer without subject rejected",
@@ -104,6 +263,63 @@ func TestParseFlags(t *testing.T) {
 			}
 			if opts.timeout != tt.wantTimeout {
 				t.Errorf("timeout = %v, want %v", opts.timeout, tt.wantTimeout)
+			}
+			if opts.knownTagsFile != tt.wantKnownTagsFile {
+				t.Errorf("knownTagsFile = %q, want %q", opts.knownTagsFile, tt.wantKnownTagsFile)
+			}
+		})
+	}
+}
+
+func TestLoadKnownTags(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "tags.txt")
+	if err := os.WriteFile(good, []byte("v0.18.0-rc1\nv0.17.0\n\n  v0.16.0  \n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	crlf := filepath.Join(dir, "crlf.txt")
+	if err := os.WriteFile(crlf, []byte("v1.0.0\r\nv1.0.0\r\nv2.0.0\r\n"), 0o600); err != nil {
+		t.Fatalf("seed crlf: %v", err)
+	}
+	oversize := filepath.Join(dir, "oversize.txt")
+	if err := os.WriteFile(oversize, bytes.Repeat([]byte("a\n"), maxKnownTagsFileBytes), 0o600); err != nil {
+		t.Fatalf("seed oversize: %v", err)
+	}
+	tests := []struct {
+		name     string
+		path     string
+		want     map[string]bool
+		wantErr  bool
+		wantCode error // when wantErr, the error must match this code via errors.Is
+	}{
+		{name: "empty path -> empty set", path: "", want: map[string]bool{}},
+		{name: "reads + trims + skips blanks", path: good, want: map[string]bool{"v0.18.0-rc1": true, "v0.17.0": true, "v0.16.0": true}},
+		{name: "crlf + duplicate tags", path: crlf, want: map[string]bool{"v1.0.0": true, "v2.0.0": true}},
+		{name: "missing file when path set -> error", path: filepath.Join(dir, "nope.txt"), wantErr: true, wantCode: errors.New(errors.ErrCodeInvalidRequest, "")},
+		{name: "oversize file -> error", path: oversize, wantErr: true, wantCode: errors.New(errors.ErrCodeInvalidRequest, "")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadKnownTags(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if tt.wantCode != nil && !stderrors.Is(err, tt.wantCode) {
+					t.Errorf("code = %v, want %v", err, tt.wantCode)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("want non-nil set")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d tags, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for k := range tt.want {
+				if !got[k] {
+					t.Errorf("missing tag %q", k)
+				}
 			}
 		})
 	}

--- a/tools/rekor-monitor/monitor.go
+++ b/tools/rekor-monitor/monitor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 	rekorv2 "github.com/sigstore/rekor-monitor/pkg/rekor/v2"
@@ -153,6 +154,53 @@ func buildMonitoredValues(certSubject, certIssuer string) (identity.MonitoredVal
 		return identity.MonitoredValues{}, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid monitored identity", err)
 	}
 	return identity.MonitoredValues{certID}, nil
+}
+
+// tagRefMarker separates the workflow-identity prefix of a release-signer SAN
+// from the git tag it signed, e.g.
+// ".../on-tag.yaml@refs/tags/v0.18.0-rc1" -> "v0.18.0-rc1".
+const tagRefMarker = "@refs/tags/"
+
+// extractTag returns the tag ref embedded in a release-signer certificate SAN.
+// ok is false when the SAN has no @refs/tags/ segment OR the tag is empty — both
+// unexpected shapes the caller must NOT suppress.
+func extractTag(certSubject string) (tag string, ok bool) {
+	i := strings.Index(certSubject, tagRefMarker)
+	if i < 0 {
+		return "", false
+	}
+	tag = certSubject[i+len(tagRefMarker):]
+	if tag == "" {
+		return "", false // empty tag ref is an unexpected shape; do not suppress
+	}
+	return tag, true
+}
+
+// filterKnownReleases drops identity-scan matches that correspond to a known
+// release tag, returning only the unexpected residual matches that warrant an
+// alert. An entry whose tag is not in known — or whose SAN has no @refs/tags/
+// segment — is kept (fail closed). A MonitoredIdentity left with no entries is
+// omitted. An empty known set is a pass-through (suppression disabled), so a
+// missing allowlist can never silently hide a real finding. See #1887.
+func filterKnownReleases(found []identity.MonitoredIdentity, known map[string]bool) []identity.MonitoredIdentity {
+	if len(known) == 0 {
+		return found
+	}
+	var residual []identity.MonitoredIdentity
+	for _, mi := range found {
+		var kept []identity.LogEntry
+		for _, e := range mi.FoundIdentityEntries {
+			if tag, ok := extractTag(e.CertSubject); ok && known[tag] {
+				continue // expected release signature
+			}
+			kept = append(kept, e)
+		}
+		if len(kept) > 0 {
+			mi.FoundIdentityEntries = kept
+			residual = append(residual, mi)
+		}
+	}
+	return residual
 }
 
 // scanWindow computes the [start, end] entry-index window to scan between the

--- a/tools/rekor-monitor/monitor_test.go
+++ b/tools/rekor-monitor/monitor_test.go
@@ -117,6 +117,60 @@ func TestScanWindow(t *testing.T) {
 	}
 }
 
+func TestFilterKnownReleases(t *testing.T) {
+	san := func(tag string) string {
+		return "https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/" + tag
+	}
+	mk := func(subjects ...string) []identity.MonitoredIdentity {
+		entries := make([]identity.LogEntry, 0, len(subjects))
+		for _, s := range subjects {
+			entries = append(entries, identity.LogEntry{CertSubject: s})
+		}
+		return []identity.MonitoredIdentity{{FoundIdentityEntries: entries}}
+	}
+	known := map[string]bool{"v0.18.0-rc1": true}
+
+	t.Run("known release suppressed -> no residual", func(t *testing.T) {
+		got := filterKnownReleases(mk(san("v0.18.0-rc1"), san("v0.18.0-rc1")), known)
+		if len(got) != 0 {
+			t.Errorf("residual = %v, want empty", got)
+		}
+	})
+	t.Run("unknown tag kept", func(t *testing.T) {
+		got := filterKnownReleases(mk(san("v9.9.9-attacker")), known)
+		if len(got) != 1 || len(got[0].FoundIdentityEntries) != 1 {
+			t.Errorf("residual = %v, want 1 entry", got)
+		}
+	})
+	t.Run("malformed SAN kept (fail closed)", func(t *testing.T) {
+		got := filterKnownReleases(mk("no-tag-ref-here"), known)
+		if len(got) != 1 {
+			t.Errorf("residual = %v, want kept", got)
+		}
+	})
+	t.Run("mixed: only unknown survives", func(t *testing.T) {
+		got := filterKnownReleases(mk(san("v0.18.0-rc1"), san("v9.9.9-attacker")), known)
+		ok := len(got) == 1 && len(got[0].FoundIdentityEntries) == 1 &&
+			got[0].FoundIdentityEntries[0].CertSubject == san("v9.9.9-attacker")
+		if !ok {
+			t.Errorf("residual = %v, want only the attacker entry", got)
+		}
+	})
+	t.Run("empty tag ref kept (fail closed)", func(t *testing.T) {
+		got := filterKnownReleases(mk(san("")), map[string]bool{"": true, "v0.18.0-rc1": true})
+		if len(got) != 1 {
+			t.Errorf("residual = %v, want kept (empty tag must not be suppressed even if \"\" is in the set)", got)
+		}
+	})
+	t.Run("empty known set -> passthrough", func(t *testing.T) {
+		in := mk(san("v0.18.0-rc1"))
+		got := filterKnownReleases(in, map[string]bool{})
+		if len(got) != 1 {
+			t.Errorf("residual = %v, want passthrough", got)
+		}
+	})
+}
+
 func TestOutcomeHasFindings(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/tools/rekor-monitor/observe_test.go
+++ b/tools/rekor-monitor/observe_test.go
@@ -39,7 +39,7 @@ func TestObserveShardRotation(t *testing.T) {
 	f := &fakeMonitor{watch: true, cur: &tlog.Checkpoint{Origin: "log2026-1", Size: 5, Hash: make([]byte, 32)}}
 
 	var buf bytes.Buffer
-	if err := observe(context.Background(), f, store, &buf); err != nil {
+	if err := observe(context.Background(), f, store, nil, &buf); err != nil {
 		t.Fatalf("observe() error = %v", err)
 	}
 	if f.scanned {
@@ -115,6 +115,7 @@ func TestObserve(t *testing.T) {
 		name      string
 		seedPrev  uint64 // 0 => first run (no prior checkpoint)
 		fake      fakeMonitor
+		knownTags map[string]bool // nil => suppression disabled (passthrough)
 		wantErr   bool
 		wantScan  bool   // whether scanIdentity should have run
 		wantAdvTo uint64 // checkpoint size expected on disk after the pass (0 => unchanged/absent)
@@ -149,6 +150,26 @@ func TestObserve(t *testing.T) {
 			wantAdvTo: 100, // must not advance past a finding (sticky until triaged)
 		},
 		{
+			name:     "known release match suppressed -> clean pass advances",
+			seedPrev: 100,
+			fake: fakeMonitor{watch: true, cur: testCheckpoint(150), found: []identity.MonitoredIdentity{
+				{FoundIdentityEntries: []identity.LogEntry{{CertSubject: "https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/v0.18.0-rc1"}}}}},
+			knownTags: map[string]bool{"v0.18.0-rc1": true},
+			wantErr:   false,
+			wantScan:  true,
+			wantAdvTo: 150,
+		},
+		{
+			name:     "unknown tag match -> finding does not advance",
+			seedPrev: 100,
+			fake: fakeMonitor{watch: true, cur: testCheckpoint(150), found: []identity.MonitoredIdentity{
+				{FoundIdentityEntries: []identity.LogEntry{{CertSubject: "https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/v9.9.9-attacker"}}}}},
+			knownTags: map[string]bool{"v0.18.0-rc1": true},
+			wantErr:   true,
+			wantScan:  true,
+			wantAdvTo: 100,
+		},
+		{
 			name:      "consistency break does not advance",
 			seedPrev:  100,
 			fake:      fakeMonitor{watch: true, consErr: boom},
@@ -173,7 +194,7 @@ func TestObserve(t *testing.T) {
 			}
 			f := tt.fake // copy so scanned is per-subtest
 
-			err := observe(context.Background(), &f, store, os.Stdout)
+			err := observe(context.Background(), &f, store, tt.knownTags, os.Stdout)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("observe() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
## Summary

Split the hourly Rekor v2 monitor's single "any failure pages maintainers" path into a classified one: only a genuine tamper or an unexplained identity hit pages, while infrastructure flakiness stays quiet. Also stop legitimate releases from tripping (and wedging) the identity alarm by correlating matches against known release tags.

## Motivation / Context

The monitor opened a scary "potential OIDC/key compromise" issue and posted a Slack alert on *any* failure, so transient Sigstore/TUF/GitHub-API outages paged maintainers with incident-response language (#1813). Separately, a legitimate release (`v0.18.0-rc1`) matched the release-signer identity scan and, because findings never advance the checkpoint, wedged the monitor into re-detecting it every hour and paging Slack indefinitely (#1887).

Fixes: #1887
Related: #1813

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/rekor-monitor` (transparency-log monitor) + `.github/workflows/rekor-monitor.yaml`

## Implementation Notes

- The tool classifies its terminal error as **tamper** (`proof.RootMismatchError`, reachable through the wrap chain), **identity** (`ErrCodeConflict` from a finding), or **operational** (everything else). It exits `0/1/2/3` and prints a machine-readable `CLASSIFICATION=` line; operational failures are retried in-pass; a security classification is never retried.
- The workflow branches on that line: tamper/identity → security issue (specific body) + Slack page + maintainer mention; operational (or an empty classification from a pre-monitor failure) → a calm `area/ci` "degraded" issue **only after 3 consecutive** failed runs; a clean run closes both. The job still goes red on every failure.
- **#1887 correlation:** the workflow fetches the repo's release tags and passes them via `--known-tags-file`; the tool suppresses identity matches whose `@refs/tags/<tag>` is a known release. Fail-closed: an unknown tag, a malformed SAN, or an empty allowlist still alerts, and a missing allowlist file is a hard error.
- **Deliberate tradeoff:** a malformed-but-not-`RootMismatchError` consistency proof is classified operational (only a true root mismatch is tamper). A persistent malformed-proof condition therefore surfaces as the calm degraded issue, not a page.
- GitHub-API fetches use a temp-file retry helper that recovers 5xx/429 (not just connection errors) and round-trips the binary artifact zip.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race ./tools/rekor-monitor/...   # ok, coverage 81.7%
golangci-lint run -c .golangci.yaml ./...                      # 0 issues
yamllint .github/workflows/rekor-monitor.yaml                  # 0 issues
```

New/changed functions are covered ~100% (`classify`, `runWithRetry`, `extractTag`, `filterKnownReleases`, `realMain`; `loadKnownTags` 94%, `observe` 91%). Full `make qualify` (e2e + grype scan) was not run locally; relying on CI for those stages.

## Risk Assessment

- [x] **Medium** — Changes alerting behavior on the supply-chain security path (it now pages *less*), though the code is isolated to one tool + one workflow, well-tested, and easy to revert.

**Rollout notes:** No migration. On merge, the next scheduled run fetches known tags, suppresses the `v0.18.0-rc1` match, records a clean pass, advances the checkpoint, and auto-closes the currently-wedged alert issue. Backwards compatible: `--known-tags-file` is optional (omitted = prior behavior).

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
