### PR TITLE
fix(skills): harden UAT debug-bundle triage against malformed input

### DIFF
--- a/.agents/skills/aicr-uat-report/uat_report.py
+++ b/.agents/skills/aicr-uat-report/uat_report.py
@@ -108,11 +108,29 @@ def failed_steps(repo, run_url):
 
 
 def debug_artifacts(repo, run_id):
-    """Return the run's non-expired debug artifacts, newest-largest first."""
+    """Return every debug artifact on the run, expired ones included.
+
+    The caller filters for expiry so it can distinguish "never uploaded"
+    (infra failure before prep) from "aged out of retention" — different
+    classifications that a silent filter here would collapse into one.
+    """
     arts = gh_json(
         ["api", f"repos/{repo}/actions/runs/{run_id}/artifacts", "--jq", ".artifacts"]
     )
     return [a for a in arts if DEBUG_ARTIFACT_HINT in a.get("name", "")]
+
+
+def slug(*parts):
+    """Build a filesystem-safe directory name from run metadata.
+
+    Reservation names reach us through the workflow's run-name, and the title
+    regexes accept any non-whitespace token, so `svc`/`gpu` are not guaranteed
+    to be well-formed. Collapsing everything outside [a-z0-9-] removes both
+    separators and dot runs, so no component can traverse out of the download
+    directory.
+    """
+    raw = "-".join(str(p) for p in parts).lower()
+    return re.sub(r"[^a-z0-9-]+", "-", raw).strip("-") or "unknown"
 
 
 def triage_digest(dest):
@@ -133,7 +151,11 @@ def triage_digest(dest):
     if os.path.isfile(report):
         try:
             with open(report, encoding="utf-8") as fh:
-                tests = json.load(fh).get("results", {}).get("tests", [])
+                # `or {}` / `or []` rather than .get(k, default): a truncated
+                # report can carry an explicit null, which a default does not
+                # catch. Nothing here may raise — triage_digest is called
+                # per-run, so one bad file must not abort the whole download.
+                tests = (json.load(fh).get("results") or {}).get("tests") or []
             bad = [t for t in tests if t.get("status") in ("failed", "other")]
             lines.append(
                 f"  report.json: {len(bad)}/{len(tests)} checks failing"
@@ -143,7 +165,7 @@ def triage_digest(dest):
                     else ""
                 )
             )
-        except (OSError, ValueError, AttributeError):
+        except (OSError, ValueError, AttributeError, TypeError):
             lines.append("  report.json present but unparseable")
     # Presence, not a full listing: which top-level artifacts the run produced
     # (is there a train-logs/? did evidence emit?) is the actionable part.
@@ -179,7 +201,7 @@ def download_debug(repo, failures, outdir, limit):
         run_id = run_id_of(f["url"])
         label = f"{f['svc']}/{f['gpu']}/{f['intent']} {f['ts']}Z run {run_id}"
         dest = os.path.join(
-            outdir, f"{f['svc']}-{f['gpu']}-{f['intent']}-{run_id}".lower()
+            outdir, slug(f["svc"], f["gpu"], f["intent"], run_id)
         )
         try:
             arts = debug_artifacts(repo, run_id)
@@ -202,12 +224,18 @@ def download_debug(repo, failures, outdir, limit):
             )
             continue
         for art in live:
+            # One run normally carries one bundle, but a caller that fans out
+            # several cloud jobs under a single run_id would produce more.
+            # Unpacking those into a shared directory would silently merge two
+            # clusters' state and make the digest describe neither, so give
+            # each artifact its own subdirectory once there is more than one.
+            art_dest = dest if len(live) == 1 else os.path.join(dest, slug(art["name"]))
             mb = art.get("size_in_bytes", 0) / 1e6
-            os.makedirs(dest, exist_ok=True)
+            os.makedirs(art_dest, exist_ok=True)
             try:
                 subprocess.run(
                     ["gh", "run", "download", run_id, "-R", repo,
-                     "-n", art["name"], "-D", dest],
+                     "-n", art["name"], "-D", art_dest],
                     capture_output=True, text=True, timeout=600, check=True,
                 )
             except subprocess.SubprocessError as err:
@@ -217,8 +245,8 @@ def download_debug(repo, failures, outdir, limit):
                     f"({stderr or err})"
                 )
                 continue
-            print(f"- {label}: {art['name']} ({mb:.1f} MB) -> {dest}")
-            print("\n".join(triage_digest(dest)))
+            print(f"- {label}: {art['name']} ({mb:.1f} MB) -> {art_dest}")
+            print("\n".join(triage_digest(art_dest)))
     print()
 
 


### PR DESCRIPTION
## Summary

Addresses the three CodeRabbit findings on #1913: a crash in the triage digest, an unsanitized download path, and a directory collision when a run carries more than one debug bundle.

## Motivation / Context

All three were raised on #1913 after it merged. The first is a genuine defect that defeats the feature's own error-handling contract; the other two are latent.

Fixes: N/A
Related: #1913

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: agent skills (`.agents/skills/aicr-uat-report/`)

## Implementation Notes

**1. `TypeError` aborted the download loop (real defect).** `report.json` with an explicit `"tests": null` made `.get("tests", [])` return `None` — a default only applies when the key is *absent* — so iteration raised `TypeError`, which the `except (OSError, ValueError, AttributeError)` clause did not list. `triage_digest` is called per run with no surrounding guard, so one truncated report killed every remaining run. That directly contradicts the contract #1913 introduced, where a bad artifact is reported per run and processing continues.

Reproduced against the merged code before fixing:

```
PRE-FIX CRASH CONFIRMED: TypeError: 'NoneType' object is not iterable
```

Fixed with `or` fallbacks for null-valued keys plus `TypeError` in the except tuple. A malformed report now degrades to `report.json present but unparseable` for that one run.

**2. Unsanitized path components.** Reservation tokens reach the script via the workflow `run-name`, and `NEW_TITLE`/`OLD_TITLE` accept any non-whitespace token, so `svc`/`gpu` are not guaranteed well-formed before being joined onto the output directory. New `slug()` collapses everything outside `[a-z0-9-]`, which removes separators and dot runs together. Reaching this requires write access to dispatch the workflow, so it is defense in depth rather than a live exposure — but it is one line and the destination is attacker-influenced in principle.

**3. Multi-artifact collision.** A run carrying more than one debug bundle unpacked them into a shared directory, merging two clusters' state so the printed digest described neither. Each artifact now gets its own subdirectory once there is more than one; the single-bundle path (every run observed so far) is unchanged.

Also corrected the `debug_artifacts` docstring, which claimed to filter expired artifacts and sort newest-first. It does neither — the caller filters deliberately, so that "never uploaded" and "aged out" stay distinguishable.

## Testing

```bash
python3 .agents/skills/aicr-uat-report/uat_report.py --days 2 \
  --download-debug /tmp/uat-debug2 --max-downloads 2
```

Live regression run: green, output unchanged from #1913 for the normal path (one bundle fetched, one "no artifact" correctly reported).

Targeted cases, all exercised directly against `triage_digest` and `slug`:

| Input | Result |
|---|---|
| `{"results": {"tests": null}}` | `0/0 checks failing` (crashed pre-fix) |
| `{"results": null}` | `0/0 checks failing` |
| `[1,2,3]` (top-level list) | `present but unparseable` |
| truncated JSON | `present but unparseable` |
| valid report | `1/1 checks failing: x(failed)` |
| `slug("EKS","GB200","training",id)` | `eks-gb200-training-<id>` — unchanged |
| `slug("../../etc","H100",…)` | `etc-h100-…`, stays under the output dir |
| `slug("AWS/../..","..",…)` | `aws----inference-2`, stays under the output dir |
| `slug("...","","","")` | `unknown` |

No exception escaped in any case; every traversal attempt resolved inside the download directory.

`make qualify` not run — no Go, YAML, or build inputs changed; verified with `py_compile` plus the runs above.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Agent tooling only. Behaviour on well-formed input is identical to #1913; the changes only affect malformed-input and multi-artifact paths.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; see Testing
- [x] Linter passes (`make lint`) — N/A, no Go/YAML changes; `py_compile` clean
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, skills have no test harness; cases exercised directly, table above
- [x] I updated docs if user-facing behavior changed — no user-visible behaviour change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
