### PR TITLE
revert(validators): pin aiperf-bench base back to python:3.13-slim

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -318,6 +318,19 @@
         executionMode: "update",
       },
     },
+
+    // ---- aiperf-bench base image is capped below python 3.14 ----
+    // aiperf's transitive deps (pyzmq, uvloop) publish no cp314 wheels yet, so
+    // on 3.14 pip falls back to a source build that needs a C toolchain the
+    // -slim image deliberately omits — breaking the performance validator image
+    // build. PR #1906 bumped this to 3.14 and broke the UAT image build; this
+    // cap stops the re-bump. Raise/drop it once upstream ships cp314 wheels.
+    {
+      matchManagers: ["dockerfile"],
+      matchFileNames: ["validators/performance/aiperf-bench.Dockerfile"],
+      matchDepNames: ["python"],
+      allowedVersions: "<3.14",
+    },
   ],
 
   // Vendor-curated GPU networking images that Renovate cannot crawl without

--- a/validators/performance/aiperf-bench.Dockerfile
+++ b/validators/performance/aiperf-bench.Dockerfile
@@ -20,7 +20,11 @@
 # to roll forward. Consumers pin to a specific aiperf-bench:<semver> tag or
 # let :latest track the CLI version via catalog.Load rewriting.
 
-FROM python:3.14-slim
+# renovate: pinned to 3.13 — do NOT bump to 3.14 until aiperf's pyzmq/uvloop
+# ship cp314 wheels. On 3.14 pip has no prebuilt wheels for them and falls back
+# to a source build, which needs a C toolchain this -slim image deliberately
+# omits, so the build fails.
+FROM python:3.13-slim
 
 ARG AIPERF_VERSION=0.7.0
 


### PR DESCRIPTION
## Summary

Re-pin the `aiperf-bench` validator base image from `python:3.14-slim` back to `python:3.13-slim`, and cap the Renovate `python` tag below 3.14 for this Dockerfile so the bump is not re-proposed.

## Motivation / Context

#1906 bumped the base image to `python:3.14-slim`, which broke the **Build and push validator images** step in the nightly UAT run (image build fails before any cluster work). `aiperf==0.7.0`'s transitive deps `pyzmq~=26.4.0` and `uvloop~=0.21.0` publish no `cp314` wheels yet, so on 3.14 pip falls back to a source build that needs a C toolchain the `-slim` image deliberately omits:

```
Building wheel for pyzmq  -> CMake Error: Could not find the compiler specified in CC: gcc
Building wheel for uvloop -> configure: error: no acceptable C compiler found in $PATH
Failed to build pyzmq uvloop
```

`python:3.13-slim` has prebuilt `cp313` wheels for both, so no compiler is needed.

Fixes: N/A
Related: #1906

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Other: `validators/performance/aiperf-bench.Dockerfile`, Renovate config

## Implementation Notes

- Added an in-file comment on the `FROM` line explaining why 3.14 is held back, so the constraint is discoverable at the point of change.
- Added a Renovate `packageRule` (`allowedVersions: "<3.14"`) scoped to this Dockerfile's `python` dep. Patch bumps within 3.13 still flow; 3.14+ is blocked until upstream ships `cp314` wheels. Drop the rule (and the comment) then.

## Testing

Change is a base-image pin + Renovate rule; no Go code affected. The `-slim` + `cp313`-wheel path was the working configuration prior to #1906.

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert; restores the previously-working base image.

**Rollout notes:** N/A — takes effect on the next validator image build.

## Checklist

- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
