### PR TITLE
feat(recipes): backfill CRD Established=True for 6 operator-owning health checks

### DIFF
--- a/recipes/checks/gatekeeper/health-check.yaml
+++ b/recipes/checks/gatekeeper/health-check.yaml
@@ -15,10 +15,14 @@
 # Gatekeeper Health Check
 #
 # Validates that gatekeeper-controller-manager and gatekeeper-audit are
-# running and healthy in the gatekeeper-system namespace. Guards against
-# vacuous pass on empty namespace by asserting both Deployments exist with
-# at least one available replica, then asserts no pods are stuck in
-# Pending, Failed, or Unknown phases.
+# running and healthy in the gatekeeper-system namespace. Also asserts
+# the two CRDs the chart installs unconditionally in crds/ —
+# constrainttemplates.templates.gatekeeper.sh and
+# configs.config.gatekeeper.sh — are Established=True (verified against
+# chart 3.22.2; re-verify on defaultVersion bump). Guards against
+# vacuous pass on empty namespace by asserting both Deployments exist
+# with at least one available replica, then asserts no pods are stuck
+# in Pending, Failed, or Unknown phases.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -27,6 +31,34 @@ spec:
   timeouts:
     assert: 5m
   steps:
+    - name: validate-crds-established
+      # Verified against chart 3.22.2 (recipes/registry.yaml): rendered
+      # `helm template gatekeeper/gatekeeper --version 3.22.2 --include-crds`
+      # and confirmed both constrainttemplates.templates.gatekeeper.sh and
+      # configs.config.gatekeeper.sh are present (17 CRDs total; the
+      # feature-conditional mutation/expansion/external-data CRDs also
+      # render under default values, confirming these two unconditional
+      # core CRDs are the correct minimal assertion set). Re-verify on
+      # defaultVersion bump — tracked systemically in #1948.
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: constrainttemplates.templates.gatekeeper.sh
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: configs.config.gatekeeper.sh
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
     - name: validate-controller-manager-deployment
       try:
         - assert:

--- a/recipes/checks/k8s-nim-operator/health-check.yaml
+++ b/recipes/checks/k8s-nim-operator/health-check.yaml
@@ -15,9 +15,12 @@
 # NIM Operator Health Check
 #
 # Validates that the NVIDIA NIM Operator is running and healthy in the
-# nvidia-nim namespace. Checks that the k8s-nim-operator deployment has
-# at least one available replica and that no pods in the namespace are
-# stuck in Pending, Failed, or Unknown phases.
+# nvidia-nim namespace. Also asserts nimservices / nimcaches /
+# nimpipelines.apps.nvidia.com are Established=True (verified against
+# chart 3.1.0; re-verify on defaultVersion bump). Checks that the
+# k8s-nim-operator deployment has at least one available replica and
+# that no pods in the namespace are stuck in Pending, Failed, or
+# Unknown phases.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -26,6 +29,35 @@ spec:
   timeouts:
     assert: 5m
   steps:
+    - name: validate-crds-established
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: nimservices.apps.nvidia.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: nimcaches.apps.nvidia.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: nimpipelines.apps.nvidia.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
     - name: validate-deployment-exists
       try:
         # Guard against vacuous pass on empty namespace: verify the

--- a/recipes/checks/kubeflow-trainer/health-check.yaml
+++ b/recipes/checks/kubeflow-trainer/health-check.yaml
@@ -14,10 +14,17 @@
 
 # Kubeflow Trainer Health Check
 #
-# Validates that the Kubeflow Trainer is running and healthy in the kubeflow
-# namespace. Checks that the kubeflow-trainer-controller-manager deployment has at least one
-# available replica and that no pods in the namespace are stuck in Pending,
-# Failed, or Unknown phases.
+# Validates that the Kubeflow Trainer is running and healthy in the
+# kubeflow namespace. Also asserts trainjobs.trainer.kubeflow.org,
+# trainingruntimes.trainer.kubeflow.org, and
+# clustertrainingruntimes.trainer.kubeflow.org are Established=True
+# (verified against chart 2.2.0; re-verify on defaultVersion bump) —
+# clustertrainingruntimes is load-bearing because platform-kubeflow.yaml
+# applies a ClusterTrainingRuntime CR
+# (torch-distributed-cluster-training-runtime.yaml) via manifestFiles.
+# Checks that the kubeflow-trainer-controller-manager deployment has at
+# least one available replica and that no pods in the namespace are
+# stuck in Pending, Failed, or Unknown phases.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -26,6 +33,40 @@ spec:
   timeouts:
     assert: 5m
   steps:
+    - name: validate-crds-established
+      # trainjobs + trainingruntimes + clustertrainingruntimes verified
+      # against chart 2.2.0 (recipes/registry.yaml). clustertrainingruntimes
+      # is the CRD platform-kubeflow.yaml actually instantiates a CR
+      # against — see the kubeflow-trainer entry's manifestFiles block
+      # in registry.yaml.
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: trainjobs.trainer.kubeflow.org
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: clustertrainingruntimes.trainer.kubeflow.org
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: trainingruntimes.trainer.kubeflow.org
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
     - name: validate-deployment-exists
       try:
         # Guard against vacuous pass on empty namespace: verify the

--- a/recipes/checks/kueue/health-check.yaml
+++ b/recipes/checks/kueue/health-check.yaml
@@ -15,11 +15,14 @@
 # Kueue Health Check
 #
 # Validates that Kueue is running and healthy in the kueue-system
-# namespace, and that the default quota CRs shipped with the component
-# (ResourceFlavor default-flavor, ClusterQueue cluster-queue, LocalQueue
-# default/default) were admitted and reconciled to Active — a functional
-# proof (CRDs installed, controller reconciling, and flavor/queue resolution)
-# within the assert/error-only allowlist.
+# namespace. Asserts resourceflavors / clusterqueues /
+# localqueues.kueue.x-k8s.io are Established=True (verified against
+# chart 0.18.2; re-verify on defaultVersion bump), and that the default
+# quota CRs shipped with the component (ResourceFlavor default-flavor,
+# ClusterQueue cluster-queue, LocalQueue default/default) were admitted
+# and reconciled to Active — a functional proof (CRDs installed,
+# controller reconciling, and flavor/queue resolution) within the
+# assert/error-only allowlist.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -28,6 +31,39 @@ spec:
   timeouts:
     assert: 5m
   steps:
+    - name: validate-crds-established
+      try:
+        # kueue.x-k8s.io group verified in-tree: the manifests this
+        # component ships (recipes/components/kueue/manifests/*.yaml)
+        # use apiVersion kueue.x-k8s.io/v1beta2 for ResourceFlavor,
+        # ClusterQueue, and LocalQueue. Chart 0.18.2 (recipes/registry.yaml).
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: resourceflavors.kueue.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: clusterqueues.kueue.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: localqueues.kueue.x-k8s.io
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
     - name: validate-deployment-exists
       try:
         # Guard against vacuous pass on empty namespace: verify the

--- a/recipes/checks/network-operator/health-check.yaml
+++ b/recipes/checks/network-operator/health-check.yaml
@@ -14,10 +14,17 @@
 
 # Network Operator Health Check
 #
-# Validates that the NVIDIA Network Operator is running and healthy in the
-# nvidia-network-operator namespace. Checks that the network-operator
-# deployment has at least one available replica and that no pods in the
-# namespace are stuck in Pending, Failed, or Unknown phases.
+# Validates that the NVIDIA Network Operator is running and healthy in
+# the nvidia-network-operator namespace. Also asserts
+# nicclusterpolicies.mellanox.com is Established=True (verified against
+# chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+# ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+# no in-tree recipe instantiates a CR against it, so it fails the same
+# load-bearing-only bar the rest of this PR's assertions are held to.
+# Checks that the
+# network-operator deployment has at least one available replica and
+# that no pods in the namespace are stuck in Pending, Failed, or
+# Unknown phases.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -26,6 +33,17 @@ spec:
   timeouts:
     assert: 5m
   steps:
+    - name: validate-crds-established
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: nicclusterpolicies.mellanox.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
     - name: validate-deployment-exists
       try:
         # Guard against vacuous pass on empty namespace: verify the

--- a/recipes/checks/slinky-slurm-operator/health-check.yaml
+++ b/recipes/checks/slinky-slurm-operator/health-check.yaml
@@ -18,6 +18,13 @@
 # running and healthy in the `slinky` namespace. Checks that both
 # deployments have at least one available replica and that no pods in
 # the namespace are stuck in Pending, Failed, or Unknown phases.
+#
+# No CRD Established=True block here (negative finding for #1246): the
+# slinky-slurm-operator chart is deployed with crds.enabled: false (see
+# the `crds.enabled: false` key in
+# components/slinky-slurm-operator/values.yaml; registry.yaml's
+# slinky-slurm-operator entry only carries the same flag as a prose
+# reminder to re-verify it on version bumps).
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:


### PR DESCRIPTION
## Summary
Backfills CRD `Established=True` assertions for the 6 operator-owning health checks that PR #1245 deferred pending chart verification.

## Motivation / Context
PR #1245 added CRD `Established=True` checks for 4 components whose CRD names were verifiable in-tree (gpu-operator, dynamo-platform, nodewright-operator, cert-manager). It explicitly deferred gatekeeper, kueue, kubeflow-trainer, network-operator, k8s-nim-operator, and slinky-slurm-operator because their CRD names weren't enumerated in-tree at the pinned chart version - bundling them blind risked typo'd names failing on live clusters.

Related: #1245

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected
- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes
Per component, in `recipes/checks/<comp>/health-check.yaml`:

| Component | CRD(s) asserted | Verification source |
|---|---|---|
| kueue | `resourceflavors/clusterqueues/localqueues.kueue.x-k8s.io` | `recipes/components/kueue/manifests/*.yaml` already ship CRs at this apiVersion - group is load-bearing today, not a guess |
| kubeflow-trainer | `trainjobs.trainer.kubeflow.org`, `trainingruntimes.trainer.kubeflow.org`, `clustertrainingruntimes.trainer.kubeflow.org` | all asserted Established=True. Verified against chart 2.2.0 via `helm template oci://ghcr.io/kubeflow/charts/kubeflow-trainer --version 2.2.0 --include-crds` (all three ship; jobsets.jobset.x-k8s.io also ships but is correctly not asserted - not load-bearing for this recipe). |
| network-operator | `nicclusterpolicies.mellanox.com` | `recipes/components/network-operator/manifests/nic-cluster-policy-aks.yaml` ships an actual `NicClusterPolicy` CR at `mellanox.com/v1alpha1` |
| k8s-nim-operator | `nimservices/nimcaches/nimpipelines.apps.nvidia.com` | `docs/conformance/cncf/v1.35/nim-eks/evidence/robust-operator.md` - live `kubectl get crds` output from an EKS run of chart 3.1.0 |
| gatekeeper | `constrainttemplates.templates.gatekeeper.sh`, `configs.config.gatekeeper.sh` | both asserted Established=True. Verified against chart 3.22.2 via `helm template gatekeeper/gatekeeper --version 3.22.2 --include-crds` - both present among 17 total CRDs; the feature-conditional mutation/expansion/external-data CRDs also render under default values, confirming these two unconditional core CRDs are the correct minimal assertion set. |
| slinky-slurm-operator | none - negative finding | Chart is deployed with `crds.enabled: false` (`recipes/registry.yaml`); all 6 `slinky.slurm.net` CRDs are owned exclusively by the sibling `slinky-slurm-operator-crds` chart, already covered by its own health check. Comment added explaining the omission per #1246's acceptance criteria. |

For network-operator, `MacvlanNetwork`/`IPoIBNetwork`/`HostDeviceNetwork` from the issue's guess table are left out pending confirmation.

## Testing
```bash
go test -race -count=1 ./validators/chainsaw/...
python -m yamllint -c .yamllint.yaml recipes/checks/gatekeeper/health-check.yaml recipes/checks/k8s-nim-operator/health-check.yaml recipes/checks/kubeflow-trainer/health-check.yaml recipes/checks/kueue/health-check.yaml recipes/checks/network-operator/health-check.yaml recipes/checks/slinky-slurm-operator/health-check.yaml
TestValidateTestReadOnly_RegistryContent: pass

TestRunChainsawTestInProcess_RegistryCorpusParses: pass

yamllint: clean, no output

Live-cluster validation not yet performed for any of the 6 - see Risk Assessment.

Risk Assessment
[x] Medium - Touches multiple components; CRD names for kueue/kubeflow-trainer/network-operator/k8s-nim-operator and gatekeeper are verified against real in-tree evidence or chart renders, and none of the 6 have been validated on a live cluster yet.

Rollout notes: Per-component revert is trivial (each is an isolated try step).

Checklist
[x] Tests pass locally (make test with -race)

[x] Linter passes (make lint)

[x] I did not skip/disable tests to make CI green

[ ] I added/updated tests for new functionality - no new tests added; existing TestComponentRegistry_RequiresHealthCheck + TestValidateTestReadOnly_RegistryContent lint guards already cover the registry content this PR touches, same as #1245

[ ] I updated docs if user-facing behavior changed - N/A, no user-facing CLI/API change

[x] Changes follow existing patterns in the codebase

[x] Commits are cryptographically signed (git commit -S)