### PR TITLE
ci(stale): drop phantom priority/critical exempt label

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -23,8 +23,7 @@
 #
 # Exemptions:
 #   - lifecycle/frozen: Never goes stale
-#   - priority/critical: Never goes stale
-#   - do-not-merge: PR won't be closed
+#   - do-not-merge: PRs never go stale
 #
 # Pattern from: gpu-operator
 
@@ -64,7 +63,7 @@ jobs:
             If this issue is no longer relevant, it's okay to let it close.
           days-before-stale: 90
           stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/frozen,priority/critical,good first issue'
+          exempt-issue-labels: 'lifecycle/frozen,good first issue'
 
           # PR settings (shorter timeline)
           stale-pr-message: |


### PR DESCRIPTION
## Summary

Removes `priority/critical` from `exempt-issue-labels` in `.github/workflows/stale.yaml`, and the matching line from the comment block above it. No such label exists in this repository, so the entry can never match.

Also corrects that same comment block's one-line description of `do-not-merge`, which understated the exemption in the way #1921 just fixed in `CONTRIBUTING.md`.

## Motivation / Context

**This is a proposal, not a settled decision.** `priority/critical` is inert either way — an unmatched exempt label simply never fires — so there are two defensible resolutions, and this PR implements one of them:

- **Delete the dead entry** (this PR), if `lifecycle/frozen` is the intended freeze mechanism.
- **Create the label**, if "never goes stale for critical issues" is wanted policy — in which case the config was right and the label is what was missing. **Closing this PR is how that option gets chosen**; the label would then be created through repo settings, with no code change needed here.

**The decisive point is that `actions/stale` can only match label names.** It has no access to Projects v2 fields. Priority in this repo lives on the AICR project board as a `Priority` field (P0/P1/P2), not as repo labels, which is why no `priority/*` label was ever created. So creating `priority/critical` would not give board-P0 issues automatic exemption — someone would still hand-apply the label to each one. That collapses it into a synonym for `lifecycle/frozen`, which already exists, already sits in the same `exempt-issue-labels` list, and already covers pull requests too via `exempt-pr-labels`.

The trade-off is therefore not "protection versus no protection" — it is "one way to freeze an issue, or two."

**Why fix it at all, given it is inert.** The entry is documentation-shaped. The comment at `:26` reads as a statement of policy, and it is where the incorrect `CONTRIBUTING.md` claim originated. #1921 removed that claim from the docs; this removes the source. Left alone, the next person auditing the workflow re-documents it and the same error returns.

Evidence: `gh api repos/NVIDIA/aicr/labels --paginate` returns no `priority/*` label of any kind. The other two exempt labels, `lifecycle/frozen` and `good first issue`, both exist and work.

Fixes: N/A
Related: #1920, #1921

This addresses one bullet of #1920 and deliberately does not close it — that issue also covers the `aicr-triage` Close-bucket label rule and the "Stalled" naming collision, both of which are independent follow-ups.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.github/workflows/stale.yaml`

## Implementation Notes

**No behavior change.** The removed label never matched, so no issue's staleness handling differs before or after. `lifecycle/frozen` and `good first issue` continue to exempt issues; `lifecycle/frozen` and `do-not-merge` continue to exempt pull requests.

**The `do-not-merge` comment was understated.** `exempt-pr-labels` (`:80`) is `actions/stale`'s exemption list, so an exempt PR is never *marked* stale — it receives neither the `lifecycle/stale` label nor the warning comment. It is not merely spared the close. "PR won't be closed" is precisely the framing #1921 replaced in `CONTRIBUTING.md` ("To prevent auto-close" → "To stay out of the stale process entirely") for this same mechanism, so leaving it would have put the workflow comment and the documentation in disagreement about the same behavior — the drift this PR exists to prevent.

**Scope is deliberately narrow**: three lines, all inside the same comment block or the config entry it describes. The documentation half was fixed separately in #1921, and the `aicr-triage` skill changes from #1920 belong in their own PR against the skill file.

**One adjacent gap left alone.** The comment block still omits `good first issue`, so it remains an incomplete summary of `:66` after this change. That is incompleteness rather than an incorrect statement, which is why it is treated differently from the `do-not-merge` wording above. Happy to add it if a reviewer prefers the block be exhaustive.

**Reversible.** If a maintainer later decides critical issues warrant a dedicated exemption, restoring it is one API call to create the label plus these two lines back. Deleting a dead string forecloses nothing.

## Testing

```bash
actionlint .github/workflows/stale.yaml   # passes
git grep -n 'priority/critical'           # no matches remain in the tree
```

`make qualify` was not run: this changes one CI workflow file and no Go, YAML-under-test, or documentation source, so the repository gate cannot regress from it. The relevant check is `actionlint`, which passes locally and also runs in CI on `.github/**` changes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration. The removed entry had no effect, so the stale bot behaves identically before and after.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; `actionlint` passes
- [x] Linter passes (`make lint`) — `actionlint` clean on the changed file
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — the doc half landed separately in #1921
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
