### PR TITLE
feat(skills): download UAT debug bundles for failure triage

### DIFF
--- a/.agents/skills/aicr-uat-report/SKILL.md
+++ b/.agents/skills/aicr-uat-report/SKILL.md
@@ -4,11 +4,12 @@ description: |
   Use when reporting on UAT health across services and GPU targets — which
   service (EKS/GKE/AKS) x GPU (H100/GB200) x intent combinations are passing
   or failing in the UAT Run workflow (uat-run.yaml). Triggers on "UAT report",
-  "/aicr-uat-report", "which UAT combos are failing", "UAT pass rate", or
+  "/aicr-uat-report", "which UAT combos are failing", "UAT pass rate",
+  "download the UAT debug bundle", "why did the UAT run fail", or
   RC/release-candidate validation prep that needs the combinations to test
-  manually. Runs the bundled uat_report.py (read-only gh calls), classifies
-  failures as product vs infra signal, and prints a summary table plus an
-  RC validation priority list.
+  manually. Runs the bundled uat_report.py, classifies failures as product
+  vs infra signal, prints a summary table plus an RC validation priority
+  list, and can download the per-run cluster debug bundles for triage.
 ---
 
 # AICR UAT Report
@@ -25,9 +26,9 @@ the ones to test more closely during RC validation.
 - User asks for a UAT report, UAT pass rates, or failing UAT combinations
 - User invokes `/aicr-uat-report` (optionally with a number of days)
 - Release prep needs the list of service/GPU combos to validate manually
+- User asks why a UAT run failed, or for the debug bundle behind a failure
 
-Do NOT use this skill to re-run, dispatch, or debug individual UAT runs —
-it only reads run history and reports.
+Do NOT use this skill to re-run, dispatch, or cancel UAT runs.
 
 ## Inputs
 
@@ -37,6 +38,9 @@ it only reads run history and reports.
 - Only runs against `main` (empty `aicr_version` input) are reported by
   default; that is the release-process signal. Add `--all-versions` only
   if the user explicitly asks to compare against release-tag runs.
+- **debug bundles** (optional): pass `--download-debug <dir>` when the user
+  asks why something failed, or when Step 2 classifies a failure as product
+  signal. Skip it for a plain pass-rate report — bundles are tens of MB.
 
 ## How the Data Works
 
@@ -49,6 +53,35 @@ kind=Kind (self-hosted nvkind lane). Runs before 2026-07-21 used a title
 without the intent word; the script derives intent from the nightly
 dispatch-key cell index (version-outer/intent-inner, training first) and
 marks those rows "(intent derived)".
+
+### Debug bundles
+
+Each per-cloud workflow (`uat-aws.yaml`, `uat-gcp.yaml`, `uat-azure.yaml`,
+`uat-kind.yaml`) runs `tests/uat/<cloud>/run debug` on failure — before
+teardown, while the cluster is still up — and uploads
+`uat-<cloud>[-<intent>]-debug-<run_id>` with **30-day retention**. Reusable
+workflows inherit the caller's `run_id`, so the artifact hangs off the
+`uat-run.yaml` run the report already lists.
+
+The upload is gated on `failure() && steps.prep.outcome != 'skipped'`, so
+**no bundle exists** when the cloud job died in bring-up or image build, or
+when the failure was in a downstream job (evidence ingest) while the cluster
+job passed. Absence is itself a classification signal, not an error.
+
+What to open, in triage order (`if-no-files-found: ignore`, so any entry can
+be missing; `cluster-debug/` prefix omitted below):
+
+| Open | When / what it answers |
+|---|---|
+| `MANIFEST.yaml` | Always first — runId, config, resolved recipe + criteria, and `failingChecks` lifted from `report.json` |
+| `report.json` | Full validator results; absent if the run died before validate |
+| `train-logs/**`, `serve-logs/**` | A CUJ check failed (NCCL, inference-perf) |
+| `cr-skyhooks.yaml`, `node-reboot-fingerprint.txt`, `readiness-gate.log` | Readiness-gate or tuning-race failure — Skyhook `status.status`, taints, bootID/kernel |
+| `pods-notready.txt`, `events.txt` | Scheduling, eviction, OOM |
+| `logs-<namespace>.txt` | The operator owning the failing resource |
+| `nodes*`, other `cr-*.yaml`, `ns-*.txt` | Broader node and operator state |
+| `snapshot.yaml`, `recipe.yaml`, `dry-run.json` | What was collected / resolved / deployed |
+| `evidence-result.json`, `evidence/pointer.yaml` | Signed-evidence emit outcome |
 
 ## Procedure
 
@@ -71,13 +104,37 @@ priority ranking, so classify every failure:
 
 | Failed step contains | Nature | Product signal? |
 |---|---|---|
-| `UAT - validate`, `UAT - prep`, CUJ/test phase names | Real test failure | YES |
+| `UAT - validate`, `UAT - prep`, CUJ/test phase names | Real test failure | YES — but the validate step also emits signed evidence, so confirm against `report.json` (Step 2b) before ranking |
 | `Bringup Infra`, provision/actuator steps | Infra bring-up failure | no |
 | `Buildx`, `Build and push`, image/GHCR steps | CI/image flake | no |
 | `Validate inputs`, `helmfile apply`, install steps | Setup/install issue | maybe — recurring = investigate |
 
 A retry that went green the same night (same combo, later timestamp,
 success) downgrades the earlier failure to a flake.
+
+### Step 2b — Pull debug bundles (only for product-signal failures)
+
+Skip this step entirely for a routine pass-rate report. Run it when the
+user asks *why* something failed, or when Step 2 found a test-phase
+failure worth root-causing:
+
+```bash
+python3 .agents/skills/aicr-uat-report/uat_report.py --days 3 \
+  --download-debug /tmp/uat-debug --max-downloads 3
+```
+
+Prefer `--run <id>` (repeatable) over raising `--max-downloads`: usually only
+the latest failure per failing combo is worth reading.
+
+Bundles land in `<dir>/<service>-<gpu>-<intent>-<run_id>/`, each with a
+printed digest — MANIFEST head, failing checks from `report.json`, and a
+one-line contents summary. Read that summary for *presence*, not file names:
+a missing `evidence/` or `report.json` says the run died before that stage,
+which is often the whole diagnosis. Then open files per the Debug bundles
+table above.
+
+Cite `file_path:line` and the run ID for every finding. Leave the download
+directory in place — the user may want to keep digging.
 
 ### Step 3 — Render the report
 
@@ -137,10 +194,23 @@ the RC list, not the table.
   `infra/uat/reservations.yaml`.
 - **A combo has very few runs** (e.g. 0/1) — flag low sample size instead
   of declaring it broken.
+- **"no debug artifact"** — expected for bring-up/Buildx/ingest failures
+  (see Debug bundles). Report it as corroborating the infra classification;
+  do not present it as a tooling problem.
+- **"debug artifact expired"** — the window exceeds the 30-day retention.
+  Nothing to recover; note it and work from failed step names.
+- **`cluster-debug/` missing or thin** — the collector is best-effort and
+  its cloud credentials can expire on a long failure. Say the bundle is
+  incomplete; do not read it as the cluster being healthy.
+- **Failing step name disagrees with `report.json`** — trust the bundle.
+  `UAT - validate (all phases) + emit signed evidence` covers two concerns,
+  so N/N passing checks under a failed step means the evidence leg failed,
+  not the product. Reclassify to infra before ranking it in Step 4.
 
 ## What This Skill Does NOT Do
 
 - Does not dispatch, re-run, or cancel workflow runs
-- Does not read job logs or diagnose root causes (it reports failed step
-  names only — deeper debugging is a follow-up task)
-- Does not modify reservations, workflows, or any in-repo file
+- Does not download raw job logs (`gh run view --log`); it reports failed
+  step names and, on request, the uploaded cluster debug bundles
+- Does not modify reservations, workflows, or any in-repo file — the only
+  writes are downloaded artifacts under the `--download-debug` directory

--- a/.agents/skills/aicr-uat-report/uat_report.py
+++ b/.agents/skills/aicr-uat-report/uat_report.py
@@ -18,13 +18,20 @@
 Fetches runs of .github/workflows/uat-run.yaml via `gh`, keeps the runs
 that exercised `main` (aicr_version empty), and prints a Markdown summary
 table plus per-failure detail (failed job/step + run URL) for the agent to
-classify and narrate. Read-only: only `gh run list` / `gh run view`.
+classify and narrate. Reporting is read-only (`gh run list` / `gh run view`).
+
+With --download-debug DIR it additionally fetches the `uat-<cloud>-debug-<run_id>`
+artifact for failing runs into DIR/<service>-<gpu>-<intent>-<run_id>/ and
+prints a triage digest (cluster-debug/MANIFEST.yaml + report.json failing
+checks). That is the only mode that writes anything, and only under DIR.
 
 Usage: uat_report.py [--days N] [--repo OWNER/REPO] [--all-versions]
+                     [--download-debug DIR] [--max-downloads N] [--run ID]
 """
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -32,6 +39,18 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
 WORKFLOW = "uat-run.yaml"
+
+# Per-cloud workflows upload the failure bundle as
+# `uat-<cloud>[-<intent>]-debug-<run_id>`. Reusable workflows share the caller's
+# run_id, so the artifact hangs off the uat-run.yaml run we already listed.
+DEBUG_ARTIFACT_HINT = "debug"
+
+# `retention-days: 30` on every "Upload failure debug" step.
+DEBUG_RETENTION_DAYS = 30
+
+# How much of MANIFEST.yaml to echo in the triage digest — enough to cover
+# generatedAt/runId/config/recipe/criteria plus the failingChecks block.
+MANIFEST_DIGEST_LINES = 40
 
 # Reservation names are <cloud>-<gpu> (infra/uat/reservations.yaml);
 # cloud maps to the managed-Kubernetes service users know it by.
@@ -67,8 +86,12 @@ def parse_title(title):
     return res, intent, ver, True
 
 
+def run_id_of(run_url):
+    return run_url.rstrip("/").rsplit("/", 1)[-1]
+
+
 def failed_steps(repo, run_url):
-    run_id = run_url.rstrip("/").rsplit("/", 1)[-1]
+    run_id = run_id_of(run_url)
     try:
         data = gh_json(["run", "view", run_id, "-R", repo, "--json", "jobs"])
     except (subprocess.SubprocessError, json.JSONDecodeError):
@@ -84,6 +107,121 @@ def failed_steps(repo, run_url):
     return "; ".join(parts) or "no failed job recorded"
 
 
+def debug_artifacts(repo, run_id):
+    """Return the run's non-expired debug artifacts, newest-largest first."""
+    arts = gh_json(
+        ["api", f"repos/{repo}/actions/runs/{run_id}/artifacts", "--jq", ".artifacts"]
+    )
+    return [a for a in arts if DEBUG_ARTIFACT_HINT in a.get("name", "")]
+
+
+def triage_digest(dest):
+    """Summarize a downloaded bundle: manifest head + failing checks + inventory."""
+    lines = []
+    manifest = os.path.join(dest, "cluster-debug", "MANIFEST.yaml")
+    if os.path.isfile(manifest):
+        with open(manifest, encoding="utf-8", errors="replace") as fh:
+            head = [next(fh, "").rstrip("\n") for _ in range(MANIFEST_DIGEST_LINES)]
+        lines.append("  MANIFEST.yaml:")
+        lines += [f"    {ln}" for ln in head if ln]
+    else:
+        lines.append(
+            "  no cluster-debug/MANIFEST.yaml — the collector did not run "
+            "(failure before prep, or kubectl unavailable)"
+        )
+    report = os.path.join(dest, "report.json")
+    if os.path.isfile(report):
+        try:
+            with open(report, encoding="utf-8") as fh:
+                tests = json.load(fh).get("results", {}).get("tests", [])
+            bad = [t for t in tests if t.get("status") in ("failed", "other")]
+            lines.append(
+                f"  report.json: {len(bad)}/{len(tests)} checks failing"
+                + (
+                    ": " + ", ".join(f"{t.get('name')}({t.get('status')})" for t in bad)
+                    if bad
+                    else ""
+                )
+            )
+        except (OSError, ValueError, AttributeError):
+            lines.append("  report.json present but unparseable")
+    # Presence, not a full listing: which top-level artifacts the run produced
+    # (is there a train-logs/? did evidence emit?) is the actionable part.
+    # cluster-debug/ collapses to a count — SKILL.md's reading order says which
+    # of its files to open, so naming all 40 here is noise.
+    contents = sorted(os.listdir(dest)) if os.path.isdir(dest) else []
+    cluster = os.path.join(dest, "cluster-debug")
+    if os.path.isdir(cluster):
+        count = len(os.listdir(cluster))
+        contents = [c for c in contents if c != "cluster-debug"]
+        contents.append(f"cluster-debug/ ({count} files)")
+    if contents:
+        lines.append(f"  contents: {', '.join(contents)}")
+    return lines
+
+
+def download_debug(repo, failures, outdir, limit):
+    """Fetch debug bundles for `failures` (newest first) into `outdir`.
+
+    Returns nothing; prints a per-run status block. An absent artifact is a
+    signal, not an error: the upload step is gated on
+    `failure() && steps.prep.outcome != 'skipped'`, so a run that died in
+    bring-up or image build has no bundle by construction.
+    """
+    print("## Debug bundles\n")
+    selected = failures[:limit]
+    if len(failures) > len(selected):
+        print(
+            f"Downloading {len(selected)} of {len(failures)} failing run(s) "
+            f"(newest first; raise --max-downloads to include the rest).\n"
+        )
+    for f in selected:
+        run_id = run_id_of(f["url"])
+        label = f"{f['svc']}/{f['gpu']}/{f['intent']} {f['ts']}Z run {run_id}"
+        dest = os.path.join(
+            outdir, f"{f['svc']}-{f['gpu']}-{f['intent']}-{run_id}".lower()
+        )
+        try:
+            arts = debug_artifacts(repo, run_id)
+        except (subprocess.SubprocessError, json.JSONDecodeError) as err:
+            print(f"- {label}: could not list artifacts ({err})")
+            continue
+        if not arts:
+            print(
+                f"- {label}: no debug artifact — either the cloud job never "
+                "reached `UAT - prep` (bring-up / image build), or the failure "
+                "was in a downstream job (evidence ingest) while the cluster "
+                "job passed. Both are infra/CI, not product signal."
+            )
+            continue
+        live = [a for a in arts if not a.get("expired")]
+        if not live:
+            print(
+                f"- {label}: debug artifact expired "
+                f"(retention is {DEBUG_RETENTION_DAYS}d)"
+            )
+            continue
+        for art in live:
+            mb = art.get("size_in_bytes", 0) / 1e6
+            os.makedirs(dest, exist_ok=True)
+            try:
+                subprocess.run(
+                    ["gh", "run", "download", run_id, "-R", repo,
+                     "-n", art["name"], "-D", dest],
+                    capture_output=True, text=True, timeout=600, check=True,
+                )
+            except subprocess.SubprocessError as err:
+                stderr = (getattr(err, "stderr", "") or "").strip()
+                print(
+                    f"- {label}: download of {art['name']} failed "
+                    f"({stderr or err})"
+                )
+                continue
+            print(f"- {label}: {art['name']} ({mb:.1f} MB) -> {dest}")
+            print("\n".join(triage_digest(dest)))
+    print()
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--days", type=int, default=3, help="lookback window (default 3)")
@@ -92,6 +230,24 @@ def main():
         "--all-versions",
         action="store_true",
         help="also report release-version runs (default: main only)",
+    )
+    ap.add_argument(
+        "--download-debug",
+        metavar="DIR",
+        help="download the failure debug bundle of each failing run into DIR",
+    )
+    ap.add_argument(
+        "--max-downloads",
+        type=int,
+        default=5,
+        help="cap on bundles fetched by --download-debug (default 5, newest first)",
+    )
+    ap.add_argument(
+        "--run",
+        action="append",
+        default=[],
+        metavar="ID",
+        help="restrict --download-debug to these run IDs (repeatable)",
     )
     opts = ap.parse_args()
 
@@ -130,6 +286,7 @@ def main():
             (r["createdAt"][:16], r["conclusion"], r["url"], derived)
         )
 
+    failures = []
     print(f"# UAT runs on {opts.repo}, last {opts.days} days (since {cutoff}Z)\n")
     for ver in sorted(agg, key=lambda v: (v != "main", v)):
         print(f"## Version: {ver}\n")
@@ -144,6 +301,9 @@ def main():
             print(f"| {svc} | {gpu} | {intent} | {ok}/{len(rows)} | {len(fails)} |")
             for ts, concl, url, derived in fails:
                 note = " (intent derived from dispatch-key cell)" if derived else ""
+                failures.append(
+                    {"ts": ts, "url": url, "svc": svc, "gpu": gpu, "intent": intent}
+                )
                 details.append(
                     f"- {svc}/{gpu}/{intent} {ts}Z {concl.upper()}{note}\n"
                     f"  {url}\n"
@@ -155,7 +315,28 @@ def main():
             print("\n".join(details))
             print()
 
+    if opts.download_debug:
+        wanted = failures
+        if opts.run:
+            wanted = [f for f in failures if run_id_of(f["url"]) in set(opts.run)]
+            missing = set(opts.run) - {run_id_of(f["url"]) for f in wanted}
+            if missing:
+                print(
+                    f"Note: run ID(s) {sorted(missing)} are not failing runs in "
+                    "this window; widen --days or drop --run.\n"
+                )
+        wanted.sort(key=lambda f: f["ts"], reverse=True)
+        if wanted:
+            download_debug(opts.repo, wanted, opts.download_debug, opts.max_downloads)
+        else:
+            print("## Debug bundles\n\nNo failing runs to download.\n")
+
     notes = []
+    if opts.days > DEBUG_RETENTION_DAYS and opts.download_debug:
+        notes.append(
+            f"window exceeds the {DEBUG_RETENTION_DAYS}d debug-artifact "
+            "retention; older bundles are gone"
+        )
     if not opts.all_versions and excluded_versions:
         notes.append(
             f"{excluded_versions} release-version run(s) excluded "

--- a/docs/contributor/skills.md
+++ b/docs/contributor/skills.md
@@ -27,7 +27,7 @@ tree. They complement — they do not replace — the coding rules in
 | [`aicr-creating-slide-decks`](https://github.com/NVIDIA/aicr/blob/main/.agents/skills/aicr-creating-slide-decks/SKILL.md) | Build a self-contained HTML slide deck (`demos/*.html`) — inline CSS/SVG, no build step — to present or teach a concept full-screen or projected. |
 | [`aicr-managing-openvex`](https://github.com/NVIDIA/aicr/blob/main/.agents/skills/aicr-managing-openvex/SKILL.md) | Add, update, or remove CVE/GHSA suppressions in `.openvex.json`, the OpenVEX document consumed by the daily image vulnerability scan. |
 | [`aicr-release-notes`](https://github.com/NVIDIA/aicr/blob/main/.agents/skills/aicr-release-notes/SKILL.md) | Draft the human-readable GitHub release-notes summary for an upcoming release by grouping commits since the last tag into thematic highlights. |
-| [`aicr-uat-report`](https://github.com/NVIDIA/aicr/blob/main/.agents/skills/aicr-uat-report/SKILL.md) | Report UAT health across service x GPU x intent combinations from the UAT Run workflow, classifying failures as product vs infra signal. |
+| [`aicr-uat-report`](https://github.com/NVIDIA/aicr/blob/main/.agents/skills/aicr-uat-report/SKILL.md) | Report UAT health across service x GPU x intent combinations from the UAT Run workflow, classifying failures as product vs infra signal, and download the per-run cluster debug bundles to triage them. |
 
 ## How Skills Are Invoked
 


### PR DESCRIPTION
## Summary

Adds `--download-debug` to the `aicr-uat-report` skill so it can fetch and triage the cluster debug bundle attached to a failing UAT run, and documents the bundle contract in `SKILL.md`.

## Motivation / Context

The skill classified each failure from its workflow step name alone. That misreads the validate step: `UAT - validate (all phases) + emit signed evidence` covers two unrelated concerns, so an evidence-emit failure with every validator passing was classified as a product-signal regression and ranked at the top of the RC validation list.

Dogfooding this on the last 3 days of runs, that is exactly what happened to EKS/GB200/training ([run 30025401058](https://github.com/NVIDIA/aicr/actions/runs/30025401058)): the bundle shows `report.json` at 14/14 passed with no `evidence/` directory, so the failure is in the evidence leg, not the product. Under the previous skill it would have led the RC list.

The bundles were already being produced and uploaded by every per-cloud workflow — nothing consumed them.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: agent skills (`.agents/skills/aicr-uat-report/`)

## Implementation Notes

**Script.** `--download-debug DIR` lists a run's artifacts via `gh api repos/{repo}/actions/runs/{id}/artifacts`, picks `uat-<cloud>[-<intent>]-debug-<run_id>`, downloads it to `DIR/<service>-<gpu>-<intent>-<run_id>/`, and prints a triage digest: MANIFEST head, failing checks parsed from `report.json`, and a one-line contents summary. `--run <id>` (repeatable) scopes the fetch; `--max-downloads` caps it at 5 by default and logs what it skipped rather than truncating silently. Reporting behaviour is byte-for-byte unchanged, and the only writes are downloaded artifacts under `DIR`.

Three non-download outcomes are reported as signal rather than errors:

- **no artifact** — the upload step is gated on `failure() && steps.prep.outcome != 'skipped'`, so a bring-up/image-build failure, or a downstream evidence-ingest failure where the cluster job passed, has no bundle by construction. Absence corroborates the infra classification.
- **expired** — 30-day retention; also warned when `--days` exceeds it.
- **list/download failure** — reported per run, loop continues.

**Docs.** `SKILL.md` gains the bundle contract (artifact naming, retention, the upload gate) and a triage-ordered table of what to open for which failure. The Step 2 classification table now carries the caveat that produced the misread above, at the point where the mistake is actually made.

## Testing

```bash
# Dogfooded end to end against live runs
python3 .agents/skills/aicr-uat-report/uat_report.py --days 3
python3 .agents/skills/aicr-uat-report/uat_report.py --days 3 \
  --download-debug /tmp/uat-debug --run 29937818785 --run 30025401058 \
  --run 29892803570 --run 30069360925 --run 29981094336
```

Five bundles fetched across all four clouds (AWS, Azure, GCP, Kind), 0.1–0.6 MB each. The digest alone resolved two failures without opening a file — AKS `nccl-all-reduce-bw` (launcher pod failed) and EKS `inference-perf` (`[TIMEOUT] job completion timeout`) — both read straight out of `MANIFEST.yaml`'s `failingChecks`. The "no artifact" path fired correctly on a GKE image-push failure. Also exercised: unknown `--run` id, the `--max-downloads` truncation notice, and bundles with no `report.json`.

`make qualify` was not run: this PR changes no Go, YAML, or build inputs. Verified instead with `python3 -m py_compile` and the live runs above.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Agent tooling only; nothing ships in a release artifact. The new flag is opt-in and the default code path is unchanged, so reverting is a clean file revert.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; see Testing
- [x] Linter passes (`make lint`) — N/A, no Go/YAML changes; `py_compile` clean
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, skills have no test harness; dogfooded against live runs instead
- [x] I updated docs if user-facing behavior changed (`SKILL.md`, `docs/contributor/skills.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
