### PR TITLE
fix(rekor-monitor): raise scan-window timeout for large backlogs

### DIFF
--- a/.github/scripts/gh-api-retry.sh
+++ b/.github/scripts/gh-api-retry.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fetch a GitHub API resource with bounded retry, publishing the response to
+# OUTFILE only on success. Recovers HTTP 5xx/429 and connection failures alike,
+# and round-trips a binary payload (e.g. an artifact zip) intact: each attempt
+# writes to OUTFILE.part and is renamed into place only when gh exits 0, so a
+# failed attempt's HTTP-error body never leaks downstream. On any non-success
+# exit an EXIT trap removes both OUTFILE and OUTFILE.part, so a failed run never
+# leaves a partial or stale OUTFILE for a later step to consume (the caller's
+# `set -e` then aborts the step, which the workflow treats as an operational
+# failure, never a security signal).
+#
+# Usage: gh-api-retry.sh OUTFILE gh-api-args...
+# Requires: gh, authenticated via GH_TOKEN in the environment.
+set -euo pipefail
+
+# Per-attempt wall-clock bound so a stalled `gh api` call fails fast and lets the
+# loop retry (and ultimately emit the fallback error), rather than hanging until
+# the job-level timeout. Comfortably above a normal paginated read yet well below
+# the workflow's job budget.
+attempt_timeout=180
+
+out="$1"
+shift
+
+# Enforce the "no OUTFILE on failure" contract even if `set -e` aborts mid-way
+# (e.g. a failing mv): drop both the temp and the target unless we publish.
+trap 'rm -f -- "${out}.part" "${out}"' EXIT
+
+for attempt in 1 2 3; do
+  if timeout "${attempt_timeout}" gh api "$@" > "${out}.part"; then
+    mv -- "${out}.part" "${out}"
+    trap - EXIT
+    exit 0
+  fi
+  echo "::warning::gh api failed (attempt ${attempt}/3): $*"
+  sleep $(( attempt * 3 ))
+done
+
+echo "::error::gh api failed after 3 attempts: $*"
+exit 1

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -112,9 +112,17 @@ jobs:
   monitor:
     name: AICR release identity + log consistency (Rekor v2)
     runs-on: ubuntu-latest
-    # Backstop the per-pass context timeout in the tool: the job is killed if a
-    # network stall somehow outlives it.
-    timeout-minutes: 20
+    # Backstop the per-pass context timeout in the tool (defaultTimeout, 45m):
+    # the job is killed if a network stall somehow outlives it. Sized so the
+    # tool's own 45m deadline (which classifies as operational) fires first, and
+    # so the post-monitor notification steps still have room, rather than a hard
+    # job kill. Paranoid worst case: three gh-api-retry fetches each exhausting
+    # 3 x 180s attempts (~27m), the 45m monitor pass, checkout/setup-go (~3m), and
+    # the post-monitor issue/Slack/degraded steps (~a few min of gh/curl). Note
+    # the fetch-outage (~27m) and backlog-scan (45m) worst cases do not actually
+    # stack (an outage that slows fetches also makes the monitor fail fast), so
+    # 90m leaves generous headroom for the realistic large-backlog case.
+    timeout-minutes: 90
     permissions:
       contents: read  # checkout to build tools/rekor-monitor
       actions: read   # read the prior checkpoint artifact via the Actions API
@@ -149,26 +157,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Writes each attempt to OUTFILE.part and publishes it only on success,
-          # so a failed attempt's HTTP-error body never leaks downstream and a
-          # binary payload (the artifact zip) round-trips intact. Recovers 5xx/429
-          # and connection failures alike.
-          gh_api_retry() {  # usage: gh_api_retry OUTFILE api-args...
-            local out="$1"; shift
-            local attempt
-            for attempt in 1 2 3; do
-              if gh api "$@" > "${out}.part"; then
-                mv "${out}.part" "${out}"
-                return 0
-              fi
-              echo "::warning::gh api failed (attempt ${attempt}/3): $*"
-              sleep $(( attempt * 3 ))
-            done
-            rm -f "${out}.part"
-            echo "::error::gh api failed after 3 attempts: $*"
-            return 1
-          }
-          gh_api_retry artifacts.json --paginate \
+          # .github/scripts/gh-api-retry.sh writes each attempt to OUTFILE.part and
+          # publishes it only on success (recovers 5xx/429, round-trips the binary
+          # zip, never leaks a failed attempt's error body). A total failure aborts
+          # the step (operational, never a security signal).
+          .github/scripts/gh-api-retry.sh artifacts.json --paginate \
             "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100"
           id="$(jq -rs '[.[].artifacts[]
                 | select(.expired == false)
@@ -179,7 +172,7 @@ jobs:
             echo "No prior checkpoint artifact from this repository on main; treating this as the first run."
             exit 0
           fi
-          gh_api_retry checkpoint.zip "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip"
+          .github/scripts/gh-api-retry.sh checkpoint.zip "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip"
           echo "Fetched checkpoint artifact ${id}."
 
       - name: Fetch known release tags
@@ -187,25 +180,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh_api_retry() {  # usage: gh_api_retry OUTFILE api-args...
-            local out="$1"; shift
-            local attempt
-            for attempt in 1 2 3; do
-              if gh api "$@" > "${out}.part"; then
-                mv "${out}.part" "${out}"
-                return 0
-              fi
-              echo "::warning::gh api failed (attempt ${attempt}/3): $*"
-              sleep $(( attempt * 3 ))
-            done
-            rm -f "${out}.part"
-            echo "::error::gh api failed after 3 attempts: $*"
-            return 1
-          }
           # All tags in this repo. The identity SAN references @refs/tags/<tag>,
           # so a tag's existence is the correlation key for "a release produced
-          # this entry". One tag per line.
-          gh_api_retry tags.json --paginate "repos/${GITHUB_REPOSITORY}/tags?per_page=100"
+          # this entry". One tag per line. Retry via the shared helper (see the
+          # checkpoint-fetch step and .github/scripts/gh-api-retry.sh).
+          .github/scripts/gh-api-retry.sh tags.json --paginate "repos/${GITHUB_REPOSITORY}/tags?per_page=100"
           jq -rs '[.[][].name] | .[]' tags.json > known-tags.txt
           echo "Fetched $(wc -l < known-tags.txt) known release tags."
 

--- a/tools/rekor-monitor/README.md
+++ b/tools/rekor-monitor/README.md
@@ -78,12 +78,15 @@ go run ./tools/rekor-monitor \
 | `--restore-zip` | Optional GitHub-artifact zip to seed `--file` from before monitoring. Missing file = first run. |
 | `--cert-subject` | Regex for the monitored certificate SAN. Empty = consistency-only (no identity scan). |
 | `--cert-issuer` | Regex for the monitored certificate issuer (requires `--cert-subject`). |
-| `--known-tags-file` | Optional file of newline-separated known release tags. Identity matches whose `@refs/tags/<tag>` is listed are suppressed as expected releases; empty/omitted disables suppression (all matches alert). |
+| `--known-tags-file` | Optional file of newline-separated known release tags. Identity matches whose `@refs/tags/<tag>` is listed are suppressed as expected releases. Omitting the flag or pointing it at an existing empty file disables suppression (all matches alert); a set-but-missing or unreadable file is a hard error (exit `2`), so a broken correlation input fails the run rather than silently alerting on everything. |
 | `--user-agent` | User-Agent for requests to the log. |
 
 ## Exit status and classification
 
-The process prints a final `CLASSIFICATION=<value>` line to stdout and exits:
+On a completed run the process prints a final `CLASSIFICATION=<value>` line to
+stdout and exits with the matching code below. A pre-run input error is the
+exception: invalid arguments or an unreadable `--known-tags-file` exit `2`
+before the run starts and print no classification line.
 
 | Exit | Classification | Meaning |
 |------|----------------|---------|
@@ -91,6 +94,6 @@ The process prints a final `CLASSIFICATION=<value>` line to stdout and exits:
 | `1` | `tamper` | The consistency (Merkle) proof failed: the log did not verify as append-only. |
 | `1` | `identity` | An entry under the release identity for a tag with no corresponding release (or an entry that failed verification). |
 | `3` | `operational` | Could not complete the check (Sigstore/Rekor/TUF/network trouble, or a timeout). Operational errors are retried a few times before this is returned. |
-| `2` | (none) | Invalid arguments. |
+| `2` | (none) | A pre-run input error: invalid arguments, or a set-but-unreadable `--known-tags-file`. |
 
 Only `tamper` and `identity` are security signals; the calling workflow pages maintainers on those and treats `operational` as infrastructure noise.

--- a/tools/rekor-monitor/doc.go
+++ b/tools/rekor-monitor/doc.go
@@ -51,7 +51,10 @@
 // workflow can distinguish a security signal from infrastructure noise: 0 clean,
 // 1 security (tamper = a failed consistency proof, or identity = an entry under
 // the release identity for a tag with no corresponding release), 3 operational
-// (transport/timeout/setup, retried a few times first), 2 invalid arguments. It
-// also prints a CLASSIFICATION=<value> line for the workflow to branch on.
-// Identity matches for known release tags are suppressed via --known-tags-file.
+// (transport/timeout/setup, retried a few times first), 2 a pre-run input error
+// (invalid arguments or an unreadable --known-tags-file). On a completed run
+// (exit 0/1/3) it prints a CLASSIFICATION=<value> line for the workflow to
+// branch on; a pre-run input error (exit 2) returns before the run and prints
+// none. Identity matches for known release tags are suppressed via
+// --known-tags-file.
 package main

--- a/tools/rekor-monitor/main.go
+++ b/tools/rekor-monitor/main.go
@@ -30,11 +30,17 @@ import (
 )
 
 // defaultTimeout bounds a single monitor pass (TUF fetch, shard discovery,
-// consistency proof, and identity scan). It is generous relative to the observed
-// few-seconds runtime so a real scan never trips it, while still capping a
-// stalled network request rather than hanging the CI job. Kept local so this
+// consistency proof, and identity scan). The steady-state hourly window scans in
+// minutes, but the identity scan is linear in the window size, and the window
+// can balloon when the checkpoint has not advanced for a while: a multi-hour
+// Sigstore/TUF outage, or a finding that a maintainer has not yet triaged (the
+// cursor deliberately holds until then). A window of several hundred thousand
+// entries is realistic in those cases, so this is sized to scan that backlog in
+// one pass rather than timing out every run and never catching up. It still caps
+// a genuinely stalled request rather than hanging the CI job (the workflow's
+// job-level timeout-minutes is the outer backstop). Kept local so this
 // standalone tool does not import the shared pkg/defaults for one constant.
-const defaultTimeout = 15 * time.Minute
+const defaultTimeout = 45 * time.Minute
 
 // options are the tool's inputs. The monitored identity is passed by the caller
 // (the workflow) rather than hardcoded so the workflow stays the auditable


### PR DESCRIPTION
## Summary

Raise the Rekor monitor's per-pass scan timeout so a large backlog window (from a wedged checkpoint or a multi-hour upstream outage) can be scanned in a single pass and let the cursor advance, and fold in the three post-merge CodeRabbit nits from #1897.

## Motivation / Context

The first scheduled run after #1897 merged hit the 15-minute per-pass timeout during the identity scan: the checkpoint had been wedged since ~14:30, so the scan window had grown to ~380k entries. The tool classified the timeout as **operational** (correct: no security page, just a calm degraded issue), but a window that large cannot finish inside 15m, so the cursor never advances and the monitor cannot catch up. This raises the timeout so one pass clears the backlog; afterward the hourly windows are minutes again.

Follow-up to #1897.
Related: #1898, #1899

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/rekor-monitor` + `.github/workflows/rekor-monitor.yaml` + `.github/scripts/`

## Implementation Notes

- Tool `defaultTimeout` 15m -> 45m; workflow `timeout-minutes` 20 -> 50 (the job backstop must exceed the tool's per-pass deadline so the tool's own deadline, which classifies as operational, fires first rather than a hard job kill). Sized for a several-hundred-thousand-entry backlog with headroom, since the window keeps growing (~70k/hour) while wedged; also a durable resilience buffer.
- **CodeRabbit nit (dedup):** extracted the duplicated `gh_api_retry` helper into `.github/scripts/gh-api-retry.sh` (repo's existing `.github/scripts/*.sh` convention), invoked by both fetch steps so the two copies cannot drift.
- **CodeRabbit nit (docs, security precision):** README now distinguishes a set-but-missing `--known-tags-file` (hard error, exit 2) from an empty file (disables suppression), matching `maintaining.md`.
- **CodeRabbit nit (docs):** README + `doc.go` clarify the `CLASSIFICATION=` line prints for a completed run (exit 0/1/3), not the exit-2 argument-error path.
- No change to the classification logic, the security/operational gating, or the known-tags correlation.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race ./tools/rekor-monitor/...   # ok
golangci-lint run -c .golangci.yaml ./tools/rekor-monitor/...   # 0 issues
shellcheck .github/scripts/gh-api-retry.sh                      # clean
yamllint .github/workflows/rekor-monitor.yaml                   # 0 issues
actionlint .github/workflows/rekor-monitor.yaml                 # clean
```

`TestParseFlags` references the `defaultTimeout` constant (not a literal), so the bump needs no test change. Full `make qualify` (e2e + scan) relies on CI.

## Risk Assessment

- [x] **Low** — A timeout increase plus a helper extraction and doc precision; no change to the security/operational classification or correlation logic. Easy to revert.

**Rollout notes:** On merge, the next scheduled (or a dispatched) run scans the full backlog within 45m, advances the checkpoint, and the workflow's clean-run close step auto-closes #1898 and #1899. Future windows are small again. If the backlog has grown past what 45m allows, the fallback is a one-time checkpoint re-baseline.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
